### PR TITLE
Add reference documentation for `azure_devops` join method

### DIFF
--- a/docs/pages/includes/provision-token/azure-devops-spec.mdx
+++ b/docs/pages/includes/provision-token/azure-devops-spec.mdx
@@ -1,0 +1,46 @@
+```yaml
+# token.yaml
+kind: token
+version: v2
+metadata:
+  # the token name is not a secret because instances must prove that they are
+  # running in your Azure DevOps organization to use this token
+  name: azure-devops-token
+spec:
+  roles: [Bot]
+  join_method: azure_devops
+  bot_name: my-bot
+  azure_devops:
+    # the UUID of the Azure DevOps organization that the pipeline will be
+    # joining from. Joins from pipelines in other organizations will be
+    # rejected.
+    organization_id: 11111111-1111-1111-1111-111111111111
+    # a list of rules that determine which Azure DevOps pipelines can use this
+    # token to join. At least one must be specified, and each rule must define
+    # at least the `sub`, `project_name` or `project_id` field.
+    allow:
+        # the `sub` field is a unique identifier for the pipeline in Azure DevOps.
+        # It is a combination of the organization, project, and pipeline name.
+        # The format is `p://<organization>/<project>/<pipeline>`.
+      - sub: p://my-organization/my-project/my-pipeline
+        # the `project_name` field is the name of the Azure DevOps project the
+        # pipeline is in.
+        project_name: my-project
+        # the `pipeline_name` field is the name of the Azure DevOps pipeline.
+        pipeline_name: my-pipeline
+        # the `project_id` field is the unique identifier for the Azure DevOps
+        # project the pipeline is in.
+        project_id: 22222222-2222-2222-2222-222222222222
+        # the `definition_id` is the unique identifier for the pipeline
+        # definition within the Azure DevOps project.
+        definition_id: 1
+        # the `repository_uri` is the URI of the source code repository that
+        # the pipeline is running against.
+        repository_uri: https://github.com/gravitational/teleport.git
+        # the `repository_version` is the commit SHA of the source code that
+        # the pipeline is running against.
+        repository_version: e6b9eb29a288b27a3a82cc19c48b9d94b80aff36
+        # the `repository_ref` is the branch or tag of the source code that
+        # the pipeline is running against.
+        repository_ref: refs/heads/main
+```

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -115,6 +115,7 @@ service account, or cloud account ID.
 
 Delegated join methods are:
 - [`azure`](#azure-managed-identity-azure)
+- [`azure_devops`](#azure-devops-azure_devops)
 - [`bitbucket`](#bitbucket-pipelines-bitbucket)
 - [`circleci`](#circleci-circleci)
 - [`ec2`](#aws-ec2-identity-document-ec2)
@@ -153,6 +154,7 @@ temporary workloads such as CI/CD pipelines or containerized environments.
 Non-renewable join methods are:
 - [`iam`](#aws-iam-role-iam)
 - [`azure`](#azure-managed-identity-azure)
+- [`azure_devops`](#azure-devops-azure_devops)
 - [`gcp`](#gcp-service-account-gcp)
 - [`github`](#github-actions-github)
 - [`circleci`](#circleci-circleci)
@@ -313,6 +315,16 @@ behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
 - [Joining Services via Azure Managed Identity](../enroll-resources/agents/azure.mdx).
 - [Deploying Machine ID on Azure](../enroll-resources/machine-id/deployment/azure.mdx)
 </Admonition>
+
+### Azure Devops: `azure_devops`
+
+The Azure DevOps is available to any Teleport process running in an Azure DevOps
+pipeline. This join method is typically used with
+[Machine & Workload Identity](../enroll-resources/machine-id/introduction.mdx)
+to access Teleport-protected resources in Azure DevOps pipelines without the
+use of long-lived secrets.
+
+(!docs/pages/includes/provision-token/azure-devops-spec.mdx!)
 
 ### GCP service account: `gcp`
 

--- a/docs/pages/reference/workload-identity/attributes.mdx
+++ b/docs/pages/reference/workload-identity/attributes.mdx
@@ -36,6 +36,25 @@ These attributes are present if the Bot joined using the Azure join method.
 | `join.azure.subscription`   | The subscription ID of the Azure account that the joining entity is a part of. |
 | `join.azure.resource_group` | The resource group of the Azure account that the joining entity is a part of.  |
 
+### `join.azure_devops`
+
+These attributes are present if the Bot joined using the Azure DevOps join
+method.
+
+| Field                                  | Description                                                                                               |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `join.azure_devops.sub`                | The `sub` claim of the Azure DevOps pipeline ID token that was used to join.                              |
+| `join.azure_devops.organization_name`  | The name of the organization that the pipeline is running within.                                         |
+| `join.azure_devops.project_name`       | The name of the project that the pipeline is running within.                                              |
+| `join.azure_devops.pipeline_name`      | The name of the pipeline that is running.                                                                 |
+| `join.azure_devops.organization_id`    | The ID of the organization that the pipeline is running within.                                           |
+| `join.azure_devops.project_id`         | The ID of the project that the pipeline is running within.                                                |
+| `join.azure_devops.definition_id`      | The ID of the pipeline that is running.                                                                   |
+| `join.azure_devops.repository_id`      | The ID of the repository that the pipeline is running within.                                             |
+| `join.azure_devops.repository_version` | The version of the repository that the pipeline is running against.  For Git this will be the commit SHA. |
+| `join.azure_devops.repository_ref`     | The ref of the repository that the pipeline is running against.                                           |
+| `join.azure_devops.run_id`             | The ID of the run that is being executed.                                                                 |
+
 ### `join.bitbucket`
 
 These attributes are present if the Bot joined using the BitBucket join method.


### PR DESCRIPTION
Add reference documentation for the new azure_devops join method introduced by https://github.com/gravitational/teleport/pull/54729

A follow-up PR in the next few weeks will add the guide for this platform.