### PR TITLE
Add topologySpreadConstraints

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1406,6 +1406,16 @@ more details on possible values for `extra_fields`.
 See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
 for more details.
 
+## `topologySpreadConstraints`
+
+| Type | Default |
+|------|---------|
+| `object` | `[]` |
+
+`topologySpreadConstraints` sets the topology spread constraints for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+for more details.
+
 ## `dnsConfig`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/.lint/topology-spread-constraints.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/topology-spread-constraints.yaml
@@ -1,0 +1,13 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app: foo
+    matchLabelKeys:
+      - pod-template-hash

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 6 }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -84,6 +84,9 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 6 }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -2210,3 +2210,76 @@ should set tolerations when set in values if action is Upgrade:
         secretName: teleport-kube-agent-join-token
     - emptyDir: {}
       name: data
+should set topologySpreadConstraints if set in values if action is Upgrade:
+  1: |
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:18.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /etc/teleport-secrets
+        name: auth-token
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    securityContext:
+      fsGroup: 9807
+    serviceAccountName: RELEASE-NAME
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app: foo
+      matchLabelKeys:
+      - pod-template-hash
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+    volumes:
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - name: auth-token
+      secret:
+        secretName: teleport-kube-agent-join-token
+    - emptyDir: {}
+      name: data

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -2748,3 +2748,87 @@ should set tolerations when set in values:
     - name: auth-token
       secret:
         secretName: teleport-kube-agent-join-token
+should set topologySpreadConstraints if set in values if action is Upgrade:
+  1: |
+    containers:
+    - args:
+      - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
+      - name: TELEPORT_REPLICA_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KUBE_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: RELEASE_NAME
+        value: RELEASE-NAME
+      - name: TELEPORT_KUBE_CLUSTER_DOMAIN
+        value: cluster.local
+      image: public.ecr.aws/gravitational/teleport-distroless:18.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      name: teleport
+      ports:
+      - containerPort: 3000
+        name: diag
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 12
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /etc/teleport
+        name: config
+        readOnly: true
+      - mountPath: /etc/teleport-secrets
+        name: auth-token
+        readOnly: true
+      - mountPath: /var/lib/teleport
+        name: data
+    securityContext:
+      fsGroup: 9807
+    serviceAccountName: RELEASE-NAME
+    terminationGracePeriodSeconds: 30
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app: foo
+      matchLabelKeys:
+      - pod-template-hash
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+    volumes:
+    - configMap:
+        name: RELEASE-NAME
+      name: config
+    - name: auth-token
+      secret:
+        secretName: teleport-kube-agent-join-token
+    - emptyDir: {}
+      name: data

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -199,6 +199,20 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set topologySpreadConstraints if set in values if action is Upgrade
+    template: deployment.yaml
+    set:
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
+      # https://github.com/helm/helm/issues/8137
+      unitTestUpgrade: true
+    values:
+      - ../.lint/topology-spread-constraints.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.topologySpreadConstraints
+      - matchSnapshot:
+          path: spec.template.spec
+
   - it: should set tolerations when set in values if action is Upgrade
     template: deployment.yaml
     set:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -160,6 +160,20 @@ tests:
       - matchSnapshot:
           path: spec.template.spec
 
+  - it: should set topologySpreadConstraints if set in values if action is Upgrade
+    template: statefulset.yaml
+    set:
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
+      # https://github.com/helm/helm/issues/8137
+      unitTestUpgrade: true
+    values:
+      - ../.lint/topology-spread-constraints.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.topologySpreadConstraints
+      - matchSnapshot:
+          path: spec.template.spec
+
   - it: should set tolerations when set in values
     template: statefulset.yaml
     values:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -519,6 +519,11 @@
             "type": "object",
             "default": {}
         },
+        "topologySpreadConstraints": {
+            "$id": "#/properties/topologySpreadConstraints",
+            "type": "array",
+            "default": {}
+        },
         "dnsConfig": {
             "$id": "#/properties/dnsConfig",
             "type": "object",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1082,6 +1082,11 @@ log:
 # for more details.
 affinity: {}
 
+# topologySpreadConstraints(object) -- sets the topology spread constraints for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+# for more details.
+topologySpreadConstraints: []
+
 # dnsConfig(object) -- contains custom Pod DNS Configuration for the agent pods.
 # This value is useful if you need to reduce the DNS load: set "ndots" to 0 and
 # only use FQDNs to refer to applications and databases.


### PR DESCRIPTION
Fairly small change - we're looking to control how Teleport schedules to different availability zones and this setting isn't currently accessible in the chart. Think I've covered all bases for tests etc etc. Wasn't sure on how to bump the chart version, looks like its managed by your release process.