### PR TITLE
[vnet] feat: DNS resolution for VNet SSH

### DIFF
--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -408,29 +408,29 @@ func (*PingResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{6}
 }
 
-// ResolveAppInfoRequest is a request for ResolveAppInfo.
-type ResolveAppInfoRequest struct {
+// ResolveFQDNRequest is a request for ResolveFQDN.
+type ResolveFQDNRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Fqdn is the fully-qualified domain name of the app.
+	// Fqdn is the fully-qualified domain name queried.
 	Fqdn          string `protobuf:"bytes,1,opt,name=fqdn,proto3" json:"fqdn,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ResolveAppInfoRequest) Reset() {
-	*x = ResolveAppInfoRequest{}
+func (x *ResolveFQDNRequest) Reset() {
+	*x = ResolveFQDNRequest{}
 	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ResolveAppInfoRequest) String() string {
+func (x *ResolveFQDNRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ResolveAppInfoRequest) ProtoMessage() {}
+func (*ResolveFQDNRequest) ProtoMessage() {}
 
-func (x *ResolveAppInfoRequest) ProtoReflect() protoreflect.Message {
+func (x *ResolveFQDNRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -442,20 +442,124 @@ func (x *ResolveAppInfoRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ResolveAppInfoRequest.ProtoReflect.Descriptor instead.
-func (*ResolveAppInfoRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ResolveFQDNRequest.ProtoReflect.Descriptor instead.
+func (*ResolveFQDNRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *ResolveAppInfoRequest) GetFqdn() string {
+func (x *ResolveFQDNRequest) GetFqdn() string {
 	if x != nil {
 		return x.Fqdn
 	}
 	return ""
 }
 
-// ResolveAppInfoResponse is a response for ResolveAppInfo.
-type ResolveAppInfoResponse struct {
+// ResolveFQDNReponse is a response for ResolveFQDN.
+type ResolveFQDNResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Match:
+	//
+	//	*ResolveFQDNResponse_MatchedTcpApp
+	//	*ResolveFQDNResponse_MatchedWebApp
+	//	*ResolveFQDNResponse_MatchedCluster
+	Match         isResolveFQDNResponse_Match `protobuf_oneof:"match"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveFQDNResponse) Reset() {
+	*x = ResolveFQDNResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveFQDNResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveFQDNResponse) ProtoMessage() {}
+
+func (x *ResolveFQDNResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveFQDNResponse.ProtoReflect.Descriptor instead.
+func (*ResolveFQDNResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ResolveFQDNResponse) GetMatch() isResolveFQDNResponse_Match {
+	if x != nil {
+		return x.Match
+	}
+	return nil
+}
+
+func (x *ResolveFQDNResponse) GetMatchedTcpApp() *MatchedTCPApp {
+	if x != nil {
+		if x, ok := x.Match.(*ResolveFQDNResponse_MatchedTcpApp); ok {
+			return x.MatchedTcpApp
+		}
+	}
+	return nil
+}
+
+func (x *ResolveFQDNResponse) GetMatchedWebApp() *MatchedWebApp {
+	if x != nil {
+		if x, ok := x.Match.(*ResolveFQDNResponse_MatchedWebApp); ok {
+			return x.MatchedWebApp
+		}
+	}
+	return nil
+}
+
+func (x *ResolveFQDNResponse) GetMatchedCluster() *MatchedCluster {
+	if x != nil {
+		if x, ok := x.Match.(*ResolveFQDNResponse_MatchedCluster); ok {
+			return x.MatchedCluster
+		}
+	}
+	return nil
+}
+
+type isResolveFQDNResponse_Match interface {
+	isResolveFQDNResponse_Match()
+}
+
+type ResolveFQDNResponse_MatchedTcpApp struct {
+	// MatchedTcpApp will be set when the query matched a TCP app.
+	MatchedTcpApp *MatchedTCPApp `protobuf:"bytes,1,opt,name=matched_tcp_app,json=matchedTcpApp,proto3,oneof"`
+}
+
+type ResolveFQDNResponse_MatchedWebApp struct {
+	// MatchedWebApp will be set when the query matched a web app.
+	MatchedWebApp *MatchedWebApp `protobuf:"bytes,2,opt,name=matched_web_app,json=matchedWebApp,proto3,oneof"`
+}
+
+type ResolveFQDNResponse_MatchedCluster struct {
+	// MatchedCluster will be set when the query did not match any app, but did
+	// match a subdomain of a proxy address. VNet will resolve the DNS query to
+	// a handler that may later resolve the FQDN to an app or SSH server.
+	MatchedCluster *MatchedCluster `protobuf:"bytes,3,opt,name=matched_cluster,json=matchedCluster,proto3,oneof"`
+}
+
+func (*ResolveFQDNResponse_MatchedTcpApp) isResolveFQDNResponse_Match() {}
+
+func (*ResolveFQDNResponse_MatchedWebApp) isResolveFQDNResponse_Match() {}
+
+func (*ResolveFQDNResponse_MatchedCluster) isResolveFQDNResponse_Match() {}
+
+// MatchedTCPApp holds info about a TCP app that matched a query.
+type MatchedTCPApp struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// AppInfo holds all necessary info for making connections to the resolved app.
 	AppInfo       *AppInfo `protobuf:"bytes,1,opt,name=app_info,json=appInfo,proto3" json:"app_info,omitempty"`
@@ -463,21 +567,21 @@ type ResolveAppInfoResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ResolveAppInfoResponse) Reset() {
-	*x = ResolveAppInfoResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[8]
+func (x *MatchedTCPApp) Reset() {
+	*x = MatchedTCPApp{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ResolveAppInfoResponse) String() string {
+func (x *MatchedTCPApp) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ResolveAppInfoResponse) ProtoMessage() {}
+func (*MatchedTCPApp) ProtoMessage() {}
 
-func (x *ResolveAppInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[8]
+func (x *MatchedTCPApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,16 +592,110 @@ func (x *ResolveAppInfoResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ResolveAppInfoResponse.ProtoReflect.Descriptor instead.
-func (*ResolveAppInfoResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{8}
+// Deprecated: Use MatchedTCPApp.ProtoReflect.Descriptor instead.
+func (*MatchedTCPApp) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *ResolveAppInfoResponse) GetAppInfo() *AppInfo {
+func (x *MatchedTCPApp) GetAppInfo() *AppInfo {
 	if x != nil {
 		return x.AppInfo
 	}
 	return nil
+}
+
+// MatchedTCPApp is a placeholder to signify that the query matched a web app.
+type MatchedWebApp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MatchedWebApp) Reset() {
+	*x = MatchedWebApp{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MatchedWebApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MatchedWebApp) ProtoMessage() {}
+
+func (x *MatchedWebApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MatchedWebApp.ProtoReflect.Descriptor instead.
+func (*MatchedWebApp) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{10}
+}
+
+// MatchedCluster holds info about a cluster that a query matched.
+type MatchedCluster struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Ipv4CidrRange is the CIDR range from which an IPv4 address should be assigned
+	// based on this cluster's vnet_config.
+	Ipv4CidrRange string `protobuf:"bytes,1,opt,name=ipv4_cidr_range,json=ipv4CidrRange,proto3" json:"ipv4_cidr_range,omitempty"`
+	// WebProxyAddr is the web proxy address of the root cluster that matched the
+	// query.
+	WebProxyAddr  string `protobuf:"bytes,2,opt,name=web_proxy_addr,json=webProxyAddr,proto3" json:"web_proxy_addr,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MatchedCluster) Reset() {
+	*x = MatchedCluster{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MatchedCluster) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MatchedCluster) ProtoMessage() {}
+
+func (x *MatchedCluster) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MatchedCluster.ProtoReflect.Descriptor instead.
+func (*MatchedCluster) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *MatchedCluster) GetIpv4CidrRange() string {
+	if x != nil {
+		return x.Ipv4CidrRange
+	}
+	return ""
+}
+
+func (x *MatchedCluster) GetWebProxyAddr() string {
+	if x != nil {
+		return x.WebProxyAddr
+	}
+	return ""
 }
 
 // AppInfo holds all necessary info for making connections to VNet TCP apps.
@@ -511,7 +709,7 @@ type AppInfo struct {
 	Cluster string `protobuf:"bytes,2,opt,name=cluster,proto3" json:"cluster,omitempty"`
 	// App is the app spec.
 	App *types.AppV3 `protobuf:"bytes,3,opt,name=app,proto3" json:"app,omitempty"`
-	// Ipv4Cidr_range is the CIDR range from which an IPv4 address should be
+	// Ipv4CidrRange is the CIDR range from which an IPv4 address should be
 	// assigned to the app.
 	Ipv4CidrRange string `protobuf:"bytes,4,opt,name=ipv4_cidr_range,json=ipv4CidrRange,proto3" json:"ipv4_cidr_range,omitempty"`
 	// DialOptions holds options that should be used when dialing the root cluster
@@ -523,7 +721,7 @@ type AppInfo struct {
 
 func (x *AppInfo) Reset() {
 	*x = AppInfo{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -535,7 +733,7 @@ func (x *AppInfo) String() string {
 func (*AppInfo) ProtoMessage() {}
 
 func (x *AppInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[9]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -548,7 +746,7 @@ func (x *AppInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppInfo.ProtoReflect.Descriptor instead.
 func (*AppInfo) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{9}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AppInfo) GetAppKey() *AppKey {
@@ -602,7 +800,7 @@ type AppKey struct {
 
 func (x *AppKey) Reset() {
 	*x = AppKey{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +812,7 @@ func (x *AppKey) String() string {
 func (*AppKey) ProtoMessage() {}
 
 func (x *AppKey) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[10]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +825,7 @@ func (x *AppKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppKey.ProtoReflect.Descriptor instead.
 func (*AppKey) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{10}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *AppKey) GetProfile() string {
@@ -671,7 +869,7 @@ type DialOptions struct {
 
 func (x *DialOptions) Reset() {
 	*x = DialOptions{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[11]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -683,7 +881,7 @@ func (x *DialOptions) String() string {
 func (*DialOptions) ProtoMessage() {}
 
 func (x *DialOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[11]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -696,7 +894,7 @@ func (x *DialOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialOptions.ProtoReflect.Descriptor instead.
 func (*DialOptions) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{11}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DialOptions) GetWebProxyAddr() string {
@@ -738,7 +936,7 @@ func (x *DialOptions) GetRootClusterCaCertPool() []byte {
 type ReissueAppCertRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// AppInfo contains info about the app, every ReissueAppCertRequest must
-	// include an app_info as returned from ResolveAppInfo.
+	// include an app_info as returned from ResolveFQDN.
 	AppInfo *AppInfo `protobuf:"bytes,1,opt,name=app_info,json=appInfo,proto3" json:"app_info,omitempty"`
 	// TargetPort is the TCP port to issue the cert for.
 	TargetPort    uint32 `protobuf:"varint,2,opt,name=target_port,json=targetPort,proto3" json:"target_port,omitempty"`
@@ -748,7 +946,7 @@ type ReissueAppCertRequest struct {
 
 func (x *ReissueAppCertRequest) Reset() {
 	*x = ReissueAppCertRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[12]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -760,7 +958,7 @@ func (x *ReissueAppCertRequest) String() string {
 func (*ReissueAppCertRequest) ProtoMessage() {}
 
 func (x *ReissueAppCertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[12]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -773,7 +971,7 @@ func (x *ReissueAppCertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReissueAppCertRequest.ProtoReflect.Descriptor instead.
 func (*ReissueAppCertRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{12}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ReissueAppCertRequest) GetAppInfo() *AppInfo {
@@ -801,7 +999,7 @@ type ReissueAppCertResponse struct {
 
 func (x *ReissueAppCertResponse) Reset() {
 	*x = ReissueAppCertResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[13]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -813,7 +1011,7 @@ func (x *ReissueAppCertResponse) String() string {
 func (*ReissueAppCertResponse) ProtoMessage() {}
 
 func (x *ReissueAppCertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[13]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -826,7 +1024,7 @@ func (x *ReissueAppCertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReissueAppCertResponse.ProtoReflect.Descriptor instead.
 func (*ReissueAppCertResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{13}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ReissueAppCertResponse) GetCert() []byte {
@@ -863,7 +1061,7 @@ type SignForAppRequest struct {
 
 func (x *SignForAppRequest) Reset() {
 	*x = SignForAppRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[14]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -875,7 +1073,7 @@ func (x *SignForAppRequest) String() string {
 func (*SignForAppRequest) ProtoMessage() {}
 
 func (x *SignForAppRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[14]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -888,7 +1086,7 @@ func (x *SignForAppRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignForAppRequest.ProtoReflect.Descriptor instead.
 func (*SignForAppRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{14}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SignForAppRequest) GetAppKey() *AppKey {
@@ -937,7 +1135,7 @@ type SignForAppResponse struct {
 
 func (x *SignForAppResponse) Reset() {
 	*x = SignForAppResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[15]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -949,7 +1147,7 @@ func (x *SignForAppResponse) String() string {
 func (*SignForAppResponse) ProtoMessage() {}
 
 func (x *SignForAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[15]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -962,7 +1160,7 @@ func (x *SignForAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignForAppResponse.ProtoReflect.Descriptor instead.
 func (*SignForAppResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{15}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SignForAppResponse) GetSignature() []byte {
@@ -983,7 +1181,7 @@ type OnNewConnectionRequest struct {
 
 func (x *OnNewConnectionRequest) Reset() {
 	*x = OnNewConnectionRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[16]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -995,7 +1193,7 @@ func (x *OnNewConnectionRequest) String() string {
 func (*OnNewConnectionRequest) ProtoMessage() {}
 
 func (x *OnNewConnectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[16]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1008,7 +1206,7 @@ func (x *OnNewConnectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnNewConnectionRequest.ProtoReflect.Descriptor instead.
 func (*OnNewConnectionRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{16}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *OnNewConnectionRequest) GetAppKey() *AppKey {
@@ -1027,7 +1225,7 @@ type OnNewConnectionResponse struct {
 
 func (x *OnNewConnectionResponse) Reset() {
 	*x = OnNewConnectionResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1039,7 +1237,7 @@ func (x *OnNewConnectionResponse) String() string {
 func (*OnNewConnectionResponse) ProtoMessage() {}
 
 func (x *OnNewConnectionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1052,7 +1250,7 @@ func (x *OnNewConnectionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnNewConnectionResponse.ProtoReflect.Descriptor instead.
 func (*OnNewConnectionResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{17}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{20}
 }
 
 // OnInvalidLocalPortRequest is a request for OnInvalidLocalPort.
@@ -1071,7 +1269,7 @@ type OnInvalidLocalPortRequest struct {
 
 func (x *OnInvalidLocalPortRequest) Reset() {
 	*x = OnInvalidLocalPortRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1083,7 +1281,7 @@ func (x *OnInvalidLocalPortRequest) String() string {
 func (*OnInvalidLocalPortRequest) ProtoMessage() {}
 
 func (x *OnInvalidLocalPortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1096,7 +1294,7 @@ func (x *OnInvalidLocalPortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnInvalidLocalPortRequest.ProtoReflect.Descriptor instead.
 func (*OnInvalidLocalPortRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{18}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *OnInvalidLocalPortRequest) GetAppInfo() *AppInfo {
@@ -1122,7 +1320,7 @@ type OnInvalidLocalPortResponse struct {
 
 func (x *OnInvalidLocalPortResponse) Reset() {
 	*x = OnInvalidLocalPortResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1134,7 +1332,7 @@ func (x *OnInvalidLocalPortResponse) String() string {
 func (*OnInvalidLocalPortResponse) ProtoMessage() {}
 
 func (x *OnInvalidLocalPortResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1147,7 +1345,7 @@ func (x *OnInvalidLocalPortResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnInvalidLocalPortResponse.ProtoReflect.Descriptor instead.
 func (*OnInvalidLocalPortResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{19}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{22}
 }
 
 // GetTargetOSConfigurationRequest is a request for the target host OS configuration.
@@ -1159,7 +1357,7 @@ type GetTargetOSConfigurationRequest struct {
 
 func (x *GetTargetOSConfigurationRequest) Reset() {
 	*x = GetTargetOSConfigurationRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1171,7 +1369,7 @@ func (x *GetTargetOSConfigurationRequest) String() string {
 func (*GetTargetOSConfigurationRequest) ProtoMessage() {}
 
 func (x *GetTargetOSConfigurationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1184,7 +1382,7 @@ func (x *GetTargetOSConfigurationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTargetOSConfigurationRequest.ProtoReflect.Descriptor instead.
 func (*GetTargetOSConfigurationRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{20}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{23}
 }
 
 // GetTargetOSConfigurationResponse is a response including the target host OS configuration.
@@ -1198,7 +1396,7 @@ type GetTargetOSConfigurationResponse struct {
 
 func (x *GetTargetOSConfigurationResponse) Reset() {
 	*x = GetTargetOSConfigurationResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1210,7 +1408,7 @@ func (x *GetTargetOSConfigurationResponse) String() string {
 func (*GetTargetOSConfigurationResponse) ProtoMessage() {}
 
 func (x *GetTargetOSConfigurationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1223,7 +1421,7 @@ func (x *GetTargetOSConfigurationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTargetOSConfigurationResponse.ProtoReflect.Descriptor instead.
 func (*GetTargetOSConfigurationResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{21}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetTargetOSConfigurationResponse) GetTargetOsConfiguration() *TargetOSConfiguration {
@@ -1253,7 +1451,7 @@ type TargetOSConfiguration struct {
 
 func (x *TargetOSConfiguration) Reset() {
 	*x = TargetOSConfiguration{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1265,7 +1463,7 @@ func (x *TargetOSConfiguration) String() string {
 func (*TargetOSConfiguration) ProtoMessage() {}
 
 func (x *TargetOSConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1278,7 +1476,7 @@ func (x *TargetOSConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetOSConfiguration.ProtoReflect.Descriptor instead.
 func (*TargetOSConfiguration) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{22}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TargetOSConfiguration) GetDnsZones() []string {
@@ -1313,11 +1511,20 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"ipv6Prefix\" \n" +
 	"\x1eReportNetworkStackInfoResponse\"\r\n" +
 	"\vPingRequest\"\x0e\n" +
-	"\fPingResponse\"+\n" +
-	"\x15ResolveAppInfoRequest\x12\x12\n" +
-	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\"R\n" +
-	"\x16ResolveAppInfoResponse\x128\n" +
-	"\bapp_info\x18\x01 \x01(\v2\x1d.teleport.lib.vnet.v1.AppInfoR\aappInfo\"\xe8\x01\n" +
+	"\fPingResponse\"(\n" +
+	"\x12ResolveFQDNRequest\x12\x12\n" +
+	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\"\x8d\x02\n" +
+	"\x13ResolveFQDNResponse\x12M\n" +
+	"\x0fmatched_tcp_app\x18\x01 \x01(\v2#.teleport.lib.vnet.v1.MatchedTCPAppH\x00R\rmatchedTcpApp\x12M\n" +
+	"\x0fmatched_web_app\x18\x02 \x01(\v2#.teleport.lib.vnet.v1.MatchedWebAppH\x00R\rmatchedWebApp\x12O\n" +
+	"\x0fmatched_cluster\x18\x03 \x01(\v2$.teleport.lib.vnet.v1.MatchedClusterH\x00R\x0ematchedClusterB\a\n" +
+	"\x05match\"I\n" +
+	"\rMatchedTCPApp\x128\n" +
+	"\bapp_info\x18\x01 \x01(\v2\x1d.teleport.lib.vnet.v1.AppInfoR\aappInfo\"\x0f\n" +
+	"\rMatchedWebApp\"^\n" +
+	"\x0eMatchedCluster\x12&\n" +
+	"\x0fipv4_cidr_range\x18\x01 \x01(\tR\ripv4CidrRange\x12$\n" +
+	"\x0eweb_proxy_addr\x18\x02 \x01(\tR\fwebProxyAddr\"\xe8\x01\n" +
 	"\aAppInfo\x125\n" +
 	"\aapp_key\x18\x01 \x01(\v2\x1c.teleport.lib.vnet.v1.AppKeyR\x06appKey\x12\x18\n" +
 	"\acluster\x18\x02 \x01(\tR\acluster\x12\x1e\n" +
@@ -1367,12 +1574,12 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x04Hash\x12\x14\n" +
 	"\x10HASH_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tHASH_NONE\x10\x01\x12\x0f\n" +
-	"\vHASH_SHA256\x10\x022\x9b\b\n" +
+	"\vHASH_SHA256\x10\x022\x92\b\n" +
 	"\x18ClientApplicationService\x12z\n" +
 	"\x13AuthenticateProcess\x120.teleport.lib.vnet.v1.AuthenticateProcessRequest\x1a1.teleport.lib.vnet.v1.AuthenticateProcessResponse\x12\x83\x01\n" +
 	"\x16ReportNetworkStackInfo\x123.teleport.lib.vnet.v1.ReportNetworkStackInfoRequest\x1a4.teleport.lib.vnet.v1.ReportNetworkStackInfoResponse\x12M\n" +
-	"\x04Ping\x12!.teleport.lib.vnet.v1.PingRequest\x1a\".teleport.lib.vnet.v1.PingResponse\x12k\n" +
-	"\x0eResolveAppInfo\x12+.teleport.lib.vnet.v1.ResolveAppInfoRequest\x1a,.teleport.lib.vnet.v1.ResolveAppInfoResponse\x12k\n" +
+	"\x04Ping\x12!.teleport.lib.vnet.v1.PingRequest\x1a\".teleport.lib.vnet.v1.PingResponse\x12b\n" +
+	"\vResolveFQDN\x12(.teleport.lib.vnet.v1.ResolveFQDNRequest\x1a).teleport.lib.vnet.v1.ResolveFQDNResponse\x12k\n" +
 	"\x0eReissueAppCert\x12+.teleport.lib.vnet.v1.ReissueAppCertRequest\x1a,.teleport.lib.vnet.v1.ReissueAppCertResponse\x12_\n" +
 	"\n" +
 	"SignForApp\x12'.teleport.lib.vnet.v1.SignForAppRequest\x1a(.teleport.lib.vnet.v1.SignForAppResponse\x12n\n" +
@@ -1393,7 +1600,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP() []
 }
 
 var file_teleport_lib_vnet_v1_client_application_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(Hash)(0),                                // 0: teleport.lib.vnet.v1.Hash
 	(*AuthenticateProcessRequest)(nil),       // 1: teleport.lib.vnet.v1.AuthenticateProcessRequest
@@ -1403,59 +1610,65 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(*ReportNetworkStackInfoResponse)(nil),   // 5: teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
 	(*PingRequest)(nil),                      // 6: teleport.lib.vnet.v1.PingRequest
 	(*PingResponse)(nil),                     // 7: teleport.lib.vnet.v1.PingResponse
-	(*ResolveAppInfoRequest)(nil),            // 8: teleport.lib.vnet.v1.ResolveAppInfoRequest
-	(*ResolveAppInfoResponse)(nil),           // 9: teleport.lib.vnet.v1.ResolveAppInfoResponse
-	(*AppInfo)(nil),                          // 10: teleport.lib.vnet.v1.AppInfo
-	(*AppKey)(nil),                           // 11: teleport.lib.vnet.v1.AppKey
-	(*DialOptions)(nil),                      // 12: teleport.lib.vnet.v1.DialOptions
-	(*ReissueAppCertRequest)(nil),            // 13: teleport.lib.vnet.v1.ReissueAppCertRequest
-	(*ReissueAppCertResponse)(nil),           // 14: teleport.lib.vnet.v1.ReissueAppCertResponse
-	(*SignForAppRequest)(nil),                // 15: teleport.lib.vnet.v1.SignForAppRequest
-	(*SignForAppResponse)(nil),               // 16: teleport.lib.vnet.v1.SignForAppResponse
-	(*OnNewConnectionRequest)(nil),           // 17: teleport.lib.vnet.v1.OnNewConnectionRequest
-	(*OnNewConnectionResponse)(nil),          // 18: teleport.lib.vnet.v1.OnNewConnectionResponse
-	(*OnInvalidLocalPortRequest)(nil),        // 19: teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	(*OnInvalidLocalPortResponse)(nil),       // 20: teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	(*GetTargetOSConfigurationRequest)(nil),  // 21: teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	(*GetTargetOSConfigurationResponse)(nil), // 22: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	(*TargetOSConfiguration)(nil),            // 23: teleport.lib.vnet.v1.TargetOSConfiguration
-	(*types.AppV3)(nil),                      // 24: types.AppV3
+	(*ResolveFQDNRequest)(nil),               // 8: teleport.lib.vnet.v1.ResolveFQDNRequest
+	(*ResolveFQDNResponse)(nil),              // 9: teleport.lib.vnet.v1.ResolveFQDNResponse
+	(*MatchedTCPApp)(nil),                    // 10: teleport.lib.vnet.v1.MatchedTCPApp
+	(*MatchedWebApp)(nil),                    // 11: teleport.lib.vnet.v1.MatchedWebApp
+	(*MatchedCluster)(nil),                   // 12: teleport.lib.vnet.v1.MatchedCluster
+	(*AppInfo)(nil),                          // 13: teleport.lib.vnet.v1.AppInfo
+	(*AppKey)(nil),                           // 14: teleport.lib.vnet.v1.AppKey
+	(*DialOptions)(nil),                      // 15: teleport.lib.vnet.v1.DialOptions
+	(*ReissueAppCertRequest)(nil),            // 16: teleport.lib.vnet.v1.ReissueAppCertRequest
+	(*ReissueAppCertResponse)(nil),           // 17: teleport.lib.vnet.v1.ReissueAppCertResponse
+	(*SignForAppRequest)(nil),                // 18: teleport.lib.vnet.v1.SignForAppRequest
+	(*SignForAppResponse)(nil),               // 19: teleport.lib.vnet.v1.SignForAppResponse
+	(*OnNewConnectionRequest)(nil),           // 20: teleport.lib.vnet.v1.OnNewConnectionRequest
+	(*OnNewConnectionResponse)(nil),          // 21: teleport.lib.vnet.v1.OnNewConnectionResponse
+	(*OnInvalidLocalPortRequest)(nil),        // 22: teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	(*OnInvalidLocalPortResponse)(nil),       // 23: teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	(*GetTargetOSConfigurationRequest)(nil),  // 24: teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	(*GetTargetOSConfigurationResponse)(nil), // 25: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	(*TargetOSConfiguration)(nil),            // 26: teleport.lib.vnet.v1.TargetOSConfiguration
+	(*types.AppV3)(nil),                      // 27: types.AppV3
 }
 var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32{
 	4,  // 0: teleport.lib.vnet.v1.ReportNetworkStackInfoRequest.network_stack_info:type_name -> teleport.lib.vnet.v1.NetworkStackInfo
-	10, // 1: teleport.lib.vnet.v1.ResolveAppInfoResponse.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	11, // 2: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	24, // 3: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
-	12, // 4: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
-	10, // 5: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	11, // 6: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	0,  // 7: teleport.lib.vnet.v1.SignForAppRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
-	11, // 8: teleport.lib.vnet.v1.OnNewConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	10, // 9: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	23, // 10: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
-	1,  // 11: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
-	3,  // 12: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
-	6,  // 13: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
-	8,  // 14: teleport.lib.vnet.v1.ClientApplicationService.ResolveAppInfo:input_type -> teleport.lib.vnet.v1.ResolveAppInfoRequest
-	13, // 15: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
-	15, // 16: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
-	17, // 17: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
-	19, // 18: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	21, // 19: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	2,  // 20: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
-	5,  // 21: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
-	7,  // 22: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
-	9,  // 23: teleport.lib.vnet.v1.ClientApplicationService.ResolveAppInfo:output_type -> teleport.lib.vnet.v1.ResolveAppInfoResponse
-	14, // 24: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
-	16, // 25: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
-	18, // 26: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
-	20, // 27: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	22, // 28: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	20, // [20:29] is the sub-list for method output_type
-	11, // [11:20] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	10, // 1: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_tcp_app:type_name -> teleport.lib.vnet.v1.MatchedTCPApp
+	11, // 2: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_web_app:type_name -> teleport.lib.vnet.v1.MatchedWebApp
+	12, // 3: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_cluster:type_name -> teleport.lib.vnet.v1.MatchedCluster
+	13, // 4: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	14, // 5: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	27, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
+	15, // 7: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
+	13, // 8: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	14, // 9: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	0,  // 10: teleport.lib.vnet.v1.SignForAppRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
+	14, // 11: teleport.lib.vnet.v1.OnNewConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	13, // 12: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	26, // 13: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
+	1,  // 14: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
+	3,  // 15: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
+	6,  // 16: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
+	8,  // 17: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
+	16, // 18: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
+	18, // 19: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
+	20, // 20: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
+	22, // 21: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	24, // 22: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	2,  // 23: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
+	5,  // 24: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
+	7,  // 25: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
+	9,  // 26: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
+	17, // 27: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
+	19, // 28: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
+	21, // 29: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
+	23, // 30: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	25, // 31: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	23, // [23:32] is the sub-list for method output_type
+	14, // [14:23] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_v1_client_application_service_proto_init() }
@@ -1463,14 +1676,19 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 	if File_teleport_lib_vnet_v1_client_application_service_proto != nil {
 		return
 	}
-	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[14].OneofWrappers = []any{}
+	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[8].OneofWrappers = []any{
+		(*ResolveFQDNResponse_MatchedTcpApp)(nil),
+		(*ResolveFQDNResponse_MatchedWebApp)(nil),
+		(*ResolveFQDNResponse_MatchedCluster)(nil),
+	}
+	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc), len(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   23,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
@@ -38,7 +38,7 @@ const (
 	ClientApplicationService_AuthenticateProcess_FullMethodName      = "/teleport.lib.vnet.v1.ClientApplicationService/AuthenticateProcess"
 	ClientApplicationService_ReportNetworkStackInfo_FullMethodName   = "/teleport.lib.vnet.v1.ClientApplicationService/ReportNetworkStackInfo"
 	ClientApplicationService_Ping_FullMethodName                     = "/teleport.lib.vnet.v1.ClientApplicationService/Ping"
-	ClientApplicationService_ResolveAppInfo_FullMethodName           = "/teleport.lib.vnet.v1.ClientApplicationService/ResolveAppInfo"
+	ClientApplicationService_ResolveFQDN_FullMethodName              = "/teleport.lib.vnet.v1.ClientApplicationService/ResolveFQDN"
 	ClientApplicationService_ReissueAppCert_FullMethodName           = "/teleport.lib.vnet.v1.ClientApplicationService/ReissueAppCert"
 	ClientApplicationService_SignForApp_FullMethodName               = "/teleport.lib.vnet.v1.ClientApplicationService/SignForApp"
 	ClientApplicationService_OnNewConnection_FullMethodName          = "/teleport.lib.vnet.v1.ClientApplicationService/OnNewConnection"
@@ -64,9 +64,9 @@ type ClientApplicationServiceClient interface {
 	// Ping is used by the admin process to regularly poll that the client
 	// application is still running.
 	Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingResponse, error)
-	// ResolveAppInfo returns info for the given app fqdn, or an error if the app
-	// is not present in any logged-in cluster.
-	ResolveAppInfo(ctx context.Context, in *ResolveAppInfoRequest, opts ...grpc.CallOption) (*ResolveAppInfoResponse, error)
+	// ResolveFQDN is called during DNS resolution to resolve a fully-qualified
+	// domain name to a target.
+	ResolveFQDN(ctx context.Context, in *ResolveFQDNRequest, opts ...grpc.CallOption) (*ResolveFQDNResponse, error)
 	// ReissueAppCert issues a new app cert.
 	ReissueAppCert(ctx context.Context, in *ReissueAppCertRequest, opts ...grpc.CallOption) (*ReissueAppCertResponse, error)
 	// SignForApp issues a signature with the private key associated with an x509
@@ -121,10 +121,10 @@ func (c *clientApplicationServiceClient) Ping(ctx context.Context, in *PingReque
 	return out, nil
 }
 
-func (c *clientApplicationServiceClient) ResolveAppInfo(ctx context.Context, in *ResolveAppInfoRequest, opts ...grpc.CallOption) (*ResolveAppInfoResponse, error) {
+func (c *clientApplicationServiceClient) ResolveFQDN(ctx context.Context, in *ResolveFQDNRequest, opts ...grpc.CallOption) (*ResolveFQDNResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ResolveAppInfoResponse)
-	err := c.cc.Invoke(ctx, ClientApplicationService_ResolveAppInfo_FullMethodName, in, out, cOpts...)
+	out := new(ResolveFQDNResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_ResolveFQDN_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -199,9 +199,9 @@ type ClientApplicationServiceServer interface {
 	// Ping is used by the admin process to regularly poll that the client
 	// application is still running.
 	Ping(context.Context, *PingRequest) (*PingResponse, error)
-	// ResolveAppInfo returns info for the given app fqdn, or an error if the app
-	// is not present in any logged-in cluster.
-	ResolveAppInfo(context.Context, *ResolveAppInfoRequest) (*ResolveAppInfoResponse, error)
+	// ResolveFQDN is called during DNS resolution to resolve a fully-qualified
+	// domain name to a target.
+	ResolveFQDN(context.Context, *ResolveFQDNRequest) (*ResolveFQDNResponse, error)
 	// ReissueAppCert issues a new app cert.
 	ReissueAppCert(context.Context, *ReissueAppCertRequest) (*ReissueAppCertResponse, error)
 	// SignForApp issues a signature with the private key associated with an x509
@@ -235,8 +235,8 @@ func (UnimplementedClientApplicationServiceServer) ReportNetworkStackInfo(contex
 func (UnimplementedClientApplicationServiceServer) Ping(context.Context, *PingRequest) (*PingResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
 }
-func (UnimplementedClientApplicationServiceServer) ResolveAppInfo(context.Context, *ResolveAppInfoRequest) (*ResolveAppInfoResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ResolveAppInfo not implemented")
+func (UnimplementedClientApplicationServiceServer) ResolveFQDN(context.Context, *ResolveFQDNRequest) (*ResolveFQDNResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResolveFQDN not implemented")
 }
 func (UnimplementedClientApplicationServiceServer) ReissueAppCert(context.Context, *ReissueAppCertRequest) (*ReissueAppCertResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ReissueAppCert not implemented")
@@ -329,20 +329,20 @@ func _ClientApplicationService_Ping_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ClientApplicationService_ResolveAppInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ResolveAppInfoRequest)
+func _ClientApplicationService_ResolveFQDN_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResolveFQDNRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ClientApplicationServiceServer).ResolveAppInfo(ctx, in)
+		return srv.(ClientApplicationServiceServer).ResolveFQDN(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: ClientApplicationService_ResolveAppInfo_FullMethodName,
+		FullMethod: ClientApplicationService_ResolveFQDN_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClientApplicationServiceServer).ResolveAppInfo(ctx, req.(*ResolveAppInfoRequest))
+		return srv.(ClientApplicationServiceServer).ResolveFQDN(ctx, req.(*ResolveFQDNRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -457,8 +457,8 @@ var ClientApplicationService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _ClientApplicationService_Ping_Handler,
 		},
 		{
-			MethodName: "ResolveAppInfo",
-			Handler:    _ClientApplicationService_ResolveAppInfo_Handler,
+			MethodName: "ResolveFQDN",
+			Handler:    _ClientApplicationService_ResolveFQDN_Handler,
 		},
 		{
 			MethodName: "ReissueAppCert",

--- a/lib/vnet/admin_process_common.go
+++ b/lib/vnet/admin_process_common.go
@@ -1,0 +1,42 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+func newNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
+	appProvider := newRemoteAppProvider(clt)
+	tcpHandlerResolver := newTCPHandlerResolver(&tcpHandlerResolverConfig{
+		fqdnResolver: clt,
+		appProvider:  appProvider,
+		clock:        clockwork.NewRealClock(),
+	})
+	ipv6Prefix, err := newIPv6Prefix()
+	if err != nil {
+		return nil, trace.Wrap(err, "creating new IPv6 prefix")
+	}
+	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
+	return &networkStackConfig{
+		tunDevice:          tun,
+		ipv6Prefix:         ipv6Prefix,
+		dnsIPv6:            dnsIPv6,
+		tcpHandlerResolver: tcpHandlerResolver,
+	}, nil
+}

--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/errgroup"
 	"golang.zx2c4.com/wireguard/tun"
 
@@ -114,22 +113,6 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 		}
 	})
 	return trace.Wrap(g.Wait(), "running VNet admin process")
-}
-
-func newNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
-	appProvider := newRemoteAppProvider(clt)
-	appResolver := newTCPAppResolver(appProvider, clockwork.NewRealClock())
-	ipv6Prefix, err := newIPv6Prefix()
-	if err != nil {
-		return nil, trace.Wrap(err, "creating new IPv6 prefix")
-	}
-	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
-	return &networkStackConfig{
-		tunDevice:          tun,
-		ipv6Prefix:         ipv6Prefix,
-		dnsIPv6:            dnsIPv6,
-		tcpHandlerResolver: appResolver,
-	}, nil
 }
 
 func createTUNDevice(ctx context.Context) (tun.Device, string, error) {

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/tun"
@@ -155,22 +154,6 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		}
 	})
 	return trace.Wrap(g.Wait(), "running VNet admin process")
-}
-
-func newNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
-	appProvider := newRemoteAppProvider(clt)
-	appResolver := newTCPAppResolver(appProvider, clockwork.NewRealClock())
-	ipv6Prefix, err := newIPv6Prefix()
-	if err != nil {
-		return nil, trace.Wrap(err, "creating new IPv6 prefix")
-	}
-	dnsIPv6 := ipv6WithSuffix(ipv6Prefix, []byte{2})
-	return &networkStackConfig{
-		tunDevice:          tun,
-		ipv6Prefix:         ipv6Prefix,
-		dnsIPv6:            dnsIPv6,
-		tcpHandlerResolver: appResolver,
-	}, nil
 }
 
 func authenticateUserProcess(ctx context.Context, clt *clientApplicationServiceClient, userSID string) error {

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -56,6 +56,7 @@ type clientApplicationService struct {
 }
 
 type clientApplicationServiceConfig struct {
+	localResolver         *localFQDNResolver
 	localAppProvider      *localAppProvider
 	localOSConfigProvider *LocalOSConfigProvider
 }
@@ -99,15 +100,10 @@ func (s *clientApplicationService) Ping(ctx context.Context, req *vnetv1.PingReq
 	return &vnetv1.PingResponse{}, nil
 }
 
-// ResolveAppInfo implements [vnetv1.ClientApplicationServiceServer.ResolveAppInfo].
-func (s *clientApplicationService) ResolveAppInfo(ctx context.Context, req *vnetv1.ResolveAppInfoRequest) (*vnetv1.ResolveAppInfoResponse, error) {
-	appInfo, err := s.cfg.localAppProvider.ResolveAppInfo(ctx, req.GetFqdn())
-	if err != nil {
-		return nil, trace.Wrap(err, "resolving app info")
-	}
-	return &vnetv1.ResolveAppInfoResponse{
-		AppInfo: appInfo,
-	}, nil
+// ResolveFQDN implements [vnetv1.ClientApplicationServiceServer.ResolveFQDN].
+func (s *clientApplicationService) ResolveFQDN(ctx context.Context, req *vnetv1.ResolveFQDNRequest) (*vnetv1.ResolveFQDNResponse, error) {
+	resp, err := s.cfg.localResolver.ResolveFQDN(ctx, req.GetFqdn())
+	return resp, trace.Wrap(err, "resolving FQDN")
 }
 
 // ReissueAppCert implements [vnetv1.ClientApplicationServiceServer.ReissueAppCert].

--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -29,7 +29,7 @@ import (
 )
 
 // clientApplicationServiceClient is a gRPC client for the client application
-// service. This client is used in the Windows admin service to make requests to
+// service. This client is used in the VNet admin process to make requests to
 // the VNet client application.
 type clientApplicationServiceClient struct {
 	clt  vnetv1.ClientApplicationServiceClient
@@ -92,21 +92,20 @@ func (c *clientApplicationServiceClient) Ping(ctx context.Context) error {
 	return nil
 }
 
-// ResolveAppInfo resolves fqdn to a [*vnetv1.AppInfo], or returns an error if
-// no matching app is found.
-func (c *clientApplicationServiceClient) ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error) {
-	resp, err := c.clt.ResolveAppInfo(ctx, &vnetv1.ResolveAppInfoRequest{
+// ResolveFQDN resolves a query for a fully-qualified domain name to a target.
+func (c *clientApplicationServiceClient) ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
+	resp, err := c.clt.ResolveFQDN(ctx, &vnetv1.ResolveFQDNRequest{
 		Fqdn: fqdn,
 	})
 	// Convert NotFound errors to errNoTCPHandler, which is what the network
-	// stack is looking for. Avoid wrapping, no need to collect a stack trace.
+	// stack is looking for.
 	if trace.IsNotFound(err) {
 		return nil, errNoTCPHandler
 	}
 	if err != nil {
-		return nil, trace.Wrap(err, "calling ResolveAppInfo rpc")
+		return nil, trace.Wrap(err, "calling ResolveFQDN rpc")
 	}
-	return resp.GetAppInfo(), nil
+	return resp, nil
 }
 
 // ReissueAppCert issues a new certificate for the requested app.

--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -19,15 +19,7 @@ package vnet
 import (
 	"context"
 	"crypto/tls"
-	"errors"
-	"fmt"
-	"strings"
 
-	"github.com/gravitational/trace"
-
-	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
@@ -40,153 +32,13 @@ type localAppProvider struct {
 }
 
 type localAppProviderConfig struct {
-	clientApplication  ClientApplication
-	clusterConfigCache *ClusterConfigCache
+	clientApplication ClientApplication
 }
 
 func newLocalAppProvider(cfg *localAppProviderConfig) *localAppProvider {
 	return &localAppProvider{
 		cfg: cfg,
 	}
-}
-
-// ResolveAppInfo implements [appProvider.ResolveAppInfo].
-func (p *localAppProvider) ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error) {
-	profileNames, err := p.cfg.clientApplication.ListProfiles()
-	if err != nil {
-		return nil, trace.Wrap(err, "listing profiles")
-	}
-	for _, profileName := range profileNames {
-		if fqdn == fullyQualify(profileName) {
-			// This is a query for the proxy address, which we'll never want to handle.
-			// The DNS request must be forwarded upstream so that the VNet
-			// process can always dial the proxy address without recursively
-			// querying the VNet DNS nameserver.
-			return nil, errNoTCPHandler
-		}
-
-		clusterClient, err := p.clusterClientForAppFQDN(ctx, profileName, fqdn)
-		if err != nil {
-			if errors.Is(err, errNoMatch) {
-				continue
-			}
-			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Log
-			// the error but don't return it so that DNS resolution will be forwarded upstream instead of
-			// failing, to avoid breaking e.g. web app access (we don't know if this is a web or TCP app yet
-			// because we can't log in).
-			log.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
-			continue
-		}
-
-		leafClusterName := ""
-		clusterName := clusterClient.ClusterName()
-		if clusterName != "" && clusterName != clusterClient.RootClusterName() {
-			leafClusterName = clusterName
-		}
-
-		return p.resolveAppInfoForCluster(ctx, clusterClient, profileName, leafClusterName, fqdn)
-	}
-	// fqdn did not match any profile, forward the request upstream.
-	return nil, errNoTCPHandler
-}
-
-func (p *localAppProvider) clusterClientForAppFQDN(ctx context.Context, profileName, fqdn string) (ClusterClient, error) {
-	rootClient, err := p.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
-	if err != nil {
-		log.ErrorContext(ctx, "Failed to get root cluster client, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
-	}
-
-	if isDescendantSubdomain(fqdn, profileName) {
-		// The queried app fqdn is a subdomain of this cluster proxy address.
-		return rootClient, nil
-	}
-
-	leafClusters, err := getLeafClusters(ctx, rootClient)
-	if err != nil {
-		// Good chance we're here because the user is not logged in to the profile.
-		log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
-	}
-
-	// Prefix with an empty string to represent the root cluster.
-	allClusters := append([]string{""}, leafClusters...)
-	for _, leafClusterName := range allClusters {
-		clusterClient, err := p.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to get cluster client, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-
-		clusterConfig, err := p.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to get VNet config, apps in the cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-		for _, zone := range clusterConfig.DNSZones {
-			if isDescendantSubdomain(fqdn, zone) {
-				return clusterClient, nil
-			}
-		}
-	}
-	return nil, errNoMatch
-}
-
-var errNoMatch = errors.New("cluster does not match queried FQDN")
-
-func (p *localAppProvider) resolveAppInfoForCluster(
-	ctx context.Context,
-	clusterClient ClusterClient,
-	profileName, leafClusterName, fqdn string,
-) (*vnetv1.AppInfo, error) {
-	log := log.With("profile", profileName, "leaf_cluster", leafClusterName, "fqdn", fqdn)
-	// An app public_addr could technically be full-qualified or not, match either way.
-	expr := fmt.Sprintf(`(resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s") && hasPrefix(resource.spec.uri, "tcp://")`,
-		strings.TrimSuffix(fqdn, "."), fqdn)
-	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clusterClient.CurrentCluster(), &proto.ListResourcesRequest{
-		ResourceType:        types.KindAppServer,
-		PredicateExpression: expr,
-		Limit:               1,
-	})
-	if err != nil {
-		// Don't return an unexpected error so we can try to find the app in different clusters or forward the
-		// request upstream.
-		log.InfoContext(ctx, "Failed to list application servers", "error", err)
-		return nil, errNoTCPHandler
-	}
-	if len(resp.Resources) == 0 {
-		// Didn't find any matching app, forward the request upstream.
-		return nil, errNoTCPHandler
-	}
-	// At this point we have found a matching app in the cluster, any error is
-	// unexpected and is preventing access to the app and should be returned to
-	// the user.
-	app, ok := resp.Resources[0].GetApp().(*types.AppV3)
-	if !ok {
-		return nil, trace.BadParameter("expected *types.AppV3, got %T", resp.Resources[0].GetApp())
-	}
-	clusterConfig, err := p.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-	if err != nil {
-		log.ErrorContext(ctx, "Failed to get cluster VNet config for matching app", "error", err)
-		return nil, trace.Wrap(err, "getting cached cluster VNet config for matching app")
-	}
-	dialOpts, err := p.cfg.clientApplication.GetDialOptions(ctx, profileName)
-	if err != nil {
-		log.ErrorContext(ctx, "Failed to get cluster dial options", "error", err)
-		return nil, trace.Wrap(err, "getting dial options for matching app")
-	}
-	appInfo := &vnetv1.AppInfo{
-		AppKey: &vnetv1.AppKey{
-			Profile:     profileName,
-			LeafCluster: leafClusterName,
-			Name:        app.GetName(),
-		},
-		Cluster:       clusterClient.ClusterName(),
-		App:           app,
-		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
-		DialOptions:   dialOpts,
-	}
-	return appInfo, nil
 }
 
 // ReissueAppCert implements [appProvider.ReissueAppCert].

--- a/lib/vnet/local_fqdn_resolver.go
+++ b/lib/vnet/local_fqdn_resolver.go
@@ -1,0 +1,312 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// localFQDNResolver implements [fqdnResolver] locally in the VNet user process.
+// The ResolveFQDN method gets exposed by [clientApplicationService] so that
+// [fqdnResolver] can also be implemented remotely by
+// [clientApplicationServiceClient].
+type localFQDNResolver struct {
+	cfg *localFQDNResolverConfig
+}
+
+type localFQDNResolverConfig struct {
+	clientApplication  ClientApplication
+	clusterConfigCache *ClusterConfigCache
+}
+
+func newLocalFQDNResolver(cfg *localFQDNResolverConfig) *localFQDNResolver {
+	return &localFQDNResolver{
+		cfg: cfg,
+	}
+}
+
+// ResolveFQDN implements [fqdnResolver.ResolveFQDN] by resolving name queries
+// to possible VNet matches. It returns [errNoTCPHandler] if VNet should not
+// handle this address and DNS queries should be forwarded upstream.
+func (r *localFQDNResolver) ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
+	profileNames, err := r.cfg.clientApplication.ListProfiles()
+	if err != nil {
+		return nil, trace.Wrap(err, "listing profiles")
+	}
+	for _, profileName := range profileNames {
+		if fqdn == fullyQualify(profileName) {
+			// This is a query for the proxy address, which we'll never want to handle.
+			// The DNS request must be forwarded upstream so that the VNet
+			// process can always dial the proxy address without recursively
+			// querying the VNet DNS nameserver.
+			return nil, errNoTCPHandler
+		}
+	}
+	resp, err := r.tryResolveApp(ctx, profileNames, fqdn)
+	switch {
+	case err == nil:
+		return resp, nil
+	case !errors.Is(err, errNoMatch):
+		return nil, err
+	}
+	resp, err = r.tryResolveSSH(ctx, profileNames, fqdn)
+	switch {
+	case err == nil:
+		return resp, nil
+	case !errors.Is(err, errNoMatch):
+		return nil, err
+	}
+	return nil, errNoTCPHandler
+}
+
+var errNoMatch = errors.New("no match for queried FQDN")
+
+func (r *localFQDNResolver) tryResolveApp(ctx context.Context, profileNames []string, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
+	for _, profileName := range profileNames {
+		clusterClient, err := r.clusterClientForAppFQDN(ctx, profileName, fqdn)
+		if err != nil {
+			if errors.Is(err, errNoMatch) {
+				continue
+			}
+			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Log
+			// the error but don't return it so that DNS resolution will be forwarded upstream instead of
+			// failing, to avoid breaking e.g. web app access (we don't know if this is a web or TCP app yet
+			// because we can't log in).
+			log.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
+			continue
+		}
+
+		leafClusterName := ""
+		clusterName := clusterClient.ClusterName()
+		if clusterName != "" && clusterName != clusterClient.RootClusterName() {
+			leafClusterName = clusterName
+		}
+
+		return r.resolveAppInfoForCluster(ctx, clusterClient, profileName, leafClusterName, fqdn)
+	}
+	return nil, errNoMatch
+}
+
+func (r *localFQDNResolver) clusterClientForAppFQDN(ctx context.Context, profileName, fqdn string) (ClusterClient, error) {
+	rootClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get root cluster client, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
+		return nil, errNoMatch
+	}
+
+	if isDescendantSubdomain(fqdn, profileName) {
+		// The queried FQDN is a subdomain of this cluster proxy address.
+		return rootClient, nil
+	}
+
+	leafClusters, err := getLeafClusters(ctx, rootClient)
+	if err != nil {
+		// Good chance we're here because the user is not logged in to the profile.
+		log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
+		return nil, errNoMatch
+	}
+
+	// Prefix with an empty string to represent the root cluster.
+	allClusters := append([]string{""}, leafClusters...)
+	for _, leafClusterName := range allClusters {
+		clusterClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get cluster client, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+
+		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get VNet config, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+		for _, zone := range clusterConfig.DNSZones {
+			if isDescendantSubdomain(fqdn, zone) {
+				return clusterClient, nil
+			}
+		}
+	}
+	return nil, errNoMatch
+}
+
+func (r *localFQDNResolver) resolveAppInfoForCluster(
+	ctx context.Context,
+	clusterClient ClusterClient,
+	profileName, leafClusterName, fqdn string,
+) (*vnetv1.ResolveFQDNResponse, error) {
+	log := log.With("profile", profileName, "leaf_cluster", leafClusterName, "fqdn", fqdn)
+	// An app public_addr could technically be fully-qualified or not, match either way.
+	expr := fmt.Sprintf(`resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s"`,
+		strings.TrimSuffix(fqdn, "."), fqdn)
+	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clusterClient.CurrentCluster(), &proto.ListResourcesRequest{
+		ResourceType:        types.KindAppServer,
+		PredicateExpression: expr,
+		Limit:               1,
+	})
+	if err != nil {
+		// Don't return an unexpected error so we can try to find the app in different clusters or forward the
+		// request upstream.
+		log.InfoContext(ctx, "Failed to list application servers", "error", err)
+		return nil, errNoMatch
+	}
+	if len(resp.Resources) == 0 {
+		// Didn't find any matching app, forward the request upstream.
+		return nil, errNoMatch
+	}
+	// At this point we have found a matching app in the cluster, any error is
+	// unexpected and is preventing access to the app and should be returned to
+	// the user.
+	app, ok := resp.Resources[0].GetApp().(*types.AppV3)
+	if !ok {
+		return nil, trace.BadParameter("expected *types.AppV3, got %T", resp.Resources[0].GetApp())
+	}
+	if !app.IsTCP() {
+		log.InfoContext(ctx, "Query matched a web app")
+		// If not a TCP app this must be a web app and we can return early.
+		return &vnetv1.ResolveFQDNResponse{
+			Match: &vnetv1.ResolveFQDNResponse_MatchedWebApp{
+				MatchedWebApp: &vnetv1.MatchedWebApp{},
+			},
+		}, nil
+	}
+	clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get cluster VNet config for matching app", "error", err)
+		return nil, trace.Wrap(err, "getting cached cluster VNet config for matching app")
+	}
+	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, profileName)
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get cluster dial options", "error", err)
+		return nil, trace.Wrap(err, "getting dial options for matching app")
+	}
+	log.InfoContext(ctx, "Query matched a TCP app")
+	appInfo := &vnetv1.AppInfo{
+		AppKey: &vnetv1.AppKey{
+			Profile:     profileName,
+			LeafCluster: leafClusterName,
+			Name:        app.GetName(),
+		},
+		Cluster:       clusterClient.ClusterName(),
+		App:           app,
+		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+		DialOptions:   dialOpts,
+	}
+	return &vnetv1.ResolveFQDNResponse{
+		Match: &vnetv1.ResolveFQDNResponse_MatchedTcpApp{
+			MatchedTcpApp: &vnetv1.MatchedTCPApp{
+				AppInfo: appInfo,
+			},
+		},
+	}, nil
+}
+
+// VNet SSH handles SSH hostnames matching "<hostname>.<cluster_name>." or
+// "<hostname>.<leaf_cluster_name>.<cluster_name>.". tryResolveSSH checks if
+// fqdn matches that pattern for any logged-in cluster and if so returns a
+// match. We never actually query for whether or not a matching SSH node exists,
+// we just attempt to dial it when the client connects to the assigned IP.
+func (r *localFQDNResolver) tryResolveSSH(ctx context.Context, profileNames []string, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
+	for _, profileName := range profileNames {
+		log := log.With("profile", profileName)
+		rootClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get root cluster client, SSH nodes in this cluster will not be resolved", "error", err)
+			continue
+		}
+		rootClusterName := rootClient.ClusterName()
+		if !isDescendantSubdomain(fqdn, rootClusterName) {
+			continue
+		}
+		leafClusters, err := getLeafClusters(ctx, rootClient)
+		if err != nil {
+			// Good chance we're here because the user is not logged in to the profile.
+			log.ErrorContext(ctx, "Failed to list leaf clusters, SSH nodes in this cluster will not be resolved", "error", err)
+			return nil, errNoMatch
+		}
+		rootDialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, profileName)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get cluster dial options, SSH nodes in this cluster will not be resolved", "error", err)
+			return nil, errNoMatch
+		}
+		for _, leafClusterName := range leafClusters {
+			log := log.With("leaf_cluster", leafClusterName)
+			if !isDescendantSubdomain(fqdn, leafClusterName+"."+rootClusterName) {
+				continue
+			}
+			leafClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
+			if err != nil {
+				log.ErrorContext(ctx, "Failed to get cluster client, SSH nodes in this cluster will not be resolved", "error", err)
+				return nil, errNoMatch
+			}
+			clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, leafClient)
+			if err != nil {
+				log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)
+				return nil, errNoMatch
+			}
+			log.InfoContext(ctx, "Query matched a leaf cluster subdomain and my later resolve to an app or SSH node")
+			return &vnetv1.ResolveFQDNResponse{
+				Match: &vnetv1.ResolveFQDNResponse_MatchedCluster{
+					MatchedCluster: &vnetv1.MatchedCluster{
+						WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
+						Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+					},
+				},
+			}, nil
+		}
+		// If it didn't match any leaf cluster assume it matches the root
+		// cluster.
+		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, rootClient)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)
+			return nil, errNoMatch
+		}
+		log.InfoContext(ctx, "Query matched a root cluster subdomain and may later resolve to an app or SSH node")
+		return &vnetv1.ResolveFQDNResponse{
+			Match: &vnetv1.ResolveFQDNResponse_MatchedCluster{
+				MatchedCluster: &vnetv1.MatchedCluster{
+					WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
+					Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+				},
+			},
+		}, nil
+	}
+	return nil, errNoMatch
+}
+
+// isDescendantSubdomain checks if fqdn is a subdomain of zone.
+func isDescendantSubdomain(fqdn, zone string) bool {
+	return strings.HasSuffix(fqdn, "."+fullyQualify(zone))
+}
+
+// fullyQualify returns a fully-qualified domain name from [domain].
+// Fully-qualified domain names always end with a ".".
+func fullyQualify(domain string) string {
+	if strings.HasSuffix(domain, ".") {
+		return domain
+	}
+	return domain + "."
+}

