### PR TITLE
Add agent report cache + service + client

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3195,6 +3195,29 @@ func (c *Client) RollbackAutoUpdateAgentGroup(ctx context.Context, groups []stri
 	return rollout, nil
 }
 
+// GetAutoUpdateAgentReport gets the AutoUpdateAgentReport from a specific Auth Service instance.
+func (c *Client) GetAutoUpdateAgentReport(ctx context.Context, name string) (*autoupdatev1pb.AutoUpdateAgentReport, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	report, err := client.GetAutoUpdateAgentReport(ctx, &autoupdatev1pb.GetAutoUpdateAgentReportRequest{Name: name})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return report, nil
+}
+
+// ListAutoUpdateAgentReports returns an AutoUpdateAgentReports page.
+func (c *Client) ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdatev1pb.AutoUpdateAgentReport, string, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.ListAutoUpdateAgentReports(ctx, &autoupdatev1pb.ListAutoUpdateAgentReportsRequest{
+		PageSize:  int32(pageSize),
+		NextToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return resp.GetAutoupdateAgentReports(), resp.GetNextKey(), nil
+}
+
 // GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
 func (c *Client) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
 	rsp, err := c.ClusterConfigClient().GetClusterAccessGraphConfig(ctx, &clusterconfigpb.GetClusterAccessGraphConfigRequest{})

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -123,6 +123,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 		out.Resource = &proto.Event_AutoUpdateAgentRollout{
 			AutoUpdateAgentRollout: r.UnwrapT(),
 		}
+	case types.Resource153UnwrapperT[*autoupdate.AutoUpdateAgentReport]:
+		out.Resource = &proto.Event_AutoUpdateAgentReport{
+			AutoUpdateAgentReport: r.UnwrapT(),
+		}
 	case types.Resource153UnwrapperT[*identitycenterv1.Account]:
 		out.Resource = &proto.Event_IdentityCenterAccount{
 			IdentityCenterAccount: r.UnwrapT(),
@@ -605,6 +609,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetAutoUpdateAgentRollout(); r != nil {
+		out.Resource = types.Resource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetAutoUpdateAgentReport(); r != nil {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetUserTask(); r != nil {

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -190,6 +190,7 @@ type Event struct {
 	//	*Event_WorkloadIdentity
 	//	*Event_WorkloadIdentityX509Revocation
 	//	*Event_HealthCheckConfig
+	//	*Event_AutoUpdateAgentReport
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -896,6 +897,15 @@ func (x *Event) GetHealthCheckConfig() *v116.HealthCheckConfig {
 	return nil
 }
 
+func (x *Event) GetAutoUpdateAgentReport() *v111.AutoUpdateAgentReport {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_AutoUpdateAgentReport); ok {
+			return x.AutoUpdateAgentReport
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1230,7 +1240,7 @@ type Event_ProvisioningPrincipalState struct {
 }
 
 type Event_AutoUpdateAgentRollout struct {
-	// AutoUpdateVersion is a resource for controlling the autoupdate agent rollout.
+	// AutoUpdateAgentRollout is a resource for controlling the autoupdate agent rollout.
 	AutoUpdateAgentRollout *v111.AutoUpdateAgentRollout `protobuf:"bytes,71,opt,name=AutoUpdateAgentRollout,proto3,oneof"`
 }
 
@@ -1269,6 +1279,11 @@ type Event_WorkloadIdentityX509Revocation struct {
 type Event_HealthCheckConfig struct {
 	// HealthCheckConfig is a resource for configuring health checks.
 	HealthCheckConfig *v116.HealthCheckConfig `protobuf:"bytes,78,opt,name=HealthCheckConfig,proto3,oneof"`
+}
+
+type Event_AutoUpdateAgentReport struct {
+	// AutoUpdateAgentReport is a resource for counting agents connected to an auth instance.
+	AutoUpdateAgentReport *v111.AutoUpdateAgentReport `protobuf:"bytes,79,opt,name=AutoUpdateAgentReport,proto3,oneof"`
 }
 
 func (*Event_ResourceHeader) isEvent_Resource() {}
@@ -1417,11 +1432,13 @@ func (*Event_WorkloadIdentityX509Revocation) isEvent_Resource() {}
 
 func (*Event_HealthCheckConfig) isEvent_Resource() {}
 
+func (*Event_AutoUpdateAgentReport) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xf6+\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xdd,\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1507,7 +1524,8 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\x17PluginStaticCredentials\x18K \x01(\v2 .types.PluginStaticCredentialsV1H\x00R\x17PluginStaticCredentials\x12\\\n" +
 	"\x10WorkloadIdentity\x18L \x01(\v2..teleport.workloadidentity.v1.WorkloadIdentityH\x00R\x10WorkloadIdentity\x12\x86\x01\n" +
 	"\x1eWorkloadIdentityX509Revocation\x18M \x01(\v2<.teleport.workloadidentity.v1.WorkloadIdentityX509RevocationH\x00R\x1eWorkloadIdentityX509Revocation\x12`\n" +
-	"\x11HealthCheckConfig\x18N \x01(\v20.teleport.healthcheckconfig.v1.HealthCheckConfigH\x00R\x11HealthCheckConfigB\n" +
+	"\x11HealthCheckConfig\x18N \x01(\v20.teleport.healthcheckconfig.v1.HealthCheckConfigH\x00R\x11HealthCheckConfig\x12e\n" +
+	"\x15AutoUpdateAgentReport\x18O \x01(\v2-.teleport.autoupdate.v1.AutoUpdateAgentReportH\x00R\x15AutoUpdateAgentReportB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1603,6 +1621,7 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v115.WorkloadIdentity)(nil),               // 69: teleport.workloadidentity.v1.WorkloadIdentity
 	(*v115.WorkloadIdentityX509Revocation)(nil), // 70: teleport.workloadidentity.v1.WorkloadIdentityX509Revocation
 	(*v116.HealthCheckConfig)(nil),              // 71: teleport.healthcheckconfig.v1.HealthCheckConfig
+	(*v111.AutoUpdateAgentReport)(nil),          // 72: teleport.autoupdate.v1.AutoUpdateAgentReport
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1679,11 +1698,12 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	69, // 71: proto.Event.WorkloadIdentity:type_name -> teleport.workloadidentity.v1.WorkloadIdentity
 	70, // 72: proto.Event.WorkloadIdentityX509Revocation:type_name -> teleport.workloadidentity.v1.WorkloadIdentityX509Revocation
 	71, // 73: proto.Event.HealthCheckConfig:type_name -> teleport.healthcheckconfig.v1.HealthCheckConfig
-	74, // [74:74] is the sub-list for method output_type
-	74, // [74:74] is the sub-list for method input_type
-	74, // [74:74] is the sub-list for extension type_name
-	74, // [74:74] is the sub-list for extension extendee
-	0,  // [0:74] is the sub-list for field type_name
+	72, // 74: proto.Event.AutoUpdateAgentReport:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReport
+	75, // [75:75] is the sub-list for method output_type
+	75, // [75:75] is the sub-list for method input_type
+	75, // [75:75] is the sub-list for extension type_name
+	75, // [75:75] is the sub-list for extension extendee
+	0,  // [0:75] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -1765,6 +1785,7 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_WorkloadIdentity)(nil),
 		(*Event_WorkloadIdentityX509Revocation)(nil),
 		(*Event_HealthCheckConfig)(nil),
+		(*Event_AutoUpdateAgentReport)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -199,7 +199,7 @@ message Event {
     // ProvisioningPrincipalState is a resource for tracking the provisioning of
     // users and groups into downstream systems.
     teleport.provisioning.v1.PrincipalState ProvisioningPrincipalState = 70;
-    // AutoUpdateVersion is a resource for controlling the autoupdate agent rollout.
+    // AutoUpdateAgentRollout is a resource for controlling the autoupdate agent rollout.
     teleport.autoupdate.v1.AutoUpdateAgentRollout AutoUpdateAgentRollout = 71;
     // IdentityCenterAccount is a resource for tracking Identity Center accounts
     teleport.identitycenter.v1.Account IdentityCenterAccount = 72;
@@ -217,5 +217,7 @@ message Event {
     teleport.workloadidentity.v1.WorkloadIdentityX509Revocation WorkloadIdentityX509Revocation = 77;
     // HealthCheckConfig is a resource for configuring health checks.
     teleport.healthcheckconfig.v1.HealthCheckConfig HealthCheckConfig = 78;
+    // AutoUpdateAgentReport is a resource for counting agents connected to an auth instance.
+    teleport.autoupdate.v1.AutoUpdateAgentReport AutoUpdateAgentReport = 79;
   }
 }

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1188,6 +1188,12 @@ type Cache interface {
 	// GetAutoUpdateAgentRollout gets the AutoUpdateAgentRollout from the backend.
 	GetAutoUpdateAgentRollout(ctx context.Context) (*autoupdate.AutoUpdateAgentRollout, error)
 
+	// GetAutoUpdateAgentReport gets the AutoUpdateAgentRollout from the backend.
+	GetAutoUpdateAgentReport(ctx context.Context, name string) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// ListAutoUpdateAgentReports lists all AutoUpdateAgentReports from the backend.
+	ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdate.AutoUpdateAgentReport, string, error)
+
 	// GetAccessGraphSettings returns the access graph settings.
 	GetAccessGraphSettings(context.Context) (*clusterconfigpb.AccessGraphSettings, error)
 

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -916,7 +916,7 @@ func (s *Service) CreateAutoUpdateAgentReport(ctx context.Context, req *autoupda
 	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
 	// In the future, if we expand the permission system and make cloud
 	// a first class citizen, we'll want to update this permission check.
-	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -945,7 +945,7 @@ func (s *Service) UpdateAutoUpdateAgentReport(ctx context.Context, req *autoupda
 	// The workaround is to check if the caller has the auth/admin system role.
 	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
 	// In the future, if we expand the permission system and make cloud
-	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -974,7 +974,7 @@ func (s *Service) UpsertAutoUpdateAgentReport(ctx context.Context, req *autoupda
 	// The workaround is to check if the caller has the auth/admin system role.
 	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
 	// In the future, if we expand the permission system and make cloud
-	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -1003,7 +1003,7 @@ func (s *Service) DeleteAutoUpdateAgentReport(ctx context.Context, req *autoupda
 	// The workaround is to check if the caller has the auth/admin system role.
 	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
 	// In the future, if we expand the permission system and make cloud
-	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) && !authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin)) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -48,6 +48,12 @@ type Cache interface {
 
 	// GetAutoUpdateAgentRollout gets the AutoUpdateAgentRollout from the backend.
 	GetAutoUpdateAgentRollout(ctx context.Context) (*autoupdate.AutoUpdateAgentRollout, error)
+
+	// GetAutoUpdateAgentReport gets a AutoUpdateAgentReport from the backend.
+	GetAutoUpdateAgentReport(ctx context.Context, name string) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// ListAutoUpdateAgentReports lists all AutoUpdateAgentReport from the backend.
+	ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdate.AutoUpdateAgentReport, string, error)
 }
 
 // ServiceConfig holds configuration options for the auto update gRPC service.
@@ -853,6 +859,166 @@ func (s *Service) RollbackAutoUpdateAgentGroup(ctx context.Context, req *autoupd
 		}
 	}
 	return nil, trace.LimitExceeded("max update tries exceeded")
+}
+
+func (s *Service) ListAutoUpdateAgentReports(ctx context.Context, req *autoupdate.ListAutoUpdateAgentReportsRequest) (*autoupdate.ListAutoUpdateAgentReportsResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbRead, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	reports, nextKey, err := s.cache.ListAutoUpdateAgentReports(ctx, int(req.GetPageSize()), req.GetNextToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &autoupdate.ListAutoUpdateAgentReportsResponse{
+		AutoupdateAgentReports: reports,
+		NextKey:                nextKey,
+	}, nil
+
+}
+
+// GetAutoUpdateAgentReport gets an AutoUpdateAgentReport.
+func (s *Service) GetAutoUpdateAgentReport(ctx context.Context, req *autoupdate.GetAutoUpdateAgentReportRequest) (*autoupdate.AutoUpdateAgentReport, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	report, err := s.cache.GetAutoUpdateAgentReport(ctx, req.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return report, nil
+}
+
+// CreateAutoUpdateAgentReport creates an AutoUpdateAgentReport.
+func (s *Service) CreateAutoUpdateAgentReport(ctx context.Context, req *autoupdate.CreateAutoUpdateAgentReportRequest) (*autoupdate.AutoUpdateAgentReport, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Editing an agent report is restricted to cluster administrators.
+	// As of today we don't have any way of having
+	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
+	// a first class citizen, we'll want to update this permission check.
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentReport, err := s.backend.CreateAutoUpdateAgentReport(ctx, req.GetAutoupdateAgentReport())
+	return autoUpdateAgentReport, trace.Wrap(err)
+}
+
+// UpdateAutoUpdateAgentReport updates an AutoUpdateAgentReport.
+func (s *Service) UpdateAutoUpdateAgentReport(ctx context.Context, req *autoupdate.UpdateAutoUpdateAgentReportRequest) (*autoupdate.AutoUpdateAgentReport, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Editing an agent report is restricted to cluster administrators.
+	// As of today we don't have any way of having
+	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentReport, err := s.backend.UpdateAutoUpdateAgentReport(ctx, req.GetAutoupdateAgentReport())
+	return autoUpdateAgentReport, trace.Wrap(err)
+}
+
+// UpsertAutoUpdateAgentReport updates or creates an AutoUpdateAgentReport.
+func (s *Service) UpsertAutoUpdateAgentReport(ctx context.Context, req *autoupdate.UpsertAutoUpdateAgentReportRequest) (*autoupdate.AutoUpdateAgentReport, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Editing an agent report is restricted to cluster administrators.
+	// As of today we don't have any way of having
+	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbCreate, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	autoUpdateAgentReport, err := s.backend.UpsertAutoUpdateAgentReport(ctx, req.GetAutoupdateAgentReport())
+	return autoUpdateAgentReport, trace.Wrap(err)
+}
+
+// DeleteAutoUpdateAgentReport deletes an AutoUpdateAgentReport.
+func (s *Service) DeleteAutoUpdateAgentReport(ctx context.Context, req *autoupdate.DeleteAutoUpdateAgentReportRequest) (*emptypb.Empty, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Editing an agent report is restricted to cluster administrators.
+	// As of today we don't have any way of having
+	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
+		return nil, trace.AccessDenied("this request can be only executed by an auth server")
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateAgentReport, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteAutoUpdateAgentReport(ctx, req.GetName()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &emptypb.Empty{}, nil
 }
 
 func (s *Service) emitEvent(ctx context.Context, e apievents.AuditEvent) {

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -529,6 +529,7 @@ func TestAutoUpdateAgentRolloutEvents(t *testing.T) {
 		authz.AdminActionAuthMFAVerified,
 		fakeChecker{
 			allowedVerbs: rwVerbs,
+			allowedKinds: []string{types.KindAutoUpdateAgentRollout},
 			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
 		mockEmitter)

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -87,6 +87,7 @@ func TestServiceAccess(t *testing.T) {
 	testCases := []struct {
 		name             string
 		allowedVerbs     []string
+		kind             string
 		allowedStates    []authz.AdminActionAuthState
 		disallowedStates []authz.AdminActionAuthState
 		builtinRole      *authz.BuiltinRole
@@ -98,6 +99,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateConfig,
 			allowedVerbs: []string{types.VerbCreate},
 		},
 		{
@@ -107,6 +109,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateConfig,
 			allowedVerbs: []string{types.VerbUpdate},
 		},
 		{
@@ -116,6 +119,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateConfig,
 			allowedVerbs: []string{types.VerbUpdate, types.VerbCreate},
 		},
 		{
@@ -126,6 +130,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateConfig,
 			allowedVerbs: []string{types.VerbRead},
 		},
 		{
@@ -135,6 +140,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateConfig,
 			allowedVerbs: []string{types.VerbDelete},
 		},
 		// AutoUpdate version check.
@@ -145,6 +151,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateVersion,
 			allowedVerbs: []string{types.VerbCreate},
 		},
 		{
@@ -154,6 +161,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateVersion,
 			allowedVerbs: []string{types.VerbUpdate},
 		},
 		{
@@ -163,6 +171,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateVersion,
 			allowedVerbs: []string{types.VerbUpdate, types.VerbCreate},
 		},
 		{
@@ -173,6 +182,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateVersion,
 			allowedVerbs: []string{types.VerbRead},
 		},
 		{
@@ -182,6 +192,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateVersion,
 			allowedVerbs: []string{types.VerbDelete},
 		},
 		// AutoUpdate agent rollout check.
@@ -193,6 +204,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbRead},
 		},
 		{
@@ -202,6 +214,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbCreate},
 			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
@@ -212,6 +225,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbUpdate},
 			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
@@ -222,6 +236,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbUpdate, types.VerbCreate},
 			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
@@ -232,6 +247,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbDelete},
 			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
@@ -242,6 +258,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbUpdate},
 		},
 		{
@@ -251,6 +268,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbUpdate},
 		},
 		{
@@ -260,7 +278,75 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthMFAVerified,
 				authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
+			kind:         types.KindAutoUpdateAgentRollout,
 			allowedVerbs: []string{types.VerbUpdate},
+		},
+		// Autoupdate agent report check
+		{
+			name: "ListAutoUpdateAgentReports",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthUnauthorized,
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbRead, types.VerbList},
+		},
+		{
+			name: "GetAutoUpdateAgentReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthUnauthorized,
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbRead},
+		},
+		{
+			name: "CreateAutoUpdateAgentReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbCreate},
+			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
+		},
+		{
+			name: "UpdateAutoUpdateAgentReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbUpdate},
+			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
+		},
+		{
+			name: "UpsertAutoUpdateAgentReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbUpdate, types.VerbCreate},
+			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
+		},
+		{
+			name: "DeleteAutoUpdateAgentReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindAutoUpdateAgentReport,
+			allowedVerbs: []string{types.VerbDelete},
+			builtinRole:  &authz.BuiltinRole{Role: types.RoleAuth},
 		},
 	}
 
@@ -272,7 +358,12 @@ func TestServiceAccess(t *testing.T) {
 					t.Run(stateToString(state), func(t *testing.T) {
 						for _, verbs := range utils.Combinations(tt.allowedVerbs) {
 							t.Run(fmt.Sprintf("verbs=%v", verbs), func(t *testing.T) {
-								service := newService(t, state, fakeChecker{allowedVerbs: verbs, builtinRole: tt.builtinRole}, &libevents.DiscardEmitter{})
+								checker := fakeChecker{
+									allowedKinds: []string{tt.kind},
+									allowedVerbs: verbs,
+									builtinRole:  tt.builtinRole,
+								}
+								service := newService(t, state, checker, &libevents.DiscardEmitter{})
 								err := callMethod(t, service, tt.name)
 								// expect access denied except with full set of verbs.
 								if len(verbs) == len(tt.allowedVerbs) {
@@ -296,7 +387,12 @@ func TestServiceAccess(t *testing.T) {
 					t.Run(stateToString(state), func(t *testing.T) {
 						// it is enough to test against tt.allowedVerbs,
 						// this is the only different data point compared to the test cases above.
-						service := newService(t, state, fakeChecker{allowedVerbs: tt.allowedVerbs, builtinRole: tt.builtinRole}, &libevents.DiscardEmitter{})
+						checker := fakeChecker{
+							allowedKinds: []string{tt.kind},
+							allowedVerbs: tt.allowedVerbs,
+							builtinRole:  tt.builtinRole,
+						}
+						service := newService(t, state, checker, &libevents.DiscardEmitter{})
 						err := callMethod(t, service, tt.name)
 						require.True(t, trace.IsAccessDenied(err))
 					})
@@ -335,7 +431,8 @@ func TestServiceAccess(t *testing.T) {
 func TestAutoUpdateConfigEvents(t *testing.T) {
 	rwVerbs := []string{types.VerbList, types.VerbCreate, types.VerbRead, types.VerbUpdate, types.VerbDelete}
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	service := newService(t, authz.AdminActionAuthMFAVerified, fakeChecker{allowedVerbs: rwVerbs}, mockEmitter)
+	checker := fakeChecker{allowedVerbs: rwVerbs, allowedKinds: []string{types.KindAutoUpdateConfig}}
+	service := newService(t, authz.AdminActionAuthMFAVerified, checker, mockEmitter)
 	ctx := context.Background()
 
 	config, err := autoupdate.NewAutoUpdateConfig(&autoupdatev1pb.AutoUpdateConfigSpec{
@@ -381,7 +478,8 @@ func TestAutoUpdateConfigEvents(t *testing.T) {
 func TestAutoUpdateVersionEvents(t *testing.T) {
 	rwVerbs := []string{types.VerbList, types.VerbCreate, types.VerbRead, types.VerbUpdate, types.VerbDelete}
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	service := newService(t, authz.AdminActionAuthMFAVerified, fakeChecker{allowedVerbs: rwVerbs}, mockEmitter)
+	checker := fakeChecker{allowedVerbs: rwVerbs, allowedKinds: []string{types.KindAutoUpdateVersion}}
+	service := newService(t, authz.AdminActionAuthMFAVerified, checker, mockEmitter)
 	ctx := context.Background()
 
 	config, err := autoupdate.NewAutoUpdateVersion(&autoupdatev1pb.AutoUpdateVersionSpec{
@@ -513,21 +611,22 @@ func TestAutoUpdateAgentRolloutEvents(t *testing.T) {
 }
 
 type fakeChecker struct {
+	allowedKinds []string
 	allowedVerbs []string
 	builtinRole  *authz.BuiltinRole
 	services.AccessChecker
 }
 
 func (f fakeChecker) CheckAccessToRule(_ services.RuleContext, _ string, resource string, verb string) error {
-	if resource == types.KindAutoUpdateConfig || resource == types.KindAutoUpdateVersion || resource == types.KindAutoUpdateAgentRollout {
-		for _, allowedVerb := range f.allowedVerbs {
-			if allowedVerb == verb {
-				return nil
-			}
-		}
+	if !slices.Contains(f.allowedKinds, resource) {
+		return trace.AccessDenied("access denied to rule=%v/verb=%v, no resource matching", resource, verb)
 	}
 
-	return trace.AccessDenied("access denied to rule=%v/verb=%v", resource, verb)
+	if !slices.Contains(f.allowedVerbs, verb) {
+		return trace.AccessDenied("access denied to rule=%v/verb=%v, no verb matching", resource, verb)
+	}
+
+	return nil
 }
 
 func (f fakeChecker) HasRole(name string) bool {

--- a/lib/cache/auto_update.go
+++ b/lib/cache/auto_update.go
@@ -230,11 +230,13 @@ func newAutoUpdateAgentReportCollection(upstream services.AutoUpdateServiceGette
 	}
 
 	return &collection[*autoupdatev1.AutoUpdateAgentReport, autoUpdateAgentReportIndex]{
-		store: newStore(map[autoUpdateAgentReportIndex]func(*autoupdatev1.AutoUpdateAgentReport) string{
-			autoUpdateAgentReportNameIndex: func(r *autoupdatev1.AutoUpdateAgentReport) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*autoupdatev1.AutoUpdateAgentReport],
+			map[autoUpdateAgentReportIndex]func(*autoupdatev1.AutoUpdateAgentReport) string{
+				autoUpdateAgentReportNameIndex: func(r *autoupdatev1.AutoUpdateAgentReport) string {
+					return r.GetMetadata().Name
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*autoupdatev1.AutoUpdateAgentReport, error) {
 			var discoveryConfigs []*autoupdatev1.AutoUpdateAgentReport
 			var nextToken string
@@ -278,7 +280,6 @@ func (c *Cache) GetAutoUpdateAgentReport(ctx context.Context, name string) (*aut
 		collection:  c.collections.autoUpdateReports,
 		index:       autoUpdateAgentReportNameIndex,
 		upstreamGet: c.Config.AutoUpdateService.GetAutoUpdateAgentReport,
-		clone:       apiutils.CloneProtoMsg[*autoupdatev1.AutoUpdateAgentReport],
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)
@@ -297,7 +298,6 @@ func (c *Cache) ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pa
 		nextToken: func(t *autoupdatev1.AutoUpdateAgentReport) string {
 			return t.GetMetadata().Name
 		},
-		clone: apiutils.CloneProtoMsg[*autoupdatev1.AutoUpdateAgentReport],
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -179,6 +179,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindAutoUpdateVersion},
 		{Kind: types.KindAutoUpdateConfig},
 		{Kind: types.KindAutoUpdateAgentRollout},
+		{Kind: types.KindAutoUpdateAgentReport},
 		{Kind: types.KindUserTask},
 		{Kind: types.KindProvisioningPrincipalState},
 		{Kind: types.KindIdentityCenterAccount},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1975,6 +1975,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*provisioningv1.PrincipalState]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*usertasksv1.UserTask]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*usertasksv1.UserTask]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*autoupdate.AutoUpdateAgentReport]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*autoupdate.AutoUpdateAgentReport]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*autoupdate.AutoUpdateAgentRollout]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*autoupdate.AutoUpdateAgentRollout]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*autoupdate.AutoUpdateVersion]:

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1934,6 +1934,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindAutoUpdateConfig:                  types.Resource153ToLegacy(newAutoUpdateConfig(t)),
 		types.KindAutoUpdateVersion:                 types.Resource153ToLegacy(newAutoUpdateVersion(t)),
 		types.KindAutoUpdateAgentRollout:            types.Resource153ToLegacy(newAutoUpdateAgentRollout(t)),
+		types.KindAutoUpdateAgentReport:             types.Resource153ToLegacy(newAutoUpdateAgentReport(t, "test")),
 		types.KindUserTask:                          types.Resource153ToLegacy(newUserTasks(t)),
 		types.KindProvisioningPrincipalState:        types.Resource153ToLegacy(newProvisioningPrincipalState("u-alice@example.com")),
 		types.KindIdentityCenterAccount:             types.Resource153ToLegacy(newIdentityCenterAccount("some_account")),
@@ -2554,6 +2555,30 @@ func newAutoUpdateAgentRollout(t *testing.T) *autoupdate.AutoUpdateAgentRollout 
 		AutoupdateMode: update.AgentsUpdateModeEnabled,
 		Strategy:       update.AgentsStrategyTimeBased,
 	})
+	require.NoError(t, err)
+	return r
+}
+
+func newAutoUpdateAgentReport(t *testing.T, name string) *autoupdate.AutoUpdateAgentReport {
+	t.Helper()
+
+	r, err := update.NewAutoUpdateAgentReport(&autoupdate.AutoUpdateAgentReportSpec{
+		Timestamp: timestamppb.Now(),
+		Groups: map[string]*autoupdate.AutoUpdateAgentReportSpecGroup{
+			"foo": {
+				Versions: map[string]*autoupdate.AutoUpdateAgentReportSpecGroupVersion{
+					"1.2.3": {Count: 1},
+					"1.2.4": {Count: 2},
+				},
+			},
+			"bar": {
+				Versions: map[string]*autoupdate.AutoUpdateAgentReportSpecGroupVersion{
+					"2.3.4": {Count: 3},
+					"2.3.5": {Count: 4},
+				},
+			},
+		},
+	}, name)
 	require.NoError(t, err)
 	return r
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -101,6 +101,7 @@ type collections struct {
 	autoUpdateConfig                   *collection[*autoupdatev1.AutoUpdateConfig, autoUpdateConfigIndex]
 	autoUpdateVerion                   *collection[*autoupdatev1.AutoUpdateVersion, autoUpdateVersionIndex]
 	autoUpdateRollout                  *collection[*autoupdatev1.AutoUpdateAgentRollout, autoUpdateAgentRolloutIndex]
+	autoUpdateReports                  *collection[*autoupdatev1.AutoUpdateAgentReport, autoUpdateAgentReportIndex]
 	oktaImportRules                    *collection[types.OktaImportRule, oktaImportRuleIndex]
 	oktaAssignments                    *collection[types.OktaAssignment, oktaAssignmentIndex]
 	samlIdPServiceProviders            *collection[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]
@@ -456,6 +457,14 @@ func setupCollections(c Config, legacyCollections map[resourceKind]legacyCollect
 
 			out.autoUpdateRollout = collect
 			out.byKind[resourceKind] = out.autoUpdateRollout
+		case types.KindAutoUpdateAgentReport:
+			collect, err := newAutoUpdateAgentReportCollection(c.AutoUpdateService, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.autoUpdateReports = collect
+			out.byKind[resourceKind] = out.autoUpdateReports
 		case types.KindOktaImportRule:
 			collect, err := newOktaImportRuleCollection(c.Okta, watch)
 			if err != nil {

--- a/lib/services/autoupdates.go
+++ b/lib/services/autoupdates.go
@@ -34,6 +34,12 @@ type AutoUpdateServiceGetter interface {
 
 	// GetAutoUpdateAgentRollout gets the AutoUpdateAgentRollout singleton resource.
 	GetAutoUpdateAgentRollout(ctx context.Context) (*autoupdate.AutoUpdateAgentRollout, error)
+
+	// GetAutoUpdateAgentReport gets an AutoUpdateAgentReport.
+	GetAutoUpdateAgentReport(ctx context.Context, name string) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// ListAutoUpdateAgentReports returns an AutoUpdateAgentReports page.
+	ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdate.AutoUpdateAgentReport, string, error)
 }
 
 // AutoUpdateService stores the autoupdate service.
@@ -75,4 +81,19 @@ type AutoUpdateService interface {
 
 	// DeleteAutoUpdateAgentRollout deletes the AutoUpdateAgentRollout singleton resource.
 	DeleteAutoUpdateAgentRollout(ctx context.Context) error
+
+	// CreateAutoUpdateAgentReport creates the AutoUpdateAgentReport singleton resource.
+	CreateAutoUpdateAgentReport(ctx context.Context, report *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// UpdateAutoUpdateAgentReport updates the AutoUpdateAgentReport singleton resource.
+	UpdateAutoUpdateAgentReport(ctx context.Context, report *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// UpsertAutoUpdateAgentReport sets the AutoUpdateAgentReport singleton resource.
+	UpsertAutoUpdateAgentReport(ctx context.Context, report *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error)
+
+	// DeleteAutoUpdateAgentReport deletes the AutoUpdateAgentReport singleton resource.
+	DeleteAutoUpdateAgentReport(ctx context.Context, name string) error
+
+	// DeleteAllAutoUpdateAgentReports deletes all AutoUpdateAgentReport resources.
+	DeleteAllAutoUpdateAgentReports(ctx context.Context) error
 }

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -35,6 +35,7 @@ const (
 	autoUpdateConfigPrefix       = "auto_update_config"
 	autoUpdateVersionPrefix      = "auto_update_version"
 	autoUpdateAgentRolloutPrefix = "auto_update_agent_rollout"
+	autoUpdateAgentReportPrefix  = "auto_update_agent_report"
 )
 
 // AutoUpdateService is responsible for managing AutoUpdateConfig and AutoUpdateVersion singleton resources.
@@ -96,7 +97,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 		generic.ServiceConfig[*autoupdate.AutoUpdateAgentReport]{
 			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateAgentRollout,
-			BackendPrefix: backend.NewKey(autoUpdateAgentRolloutPrefix),
+			BackendPrefix: backend.NewKey(autoUpdateAgentReportPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
 		})

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -102,6 +102,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newAutoUpdateVersionParser()
 		case types.KindAutoUpdateAgentRollout:
 			parser = newAutoUpdateAgentRolloutParser()
+		case types.KindAutoUpdateAgentReport:
+			parser = newAutoUpdateAgentReportParser()
 		case types.KindNamespace:
 			parser = newNamespaceParser(kind.Name)
 		case types.KindRole:
@@ -860,6 +862,45 @@ func (p *autoUpdateAgentRolloutParser) parse(event backend.Event) (types.Resourc
 			return nil, trace.Wrap(err)
 		}
 		return types.Resource153ToLegacy(autoUpdateAgentRollout), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+func newAutoUpdateAgentReportParser() *autoUpdateAgentReportParser {
+	return &autoUpdateAgentReportParser{
+		baseParser: newBaseParser(backend.NewKey(autoUpdateAgentReportPrefix)),
+	}
+}
+
+type autoUpdateAgentReportParser struct {
+	baseParser
+}
+
+func (p *autoUpdateAgentReportParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(autoUpdateAgentReportPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+		return &types.ResourceHeader{
+			Kind:    types.KindAutoUpdateAgentReport,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		autoUpdateAgentReport, err := services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentReport](event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(autoUpdateAgentReport), nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}


### PR DESCRIPTION
This PR adds:
- autoupdate agent report service RPCs
- autoupdate agent report client
- autoupdate agent report cache

This also fixes one backend key issue in the existing autoupdate report backend (it was using the rollout key instead of the report one).

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856