### PR TITLE
Remove superfluous DeleteAll methods

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -161,11 +161,6 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
-// DeleteAllAccessLists removes all access lists.
-func (c *Client) DeleteAllAccessLists(ctx context.Context) error {
-	return trace.NotImplemented("DeleteAllAccessLists not supported in the gRPC client")
-}
-
 // CountAccessListMembers will count all access list members.
 func (c *Client) CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error) {
 	resp, err := c.grpcClient.CountAccessListMembers(ctx, &accesslistv1.CountAccessListMembersRequest{
@@ -298,11 +293,6 @@ func (c *Client) DeleteAllAccessListMembersForAccessList(ctx context.Context, ac
 	return trace.Wrap(err)
 }
 
-// DeleteAllAccessListMembers hard deletes all access list members.
-func (c *Client) DeleteAllAccessListMembers(ctx context.Context) error {
-	return trace.NotImplemented("DeleteAllAccessListMembers is not supported in the gRPC client")
-}
-
 // UpsertAccessListWithMembers creates or updates an access list resource and its members.
 func (c *Client) UpsertAccessListWithMembers(ctx context.Context, list *accesslist.AccessList, members []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
 	resp, err := c.grpcClient.UpsertAccessListWithMembers(ctx, &accesslistv1.UpsertAccessListWithMembersRequest{
@@ -403,11 +393,6 @@ func (c *Client) DeleteAccessListReview(ctx context.Context, accessListName, rev
 		ReviewName:     reviewName,
 	})
 	return trace.Wrap(err)
-}
-
-// DeleteAllAccessListReviews will delete all access list reviews from all access lists.
-func (c *Client) DeleteAllAccessListReviews(ctx context.Context) error {
-	return trace.NotImplemented("DeleteAllAccessListReviews is not supported in the gRPC client")
 }
 
 // GetSuggestedAccessLists returns a list of access lists that are suggested for a given request.

--- a/api/client/crownjewel/crownjewel.go
+++ b/api/client/crownjewel/crownjewel.go
@@ -98,9 +98,3 @@ func (c *Client) DeleteCrownJewel(ctx context.Context, name string) error {
 	})
 	return trace.Wrap(err)
 }
-
-// DeleteAllCrownJewels deletes all Crown Jewels.
-// Not implemented. Added to satisfy the interface.
-func (c *Client) DeleteAllCrownJewels(_ context.Context) error {
-	return trace.NotImplemented("DeleteAllCrownJewels is not implemented")
-}

--- a/api/client/dynamicwindows/dynamicwindows.go
+++ b/api/client/dynamicwindows/dynamicwindows.go
@@ -103,7 +103,3 @@ func (c *Client) DeleteDynamicWindowsDesktop(ctx context.Context, name string) e
 	})
 	return trace.Wrap(err)
 }
-
-func (c *Client) DeleteAllDynamicWindowsDesktops(ctx context.Context) error {
-	return trace.NotImplemented("DeleteAllDynamicWindowsDesktops is not supported in the gRPC client")
-}

