### PR TITLE
Generate autoupdate agent report periodically

### DIFF
--- a/api/types/autoupdate/report.go
+++ b/api/types/autoupdate/report.go
@@ -62,7 +62,7 @@ func ValidateAutoUpdateAgentReport(v *autoupdate.AutoUpdateAgentReport) error {
 		return trace.BadParameter("Spec is nil")
 	}
 
-	if ts := v.GetSpec().GetTimestamp(); ts == nil || (ts.Seconds == 0 && ts.Nanos == 0) {
+	if ts := v.GetSpec().GetTimestamp(); ts.GetSeconds() == 0 && ts.GetNanos() == 0 {
 		return trace.BadParameter("Spec.Timestamp is empty or zero")
 	}
 

--- a/api/types/autoupdate/report.go
+++ b/api/types/autoupdate/report.go
@@ -17,7 +17,10 @@ limitations under the License.
 package autoupdate
 
 import (
+	"time"
+
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -30,7 +33,8 @@ func NewAutoUpdateAgentReport(spec *autoupdate.AutoUpdateAgentReportSpec, authNa
 		Kind:    types.KindAutoUpdateAgentReport,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
-			Name: authName,
+			Name:    authName,
+			Expires: timestamppb.New(spec.GetTimestamp().AsTime().Add(time.Hour)),
 		},
 		Spec: spec,
 	}

--- a/api/types/autoupdate/report_test.go
+++ b/api/types/autoupdate/report_test.go
@@ -1,0 +1,72 @@
+package autoupdate
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNewAutoUpdateAgentReport(t *testing.T) {
+	now := timestamppb.Now()
+	expires := timestamppb.New(now.AsTime().Add(autoUpdateAgentReportTTL))
+	tests := []struct {
+		name     string
+		spec     *autoupdate.AutoUpdateAgentReportSpec
+		authName string
+
+		want    *autoupdate.AutoUpdateAgentReport
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name:     "nil spec",
+			authName: "test",
+			wantErr:  require.Error,
+		},
+		{
+			name: "empty name",
+			spec: &autoupdate.AutoUpdateAgentReportSpec{
+				Timestamp: now,
+			},
+			wantErr: require.Error,
+		},
+		{
+			name:     "no timestamp",
+			authName: "test",
+			spec:     &autoupdate.AutoUpdateAgentReportSpec{},
+			wantErr:  require.Error,
+		},
+		{
+			name:     "ok",
+			authName: "test",
+			spec: &autoupdate.AutoUpdateAgentReportSpec{
+				Timestamp: now,
+			},
+			want: &autoupdate.AutoUpdateAgentReport{
+				Kind:    types.KindAutoUpdateAgentReport,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "test",
+					Expires: expires,
+				},
+				Spec: &autoupdate.AutoUpdateAgentReportSpec{
+					Timestamp: now,
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NewAutoUpdateAgentReport(tt.spec, tt.authName)
+			tt.wantErr(t, err)
+			require.Empty(t, cmp.Diff(tt.want, result, protocmp.Transform()))
+		})
+	}
+}

