### PR TITLE
Support namespaced CRD access via namespace kind

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1531,51 +1531,49 @@ var KubernetesClusterWideResourceKinds = []string{
 	KindKubeCertificateSigningRequest,
 }
 
+type groupKind = struct{ apiGroup, kind string }
+
 // KubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
 // that are namespaced.
 // Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
 // (added .core to core resources.)
 // The format is "<plural>.<apigroup>".
 //
-// NOTE: As role >= v8 supports custom resources, we can't know from a static list
-// if an arbitrary resource is namespaced or not, so we maintain a list of
-// of known namespaced ones to help with validation.
-// This means that if there is a match, we know we expect a namespace, but if there is
-// not a match, we don't know that it doesn't.
-//
-// TODO(@creack): Remove in favor of a dynamic lookup.
-var KubernetesNamespacedResourceKinds = []string{
-	"bindings",
-	"configmaps",
-	"controllerrevisions.apps",
-	"cronjobs.batch",
-	"csistoragecapacities.storage.k8s.io",
-	"daemonsets.apps",
-	"deployments.apps",
-	"endpoints",
-	"endpointslices.discovery.k8s.io",
-	"events.events.k8s.io",
-	"events",
-	"horizontalpodautoscalers.autoscaling",
-	"ingresses.networking.k8s.io",
-	"jobs.batch",
-	"leases.coordination.k8s.io",
-	"limitranges",
-	"localsubjectaccessreviews.authorization.k8s.io",
-	"networkpolicies.networking.k8s.io",
-	"persistentvolumeclaims",
-	"poddisruptionbudgets.policy",
-	"pods",
-	"podtemplates",
-	"replicasets.apps",
-	"replicationcontrollers",
-	"resourcequotas",
-	"rolebindings.rbac.authorization.k8s.io",
-	"roles.rbac.authorization.k8s.io",
-	"secrets",
-	"serviceaccounts",
-	"services",
-	"statefulsets.apps",
+// Only used in role >=v8 to attempt to validate the api_group field.
+// If we have a match, we know we need a namespaced value, if we don't
+// have a match, we don't know we don't. Best effort basis.
+var kubernetesNamespacedResourceKinds = map[groupKind]struct{}{
+	{"", "bindings"}:                                      {},
+	{"", "configmaps"}:                                    {},
+	{"apps", "controllerrevisions"}:                       {},
+	{"batch", "cronjobs"}:                                 {},
+	{"storage.k8s.io", "csistoragecapacities"}:            {},
+	{"apps", "daemonsets"}:                                {},
+	{"apps", "deployments"}:                               {},
+	{"", "endpoints"}:                                     {},
+	{"discovery.k8s.io", "endpointslices"}:                {},
+	{"events.k8s.io", "events"}:                           {},
+	{"", "events"}:                                        {},
+	{"autoscaling", "horizontalpodautoscalers"}:           {},
+	{"networking.k8s.io", "ingresses"}:                    {},
+	{"batch", "jobs"}:                                     {},
+	{"coordination.k8s.io", "leases"}:                     {},
+	{"", "limitranges"}:                                   {},
+	{"authorization.k8s.io", "localsubjectaccessreviews"}: {},
+	{"networking.k8s.io", "networkpolicies"}:              {},
+	{"", "persistentvolumeclaims"}:                        {},
+	{"policy", "poddisruptionbudgets"}:                    {},
+	{"", "pods"}:                                          {},
+	{"", "podtemplates"}:                                  {},
+	{"apps", "replicasets"}:                               {},
+	{"", "replicationcontrollers"}:                        {},
+	{"", "resourcequotas"}:                                {},
+	{"rbac.authorization.k8s.io", "rolebindings"}:         {},
+	{"rbac.authorization.k8s.io", "roles"}:                {},
+	{"", "secrets"}:                                       {},
+	{"", "serviceaccounts"}:                               {},
+	{"", "services"}:                                      {},
+	{"apps", "statefulsets"}:                              {},
 }
 
 // List of "" (core / legacy) resources.

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -1981,10 +1981,11 @@ func validateKubeResources(roleVersion string, kubeResources []KubernetesResourc
 					return trace.BadParameter("KubernetesResource api_group is required for resource %q in role version %q", kubeResource.Kind, roleVersion)
 				}
 			}
