### PR TITLE
Move AWS tags helper methods to their own package

### DIFF
--- a/api/types/common/constants.go
+++ b/api/types/common/constants.go
@@ -62,6 +62,10 @@ const (
 	// created from the AWS OIDC Integration.
 	OriginIntegrationAWSOIDC = "integration_awsoidc"
 
+	// OriginIntegrationAWSRolesAnywhere is an origin value indicating that the resource was
+	// created from the AWS IAM Roles Anywhere Integration.
+	OriginIntegrationAWSRolesAnywhere = "integration_awsrolesanywhere"
+
 	// OriginDiscoveryKubernetes indicates that the resource was imported
 	// from kubernetes cluster by discovery service.
 	OriginDiscoveryKubernetes = "discovery-kubernetes"

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -760,6 +760,10 @@ const (
 	// created from the AWS OIDC Integration.
 	OriginIntegrationAWSOIDC = common.OriginIntegrationAWSOIDC
 
+	// OriginIntegrationAWSRolesAnywhere is an origin value indicating that the resource was
+	// created from the AWS IAM Roles Anywhere Integration.
+	OriginIntegrationAWSRolesAnywhere = common.OriginIntegrationAWSRolesAnywhere
+
 	// OriginDiscoveryKubernetes indicates that the resource was imported
 	// from kubernetes cluster by discovery service.
 	OriginDiscoveryKubernetes = common.OriginDiscoveryKubernetes

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.95.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4
 	github.com/aws/aws-sdk-go-v2/service/sns v1.34.4

--- a/go.sum
+++ b/go.sum
@@ -943,6 +943,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3 h1:LNOKEsPjtoBrV2WYUb2zPLO
 github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3/go.mod h1:TC8pNvjiikrjpX2MEzX/cEJ4/T4XIoSY4BskVvHj8bk=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1 h1:+nldYGx2Kdn7jzntjm2fG7sRonfQ08l1RqkLSTed8G8=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1/go.mod h1:gpRsJN3qxZbsj1NhAoCNX02zJ4RZUB5v/7o4QrnGTcA=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 h1:0LBxtAX2bHcfPr6VSzQSvJlR1nzlna7xp031gEjbWGU=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2/go.mod h1:NW+LcIadUUlDgM3gb8+97lr6zSKExHR58NRRWSWkXl8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3/go.mod h1:bNXKFFyaiVvWuR6O16h/I1724+aXe/tAkA9/QS01t5k=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 h1:EKXYJ8kgz4fiqef8xApu7eH0eae2SrVG+oHCLFybMRI=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.95.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -182,6 +182,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3 h1:LNOKEsPjtoBrV2WYUb2zPLO
 github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3/go.mod h1:TC8pNvjiikrjpX2MEzX/cEJ4/T4XIoSY4BskVvHj8bk=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1 h1:+nldYGx2Kdn7jzntjm2fG7sRonfQ08l1RqkLSTed8G8=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1/go.mod h1:gpRsJN3qxZbsj1NhAoCNX02zJ4RZUB5v/7o4QrnGTcA=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 h1:0LBxtAX2bHcfPr6VSzQSvJlR1nzlna7xp031gEjbWGU=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2/go.mod h1:NW+LcIadUUlDgM3gb8+97lr6zSKExHR58NRRWSWkXl8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3/go.mod h1:bNXKFFyaiVvWuR6O16h/I1724+aXe/tAkA9/QS01t5k=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 h1:EKXYJ8kgz4fiqef8xApu7eH0eae2SrVG+oHCLFybMRI=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.95.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -294,6 +294,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3 h1:LNOKEsPjtoBrV2WYUb2zPLO
 github.com/aws/aws-sdk-go-v2/service/redshift v1.54.3/go.mod h1:TC8pNvjiikrjpX2MEzX/cEJ4/T4XIoSY4BskVvHj8bk=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1 h1:+nldYGx2Kdn7jzntjm2fG7sRonfQ08l1RqkLSTed8G8=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.27.1/go.mod h1:gpRsJN3qxZbsj1NhAoCNX02zJ4RZUB5v/7o4QrnGTcA=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2 h1:0LBxtAX2bHcfPr6VSzQSvJlR1nzlna7xp031gEjbWGU=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.2/go.mod h1:NW+LcIadUUlDgM3gb8+97lr6zSKExHR58NRRWSWkXl8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3/go.mod h1:bNXKFFyaiVvWuR6O16h/I1724+aXe/tAkA9/QS01t5k=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4 h1:EKXYJ8kgz4fiqef8xApu7eH0eae2SrVG+oHCLFybMRI=

--- a/lib/cloud/aws/tags/tags_test.go
+++ b/lib/cloud/aws/tags/tags_test.go
@@ -25,6 +25,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,8 @@ import (
 func TestDefaultTags(t *testing.T) {
 	clusterName := "mycluster"
 	integrationName := "myawsaccount"
-	d := DefaultResourceCreationTags(clusterName, integrationName)
+	origin := "integration_awsoidc"
+	d := DefaultResourceCreationTags(clusterName, integrationName, origin)
 
 	expectedTags := AWSTags{
 		"teleport.dev/cluster":     "mycluster",
@@ -75,6 +77,15 @@ func TestDefaultTags(t *testing.T) {
 			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 		}
 		require.ElementsMatch(t, expectedTags, d.ToSSMTags())
+	})
+
+	t.Run("roles anywhere tags", func(t *testing.T) {
+		expectedTags := []ratypes.Tag{
+			{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+			{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+		}
+		require.ElementsMatch(t, expectedTags, d.ToRolesAnywhereTags())
 	})
 
 	t.Run("resource is teleport managed", func(t *testing.T) {

--- a/lib/cloud/provisioning/awsactions/create_document.go
+++ b/lib/cloud/provisioning/awsactions/create_document.go
@@ -31,8 +31,8 @@ import (
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // DocumentCreator can create an AWS SSM document.

--- a/lib/cloud/provisioning/awsactions/create_oidc_idp.go
+++ b/lib/cloud/provisioning/awsactions/create_oidc_idp.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // OpenIDConnectProviderCreator can create an OpenID Connect Identity Provider

--- a/lib/cloud/provisioning/awsactions/create_role.go
+++ b/lib/cloud/provisioning/awsactions/create_role.go
@@ -29,8 +29,8 @@ import (
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // RoleCreator can create an IAM role.

--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -27,7 +27,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 // CreateEC2ICERequest contains the required fields to create an AWS EC2 Instance Connect Endpoint.
@@ -85,7 +85,7 @@ func (req *CreateEC2ICERequest) CheckAndSetDefaults() error {
 	}
 
 	if len(req.ResourceCreationTags) == 0 {
-		req.ResourceCreationTags = tags.DefaultResourceCreationTags(req.Cluster, req.IntegrationName)
+		req.ResourceCreationTags = defaultResourceCreationTags(req.Cluster, req.IntegrationName)
 	}
 
 	return nil

--- a/lib/integrations/awsoidc/create_ec2ice_test.go
+++ b/lib/integrations/awsoidc/create_ec2ice_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 type mockCreateEC2ICEClient struct {

--- a/lib/integrations/awsoidc/deploydatabaseservice.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 // DeployDatabaseServiceRequest contains the required fields to deploy multiple Teleport Databases Services.
@@ -116,7 +116,7 @@ func (r *DeployDatabaseServiceRequest) CheckAndSetDefaults() error {
 	}
 
 	if r.ResourceCreationTags == nil {
-		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
 	r.ecsClusterName = normalizeECSClusterName(r.TeleportClusterName)

--- a/lib/integrations/awsoidc/deploydatabaseservice_test.go
+++ b/lib/integrations/awsoidc/deploydatabaseservice_test.go
@@ -39,7 +39,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 func TestDeployDatabaseServiceRequest_CheckAndSetDefaults(t *testing.T) {

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiaws "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
@@ -247,7 +247,7 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 	}
 
 	if r.ResourceCreationTags == nil {
-		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
 	if r.TeleportConfigString == "" {

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -29,9 +29,9 @@ import (
 
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	awslibutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
@@ -112,7 +112,7 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 	}
 
 	if len(r.ResourceCreationTags) == 0 {
-		r.ResourceCreationTags = tags.DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
+		r.ResourceCreationTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
 	}
 
 	r.partitionID = awsapiutils.GetPartitionFromRegion(r.Region)

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 func TestDeployServiceRequest(t *testing.T) {

--- a/lib/integrations/awsoidc/deployservice_update.go
+++ b/lib/integrations/awsoidc/deployservice_update.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 )
 
 // waitDuration specifies the amount of time to wait for a service to become healthy after an update.

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -161,7 +160,7 @@ func TestUpdateDeployServices(t *testing.T) {
 
 	clusterName := "my-cluster"
 	integrationName := "my-integration"
-	ownershipTags := tags.DefaultResourceCreationTags(clusterName, integrationName)
+	ownershipTags := defaultResourceCreationTags(clusterName, integrationName)
 	semVer := teleport.SemVer()
 	semVer.PreRelease = ""
 	teleportVersion := semVer.String()

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config.go
@@ -31,7 +31,6 @@ import (
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
@@ -186,7 +185,7 @@ func ConfigureEC2SSM(ctx context.Context, clt EC2SSMConfigureClient, req EC2SSMI
 	content := awslib.EC2DiscoverySSMDocument(req.ProxyPublicURL,
 		awslib.WithInsecureSkipInstallPathRandomization(req.insecureSkipInstallPathRandomization),
 	)
-	tags := tags.DefaultResourceCreationTags(req.ClusterName, req.IntegrationName)
+	tags := defaultResourceCreationTags(req.ClusterName, req.IntegrationName)
 	createDoc, err := awsactions.CreateDocument(clt, req.SSMDocumentName, content, ssmtypes.DocumentTypeCommand, ssmtypes.DocumentFormatYaml, tags)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -54,8 +54,8 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -414,7 +414,7 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		return "", "", trace.Wrap(err)
 	}
 
-	ownershipTags := tags.DefaultResourceCreationTags(req.TeleportClusterName, req.IntegrationName)
+	ownershipTags := defaultResourceCreationTags(req.TeleportClusterName, req.IntegrationName)
 
 	wasAdded, err := maybeAddAccessEntry(ctx, log, clusterName, principalArn, clt, ownershipTags)
 	if err != nil {

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -30,11 +30,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/common"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/cloud/provisioning"
 	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
@@ -144,7 +145,7 @@ func (r *IdPIAMConfigureRequest) CheckAndSetDefaults() error {
 	}
 	r.issuerURL = issuerURL.String()
 
-	r.ownershipTags = tags.DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
+	r.ownershipTags = tags.DefaultResourceCreationTags(r.Cluster, r.IntegrationName, common.OriginIntegrationAWSOIDC)
 
 	switch r.IntegrationPolicyPreset {
 	case PolicyPresetUnspecified, PolicyPresetAWSIdentityCenter:

--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/lib"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 

--- a/lib/integrations/awsoidc/listdeployeddatabaseservice.go
+++ b/lib/integrations/awsoidc/listdeployeddatabaseservice.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/trace"
 
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
 // ListDeployedDatabaseServicesRequest contains the required fields to list the deployed database services in Amazon ECS.
@@ -157,7 +156,7 @@ func ListDeployedDatabaseServices(ctx context.Context, clt ListDeployedDatabaseS
 		return nil, trace.Wrap(err)
 	}
 
-	ownershipTags := tags.DefaultResourceCreationTags(req.TeleportClusterName, req.Integration)
+	ownershipTags := defaultResourceCreationTags(req.TeleportClusterName, req.Integration)
 
 	deployedDatabaseServices := []DeployedDatabaseService{}
 	for _, ecsService := range describeServicesOutput.Services {

--- a/lib/integrations/awsoidc/resource_tags.go
+++ b/lib/integrations/awsoidc/resource_tags.go
@@ -1,0 +1,32 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+)
+
+// defaultResourceCreationTags returns the AWS Tags which are set on resources created by this integration.
+// It will serve two purposes:
+// - to identify resources created by this integration
+// - when updating AWS resources, only those containing this label will be updated
+func defaultResourceCreationTags(clusterName, integrationName string) tags.AWSTags {
+	return tags.DefaultResourceCreationTags(clusterName, integrationName, common.OriginIntegrationAWSOIDC)
+}

--- a/lib/integrations/externalauditstorage/bootstrap.go
+++ b/lib/integrations/externalauditstorage/bootstrap.go
@@ -34,8 +34,9 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types/common"
 	eastypes "github.com/gravitational/teleport/api/types/externalauditstorage"
-	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
 	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -44,6 +45,8 @@ const (
 	defaultObjectLockRetentionYears = 4
 	// glueDatabaseDescription is the description of the glue database created by bootstrapping.
 	glueDatabaseDescription = "Teleport External Audit Storage events database for Athena"
+	// defaultTagsOrigin is the teleport.dev/origin label value set on the resources created in AWS.
+	defaultTagsOrigin = common.OriginIntegrationAWSOIDC
 )
 
 // BootstrapInfraParams are the input parameters for [BootstrapInfra].
@@ -117,7 +120,7 @@ func BootstrapInfra(ctx context.Context, params BootstrapInfraParams) error {
 		return trace.Wrap(err)
 	}
 
-	ownershipTags := tags.DefaultResourceCreationTags(params.ClusterName, params.IntegrationName)
+	ownershipTags := tags.DefaultResourceCreationTags(params.ClusterName, params.IntegrationName, defaultTagsOrigin)
 	s3OwnershipTags := ownershipTags.ToS3Tags()
 
 	if err := createLTSBucket(ctx, params.S3, ltsBucket, params.Region, s3OwnershipTags); err != nil {


### PR DESCRIPTION
No functional change, just prep work for the AWS IAM Roles Anywhere integration requirements.