--- a/api/types/autoupdate/report_test.go
+++ b/api/types/autoupdate/report_test.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package autoupdate
 
 import (

--- a/lib/auth/agent_version_report.go
+++ b/lib/auth/agent_version_report.go
@@ -44,7 +44,7 @@ func (ir instanceReport) collectInstance(handle inventory.UpstreamHandle) {
 
 	// We skip servers that joined less than a minute ago as they might have been
 	// connected to another auth instance a few seconds ago, which would lead to double-counting.
-	if handle.RegistrationTime().After(ir.timestamp.Add(-time.Minute)) {
+	if ir.timestamp.Sub(handle.RegistrationTime()) < time.Minute {
 		return
 	}
 	// We skip control planes instances because we don't update them.
@@ -61,7 +61,7 @@ func (ir instanceReport) collectInstance(handle inventory.UpstreamHandle) {
 
 	// Reject instances who are not advertising the group properly.
 	// They might be running too old versions.
-	updateGroup := hello.GetUpdaterInfo().UpdateGroup
+	updateGroup := hello.GetUpdaterInfo().GetUpdateGroup()
 	if updateGroup == "" {
 		return
 	}

--- a/lib/auth/agent_version_report.go
+++ b/lib/auth/agent_version_report.go
@@ -1,0 +1,162 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/autoupdate"
+	"github.com/gravitational/teleport/lib/inventory"
+)
+
+type instanceReport struct {
+	data      map[string]instanceGroupReport
+	timestamp time.Time
+}
+
+func (ir instanceReport) collectInstance(handle inventory.UpstreamHandle) {
+	// If the instance is being soft-reloaded or shut down, we ignore it.
+	if goodbye := handle.Goodbye(); goodbye != nil && (goodbye.GetSoftReload() || goodbye.GetDeleteResources()) {
+		return
+	}
+
+	// We skip servers that joined less than a minute ago as they might have been
+	// connected to another auth instance a few seconds ago, which would lead to double-counting.
+	if handle.RegistrationTime().After(ir.timestamp.Add(-time.Minute)) {
+		return
+	}
+	// We skip auth and proxy instances because we don't update them.
+	if handle.HasService(types.RoleAuth) || handle.HasService(types.RoleProxy) {
+		return
+	}
+
+	hello := handle.Hello()
+
+	// If the machine has no updater, we skip it
+	if hello.ExternalUpgrader == "" {
+		return
+	}
+
+	// Reject instances who are not advertising the group properly.
+	// They might be running too old versions.
+	updateGroup := hello.GetUpdaterInfo().UpdateGroup
+	if updateGroup == "" {
+		return
+	}
+
+	// We skip instances whose updater status is not unknown or OK.
+	// Note: is it OK to allow unknown? Discuss this with Stephen.
+	status := hello.GetUpdaterInfo().UpdaterStatus
+	if status != types.UpdaterStatus_UPDATER_STATUS_OK && status != types.UpdaterStatus_UPDATER_STATUS_UNSPECIFIED {
+		return
+	}
+
+	if _, ok := ir.data[updateGroup]; !ok {
+		ir.data[updateGroup] = instanceGroupReport{}
+	}
+
+	ir.data[updateGroup].collectInstance(handle)
+}
+
+type instanceGroupReport map[string]instanceGroupVersionReport
+
+func (ir instanceGroupReport) collectInstance(handle inventory.UpstreamHandle) {
+	hello := handle.Hello()
+
+	// Note: not validating if the semver is correct, is this an issue?
+	stats, ok := ir[hello.Version]
+	if !ok {
+		stats = instanceGroupVersionReport{}
+	}
+
+	stats.count += 1
+
+	ir[hello.Version] = stats
+}
+
+type instanceGroupVersionReport struct {
+	count int
+	// Leaving room here to add the lowest UUID, as described in RFD 184.
+}
+
+func (a *Server) generateAgentVersionReport(ctx context.Context) (*autoupdatev1pb.AutoUpdateAgentReport, error) {
+	now := a.clock.Now()
+
+	a.logger.DebugContext(ctx, "Collecting agent versions from inventory")
+	rawreport := instanceReport{timestamp: now, data: make(map[string]instanceGroupReport)}
+	a.inventory.AllHandles(rawreport.collectInstance)
+
+	a.logger.DebugContext(ctx, "Building the agent version report")
+	spec := &autoupdatev1pb.AutoUpdateAgentReportSpec{
+		Timestamp: timestamppb.New(a.clock.Now()),
+		Groups:    make(map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup, len(rawreport.data)),
+	}
+
+	// TODO: cap the group and version map size
+
+	for groupName, groupData := range rawreport.data {
+		versions := make(map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion, len(groupData))
+		for versionName, groupVersionData := range groupData {
+			versions[versionName] = &autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+				Count: int32(groupVersionData.count),
+			}
+		}
+		spec.Groups[groupName] = &autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+			Versions: versions,
+		}
+	}
+
+	report, err := autoupdate.NewAutoUpdateAgentReport(spec, a.ServerID)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to generate agent version report")
+	}
+
+	return report, nil
+}
+
+func (a *Server) reportAgentVersions(ctx context.Context) {
+	if _, err := a.GetAutoUpdateAgentRollout(ctx); err != nil {
+		if trace.IsNotFound(err) {
+			a.logger.DebugContext(ctx, "Skipping periodic agent report because the cluster doesn't contain an autoupdate_agent_rollout.")
+			return
+		}
+		a.logger.WarnContext(ctx, "Failed to check if autoupdate_agent_rollout resource exists, aborting periodic agent report", "error", err)
+	}
+
+	a.logger.DebugContext(ctx, "Periodic agent version report routine started")
+	report, err := a.generateAgentVersionReport(ctx)
+	if err != nil {
+		a.logger.WarnContext(ctx, "Failed to report agent versions", "error", err)
+		return
+	}
+
+	a.logger.DebugContext(ctx, "Writing agent version report to the backend", "name", report.GetMetadata().GetName())
+	_, err = a.UpsertAutoUpdateAgentReport(ctx, report)
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to write agent version report", "error", err)
+	}
+	a.logger.DebugContext(ctx, "Finished exporting the agent version report")
+
+}

