### PR TITLE
[v16] Correct redirects

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -152,7 +152,7 @@
     },
     {
       "source": "/database-access/guides/",
-      "destination": "/enroll-resources/database-access/guides/guides/",
+      "destination": "/enroll-resources/database-access/guides/",
       "permanent": true
     },
     {
@@ -192,7 +192,7 @@
     },
     {
       "source": "/agents/join-services-to-your-cluster/",
-      "destination": "/enroll-resources/agents/join-services-to-your-cluster/join-services-to-your-cluster/",
+      "destination": "/enroll-resources/agents/join-services-to-your-cluster/",
       "permanent": true
     },
     {
@@ -227,7 +227,7 @@
     },
     {
       "source": "/application-access/cloud-apis/",
-      "destination": "/enroll-resources/application-access/cloud-apis/cloud-apis/",
+      "destination": "/enroll-resources/application-access/cloud-apis/",
       "permanent": true
     },
     {
@@ -262,7 +262,7 @@
     },
     {
       "source": "/application-access/guides/",
-      "destination": "/enroll-resources/application-access/guides/guides/",
+      "destination": "/enroll-resources/application-access/guides/",
       "permanent": true
     },
     {
@@ -307,7 +307,7 @@
     },
     {
       "source": "/application-access/jwt/",
-      "destination": "/enroll-resources/application-access/jwt/jwt/",
+      "destination": "/enroll-resources/application-access/jwt/",
       "permanent": true
     },
     {
@@ -322,7 +322,7 @@
     },
     {
       "source": "/application-access/okta/",
-      "destination": "/enroll-resources/application-access/okta/okta/",
+      "destination": "/enroll-resources/application-access/okta/",
       "permanent": true
     },
     {
@@ -357,7 +357,7 @@
     },
     {
       "source": "/auto-discovery/databases/",
-      "destination": "/enroll-resources/auto-discovery/databases/databases/",
+      "destination": "/enroll-resources/auto-discovery/databases/",
       "permanent": true
     },
     {
@@ -367,12 +367,12 @@
     },
     {
       "source": "/auto-discovery/introduction/",
-      "destination": "/enroll-resources/auto-discovery/auto-discovery/",
+      "destination": "/enroll-resources/auto-discovery/",
       "permanent": true
     },
     {
       "source": "/auto-discovery/kubernetes-applications/",
-      "destination": "/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications/",
+      "destination": "/enroll-resources/auto-discovery/kubernetes-applications/",
       "permanent": true
     },
     {
@@ -392,7 +392,7 @@
     },
     {
       "source": "/auto-discovery/kubernetes/",
-      "destination": "/enroll-resources/auto-discovery/kubernetes/kubernetes/",
+      "destination": "/enroll-resources/auto-discovery/kubernetes/",
       "permanent": true
     },
     {
@@ -412,7 +412,7 @@
     },
     {
       "source": "/auto-discovery/servers/",
-      "destination": "/enroll-resources/auto-discovery/servers/servers/",
+      "destination": "/enroll-resources/auto-discovery/servers/",
       "permanent": true
     },
     {
@@ -432,7 +432,7 @@
     },
     {
       "source": "/database-access/auto-user-provisioning/",
-      "destination": "/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning/",
+      "destination": "/enroll-resources/database-access/auto-user-provisioning/",
       "permanent": true
     },
     {
@@ -462,7 +462,7 @@
     },
     {
       "source": "/database-access/enroll-aws-databases/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/",
       "permanent": true
     },
     {
@@ -527,7 +527,7 @@
     },
     {
       "source": "/database-access/enroll-azure-databases/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases/",
+      "destination": "/enroll-resources/database-access/enroll-azure-databases/",
       "permanent": true
     },
     {
@@ -547,7 +547,7 @@
     },
     {
       "source": "/database-access/enroll-google-cloud-databases/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases/",
+      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/",
       "permanent": true
     },
     {
@@ -566,11 +566,6 @@
       "permanent": true
     },
     {
-      "source": "/database-access/enroll-managed-databases/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/enroll-managed-databases/mongodb-atlas/",
       "destination": "/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas/",
       "permanent": true
@@ -578,11 +573,6 @@
     {
       "source": "/database-access/enroll-managed-databases/snowflake/",
       "destination": "/enroll-resources/database-access/enroll-managed-databases/snowflake/",
-      "permanent": true
-    },
-    {
-      "source": "/database-access/enroll-self-hosted-databases/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases/",
       "permanent": true
     },
     {
@@ -661,18 +651,13 @@
       "permanent": true
     },
     {
-      "source": "/database-access/introduction/",
-      "destination": "/enroll-resources/database-access/database-access/",
-      "permanent": true
-    },
-    {
       "source": "/database-access/rbac/",
       "destination": "/enroll-resources/database-access/rbac/",
       "permanent": true
     },
     {
       "source": "/database-access/reference/",
-      "destination": "/reference/agent-services/database-access-reference/database-access-reference/",
+      "destination": "/reference/agent-services/database-access-reference/",
       "permanent": true
     },
     {
@@ -732,7 +717,7 @@
     },
     {
       "source": "/desktop-access/reference/",
-      "destination": "/reference/agent-services/desktop-access-reference/desktop-access-reference/",
+      "destination": "/reference/agent-services/desktop-access-reference/",
       "permanent": true
     },
     {
@@ -797,7 +782,7 @@
     },
     {
       "source": "/kubernetes-access/register-clusters/",
-      "destination": "/enroll-resources/kubernetes-access/register-clusters/register-clusters/",
+      "destination": "/enroll-resources/kubernetes-access/register-clusters/",
       "permanent": true
     },
     {
@@ -822,7 +807,7 @@
     },
     {
       "source": "/machine-id/access-guides/",
-      "destination": "/enroll-resources/machine-id/access-guides/access-guides/",
+      "destination": "/enroll-resources/machine-id/access-guides/",
       "permanent": true
     },
     {
@@ -867,7 +852,7 @@
     },
     {
       "source": "/machine-id/deployment/",
-      "destination": "/enroll-resources/machine-id/deployment/deployment/",
+      "destination": "/enroll-resources/machine-id/deployment/",
       "permanent": true
     },
     {
@@ -922,7 +907,7 @@
     },
     {
       "source": "/machine-id/reference/",
-      "destination": "/reference/machine-id/machine-id/",
+      "destination": "/reference/machine-id/",
       "permanent": true
     },
     {
@@ -997,7 +982,7 @@
     },
     {
       "source": "/server-access/guides/",
-      "destination": "/enroll-resources/server-access/guides/guides/",
+      "destination": "/enroll-resources/server-access/guides/",
       "permanent": true
     },
     {
@@ -1047,17 +1032,12 @@
     },
     {
       "source": "/server-access/openssh/",
-      "destination": "/enroll-resources/server-access/openssh/openssh/",
+      "destination": "/enroll-resources/server-access/openssh/",
       "permanent": true
     },
     {
       "source": "/server-access/openssh/openssh-manual-install/",
       "destination": "/enroll-resources/server-access/openssh/openssh-manual-install/",
-      "permanent": true
-    },
-    {
-      "source": "/server-access/openssh/openssh/",
-      "destination": "/enroll-resources/server-access/openssh/openssh-agentless/",
       "permanent": true
     },
     {
@@ -1152,17 +1132,17 @@
     },
     {
       "source": "/enterprise/sso/",
-      "destination": "/admin-guides/access-controls/sso/sso/",
+      "destination": "/admin-guides/access-controls/sso/",
       "permanent": true
     },
     {
       "source": "/access-controls/guides/device-trust/",
-      "destination": "/admin-guides/access-controls/device-trust/device-trust/",
+      "destination": "/admin-guides/access-controls/device-trust/",
       "permanent": true
     },
     {
       "source": "/deploy-a-cluster/teleport-enterprise/getting-started/",
-      "destination": "/admin-guides/deploy-a-cluster/deploy-a-cluster/",
+      "destination": "/admin-guides/deploy-a-cluster/",
       "permanent": true
     },
     {
@@ -1172,7 +1152,7 @@
     },
     {
       "source": "/application-access/okta/guide/",
-      "destination": "/enroll-resources/application-access/okta/okta/",
+      "destination": "/enroll-resources/application-access/okta/",
       "permanent": true
     },
     {
@@ -1222,7 +1202,7 @@
     },
     {
       "source": "/setup/operations/upgrading/",
-      "destination": "/upgrading/upgrading/",
+      "destination": "/upgrading/",
       "permanent": true
     },
     {
@@ -1247,7 +1227,7 @@
     },
     {
       "source": "/reference/api/introduction/",
-      "destination": "/admin-guides/api/api/",
+      "destination": "/admin-guides/api/",
       "permanent": true
     },
     {
@@ -1312,7 +1292,7 @@
     },
     {
       "source": "/access-controls/access-graph/",
-      "destination": "/admin-guides/deploy-a-cluster/access-graph/access-graph/",
+      "destination": "/admin-guides/deploy-a-cluster/access-graph/",
       "permanent": true
     },
     {
@@ -1342,7 +1322,7 @@
     },
     {
       "source": "/access-controls/access-lists/",
-      "destination": "/admin-guides/access-controls/access-lists/access-lists/",
+      "destination": "/admin-guides/access-controls/access-lists/",
       "permanent": true
     },
     {
@@ -1362,7 +1342,7 @@
     },
     {
       "source": "/access-controls/access-request-plugins/",
-      "destination": "/admin-guides/access-controls/access-request-plugins/access-request-plugins/",
+      "destination": "/admin-guides/access-controls/access-request-plugins/",
       "permanent": true
     },
     {
@@ -1422,7 +1402,7 @@
     },
     {
       "source": "/access-controls/access-requests/",
-      "destination": "/admin-guides/access-controls/access-requests/access-requests/",
+      "destination": "/admin-guides/access-controls/access-requests/",
       "permanent": true
     },
     {
@@ -1447,7 +1427,7 @@
     },
     {
       "source": "/access-controls/compliance-frameworks/",
-      "destination": "/admin-guides/access-controls/compliance-frameworks/compliance-frameworks/",
+      "destination": "/admin-guides/access-controls/compliance-frameworks/",
       "permanent": true
     },
     {
@@ -1462,7 +1442,7 @@
     },
     {
       "source": "/access-controls/device-trust/",
-      "destination": "/admin-guides/access-controls/device-trust/device-trust/",
+      "destination": "/admin-guides/access-controls/device-trust/",
       "permanent": true
     },
     {
@@ -1492,7 +1472,7 @@
     },
     {
       "source": "/access-controls/guides/",
-      "destination": "/admin-guides/access-controls/guides/guides/",
+      "destination": "/admin-guides/access-controls/guides/",
       "permanent": true
     },
     {
@@ -1557,7 +1537,7 @@
     },
     {
       "source": "/access-controls/idps/",
-      "destination": "/admin-guides/access-controls/idps/idps/",
+      "destination": "/admin-guides/access-controls/idps/",
       "permanent": true
     },
     {
@@ -1587,12 +1567,12 @@
     },
     {
       "source": "/access-controls/introduction/",
-      "destination": "/admin-guides/access-controls/access-controls/",
+      "destination": "/admin-guides/access-controls/",
       "permanent": true
     },
     {
       "source": "/access-controls/login-rules/",
-      "destination": "/admin-guides/access-controls/login-rules/login-rules/",
+      "destination": "/admin-guides/access-controls/login-rules/",
       "permanent": true
     },
     {
@@ -1622,7 +1602,7 @@
     },
     {
       "source": "/access-controls/sso/",
-      "destination": "/admin-guides/access-controls/sso/sso/",
+      "destination": "/admin-guides/access-controls/sso/",
       "permanent": true
     },
     {
@@ -1667,7 +1647,7 @@
     },
     {
       "source": "/access-controls/teleport-policy/getting-started-policy/",
-      "destination": "/admin-guides/teleport-policy/teleport-policy/",
+      "destination": "/admin-guides/teleport-policy/",
       "permanent": true
     },
     {
@@ -1682,7 +1662,7 @@
     },
     {
       "source": "/access-controls/teleport-policy/policy-integrations/",
-      "destination": "/admin-guides/teleport-policy/integrations/integrations/",
+      "destination": "/admin-guides/teleport-policy/integrations/",
       "permanent": true
     },
     {
@@ -1707,7 +1687,7 @@
     },
     {
       "source": "/api/introduction/",
-      "destination": "/admin-guides/api/api/",
+      "destination": "/admin-guides/api/",
       "permanent": true
     },
     {
@@ -1737,7 +1717,7 @@
     },
     {
       "source": "/architecture/introduction/",
-      "destination": "/reference/architecture/architecture/",
+      "destination": "/reference/architecture/",
       "permanent": true
     },
     {
@@ -1822,7 +1802,7 @@
     },
     {
       "source": "/deploy-a-cluster/deployments/",
-      "destination": "/admin-guides/deploy-a-cluster/deployments/deployments/",
+      "destination": "/admin-guides/deploy-a-cluster/deployments/",
       "permanent": true
     },
     {
@@ -1852,7 +1832,7 @@
     },
     {
       "source": "/deploy-a-cluster/helm-deployments/",
-      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/helm-deployments/",
+      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/",
       "permanent": true
     },
     {
@@ -2027,7 +2007,7 @@
     },
     {
       "source": "/management/admin/",
-      "destination": "/admin-guides/management/admin/admin/",
+      "destination": "/admin-guides/management/admin/",
       "permanent": true
     },
     {
@@ -2072,7 +2052,7 @@
     },
     {
       "source": "/management/diagnostics/",
-      "destination": "/admin-guides/management/diagnostics/diagnostics/",
+      "destination": "/admin-guides/management/diagnostics/",
       "permanent": true
     },
     {
@@ -2107,7 +2087,7 @@
     },
     {
       "source": "/management/dynamic-resources/",
-      "destination": "/admin-guides/infrastructure-as-code/infrastructure-as-code/",
+      "destination": "/admin-guides/infrastructure-as-code/",
       "permanent": true
     },
     {
@@ -2132,12 +2112,12 @@
     },
     {
       "source": "/management/dynamic-resources/teleport-operator/",
-      "destination": "/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator/",
+      "destination": "/admin-guides/infrastructure-as-code/teleport-operator/",
       "permanent": true
     },
     {
       "source": "/management/dynamic-resources/terraform-provider/",
-      "destination": "/admin-guides/infrastructure-as-code/terraform-provider/terraform-provider/",
+      "destination": "/admin-guides/infrastructure-as-code/terraform-provider/",
       "permanent": true
     },
     {
@@ -2147,7 +2127,7 @@
     },
     {
       "source": "/management/export-audit-events/",
-      "destination": "/admin-guides/management/export-audit-events/export-audit-events/",
+      "destination": "/admin-guides/management/export-audit-events/",
       "permanent": true
     },
     {
@@ -2172,7 +2152,7 @@
     },
     {
       "source": "/management/guides/",
-      "destination": "/admin-guides/management/guides/guides/",
+      "destination": "/admin-guides/management/guides/",
       "permanent": true
     },
     {
@@ -2202,7 +2182,7 @@
     },
     {
       "source": "/management/operations/",
-      "destination": "/admin-guides/management/operations/operations/",
+      "destination": "/admin-guides/management/operations/",
       "permanent": true
     },
     {
@@ -2242,7 +2222,7 @@
     },
     {
       "source": "/management/security/",
-      "destination": "/admin-guides/management/security/security/",
+      "destination": "/admin-guides/management/security/",
       "permanent": true
     },
     {
@@ -2287,7 +2267,7 @@
     },
     {
       "source": "/choose-an-edition/teleport-enterprise/introduction/",
-      "destination": "/admin-guides/deploy-a-cluster/deploy-a-cluster/",
+      "destination": "/admin-guides/deploy-a-cluster/",
       "permanent": true
     },
     {
@@ -2297,7 +2277,7 @@
     },
     {
       "source": "/kubernetes-access/helm/guides/",
-      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/helm-deployments/",
+      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/",
       "permanent": true
     },
     {
@@ -2341,386 +2321,6 @@
       "permanent": true
     },
     {
-      "source": "/admin-guides/access-controls/access-lists/",
-      "destination": "/admin-guides/access-controls/access-lists/access-lists/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/access-request-plugins/",
-      "destination": "/admin-guides/access-controls/access-request-plugins/access-request-plugins/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/access-requests/",
-      "destination": "/admin-guides/access-controls/access-requests/access-requests/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/compliance-frameworks/",
-      "destination": "/admin-guides/access-controls/compliance-frameworks/compliance-frameworks/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/device-trust/",
-      "destination": "/admin-guides/access-controls/device-trust/device-trust/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/guides/",
-      "destination": "/admin-guides/access-controls/guides/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/login-rules/",
-      "destination": "/admin-guides/access-controls/login-rules/login-rules/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/infrastructure-as-code/",
-      "destination": "/admin-guides/infrastructure-as-code/infrastructure-as-code/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/infrastructure-as-code/teleport-operator/",
-      "destination": "/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/diagnostics/",
-      "destination": "/admin-guides/management/diagnostics/diagnostics/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/export-audit-events/",
-      "destination": "/admin-guides/management/export-audit-events/export-audit-events/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/guides/",
-      "destination": "/admin-guides/management/guides/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/security/",
-      "destination": "/admin-guides/management/security/security/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/jwt/",
-      "destination": "/enroll-resources/application-access/jwt/jwt/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/databases/",
-      "destination": "/enroll-resources/auto-discovery/databases/databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/kubernetes-applications/",
-      "destination": "/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/kubernetes/",
-      "destination": "/enroll-resources/auto-discovery/kubernetes/kubernetes/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/servers/",
-      "destination": "/enroll-resources/auto-discovery/servers/servers/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/terraform-provider/",
-      "destination": "/reference/terraform-provider/terraform-provider/",
-      "permanent": true
-    },
-    {
-      "source": "/connect-your-client/",
-      "destination": "/connect-your-client/connect-your-client/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/",
-      "destination": "/enroll-resources/enroll-resources/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/",
-      "destination": "/enroll-resources/database-access/database-access/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/auto-user-provisioning/",
-      "destination": "/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/enroll-google-cloud-databases/",
-      "destination": "/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/enroll-self-hosted-databases/",
-      "destination": "/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/enroll-managed-databases/",
-      "destination": "/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/guides/",
-      "destination": "/enroll-resources/database-access/guides/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/enroll-aws-databases/",
-      "destination": "/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/database-access/enroll-azure-databases/",
-      "destination": "/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/machine-id/",
-      "destination": "/enroll-resources/machine-id/machine-id/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/machine-id/access-guides/",
-      "destination": "/enroll-resources/machine-id/access-guides/access-guides/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/machine-id/deployment/",
-      "destination": "/enroll-resources/machine-id/deployment/deployment/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/desktop-access/",
-      "destination": "/enroll-resources/desktop-access/desktop-access/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/kubernetes-access/",
-      "destination": "/enroll-resources/kubernetes-access/kubernetes-access/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/kubernetes-access/register-clusters/",
-      "destination": "/enroll-resources/kubernetes-access/register-clusters/register-clusters/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/agents/",
-      "destination": "/enroll-resources/agents/agents/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/agents/join-services-to-your-cluster/",
-      "destination": "/enroll-resources/agents/join-services-to-your-cluster/join-services-to-your-cluster/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/",
-      "destination": "/enroll-resources/auto-discovery/auto-discovery/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/auto-discovery/reference/",
-      "destination": "/enroll-resources/auto-discovery/reference/reference/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/server-access/",
-      "destination": "/enroll-resources/server-access/server-access/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/server-access/openssh/",
-      "destination": "/enroll-resources/server-access/openssh/openssh/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/server-access/guides/",
-      "destination": "/enroll-resources/server-access/guides/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/workload-identity/",
-      "destination": "/enroll-resources/workload-identity/workload-identity/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/",
-      "destination": "/enroll-resources/application-access/application-access/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/guides/",
-      "destination": "/enroll-resources/application-access/guides/guides/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/okta/",
-      "destination": "/enroll-resources/application-access/okta/okta/",
-      "permanent": true
-    },
-    {
-      "source": "/enroll-resources/application-access/cloud-apis/",
-      "destination": "/enroll-resources/application-access/cloud-apis/cloud-apis/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/",
-      "destination": "/reference/reference/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/machine-id/",
-      "destination": "/reference/machine-id/machine-id/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/access-controls/",
-      "destination": "/reference/access-controls/access-controls/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/terraform-provider/resources/",
-      "destination": "/reference/terraform-provider/resources/resources/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/terraform-provider/data-sources/",
-      "destination": "/reference/terraform-provider/data-sources/data-sources/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/cli/",
-      "destination": "/reference/cli/cli/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/helm-reference/",
-      "destination": "/reference/helm-reference/helm-reference/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/architecture/",
-      "destination": "/reference/architecture/architecture/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/agent-services/",
-      "destination": "/reference/agent-services/agent-services/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/agent-services/database-access-reference/",
-      "destination": "/reference/agent-services/database-access-reference/database-access-reference/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/agent-services/desktop-access-reference/",
-      "destination": "/reference/agent-services/desktop-access-reference/desktop-access-reference/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/operator-resources/",
-      "destination": "/reference/operator-resources/operator-resources/",
-      "permanent": true
-    },
-    {
-      "source": "/reference/monitoring/",
-      "destination": "/reference/monitoring/monitoring/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/",
-      "destination": "/admin-guides/admin-guides/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/infrastructure-as-code/managing-resources/",
-      "destination": "/admin-guides/infrastructure-as-code/managing-resources/managing-resources/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/infrastructure-as-code/terraform-provider/",
-      "destination": "/admin-guides/infrastructure-as-code/terraform-provider/terraform-provider/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/infrastructure-as-code/terraform-starter/",
-      "destination": "/admin-guides/infrastructure-as-code/terraform-starter/terraform-starter/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/",
-      "destination": "/admin-guides/access-controls/access-controls/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/access-controls/idps/",
-      "destination": "/admin-guides/access-controls/idps/idps/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/deploy-a-cluster/",
-      "destination": "/admin-guides/deploy-a-cluster/deploy-a-cluster/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/deploy-a-cluster/access-graph/",
-      "destination": "/admin-guides/deploy-a-cluster/access-graph/access-graph/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/deploy-a-cluster/helm-deployments/",
-      "destination": "/admin-guides/deploy-a-cluster/helm-deployments/helm-deployments/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/deploy-a-cluster/deployments/",
-      "destination": "/admin-guides/deploy-a-cluster/deployments/deployments/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/",
-      "destination": "/admin-guides/management/management/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/admin/",
-      "destination": "/admin-guides/management/admin/admin/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/management/operations/",
-      "destination": "/admin-guides/management/operations/operations/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/api/",
-      "destination": "/admin-guides/api/api/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/teleport-policy/",
-      "destination": "/admin-guides/teleport-policy/teleport-policy/",
-      "permanent": true
-    },
-    {
-      "source": "/admin-guides/teleport-policy/integrations/",
-      "destination": "/admin-guides/teleport-policy/integrations/integrations/",
-      "permanent": true
-    },
-    {
       "source": "/choose-an-edition/introduction/",
       "destination": "/get-started/",
       "permanent": true
@@ -2731,13 +2331,8 @@
       "permanent": true
     },
     {
-      "source": "/upgrading/",
-      "destination": "/upgrading/upgrading/",
-      "permanent": true
-    },
-    {
       "source": "/admin-guide/",
-      "destination": "/admin-guides/admin-guides/",
+      "destination": "/admin-guides/",
       "permanent": true
     },
     {
@@ -2761,13 +2356,8 @@
       "permanent": true
     },
     {
-      "source": "/admin-guides/access-controls/sso/",
-      "destination": "/admin-guides/access-controls/sso/sso/",
-      "permanent": true
-    },
-    {
       "source": "/management/operations/upgrading/",
-      "destination": "/upgrading/upgrading/",
+      "destination": "/upgrading/",
       "permanent": true
     },
     {
@@ -2777,7 +2367,7 @@
     },
     {
       "source": "/architecture/overview/",
-      "destination": "/reference/architecture/architecture/",
+      "destination": "/reference/architecture/",
       "permanent": true
     },
     {
@@ -2802,12 +2392,12 @@
     },
     {
       "source": "/setup/admin/adding-nodes/",
-      "destination": "/enroll-resources/agents/join-services-to-your-cluster/join-services-to-your-cluster/",
+      "destination": "/enroll-resources/agents/join-services-to-your-cluster/",
       "permanent": true
     },
     {
       "source": "/setup/reference/cli/",
-      "destination": "/reference/cli/cli/",
+      "destination": "/reference/cli/",
       "permanent": true
     },
     {


### PR DESCRIPTION
- Remove redirects that navigate away from a path that exists. Docusaurus ignores these with a warning, so this removes a warning.
- Remove duplicate redirects.
- Where a redirect uses a section index page path from our legacy custom site, e.g., `/slug/slug/`, use the Docusaurus format instead, e.g., `/slug/`. This lets us remove some migration logic from the docs engine.