--- a/api/client/gitserver/gitserver.go
+++ b/api/client/gitserver/gitserver.go
@@ -127,11 +127,6 @@ func (c *Client) DeleteGitServer(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
-// DeleteAllGitServers removes all Git server resources.
-func (c *Client) DeleteAllGitServers(ctx context.Context) error {
-	return trace.NotImplemented("DeleteAllGitServers servers not implemented")
-}
-
 // CreateGitHubAuthRequest starts GitHub OAuth flow for authenticated user.
 func (c *Client) CreateGitHubAuthRequest(ctx context.Context, req *types.GithubAuthRequest, org string) (*types.GithubAuthRequest, error) {
 	resp, err := c.grpcClient.CreateGitHubAuthRequest(ctx, &gitserverv1.CreateGitHubAuthRequestRequest{

--- a/api/client/usertask/usertask.go
+++ b/api/client/usertask/usertask.go
@@ -99,9 +99,3 @@ func (c *Client) DeleteUserTask(ctx context.Context, name string) error {
 	})
 	return trace.Wrap(err)
 }
-
-// DeleteAllUserTasks deletes all User Tasks.
-// Not implemented. Added to satisfy the interface.
-func (c *Client) DeleteAllUserTasks(_ context.Context) error {
-	return trace.NotImplemented("DeleteAllUserTasks is not implemented")
-}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2246,14 +2246,6 @@ func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 	return a.authServer.GetAuthServers()
 }
 
-// DeleteAllAuthServers deletes all auth servers
-func (a *ServerWithRoles) DeleteAllAuthServers() error {
-	if err := a.action(types.KindAuthServer, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteAllAuthServers()
-}
-
 // DeleteAuthServer deletes auth server by name
 func (a *ServerWithRoles) DeleteAuthServer(name string) error {
 	if err := a.action(types.KindAuthServer, types.VerbDelete); err != nil {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -300,11 +300,6 @@ func (c *Client) GetReverseTunnel(ctx context.Context, name string) (types.Rever
 	return nil, trace.NotImplemented(notImplementedMessage)
 }
 
-// DeleteAllTokens not implemented: can only be called locally.
-func (c *Client) DeleteAllTokens() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // PatchToken not implemented: can only be called locally
 func (c *Client) PatchToken(
 	ctx context.Context,
@@ -322,11 +317,6 @@ func (c *Client) AddUserLoginAttempt(user string, attempt services.LoginAttempt,
 // GetUserLoginAttempts returns user login attempts
 func (c *Client) GetUserLoginAttempts(user string) ([]services.LoginAttempt, error) {
 	panic("not implemented")
-}
-
-// DeleteAllAuthServers not implemented: can only be called locally.
-func (c *Client) DeleteAllAuthServers() error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // DeleteAuthServer not implemented: can only be called locally.
@@ -381,21 +371,6 @@ func (c *Client) DeleteClusterName() error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// DeleteAllCertAuthorities not implemented: can only be called locally.
-func (c *Client) DeleteAllCertAuthorities(caType types.CertAuthType) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllReverseTunnels not implemented: can only be called locally.
-func (c *Client) DeleteAllReverseTunnels(ctx context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllRemoteClusters not implemented: can only be called locally.
-func (c *Client) DeleteAllRemoteClusters(ctx context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // CreateRemoteCluster not implemented: can only be called locally.
 func (c *Client) CreateRemoteCluster(ctx context.Context, rc types.RemoteCluster) (types.RemoteCluster, error) {
 	return nil, trace.NotImplemented(notImplementedMessage)
@@ -406,16 +381,6 @@ func (c *Client) PatchRemoteCluster(ctx context.Context, name string, updateFn f
 	return nil, trace.NotImplemented(notImplementedMessage)
 }
 
-// DeleteAllNamespaces not implemented: can only be called locally.
-func (c *Client) DeleteAllNamespaces() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllRoles not implemented: can only be called locally.
-func (c *Client) DeleteAllRoles(context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // ListWindowsDesktops not implemented: can only be called locally.
 func (c *Client) ListWindowsDesktops(ctx context.Context, req types.ListWindowsDesktopsRequest) (*types.ListWindowsDesktopsResponse, error) {
 	return nil, trace.NotImplemented(notImplementedMessage)
@@ -424,11 +389,6 @@ func (c *Client) ListWindowsDesktops(ctx context.Context, req types.ListWindowsD
 // ListWindowsDesktopServices not implemented: can only be called locally.
 func (c *Client) ListWindowsDesktopServices(ctx context.Context, req types.ListWindowsDesktopServicesRequest) (*types.ListWindowsDesktopServicesResponse, error) {
 	return nil, trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllUsers not implemented: can only be called locally.
-func (c *Client) DeleteAllUsers(ctx context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 const (
@@ -614,11 +574,6 @@ func (c *Client) DeleteClusterAuditConfig(ctx context.Context) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// DeleteAllLocks not implemented: can only be called locally.
-func (c *Client) DeleteAllLocks(context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 func (c *Client) UpdatePresence(ctx context.Context, sessionID, user string) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
@@ -764,26 +719,6 @@ func (c *Client) DeleteUserNotification(ctx context.Context, username string, no
 		NotificationId: notificationId,
 	})
 	return trace.Wrap(err)
-}
-
-// DeleteAllGlobalNotifications not implemented: can only be called locally.
-func (c *Client) DeleteAllGlobalNotifications(ctx context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllUserNotificationStatesForUser not implemented: can only be called locally.
-func (c *Client) DeleteAllUserNotificationStatesForUser(ctx context.Context, username string) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllUserNotifications not implemented: can only be called locally.
-func (c *Client) DeleteAllUserNotifications(ctx context.Context) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllUserNotificationsForUser not implemented: can only be called locally.
-func (c *Client) DeleteAllUserNotificationsForUser(ctx context.Context, username string) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // DeleteUserLastSeenNotification not implemented: can only be called locally.
@@ -1162,9 +1097,6 @@ type IdentityService interface {
 	// access the Target.
 	IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
 
-	// DeleteAllUsers deletes all users
-	DeleteAllUsers(ctx context.Context) error
-
 	// CreateResetPasswordToken creates a new user reset token
 	CreateResetPasswordToken(ctx context.Context, req CreateUserTokenRequest) (types.UserToken, error)
 
@@ -1234,9 +1166,6 @@ type ProvisioningService interface {
 	// DeleteToken deletes a given provisioning token on the auth server (CA). It
 	// could be a reset password token or a machine token
 	DeleteToken(ctx context.Context, token string) error
-
-	// DeleteAllTokens deletes all provisioning tokens
-	DeleteAllTokens() error
 
 	// UpsertToken adds provisioning tokens for the auth server
 	UpsertToken(ctx context.Context, token types.ProvisionToken) error

--- a/lib/auth/migration/0001_db_ca.go
+++ b/lib/auth/migration/0001_db_ca.go
@@ -34,7 +34,7 @@ import (
 // Database CA for all existing clusters that do not already
 // have one. Introduced in v10.
 type createDBAuthority struct {
-	trustServiceFn  func(b backend.Backend) services.Trust
+	trustServiceFn  func(b backend.Backend) *local.CA
 	configServiceFn func(b backend.Backend) (services.ClusterConfiguration, error)
 }
 
@@ -54,9 +54,7 @@ func (d createDBAuthority) Up(ctx context.Context, b backend.Backend) error {
 	defer span.End()
 
 	if d.trustServiceFn == nil {
-		d.trustServiceFn = func(b backend.Backend) services.Trust {
-			return local.NewCAService(b)
-		}
+		d.trustServiceFn = local.NewCAService
 	}
 
 	if d.configServiceFn == nil {
@@ -103,7 +101,7 @@ func (d createDBAuthority) Down(ctx context.Context, b backend.Backend) error {
 	defer span.End()
 
 	if d.trustServiceFn == nil {
-		d.trustServiceFn = func(b backend.Backend) services.Trust {
+		d.trustServiceFn = func(b backend.Backend) *local.CA {
 			return local.NewCAService(b)
 		}
 	}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -104,48 +104,47 @@ type testPack struct {
 	cache        *Cache
 	cacheBackend backend.Backend
 
-	eventsS        *proxyEvents
-	trustS         services.Trust
-	provisionerS   services.Provisioner
-	clusterConfigS services.ClusterConfigurationInternal
-
-	usersS                  services.UsersService
-	accessS                 services.Access
-	dynamicAccessS          services.DynamicAccessCore
-	presenceS               services.Presence
-	appSessionS             services.AppSession
-	snowflakeSessionS       services.SnowflakeSession
-	samlIdPSessionsS        services.SAMLIdPSession //nolint:revive // Because we want this to be IdP.
-	restrictions            services.Restrictions
-	apps                    services.Apps
-	kubernetes              services.Kubernetes
-	databases               services.Databases
-	databaseServices        services.DatabaseServices
+	eventsS                 *proxyEvents
+	trustS                  *local.CA
+	provisionerS            *local.ProvisioningService
+	clusterConfigS          *local.ClusterConfigurationService
+	usersS                  *local.IdentityService
+	accessS                 *local.AccessService
+	dynamicAccessS          *local.DynamicAccessService
+	presenceS               *local.PresenceService
+	appSessionS             *local.IdentityService
+	snowflakeSessionS       *local.IdentityService
+	samlIdPSessionsS        *local.IdentityService
+	restrictions            *local.RestrictionsService
+	apps                    *local.AppService
+	kubernetes              *local.KubernetesService
+	databases               *local.DatabaseService
+	databaseServices        *local.DatabaseServicesService
 	webSessionS             types.WebSessionInterface
 	webTokenS               types.WebTokenInterface
-	windowsDesktops         services.WindowsDesktops
-	dynamicWindowsDesktops  services.DynamicWindowsDesktops
-	samlIDPServiceProviders services.SAMLIdPServiceProviders
-	userGroups              services.UserGroups
-	okta                    services.Okta
-	integrations            services.Integrations
-	userTasks               services.UserTasks
-	discoveryConfigs        services.DiscoveryConfigs
-	userLoginStates         services.UserLoginStates
-	secReports              services.SecReports
-	accessLists             services.AccessLists
-	kubeWaitingContainers   services.KubeWaitingContainer
-	notifications           services.Notifications
-	accessMonitoringRules   services.AccessMonitoringRules
-	crownJewels             services.CrownJewels
-	databaseObjects         services.DatabaseObjects
+	windowsDesktops         *local.WindowsDesktopService
+	dynamicWindowsDesktops  *local.DynamicWindowsDesktopService
+	samlIDPServiceProviders *local.SAMLIdPServiceProviderService
+	userGroups              *local.UserGroupService
+	okta                    *local.OktaService
+	integrations            *local.IntegrationsService
+	userTasks               *local.UserTasksService
+	discoveryConfigs        *local.DiscoveryConfigService
+	userLoginStates         *local.UserLoginStateService
+	secReports              *local.SecReportsService
+	accessLists             *local.AccessListService
+	kubeWaitingContainers   *local.KubeWaitingContainerService
+	notifications           *local.NotificationsService
+	accessMonitoringRules   *local.AccessMonitoringRulesService
+	crownJewels             *local.CrownJewelsService
+	databaseObjects         *local.DatabaseObjectService
 	spiffeFederations       *local.SPIFFEFederationService
 	staticHostUsers         *local.StaticHostUserService
-	autoUpdateService       services.AutoUpdateService
-	provisioningStates      services.ProvisioningStates
-	identityCenter          services.IdentityCenter
+	autoUpdateService       *local.AutoUpdateService
+	provisioningStates      *local.ProvisioningStateService
+	identityCenter          *local.IdentityCenterService
 	pluginStaticCredentials *local.PluginStaticCredentialsService
-	gitServers              services.GitServers
+	gitServers              *local.GitServerService
 	workloadIdentity        *local.WorkloadIdentityService
 	healthCheckConfig       *local.HealthCheckConfigService
 }

--- a/lib/services/access.go
+++ b/lib/services/access.go
@@ -49,8 +49,6 @@ type Access interface {
 	UpdateRole(ctx context.Context, role types.Role) (types.Role, error)
 	// UpsertRole creates or updates role.
 	UpsertRole(ctx context.Context, role types.Role) (types.Role, error)
-	// DeleteAllRoles deletes all roles.
-	DeleteAllRoles(ctx context.Context) error
 	// GetRole returns role by name.
 	GetRole(ctx context.Context, name string) (types.Role, error)
 	// DeleteRole deletes role by name.
@@ -61,8 +59,6 @@ type Access interface {
 	UpsertLock(context.Context, types.Lock) error
 	// DeleteLock deletes a lock.
 	DeleteLock(context.Context, string) error
-	// DeleteAllLocks deletes all/in-force locks.
-	DeleteAllLocks(context.Context) error
 	// ReplaceRemoteLocks replaces the set of locks associated with a remote cluster.
 	ReplaceRemoteLocks(ctx context.Context, clusterName string, locks []types.Lock) error
 }

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -67,8 +67,6 @@ type AccessLists interface {
 	UpdateAccessList(context.Context, *accesslist.AccessList) (*accesslist.AccessList, error)
 	// DeleteAccessList removes the specified access list resource.
 	DeleteAccessList(context.Context, string) error
-	// DeleteAllAccessLists removes all access lists.
-	DeleteAllAccessLists(context.Context) error
 
 	// UpsertAccessListWithMembers creates or updates an access list resource and its members.
 	UpsertAccessListWithMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
@@ -174,8 +172,6 @@ type AccessListMembers interface {
 	DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error
 	// DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 	DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error
-	// DeleteAllAccessListMembers hard deletes all access list members.
-	DeleteAllAccessListMembers(ctx context.Context) error
 }
 
 // MarshalAccessListMember marshals the access list member resource to JSON.
@@ -235,9 +231,6 @@ type AccessListReviews interface {
 
 	// DeleteAccessListReview will delete an access list review from the backend.
 	DeleteAccessListReview(ctx context.Context, accessListName, reviewName string) error
-
-	// DeleteAllAccessListReviews will delete all access list reviews from all access lists.
-	DeleteAllAccessListReviews(ctx context.Context) error
 }
 
 // MarshalAccessListReview marshals the access list review resource to JSON.

--- a/lib/services/crown_jewel.go
+++ b/lib/services/crown_jewel.go
@@ -38,8 +38,6 @@ type CrownJewels interface {
 	UpsertCrownJewel(context.Context, *crownjewelv1.CrownJewel) (*crownjewelv1.CrownJewel, error)
 	// DeleteCrownJewel deletes the crown jewel resource by name.
 	DeleteCrownJewel(context.Context, string) error
-	// DeleteAllCrownJewels deletes all crown jewel resources.
-	DeleteAllCrownJewels(context.Context) error
 }
 
 // MarshalCrownJewel marshals the CrownJewel object into a JSON byte array.

--- a/lib/services/dynamic_desktop.go
+++ b/lib/services/dynamic_desktop.go
@@ -34,7 +34,6 @@ type DynamicWindowsDesktops interface {
 	UpdateDynamicWindowsDesktop(context.Context, types.DynamicWindowsDesktop) (types.DynamicWindowsDesktop, error)
 	UpsertDynamicWindowsDesktop(context.Context, types.DynamicWindowsDesktop) (types.DynamicWindowsDesktop, error)
 	DeleteDynamicWindowsDesktop(ctx context.Context, name string) error
-	DeleteAllDynamicWindowsDesktops(ctx context.Context) error
 	ListDynamicWindowsDesktops(ctx context.Context, pageSize int, pageToken string) ([]types.DynamicWindowsDesktop, string, error)
 }
 

--- a/lib/services/git_server.go
+++ b/lib/services/git_server.go
@@ -40,8 +40,6 @@ type GitServers interface {
 	UpsertGitServer(ctx context.Context, item types.Server) (types.Server, error)
 	// DeleteGitServer removes the specified Git server resource.
 	DeleteGitServer(ctx context.Context, name string) error
-	// DeleteAllGitServers removes all Git server resources.
-	DeleteAllGitServers(ctx context.Context) error
 }
 
 // MarshalGitServer marshals the Git Server resource to JSON.

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -65,8 +65,6 @@ type UsersService interface {
 	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
 	// ListUsers returns a page of users.
 	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
-	// DeleteAllUsers deletes all users
-	DeleteAllUsers(ctx context.Context) error
 }
 
 // Identity is responsible for managing user entries and external identities

--- a/lib/services/notifications.go
+++ b/lib/services/notifications.go
@@ -31,18 +31,14 @@ import (
 type Notifications interface {
 	ListUserNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.Notification, string, error)
 	ListGlobalNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.GlobalNotification, string, error)
-	DeleteAllUserNotifications(ctx context.Context) error
-	DeleteAllGlobalNotifications(ctx context.Context) error
 	CreateUserNotification(ctx context.Context, notification *notificationsv1.Notification) (*notificationsv1.Notification, error)
 	UpsertUserNotification(ctx context.Context, notification *notificationsv1.Notification) (*notificationsv1.Notification, error)
 	DeleteUserNotification(ctx context.Context, username string, notificationId string) error
-	DeleteAllUserNotificationsForUser(ctx context.Context, username string) error
 	CreateGlobalNotification(ctx context.Context, globalNotification *notificationsv1.GlobalNotification) (*notificationsv1.GlobalNotification, error)
 	UpsertGlobalNotification(ctx context.Context, globalNotification *notificationsv1.GlobalNotification) (*notificationsv1.GlobalNotification, error)
 	DeleteGlobalNotification(ctx context.Context, notificationId string) error
 	UpsertUserNotificationState(ctx context.Context, username string, state *notificationsv1.UserNotificationState) (*notificationsv1.UserNotificationState, error)
 	DeleteUserNotificationState(ctx context.Context, username string, notificationId string) error
-	DeleteAllUserNotificationStatesForUser(ctx context.Context, username string) error
 	ListUserNotificationStates(ctx context.Context, username string, pageSize int, nextToken string) ([]*notificationsv1.UserNotificationState, string, error)
 	ListNotificationStatesForAllUsers(ctx context.Context, pageSize int, nextToken string) ([]*notificationsv1.UserNotificationState, string, error)
 	UpsertUserLastSeenNotification(ctx context.Context, username string, ulsn *notificationsv1.UserLastSeenNotification) (*notificationsv1.UserLastSeenNotification, error)

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -91,9 +91,6 @@ type Presence interface {
 	// DeleteAuthServer deletes auth server by name
 	DeleteAuthServer(name string) error
 
-	// DeleteAllAuthServers deletes all auth servers
-	DeleteAllAuthServers() error
-
 	// UpsertProxy registers proxy server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertProxy(ctx context.Context, server types.Server) error
@@ -115,9 +112,6 @@ type Presence interface {
 
 	// DeleteReverseTunnel deletes reverse tunnel by its domain name
 	DeleteReverseTunnel(ctx context.Context, domainName string) error
-
-	// DeleteAllReverseTunnels deletes all reverse tunnels
-	DeleteAllReverseTunnels(ctx context.Context) error
 
 	// ListReverseTunnels returns a page of ReverseTunnels.
 	ListReverseTunnels(ctx context.Context, pageSize int, pageToken string) ([]types.ReverseTunnel, string, error)

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -44,9 +44,6 @@ type Provisioner interface {
 	// Imlementations must guarantee that this returns trace.NotFound error if the token doesn't exist
 	DeleteToken(ctx context.Context, token string) error
 
-	// DeleteAllTokens deletes all provisioning tokens
-	DeleteAllTokens() error
-
 	// GetTokens returns all non-expired tokens
 	GetTokens(ctx context.Context) ([]types.ProvisionToken, error)
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -729,7 +729,7 @@ func (s *ServicesTestSuite) TokenCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(out, v2))
 
-	// Test delete all tokens
+	// Test delete tokens
 	tok, err = types.NewProvisionToken("token1", types.SystemRoles{types.RoleAuth, types.RoleNode}, time.Time{})
 	require.NoError(t, err)
 	require.NoError(t, s.ProvisioningS.UpsertToken(ctx, tok))
@@ -742,7 +742,10 @@ func (s *ServicesTestSuite) TokenCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tokens, 2)
 
-	err = s.ProvisioningS.DeleteAllTokens()
+	err = s.ProvisioningS.DeleteToken(ctx, tokens[0].GetName())
+	require.NoError(t, err)
+
+	err = s.ProvisioningS.DeleteToken(ctx, tokens[1].GetName())
 	require.NoError(t, err)
 
 	tokens, err = s.ProvisioningS.GetTokens(ctx)

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -64,9 +64,6 @@ type Trust interface {
 	// DeleteCertAuthority deletes particular certificate authority
 	DeleteCertAuthority(ctx context.Context, id types.CertAuthID) error
 
-	// DeleteAllCertAuthorities deletes cert authorities of a certain type
-	DeleteAllCertAuthorities(caType types.CertAuthType) error
-
 	// ActivateCertAuthority moves a CertAuthority from the deactivated list to
 	// the normal list.
 	ActivateCertAuthority(id types.CertAuthID) error
@@ -173,7 +170,4 @@ type Clusters interface {
 
 	// DeleteRemoteCluster deletes remote cluster by name
 	DeleteRemoteCluster(ctx context.Context, clusterName string) error
-
-	// DeleteAllRemoteClusters deletes all remote clusters
-	DeleteAllRemoteClusters(ctx context.Context) error
 }

--- a/lib/services/user_task.go
+++ b/lib/services/user_task.go
@@ -38,8 +38,6 @@ type UserTasks interface {
 	UpdateUserTask(context.Context, *usertasksv1.UserTask) (*usertasksv1.UserTask, error)
 	// DeleteUserTask deletes the user tasks resource by name.
 	DeleteUserTask(context.Context, string) error
-	// DeleteAllUserTasks deletes all user tasks.
-	DeleteAllUserTasks(context.Context) error
 }
 
 // MarshalUserTask marshals the UserTask object into a JSON byte array.

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -252,7 +252,18 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 			t.Cleanup(func() {
 				reconciler.Close()
 				require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(ctx))
-				require.NoError(t, authServer.AuthServer.DeleteAllDynamicWindowsDesktops(ctx))
+				var key string
+				for {
+					page, next, err := authServer.AuthServer.ListDynamicWindowsDesktops(ctx, 0, key)
+					require.NoError(t, err)
+					for _, dwd := range page {
+						require.NoError(t, authServer.AuthServer.DeleteDynamicWindowsDesktop(ctx, dwd.GetName()))
+					}
+					if next == "" {
+						break
+					}
+					key = next
+				}
 			})
 
 			desktop, err := types.NewDynamicWindowsDesktopV1("test", testCase.labels, types.DynamicWindowsDesktopSpecV1{


### PR DESCRIPTION
Historically any resource that was cached required a DeleteAllFoo method so the cache could clear out all resources for a given type. Now that the caching mechanism does not rely on the lib/services interfaces the DeleteAll methods are largely unused. Some of them unfortunately are exposed via gRPC and must remain, however, any place a DeleteAll existed solely to satisy the authclient.ClientI interface have been removed


Depends on https://github.com/gravitational/teleport.e/pull/6530 in order to not break builds. 