### PR TITLE
Terraform: Fix Access List import

### DIFF
--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -41,8 +41,12 @@ exclude_fields:
 # These fields will be marked as Computed: true
 computed_fields:
     # Metadata
+    - "AccessList.header.kind"
+    - "AccessList.header.metadata.expires"
     - "AccessList.header.metadata.namespace"
+    - "AccessList.header.metadata.revision"
     - "AccessList.spec.audit.next_audit_date"
+
 
 # These fields will be marked as Required: true
 required_fields:

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -50,9 +50,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 		"header": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 				"kind": {
-					Description: "kind is a resource kind.",
-					Optional:    true,
-					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+					Computed:      true,
+					Description:   "kind is a resource kind.",
+					Optional:      true,
+					PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+					Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"metadata": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
@@ -62,9 +64,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"expires": GenSchemaTimestamp(ctx, github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-							Description: "expires is a global expiry time header can be set on any resource in the system.",
-							Optional:    true,
-							Validators:  []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
+							Computed:      true,
+							Description:   "expires is a global expiry time header can be set on any resource in the system.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							Validators:    []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributeValidator{github_com_gravitational_teleport_integrations_terraform_tfschema.MustTimeBeInFuture()},
 						}),
 						"labels": {
 							Description: "labels is a set of labels.",
@@ -85,9 +89,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"revision": {
-							Description: "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
-							Optional:    true,
-							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							Computed:      true,
+							Description:   "revision is an opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+							Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 					}),
 					Description: "metadata is resource metadata.",

--- a/integrations/terraform/tfschema/resource153/custom_types.go
+++ b/integrations/terraform/tfschema/resource153/custom_types.go
@@ -19,6 +19,7 @@ package resource153
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -63,6 +64,7 @@ func CopyToTimestamp(diags diag.Diagnostics, o *timestamppb.Timestamp, t attr.Ty
 	}
 
 	value.Value = (*o).AsTime()
+	value.Format = time.RFC3339
 
 	return value
 }


### PR DESCRIPTION
Issue #52313

The most important bit is set tfschema.TimeValue.Format in CopyToTimestamp so non-nil times are parsed correctly. Otherwise the import results in `parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"`. That affected all resources, because all of them have `metadata.expires` field, but AccessList was hit the most because it has `spec.audit.next_audit_date` Timestamp field, so the import for it was basically failing every time for it.

The other part is marking more header fields as computed so the `apply` after the `import` goes smoothly and is less confusing.

changelog: Terraform: Fixed Access List resource import.