### PR TITLE
Correct redirects

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -101,11 +101,6 @@
       "permanent": true
     },
     {
-      "source": "/admin-guides/management/guides/aws-iam-identity-center/",
-      "destination": "/admin-guides/management/guides/aws-iam-identity-center/guide/",
-      "permanent": true
-    },
-    {
       "source": "/reference/operator-resources/resources.teleport.dev_accesslists/",
       "destination": "/reference/operator-resources/resources-teleport-dev-accesslists/",
       "permanent": true
@@ -173,11 +168,6 @@
     {
       "source": "/reference/operator-resources/resources.teleport.dev_users/",
       "destination": "/reference/operator-resources/resources-teleport-dev-users/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/workload-identity/workload-attestation/",
-      "destination": "/reference/workload-identity/workload-identity-api-and-workload-attestation/",
       "permanent": true
     },
     {
@@ -251,11 +241,6 @@
       "permanent": true
     },
     {
-      "source": "/enterprise/sso/",
-      "destination": "/admin-guides/access-controls/sso/",
-      "permanent": true
-    },
-    {
       "source": "/access-controls/access-request-plugins/",
       "destination": "/admin-guides/access-controls/access-request-plugins/",
       "permanent": true
@@ -321,8 +306,8 @@
       "permanent": true
     },
     {
-      "source": "/enroll-resources/application-access/okta/okta/",
-      "destination": "/admin-guides/access-controls/okta/okta/",
+      "source": "/enroll-resources/application-access/okta/",
+      "destination": "/admin-guides/access-controls/okta/",
       "permanent": true
     },
     {
@@ -333,11 +318,6 @@
     {
       "source": "/enroll-resources/application-access/okta/user-sync/",
       "destination": "/admin-guides/access-controls/okta/user-sync/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/okta/",
-      "destination": "/admin-guides/access-controls/okta/",
       "permanent": true
     },
     {
@@ -387,11 +367,6 @@
     },
     {
       "source": "/enroll-resources/agents/introduction/",
-      "destination": "/enroll-resources/agents/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/agents/join-services-to-your-cluster/",
       "destination": "/enroll-resources/agents/",
       "permanent": true
     }


### PR DESCRIPTION
- Remove redirects that navigate away from a path that exists. Docusaurus ignores these with a warning, so this removes a warning.
- Remove duplicate redirects.
- Where a redirect uses a section index page path from our legacy custom site, e.g., `/slug/slug/`, use the Docusaurus format instead, e.g., `/slug/`. This lets us remove some migration logic from the docs engine.