### PR TITLE
docs: update url block for okta

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -91,13 +91,13 @@ Cloud account domain and port (`443` by default).
 
 - Single sign on URL: 
    
-  ```
+  ```code
   https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
   ```
 
 - Audience URI (SP Entity ID):
 
-  ```
+  ```code
   https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
   ```
 


### PR DESCRIPTION
copying and pasting does not include the variables with the previous style