--- a/lib/vnet/local_fqdn_resolver.go
+++ b/lib/vnet/local_fqdn_resolver.go
@@ -66,6 +66,10 @@ func (r *localFQDNResolver) ResolveFQDN(ctx context.Context, fqdn string) (*vnet
 			return nil, errNoTCPHandler
 		}
 	}
+	// First try to resolve a matching TCP or web app. A matching app is more
+	// specific than the cluster match we do for SSH, and checking for a
+	// matching app first maintains backward compatibility because apps were
+	// supported before SSH.
 	resp, err := r.tryResolveApp(ctx, profileNames, fqdn)
 	switch {
 	case err == nil:
@@ -267,7 +271,7 @@ func (r *localFQDNResolver) tryResolveSSH(ctx context.Context, profileNames []st
 				log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)
 				return nil, errNoMatch
 			}
-			log.InfoContext(ctx, "Query matched a leaf cluster subdomain and my later resolve to an app or SSH node")
+			log.InfoContext(ctx, "Query matched a leaf cluster subdomain and may later resolve to an app or SSH node")
 			return &vnetv1.ResolveFQDNResponse{
 				Match: &vnetv1.ResolveFQDNResponse_MatchedCluster{
 					MatchedCluster: &vnetv1.MatchedCluster{

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -63,9 +63,9 @@ type networkStackConfig struct {
 	ipv6Prefix tcpip.Address
 	// dnsIPv6 is the IPv6 address on which to host the DNS server. It must be under IPv6Prefix.
 	dnsIPv6 tcpip.Address
-	// tcpHandlerResolver will be used to resolve all DNS queries that may be valid public addresses for
-	// Teleport apps.
-	tcpHandlerResolver tcpHandlerResolver
+	// tcpHandlerResolver will be used to resolve all DNS queries that VNet may
+	// need to handle.
+	tcpHandlerResolver *tcpHandlerResolver
 
 	// upstreamNameserverSource, if set, overrides the default OS UpstreamNameserverSource which provides the
 	// IP addresses that unmatched DNS queries should be forwarded to. It is used in tests.
@@ -86,25 +86,6 @@ func (c *networkStackConfig) checkAndSetDefaults() error {
 	return nil
 }
 
-// tcpHandlerResolver describes a type that can resolve a fully-qualified domain
-// name to a tcpHandlerSpec that defines the CIDR range to assign an IP to
-// that handler from, and a handler for all future connections to that IP
-// address.
-//
-// Implementations beware - an FQDN always ends with a '.'.
-type tcpHandlerResolver interface {
-	// resolveTCPHandler decides if fqdn should match a TCP handler.
-	//
-	// If fqdn matches a Teleport-managed TCP app it must return a
-	// tcpHandlerSpec defining the CIDR range to assign an IP from, and a
-	// handler for future connections to any assigned IPs.
-	//
-	// If fqdn does not match it must return errNoTCPHandler. Avoid using
-	// [trace.Wrap] on errNoTCPHandler to prevent collecting a full stack trace
-	// on every unhandled query.
-	resolveTCPHandler(ctx context.Context, fqdn string) (*tcpHandlerSpec, error)
-}
-
 // errNoTCPHandler should be returned by tcpHandlerResolvers when no handler
 // matches the FQDN.
 //
@@ -122,7 +103,7 @@ type tcpHandlerSpec struct {
 
 // tcpHandler defines the behavior for handling TCP connections from VNet.
 //
-// Implementations should attempt to dial the target application and return any errors before calling
+// Implementations should attempt to dial the target and return any errors before calling
 // [connector] to complete the TCP handshake and get the TCP conn. This is so that clients will see that the
 // TCP connection was refused, instead of seeing a successful TCP dial that is immediately closed.
 type tcpHandler interface {
@@ -177,9 +158,9 @@ type networkStack struct {
 	// ipv6Prefix holds the 96-bit prefix that will be used for all IPv6 addresses assigned in the VNet.
 	ipv6Prefix tcpip.Address
 
-	// tcpHandlerResolver resolves app FQDNs to a TCP handler that will be used to handle all future TCP
+	// tcpHandlerResolver resolves FQDNs to a TCP handler that will be used to handle all future TCP
 	// connections to IP addresses that will be assigned to that FQDN.
-	tcpHandlerResolver tcpHandlerResolver
+	tcpHandlerResolver *tcpHandlerResolver
 	// resolveHandlerGroup is a [singleflight.Group] that will be used to avoid resolving the same FQDN
 	// multiple times concurrently. Every call to [tcpHandlerResolver.ResolveTCPHandler] will be wrapped by
 	// this. The key will be the FQDN.
@@ -202,14 +183,14 @@ type state struct {
 	// mu is a single mutex that protects the whole state struct. This could be optimized as necessary.
 	mu sync.RWMutex
 
-	// Each app gets assigned both an IPv4 address and an IPv6 address, where the 4-bit suffix of the IPv6
-	// matches the IPv4 address exactly. All per-app state references the smaller IPv4 address only and
+	// Each FQDN gets assigned both an IPv4 address and an IPv6 address, where the 4-bit suffix of the IPv6
+	// matches the IPv4 address exactly. All per-FQDN state references the smaller IPv4 address only and
 	// lookups based on an IPv6 address can use the 4-byte suffix.
 
 	// tcpHandlers holds the map of IP addresses to assigned TCP handlers.
 	tcpHandlers map[ipv4]tcpHandler
-	// appIPs holds the map of app FQDNs to their assigned IP address, it like a reverse map of [tcpHandlers].
-	appIPs map[string]ipv4
+	// assignedIPs holds the map of app FQDNs to their assigned IP address, it's a reverse map of [tcpHandlers].
+	assignedIPs map[string]ipv4
 
 	// udpHandlers holds the map of IP addresses to assigned UDP handlers.
 	udpHandlers map[ipv4]udpHandler
@@ -219,7 +200,7 @@ func newState() state {
 	return state{
 		tcpHandlers: make(map[ipv4]tcpHandler),
 		udpHandlers: make(map[ipv4]udpHandler),
-		appIPs:      make(map[string]ipv4),
+		assignedIPs: make(map[string]ipv4),
 	}
 }
 
@@ -469,7 +450,7 @@ func (ns *networkStack) assignTCPHandler(handlerSpec *tcpHandlerSpec, fqdn strin
 	}
 
 	ns.state.tcpHandlers[ip] = handlerSpec.tcpHandler
-	ns.state.appIPs[fqdn] = ip
+	ns.state.assignedIPs[fqdn] = ip
 
 	if err := ns.addProtocolAddress(tcpip.AddrFrom4(ip.asArray())); err != nil {
 		return 0, trace.Wrap(err)
@@ -566,24 +547,25 @@ func (ns *networkStack) ResolveA(ctx context.Context, fqdn string) (dns.Result, 
 	// Do the actual resolution within a [singleflight.Group] keyed by [fqdn] to avoid concurrent requests to
 	// resolve an FQDN and then assign an address to it.
 	resultAny, err, _ := ns.resolveHandlerGroup.Do(fqdn, func() (any, error) {
-		// If we've already assigned an IP address to this app, resolve to it.
-		if ip, ok := ns.appIPv4(fqdn); ok {
+		// If we've already assigned an IP address to this fqdn, resolve to it.
+		if ip, ok := ns.assignedIPv4(fqdn); ok {
 			return dns.Result{
 				A: ip.asArray(),
 			}, nil
 		}
 
-		// If fqdn is a Teleport-managed app, create a new handler for it.
+		// If fqdn matches an address that should be handled by VNet, create a
+		// new handler for it.
 		handlerSpec, err := ns.tcpHandlerResolver.resolveTCPHandler(ctx, fqdn)
 		if err != nil {
 			if errors.Is(err, errNoTCPHandler) {
-				// Did not find any known app, forward the DNS request upstream.
+				// Did not find any match, forward the DNS request upstream.
 				return dns.Result{}, nil
 			}
 			return dns.Result{}, trace.Wrap(err, "resolving TCP handler for fqdn %q", fqdn)
 		}
 
-		// Assign an unused IP address to this app's handler.
+		// Assign an unused IP address to this handler.
 		ip, err := ns.assignTCPHandler(handlerSpec, fqdn)
 		if err != nil {
 			return dns.Result{}, trace.Wrap(err, "assigning address to handler for %q", fqdn)
@@ -613,10 +595,10 @@ func (ns *networkStack) ResolveAAAA(ctx context.Context, fqdn string) (dns.Resul
 	return result, nil
 }
 
-func (ns *networkStack) appIPv4(fqdn string) (ipv4, bool) {
+func (ns *networkStack) assignedIPv4(fqdn string) (ipv4, bool) {
 	ns.state.mu.RLock()
 	defer ns.state.mu.RUnlock()
-	ipv4, ok := ns.state.appIPs[fqdn]
+	ipv4, ok := ns.state.assignedIPs[fqdn]
 	return ipv4, ok
 }
 

--- a/lib/vnet/remote_app_provider.go
+++ b/lib/vnet/remote_app_provider.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -30,8 +29,8 @@ import (
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
-// remoteAppProvider implements appProvider when the client application is
-// available over gRPC.
+// remoteAppProvider implements [appProvider] in the VNet admin process when the
+// client application is available remotely over gRPC.
 type remoteAppProvider struct {
 	clt *clientApplicationServiceClient
 }
@@ -40,16 +39,6 @@ func newRemoteAppProvider(clt *clientApplicationServiceClient) *remoteAppProvide
 	return &remoteAppProvider{
 		clt: clt,
 	}
-}
-
-// ResolveAppInfo implements [appProvider.ResolveAppInfo].
-func (p *remoteAppProvider) ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error) {
-	appInfo, err := p.clt.ResolveAppInfo(ctx, fqdn)
-	// Avoid wrapping errNoTCPHandler, no need to collect a stack trace.
-	if errors.Is(err, errNoTCPHandler) {
-		return nil, errNoTCPHandler
-	}
-	return appInfo, trace.Wrap(err)
 }
 
 // ReissueAppCert issues a new cert for the target app. Signatures made with the

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -1,0 +1,227 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/defaults"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// tcpHandlerResolver resolves a fully-qualified domain names to a
+// tcpHandlerSpec that defines the CIDR range to assign an IP to that handler
+// from, and a handler for all future connections to that IP address.
+type tcpHandlerResolver struct {
+	cfg *tcpHandlerResolverConfig
+}
+
+type tcpHandlerResolverConfig struct {
+	fqdnResolver fqdnResolver
+	appProvider  appProvider
+	clock        clockwork.Clock
+}
+
+type fqdnResolver interface {
+	ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.ResolveFQDNResponse, error)
+}
+
+func newTCPHandlerResolver(cfg *tcpHandlerResolverConfig) *tcpHandlerResolver {
+	return &tcpHandlerResolver{
+		cfg: cfg,
+	}
+}
+
+// resolveTCPHandler decides if fqdn should match a TCP handler.
+//
+// If fqdn matches a valid VNet target it returns a tcpHandlerSpec
+// defining the CIDR range to assign an IP from, and a handler for future
+// connections to any assigned IPs.
+//
+// If fqdn does not match anything it must return errNoTCPHandler.
+func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string) (*tcpHandlerSpec, error) {
+	resp, err := r.cfg.fqdnResolver.ResolveFQDN(ctx, fqdn)
+	if err != nil {
+		return nil, err
+	}
+	if matchedTCPApp := resp.GetMatchedTcpApp(); matchedTCPApp != nil {
+		// The query matched a valid TCP app, return a handler that will proxy
+		// all connections to that app.
+		appInfo := matchedTCPApp.GetAppInfo()
+		return &tcpHandlerSpec{
+			ipv4CIDRRange: appInfo.GetIpv4CidrRange(),
+			tcpHandler: newTCPAppHandler(&tcpAppHandlerConfig{
+				appInfo:     appInfo,
+				appProvider: r.cfg.appProvider,
+				clock:       r.cfg.clock,
+			}),
+		}, nil
+	}
+	if resp.GetMatchedWebApp() != nil {
+		// We prefer not to assign a handler for web apps so that the DNS query
+		// gets forwarded to upstream resolvers, it should eventually resolve to
+		// the proxy address so that regular web app access continues to work
+		// without sending any traffic through VNet.
+		return nil, errNoTCPHandler
+	}
+	if matchedCluster := resp.GetMatchedCluster(); matchedCluster != nil {
+		// We know the query matched a cluster, but we won't know until we get a
+		// TCP connection if this may match an SSH node or an app that may be
+		// added later so we return an undecidedHandler.
+		handler, err := newUndecidedHandler(&undecidedHandlerConfig{
+			fqdnResolver: r.cfg.fqdnResolver,
+			appProvider:  r.cfg.appProvider,
+			clock:        r.cfg.clock,
+			fqdn:         fqdn,
+			webProxyAddr: matchedCluster.GetWebProxyAddr(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &tcpHandlerSpec{
+			ipv4CIDRRange: matchedCluster.GetIpv4CidrRange(),
+			tcpHandler:    handler,
+		}, nil
+	}
+	return nil, errNoTCPHandler
+}
+
+// undecidedHandler handles TCP connections at addresses that matched a
+// subdomain of the cluster name but haven't been confirmed to match an SSH node
+// yet. When receiving a TCP connection the cluster will be queried again for a
+// match and the handler may become "decided".
+type undecidedHandler struct {
+	cfg          *undecidedHandlerConfig
+	webProxyPort uint16
+
+	// mu guards access to the below fields.
+	mu sync.Mutex
+	// decidedHandler will be set when it's decided which target this handler
+	// should actually forward connections to.
+	decidedHandler tcpHandler
+}
+
+type undecidedHandlerConfig struct {
+	fqdnResolver fqdnResolver
+	appProvider  appProvider
+	clock        clockwork.Clock
+	fqdn         string
+	webProxyAddr string
+}
+
+func newUndecidedHandler(cfg *undecidedHandlerConfig) (*undecidedHandler, error) {
+	_, proxyPort, err := net.SplitHostPort(cfg.webProxyAddr)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing web proxy address")
+	}
+	webProxyPort, err := strconv.ParseUint(proxyPort, 10, 16)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing web proxy port")
+	}
+	return &undecidedHandler{
+		cfg:          cfg,
+		webProxyPort: uint16(webProxyPort),
+	}, nil
+}
+
+func (h *undecidedHandler) getDecidedHandler() tcpHandler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.decidedHandler
+}
+
+func (h *undecidedHandler) setDecidedHandler(handler tcpHandler) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.decidedHandler = handler
+}
+
+func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
+	if decidedHandler := h.getDecidedHandler(); decidedHandler != nil {
+		return decidedHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+
+	// Handling an incoming TCP connection but we're not sure what this
+	// address should point to yet, query again in case an app was added.
+	resp, err := h.cfg.fqdnResolver.ResolveFQDN(ctx, h.cfg.fqdn)
+	if err != nil {
+		return trace.Wrap(err, "resolving target in undecidedHandler")
+	}
+	if matchedTCPApp := resp.GetMatchedTcpApp(); matchedTCPApp != nil {
+		// If matched a TCP app, build a tcpAppHandler that will be used for this
+		// and all subsequent connections to this address.
+		log.DebugContext(ctx, "Resolved FQDN to a matched TCP app", "fqdn", h.cfg.fqdn)
+		tcpAppHandler := newTCPAppHandler(&tcpAppHandlerConfig{
+			appInfo:     matchedTCPApp.GetAppInfo(),
+			appProvider: h.cfg.appProvider,
+			clock:       h.cfg.clock,
+		})
+		h.setDecidedHandler(tcpAppHandler)
+		return tcpAppHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+	if matchedWebApp := resp.GetMatchedWebApp(); matchedWebApp != nil && localPort == h.webProxyPort {
+		// If matched a web app, build a webAppHandler that will be used for this
+		// and all subsequent connections to this address.
+		log.DebugContext(ctx, "Resolved FQDN to a matched web app", "fqdn", h.cfg.fqdn)
+		webAppHandler := newWebAppHandler(h.cfg.webProxyAddr, h.webProxyPort)
+		h.setDecidedHandler(webAppHandler)
+		return webAppHandler.handleTCPConnector(ctx, localPort, connector)
+	}
+	if matchedCluster := resp.GetMatchedCluster(); matchedCluster != nil && localPort == 22 {
+		return trace.NotImplemented("SSH connection forwarding not yet implemented")
+	}
+	return trace.Errorf("rejecting connection to %s:%d", h.cfg.fqdn, localPort)
+}
+
+// webAppHandler proxies incoming TCP connections on webProxyPort to the
+// webProxyAddr. This is a plain TCP proxy, VNet does not add any user
+// authentication for web app access, auth happens in the browser as it usually
+// does for web apps as if VNet was not even in the network path.
+type webAppHandler struct {
+	webProxyAddr string
+	webProxyPort uint16
+}
+
+func newWebAppHandler(webProxyAddr string, webProxyPort uint16) *webAppHandler {
+	return &webAppHandler{
+		webProxyAddr: webProxyAddr,
+		webProxyPort: webProxyPort,
+	}
+}
+
+func (h *webAppHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
+	if localPort != h.webProxyPort {
+		return trace.Errorf("rejecting web app connection on port %d not matching web proxy port %d", localPort, h.webProxyPort)
+	}
+	dialer := &net.Dialer{Timeout: defaults.DefaultIOTimeout}
+	proxyConn, err := dialer.DialContext(ctx, "tcp", h.webProxyAddr)
+	if err != nil {
+		return trace.Wrap(err, "dialing proxy addr %s", h.webProxyAddr)
+	}
+	localConn, err := connector()
+	if err != nil {
+		return trace.Wrap(err, "accepting incoming TCP conn")
+	}
+	return trace.Wrap(utils.ProxyConn(ctx, localConn, proxyConn))
+}

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -30,9 +30,9 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// tcpHandlerResolver resolves a fully-qualified domain names to a
-// tcpHandlerSpec that defines the CIDR range to assign an IP to that handler
-// from, and a handler for all future connections to that IP address.
+// tcpHandlerResolver resolves fully-qualified domain names to a tcpHandlerSpec
+// that defines the CIDR range to assign an IP to that handler from, and a
+// handler for future TCP connections to that IP address.
 type tcpHandlerResolver struct {
 	cfg *tcpHandlerResolverConfig
 }
@@ -55,9 +55,9 @@ func newTCPHandlerResolver(cfg *tcpHandlerResolverConfig) *tcpHandlerResolver {
 
 // resolveTCPHandler decides if fqdn should match a TCP handler.
 //
-// If fqdn matches a valid VNet target it returns a tcpHandlerSpec
-// defining the CIDR range to assign an IP from, and a handler for future
-// connections to any assigned IPs.
+// If fqdn matches a valid VNet target it returns a tcpHandlerSpec defining the
+// CIDR range to assign an IP from, and a TCP handler for future connections to
+// the assigned IP.
 //
 // If fqdn does not match anything it must return errNoTCPHandler.
 func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string) (*tcpHandlerSpec, error) {

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -43,4 +43,5 @@ var (
 	_ = newOSConfigurator
 	_ = (*osConfigurator).runOSConfigurationLoop
 	_ = runCommand
+	_ = newNetworkStackConfig
 )

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -84,15 +84,19 @@ type ClusterClient interface {
 func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*UserProcess, error) {
 	clock := clockwork.NewRealClock()
 	clusterConfigCache := NewClusterConfigCache(clock)
-	appProvider := newLocalAppProvider(&localAppProviderConfig{
+	localResolver := newLocalFQDNResolver(&localFQDNResolverConfig{
 		clientApplication:  clientApplication,
 		clusterConfigCache: clusterConfigCache,
+	})
+	appProvider := newLocalAppProvider(&localAppProviderConfig{
+		clientApplication: clientApplication,
 	})
 	osConfigProvider := NewLocalOSConfigProvider(&LocalOSConfigProviderConfig{
 		clientApplication:  clientApplication,
 		clusterConfigCache: clusterConfigCache,
 	})
 	clientApplicationService := newClientApplicationService(&clientApplicationServiceConfig{
+		localResolver:         localResolver,
 		localAppProvider:      appProvider,
 		localOSConfigProvider: osConfigProvider,
 	})

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -36,9 +36,9 @@ service ClientApplicationService {
   // Ping is used by the admin process to regularly poll that the client
   // application is still running.
   rpc Ping(PingRequest) returns (PingResponse);
-  // ResolveAppInfo returns info for the given app fqdn, or an error if the app
-  // is not present in any logged-in cluster.
-  rpc ResolveAppInfo(ResolveAppInfoRequest) returns (ResolveAppInfoResponse);
+  // ResolveFQDN is called during DNS resolution to resolve a fully-qualified
+  // domain name to a target.
+  rpc ResolveFQDN(ResolveFQDNRequest) returns (ResolveFQDNResponse);
   // ReissueAppCert issues a new app cert.
   rpc ReissueAppCert(ReissueAppCertRequest) returns (ReissueAppCertResponse);
   // SignForApp issues a signature with the private key associated with an x509
@@ -94,16 +94,43 @@ message PingRequest {}
 // PingResponse is a response for the Ping rpc.
 message PingResponse {}
 
-// ResolveAppInfoRequest is a request for ResolveAppInfo.
-message ResolveAppInfoRequest {
-  // Fqdn is the fully-qualified domain name of the app.
+// ResolveFQDNRequest is a request for ResolveFQDN.
+message ResolveFQDNRequest {
+  // Fqdn is the fully-qualified domain name queried.
   string fqdn = 1;
 }
 
-// ResolveAppInfoResponse is a response for ResolveAppInfo.
-message ResolveAppInfoResponse {
+// ResolveFQDNReponse is a response for ResolveFQDN.
+message ResolveFQDNResponse {
+  oneof match {
+    // MatchedTcpApp will be set when the query matched a TCP app.
+    MatchedTCPApp matched_tcp_app = 1;
+    // MatchedWebApp will be set when the query matched a web app.
+    MatchedWebApp matched_web_app = 2;
+    // MatchedCluster will be set when the query did not match any app, but did
+    // match a subdomain of a proxy address. VNet will resolve the DNS query to
+    // a handler that may later resolve the FQDN to an app or SSH server.
+    MatchedCluster matched_cluster = 3;
+  }
+}
+
+// MatchedTCPApp holds info about a TCP app that matched a query.
+message MatchedTCPApp {
   // AppInfo holds all necessary info for making connections to the resolved app.
   AppInfo app_info = 1;
+}
+
+// MatchedTCPApp is a placeholder to signify that the query matched a web app.
+message MatchedWebApp {}
+
+// MatchedCluster holds info about a cluster that a query matched.
+message MatchedCluster {
+  // Ipv4CidrRange is the CIDR range from which an IPv4 address should be assigned
+  // based on this cluster's vnet_config.
+  string ipv4_cidr_range = 1;
+  // WebProxyAddr is the web proxy address of the root cluster that matched the
+  // query.
+  string web_proxy_addr = 2;
 }
 
 // AppInfo holds all necessary info for making connections to VNet TCP apps.
@@ -116,7 +143,7 @@ message AppInfo {
   string cluster = 2;
   // App is the app spec.
   types.AppV3 app = 3;
-  // Ipv4Cidr_range is the CIDR range from which an IPv4 address should be
+  // Ipv4CidrRange is the CIDR range from which an IPv4 address should be
   // assigned to the app.
   string ipv4_cidr_range = 4;
   // DialOptions holds options that should be used when dialing the root cluster
@@ -153,7 +180,7 @@ message DialOptions {
 // ReissueAppCertRequest is a request for ReissueAppCert.
 message ReissueAppCertRequest {
   // AppInfo contains info about the app, every ReissueAppCertRequest must
-  // include an app_info as returned from ResolveAppInfo.
+  // include an app_info as returned from ResolveFQDN.
   AppInfo app_info = 1;
   // TargetPort is the TCP port to issue the cert for.
   uint32 target_port = 2;


### PR DESCRIPTION
Part of [RFD 207](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md).

This PR implements the DNS resolution stage of VNet SSH. According to the design, DNS queries for `*.<cluster_name>` or `*.<leaf_cluster_name>.<root_cluster_name>` should resolve to an IP address (unless they match the public_addr of a web app).

Because the IP gets assigned before we've actually confirmed there's a matching SSH node, to support access to apps added after the IP got resolved the handler at the assigned IP needs to query again for a matching TCP or web app and handle those accordingly.

The major change here is that we no longer have `ResolveAppInfo` as part of the `appProvider` interface ultimately handling most of VNet's DNS resolution. This logic got moved into `localFQDNResolver.ResolveFQDN` which also returns a result for web app matches or cluster matches that could potentially match an SSH node.

Most new logic is in `local_fqdn_resolver.go` which runs in the user process and queries the Teleport cluster, and `tcp_handler_resolver.go` which runs in the admin/networking process, calls localFQDNResolver over gRPC, and assigns a TCP handler if a match is found.

Ignoring protobufs this change is +693, -340.