### PR TITLE
codeowners: Look only at top-level pnpm-lock.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3
 
 # Owners for dependency updates in JS packages.
-pnpm-lock.yaml @avatus @gzdunek @ravicious
+/pnpm-lock.yaml @avatus @gzdunek @ravicious
 web/packages/teleterm/package.json @gzdunek @ravicious


### PR DESCRIPTION
#54756 added pnpm-lock.yaml to codeowners so that Dependabot PRs are automatically assigned to people since Dependabot deprecated the "reviewers" config option.

However, #52007 adds another pnpm-lock.yaml in the repo which, I assume at least for now, will not be a subject to Dependabot PRs. This PR changes that line in codeowners so that we are assigned only to changed to the top-level pnpm-lock.yaml.