--- a/lib/auth/agent_version_report.go
+++ b/lib/auth/agent_version_report.go
@@ -59,17 +59,22 @@ func (ir instanceReport) collectInstance(handle inventory.UpstreamHandle) {
 		return
 	}
 
+	// Reject instance not advertising
+	updaterInfo := hello.GetUpdaterInfo()
+	if updaterInfo == nil {
+		return
+	}
+
 	// Reject instances who are not advertising the group properly.
 	// They might be running too old versions.
-	updateGroup := hello.GetUpdaterInfo().GetUpdateGroup()
+	updateGroup := updaterInfo.UpdateGroup
 	if updateGroup == "" {
 		return
 	}
 
-	// We skip instances whose updater status is not unknown or OK.
-	// Note: is it OK to allow unknown? Discuss this with Stephen.
-	status := hello.GetUpdaterInfo().UpdaterStatus
-	if status != types.UpdaterStatus_UPDATER_STATUS_OK && status != types.UpdaterStatus_UPDATER_STATUS_UNSPECIFIED {
+	// We skip instances whose updater status is not OK.
+	status := updaterInfo.UpdaterStatus
+	if status != types.UpdaterStatus_UPDATER_STATUS_OK {
 		return
 	}
 
@@ -85,7 +90,6 @@ type instanceGroupReport map[string]instanceGroupVersionReport
 func (ir instanceGroupReport) collectInstance(handle inventory.UpstreamHandle) {
 	hello := handle.Hello()
 
-	// Note: not validating if the semver is correct, is this an issue?
 	stats, ok := ir[hello.Version]
 	if !ok {
 		stats = instanceGroupVersionReport{}

--- a/lib/auth/agent_version_report_test.go
+++ b/lib/auth/agent_version_report_test.go
@@ -241,12 +241,16 @@ func TestServer_generateAgentVersionReport(t *testing.T) {
 			for _, fixture := range tt.fixtures {
 				clock.Advance(fixture.delay)
 				stream := newFakeControlStream()
+				status := fixture.updaterStatus
+				if status == types.UpdaterStatus_UPDATER_STATUS_UNSPECIFIED {
+					status = types.UpdaterStatus_UPDATER_STATUS_OK
+				}
 				controller.RegisterControlStream(stream, proto.UpstreamInventoryHello{
 					Services:         fixture.roles,
 					ServerID:         uuid.New().String(),
 					Version:          fixture.version,
 					ExternalUpgrader: types.UpgraderKindTeleportUpdate,
-					UpdaterInfo:      &types.UpdaterV2Info{UpdaterStatus: fixture.updaterStatus, UpdateGroup: fixture.updateGroup},
+					UpdaterInfo:      &types.UpdaterV2Info{UpdaterStatus: status, UpdateGroup: fixture.updateGroup},
 				})
 				if fixture.goodbye != nil {
 					stream.fakeMsg(*fixture.goodbye)

--- a/lib/auth/agent_version_report_test.go
+++ b/lib/auth/agent_version_report_test.go
@@ -1,0 +1,331 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/autoupdate"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/inventory"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func newFakeControlStream() fakeControlStream {
+	return fakeControlStream{
+		msgChan:  make(chan proto.UpstreamInventoryMessage),
+		doneChan: make(chan struct{}),
+	}
+}
+
+type fakeControlStream struct {
+	client.UpstreamInventoryControlStream
+	msgChan  chan proto.UpstreamInventoryMessage
+	doneChan chan struct{}
+}
+
+func (f fakeControlStream) CloseWithError(err error) error {
+	return nil
+}
+
+func (f fakeControlStream) Close() error {
+	return nil
+}
+
+func (f fakeControlStream) Recv() <-chan proto.UpstreamInventoryMessage {
+	return f.msgChan
+}
+
+func (f fakeControlStream) Done() <-chan struct{} {
+	return f.doneChan
+}
+
+func (f fakeControlStream) fakeMsg(msg proto.UpstreamInventoryMessage) {
+	f.msgChan <- msg
+}
+
+func (f fakeControlStream) close() {
+	close(f.msgChan)
+}
+
+type fakeServer struct {
+	version       string
+	updateGroup   string
+	delay         time.Duration
+	roles         types.SystemRoles
+	updaterStatus types.UpdaterStatus
+	goodbye       *proto.UpstreamInventoryGoodbye
+}
+
+func TestServer_generateAgentVersionReport(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	twoMinutesAgo := now.Add(-time.Minute * 2)
+	// agentRole are typicial roles an agent can have
+	agentRoles := types.SystemRoles{types.RoleNode, types.RoleApp}
+	updaterOK := types.UpdaterStatus_UPDATER_STATUS_OK
+
+	tests := []struct {
+		name     string
+		fixtures []fakeServer
+		expected *autoupdatev1pb.AutoUpdateAgentReportSpec
+	}{
+		{
+			name: "no servers",
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+			},
+		},
+		{
+			name: "no group, same version",
+			fixtures: []fakeServer{
+				{version: "1.2.3", roles: agentRoles, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updateGroup: "default"},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 4},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "control plane servers are ignored",
+			fixtures: []fakeServer{
+				{version: "1.2.3", roles: types.SystemRoles{types.RoleKube, types.RoleAuth}, updateGroup: "default"},
+				{version: "1.2.3", roles: types.SystemRoles{types.RoleApp, types.RoleProxy}, updateGroup: "default"},
+				{version: "1.2.3", roles: types.SystemRoles{types.RoleApp, types.RoleKube}, updateGroup: "default"},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 1},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "disabled or pinned updaters are ignored",
+			fixtures: []fakeServer{
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: types.UpdaterStatus_UPDATER_STATUS_PINNED, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: types.UpdaterStatus_UPDATER_STATUS_DISABLED, updateGroup: "default"},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 1},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reloaded and terminating instances are ignored",
+			fixtures: []fakeServer{
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default", goodbye: &proto.UpstreamInventoryGoodbye{SoftReload: true}},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default", goodbye: &proto.UpstreamInventoryGoodbye{DeleteResources: true}},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 1},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "too recent servers are ignored",
+			fixtures: []fakeServer{
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+				{version: "1.2.3", delay: 90 * time.Second, roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+				{version: "1.2.3", roles: agentRoles, updaterStatus: updaterOK, updateGroup: "default"},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 1},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple versions and groups",
+			fixtures: []fakeServer{
+				{version: "1.2.3", updateGroup: "default", roles: agentRoles, updaterStatus: updaterOK},
+				{version: "1.2.4", updateGroup: "default", roles: agentRoles, updaterStatus: updaterOK},
+				{version: "1.2.5", updateGroup: "prod", roles: agentRoles, updaterStatus: updaterOK},
+				{version: "1.2.5", updateGroup: "prod", roles: agentRoles, updaterStatus: updaterOK},
+				{version: "1.2.5", updateGroup: "dev", roles: agentRoles, updaterStatus: updaterOK},
+			},
+			expected: &autoupdatev1pb.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(now),
+				Groups: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroup{
+					"default": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.3": {Count: 1},
+							"1.2.4": {Count: 1},
+						},
+					},
+					"dev": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.5": {Count: 1},
+						},
+					},
+					"prod": {
+						Versions: map[string]*autoupdatev1pb.AutoUpdateAgentReportSpecGroupVersion{
+							"1.2.5": {Count: 2},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClockAt(twoMinutesAgo)
+			auth := &Server{
+				logger:   utils.NewSlogLoggerForTests(),
+				ServerID: uuid.NewString(),
+			}
+			controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
+			for _, fixture := range tt.fixtures {
+				clock.Advance(fixture.delay)
+				stream := newFakeControlStream()
+				controller.RegisterControlStream(stream, proto.UpstreamInventoryHello{
+					Services:         fixture.roles,
+					ServerID:         uuid.New().String(),
+					Version:          fixture.version,
+					ExternalUpgrader: types.UpgraderKindTeleportUpdate,
+					UpdaterInfo:      &types.UpdaterV2Info{UpdaterStatus: fixture.updaterStatus, UpdateGroup: fixture.updateGroup},
+				})
+				if fixture.goodbye != nil {
+					stream.fakeMsg(*fixture.goodbye)
+				}
+				t.Cleanup(stream.close)
+			}
+			auth.inventory = controller
+			auth.clock = clockwork.NewFakeClockAt(now)
+
+			report, err := auth.generateAgentVersionReport(ctx)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(tt.expected, report.GetSpec(), protocmp.Transform()))
+		})
+	}
+}
+
+func TestServer_reportAgentVersions(t *testing.T) {
+	// Test setup: create auth.
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	svc, err := local.NewAutoUpdateService(bk)
+	require.NoError(t, err)
+
+	now := time.Now()
+	twoMinutesAgo := now.Add(-time.Minute * 2)
+	clock := clockwork.NewFakeClockAt(twoMinutesAgo)
+
+	// Test setup: load fixtures.
+	const testNodeCount = 10
+	auth := &Server{
+		clock:    clock,
+		ServerID: uuid.NewString(),
+		Services: &Services{AutoUpdateService: svc},
+		logger:   utils.NewSlogLoggerForTests(),
+	}
+	auth.Cache = auth.Services
+	controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
+	auth.inventory = controller
+
+	for range testNodeCount {
+		stream := newFakeControlStream()
+		controller.RegisterControlStream(stream, proto.UpstreamInventoryHello{
+			Services:         types.SystemRoles{types.RoleNode},
+			Version:          "1.2.3",
+			ServerID:         uuid.NewString(),
+			ExternalUpgrader: types.UpgraderKindTeleportUpdate,
+			UpdaterInfo: &types.UpdaterV2Info{
+				UpdaterStatus: types.UpdaterStatus_UPDATER_STATUS_OK,
+				UpdateGroup:   "default",
+			},
+		})
+		t.Cleanup(stream.close)
+	}
+	ctx := context.Background()
+	rollout, err := autoupdate.NewAutoUpdateAgentRollout(&autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+		StartVersion:              "1.2.3",
+		TargetVersion:             "1.2.4",
+		Schedule:                  autoupdate.AgentsScheduleRegular,
+		AutoupdateMode:            autoupdate.AgentsUpdateModeEnabled,
+		Strategy:                  autoupdate.AgentsStrategyHaltOnError,
+		MaintenanceWindowDuration: nil,
+	})
+	require.NoError(t, err)
+	_, err = svc.CreateAutoUpdateAgentRollout(ctx, rollout)
+	require.NoError(t, err)
+
+	// Test execution: compute and write report.
+	clock.Advance(2 * time.Minute)
+	auth.reportAgentVersions(ctx)
+
+	// Test validation
+	report, err := svc.GetAutoUpdateAgentReport(ctx, auth.ServerID)
+	require.NoError(t, err)
+
+	require.NotNil(t, report)
+	require.NotEmpty(t, report.GetSpec().GetGroups())
+	require.NotNil(t, report.GetSpec().GetGroups()["default"])
+	require.NotNil(t, report.GetSpec().GetGroups()["default"].GetVersions())
+	require.NotNil(t, report.GetSpec().GetGroups()["default"].GetVersions()["1.2.3"])
+	require.Equal(t, testNodeCount, int(report.GetSpec().GetGroups()["default"].GetVersions()["1.2.3"].GetCount()))
+}

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -342,7 +342,7 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 
 // RegisterControlStream registers a new control stream with the controller.
 func (c *Controller) RegisterControlStream(stream client.UpstreamInventoryControlStream, hello proto.UpstreamInventoryHello) {
-	handle := newUpstreamHandle(stream, hello)
+	handle := newUpstreamHandle(stream, hello, c.clock.Now())
 	c.store.Insert(handle)
 
 	// Increment the concurrent connection counter that we use to calculate the
@@ -553,7 +553,7 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 			case proto.UpstreamInventoryPong:
 				c.handlePong(handle, m)
 			case proto.UpstreamInventoryGoodbye:
-				handle.goodbye = m
+				handle.setGoodbye(&m)
 			default:
 				slog.WarnContext(c.closeContext, "Unexpected upstream message type on control stream",
 					"message_type", logutils.TypeAttr(m),

--- a/lib/player/player_experimental_test.go
+++ b/lib/player/player_experimental_test.go
@@ -22,10 +22,10 @@ package player_test
 
 import (
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"testing/synctest"
 
 	"github.com/gravitational/teleport/lib/player"
 )

--- a/lib/player/player_experimental_test.go
+++ b/lib/player/player_experimental_test.go
@@ -22,10 +22,10 @@ package player_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"testing/synctest"
 
 	"github.com/gravitational/teleport/lib/player"
 )


### PR DESCRIPTION
This PR adds:
- tracking of the control stream registration time by the upstreamHandler
- the ability to retrieve the goodbye message associated to a handle
- the logic iterating over every instance and generating the report
- a periodic auth operator generating and writing agent report to the backend
- 1h expiration for every report

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856