-			// TODO(@creack): Replace this in favor of proper lookup.
-			kindAPI := kubeResource.Kind + "." + kubeResource.APIGroup
-			if kubeResource.Namespace == "" && slices.Contains(KubernetesNamespacedResourceKinds, kindAPI) {
-				return trace.BadParameter("KubernetesResource must include Namespace")
+			// Best effort attempt to validate if the namespace field is needed.
+			if kubeResource.Namespace == "" {
+				if _, ok := kubernetesNamespacedResourceKinds[groupKind{kubeResource.APIGroup, kubeResource.Kind}]; ok {
+					return trace.BadParameter("KubernetesResource %q must include Namespace", kubeResource.Kind)
+				}
 			}
 		}
 

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -136,9 +136,20 @@ func TestGetKubeCreds(t *testing.T) {
 	t.Cleanup(func() { kubeMock.Close() })
 	targetAddr := kubeMock.Address
 
+	crdResource := metav1.APIResource{
+		Name:         "teleportroles",
+		SingularName: "teleportrole",
+		Namespaced:   true,
+		Kind:         "TeleportRole",
+		Version:      "v6",
+		Group:        "resources.teleport.dev",
+		Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+	}
 	rbacSupportedTypes := maps.Clone(defaultRBACResources)
-	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles"}] = "teleportroles"
-	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles/status"}] = "teleportroles"
+	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles"}] = crdResource
+	crdResource.Name = "teleportroles/status"
+	crdResource.Verbs = []string{"get", "patch", "update"}
+	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles/status"}] = crdResource
 
 	ctx := context.TODO()
 	const teleClusterName = "teleport-cluster"

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -148,8 +148,8 @@ func (f *Forwarder) ephemeralContainersLocal(authCtx *authContext, sess *cluster
 		req.Context(),
 		mergeEphemeralPatchWithCurrentPodConfig{
 			kubeCluster:   sess.kubeClusterName,
-			kubeNamespace: authCtx.kubeResource.Namespace,
-			podName:       authCtx.kubeResource.Name,
+			kubeNamespace: authCtx.metaResource.requestedResource.namespace,
+			podName:       authCtx.metaResource.requestedResource.resourceName,
 			decoder:       decoder,
 			encoder:       encoder,
 			podPatch:      podPatch,
@@ -226,8 +226,8 @@ func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContNam
 		&kubewaitingcontainerpb.KubernetesWaitingContainerSpec{
 			Username:      authCtx.User.GetName(),
 			Cluster:       authCtx.kubeClusterName,
-			Namespace:     authCtx.kubeResource.Namespace,
-			PodName:       authCtx.kubeResource.Name,
+			Namespace:     authCtx.metaResource.requestedResource.namespace,
+			PodName:       authCtx.metaResource.requestedResource.resourceName,
 			ContainerName: ephemeralContName,
 			Patch:         podPatch,
 			PatchType:     string(patchType),

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -446,20 +446,17 @@ type authContext struct {
 	// kubeCluster is the Kubernetes cluster the request is targeted to.
 	// It's only available after authorization layer.
 	kubeCluster types.KubeCluster
-	// kubeResource is the kubernetes resource the request is targeted at.
-	// Can be nil, if the resource is not a pod or the request is not targeted
-	// at a specific pod.
-	// If non empty, kubeResource.Kind is populated with type "pod",
-	// kubeResource.Namespace is the resource namespace and kubeResource.Name
-	// is the resource name.
-	kubeResource *types.KubernetesResource
-	// requestVerb is the Kubernetes Verb.
-	requestVerb string
+
+	// metaResource holds the resource data:
+	// - the requested resource
+	// - the looked up resource definition, including the flag to know if it is namespaced
+	// - the verb used to access the resource
+	metaResource metaResource
+
 	// kubeServers are the registered agents for the kubernetes cluster the request
 	// is targeted to.
 	kubeServers []types.KubeServer
-	// apiResource holds the information about the requested API resource.
-	apiResource apiResource
+
 	// isLocalKubernetesCluster is true if the target cluster is served by this teleport service.
 	// It is false if the target cluster is served by another teleport service or a different
 	// Teleport cluster.
@@ -787,8 +784,7 @@ func (f *Forwarder) setupContext(
 
 	var (
 		kubeServers  []types.KubeServer
-		kubeResource *types.KubernetesResource
-		apiResource  apiResource
+		kubeResource metaResource
 		err          error
 	)
 
@@ -805,15 +801,12 @@ func (f *Forwarder) setupContext(
 	}
 	isLocalKubernetesCluster := f.isLocalKubeCluster(isRemoteCluster, kubeCluster)
 	if isLocalKubernetesCluster {
-		kubeResource, apiResource, err = f.parseResourceFromRequest(req, kubeCluster)
+		kubeResource, err = f.parseResourceFromRequest(req, kubeCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		// TODO(@creack): Remove this once we have the new RBAC system in place using subresources.
-		// We use the verb to determine access to subresource.
-		if kubeResource != nil {
-			kubeResource.Kind = strings.Split(apiResource.resourceKind, "/")[0]
-		}
+	} else {
+		kubeResource.verb = kubeResource.requestedResource.getVerb(req)
 	}
 
 	netConfig, err := f.cfg.CachingAuthClient.GetClusterNetworkingConfig(f.ctx)
@@ -845,19 +838,17 @@ func (f *Forwarder) setupContext(
 			isRemote:   isRemoteCluster,
 		},
 		kubeServers:              kubeServers,
-		requestVerb:              apiResource.getVerb(req),
-		apiResource:              apiResource,
-		kubeResource:             kubeResource,
+		metaResource:             kubeResource,
 		isLocalKubernetesCluster: isLocalKubernetesCluster,
 	}, nil
 }
 
-func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName string) (*types.KubernetesResource, apiResource, error) {
+func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName string) (metaResource, error) {
 	switch f.cfg.KubeServiceType {
 	case LegacyProxyService:
 		if details, err := f.findKubeDetailsByClusterName(kubeClusterName); err == nil {
-			resource, apiRes, err := getResourceFromRequest(req, details)
-			return resource, apiRes, trace.Wrap(err)
+			out, err := getResourceFromRequest(req, details)
+			return out, trace.Wrap(err)
 		}
 		// When the cluster is not being served by the local service, the LegacyProxy
 		// is working as a normal proxy and will forward the request to the remote
@@ -872,18 +863,18 @@ func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName 
 		// to the remote service without enforcing any RBAC rules - we send the
 		// details = nil to indicate that we don't want to extract the kube resource
 		// from the request.
-		resource, apiRes, err := getResourceFromRequest(req, nil /*details*/)
-		return resource, apiRes, trace.Wrap(err)
+		out, err := getResourceFromRequest(req, nil /*details*/)
+		return out, trace.Wrap(err)
 	case KubeService:
 		details, err := f.findKubeDetailsByClusterName(kubeClusterName)
 		if err != nil {
-			return nil, apiResource{}, trace.Wrap(err)
+			return metaResource{}, trace.Wrap(err)
 		}
-		resource, apiRes, err := getResourceFromRequest(req, details)
-		return resource, apiRes, trace.Wrap(err)
+		out, err := getResourceFromRequest(req, details)
+		return out, trace.Wrap(err)
 
 	default:
-		return nil, apiResource{}, trace.BadParameter("unsupported kube service type: %q", f.cfg.KubeServiceType)
+		return metaResource{}, trace.BadParameter("unsupported kube service type: %q", f.cfg.KubeServiceType)
 	}
 }
 
@@ -906,7 +897,7 @@ func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, stat
 		return
 	}
 
-	r := sess.apiResource
+	r := sess.metaResource.requestedResource
 	if r.skipEvent {
 		return
 	}
@@ -974,6 +965,7 @@ func (f *Forwarder) getKubeAccessDetails(
 	kubeClusterName string,
 	sessionTTL time.Duration,
 	kubeResource *types.KubernetesResource,
+	isClusterWideResource bool,
 ) (kubeAccessDetails, error) {
 	// Find requested kubernetes cluster name and get allowed kube users/groups names.
 	for _, s := range kubeServers {
@@ -1005,7 +997,7 @@ func (f *Forwarder) getKubeAccessDetails(
 		if kubeResource != nil {
 			matchers = append(
 				matchers,
-				services.NewKubernetesResourceMatcher(*kubeResource),
+				services.NewKubernetesResourceMatcher(*kubeResource, isClusterWideResource),
 			)
 		}
 		// accessChecker.CheckKubeGroupsAndUsers returns the accumulated kubernetes_groups
@@ -1071,16 +1063,16 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 
 	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
 	var roleMatchers services.RoleMatchers
-	if actx.kubeResource != nil {
+	if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil {
 		notFoundMessage = f.kubeResourceDeniedAccessMsg(
 			actx.User.GetName(),
-			actx.requestVerb,
-			actx.apiResource,
+			actx.metaResource.verb,
+			actx.metaResource.requestedResource,
 		)
 		roleMatchers = services.RoleMatchers{
 			// Append a matcher that validates if the Kubernetes resource is allowed
 			// by the roles that satisfy the Kubernetes Cluster.
-			services.NewKubernetesResourceMatcher(*actx.kubeResource),
+			services.NewKubernetesResourceMatcher(*rbacResource, actx.metaResource.isClusterWideResource()),
 		}
 	}
 	var kubeUsers, kubeGroups []string
@@ -1090,9 +1082,16 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	// leaf and checked there.
 	if !actx.teleportCluster.isRemote {
 		// check signing TTL and return a list of allowed logins for local cluster based on Kubernetes service labels.
-		kubeAccessDetails, err := f.getKubeAccessDetails(actx.kubeServers, actx.Checker, actx.kubeClusterName, actx.sessionTTL, actx.kubeResource)
+		kubeAccessDetails, err := f.getKubeAccessDetails(
+			actx.kubeServers,
+			actx.Checker,
+			actx.kubeClusterName,
+			actx.sessionTTL,
+			actx.metaResource.rbacResource(),
+			actx.metaResource.isClusterWideResource(),
+		)
 		if err != nil && !trace.IsNotFound(err) {
-			if actx.kubeResource != nil {
+			if actx.metaResource.resourceDefinition != nil {
 				return trace.AccessDenied("%s", notFoundMessage)
 			}
 			// TODO (tigrato): should return another message here.
@@ -1136,7 +1135,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		// If the user has active Access requests we need to validate that they allow
 		// the kubeResource.
 		// This is required because CheckAccess does not validate the subresource type.
-		if actx.kubeResource != nil && len(actx.Checker.GetAllowedResourceIDs()) > 0 {
+		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil && len(actx.Checker.GetAllowedResourceIDs()) > 0 {
 			// GetKubeResources returns the allowed and denied Kubernetes resources
 			// for the user. Since we have active access requests, the allowed
 			// resources will be the list of pods that the user requested access to if he
@@ -1145,7 +1144,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// did not request access to any Kubernetes resource type, the allowed
 			// list will be empty.
 			allowed, denied := actx.Checker.GetKubeResources(ks)
-			if result, err := matchKubernetesResource(*actx.kubeResource, allowed, denied); err != nil || !result {
+			if result, err := matchKubernetesResource(*rbacResource, actx.metaResource.isClusterWideResource(), allowed, denied); err != nil || !result {
 				return trace.AccessDenied("%s", notFoundMessage)
 			}
 		}
@@ -1164,18 +1163,18 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 
 // matchKubernetesResource checks if the Kubernetes Resource does not match any
 // entry from the deny list and matches at least one entry from the allowed list.
-func matchKubernetesResource(resource types.KubernetesResource, allowed, denied []types.KubernetesResource) (bool, error) {
+func matchKubernetesResource(resource types.KubernetesResource, isClusterWideResource bool, allowed, denied []types.KubernetesResource) (bool, error) {
 	// utils.KubeResourceMatchesRegex checks if the resource.Kind is strictly equal
 	// to each entry and validates if the Name and Namespace fields matches the
 	// regex allowed by each entry.
-	result, err := utils.KubeResourceMatchesRegex(resource, denied, types.Deny)
+	result, err := utils.KubeResourceMatchesRegex(resource, isClusterWideResource, denied, types.Deny)
 	if err != nil {
 		return false, trace.Wrap(err)
 	} else if result {
 		return false, nil
 	}
 
-	result, err = utils.KubeResourceMatchesRegex(resource, allowed, types.Allow)
+	result, err = utils.KubeResourceMatchesRegex(resource, isClusterWideResource, allowed, types.Allow)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -2118,17 +2117,17 @@ func (f *Forwarder) catchAll(authCtx *authContext, w http.ResponseWriter, req *h
 	}
 
 	isLocalKubeCluster := sess.isLocalKubernetesCluster
-	isListRequest := authCtx.requestVerb == types.KubeVerbList
+	isListRequest := authCtx.metaResource.verb == types.KubeVerbList
 	// Watch requests can be send to a single resource or to a collection of resources.
 	// isWatchingCollectionRequest is true when the request is a watch request and
 	// the resource is a collection of resources, e.g. /api/v1/pods?watch=true.
 	// authCtx.kubeResource is only set when the request targets a single resource.
-	isWatchingCollectionRequest := authCtx.requestVerb == types.KubeVerbWatch && authCtx.kubeResource == nil
+	isWatchingCollectionRequest := authCtx.metaResource.verb == types.KubeVerbWatch && authCtx.metaResource.resourceDefinition == nil
 
 	switch {
 	case isListRequest || isWatchingCollectionRequest:
 		return f.listResources(sess, w, req)
-	case authCtx.requestVerb == types.KubeVerbDeleteCollection && isLocalKubeCluster:
+	case authCtx.metaResource.verb == types.KubeVerbDeleteCollection && isLocalKubeCluster:
 		return f.deleteResourcesCollection(sess, w, req)
 	default:
 		rw := httplib.NewResponseStatusRecorder(w)
@@ -2692,6 +2691,7 @@ func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, kubeCluster
 // https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go#L51
 func (f *Forwarder) kubeResourceDeniedAccessMsg(user, verb string, resource apiResource) string {
 	kind := strings.Split(resource.resourceKind, "/")[0]
+
 	apiGroup := resource.apiGroup
 	teleportType, ok := defaultRBACResources.getTeleportResourceKindFromAPIResource(resource)
 	// If the resource is not in the default resources list, it is a custom resource

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -758,8 +758,8 @@ func TestAuthenticate(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
-				cmp.AllowUnexported(authContext{}, teleportClusterClient{}, apiResource{}),
-				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "Context", "recordingConfig", "disconnectExpiredCert", "kubeCluster", "apiResource"),
+				cmp.AllowUnexported(authContext{}, teleportClusterClient{}, metaResource{}, apiResource{}),
+				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "Context", "recordingConfig", "disconnectExpiredCert", "kubeCluster"),
 			))
 
 			// validate authCtx.key() to make sure it includes certExpires timestamp.

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -173,8 +173,8 @@ func (f *Forwarder) handleDeleteCollectionReq(req *http.Request, sess *clusterSe
 		}
 		items, err := deleteResources(
 			params,
-			sess.apiResource.resourceKind,
-			sess.apiResource.apiGroup,
+			sess.metaResource.requestedResource.resourceKind,
+			sess.metaResource.requestedResource.apiGroup,
 			o.GetAPIVersion(),
 			slices.ToPointers(list.Items),
 			deleteOptions,
@@ -218,8 +218,8 @@ func (f *Forwarder) handleDeleteCollectionReq(req *http.Request, sess *clusterSe
 		}
 		items, err := deleteResources(
 			params,
-			sess.apiResource.resourceKind,
-			sess.apiResource.apiGroup,
+			sess.metaResource.requestedResource.resourceKind,
+			sess.metaResource.requestedResource.apiGroup,
 			apiVersion,
 			objs,
 			deleteOptions,
@@ -317,6 +317,7 @@ func deleteResources[T kubeObjectInterface](
 			),
 			services.NewKubernetesResourceMatcher(
 				getKubeResource(kind, group, types.KubeVerbDeleteCollection, item),
+				params.authCtx.metaResource.isClusterWideResource(),
 			),
 		)
 		// no match was found, we ignore the request.

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -176,7 +176,7 @@ func Test_filterBuffer(t *testing.T) {
 
 				buf, decompress := newMemoryResponseWriter(t, data.Bytes(), tt.args.contentEncoding)
 
-				err = filterBuffer(newResourceFilterer(r, "", types.KubeVerbList, &globalKubeCodecs, allowedResources, nil, utils.NewSlogLoggerForTests()), buf)
+				err = filterBuffer(newResourceFilterer(r, "", types.KubeVerbList, false, &globalKubeCodecs, allowedResources, nil, utils.NewSlogLoggerForTests()), buf)
 				require.NoError(t, err)
 
 				// Decompress the buffer to compare the result.

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -56,7 +56,7 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 	isLocalKubeCluster := sess.isLocalKubernetesCluster
 	supportsType := false
 	if isLocalKubeCluster {
-		_, supportsType = sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.apiResource)
+		_, supportsType = sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.metaResource.requestedResource)
 	}
 
 	// status holds the returned response code.
@@ -71,21 +71,21 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 	} else {
 		allowedResources, deniedResources := sess.Checker.GetKubeResources(sess.kubeCluster)
 
-		shouldBeAllowed, err := matchListRequestShouldBeAllowed(sess, strings.Split(sess.apiResource.resourceKind, "/")[0], sess.apiResource.apiGroup, allowedResources, deniedResources)
+		shouldBeAllowed, err := matchListRequestShouldBeAllowed(sess, sess.metaResource.requestedResource.resourceKind, sess.metaResource.requestedResource.apiGroup, allowedResources, deniedResources)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		if !shouldBeAllowed {
 			notFoundMessage := f.kubeResourceDeniedAccessMsg(
 				sess.User.GetName(),
-				sess.requestVerb,
-				sess.apiResource,
+				sess.metaResource.verb,
+				sess.metaResource.requestedResource,
 			)
 			return nil, trace.AccessDenied("%s", notFoundMessage)
 		}
 		// isWatch identifies if the request is long-lived watch stream based on
 		// HTTP connection.
-		isWatch := isKubeWatchRequest(req, sess.authContext.apiResource)
+		isWatch := isKubeWatchRequest(req, sess.authContext.metaResource.requestedResource)
 		if !isWatch {
 			// List resources.
 			status, err = f.listResourcesList(req, w, sess, allowedResources, deniedResources)
@@ -115,15 +115,16 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 	memBuffer := responsewriters.NewMemoryResponseWriter()
 	// Forward the request to the target cluster.
 	sess.forwarder.ServeHTTP(memBuffer, req)
-	_, ok := sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.apiResource)
+	_, ok := sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.metaResource.requestedResource)
 	if !ok {
-		return http.StatusBadRequest, trace.BadParameter("unknown resource kind %q", sess.apiResource.resourceKind)
+		return http.StatusBadRequest, trace.BadParameter("unknown resource kind %q", sess.metaResource.requestedResource.resourceKind)
 	}
-	verb := sess.requestVerb
+	verb := sess.metaResource.verb
+
 	// filterBuffer filters the response to exclude resources the user doesn't have access to.
 	// The filtered payload will be written into memBuffer again.
 	if err := filterBuffer(
-		newResourceFilterer(strings.Split(sess.apiResource.resourceKind, "/")[0], sess.apiResource.apiGroup, verb, sess.codecFactory, allowedResources, deniedResources, f.log),
+		newResourceFilterer(sess.metaResource.requestedResource.resourceKind, sess.metaResource.requestedResource.apiGroup, verb, sess.metaResource.isClusterWideResource(), sess.codecFactory, allowedResources, deniedResources, f.log),
 		memBuffer,
 	); err != nil {
 		return memBuffer.Status(), trace.Wrap(err)
@@ -141,21 +142,22 @@ func (f *Forwarder) listResourcesList(req *http.Request, w http.ResponseWriter, 
 // an empty list.
 // This function is not responsible for enforcing access rules.
 func matchListRequestShouldBeAllowed(sess *clusterSession, resourceKind, resourceGroup string, allowedResources, deniedResources []types.KubernetesResource) (bool, error) {
+	// TODO(@creack): Use metaResource.rbac()?
 	resource := types.KubernetesResource{
 		Kind:      resourceKind,
-		Namespace: sess.apiResource.namespace,
-		Verbs:     []string{sess.requestVerb},
+		Namespace: sess.metaResource.requestedResource.namespace,
+		Verbs:     []string{sess.metaResource.verb},
 		APIGroup:  resourceGroup,
 	}
 
-	result, err := utils.KubeResourceCouldMatchRules(resource, deniedResources, types.Deny)
+	result, err := utils.KubeResourceCouldMatchRules(resource, sess.metaResource.isClusterWideResource(), deniedResources, types.Deny)
 	if err != nil {
 		return false, trace.Wrap(err)
 	} else if result {
 		return false, nil
 	}
 
-	result, err = utils.KubeResourceCouldMatchRules(resource, allowedResources, types.Allow)
+	result, err = utils.KubeResourceCouldMatchRules(resource, sess.metaResource.isClusterWideResource(), allowedResources, types.Allow)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -174,18 +176,19 @@ func matchListRequestShouldBeAllowed(sess *clusterSession, resourceKind, resourc
 // for the next event.
 func (f *Forwarder) listResourcesWatcher(req *http.Request, w http.ResponseWriter, sess *clusterSession, allowedResources, deniedResources []types.KubernetesResource) (int, error) {
 	negotiator := newClientNegotiator(sess.codecFactory)
-	_, ok := sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.apiResource)
+	_, ok := sess.rbacSupportedResources.getTeleportResourceKindFromAPIResource(sess.metaResource.requestedResource)
 	if !ok {
-		return http.StatusBadRequest, trace.BadParameter("unknown resource kind %q", sess.apiResource.resourceKind)
+		return http.StatusBadRequest, trace.BadParameter("unknown resource kind %q", sess.metaResource.requestedResource.resourceKind)
 	}
-	verb := sess.requestVerb
+	verb := sess.metaResource.verb
 	rw, err := responsewriters.NewWatcherResponseWriter(
 		w,
 		negotiator,
 		newResourceFilterer(
-			strings.Split(sess.apiResource.resourceKind, "/")[0],
-			sess.apiResource.apiGroup,
+			sess.metaResource.requestedResource.resourceKind,
+			sess.metaResource.requestedResource.apiGroup,
 			verb,
+			sess.metaResource.isClusterWideResource(),
 			sess.codecFactory,
 			allowedResources,
 			deniedResources,
@@ -202,7 +205,7 @@ func (f *Forwarder) listResourcesWatcher(req *http.Request, w http.ResponseWrite
 	// by this user
 	done := make(chan struct{})
 	var wg sync.WaitGroup
-	if podName := isRequestTargetedToPod(req, sess.apiResource); podName != "" && ok {
+	if podName := isRequestTargetedToPod(req, sess.metaResource.requestedResource); podName != "" && ok {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -236,7 +239,7 @@ func (f *Forwarder) sendEphemeralContainerEvents(done <-chan struct{}, req *http
 			req.Context(),
 			sess.User.GetName(),
 			sess.kubeClusterName,
-			sess.apiResource.namespace,
+			sess.metaResource.requestedResource.namespace,
 			podName,
 		)
 		if err != nil {

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -641,7 +641,7 @@ func TestWatcherResponseWriter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			userReader, userWriter := io.Pipe()
 			negotiator := newClientNegotiator(&globalKubeCodecs)
-			filterWrapper := newResourceFilterer("pods", "", types.KubeVerbWatch, &globalKubeCodecs, tt.args.allowed, tt.args.denied, utils.NewSlogLoggerForTests())
+			filterWrapper := newResourceFilterer("pods", "", types.KubeVerbWatch, false, &globalKubeCodecs, tt.args.allowed, tt.args.denied, utils.NewSlogLoggerForTests())
 			// watcher parses the data written into itself and if the user is allowed to
 			// receive the update, it writes the event into target.
 			watcher, err := responsewriters.NewWatcherResponseWriter(newFakeResponseWriter(userWriter) /*target*/, negotiator, filterWrapper)

--- a/lib/kube/proxy/response_rewriter.go
+++ b/lib/kube/proxy/response_rewriter.go
@@ -148,10 +148,10 @@ func collectSystemMastersTeleportRoles(s *clusterSession) []string {
 	// results in the intersection of roles that match the "kubernetes_labels" and
 	// roles that allow access to the desired "kubernetes_resource".
 	// If from the intersection results an empty set, the request is denied.
-	if s.kubeResource != nil {
+	if rbacRes := s.metaResource.rbacResource(); rbacRes != nil {
 		matchers = append(
 			matchers,
-			services.NewKubernetesResourceMatcher(*s.kubeResource),
+			services.NewKubernetesResourceMatcher(*rbacRes, s.metaResource.isClusterWideResource()),
 		)
 	}
 	var rolesWithSystemMasters []string

--- a/lib/kube/proxy/scheme.go
+++ b/lib/kube/proxy/scheme.go
@@ -177,7 +177,7 @@ func newClusterSchemaBuilder(log *slog.Logger, client kubernetes.Interface) (*se
 			}
 
 			// TODO(@creack): Keep track of the namespaced field.
-			supportedResources[resourceKey] = strings.Split(apiResource.Name, "/")[0]
+			supportedResources[resourceKey] = apiResource
 
 			// Create the group version kind for the resource.
 			gvk := groupVersion.WithKind(apiResource.Kind)

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -261,11 +261,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 					},
 				},
 			},
-			// TODO(@creack): Reverse this back to true once we implement proper
-			// lookup to know if a resource is namespaced or not.
-			// Currently, as we rely on a hard-coded list, we can't grant access to unknown
-			// resources at the namespace level.
-			want: false,
+			want: true,
 		},
 		{
 			name: "user without namespace access to custom resource in namespace=namespace",

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1487,7 +1487,7 @@ func (s *session) patchAndWaitForPodEphemeralContainer(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	podClient := clientSet.CoreV1().Pods(authCtx.kubeResource.Namespace)
+	podClient := clientSet.CoreV1().Pods(authCtx.metaResource.requestedResource.namespace)
 	result, err := podClient.Patch(ctx,
 		waitingCont.Spec.PodName,
 		apimachinerytypes.StrategicMergePatchType,

--- a/lib/kube/proxy/testing/kube_server/discovery.go
+++ b/lib/kube/proxy/testing/kube_server/discovery.go
@@ -125,6 +125,8 @@ func crdDiscovery(crd *CRD) httplib.HandlerFunc {
 			    "singularName": "%s",
 			    "namespaced": %t,
 			    "kind": "%s",
+			    "group": "%s",
+			    "version": "%s",
 			    "verbs": [
 			      "delete",
 			      "deletecollection",
@@ -135,13 +137,15 @@ func crdDiscovery(crd *CRD) httplib.HandlerFunc {
 			      "update",
 			      "watch"
 			    ],
-			    "storageVersionHash": "eQsgEapFuzY="
+			    "storageVersionHash": ""
 			  },
 			  {
 			    "name": "%s/status",
-			    "singularName": "",
+			    "singularName": "%s",
 			    "namespaced": %t,
 			    "kind": "%s",
+			    "group": "%s",
+			    "version": "%s",
 			    "verbs": [
 			      "get",
 			      "patch",
@@ -150,7 +154,20 @@ func crdDiscovery(crd *CRD) httplib.HandlerFunc {
 			  }
 			]
 		      }`,
-			crd.group, crd.version, crd.plural, strings.ToLower(crd.kind), crd.namespaced, crd.kind, crd.plural, crd.namespaced, crd.kind,
+			crd.group,
+			crd.version,
+			crd.plural,
+			strings.ToLower(crd.kind),
+			crd.namespaced,
+			crd.kind,
+			crd.group,
+			crd.version,
+			crd.plural,
+			strings.ToLower(crd.kind),
+			crd.namespaced,
+			crd.kind,
+			crd.group,
+			crd.version,
 		)
 		return nil, err
 	}

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
@@ -34,6 +35,34 @@ import (
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 )
 
+// metaResource wraps the various representations of a Kubernetes resource.
+type metaResource struct {
+	resourceDefinition *metav1.APIResource // Resource definition data from the schema.
+	requestedResource  apiResource         // User input, based on URL.
+	verb               string              // Verb of the user request.
+}
+
+func (mr *metaResource) isClusterWideResource() bool {
+	if mr == nil || mr.resourceDefinition == nil {
+		return false
+	}
+	return !mr.resourceDefinition.Namespaced
+}
+
+func (mr *metaResource) rbacResource() *types.KubernetesResource {
+	if mr == nil || mr.resourceDefinition == nil {
+		return nil
+	}
+	return &types.KubernetesResource{
+		Kind:      mr.resourceDefinition.Name,
+		Namespace: mr.requestedResource.namespace,
+		Name:      mr.requestedResource.resourceName,
+		Verbs:     []string{mr.verb},
+		APIGroup:  mr.requestedResource.apiGroup,
+	}
+}
+
+// apiResource represents the resource requested by the user.
 type apiResource struct {
 	apiGroup        string
 	apiGroupVersion string
@@ -164,95 +193,101 @@ type allowedResourcesKey struct {
 	resourceKind string
 }
 
-type rbacSupportedResources map[allowedResourcesKey]string
+type rbacSupportedResources map[allowedResourcesKey]metav1.APIResource
 
 // getResourceWithKey returns the teleport resource kind for a given resource key if
 // it exists, otherwise returns an empty string.
-func (r rbacSupportedResources) getResourceWithKey(k allowedResourcesKey) string {
-	if plural, ok := types.KubernetesResourcesKindsPlurals[r[k]]; ok {
-		return plural
+func (r rbacSupportedResources) getResource(apiGroup, resourceKind string) (metav1.APIResource, bool) {
+	k := allowedResourcesKey{
+		apiGroup:     apiGroup,
+		resourceKind: getResourceFromAPIResource(resourceKind),
 	}
-	return r[k]
+	out, ok := r[k]
+	return out, ok
 }
 
 func (r rbacSupportedResources) getTeleportResourceKindFromAPIResource(api apiResource) (string, bool) {
 	resource := getResourceFromAPIResource(api.resourceKind)
 	resourceType, ok := r[allowedResourcesKey{apiGroup: api.apiGroup, resourceKind: resource}]
-	return resourceType, ok
+	return resourceType.Kind, ok
 }
 
 // defaultRBACResources is a map of supported resources and their corresponding
 // teleport resource kind for the purpose of resource rbac.
 // TODO(@creack): Remove this (keep a form of it for maybedowngraderole).
 var defaultRBACResources = rbacSupportedResources{
-	{apiGroup: "", resourceKind: "pods"}:                                          types.KindKubePod,
-	{apiGroup: "", resourceKind: "secrets"}:                                       types.KindKubeSecret,
-	{apiGroup: "", resourceKind: "configmaps"}:                                    types.KindKubeConfigmap,
-	{apiGroup: "", resourceKind: "namespaces"}:                                    types.KindKubeNamespace,
-	{apiGroup: "", resourceKind: "services"}:                                      types.KindKubeService,
-	{apiGroup: "", resourceKind: "endpoints"}:                                     types.KindKubeService,
-	{apiGroup: "", resourceKind: "serviceaccounts"}:                               types.KindKubeServiceAccount,
-	{apiGroup: "", resourceKind: "nodes"}:                                         types.KindKubeNode,
-	{apiGroup: "", resourceKind: "persistentvolumes"}:                             types.KindKubePersistentVolume,
-	{apiGroup: "", resourceKind: "persistentvolumeclaims"}:                        types.KindKubePersistentVolumeClaim,
-	{apiGroup: "", resourceKind: "replicationcontrollers"}:                        types.KindKubeReplicationController,
-	{apiGroup: "apps", resourceKind: "deployments"}:                               types.KindKubeDeployment,
-	{apiGroup: "apps", resourceKind: "replicasets"}:                               types.KindKubeReplicaSet,
-	{apiGroup: "apps", resourceKind: "statefulsets"}:                              types.KindKubeStatefulset,
-	{apiGroup: "apps", resourceKind: "daemonsets"}:                                types.KindKubeDaemonSet,
-	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "clusterroles"}:         types.KindKubeClusterRole,
-	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "roles"}:                types.KindKubeRole,
-	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "clusterrolebindings"}:  types.KindKubeClusterRoleBinding,
-	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "rolebindings"}:         types.KindKubeRoleBinding,
-	{apiGroup: "batch", resourceKind: "cronjobs"}:                                 types.KindKubeCronjob,
-	{apiGroup: "batch", resourceKind: "jobs"}:                                     types.KindKubeJob,
-	{apiGroup: "certificates.k8s.io", resourceKind: "certificatesigningrequests"}: types.KindKubeCertificateSigningRequest,
-	{apiGroup: "networking.k8s.io", resourceKind: "ingresses"}:                    types.KindKubeIngress,
-	{apiGroup: "extensions", resourceKind: "deployments"}:                         types.KindKubeDeployment,
-	{apiGroup: "extensions", resourceKind: "replicasets"}:                         types.KindKubeReplicaSet,
-	{apiGroup: "extensions", resourceKind: "daemonsets"}:                          types.KindKubeDaemonSet,
-	{apiGroup: "extensions", resourceKind: "ingresses"}:                           types.KindKubeIngress,
+	{apiGroup: "", resourceKind: "pods"}:                                          {Name: "pods", Kind: types.KindKubePod, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "secrets"}:                                       {Name: "secrets", Kind: types.KindKubeSecret, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "configmaps"}:                                    {Name: "configmaps", Kind: types.KindKubeConfigmap, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "namespaces"}:                                    {Name: "namespaces", Kind: types.KindKubeNamespace, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "services"}:                                      {Name: "services", Kind: types.KindKubeService, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "endpoints"}:                                     {Name: "endpoints", Kind: types.KindKubeService, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "serviceaccounts"}:                               {Name: "serviceaccounts", Kind: types.KindKubeServiceAccount, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "nodes"}:                                         {Name: "nodes", Kind: types.KindKubeNode, Group: "", Namespaced: false},
+	{apiGroup: "", resourceKind: "persistentvolumes"}:                             {Name: "persistentvolumes", Kind: types.KindKubePersistentVolume, Group: "", Namespaced: false},
+	{apiGroup: "", resourceKind: "persistentvolumeclaims"}:                        {Name: "persistentvolumeclaims", Kind: types.KindKubePersistentVolumeClaim, Group: "", Namespaced: true},
+	{apiGroup: "", resourceKind: "replicationcontrollers"}:                        {Name: "replicationcontrollers", Kind: types.KindKubeReplicationController, Group: "", Namespaced: true},
+	{apiGroup: "apps", resourceKind: "deployments"}:                               {Name: "deployments", Kind: types.KindKubeDeployment, Group: "apps", Namespaced: true},
+	{apiGroup: "apps", resourceKind: "replicasets"}:                               {Name: "replicasets", Kind: types.KindKubeReplicaSet, Group: "apps", Namespaced: true},
+	{apiGroup: "apps", resourceKind: "statefulsets"}:                              {Name: "statefulsets", Kind: types.KindKubeStatefulset, Group: "apps", Namespaced: true},
+	{apiGroup: "apps", resourceKind: "daemonsets"}:                                {Name: "daemonsets", Kind: types.KindKubeDaemonSet, Group: "apps", Namespaced: true},
+	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "clusterroles"}:         {Name: "clusterroles", Kind: types.KindKubeClusterRole, Group: "rbac.authorization.k8s.io", Namespaced: false},
+	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "roles"}:                {Name: "roles", Kind: types.KindKubeRole, Group: "rbac.authorization.k8s.io", Namespaced: true},
+	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "clusterrolebindings"}:  {Name: "clusterrolebindings", Kind: types.KindKubeClusterRoleBinding, Group: "rbac.authorization.k8s.io", Namespaced: false},
+	{apiGroup: "rbac.authorization.k8s.io", resourceKind: "rolebindings"}:         {Name: "rolebindings", Kind: types.KindKubeRoleBinding, Group: "rbac.authorization.k8s.io", Namespaced: true},
+	{apiGroup: "batch", resourceKind: "cronjobs"}:                                 {Name: "cronjobs", Kind: types.KindKubeCronjob, Group: "batch", Namespaced: true},
+	{apiGroup: "batch", resourceKind: "jobs"}:                                     {Name: "jobs", Kind: types.KindKubeJob, Group: "batch", Namespaced: true},
+	{apiGroup: "certificates.k8s.io", resourceKind: "certificatesigningrequests"}: {Name: "certificatesigningrequests", Kind: types.KindKubeCertificateSigningRequest, Group: "certificates.k8s.io", Namespaced: false},
+	{apiGroup: "networking.k8s.io", resourceKind: "ingresses"}:                    {Name: "ingresses", Kind: types.KindKubeIngress, Group: "networking.k8s.io", Namespaced: true},
+	{apiGroup: "extensions", resourceKind: "deployments"}:                         {Name: "deployments", Kind: types.KindKubeDeployment, Group: "extensions", Namespaced: true},
+	{apiGroup: "extensions", resourceKind: "replicasets"}:                         {Name: "replicasets", Kind: types.KindKubeReplicaSet, Group: "extensions", Namespaced: true},
+	{apiGroup: "extensions", resourceKind: "daemonsets"}:                          {Name: "daemonsets", Kind: types.KindKubeDaemonSet, Group: "extensions", Namespaced: true},
+	{apiGroup: "extensions", resourceKind: "ingresses"}:                           {Name: "ingresses", Kind: types.KindKubeIngress, Group: "extensions", Namespaced: true},
 }
 
 // getResourceFromRequest returns a KubernetesResource if the user tried to access
 // a specific endpoint that Teleport support resource filtering. Otherwise, returns nil.
-func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (*types.KubernetesResource, apiResource, error) {
+func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaResource, error) {
 	apiResource := parseResourcePath(req.URL.Path)
-	verb := apiResource.getVerb(req)
+
+	out := metaResource{
+		requestedResource: apiResource,
+		verb:              apiResource.getVerb(req),
+	}
 	if kubeDetails == nil {
-		return nil, apiResource, nil
+		return out, nil
 	}
 
 	codecFactory, rbacSupportedTypes, err := kubeDetails.getClusterSupportedResources()
 	if err != nil {
-		return nil, apiResource, trace.Wrap(err)
+		return out, trace.Wrap(err)
 	}
 
-	resourceType, ok := rbacSupportedTypes.getTeleportResourceKindFromAPIResource(apiResource)
-	switch {
-	case !ok:
-		// if the resource is not supported, return nil.
-		return nil, apiResource, nil
-	case apiResource.resourceName == "" && verb != types.KubeVerbCreate:
+	resource, ok := rbacSupportedTypes.getResource(apiResource.apiGroup, apiResource.resourceKind)
+	if !ok {
+		// TODO(@creack): Change this behavior, unsupported resource should be rejected.
+		// If the resource is not supported, return nil.
+		return out, nil
+	}
+
+	if apiResource.resourceName == "" && out.verb != types.KubeVerbCreate {
 		// if the resource is supported but the resource name is not present and not a create request,
 		// return nil because it's a list request.
-		return nil, apiResource, nil
-
-	case apiResource.resourceName == "" && verb == types.KubeVerbCreate:
-		// If the request is a create request, extract the resource name from the request body.
-		var err error
-		if apiResource.resourceName, err = extractResourceNameFromPostRequest(req, codecFactory, kubeDetails.getObjectGVK(apiResource)); err != nil {
-			return nil, apiResource, trace.Wrap(err)
-		}
+		return out, nil
 	}
 
-	return &types.KubernetesResource{
-		Kind:      resourceType,
-		Namespace: apiResource.namespace,
-		Name:      apiResource.resourceName,
-		Verbs:     []string{verb},
-		APIGroup:  apiResource.apiGroup,
-	}, apiResource, nil
+	if apiResource.resourceName == "" && out.verb == types.KubeVerbCreate {
+		// If the request is a create request, extract the resource name from the request body.
+		resourceName, err := extractResourceNameFromPostRequest(req, codecFactory, kubeDetails.getObjectGVK(apiResource))
+		if err != nil {
+			return out, trace.Wrap(err)
+		}
+		apiResource.resourceName = resourceName
+		out.requestedResource = apiResource
+	}
+	out.resourceDefinition = &resource
+
+	return out, nil
 }
 
 // extractResourceNameFromPostRequest extracts the resource name from a POST body.

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -102,120 +102,120 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/apis/apps/v1/", want: nil},
 		{path: "/api/v1/pods", want: nil},
 		{path: "/api/v1/watch/pods", want: nil},
-		{path: "/api/v1/namespaces/kube-system", want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "kube-system", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/kube-system", want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "kube-system", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/kube-system", want: &types.KubernetesResource{Kind: "namespaces", Name: "kube-system", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/kube-system", want: &types.KubernetesResource{Kind: "namespaces", Name: "kube-system", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/kube-system/pods", want: nil},
 		{path: "/api/v1/watch/namespaces/kube-system/pods", want: nil},
-		{path: "/api/v1/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/apis/apiregistration.k8s.io/v1/apiservices/foo/status", want: nil},
 
 		// core
 		// Pods
 		{path: "/api/v1/pods", want: nil},
 		{path: "/api/v1/namespaces/default/pods", want: nil},
-		{path: "/api/v1/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/kube-system/pods/foo/exec", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/kube-system/pods/foo/attach", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/kube-system/pods/foo/portforward", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"portforward"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/pods", body: bodyFunc("Pod", "v1"), want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/pods", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/exec", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/attach", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/portforward", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"portforward"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/pods", body: bodyFunc("Pod", "v1"), want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/pods", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Secrets
 		{path: "/api/v1/secrets", want: nil},
 		{path: "/api/v1/namespaces/default/secrets", want: nil},
-		{path: "/api/v1/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: types.KindKubeSecret, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: types.KindKubeSecret, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/secrets", body: bodyFunc("Secret", "v1"), want: &types.KubernetesResource{Kind: types.KindKubeSecret, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/secrets", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: types.KindKubeSecret, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/secrets", body: bodyFunc("Secret", "v1"), want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/secrets", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Configmaps
 		{path: "/api/v1/configmaps", want: nil},
 		{path: "/api/v1/namespaces/default/configmaps", want: nil},
-		{path: "/api/v1/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: types.KindKubeConfigmap, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: types.KindKubeConfigmap, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/configmaps", body: bodyFunc("ConfigMap", "v1"), want: &types.KubernetesResource{Kind: types.KindKubeConfigmap, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/configmaps", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: types.KindKubeConfigmap, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/configmaps", body: bodyFunc("ConfigMap", "v1"), want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/configmaps", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Namespaces
 		{path: "/api/v1/namespaces", want: nil},
-		{path: "/api/v1/namespaces/default", want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "default", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default", want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "default", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces", body: bodyFunc("Namespace", "v1"), want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: types.KindKubeNamespace, Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default", want: &types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default", want: &types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces", body: bodyFunc("Namespace", "v1"), want: &types.KubernetesResource{Kind: "namespaces", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "namespaces", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Nodes
 		{path: "/api/v1/nodes", want: nil},
-		{path: "/api/v1/nodes/foo/proxy/bar", want: &types.KubernetesResource{Kind: types.KindKubeNode, Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/nodes/foo/proxy/bar", want: &types.KubernetesResource{Kind: "nodes", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		// Services
 		{path: "/api/v1/services", want: nil},
 		{path: "/api/v1/namespaces/default/services", want: nil},
-		{path: "/api/v1/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: types.KindKubeService, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: types.KindKubeService, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/default/services", body: bodyFunc("Service", "v1"), want: &types.KubernetesResource{Kind: types.KindKubeService, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/services", body: bodyFunc("Service", "v1"), want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// ServiceAccounts
 		{path: "/api/v1/serviceaccounts", want: nil},
 		{path: "/api/v1/namespaces/default/serviceaccounts", want: nil},
-		{path: "/api/v1/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: types.KindKubeServiceAccount, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: types.KindKubeServiceAccount, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: "serviceaccounts", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: "serviceaccounts", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		// PersistentVolumes
 		{path: "/api/v1/persistentvolumes", want: nil},
 		{path: "/api/v1/namespaces/default/persistentvolumes", want: nil},
-		{path: "/api/v1/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: types.KindKubePersistentVolume, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: types.KindKubePersistentVolume, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: "persistentvolumes", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: "persistentvolumes", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		// PersistentVolumeClaims
 		{path: "/api/v1/persistentvolumeclaims", want: nil},
 		{path: "/api/v1/namespaces/default/persistentvolumeclaims", want: nil},
-		{path: "/api/v1/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: types.KindKubePersistentVolumeClaim, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
-		{path: "/api/v1/watch/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: types.KindKubePersistentVolumeClaim, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 
 		// apis/apps
 		// Deployments
 		{path: "/apis/apps/v1/deployments", want: nil},
 		{path: "/apis/apps/v1/namespaces/default/deployments", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/watch/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1"), want: &types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1beta2/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1beta2"), want: &types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: types.KindKubeDeployment, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/watch/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1"), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1beta2/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1beta2"), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
 
 		// Statefulsets
 		{path: "/apis/apps/v1/statefulsets", want: nil},
 		{path: "/apis/apps/v1/namespaces/default/statefulsets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: types.KindKubeStatefulset, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/watch/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: types.KindKubeStatefulset, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: "statefulsets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/watch/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: "statefulsets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 		// Replicasets
 		{path: "/apis/apps/v1/replicasets", want: nil},
 		{path: "/apis/apps/v1/namespaces/default/replicasets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: types.KindKubeReplicaSet, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/watch/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: types.KindKubeReplicaSet, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: "replicasets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/watch/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: "replicasets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 		// Daemonsets
 		{path: "/apis/apps/v1/daemonsets", want: nil},
 		{path: "/apis/apps/v1/namespaces/default/daemonsets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: types.KindKubeDaemonSet, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
-		{path: "/apis/apps/v1/watch/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: types.KindKubeDaemonSet, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: "daemonsets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/watch/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: "daemonsets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 
 		// apis/batch
 		// Job
 		{path: "/apis/batch/v1/jobs", want: nil},
 		{path: "/apis/batch/v1/namespaces/default/jobs", want: nil},
-		{path: "/apis/batch/v1/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: types.KindKubeJob, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
-		{path: "/apis/batch/v1/watch/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: types.KindKubeJob, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: "jobs", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/watch/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: "jobs", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
 		// CronJob
 		{path: "/apis/batch/v1/cronjobs", want: nil},
 		{path: "/apis/batch/v1/namespaces/default/cronjobs", want: nil},
-		{path: "/apis/batch/v1/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: types.KindKubeCronjob, Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
-		{path: "/apis/batch/v1/watch/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: types.KindKubeCronjob, Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: "cronjobs", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/watch/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: "cronjobs", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
 
 		// apis/certificates.k8s.io
 		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests", want: nil},
-		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/foo", want: &types.KubernetesResource{Kind: types.KindKubeCertificateSigningRequest, Name: "foo", Verbs: []string{"get"}, APIGroup: "certificates.k8s.io"}},
+		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/foo", want: &types.KubernetesResource{Kind: "certificatesigningrequests", Name: "foo", Verbs: []string{"get"}, APIGroup: "certificates.k8s.io"}},
 
 		// apis/networking.k8s.io
 		{path: "/apis/networking.k8s.io/v1/ingresses", want: nil},
-		{path: "/apis/networking.k8s.io/v1/ingresses/foo", want: &types.KubernetesResource{Kind: types.KindKubeIngress, Name: "foo", Verbs: []string{"get"}, APIGroup: "networking.k8s.io"}},
+		{path: "/apis/networking.k8s.io/v1/ingresses/foo", want: &types.KubernetesResource{Kind: "ingresses", Name: "foo", Verbs: []string{"get"}, APIGroup: "networking.k8s.io"}},
 	}
 
 	for _, tt := range tests {
@@ -224,7 +224,7 @@ func Test_getResourceFromRequest(t *testing.T) {
 			if tt.body != nil {
 				verb = http.MethodPost
 			}
-			got, _, err := getResourceFromRequest(&http.Request{Method: verb, URL: &url.URL{Path: tt.path}, Body: tt.body}, &kubeDetails{
+			got, err := getResourceFromRequest(&http.Request{Method: verb, URL: &url.URL{Path: tt.path}, Body: tt.body}, &kubeDetails{
 				kubeCodecs:         &globalKubeCodecs,
 				rbacSupportedTypes: defaultRBACResources,
 				gvkSupportedResources: map[gvkSupportedResourcesKey]*schema.GroupVersionKind{
@@ -276,7 +276,7 @@ func Test_getResourceFromRequest(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got, "parsing path %q", tt.path)
+			require.Equal(t, tt.want, got.rbacResource(), "parsing path %q", tt.path)
 		})
 	}
 }

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -98,9 +98,10 @@ func TestAccessCheckerKubeResources(t *testing.T) {
 	)
 	localCluster := "cluster"
 	type fields struct {
-		info     *AccessInfo
-		roleSet  RoleSet
-		resource types.KubernetesResource
+		info          *AccessInfo
+		roleSet       RoleSet
+		resource      types.KubernetesResource
+		isClusterWide bool
 	}
 	tests := []struct {
 		name         string
@@ -531,7 +532,7 @@ func TestAccessCheckerKubeResources(t *testing.T) {
 				AccessState{MFARequired: MFARequiredNever},
 				// Append a matcher that validates if the Kubernetes resource is allowed
 				// by the roles that satisfy the Kubernetes Cluster.
-				NewKubernetesResourceMatcher(tt.fields.resource),
+				NewKubernetesResourceMatcher(tt.fields.resource, tt.fields.isClusterWide),
 			)
 			tt.assertAccess(t, err)
 			sortKubeResourceSlice(gotAllowed)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2470,20 +2470,22 @@ func (m *KubeResourcesMatcher) Unmatched() []string {
 // KubernetesResourceMatcher matches a role against a Kubernetes Resource.
 // Kind is must be stricly equal but namespace and name allow wildcards.
 type KubernetesResourceMatcher struct {
-	resource types.KubernetesResource
+	resource              types.KubernetesResource
+	isClusterWideResource bool
 }
 
 // NewKubernetesResourceMatcher creates a KubernetesResourceMatcher that checks
 // whether the role's KubeResources match the specified condition.
-func NewKubernetesResourceMatcher(resource types.KubernetesResource) *KubernetesResourceMatcher {
+func NewKubernetesResourceMatcher(resource types.KubernetesResource, isClusterWideResource bool) *KubernetesResourceMatcher {
 	return &KubernetesResourceMatcher{
-		resource: resource,
+		resource:              resource,
+		isClusterWideResource: isClusterWideResource,
 	}
 }
 
 // Match matches a Kubernetes Resource against provided role and condition.
 func (m *KubernetesResourceMatcher) Match(role types.Role, condition types.RoleConditionType) (bool, error) {
-	result, err := utils.KubeResourceMatchesRegex(m.resource, role.GetKubeResources(condition), condition)
+	result, err := utils.KubeResourceMatchesRegex(m.resource, m.isClusterWideResource, role.GetKubeResources(condition), condition)
 	return result, trace.Wrap(err)
 }
 

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -175,13 +175,11 @@ func KubeResourceMatchesRegexWithVerbsCollector(input types.KubernetesResource, 
 // resources is a list of resources that the user has access to - collected from
 // their roles that match the Kubernetes cluster where the resource is defined.
 // cond is the deny or allow condition of the role that we are evaluating.
-func KubeResourceMatchesRegex(input types.KubernetesResource, resources []types.KubernetesResource, cond types.RoleConditionType) (bool, error) {
+func KubeResourceMatchesRegex(input types.KubernetesResource, isClusterWideResource bool, resources []types.KubernetesResource, cond types.RoleConditionType) (bool, error) {
 	if len(input.Verbs) != 1 {
 		return false, trace.BadParameter("only one verb is supported, input: %v", input.Verbs)
 	}
-	// isClusterWideResource is true if the resource is cluster-wide, e.g. a
-	// namespace resource or a clusterrole.
-	isClusterWideResource := slices.Contains(types.KubernetesClusterWideResourceKinds, input.Kind)
+
 	verb := input.Verbs[0]
 	// If the user is list/read/watch a namespace, they should be able to see the
 	// namespace they have resources defined for.
@@ -257,7 +255,7 @@ func KubeResourceMatchesRegex(input types.KubernetesResource, resources []types.
 // has no access and present then a more user-friendly error message instead of returning
 // an empty list.
 // This function is not responsible for enforcing access rules.
-func KubeResourceCouldMatchRules(input types.KubernetesResource, resources []types.KubernetesResource, cond types.RoleConditionType) (bool, error) {
+func KubeResourceCouldMatchRules(input types.KubernetesResource, isClusterWideResource bool, resources []types.KubernetesResource, cond types.RoleConditionType) (bool, error) {
 	if len(input.Verbs) != 1 {
 		return false, trace.BadParameter("only one verb is supported, input: %v", input.Verbs)
 	}
@@ -267,10 +265,6 @@ func KubeResourceCouldMatchRules(input types.KubernetesResource, resources []typ
 
 	verb := input.Verbs[0]
 	isDeny := cond == types.Deny
-
-	// isClusterWideResource is true if the resource is cluster-wide, e.g. a
-	// namespace resource or a clusterrole.
-	isClusterWideResource := slices.Contains(types.KubernetesClusterWideResourceKinds, input.Kind)
 
 	// If the user is allowed to list/read/watch a resource, they should be able to see the
 	// namespace in which the resource is.

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -160,12 +160,13 @@ func TestRegexMatchesAny(t *testing.T) {
 
 func TestKubeResourceMatchesRegex(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     types.KubernetesResource
-		resources []types.KubernetesResource
-		action    types.RoleConditionType
-		matches   bool
-		assert    require.ErrorAssertionFunc
+		name          string
+		input         types.KubernetesResource
+		isClusterWide bool
+		resources     []types.KubernetesResource
+		action        types.RoleConditionType
+		matches       bool
+		assert        require.ErrorAssertionFunc
 	}{
 		{
 			name: "input misses verb",
@@ -228,6 +229,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "default",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -247,6 +249,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "default",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "secrets",
@@ -473,6 +476,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "clusterrole",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:  "clusterroles",
@@ -491,6 +495,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "clusterrole",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -510,6 +515,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "clusterrole",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -529,6 +535,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "default",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -549,6 +556,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 				Name:  "default",
 				Verbs: []string{types.KubeVerbUpdate},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -713,7 +721,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeResourceMatchesRegex(tt.input, tt.resources, tt.action)
+			got, err := KubeResourceMatchesRegex(tt.input, tt.isClusterWide, tt.resources, tt.action)
 			tt.assert(t, err)
 			require.Equal(t, tt.matches, got)
 		})
@@ -722,12 +730,13 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 
 func TestKubeResourceCouldMatchRules(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     types.KubernetesResource
-		resources []types.KubernetesResource
-		action    types.RoleConditionType
-		matches   bool
-		assert    require.ErrorAssertionFunc
+		name          string
+		input         types.KubernetesResource
+		resources     []types.KubernetesResource
+		isClusterWide bool
+		action        types.RoleConditionType
+		matches       bool
+		assert        require.ErrorAssertionFunc
 	}{
 		{
 			name: "input misses verb",
@@ -786,6 +795,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbList},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "secrets",
@@ -804,6 +814,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbList},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "secrets",
@@ -1093,6 +1104,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "clusterroles",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:  "clusterroles",
@@ -1110,6 +1122,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "clusterroles",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -1128,6 +1141,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "clusterroles",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -1146,6 +1160,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "clusterroles",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -1161,10 +1176,10 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 		{
 			name: "list clusterrole with wildcard deny verb",
 			input: types.KubernetesResource{
-				Kind: "clusterroles",
-
+				Kind:  "clusterroles",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
@@ -1182,6 +1197,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -1200,6 +1216,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -1218,6 +1235,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbGet},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -1237,6 +1255,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 				Kind:  "namespaces",
 				Verbs: []string{types.KubeVerbUpdate},
 			},
+			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
@@ -1360,7 +1379,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := KubeResourceCouldMatchRules(tt.input, tt.resources, tt.action)
+			got, err := KubeResourceCouldMatchRules(tt.input, tt.isClusterWide, tt.resources, tt.action)
 			tt.assert(t, err)
 			require.Equal(t, tt.matches, got)
 		})


### PR DESCRIPTION
Update rbacSupportedType to hold the whole api resource instead of just the name so we can know wheter a resource is namespaced or not (and maybe in the future, allow for more flexible rbac including Kind, Singular etc)
The way it worked previously, as CRDs were not supported was to reply on a hard-coded list.