### PR TITLE
MWI: Add new JWT CA for signing bound keypair documents

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -66,6 +66,9 @@ const (
 	// AWSRACA identifies the certificate authority that will be used by the
 	// AWS IAM Roles Anywhere integration functionality.
 	AWSRACA CertAuthType = "awsra"
+	// BoundKeypairCA identifies the CA used to sign bound keypair client state
+	// documents.
+	BoundKeypairCA CertAuthType = "bound_keypair"
 )
 
 // CertAuthTypes lists all certificate authority types.
@@ -80,6 +83,7 @@ var CertAuthTypes = []CertAuthType{HostCA,
 	SPIFFECA,
 	OktaCA,
 	AWSRACA,
+	BoundKeypairCA,
 }
 
 // NewlyAdded should return true for CA types that were added in the current
@@ -102,7 +106,7 @@ func (c CertAuthType) addedInMajorVer() int64 {
 		return 15
 	case OktaCA:
 		return 16
-	case AWSRACA:
+	case AWSRACA, BoundKeypairCA:
 		return 18
 	default:
 		// We don't care about other CAs added before v4.0.0

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7706,7 +7706,7 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 
 	// Add JWT keys if necessary.
 	switch caID.Type {
-	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA:
+	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA, types.BoundKeypairCA:
 		jwtKeyPair, err := keyStore.NewJWTKeyPair(ctx, jwtCAKeyPurpose(caID.Type))
 		if err != nil {
 			return keySet, trace.Wrap(err)
@@ -7759,6 +7759,8 @@ func jwtCAKeyPurpose(caType types.CertAuthType) cryptosuites.KeyPurpose {
 		return cryptosuites.SPIFFECAJWT
 	case types.OktaCA:
 		return cryptosuites.OktaCAJWT
+	case types.BoundKeypairCA:
+		return cryptosuites.BoundKeypairCAJWT
 	}
 	return cryptosuites.KeyPurposeUnspecified
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1387,7 +1387,7 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
 			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
-			case types.JWTSigner, types.OIDCIdPCA, types.OktaCA:
+			case types.JWTSigner, types.OIDCIdPCA, types.OktaCA, types.BoundKeypairCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)
 			default:
 				return trace.BadParameter("unexpected cert_authority type %s for cluster %v", r.GetType(), clusterName)

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -171,7 +171,10 @@ type suite map[KeyPurpose]Algorithm
 var (
 	// legacy is the original algorithm suite, which exclusively uses RSA2048
 	// for features developed before ECDSA and Ed25519 support were added. New
-	// features should always use the new algorithms.
+	// features should always use the new algorithms, and new CAs should use the
+	// algorithms in `fipsV1` for compatibility with FIPS mode clusters and
+	// HSMs. See also:
+	// https://github.com/gravitational/teleport/blob/master/rfd/0136-modern-signature-algorithms.md#legacy-suite
 	legacy = suite{
 		UserCATLS:               RSA2048,
 		UserCASSH:               RSA2048,

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -125,6 +125,9 @@ const (
 	// identity.
 	BoundKeypairJoining
 
+	// BoundKeypairCAJWT represents the JWT key for the bound_keypair CA.
+	BoundKeypairCAJWT
+
 	// keyPurposeMax is 1 greater than the last valid key purpose, used to test that all values less than this
 	// are valid for each suite.
 	keyPurposeMax
@@ -202,6 +205,7 @@ var (
 		GitClient:           Ed25519,
 		AWSRACATLS:          ECDSAP256,
 		BoundKeypairJoining: Ed25519,
+		BoundKeypairCAJWT:   Ed25519,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -235,6 +239,7 @@ var (
 		GitClient:               Ed25519,
 		AWSRACATLS:              ECDSAP256,
 		BoundKeypairJoining:     Ed25519,
+		BoundKeypairCAJWT:       Ed25519,
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
@@ -269,6 +274,7 @@ var (
 		GitClient:               ECDSAP256,
 		AWSRACATLS:              ECDSAP256,
 		BoundKeypairJoining:     ECDSAP256,
+		BoundKeypairCAJWT:       ECDSAP256,
 	}
 
 	// hsmv1 in an algorithm suite tailored for clusters using an HSM or KMS
@@ -305,6 +311,7 @@ var (
 		GitClient:               Ed25519,
 		AWSRACATLS:              ECDSAP256,
 		BoundKeypairJoining:     Ed25519,
+		BoundKeypairCAJWT:       ECDSAP256,
 	}
 
 	allSuites = map[types.SignatureAlgorithmSuite]suite{

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -205,7 +205,7 @@ var (
 		GitClient:           Ed25519,
 		AWSRACATLS:          ECDSAP256,
 		BoundKeypairJoining: Ed25519,
-		BoundKeypairCAJWT:   Ed25519,
+		BoundKeypairCAJWT:   ECDSAP256,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -68,7 +68,7 @@ func ValidateCertAuthority(ca types.CertAuthority) (err error) {
 		err = checkDatabaseCA(ca)
 	case types.OpenSSHCA:
 		err = checkOpenSSHCA(ca)
-	case types.JWTSigner, types.OIDCIdPCA, types.OktaCA:
+	case types.JWTSigner, types.OIDCIdPCA, types.OktaCA, types.BoundKeypairCA:
 		err = checkJWTKeys(ca)
 	case types.SAMLIDPCA:
 		err = checkSAMLIDPCA(ca)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -175,7 +175,7 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 
 	// Add JWT keys if necessary.
 	switch config.Type {
-	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA:
+	case types.JWTSigner, types.OIDCIdPCA, types.SPIFFECA, types.OktaCA, types.BoundKeypairCA:
 		pubKeyPEM, err := keys.MarshalPublicKey(key.Public())
 		if err != nil {
 			panic(err)

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -221,7 +221,6 @@ var allowedCertificateTypes = []string{
 	"saml-idp",
 	"github",
 	"awsra",
-	"bound_keypair",
 }
 
 // allowedCRLCertificateTypes list of certificate authorities types that can

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -221,6 +221,7 @@ var allowedCertificateTypes = []string{
 	"saml-idp",
 	"github",
 	"awsra",
+	"bound_keypair",
 }
 
 // allowedCRLCertificateTypes list of certificate authorities types that can

--- a/tool/tctl/common/auth_rotate_command.go
+++ b/tool/tctl/common/auth_rotate_command.go
@@ -1238,6 +1238,9 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 	case types.AWSRACA:
 		// TODO(marco): populate any known manual steps during AWS IAM Roles Anywhere CA rotation.
 		fallthrough
+	case types.BoundKeypairCA:
+		// TODO(timothyb89): add any manual steps; this should mostly be handled automatically.
+		fallthrough
 	default:
 		return []string{"Consult the CA rotation docs for any manual steps that may be required: https://goteleport.com/docs/admin-guides/management/operations/ca-rotation/"}
 	}


### PR DESCRIPTION
This adds a new JWT CA for issuing JWT documents related to bound keypair joining, particularly client state document that clients are expected to present back to auth when rejoining.