### PR TITLE
Web/Teleterm: add health status filter dropdown menu

### DIFF
--- a/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
@@ -59,6 +59,10 @@ export default {
       description: 'Buffer selections until "Apply" is clicked',
       table: { defaultValue: { summary: 'false' } },
     },
+    disableMenu: {
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'false' } },
+    },
     showIndicator: {
       control: { type: 'boolean' },
       description: 'Show indicator when there are selected options',
@@ -106,6 +110,7 @@ export default {
     showIndicator: true,
     showSelectControls: true,
     onChange: action('onChange'),
+    disableMenu: false,
   },
   render: (args => {
     const [{ selected }, updateArgs] =
@@ -142,4 +147,11 @@ const WithDisabledOption: Story = {
   },
 };
 
-export { Default, WithCustomLabels, WithDisabledOption };
+const WithDisabledMenu: Story = {
+  args: {
+    options,
+    disableMenu: true,
+  },
+};
+
+export { Default, WithCustomLabels, WithDisabledOption, WithDisabledMenu };

--- a/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
@@ -59,7 +59,7 @@ export default {
       description: 'Buffer selections until "Apply" is clicked',
       table: { defaultValue: { summary: 'false' } },
     },
-    disableMenu: {
+    disabled: {
       control: { type: 'boolean' },
       table: { defaultValue: { summary: 'false' } },
     },
@@ -110,7 +110,7 @@ export default {
     showIndicator: true,
     showSelectControls: true,
     onChange: action('onChange'),
-    disableMenu: false,
+    disabled: false,
   },
   render: (args => {
     const [{ selected }, updateArgs] =
@@ -150,7 +150,7 @@ const WithDisabledOption: Story = {
 const WithDisabledMenu: Story = {
   args: {
     options,
-    disableMenu: true,
+    disabled: true,
   },
 };
 

--- a/web/packages/shared/components/Controls/MultiselectMenu.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.tsx
@@ -54,7 +54,7 @@ type MultiselectMenuProps<T> = {
   showIndicator?: boolean;
   showSelectControls?: boolean;
   /**
-   * If true, disables clicking of the button that
+   * If true, disables the button that
    * opens the dropdown menu.
    */
   disabled?: boolean;

--- a/web/packages/shared/components/Controls/MultiselectMenu.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.tsx
@@ -57,7 +57,7 @@ type MultiselectMenuProps<T> = {
    * If true, disables clicking of the button that
    * opens the dropdown menu.
    */
-  disableMenu?: boolean;
+  disabled?: boolean;
 };
 
 export const MultiselectMenu = <T extends string>({
@@ -69,7 +69,7 @@ export const MultiselectMenu = <T extends string>({
   buffered = false,
   showIndicator = true,
   showSelectControls = true,
-  disableMenu = false,
+  disabled = false,
 }: MultiselectMenuProps<T>) => {
   // we have a separate state in the filter so we can select a few different things and then click "apply"
   const [intSelected, setIntSelected] = useState<T[]>([]);
@@ -126,13 +126,13 @@ export const MultiselectMenu = <T extends string>({
           onClick={handleOpen}
           aria-haspopup="true"
           aria-expanded={!!anchorEl}
-          disabled={disableMenu}
+          disabled={disabled}
         >
           {label} {selected?.length > 0 ? `(${selected?.length})` : ''}
           <ChevronDown
             ml={2}
             size="small"
-            color={disableMenu ? 'text.disabled' : 'text.slightlyMuted'}
+            color={disabled ? 'text.disabled' : 'text.slightlyMuted'}
           />
           {selected?.length > 0 && showIndicator && <FiltersExistIndicator />}
         </ButtonSecondary>

--- a/web/packages/shared/components/Controls/MultiselectMenu.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.tsx
@@ -42,9 +42,22 @@ type MultiselectMenuProps<T> = {
   onChange: (selected: T[]) => void;
   label: string | ReactNode;
   tooltip: string;
+  /**
+   * If true, renders inner control buttons (eg: apply, cancel),
+   * and changes made to dropdown don't take affect until user
+   * explicitly clicks on these inner control buttons.
+   *
+   * If false, no inner control buttons are rendered and changes
+   * take affect immediately.
+   */
   buffered?: boolean;
   showIndicator?: boolean;
   showSelectControls?: boolean;
+  /**
+   * If true, disables clicking of the button that
+   * opens the dropdown menu.
+   */
+  disableMenu?: boolean;
 };
 
 export const MultiselectMenu = <T extends string>({
@@ -56,6 +69,7 @@ export const MultiselectMenu = <T extends string>({
   buffered = false,
   showIndicator = true,
   showSelectControls = true,
+  disableMenu = false,
 }: MultiselectMenuProps<T>) => {
   // we have a separate state in the filter so we can select a few different things and then click "apply"
   const [intSelected, setIntSelected] = useState<T[]>([]);
@@ -112,9 +126,14 @@ export const MultiselectMenu = <T extends string>({
           onClick={handleOpen}
           aria-haspopup="true"
           aria-expanded={!!anchorEl}
+          disabled={disableMenu}
         >
           {label} {selected?.length > 0 ? `(${selected?.length})` : ''}
-          <ChevronDown ml={2} size="small" color="text.slightlyMuted" />
+          <ChevronDown
+            ml={2}
+            size="small"
+            color={disableMenu ? 'text.disabled' : 'text.slightlyMuted'}
+          />
           {selected?.length > 0 && showIndicator && <FiltersExistIndicator />}
         </ButtonSecondary>
       </HoverTooltip>

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -32,7 +32,7 @@ import { ViewModeSwitch } from 'shared/components/Controls/ViewModeSwitch';
 
 import {
   IncludedResourceMode,
-  ResourceStatus,
+  ResourceHealthStatus,
   SharedUnifiedResource,
   UnifiedResourcesQueryParams,
 } from './types';
@@ -53,11 +53,12 @@ const sortFieldOptions = [
   { label: 'Type', value: 'kind' },
 ];
 
-const resourceStatusOptions: { label: string; value: ResourceStatus }[] = [
-  { label: 'Healthy', value: 'healthy' },
-  { label: 'Unhealthy', value: 'unhealthy' },
-  { label: 'Unknown', value: 'unknown' },
-];
+const resourceStatusOptions: { label: string; value: ResourceHealthStatus }[] =
+  [
+    { label: 'Healthy', value: 'healthy' },
+    { label: 'Unhealthy', value: 'unhealthy' },
+    { label: 'Unknown', value: 'unknown' },
+  ];
 
 interface FilterPanelProps {
   availableKinds: FilterKind[];
@@ -120,7 +121,7 @@ export function FilterPanel({
     setParams({ ...params, sort: oppositeSort(sort) });
   };
 
-  const onHealthStatusChange = (newStatuses: ResourceStatus[]) => {
+  const onHealthStatusChange = (newStatuses: ResourceHealthStatus[]) => {
     setParams({ ...params, statuses: newStatuses });
   };
 

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -32,6 +32,7 @@ import { ViewModeSwitch } from 'shared/components/Controls/ViewModeSwitch';
 
 import {
   IncludedResourceMode,
+  ResourceStatus,
   SharedUnifiedResource,
   UnifiedResourcesQueryParams,
 } from './types';
@@ -50,6 +51,12 @@ const kindToLabel: Record<SharedUnifiedResource['resource']['kind'], string> = {
 const sortFieldOptions = [
   { label: 'Name', value: 'name' },
   { label: 'Type', value: 'kind' },
+];
+
+const resourceStatusOptions: { label: string; value: ResourceStatus }[] = [
+  { label: 'Healthy', value: 'healthy' },
+  { label: 'Unhealthy', value: 'unhealthy' },
+  { label: 'Unknown', value: 'unknown' },
 ];
 
 interface FilterPanelProps {
@@ -91,13 +98,17 @@ export function FilterPanel({
   ClusterDropdown = null,
   onRefresh,
 }: FilterPanelProps) {
-  const { sort, kinds } = params;
+  const { sort, kinds, statuses } = params;
 
   const activeSortFieldOption = sortFieldOptions.find(
     opt => opt.value === sort.fieldName
   );
 
   const onKindsChanged = (newKinds: string[]) => {
+    if (statuses?.length && !resourceStatusFilterSupported(newKinds)) {
+      setParams({ ...params, statuses: null, kinds: newKinds });
+      return;
+    }
     setParams({ ...params, kinds: newKinds });
   };
 
@@ -108,6 +119,12 @@ export function FilterPanel({
   const onSortOrderButtonClicked = () => {
     setParams({ ...params, sort: oppositeSort(sort) });
   };
+
+  const onHealthStatusChange = (newStatuses: ResourceStatus[]) => {
+    setParams({ ...params, statuses: newStatuses });
+  };
+
+  const isResourceStatusFilterSupported = resourceStatusFilterSupported(kinds);
 
   return (
     // minHeight is set to 32px so there isn't layout shift when a bulk action button shows up
@@ -148,6 +165,20 @@ export function FilterPanel({
             onChange={changeAvailableResourceMode}
           />
         )}
+        <MultiselectMenu
+          options={resourceStatusOptions.map(({ label, value }) => ({
+            value,
+            label,
+          }))}
+          selected={statuses || []}
+          onChange={onHealthStatusChange}
+          label="Health Status"
+          tooltip={
+            'Health status filter is only available with database resources. Support for more resources will be added in the future.'
+          }
+          disableMenu={!isResourceStatusFilterSupported}
+          buffered
+        />
       </Flex>
       <Flex gap={2} alignItems="center">
         <Flex mr={1}>{BulkActions}</Flex>
@@ -331,3 +362,7 @@ const AccessRequestsToggleItem = styled.div`
   text-decoration: none;
   white-space: nowrap;
 `;
+
+function resourceStatusFilterSupported(kinds: string[]) {
+  return !kinds || kinds.length === 0 || !!kinds.find(k => k === 'db');
+}

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -105,7 +105,7 @@ export function FilterPanel({
   );
 
   const onKindsChanged = (newKinds: string[]) => {
-    if (statuses?.length && !resourceStatusFilterSupported(newKinds)) {
+    if (!resourceStatusFilterSupported(newKinds)) {
       setParams({ ...params, statuses: null, kinds: newKinds });
       return;
     }
@@ -174,9 +174,9 @@ export function FilterPanel({
           onChange={onHealthStatusChange}
           label="Health Status"
           tooltip={
-            'Health status filter is only available with database resources. Support for more resources will be added in the future.'
+            'Health status filter is only available for database resources. Support for more resource types will be added in the future.'
           }
-          disableMenu={!isResourceStatusFilterSupported}
+          disabled={!isResourceStatusFilterSupported}
           buffered
         />
       </Flex>
@@ -364,5 +364,5 @@ const AccessRequestsToggleItem = styled.div`
 `;
 
 function resourceStatusFilterSupported(kinds: string[]) {
-  return !kinds || kinds.length === 0 || !!kinds.find(k => k === 'db');
+  return !kinds || kinds.length === 0 || kinds.includes('db');
 }

--- a/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
@@ -61,14 +61,14 @@ describe('getPredicateExpression', () => {
       name: 'with status and query',
       requestedStatuses: ['healthy'],
       requestedQuery: 'name == "mysql"',
-      expected: 'name == "mysql" && (health.status == "healthy")',
+      expected: '(name == "mysql") && (health.status == "healthy")',
     },
     {
       name: 'with multi status and query',
       requestedStatuses: ['healthy', '', 'unhealthy'],
-      requestedQuery: 'name == "mysql"',
+      requestedQuery: 'name == "mysql" || name == "postgres"',
       expected:
-        'name == "mysql" && (health.status == "healthy" || health.status == "unhealthy")',
+        '(name == "mysql" || name == "postgres") && (health.status == "healthy" || health.status == "unhealthy")',
     },
   ];
 

--- a/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ResourceStatus } from '../types';
+import { buildPredicateExpression } from './predicateExpression';
+
+describe('getPredicateExpression', () => {
+  const testCases: {
+    name: string;
+    requestedStatuses?: ResourceStatus[];
+    requestedQuery?: string;
+    expected: string | undefined;
+  }[] = [
+    {
+      name: 'undefined fields',
+      requestedStatuses: undefined,
+      requestedQuery: undefined,
+      expected: '',
+    },
+    {
+      name: 'empty status array',
+      requestedStatuses: [],
+      expected: '',
+    },
+    {
+      name: 'empty value in status array',
+      requestedStatuses: ['', ''],
+      expected: '',
+    },
+    {
+      name: 'with only status',
+      requestedStatuses: ['healthy'],
+      expected: 'health.status == "healthy"',
+    },
+    {
+      name: 'with multiple statuses',
+      requestedStatuses: ['healthy', '', 'unhealthy'],
+      expected: 'health.status == "healthy" || health.status == "unhealthy"',
+    },
+    {
+      name: 'with only query',
+      requestedQuery: 'name == "mysql"',
+      expected: 'name == "mysql"',
+    },
+    {
+      name: 'with status and query',
+      requestedStatuses: ['healthy'],
+      requestedQuery: 'name == "mysql"',
+      expected: 'name == "mysql" && (health.status == "healthy")',
+    },
+    {
+      name: 'with multi status and query',
+      requestedStatuses: ['healthy', '', 'unhealthy'],
+      requestedQuery: 'name == "mysql"',
+      expected:
+        'name == "mysql" && (health.status == "healthy" || health.status == "unhealthy")',
+    },
+  ];
+
+  test.each(testCases)(
+    '$name',
+    ({ requestedStatuses, requestedQuery, expected }) => {
+      expect(
+        buildPredicateExpression(requestedStatuses, requestedQuery)
+      ).toEqual(expected);
+    }
+  );
+});

--- a/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/predicateExpression.test.ts
@@ -16,8 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ResourceStatus } from '../types';
+import { ResourceHealthStatus } from '../types';
 import { buildPredicateExpression } from './predicateExpression';
+
+type ResourceStatus = ResourceHealthStatus | '';
 
 describe('getPredicateExpression', () => {
   const testCases: {
@@ -38,7 +40,7 @@ describe('getPredicateExpression', () => {
       expected: '',
     },
     {
-      name: 'empty value in status array',
+      name: 'empty value in status array are ignored',
       requestedStatuses: ['', ''],
       expected: '',
     },

--- a/web/packages/shared/components/UnifiedResources/shared/predicateExpression.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/predicateExpression.ts
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function buildPredicateExpression(
+  requestedStatuses: string[],
+  requestedPredicateExpression: string = ''
+): string {
+  let statusPredicate = '';
+
+  if (requestedStatuses && requestedStatuses.length) {
+    // deduplicate and ignore empty strings
+    const seenMap = {};
+    statusPredicate = requestedStatuses
+      .filter(status => {
+        if (status && !seenMap[status]) {
+          seenMap[status] = true;
+          return true;
+        }
+      })
+      .map(status => `health.status == "${status}"`)
+      .join(' || ');
+  }
+
+  let newPredicateExpression = requestedPredicateExpression;
+
+  if (!newPredicateExpression) {
+    newPredicateExpression = statusPredicate;
+  } else if (statusPredicate != '') {
+    newPredicateExpression = `${newPredicateExpression} && (${statusPredicate})`;
+  }
+
+  return newPredicateExpression;
+}

--- a/web/packages/shared/components/UnifiedResources/types.test.ts
+++ b/web/packages/shared/components/UnifiedResources/types.test.ts
@@ -16,16 +16,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isResourceStatus, ResourceStatus } from './types';
+import { isResourceHealthStatus, ResourceHealthStatus } from './types';
 
 test('isResourceStatus', () => {
-  const validStatuses: ResourceStatus[] = [
+  const validStatuses: ResourceHealthStatus[] = [
     'healthy',
     'unhealthy',
     'unknown',
-    '',
+    'mixed',
   ];
-  const statuses = ['healthy', 'random', 'unhealthy', 'llama', 'unknown', ''];
+  const statuses = [
+    'healthy',
+    'random',
+    'unhealthy',
+    'llama',
+    'unknown',
+    '',
+    'mixed',
+  ];
 
-  expect(statuses.filter(isResourceStatus)).toEqual(validStatuses);
+  expect(statuses.filter(isResourceHealthStatus)).toEqual(validStatuses);
 });

--- a/web/packages/shared/components/UnifiedResources/types.test.ts
+++ b/web/packages/shared/components/UnifiedResources/types.test.ts
@@ -16,18 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function buildPredicateExpression(
-  requestedStatuses: string[] = [],
-  requestedPredicateExpression = ''
-): string {
-  // deduplicate statuses
-  const statusPredicate = [...new Set(requestedStatuses)]
-    // ignore empty
-    .filter(Boolean)
-    .map(status => `health.status == "${status}"`)
-    .join(' || ');
-  if (requestedPredicateExpression && statusPredicate) {
-    return `(${requestedPredicateExpression}) && (${statusPredicate})`;
-  }
-  return requestedPredicateExpression || statusPredicate;
-}
+import { isResourceStatus, ResourceStatus } from './types';
+
+test('isResourceStatus', () => {
+  const validStatuses: ResourceStatus[] = [
+    'healthy',
+    'unhealthy',
+    'unknown',
+    '',
+  ];
+  const statuses = ['healthy', 'random', 'unhealthy', 'llama', 'unknown', ''];
+
+  expect(statuses.filter(isResourceStatus)).toEqual(validStatuses);
+});

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -145,6 +145,7 @@ export type UnifiedResourcesQueryParams = {
     dir: 'ASC' | 'DESC';
   };
   pinnedOnly?: boolean;
+  statuses?: ResourceStatus[];
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
   includedResourceMode?: IncludedResourceMode;

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -34,6 +34,22 @@ export type ResourceHealthStatus =
   | 'unknown'
   | 'mixed';
 
+const resourcesStatuses = new Set<ResourceHealthStatus>([
+  'healthy',
+  'unhealthy',
+  'unknown',
+  'mixed',
+]);
+
+export function isResourceStatus(
+  status: unknown
+): status is ResourceHealthStatus {
+  return (
+    typeof status === 'string' &&
+    resourcesStatuses.has(status as ResourceHealthStatus)
+  );
+}
+
 export type ResourceTargetHealth = {
   status: ResourceHealthStatus;
   // additional information meant for user.
@@ -145,7 +161,7 @@ export type UnifiedResourcesQueryParams = {
     dir: 'ASC' | 'DESC';
   };
   pinnedOnly?: boolean;
-  statuses?: ResourceStatus[];
+  statuses?: ResourceHealthStatus[];
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
   includedResourceMode?: IncludedResourceMode;

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -34,19 +34,19 @@ export type ResourceHealthStatus =
   | 'unknown'
   | 'mixed';
 
-const resourcesStatuses = new Set<ResourceHealthStatus>([
+const resourceHealthStatuses = new Set<ResourceHealthStatus>([
   'healthy',
   'unhealthy',
   'unknown',
   'mixed',
 ]);
 
-export function isResourceStatus(
+export function isResourceHealthStatus(
   status: unknown
 ): status is ResourceHealthStatus {
   return (
     typeof status === 'string' &&
-    resourcesStatuses.has(status as ResourceHealthStatus)
+    resourceHealthStatuses.has(status as ResourceHealthStatus)
   );
 }
 

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -33,6 +33,7 @@ import {
   UnifiedResourcesPinning,
   useUnifiedResourcesFetch,
 } from 'shared/components/UnifiedResources';
+import { buildPredicateExpression } from 'shared/components/UnifiedResources/shared/predicateExpression';
 import {
   getResourceId,
   openStatusInfoPanel,
@@ -187,7 +188,7 @@ export function ClusterResources({
           clusterId,
           {
             search: params.search,
-            query: params.query,
+            query: buildPredicateExpression(params.statuses, params.query),
             pinnedOnly: params.pinnedOnly,
             sort: params.sort,
             kinds: params.kinds,
@@ -213,6 +214,7 @@ export function ClusterResources({
         params.search,
         params.sort,
         params.includedResourceMode,
+        params.statuses,
         teleCtx.resourceService,
       ]
     ),

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.test.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.test.ts
@@ -68,15 +68,16 @@ const testCases: {
     expected: '/test?sort=name%3Aasc&pinnedOnly=false',
   },
   {
-    title: 'Search, sort, and filter by kind',
+    title: 'Search, sort, filter by kind, and filter by statuses',
     args: {
       pathname: '/test',
       searchString: 'foo',
       sort: { fieldName: 'name', dir: 'DESC' },
       kinds: ['db', 'node'],
+      statuses: ['healthy', 'unhealthy'],
     },
     expected:
-      '/test?search=foo&sort=name%3Adesc&pinnedOnly=false&kinds=db&kinds=node',
+      '/test?search=foo&sort=name%3Adesc&pinnedOnly=false&kinds=db&kinds=node&status=healthy&status=unhealthy',
   },
 ];
 

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
@@ -17,14 +17,14 @@
  */
 
 import { SortType } from 'design/DataTable/types';
-import { ResourceStatus } from 'shared/components/UnifiedResources';
+import { ResourceHealthStatus } from 'shared/components/UnifiedResources';
 
 export type EncodeUrlQueryParamsProps = {
   pathname: string;
   searchString?: string;
   sort?: SortType | null;
   kinds?: string[] | null;
-  statuses?: ResourceStatus[] | null;
+  statuses?: ResourceHealthStatus[] | null;
   isAdvancedSearch?: boolean;
   pinnedOnly?: boolean;
 };

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
@@ -17,12 +17,14 @@
  */
 
 import { SortType } from 'design/DataTable/types';
+import { ResourceStatus } from 'shared/components/UnifiedResources';
 
 export type EncodeUrlQueryParamsProps = {
   pathname: string;
   searchString?: string;
   sort?: SortType | null;
   kinds?: string[] | null;
+  statuses?: ResourceStatus[] | null;
   isAdvancedSearch?: boolean;
   pinnedOnly?: boolean;
 };
@@ -34,6 +36,7 @@ export function encodeUrlQueryParams({
   kinds,
   isAdvancedSearch = false,
   pinnedOnly = false,
+  statuses,
 }: EncodeUrlQueryParamsProps) {
   const urlParams = new URLSearchParams();
 
@@ -52,6 +55,12 @@ export function encodeUrlQueryParams({
   if (kinds) {
     for (const kind of kinds) {
       urlParams.append('kinds', kind);
+    }
+  }
+
+  if (statuses) {
+    for (const status of statuses) {
+      urlParams.append('status', status);
     }
   }
 

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
@@ -118,7 +118,8 @@ test('extracting params from URL with no search param and with sort param with u
 });
 
 test('extracting params from URL with resource kinds and statuses', () => {
-  const url = '/test?kinds=node&status=unknown&&kinds=db&status=healthy';
+  const url =
+    '/test?kinds=node&status=unknown&kinds=db&status=healthy&status=random-word';
   const expected = {
     kinds: ['node', 'db'],
     search: null,

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
@@ -34,6 +34,7 @@ test('extracting params from URL with simple search and sort params', () => {
     },
     query: null,
     kinds: null,
+    statuses: null,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -59,6 +60,7 @@ test('extracting params from URL with advanced search and sort params', () => {
     },
     search: null,
     kinds: null,
+    statuses: null,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -80,6 +82,7 @@ test('extracting params from URL with simple search param but no sort param', ()
     sort: initialSort,
     query: null,
     kinds: null,
+    statuses: null,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -100,6 +103,7 @@ test('extracting params from URL with no search param and with sort param with u
     search: null,
     query: null,
     kinds: null,
+    statuses: null,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -113,13 +117,14 @@ test('extracting params from URL with no search param and with sort param with u
   expect(result.current.params).toEqual(expected);
 });
 
-test('extracting params from URL with resource kinds', () => {
-  const url = '/test?kinds=node&kinds=db';
+test('extracting params from URL with resource kinds and statuses', () => {
+  const url = '/test?kinds=node&status=unknown&&kinds=db&status=healthy';
   const expected = {
     kinds: ['node', 'db'],
     search: null,
     sort: initialSort,
     query: null,
+    statuses: ['unknown', 'healthy'],
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
@@ -34,7 +34,7 @@ test('extracting params from URL with simple search and sort params', () => {
     },
     query: null,
     kinds: null,
-    statuses: null,
+    statuses: undefined,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -60,7 +60,7 @@ test('extracting params from URL with advanced search and sort params', () => {
     },
     search: null,
     kinds: null,
-    statuses: null,
+    statuses: undefined,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -82,7 +82,7 @@ test('extracting params from URL with simple search param but no sort param', ()
     sort: initialSort,
     query: null,
     kinds: null,
-    statuses: null,
+    statuses: undefined,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });
@@ -103,7 +103,7 @@ test('extracting params from URL with no search param and with sort param with u
     search: null,
     query: null,
     kinds: null,
-    statuses: null,
+    statuses: undefined,
   };
 
   const history = createMemoryHistory({ initialEntries: [url] });

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -20,7 +20,10 @@ import { useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 
 import { SortType } from 'design/DataTable/types';
-import { IncludedResourceMode } from 'shared/components/UnifiedResources';
+import {
+  IncludedResourceMode,
+  ResourceStatus,
+} from 'shared/components/UnifiedResources';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
 import { ResourceFilter, ResourceLabel } from 'teleport/services/agents';
@@ -87,6 +90,7 @@ export function useUrlFiltering(
         kinds: newParams.kinds,
         isAdvancedSearch: !!newParams.query,
         pinnedOnly: newParams.pinnedOnly,
+        statuses: newParams.statuses,
       })
     );
   }
@@ -129,6 +133,9 @@ export default function getResourceUrlQueryParams(
   const pinnedOnly = searchParams.get('pinnedOnly');
   const sort = searchParams.get('sort');
   const kinds = searchParams.has('kinds') ? searchParams.getAll('kinds') : null;
+  const statuses = searchParams.has('status')
+    ? (searchParams.getAll('status') as ResourceStatus[])
+    : null;
 
   const sortParam = sort ? sort.split(':') : null;
 
@@ -144,6 +151,7 @@ export default function getResourceUrlQueryParams(
     query,
     search,
     kinds,
+    statuses,
     // Conditionally adds the sort field based on whether it exists or not
     ...(!!processedSortParam && { sort: processedSortParam }),
     // Conditionally adds the pinnedResources field based on whether its true or not

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -22,7 +22,7 @@ import { useLocation } from 'react-router';
 import { SortType } from 'design/DataTable/types';
 import {
   IncludedResourceMode,
-  ResourceStatus,
+  isResourceStatus,
 } from 'shared/components/UnifiedResources';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
@@ -134,7 +134,7 @@ export default function getResourceUrlQueryParams(
   const sort = searchParams.get('sort');
   const kinds = searchParams.has('kinds') ? searchParams.getAll('kinds') : null;
   const statuses = searchParams.has('status')
-    ? (searchParams.getAll('status') as ResourceStatus[])
+    ? searchParams.getAll('status').filter(isResourceStatus)
     : null;
 
   const sortParam = sort ? sort.split(':') : null;

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -22,7 +22,7 @@ import { useLocation } from 'react-router';
 import { SortType } from 'design/DataTable/types';
 import {
   IncludedResourceMode,
-  isResourceStatus,
+  isResourceHealthStatus,
 } from 'shared/components/UnifiedResources';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
@@ -134,8 +134,8 @@ export default function getResourceUrlQueryParams(
   const sort = searchParams.get('sort');
   const kinds = searchParams.has('kinds') ? searchParams.getAll('kinds') : null;
   const statuses = searchParams.has('status')
-    ? searchParams.getAll('status').filter(isResourceStatus)
-    : null;
+    ? searchParams.getAll('status').filter(isResourceHealthStatus)
+    : undefined;
 
   const sortParam = sort ? sort.split(':') : null;
 

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -34,6 +34,8 @@ export default function generateResourcePath(
       ].dir.toLowerCase()}`;
     } else if (param === 'kinds') {
       processedParams[param] = (params[param] ?? []).join('&kinds=');
+    } else if (param === 'statuses') {
+      processedParams[param] = (params[param] ?? []).join('&status=');
     } else if (param === 'regions') {
       processedParams[param] = (params[param] ?? []).join('&regions=');
     } else
@@ -57,6 +59,7 @@ export default function generateResourcePath(
     // param
     .replace(':kind?', processedParams.kind || '')
     .replace(':kinds?', processedParams.kinds || '')
+    .replace(':status?', processedParams.statuses || '')
     .replace(':kubeCluster?', processedParams.kubeCluster || '')
     .replace(':kubeNamespace?', processedParams.kubeNamespace || '')
     .replace(':limit?', params.limit || '')

--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -19,7 +19,10 @@
 import { GitServer } from 'web/packages/teleport/src/services/gitServers';
 
 import type { Platform } from 'design/platform';
-import { IncludedResourceMode } from 'shared/components/UnifiedResources';
+import {
+  IncludedResourceMode,
+  ResourceStatus,
+} from 'shared/components/UnifiedResources';
 
 import { App } from 'teleport/services/apps';
 import { Database } from 'teleport/services/databases';
@@ -64,6 +67,7 @@ export type ResourceFilter = {
   pinnedOnly?: boolean;
   searchAsRoles?: '' | 'yes';
   includedResourceMode?: IncludedResourceMode;
+  statuses?: ResourceStatus[];
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
 };

--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -21,7 +21,7 @@ import { GitServer } from 'web/packages/teleport/src/services/gitServers';
 import type { Platform } from 'design/platform';
 import {
   IncludedResourceMode,
-  ResourceStatus,
+  ResourceHealthStatus,
 } from 'shared/components/UnifiedResources';
 
 import { App } from 'teleport/services/apps';
@@ -67,7 +67,7 @@ export type ResourceFilter = {
   pinnedOnly?: boolean;
   searchAsRoles?: '' | 'yes';
   includedResourceMode?: IncludedResourceMode;
-  statuses?: ResourceStatus[];
+  statuses?: ResourceHealthStatus[];
   // TODO(bl-nero): Remove this once filters are expressed as advanced search.
   kinds?: string[];
 };

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -45,6 +45,7 @@ import {
   UnifiedResourcesQueryParams,
   useUnifiedResourcesFetch,
 } from 'shared/components/UnifiedResources';
+import { buildPredicateExpression } from 'shared/components/UnifiedResources/shared/predicateExpression';
 import {
   getResourceId,
   openStatusInfoPanel,
@@ -128,12 +129,14 @@ export function UnifiedResources(props: {
       query: props.queryParams.advancedSearchEnabled
         ? props.queryParams.search
         : '',
+      statuses: props.queryParams.statuses,
     }),
     [
       props.queryParams.advancedSearchEnabled,
       props.queryParams.resourceKinds,
       props.queryParams.search,
       props.queryParams.sort,
+      props.queryParams.statuses,
       unifiedResourcePreferences.defaultTab,
     ]
   );
@@ -190,6 +193,7 @@ export function UnifiedResources(props: {
           newParams.kinds as DocumentClusterResourceKind[];
         queryParams.search = newParams.search || newParams.query;
         queryParams.advancedSearchEnabled = !!newParams.query;
+        queryParams.statuses = newParams.statuses;
       });
     },
     [documentsService, props.docUri]
@@ -308,7 +312,10 @@ const Resources = memo(
                   },
                   search: props.queryParams.search,
                   kinds: props.queryParams.kinds,
-                  query: props.queryParams.query,
+                  query: buildPredicateExpression(
+                    props.queryParams.statuses,
+                    props.queryParams.query
+                  ),
                   pinnedOnly: props.queryParams.pinnedOnly,
                   startKey: paginationParams.startKey,
                   limit: paginationParams.limit,
@@ -332,6 +339,7 @@ const Resources = memo(
           props.queryParams.search,
           props.queryParams.sort.dir,
           props.queryParams.sort.fieldName,
+          props.queryParams.statuses,
           props.clusterUri,
           props.integratedAccessRequests,
         ]

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -260,6 +260,7 @@ test('search bar state is adjusted to the active document', () => {
         resourceKinds: ['db'],
         sort: { dir: 'ASC', fieldName: 'name' },
         advancedSearchEnabled: true,
+        statuses: ['healthy'],
       },
     });
     docService.add(clusterDoc);
@@ -281,6 +282,7 @@ test('search bar state is adjusted to the active document', () => {
         resourceKinds: ['kube_cluster'],
         sort: { dir: 'ASC', fieldName: 'name' },
         advancedSearchEnabled: false,
+        statuses: [],
       },
     });
     docService.add(clusterDoc);
@@ -316,6 +318,7 @@ test('search bar state is adjusted to the active document', () => {
         resourceKinds: ['kube_cluster'],
         sort: { dir: 'ASC', fieldName: 'name' },
         advancedSearchEnabled: false,
+        statuses: [],
       },
     });
     docService.add(clusterDoc);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -584,5 +584,6 @@ export function getDefaultDocumentClusterQueryParams(): DocumentClusterQueryPara
     search: '',
     sort: { fieldName: 'name', dir: 'ASC' },
     advancedSearchEnabled: false,
+    statuses: [],
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -44,6 +44,7 @@ export function makeDocumentCluster(
       resourceKinds: [],
       search: '',
       advancedSearchEnabled: false,
+      statuses: [],
     },
     ...props,
   };

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -18,7 +18,7 @@
 
 import { Report } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 import {
-  ResourceStatus,
+  ResourceHealthStatus,
   SharedUnifiedResource,
 } from 'shared/components/UnifiedResources';
 
@@ -176,7 +176,7 @@ export interface DocumentClusterQueryParams {
     fieldName: string;
     dir: 'ASC' | 'DESC';
   };
-  statuses: ResourceStatus[];
+  statuses: ResourceHealthStatus[];
 }
 
 // Any changes done to this type must be backwards compatible as

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -17,7 +17,10 @@
  */
 
 import { Report } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
-import { SharedUnifiedResource } from 'shared/components/UnifiedResources';
+import {
+  ResourceStatus,
+  SharedUnifiedResource,
+} from 'shared/components/UnifiedResources';
 
 import type * as tsh from 'teleterm/services/tshd/types';
 import * as uri from 'teleterm/ui/uri';
@@ -173,6 +176,7 @@ export interface DocumentClusterQueryParams {
     fieldName: string;
     dir: 'ASC' | 'DESC';
   };
+  statuses: ResourceStatus[];
 }
 
 // Any changes done to this type must be backwards compatible as

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -579,6 +579,9 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
                 ...defaultParams.sort,
                 ...d.queryParams?.sort,
               },
+              statuses: d.queryParams?.statuses
+                ? [...d.queryParams.statuses] // makes the array mutable
+                : defaultParams.statuses,
               resourceKinds: d.queryParams?.resourceKinds
                 ? [...d.queryParams.resourceKinds] // makes the array mutable
                 : defaultParams.resourceKinds,


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/20544

- [ ] requires https://github.com/gravitational/teleport/pull/54857

recommend reviewing by commit

Adds a `health status` filter dropdown to both web and teleterm unified resource view

demo web:
https://github.com/user-attachments/assets/f3a4fe03-72b0-4de1-b2af-d7a75e78be6d


demo teleterm:
https://github.com/user-attachments/assets/c9fee032-8aee-4230-afaa-049e3d5e16a1

