### PR TITLE
Web: fix useInfiniteScroll.ts

### DIFF
--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -38,9 +38,15 @@ export function useInfiniteScroll({
   const recreateObserver = useCallback(() => {
     observer.current?.disconnect();
     if (trigger.current) {
+      // multiple entries can be received even from a single target, so we loop
+      // through each entry to look for intersection:
+      // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#intersection_change_callbacks
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0]?.isIntersecting) {
-          fetch();
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            fetch();
+            break;
+          }
         }
       });
       observer.current.observe(trigger.current);


### PR DESCRIPTION
This PR checks all intersection observer entry for an`isIntersecting` flag instead of only the first one in array.

Ran into an issue with StatusInfo.tsx, where sometimes the `fetch` was not run and it was because in the `useInfiniteScroll.ts` we were only checking the first in array for the `isIntersecting` flag, but sometimes for StatusInfo, it was the second element in the array that was finally intersecting:

![image](https://github.com/user-attachments/assets/779312cc-5729-495a-854d-a039a32a45f6)

You'll see that the first element in array ^, says [intersectionRatio](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/intersectionRatio) is 0, which means the target is not visible within root.

I'm not entirely sure why this happens, but my _guess_ is probably the [css transition](https://github.com/gravitational/teleport/blob/24674f6fc6f4eddb4250ee3b078f0a31acd79a10/web/packages/shared/components/SlidingSidePanel/InfoGuide/const.ts#L36) (the panel slides in from the right) causes some delay sometimes.