### PR TITLE
Fix malformed redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -366,8 +366,8 @@
       "permanent": true
     },
     {
-      "source": "/enroll-resources/agents/join-services-to-your-cluster/join-services-to-your-cluster/",
-      "destination": "docs/pages/enroll-resources/agents/",
+      "source": "/enroll-resources/agents/join-services-to-your-cluster/",
+      "destination": "/enroll-resources/agents/",
       "permanent": true
     },
     {


### PR DESCRIPTION
This change fixes a redirect with a malformed destination path and source path. The source path needs to have a single instance of the `join-services-to-your-cluster` segment, since this is a section index page. The destination path erroneously uses the beginning of a local file path, and needs to omit the base `/docs/` segment.