### PR TITLE
Web/Teleterm: Update UI health warning indicators

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/target_health.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/target_health.pb.go
@@ -46,7 +46,9 @@ type TargetHealth struct {
 	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	// error is the health check error observed, when
 	// "status" field != "healthy".
-	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	Error string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	// message is additional information meant for a user.
+	Message       string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -95,14 +97,22 @@ func (x *TargetHealth) GetError() string {
 	return ""
 }
 
+func (x *TargetHealth) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_teleport_lib_teleterm_v1_target_health_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_teleterm_v1_target_health_proto_rawDesc = "" +
 	"\n" +
-	",teleport/lib/teleterm/v1/target_health.proto\x12\x18teleport.lib.teleterm.v1\"<\n" +
+	",teleport/lib/teleterm/v1/target_health.proto\x12\x18teleport.lib.teleterm.v1\"V\n" +
 	"\fTargetHealth\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05errorBTZRgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1;teletermv1b\x06proto3"
+	"\x05error\x18\x02 \x01(\tR\x05error\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessageBTZRgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1;teletermv1b\x06proto3"
 
 var (
 	file_teleport_lib_teleterm_v1_target_health_proto_rawDescOnce sync.Once

--- a/gen/proto/ts/teleport/lib/teleterm/v1/target_health_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/target_health_pb.ts
@@ -50,19 +50,27 @@ export interface TargetHealth {
      * @generated from protobuf field: string error = 2;
      */
     error: string;
+    /**
+     * message is additional information meant for a user.
+     *
+     * @generated from protobuf field: string message = 3;
+     */
+    message: string;
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class TargetHealth$Type extends MessageType<TargetHealth> {
     constructor() {
         super("teleport.lib.teleterm.v1.TargetHealth", [
             { no: 1, name: "status", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "error", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<TargetHealth>): TargetHealth {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.status = "";
         message.error = "";
+        message.message = "";
         if (value !== undefined)
             reflectionMergePartial<TargetHealth>(this, message, value);
         return message;
@@ -77,6 +85,9 @@ class TargetHealth$Type extends MessageType<TargetHealth> {
                     break;
                 case /* string error */ 2:
                     message.error = reader.string();
+                    break;
+                case /* string message */ 3:
+                    message.message = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -96,6 +107,9 @@ class TargetHealth$Type extends MessageType<TargetHealth> {
         /* string error = 2; */
         if (message.error !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.error);
+        /* string message = 3; */
+        if (message.message !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.message);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/apiserver/handler/handler_databases.go
+++ b/lib/teleterm/apiserver/handler/handler_databases.go
@@ -82,8 +82,9 @@ func newAPIDatabase(db clusters.Database) *api.Database {
 		Type:     db.GetType(),
 		Labels:   apiLabels,
 		TargetHealth: &api.TargetHealth{
-			Status: db.TargetHealth.Status,
-			Error:  db.TargetHealth.TransitionError,
+			Status:  db.TargetHealth.Status,
+			Error:   db.TargetHealth.TransitionError,
+			Message: db.TargetHealth.Message,
 		},
 	}
 }
@@ -94,8 +95,9 @@ func newAPIDatabaseServer(dbServer clusters.DatabaseServer) *api.DatabaseServer 
 		Hostname: dbServer.GetHostname(),
 		HostId:   dbServer.GetHostID(),
 		TargetHealth: &api.TargetHealth{
-			Status: dbServer.GetTargetHealth().Status,
-			Error:  dbServer.GetTargetHealth().TransitionError,
+			Status:  dbServer.GetTargetHealth().Status,
+			Error:   dbServer.GetTargetHealth().TransitionError,
+			Message: dbServer.GetTargetHealth().Message,
 		},
 	}
 }

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -45,7 +45,7 @@ type Database struct {
 	URI uri.ResourceURI
 	types.Database
 	// TargetHealth describes the health status of network connectivity
-	// of the db_server that is serving this database.
+	// reported from an agent (db_service) that is proxying this database.
 	TargetHealth types.TargetHealth
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1339,7 +1339,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add nodes
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		name := fmt.Sprintf("server-%d", i)
 		node, err := types.NewServer(name, types.KindNode, types.ServerSpecV2{
 			Hostname: name,

--- a/proto/teleport/lib/teleterm/v1/target_health.proto
+++ b/proto/teleport/lib/teleterm/v1/target_health.proto
@@ -30,4 +30,6 @@ message TargetHealth {
   // error is the health check error observed, when
   // "status" field != "healthy".
   string error = 2;
+  // message is additional information meant for a user.
+  string message = 3;
 }

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -35,7 +35,7 @@ import {
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { SingleLineBox } from '../shared/SingleLineBox';
-import { isUnhealthy } from '../shared/StatusInfo';
+import { shouldWarnResourceStatus } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
 import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
 
@@ -168,7 +168,7 @@ export function ResourceCard({
     }
   };
 
-  const hasUnhealthyStatus = isUnhealthy(status);
+  const shouldDisplayStatusWarning = shouldWarnResourceStatus(status);
 
   return (
     <CardContainer
@@ -178,7 +178,7 @@ export function ResourceCard({
     >
       <CardOuterContainer
         showAllLabels={showAllLabels}
-        hasUnhealthyStatus={hasUnhealthyStatus}
+        shouldDisplayWarning={shouldDisplayStatusWarning}
       >
         <CardInnerContainer
           ref={innerContainer}
@@ -192,11 +192,11 @@ export function ResourceCard({
           requiresRequest={requiresRequest}
           selected={selected}
           showingStatusInfo={showingStatusInfo}
-          hasUnhealthyStatus={hasUnhealthyStatus}
+          shouldDisplayWarning={shouldDisplayStatusWarning}
           // we set extra padding to push contents to the right to make
           // space for the WarningRightEdgeBadgeIcon.
-          {...(hasUnhealthyStatus && !showAllLabels && { pr: '35px' })}
-          {...(hasUnhealthyStatus && showAllLabels && { pr: '7px' })}
+          {...(shouldDisplayStatusWarning && !showAllLabels && { pr: '35px' })}
+          {...(shouldDisplayStatusWarning && showAllLabels && { pr: '7px' })}
         >
           <CheckboxInput
             checked={selected}
@@ -263,7 +263,7 @@ export function ResourceCard({
             <LabelsContainer showAll={showAllLabels}>
               <LabelsInnerContainer
                 ref={labelsInnerContainer}
-                hasUnhealthyStatus={hasUnhealthyStatus}
+                hasUnhealthyStatus={shouldDisplayStatusWarning}
               >
                 <MoreLabelsButton
                   style={{
@@ -293,7 +293,7 @@ export function ResourceCard({
               </LabelsInnerContainer>
             </LabelsContainer>
           </Flex>
-          {hasUnhealthyStatus && !showAllLabels && (
+          {shouldDisplayStatusWarning && !showAllLabels && (
             <HoverTooltip tipContent={'Show Connection Issue'} placement="left">
               <WarningRightEdgeBadgeIcon onClick={onShowStatusInfo} />
             </HoverTooltip>
@@ -303,7 +303,9 @@ export function ResourceCard({
       {/* This is to let the WarningRightEdgeBadgeIcon stay in place while the
         InnerContainer pops out and expands vertically from rendering all
         labels. */}
-      {hasUnhealthyStatus && showAllLabels && <WarningRightEdgeBadgeIcon />}
+      {shouldDisplayStatusWarning && showAllLabels && (
+        <WarningRightEdgeBadgeIcon />
+      )}
     </CardContainer>
   );
 }
@@ -364,7 +366,7 @@ const CardContainer = styled(Box)<{
 
 const CardOuterContainer = styled(Box)<{
   showAllLabels?: boolean;
-  hasUnhealthyStatus: boolean;
+  shouldDisplayWarning: boolean;
 }>`
   border-radius: ${props => props.theme.radii[3]}px;
 
@@ -374,7 +376,7 @@ const CardOuterContainer = styled(Box)<{
       position: absolute;
       left: 0;
       // The padding is required to show the WarningRightEdgeBadgeIcon
-      right: ${props.hasUnhealthyStatus ? '28px' : 0};
+      right: ${props.shouldDisplayWarning ? '28px' : 0};
       z-index: 1;
     `}
   transition: all 150ms;
@@ -415,7 +417,7 @@ const CardInnerContainer = styled(Flex)<BackgroundColorProps>`
   background-color: ${props => getBackgroundColor(props)};
 
   ${p =>
-    p.hasUnhealthyStatus &&
+    p.shouldDisplayWarning &&
     css`
       border: 2px solid ${p.theme.colors.interactive.solid.alert.default};
       background-color: ${getStatusBackgroundColor({
@@ -437,7 +439,7 @@ const CardInnerContainer = styled(Flex)<BackgroundColorProps>`
     border: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
 
     ${p =>
-      p.hasUnhealthyStatus &&
+      p.shouldDisplayWarning &&
       css`
         border-color: ${p.theme.colors.interactive.solid.alert.hover};
         background-color: ${getStatusBackgroundColor({

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -35,7 +35,7 @@ import {
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
-import { isUnhealthy } from '../shared/StatusInfo';
+import { shouldWarnResourceStatus } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
@@ -71,7 +71,7 @@ export function ResourceListItem({
   }, [expandAllLabels]);
 
   const showLabelsButton = labels.length > 0 && (hovered || showLabels);
-  const hasUnhealthyStatus = isUnhealthy(status);
+  const shouldDisplayStatusWarning = shouldWarnResourceStatus(status);
 
   // Determines which column the resource type text should end at.
   // We do this because if there is no address, or the labels button
@@ -91,7 +91,7 @@ export function ResourceListItem({
     <RowContainer
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      hasUnhealthyStatus={hasUnhealthyStatus}
+      shouldDisplayWarning={shouldDisplayStatusWarning}
       showingStatusInfo={showingStatusInfo}
     >
       <RowInnerContainer
@@ -99,7 +99,7 @@ export function ResourceListItem({
         alignItems="start"
         pinned={pinned}
         selected={selected}
-        hasUnhealthyStatus={hasUnhealthyStatus}
+        shouldDisplayWarning={shouldDisplayStatusWarning}
         showingStatusInfo={showingStatusInfo}
       >
         {/* checkbox */}
@@ -235,7 +235,7 @@ export function ResourceListItem({
         )}
 
         {/* warning icon if status is unhealthy */}
-        {hasUnhealthyStatus && (
+        {shouldDisplayStatusWarning && (
           <HoverTooltip
             tipContent={'Show Connection Issue'}
             css={`
@@ -305,14 +305,14 @@ const ResTypeIconBox = styled(Box)`
 `;
 
 const RowContainer = styled(Box)<{
-  hasUnhealthyStatus: boolean;
+  shouldDisplayWarning: boolean;
   showingStatusInfo: boolean;
 }>`
   transition: all 150ms;
   position: relative;
 
   ${p =>
-    p.hasUnhealthyStatus &&
+    p.shouldDisplayWarning &&
     css`
       background-color: ${getStatusBackgroundColor({
         showingStatusInfo: p.showingStatusInfo,
@@ -326,7 +326,7 @@ const RowContainer = styled(Box)<{
     background-color: ${props => props.theme.colors.levels.surface};
 
     ${p =>
-      p.hasUnhealthyStatus &&
+      p.shouldDisplayWarning &&
       css`
         background-color: ${getStatusBackgroundColor({
           showingStatusInfo: p.showingStatusInfo,

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
@@ -25,7 +25,6 @@ import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import {
   DatabaseServer,
-  ResourceStatus,
   SharedResourceServer,
   UnifiedResourceDefinition,
 } from '../types';
@@ -37,7 +36,7 @@ import {
 type StoryProps = {
   attemptState: 'success' | 'processing' | 'failed' | '';
   resourceKind: 'db';
-  healthStatus: ResourceStatus | 'empty';
+  healthStatus: 'unhealthy' | 'unknown' | 'mixed';
   serverLength: 'few' | 'none' | 'many' | 'single';
 };
 
@@ -55,7 +54,8 @@ const meta: Meta<StoryProps> = {
     },
     healthStatus: {
       control: { type: 'select' },
-      options: ['unhealthy', 'unknown', 'empty'],
+      description: 'Specifies the health status of the servers listed',
+      options: ['unhealthy', 'mixed', 'unknown'],
     },
     serverLength: {
       control: { type: 'select' },
@@ -89,17 +89,21 @@ export function UnhealthyStatusInfo(props: StoryProps) {
       protocol: 'postgres',
       labels: [],
       targetHealth: {
-        status: props.healthStatus === 'empty' ? '' : props.healthStatus,
+        status: 'unhealthy',
       },
     };
-    if (props.serverLength === 'many') {
-      servers = manyDbServers;
+
+    if (props.healthStatus === 'unhealthy') {
+      servers = getDbServers(props, unhealthyDbServers);
     }
-    if (props.serverLength === 'few') {
-      servers = fewDbServers;
+    if (props.healthStatus === 'unknown') {
+      servers = getDbServers(props, unknownDbServers);
     }
-    if (props.serverLength === 'single') {
-      servers = [fewDbServers[0]];
+    if (props.healthStatus === 'mixed') {
+      servers = getDbServers(props, [
+        ...unknownDbServers,
+        ...unhealthyDbServers,
+      ]);
     }
   }
 
@@ -132,18 +136,16 @@ const loremTxt =
   quas reiciendis fugiat molestias delectus perspiciatis vero \
   similique minima mollitia accusantium eligendi impedit.';
 
-const fewDbServers: DatabaseServer[] = [
+const unhealthyDbServers: DatabaseServer[] = [
   {
     kind: 'db_server',
     hostId: 'host-id-1',
     hostname: 'hostname-1',
-    targetHealth: { status: 'unhealthy', error: 'error reason 1' },
-  },
-  {
-    kind: 'db_server',
-    hostId: 'host-id-2',
-    hostname: 'hostname-2',
-    targetHealth: { status: 'unhealthy', error: 'error reason 2' },
+    targetHealth: {
+      status: 'unhealthy',
+      error: 'unhealthy error reason 1',
+      message: 'some unhealthy message 1',
+    },
   },
   {
     kind: 'db_server',
@@ -151,14 +153,44 @@ const fewDbServers: DatabaseServer[] = [
       'host-id-long-george-washington-cherry-blossom-apple-banana-orange-chocolate-meow',
     hostname:
       'hostname-long-really-long-like-really-long-longer-pumpkin-pie-halloween',
-    targetHealth: { status: 'unknown', error: loremTxt },
+    targetHealth: { status: 'unhealthy', error: loremTxt },
   },
 ];
 
-const manyDbServers: DatabaseServer[] = [
-  ...fewDbServers,
-  ...fewDbServers,
-  ...fewDbServers,
-  ...fewDbServers,
-  ...fewDbServers,
+const unknownDbServers: DatabaseServer[] = [
+  {
+    kind: 'db_server',
+    hostId: 'host-id-1',
+    hostname: 'hostname-1',
+    targetHealth: {
+      status: 'unknown',
+      error: 'unknown error reason 1',
+      message: 'some unknown message 1',
+    },
+  },
+  {
+    kind: 'db_server',
+    hostId: 'host-id-2',
+    hostname: 'hostname-2',
+    targetHealth: {
+      status: 'unknown',
+      error: 'unknown error reason 2',
+      message: 'some unknown message 2',
+    },
+  },
 ];
+
+function getDbServers(
+  props: Pick<StoryProps, 'serverLength'>,
+  servers: DatabaseServer[]
+) {
+  if (props.serverLength === 'many') {
+    return [...servers, ...servers, ...servers, ...servers];
+  }
+  if (props.serverLength === 'few') {
+    return servers;
+  }
+  if (props.serverLength === 'single') {
+    return [servers[0]];
+  }
+}

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ResourceHealthStatus } from '../types';
+import { shouldWarnResourceStatus } from './StatusInfo';
+
+describe('shouldWarnResourceStatus', () => {
+  const testCases: {
+    name: string;
+    status: ResourceHealthStatus;
+    shouldWarn: boolean;
+  }[] = [
+    {
+      name: 'undefined/empty',
+      status: undefined,
+      shouldWarn: false,
+    },
+    {
+      name: 'healthy status',
+      status: 'healthy',
+      shouldWarn: false,
+    },
+    {
+      name: 'unknown status',
+      status: 'unknown',
+      shouldWarn: false,
+    },
+    {
+      name: 'unhealthy status',
+      status: 'unhealthy',
+      shouldWarn: true,
+    },
+    {
+      name: 'mixed',
+      status: 'mixed',
+      shouldWarn: true,
+    },
+  ];
+
+  test.each(testCases)('$name', ({ status, shouldWarn }) => {
+    expect(shouldWarnResourceStatus(status)).toEqual(shouldWarn);
+  });
+});

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -19,7 +19,7 @@
 import { type JSX } from 'react';
 import styled, { css } from 'styled-components';
 
-import { Box, ButtonBorder, Indicator, Mark, Text } from 'design';
+import { Box, ButtonBorder, Indicator, Text } from 'design';
 import { Alert } from 'design/Alert';
 import Flex from 'design/Flex';
 import {
@@ -40,7 +40,8 @@ import { Attempt } from 'shared/hooks/useAttemptNext';
 import { pluralize } from 'shared/utils/text';
 
 import {
-  ResourceStatus,
+  DatabaseServer,
+  ResourceHealthStatus,
   SharedResourceServer,
   UnifiedResourceDefinition,
 } from '../types';
@@ -66,7 +67,7 @@ export function UnhealthyStatusInfo({
     fetch({ force: true });
   }
 
-  const unhealthyOrUnknownServers = servers.filter(
+  const unhealthyOrUnknownServers = servers?.filter(
     s => s.targetHealth?.status !== 'healthy'
   );
 
@@ -74,12 +75,14 @@ export function UnhealthyStatusInfo({
     <>
       <Box>
         <ConnectionHeader resource={resource} />
-        <InfoParagraph>
-          <StatusDescription
-            resource={resource}
-            numUnhealthyServers={unhealthyOrUnknownServers.length}
-          />
-        </InfoParagraph>
+        {unhealthyOrUnknownServers.length > 0 && (
+          <InfoParagraph>
+            <StatusDescription
+              fetchedServers={unhealthyOrUnknownServers}
+              resource={resource}
+            />
+          </InfoParagraph>
+        )}
         <InfoParagraph mb={4}>
           <ButtonBorder
             as="a"
@@ -108,7 +111,9 @@ export function UnhealthyStatusInfo({
         )}
         <InfoParagraph>
           {attempt.status === 'success' && !servers?.length && (
-            <Text bold>No Results</Text>
+            // Refresh might be required if all health checks passed
+            // while unified resources page has been stale.
+            <Text bold>No Results. Try refreshing the page.</Text>
           )}
           {attempt.status === 'success' && servers?.length > 0 && (
             <Box
@@ -184,47 +189,60 @@ function ConnectionHeader({
 }
 
 function StatusDescription({
+  fetchedServers,
   resource,
-  numUnhealthyServers,
 }: {
+  fetchedServers: DatabaseServer[];
   resource: UnifiedResourceDefinition;
-  numUnhealthyServers: number;
 }) {
   if (resource.kind === 'db') {
-    const health = resource.targetHealth;
-    const startingWord = numUnhealthyServers > 1 ? 'Some' : 'A';
-    const servicedWord = numUnhealthyServers
-      ? pluralize(numUnhealthyServers, 'service')
-      : 'service';
-    switch (health.status) {
-      case 'unhealthy':
-        return (
-          <>
-            {startingWord} Teleport database {servicedWord} proxying access to
-            this database cannot reach the database endpoint.
-          </>
-        );
-      case 'unknown':
-        return (
-          <>
-            {startingWord} Teleport database {servicedWord} proxying access to
-            this database {numUnhealthyServers > 1 ? 'are' : 'is'} not running
-            network health checks for the database endpoint. User connections
-            will not be routed through affected Teleport database services as
-            long as other database services report a healthy connection to the
-            database.
-          </>
-        );
-      default: // empty
-        return (
-          <>
-            {startingWord} Teleport database {servicedWord} proxying access to
-            this database requires upgrading to Teleport version{' '}
-            <Mark>18.0.0</Mark> to run network health checks.
-          </>
-        );
+    const unhealthyServers = fetchedServers.filter(
+      s => s.targetHealth?.status === 'unhealthy'
+    ).length;
+    const unknownHealthServers = fetchedServers.filter(
+      s => s.targetHealth?.status === 'unknown'
+    ).length;
+
+    if (unhealthyServers && unknownHealthServers) {
+      return (
+        <StyledUl>
+          <li>{unhealthyStatus(unhealthyServers)}</li>
+          <li>{unknownStatus(unknownHealthServers)}</li>
+        </StyledUl>
+      );
     }
+
+    if (unhealthyServers) {
+      return <>{unhealthyStatus(unhealthyServers)}</>;
+    }
+
+    return <>{unknownStatus(unknownHealthServers)}</>;
   }
+}
+
+function unhealthyStatus(numServers: number) {
+  const startingWord = numServers > 1 ? 'Some' : 'A';
+  const serviceWord = numServers ? pluralize(numServers, 'service') : 'service';
+  return (
+    <>
+      {startingWord} Teleport database {serviceWord} proxying access to this
+      database cannot reach the database endpoint.
+    </>
+  );
+}
+
+function unknownStatus(numServers: number) {
+  const startingWord = numServers > 1 ? 'Some' : 'A';
+  const serviceWord = numServers ? pluralize(numServers, 'service') : 'service';
+  return (
+    <>
+      {startingWord} Teleport database {serviceWord} proxying access to this
+      database {numServers > 1 ? 'are' : 'is'} not running network health checks
+      for the database endpoint. User connections will not be routed through
+      affected Teleport database services as long as other database services
+      report a healthy connection to the database.
+    </>
+  );
 }
 
 function getTroubleShootingLink(resource: UnifiedResourceDefinition) {
@@ -264,9 +282,18 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
       <Text>
         <InfoField>UUID:</InfoField> {server.hostId}
       </Text>
+      <Text>
+        <InfoField>Status:</InfoField>{' '}
+        {server.targetHealth?.status || 'unknown'}
+      </Text>
+      {server.targetHealth?.message && (
+        <Text>
+          <InfoField>Message:</InfoField> {server.targetHealth.message}
+        </Text>
+      )}
       {server.targetHealth?.error && (
         <Text>
-          <InfoField>Reason:</InfoField> {server.targetHealth.error}
+          <InfoField>Error:</InfoField> {server.targetHealth.error}
         </Text>
       )}
     </Flex>
@@ -316,6 +343,18 @@ export function openStatusInfoPanel({
   }
 }
 
-export function isUnhealthy(status: ResourceStatus): boolean {
-  return status && status === 'unhealthy';
+/**
+ * Returns true if any status is unhealthy or if there are a mix of different
+ * health statuses.
+ */
+export function shouldWarnResourceStatus(
+  status: ResourceHealthStatus
+): boolean {
+  return status === 'mixed' || status === 'unhealthy';
 }
+
+export const StyledUl = styled.ul`
+  margin: 0;
+  padding-left: ${p => p.theme.space[4]}px;
+  padding-bottom: ${p => p.theme.space[1]}px;
+`;

--- a/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
@@ -23,12 +23,12 @@ export interface BackgroundColorProps {
   selected?: boolean;
   pinned?: boolean;
   theme: Theme;
-  hasUnhealthyStatus: boolean;
+  shouldDisplayWarning: boolean;
   showingStatusInfo: boolean;
 }
 
 export const getBackgroundColor = (props: BackgroundColorProps) => {
-  if (props.hasUnhealthyStatus) {
+  if (props.shouldDisplayWarning) {
     return 'transparent';
   }
   if (props.selected) {

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -26,14 +26,18 @@ import { DbProtocol } from 'shared/services/databases';
 import { ResourceLabel } from 'teleport/services/agents';
 import { AppSubKind, PermissionSet } from 'teleport/services/apps';
 
-/**
- * status == '' is a result of an older agent that does not
- * support the health check feature.
- */
-export type ResourceStatus = 'healthy' | 'unhealthy' | 'unknown' | '';
+// "mixed" indicates the resource has a mix of health
+// statuses. This can happen when multiple agents proxy the same resource.
+export type ResourceHealthStatus =
+  | 'healthy'
+  | 'unhealthy'
+  | 'unknown'
+  | 'mixed';
 
 export type ResourceTargetHealth = {
-  status: ResourceStatus;
+  status: ResourceHealthStatus;
+  // additional information meant for user.
+  message?: string;
   error?: string;
 };
 
@@ -156,7 +160,7 @@ export interface UnifiedResourceViewItem {
   cardViewProps: CardViewSpecificProps;
   listViewProps: ListViewSpecificProps;
   requiresRequest?: boolean;
-  status?: ResourceStatus;
+  status?: ResourceHealthStatus;
 }
 
 export enum PinningSupport {

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -61,6 +61,7 @@ export function makeDatabase(json: any): Database {
     targetHealth: targetHealth && {
       status: targetHealth.status,
       error: targetHealth.transition_error,
+      message: targetHealth.message,
     },
   };
 }
@@ -109,6 +110,7 @@ export function makeDatabaseServer(json: any): DatabaseServer {
     targetHealth: status &&
       status.target_health && {
         status: status.target_health.status,
+        message: status.target_health.message,
         error: status.target_health.transition_error,
       },
   };

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -94,6 +94,7 @@ export const OnlineLoadedResources = () => {
               targetHealth: {
                 status: 'unhealthy',
                 error: 'some unhealthy error message',
+                message: 'some message',
               },
             }),
             requiresRequest: false,
@@ -323,15 +324,20 @@ function renderState({
           hostname: 'some-hostname-1',
           hostId: 'some-host-id-1',
           uri: 'some-uri-1',
-          targetHealth: { status: 'unhealthy', error: 'some unhealthy error' },
+          targetHealth: {
+            status: 'unhealthy',
+            error: 'some unhealthy error',
+            message: '',
+          },
         },
         {
           hostname: 'some-hostname-2',
           hostId: 'some-host-id-2',
           uri: 'some-uri-2',
           targetHealth: {
-            status: 'unhealthy',
-            error: 'some other unhealthy error',
+            status: 'unknown',
+            message: 'some unknown related message',
+            error: 'some other unknown error',
           },
         },
       ],

--- a/web/packages/teleterm/src/ui/DocumentCluster/StatusInfo.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/StatusInfo.tsx
@@ -18,7 +18,7 @@
 
 import {
   DatabaseServer,
-  ResourceStatus,
+  ResourceHealthStatus,
   SharedResourceServer,
   UnifiedResourceDefinition,
   useResourceServersFetch,
@@ -62,8 +62,9 @@ export function StatusInfo({
           hostname: d.hostname,
           hostId: d.hostId,
           targetHealth: d.targetHealth && {
-            status: d.targetHealth.status as ResourceStatus,
+            status: d.targetHealth.status as ResourceHealthStatus,
             error: d.targetHealth.error,
+            message: d.targetHealth.message,
           },
         }));
         return {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -37,7 +37,7 @@ import {
 import {
   getResourceAvailabilityFilter,
   ResourceAvailabilityFilter,
-  ResourceStatus,
+  ResourceHealthStatus,
   SharedUnifiedResource,
   UnifiedResources as SharedUnifiedResources,
   UnifiedResourceDefinition,
@@ -539,8 +539,9 @@ const mapToSharedResource = (
           protocol: database.protocol as DbProtocol,
           requiresRequest: resource.requiresRequest,
           targetHealth: database.targetHealth && {
-            status: database.targetHealth.status as ResourceStatus,
+            status: database.targetHealth.status as ResourceHealthStatus,
             error: database.targetHealth.error,
+            message: database.targetHealth.message,
           },
         },
         ui: {


### PR DESCRIPTION
This changes fetches all health statuses for HA deployed resources that
are health checked (databases for now) and shows warning indicators if
any are unhealthy or a mix of healthy/unknown/unhealthy (likely
misconfiguration).


Part of:
- #20544

Stacked on top of another PR:
- https://github.com/gravitational/teleport/pull/54868