### PR TITLE
Aggregate health status in unified resource cache

### DIFF
--- a/api/types/databaseserver.go
+++ b/api/types/databaseserver.go
@@ -59,8 +59,12 @@ type DatabaseServer interface {
 	ProxiedService
 	// GetTargetHealth returns the database server's target health.
 	GetTargetHealth() TargetHealth
-	// SetTargetHealth sets the database server's target health status.
+	// SetTargetHealth sets the database server's target health.
 	SetTargetHealth(h TargetHealth)
+	// GetTargetHealthStatus returns target health status
+	GetTargetHealthStatus() TargetHealthStatus
+	// SetTargetHealthStatus sets target health status
+	SetTargetHealthStatus(status TargetHealthStatus)
 }
 
 // NewDatabaseServerV3 creates a new database server instance.
@@ -300,6 +304,22 @@ func (s *DatabaseServerV3) GetTargetHealth() TargetHealth {
 // SetTargetHealth sets the database server's target health status.
 func (s *DatabaseServerV3) SetTargetHealth(h TargetHealth) {
 	s.Status.TargetHealth = &h
+}
+
+// GetTargetHealthStatus returns target health status
+func (s *DatabaseServerV3) GetTargetHealthStatus() TargetHealthStatus {
+	if s.Status.TargetHealth == nil {
+		return ""
+	}
+	return TargetHealthStatus(s.Status.TargetHealth.Status)
+}
+
+// SetTargetHealthStatus sets target health status
+func (s *DatabaseServerV3) SetTargetHealthStatus(status TargetHealthStatus) {
+	if s.Status.TargetHealth == nil {
+		s.Status.TargetHealth = &TargetHealth{}
+	}
+	s.Status.TargetHealth.Status = string(status)
 }
 
 // DatabaseServers represents a list of database servers.

--- a/api/types/target_health.go
+++ b/api/types/target_health.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"iter"
 	"time"
 )
 
@@ -38,7 +39,37 @@ const (
 	TargetHealthStatusUnhealthy TargetHealthStatus = "unhealthy"
 	// TargetHealthStatusUnknown indicates that an unknown health check target health status.
 	TargetHealthStatusUnknown TargetHealthStatus = "unknown"
+	// TargetHealthStatusMixed indicates the resource has a mix of health
+	// statuses. This can happen when multiple agents proxy the same resource.
+	TargetHealthStatusMixed TargetHealthStatus = "mixed"
 )
+
+// Canonical converts a status into its canonical form.
+// An empty or unknown status is converted to [TargetHealthStatusUnknown].
+func (s TargetHealthStatus) Canonical() TargetHealthStatus {
+	switch s {
+	case TargetHealthStatusHealthy, TargetHealthStatusUnhealthy:
+		return s
+	default:
+		return TargetHealthStatusUnknown
+	}
+}
+
+// Aggregates health statuses into a single status. If there are a mix of
+// different statuses then the aggregate status is "mixed".
+func AggregateHealthStatus(statuses iter.Seq[TargetHealthStatus]) TargetHealthStatus {
+	first := true
+	out := TargetHealthStatusUnknown
+	for s := range statuses {
+		if first {
+			out = s.Canonical()
+			first = false
+		} else if out != s.Canonical() {
+			return TargetHealthStatusMixed
+		}
+	}
+	return out
+}
 
 // TargetHealthTransitionReason is the reason for the target health status
 // transition.
@@ -96,9 +127,14 @@ type TargetHealthGroups[T TargetHealthGetter] struct {
 	// Unhealthy is the resources with [TargetHealthStatusUnhealthy].
 	Unhealthy []T
 	// Unknown is the resources with any status that isn't healthy or unhealthy.
-	// Namely [TargetHealthStatusUnknown] and the empty string are grouped
-	// together.
+	// Namely [TargetHealthStatusUnknown], [TargetHealthStatusMixed], and the
+	// empty string are grouped together.
 	// Agents running with a version prior to health checks will always report
 	// an empty health status.
+	// A mixed status should only be set if health status for multiple servers
+	// are aggregated. An aggregated mixed status is equivalent to "unknown"
+	// because the underlying statuses that compose the mix are not known,
+	// although it really doesn't make sense to aggregate the health status
+	// before grouping it (please don't do that).
 	Unknown []T
 }

--- a/api/types/target_health.go
+++ b/api/types/target_health.go
@@ -55,8 +55,8 @@ func (s TargetHealthStatus) Canonical() TargetHealthStatus {
 	}
 }
 
-// Aggregates health statuses into a single status. If there are a mix of
-// different statuses then the aggregate status is "mixed".
+// AggregateHealthStatus health statuses into a single status. If there are a
+// mix of different statuses then the aggregate status is "mixed".
 func AggregateHealthStatus(statuses iter.Seq[TargetHealthStatus]) TargetHealthStatus {
 	first := true
 	out := TargetHealthStatusUnknown
@@ -97,17 +97,17 @@ func (t *TargetHealth) GetTransitionTimestamp() time.Time {
 	return *t.TransitionTimestamp
 }
 
-// TargetHealthGetter provides [TargetHealth] information.
-type TargetHealthGetter interface {
-	// GetTargetHealth returns the target health.
-	GetTargetHealth() TargetHealth
+// TargetHealthStatusGetter is a type that can return [TargetHealthStatus].
+type TargetHealthStatusGetter interface {
+	// GetTargetHealthStatus returns the target health status.
+	GetTargetHealthStatus() TargetHealthStatus
 }
 
-// GroupByTargetHealth groups resources by target health and returns [TargetHealthGroups].
-func GroupByTargetHealth[T TargetHealthGetter](resources []T) TargetHealthGroups[T] {
+// GroupByTargetHealthStatus groups resources by target health and returns [TargetHealthGroups].
+func GroupByTargetHealthStatus[T TargetHealthStatusGetter](resources []T) TargetHealthGroups[T] {
 	var groups TargetHealthGroups[T]
 	for _, r := range resources {
-		switch TargetHealthStatus(r.GetTargetHealth().Status) {
+		switch r.GetTargetHealthStatus() {
 		case TargetHealthStatusHealthy:
 			groups.Healthy = append(groups.Healthy, r)
 		case TargetHealthStatusUnhealthy:
@@ -121,7 +121,7 @@ func GroupByTargetHealth[T TargetHealthGetter](resources []T) TargetHealthGroups
 }
 
 // TargetHealthGroups holds resources grouped by target health status.
-type TargetHealthGroups[T TargetHealthGetter] struct {
+type TargetHealthGroups[T TargetHealthStatusGetter] struct {
 	// Healthy is the resources with [TargetHealthStatusHealthy].
 	Healthy []T
 	// Unhealthy is the resources with [TargetHealthStatusUnhealthy].

--- a/api/types/target_health_test.go
+++ b/api/types/target_health_test.go
@@ -66,22 +66,22 @@ func TestGroupByTargetHealth(t *testing.T) {
 	rand.Shuffle(len(servers), func(i, j int) {
 		servers[i], servers[j] = servers[j], servers[i]
 	})
-	groups := GroupByTargetHealth(servers)
+	groups := GroupByTargetHealthStatus(servers)
 	for _, server := range groups.Healthy {
 		require.Equal(t, TargetHealthStatusHealthy,
-			TargetHealthStatus(server.GetTargetHealth().Status),
+			server.GetTargetHealthStatus(),
 			"server %s is in the wrong group", server.GetName(),
 		)
 	}
 	for _, server := range groups.Unhealthy {
 		require.Equal(t, TargetHealthStatusUnhealthy,
-			TargetHealthStatus(server.GetTargetHealth().Status),
+			server.GetTargetHealthStatus(),
 			"server %s is in the wrong group", server.GetName(),
 		)
 	}
 	for _, server := range groups.Unknown {
 		require.Contains(t, []TargetHealthStatus{TargetHealthStatusUnknown, ""},
-			TargetHealthStatus(server.GetTargetHealth().Status),
+			server.GetTargetHealthStatus(),
 			"server %s is in the wrong group", server.GetName(),
 		)
 	}

--- a/api/types/target_health_test.go
+++ b/api/types/target_health_test.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,5 +84,54 @@ func TestGroupByTargetHealth(t *testing.T) {
 			TargetHealthStatus(server.GetTargetHealth().Status),
 			"server %s is in the wrong group", server.GetName(),
 		)
+	}
+}
+
+func TestTargetHealthStatusCanonical(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    TargetHealthStatus
+		expected TargetHealthStatus
+	}{
+		{"healthy remains healthy", TargetHealthStatusHealthy, TargetHealthStatusHealthy},
+		{"unhealthy remains unhealthy", TargetHealthStatusUnhealthy, TargetHealthStatusUnhealthy},
+		{"unknown becomes unknown", TargetHealthStatusUnknown, TargetHealthStatusUnknown},
+		{"mixed becomes unknown", TargetHealthStatusMixed, TargetHealthStatusUnknown},
+		{"empty string becomes unknown", TargetHealthStatus(""), TargetHealthStatusUnknown},
+		{"random string becomes unknown", TargetHealthStatus("invalid"), TargetHealthStatusUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.input.Canonical()
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestTargetHealthStatusesAggregate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []TargetHealthStatus
+		expected TargetHealthStatus
+	}{
+		{"empty list returns unknown", []TargetHealthStatus{}, TargetHealthStatusUnknown},
+		{"one healthy", []TargetHealthStatus{TargetHealthStatusHealthy}, TargetHealthStatusHealthy},
+		{"one unhealthy", []TargetHealthStatus{TargetHealthStatusUnhealthy}, TargetHealthStatusUnhealthy},
+		{"one unknown", []TargetHealthStatus{TargetHealthStatusUnknown}, TargetHealthStatusUnknown},
+		{"one mixed", []TargetHealthStatus{TargetHealthStatusMixed}, TargetHealthStatusUnknown},
+		{"all healthy", []TargetHealthStatus{TargetHealthStatusHealthy, TargetHealthStatusHealthy}, TargetHealthStatusHealthy},
+		{"all unhealthy", []TargetHealthStatus{TargetHealthStatusUnhealthy, TargetHealthStatusUnhealthy}, TargetHealthStatusUnhealthy},
+		{"all unknown", []TargetHealthStatus{TargetHealthStatusUnknown, TargetHealthStatusUnknown}, TargetHealthStatusUnknown},
+		{"all empty", []TargetHealthStatus{"", ""}, TargetHealthStatusUnknown},
+		{"empty and unknown", []TargetHealthStatus{"", TargetHealthStatusUnknown}, TargetHealthStatusUnknown},
+		{"healthy and unhealthy", []TargetHealthStatus{TargetHealthStatusHealthy, TargetHealthStatusUnhealthy}, TargetHealthStatusMixed},
+		{"unhealthy and unknown", []TargetHealthStatus{TargetHealthStatusUnhealthy, TargetHealthStatusUnknown}, TargetHealthStatusMixed},
+		{"healthy and unhealthy and unknown", []TargetHealthStatus{TargetHealthStatusHealthy, TargetHealthStatusUnhealthy, TargetHealthStatusUnknown}, TargetHealthStatusMixed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := AggregateHealthStatus(slices.Values(test.input))
+			require.Equal(t, test.expected, actual)
+		})
 	}
 }

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6290,12 +6290,13 @@ func TestUnifiedResources_IdentityCenter(t *testing.T) {
 func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 	const nodeCount = 150_000
 	const roleCount = 32
+	const dbCount = 150_000
 
 	ctx := context.Background()
 	srv := newTestTLSServer(b)
 
 	var ids []string
-	for i := 0; i < roleCount; i++ {
+	for range roleCount {
 		ids = append(ids, uuid.New().String())
 	}
 
@@ -6303,7 +6304,7 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 
 	var hiddenNodes int
 	// Create test nodes.
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		name := uuid.New().String()
 		id := ids[i%len(ids)]
 		if id == "hidden" {
@@ -6335,16 +6336,64 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 		require.NoError(b, err)
 	}
 
+	// Create test HA databases (multiple agents per database)
+	var hiddenDBs int
+	for i := range dbCount {
+		id := ids[i%len(ids)]
+		if id == "hidden" {
+			hiddenDBs++
+		}
+		name := "db-" + strconv.Itoa(i)
+		labels := map[string]string{
+			"kEy":   id,
+			"grouP": "useRs",
+		}
+		if i == 10 {
+			labels["ip"] = "10.20.30.40"
+			labels["ADDRESS"] = "10.20.30.41"
+			labels["food"] = "POTATO"
+		}
+
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name:   name,
+			Labels: labels,
+		}, types.DatabaseSpecV3{
+			Protocol: "test-protocol",
+			URI:      "test-uri:1234",
+		})
+		require.NoError(b, err)
+
+		statuses := []string{"healthy", "unknown", "healthy"}
+		if i == 10 {
+			statuses = []string{"unhealthy", "unhealthy", "unhealthy"}
+		}
+		for _, healthStatus := range statuses {
+			dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+				Name: db.GetName(),
+			}, types.DatabaseServerSpecV3{
+				Database: db.Copy(),
+				Hostname: name,
+				HostID:   uuid.New().String(),
+			})
+			require.NoError(b, err)
+			dbServer.SetTargetHealth(types.TargetHealth{Status: healthStatus})
+			_, err = srv.Auth().UpsertDatabaseServer(ctx, dbServer)
+			require.NoError(b, err)
+		}
+	}
+
 	b.Run("labels", func(b *testing.B) {
 		benchmarkListUnifiedResources(
 			b, ctx,
-			1,
+			2,
 			srv,
 			ids,
 			func(role types.Role, id string) {
 				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
 			},
 			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
 				req.Labels = map[string]string{"ip": "10.20.30.40"}
 			},
 		)
@@ -6352,13 +6401,15 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 	b.Run("predicate path", func(b *testing.B) {
 		benchmarkListUnifiedResources(
 			b, ctx,
-			1,
+			2,
 			srv,
 			ids,
 			func(role types.Role, id string) {
 				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
 			},
 			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
 				req.PredicateExpression = `labels.ip == "10.20.30.40"`
 			},
 		)
@@ -6366,18 +6417,20 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 	b.Run("predicate index", func(b *testing.B) {
 		benchmarkListUnifiedResources(
 			b, ctx,
-			1,
+			2,
 			srv,
 			ids,
 			func(role types.Role, id string) {
 				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
 			},
 			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
 				req.PredicateExpression = `labels["ip"] == "10.20.30.40"`
 			},
 		)
 	})
-	b.Run("search lower", func(b *testing.B) {
+	b.Run("predicate health status", func(b *testing.B) {
 		benchmarkListUnifiedResources(
 			b, ctx,
 			1,
@@ -6385,8 +6438,26 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 			ids,
 			func(role types.Role, id string) {
 				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
 			},
 			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
+				req.PredicateExpression = `health.status == "unhealthy"`
+			},
+		)
+	})
+	b.Run("search lower", func(b *testing.B) {
+		benchmarkListUnifiedResources(
+			b, ctx,
+			2,
+			srv,
+			ids,
+			func(role types.Role, id string) {
+				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+			},
+			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
 				req.SearchKeywords = []string{"10.20.30.40"}
 			},
 		)
@@ -6394,13 +6465,15 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 	b.Run("search upper", func(b *testing.B) {
 		benchmarkListUnifiedResources(
 			b, ctx,
-			1,
+			2,
 			srv,
 			ids,
 			func(role types.Role, id string) {
 				role.SetNodeLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+				role.SetDatabaseLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
 			},
 			func(req *proto.ListUnifiedResourcesRequest) {
+				req.Kinds = []string{types.KindNode, types.KindDatabase}
 				req.SearchKeywords = []string{"POTATO"}
 			},
 		)
@@ -6419,12 +6492,13 @@ func BenchmarkListUnifiedResourcesFilter(b *testing.B) {
 func BenchmarkListUnifiedResources(b *testing.B) {
 	const nodeCount = 150_000
 	const roleCount = 32
+	const dbCount = 150_000
 
 	ctx := context.Background()
 	srv := newTestTLSServer(b)
 
 	var ids []string
-	for i := 0; i < roleCount; i++ {
+	for range roleCount {
 		ids = append(ids, uuid.New().String())
 	}
 
@@ -6432,7 +6506,7 @@ func BenchmarkListUnifiedResources(b *testing.B) {
 
 	var hiddenNodes int
 	// Create test nodes.
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		name := uuid.New().String()
 		id := ids[i%len(ids)]
 		if id == "hidden" {
@@ -6455,6 +6529,40 @@ func BenchmarkListUnifiedResources(b *testing.B) {
 		require.NoError(b, err)
 	}
 
+	// Create test HA databases (multiple agents per database)
+	var hiddenDBs int
+	for i := range dbCount {
+		id := ids[i%len(ids)]
+		if id == "hidden" {
+			hiddenDBs++
+		}
+		name := "db-" + strconv.Itoa(i)
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name: name,
+			Labels: map[string]string{
+				"key":   id,
+				"group": "users",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: "test-protocol",
+			URI:      "test-uri:1234",
+		})
+		require.NoError(b, err)
+		for _, healthStatus := range []string{"healthy", "unhealthy", "unknown"} {
+			dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+				Name: db.GetName(),
+			}, types.DatabaseServerSpecV3{
+				Database: db.Copy(),
+				Hostname: name,
+				HostID:   uuid.New().String(),
+			})
+			require.NoError(b, err)
+			dbServer.SetTargetHealth(types.TargetHealth{Status: healthStatus})
+			_, err = srv.Auth().UpsertDatabaseServer(ctx, dbServer)
+			require.NoError(b, err)
+		}
+	}
+
 	for _, tc := range []struct {
 		desc     string
 		editRole func(types.Role, string)
@@ -6464,8 +6572,10 @@ func BenchmarkListUnifiedResources(b *testing.B) {
 			editRole: func(r types.Role, id string) {
 				if id == "hidden" {
 					r.SetNodeLabels(types.Deny, types.Labels{"key": {id}})
+					r.SetDatabaseLabels(types.Deny, types.Labels{"key": {id}})
 				} else {
 					r.SetNodeLabels(types.Allow, types.Labels{"key": {id}})
+					r.SetDatabaseLabels(types.Allow, types.Labels{"key": {id}})
 				}
 			},
 		},
@@ -6473,11 +6583,13 @@ func BenchmarkListUnifiedResources(b *testing.B) {
 		b.Run(tc.desc, func(b *testing.B) {
 			benchmarkListUnifiedResources(
 				b, ctx,
-				nodeCount-hiddenNodes,
+				nodeCount-hiddenNodes+dbCount-hiddenDBs,
 				srv,
 				ids,
 				tc.editRole,
-				func(req *proto.ListUnifiedResourcesRequest) {},
+				func(req *proto.ListUnifiedResourcesRequest) {
+					req.Kinds = []string{types.KindNode, types.KindDatabase}
+				},
 			)
 		})
 	}

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -361,13 +361,21 @@ func (w *worker) getThreshold(cfg *healthCheckConfig) uint32 {
 
 func (w *worker) setThresholdReached(ctx context.Context) {
 	const transitionReason = types.TargetHealthTransitionReasonThreshold
+	checkWord := pluralize(w.lastResultCount, "check")
 	if w.lastResultErr == nil {
-		msg := fmt.Sprintf("%d health checks passed", w.lastResultCount)
+		msg := fmt.Sprintf("%d health %v passed", w.lastResultCount, checkWord)
 		w.setTargetHealthy(ctx, transitionReason, msg)
 	} else {
-		msg := fmt.Sprintf("%d health checks failed", w.lastResultCount)
+		msg := fmt.Sprintf("%d health %v failed", w.lastResultCount, checkWord)
 		w.setTargetUnhealthy(ctx, transitionReason, msg)
 	}
+}
+
+func pluralize(count uint32, word string) string {
+	if count != 1 {
+		return word + "s"
+	}
+	return word
 }
 
 func (w *worker) setTargetInit(ctx context.Context) {

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -133,12 +133,10 @@ func MatchResourceLabels(matchers []ResourceMatcher, labels map[string]string) b
 // resourceWithTargetHealth wraps a resource to provide target health info.
 type resourceWithTargetHealth struct {
 	types.ResourceWithLabels
-	health types.TargetHealth
+	health types.TargetHealthStatus
 }
 
-var _ types.TargetHealthGetter = (*resourceWithTargetHealth)(nil)
-
-func (r *resourceWithTargetHealth) GetTargetHealth() types.TargetHealth {
+func (r *resourceWithTargetHealth) GetTargetHealthStatus() types.TargetHealthStatus {
 	return r.health
 }
 
@@ -191,7 +189,7 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 		}
 		specResource = &resourceWithTargetHealth{
 			ResourceWithLabels: server.GetDatabase(),
-			health:             server.GetTargetHealth(),
+			health:             server.GetTargetHealthStatus(),
 		}
 		key.name = specResource.GetName()
 	case types.KindAppServer, types.KindSAMLIdPServiceProvider:

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -475,9 +475,9 @@ func TestMatchResourceByHealthStatus(t *testing.T) {
 			matchedNames:     []string{"db-server-0"},
 		},
 		{
-			name:             "unhealthy db status and message",
+			name:             "unhealthy db status",
 			resources:        dbServers,
-			filterExpression: `health.message == "failed to fizz the buzz" && health.status == "unhealthy"`,
+			filterExpression: `health.status == "unhealthy"`,
 			matchedNames:     []string{"db-server-1"},
 		},
 		{
@@ -495,7 +495,7 @@ func TestMatchResourceByHealthStatus(t *testing.T) {
 		{
 			name:             "server health is empty",
 			resources:        []types.ResourceWithLabels{server},
-			filterExpression: `!exists(health.status) && health.message == ""`,
+			filterExpression: `!exists(health.status)`,
 			matchedNames:     []string{"server"},
 		},
 	}

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -110,6 +110,9 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		Database: db,
 	})
 	require.NoError(t, err)
+	health := dbServer.GetTargetHealth()
+	health.Status = "unknown"
+	dbServer.SetTargetHealth(health)
 	_, err = clt.UpsertDatabaseServer(ctx, dbServer)
 	require.NoError(t, err)
 	gitServer := newGitServer(t, "my-org")
@@ -253,6 +256,9 @@ func TestUnifiedResourceCacheIterateResources(t *testing.T) {
 		Database: db,
 	})
 	require.NoError(t, err)
+	health := dbServer.GetTargetHealth()
+	health.Status = "unknown"
+	dbServer.SetTargetHealth(health)
 	_, err = clt.UpsertDatabaseServer(ctx, dbServer)
 	require.NoError(t, err)
 	gitServer := newGitServer(t, "my-org")
@@ -405,7 +411,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 
 	const resourceCount = 1234
 	ids := make([]string, 0, resourceCount)
-	for i := 0; i < resourceCount; i++ {
+	for i := range resourceCount {
 		ids = append(ids, "resource"+strconv.Itoa(i))
 	}
 
@@ -445,27 +451,33 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 		{
 			name: "databases",
 			createResource: func(name string, c *client) error {
-				db, err := types.NewDatabaseV3(types.Metadata{
-					Name: name,
-				}, types.DatabaseSpecV3{
-					Protocol: "test-protocol",
-					URI:      "test-uri",
-				})
-				if err != nil {
-					return err
+				for _, status := range []string{"healthy", "unhealthy", "unknown"} {
+					db, err := types.NewDatabaseV3(types.Metadata{
+						Name: name,
+					}, types.DatabaseSpecV3{
+						Protocol: "test-protocol",
+						URI:      "test-uri",
+					})
+					if err != nil {
+						return err
+					}
+					dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+						Name: name,
+					}, types.DatabaseServerSpecV3{
+						Hostname: "hostname:" + name,
+						HostID:   uuid.NewString(),
+						Database: db,
+					})
+					if err != nil {
+						return err
+					}
+					dbServer.SetTargetHealth(types.TargetHealth{Status: status})
+					_, err = c.UpsertDatabaseServer(ctx, dbServer)
+					if err != nil {
+						return err
+					}
 				}
-				dbServer, err := types.NewDatabaseServerV3(types.Metadata{
-					Name: name,
-				}, types.DatabaseServerSpecV3{
-					Hostname: "hostname:" + name,
-					HostID:   uuid.NewString(),
-					Database: db,
-				})
-				if err != nil {
-					return err
-				}
-				_, err = c.UpsertDatabaseServer(ctx, dbServer)
-				return err
+				return nil
 			},
 			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
@@ -663,7 +675,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			for i := 0; i < resourceCount; i++ {
+			for i := range resourceCount {
 				require.NoError(t, test.createResource(ids[i], clt), "creating resource %d", i)
 			}
 
@@ -720,6 +732,10 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 							if r.GetName() != ids[count] {
 								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
 							}
+							if r, ok := r.(types.TargetHealthGetter); ok {
+								require.Equal(t, "mixed", r.GetTargetHealth().Status, "resource %v", r)
+								require.IsTypef(t, &types.DatabaseServerV3{}, r, "resource %v", r)
+							}
 							count++
 						}
 
@@ -747,6 +763,10 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 						for _, r := range resources {
 							if r.GetName() != ids[count] {
 								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+							}
+							if r, ok := r.(types.TargetHealthGetter); ok {
+								require.Equal(t, "mixed", r.GetTargetHealth().Status, "resource %v", r)
+								require.IsTypef(t, &types.DatabaseServerV3{}, r, "resource %v", r)
 							}
 							count--
 						}
@@ -821,24 +841,28 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	_, err = clt.UpsertNode(ctx, node)
 	require.NoError(t, err)
 
-	// add a database server
-	db, err := types.NewDatabaseV3(types.Metadata{
-		Name: "db1",
-	}, types.DatabaseSpecV3{
-		Protocol: "test-protocol",
-		URI:      "test-uri",
-	})
-	require.NoError(t, err)
-	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
-		Name: "db1-server",
-	}, types.DatabaseServerSpecV3{
-		Hostname: "db-hostname",
-		HostID:   uuid.NewString(),
-		Database: db,
-	})
-	require.NoError(t, err)
-	_, err = clt.UpsertDatabaseServer(ctx, dbServer)
-	require.NoError(t, err)
+	// add multiple database servers for the same db (HA setup)
+	var dbServers []*types.DatabaseServerV3
+	for range 3 {
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name: "db1",
+		}, types.DatabaseSpecV3{
+			Protocol: "test-protocol",
+			URI:      "test-uri",
+		})
+		require.NoError(t, err)
+		dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+			Name: "db1-server",
+		}, types.DatabaseServerSpecV3{
+			Hostname: "db-hostname",
+			HostID:   uuid.NewString(),
+			Database: db,
+		})
+		require.NoError(t, err)
+		_, err = clt.UpsertDatabaseServer(ctx, dbServer)
+		require.NoError(t, err)
+		dbServers = append(dbServers, dbServer)
+	}
 
 	// add a saml app
 	samlapp, err := types.NewSAMLIdPServiceProvider(
@@ -854,52 +878,64 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	err = clt.CreateSAMLIdPServiceProvider(ctx, samlapp)
 	require.NoError(t, err)
 
-	// Add an app server
-	app, err := types.NewAppServerV3(
-		types.Metadata{Name: "app1"},
-		types.AppServerSpecV3{
-			HostID: "app1-host-id",
-			App:    newApp(t, "app1"),
-		},
-	)
-	require.NoError(t, err)
-	_, err = clt.UpsertApplicationServer(ctx, app)
-	require.NoError(t, err)
+	// Add multiple app servers for the same app (HA setup)
+	var appServers []*types.AppServerV3
+	for range 3 {
+		app, err := types.NewAppServerV3(
+			types.Metadata{Name: "app1"},
+			types.AppServerSpecV3{
+				HostID: uuid.NewString(),
+				App:    newApp(t, "app1"),
+			},
+		)
+		require.NoError(t, err)
+		_, err = clt.UpsertApplicationServer(ctx, app)
+		require.NoError(t, err)
+		appServers = append(appServers, app)
+	}
 
-	// add desktop
-	desktop, err := types.NewWindowsDesktopV3(
-		"desktop",
-		map[string]string{"label": string(make([]byte, 0))},
-		types.WindowsDesktopSpecV3{
-			Addr:   "addr",
-			HostID: "HostID",
-		})
-	require.NoError(t, err)
-	err = clt.UpsertWindowsDesktop(ctx, desktop)
-	require.NoError(t, err)
+	// add multiple desktops (HA setup)
+	var desktops []*types.WindowsDesktopV3
+	for range 3 {
+		desktop, err := types.NewWindowsDesktopV3(
+			"desktop",
+			map[string]string{"label": string(make([]byte, 0))},
+			types.WindowsDesktopSpecV3{
+				Addr:   "addr",
+				HostID: uuid.NewString(),
+			})
+		require.NoError(t, err)
+		err = clt.UpsertWindowsDesktop(ctx, desktop)
+		require.NoError(t, err)
+		desktops = append(desktops, desktop)
+	}
 
-	// add kube
-	kube, err := types.NewKubernetesClusterV3(
-		types.Metadata{
-			Name:      "kube",
-			Namespace: defaults.Namespace,
-		},
-		types.KubernetesClusterSpecV3{},
-	)
-	require.NoError(t, err)
-	kubeServer, err := types.NewKubernetesServerV3(
-		types.Metadata{
-			Name:      "kube_server",
-			Namespace: defaults.Namespace,
-		},
-		types.KubernetesServerSpecV3{
-			Cluster: kube,
-			HostID:  "hostID",
-		},
-	)
-	require.NoError(t, err)
-	_, err = clt.UpsertKubernetesServer(ctx, kubeServer)
-	require.NoError(t, err)
+	// add multiple kube servers (HA setup)
+	var kubeServers []*types.KubernetesServerV3
+	for range 3 {
+		kube, err := types.NewKubernetesClusterV3(
+			types.Metadata{
+				Name:      "kube",
+				Namespace: defaults.Namespace,
+			},
+			types.KubernetesClusterSpecV3{},
+		)
+		require.NoError(t, err)
+		kubeServer, err := types.NewKubernetesServerV3(
+			types.Metadata{
+				Name:      "kube_server",
+				Namespace: defaults.Namespace,
+			},
+			types.KubernetesServerSpecV3{
+				Cluster: kube,
+				HostID:  uuid.NewString(),
+			},
+		)
+		require.NoError(t, err)
+		_, err = clt.UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
+		kubeServers = append(kubeServers, kubeServer)
+	}
 
 	icAcct := newICAccount(t, ctx, clt)
 
@@ -913,28 +949,69 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 		return len(res) == 8
 	}, 5*time.Second, 10*time.Millisecond, "Timed out waiting for unified resources to be added")
 
-	// delete everything
+	// delete just one of each of the HA servers
+	err = clt.DeleteDatabaseServer(ctx, "default", dbServers[0].Spec.HostID, dbServers[0].GetName())
+	require.NoError(t, err)
+	dbServers = dbServers[1:]
+	err = clt.DeleteApplicationServer(ctx, "default", appServers[0].Spec.HostID, appServers[0].GetName())
+	require.NoError(t, err)
+	appServers = appServers[1:]
+	err = clt.DeleteWindowsDesktop(ctx, desktops[0].Spec.HostID, desktops[0].GetName())
+	require.NoError(t, err)
+	desktops = desktops[1:]
+	err = clt.DeleteKubernetesServer(ctx, kubeServers[0].Spec.HostID, kubeServers[0].GetName())
+	require.NoError(t, err)
+	kubeServers = kubeServers[1:]
+
+	// delete everything else
 	err = clt.DeleteNode(ctx, "default", node.GetName())
 	require.NoError(t, err)
-	err = clt.DeleteDatabaseServer(ctx, "default", dbServer.Spec.HostID, dbServer.GetName())
-	require.NoError(t, err)
 	err = clt.DeleteSAMLIdPServiceProvider(ctx, samlapp.GetName())
-	require.NoError(t, err)
-	err = clt.DeleteApplicationServer(ctx, "default", app.Spec.HostID, app.GetName())
-	require.NoError(t, err)
-	err = clt.DeleteWindowsDesktop(ctx, desktop.Spec.HostID, desktop.GetName())
-	require.NoError(t, err)
-	err = clt.DeleteKubernetesServer(ctx, kubeServer.Spec.HostID, kubeServer.GetName())
 	require.NoError(t, err)
 	err = clt.DeleteIdentityCenterAccount(ctx, services.IdentityCenterAccountID(icAcct.GetMetadata().GetName()))
 	require.NoError(t, err)
 	err = clt.DeleteGitServer(ctx, gitServer.GetName())
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
-		res, _ := w.GetUnifiedResources(ctx)
-		return len(res) == 0
-	}, 5*time.Second, 10*time.Millisecond, "Timed out waiting for unified resources to be deleted")
+	duplicatedServerNames := []string{
+		appServers[0].GetName(),
+		dbServers[0].GetName(),
+		desktops[0].GetName(),
+		kubeServers[0].GetName(),
+	}
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.ElementsMatch(t, duplicatedServerNames, slices.Collect(types.ResourceNames(res)))
+	}, 5*time.Second, 100*time.Millisecond, "Timed out waiting for unified resources to be deleted except for HA servers")
+
+	// delete all remaining (db, kube, app, desktop) servers
+	for _, dbServer := range dbServers {
+		err = clt.DeleteDatabaseServer(ctx, "default", dbServer.Spec.HostID, dbServer.GetName())
+		require.NoError(t, err)
+	}
+	for _, appServer := range appServers {
+		err = clt.DeleteApplicationServer(ctx, "default", appServer.Spec.HostID, appServer.GetName())
+		require.NoError(t, err)
+	}
+	for _, desktop := range desktops {
+		err = clt.DeleteWindowsDesktop(ctx, desktop.Spec.HostID, desktop.GetName())
+		require.NoError(t, err)
+	}
+	for _, kubeServer := range kubeServers {
+		err = clt.DeleteKubernetesServer(ctx, kubeServer.Spec.HostID, kubeServer.GetName())
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Empty(t, res)
+	}, 5*time.Second, 100*time.Millisecond, "Timed out waiting for unified resources to be deleted")
 }
 
 func newTestEntityDescriptor(entityID string) string {

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -696,6 +696,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 						if r.GetName() != ids[count] {
 							t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
 						}
+						requireHealthStatusIfGiven(t, r, types.TargetHealthStatusMixed)
 						count++
 					}
 
@@ -710,6 +711,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 						if r.GetName() != ids[count] {
 							t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
 						}
+						requireHealthStatusIfGiven(t, r, types.TargetHealthStatusMixed)
 						count--
 					}
 
@@ -732,10 +734,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 							if r.GetName() != ids[count] {
 								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
 							}
-							if r, ok := r.(types.TargetHealthGetter); ok {
-								require.Equal(t, "mixed", r.GetTargetHealth().Status, "resource %v", r)
-								require.IsTypef(t, &types.DatabaseServerV3{}, r, "resource %v", r)
-							}
+							requireHealthStatusIfGiven(t, r, types.TargetHealthStatusMixed)
 							count++
 						}
 
@@ -764,10 +763,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 							if r.GetName() != ids[count] {
 								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
 							}
-							if r, ok := r.(types.TargetHealthGetter); ok {
-								require.Equal(t, "mixed", r.GetTargetHealth().Status, "resource %v", r)
-								require.IsTypef(t, &types.DatabaseServerV3{}, r, "resource %v", r)
-							}
+							requireHealthStatusIfGiven(t, r, types.TargetHealthStatusMixed)
 							count--
 						}
 
@@ -1123,4 +1119,11 @@ func mustCreateOktaAppServer(t *testing.T, name, friendlyName string) *types.App
 	})
 	require.NoError(t, err)
 	return resource
+}
+
+func requireHealthStatusIfGiven(t *testing.T, r any, want types.TargetHealthStatus) {
+	t.Helper()
+	if r, ok := r.(types.TargetHealthStatusGetter); ok {
+		require.Equal(t, want, r.GetTargetHealthStatus(), "resource %v", r)
+	}
 }

--- a/lib/srv/db/common/connect/connect.go
+++ b/lib/srv/db/common/connect/connect.go
@@ -304,7 +304,7 @@ func Connect(ctx context.Context, params ConnectParams) (net.Conn, ConnectStats,
 	// group the servers by target health, shuffle each group, and then iterate
 	// over the concatenated groups in order ascending order of health.
 	params.ShuffleFunc(params.Servers)
-	groups := types.GroupByTargetHealth(params.Servers)
+	groups := types.GroupByTargetHealthStatus(params.Servers)
 	// There may be multiple database servers proxying the same database. If
 	// we get a connection problem error trying to dial one of them, likely
 	// the database server is down so try the next one.

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -782,8 +782,7 @@ func waitForHealthStatus(t *testing.T, ctx context.Context, name string, serverG
 			assert.FailNowf(t, "failed to find db_server", "db_server=%s", name)
 			return
 		}
-		health := server.GetTargetHealth()
-		assert.Equal(t, string(want), health.Status)
+		assert.Equal(t, want, server.GetTargetHealthStatus())
 	}, timeout, time.Millisecond*250, "waiting for database %s to become healthy", name)
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3166,12 +3166,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 				unifiedResources = append(unifiedResources, ui.MakeGitServer(site.GetName(), r, enriched.RequiresRequest))
 			}
 		case types.DatabaseServer:
-			db := ui.MakeDatabaseFromDatabaseServer(
-				r,
-				accessChecker,
-				h.cfg.DatabaseREPLRegistry,
-				enriched.RequiresRequest,
-			)
+			db := ui.MakeDatabaseFromDatabaseServer(r, accessChecker, h.cfg.DatabaseREPLRegistry, enriched.RequiresRequest)
 			unifiedResources = append(unifiedResources, db)
 		case types.AppServer:
 			allowedAWSRoles, err := calculateAppLogins(accessChecker, r, enriched.Logins)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3166,7 +3166,12 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 				unifiedResources = append(unifiedResources, ui.MakeGitServer(site.GetName(), r, enriched.RequiresRequest))
 			}
 		case types.DatabaseServer:
-			db := ui.MakeDatabaseFromDatabaseServer(r, accessChecker, h.cfg.DatabaseREPLRegistry, enriched.RequiresRequest)
+			db := ui.MakeDatabaseFromDatabaseServer(
+				r,
+				accessChecker,
+				h.cfg.DatabaseREPLRegistry,
+				enriched.RequiresRequest,
+			)
 			unifiedResources = append(unifiedResources, db)
 		case types.AppServer:
 			allowedAWSRoles, err := calculateAppLogins(accessChecker, r, enriched.Logins)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1349,28 +1349,30 @@ func TestUnifiedResourcesGet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// add db
-	db, err := types.NewDatabaseV3(types.Metadata{
-		Name: "dbdb",
-		Labels: map[string]string{
-			"env": "prod",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: "test-protocol",
-		URI:      "test-uri",
-	})
-	require.NoError(t, err)
-	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
-		Name: "dddb1",
-	}, types.DatabaseServerSpecV3{
-		Hostname: "dddb1",
-		HostID:   uuid.NewString(),
-		Database: db,
-	})
-	require.NoError(t, err)
-	dbServer.SetTargetHealth(types.TargetHealth{Status: "testing-status"})
-	_, err = env.server.Auth().UpsertDatabaseServer(context.Background(), dbServer)
-	require.NoError(t, err)
+	// add HA dbs
+	for _, healthStatus := range []string{"healthy", "unhealthy", "unknown"} {
+		db, err := types.NewDatabaseV3(types.Metadata{
+			Name: "dbdb",
+			Labels: map[string]string{
+				"env": "prod",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: "test-protocol",
+			URI:      "test-uri",
+		})
+		require.NoError(t, err)
+		dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+			Name: db.GetName(),
+		}, types.DatabaseServerSpecV3{
+			Hostname: "dddb1",
+			HostID:   uuid.NewString(),
+			Database: db,
+		})
+		require.NoError(t, err)
+		dbServer.SetTargetHealth(types.TargetHealth{Status: healthStatus})
+		_, err = env.server.Auth().UpsertDatabaseServer(context.Background(), dbServer)
+		require.NoError(t, err)
+	}
 
 	// add windows desktop
 	win, err := types.NewWindowsDesktopV3(
@@ -1430,7 +1432,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 		Items      []webui.Database `json:"items"`
 		TotalCount int              `json:"totalCount"`
 	}
-	query = url.Values{"sort": []string{"name"}, "limit": []string{"1"}, "kinds": []string{types.KindDatabase}}
+	query = url.Values{"sort": []string{"name"}, "limit": []string{"1"}, "kinds": []string{types.KindDatabase}, "query": []string{`health.status == "mixed"`}}
 	re, err = pack.clt.Get(context.Background(), endpoint, query)
 	require.NoError(t, err)
 	dbRes := dbResponse{}
@@ -1444,7 +1446,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 		Protocol:     "test-protocol",
 		Hostname:     "test-uri",
 		URI:          "test-uri",
-		TargetHealth: types.TargetHealth{Status: "testing-status"},
+		TargetHealth: types.TargetHealth{Status: "mixed"},
 	}})
 
 	// should return first page and have a second page
@@ -3950,7 +3952,7 @@ func TestClusterDatabasesGet_NoRole(t *testing.T) {
 		Database: db,
 	})
 	require.NoError(t, err)
-	dbServer.SetTargetHealth(types.TargetHealth{Status: "testing-status"})
+	dbServer.SetTargetHealth(types.TargetHealth{Status: "healthy"})
 
 	_, err = env.server.Auth().UpsertDatabaseServer(context.Background(), dbServer)
 	require.NoError(t, err)
@@ -3970,7 +3972,7 @@ func TestClusterDatabasesGet_NoRole(t *testing.T) {
 		Protocol:     "test-protocol",
 		Hostname:     "test-uri",
 		URI:          "test-uri:1234",
-		TargetHealth: types.TargetHealth{Status: "testing-status"},
+		TargetHealth: types.TargetHealth{Status: "healthy"},
 	}})
 }
 

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -303,11 +303,14 @@ func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 
-	dbServer, err := fetchDatabaseServerByDatabaseName(r.Context(), clt, r, databaseName)
+	dbServers, err := fetchDatabaseServersWithName(r.Context(), clt, r, databaseName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	database := dbServer.GetDatabase()
+	if len(dbServers) == 0 {
+		return nil, trace.NotFound("database %q not found", databaseName)
+	}
+	database := dbServers[0].GetDatabase()
 
 	switch {
 	case database.IsAWSHosted():
@@ -819,8 +822,8 @@ func (s *databaseInteractiveSession) sendSessionMetadata() error {
 	return nil
 }
 
-// fetchDatabaseServerByDatabaseName fetch a database with provided database name.
-func fetchDatabaseServerByDatabaseName(ctx context.Context, clt resourcesAPIGetter, r *http.Request, databaseName string) (types.DatabaseServer, error) {
+// fetchDatabaseServersWithName fetches all database servers with provided database name.
+func fetchDatabaseServersWithName(ctx context.Context, clt resourcesAPIGetter, r *http.Request, databaseName string) ([]types.DatabaseServer, error) {
 	resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
 		Limit:               defaults.MaxIterationLimit,
 		ResourceType:        types.KindDatabaseServer,
@@ -832,16 +835,7 @@ func fetchDatabaseServerByDatabaseName(ctx context.Context, clt resourcesAPIGett
 	}
 
 	servers, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	switch len(servers) {
-	case 0:
-		return nil, trace.NotFound("database %q not found", databaseName)
-	default:
-		return servers[0], nil
-	}
+	return servers, trace.Wrap(err)
 }
 
 func getNewDatabaseResource(req createOrOverwriteDatabaseRequest) (*types.DatabaseV3, error) {

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -307,9 +307,6 @@ func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if len(dbServers) == 0 {
-		return nil, trace.NotFound("database %q not found", databaseName)
-	}
 	database := dbServers[0].GetDatabase()
 
 	switch {
@@ -835,7 +832,13 @@ func fetchDatabaseServersWithName(ctx context.Context, clt resourcesAPIGetter, r
 	}
 
 	servers, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServers()
-	return servers, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(servers) == 0 {
+		return nil, trace.NotFound("database %q not found", databaseName)
+	}
+	return servers, nil
 }
 
 func getNewDatabaseResource(req createOrOverwriteDatabaseRequest) (*types.DatabaseV3, error) {

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -143,17 +143,35 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	dbServer, err := fetchDatabaseServerByDatabaseName(r.Context(), clt, r, databaseName)
+	dbServers, err := fetchDatabaseServersWithName(r.Context(), clt, r, databaseName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if len(dbServers) == 0 {
+		return nil, trace.NotFound("database %q not found", databaseName)
+	}
+	aggregateStatus := types.AggregateHealthStatus(func(yield func(types.TargetHealthStatus) bool) {
+		for _, srv := range dbServers {
+			if !yield(types.TargetHealthStatus(srv.GetTargetHealth().Status)) {
+				return
+			}
+		}
+	})
+	health := dbServers[0].GetTargetHealth()
+	health.Status = string(aggregateStatus)
+	dbServers[0].SetTargetHealth(health)
 
 	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return webui.MakeDatabaseFromDatabaseServer(dbServer, accessChecker, h.cfg.DatabaseREPLRegistry, false /* requiresRequest */), nil
+	return webui.MakeDatabaseFromDatabaseServer(
+		dbServers[0],
+		accessChecker,
+		h.cfg.DatabaseREPLRegistry,
+		false, /* requiresRequest */
+	), nil
 }
 
 // clusterDatabaseServicesList returns a list of DatabaseServices (database agents) in a form the UI can present.

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -147,19 +147,14 @@ func (h *Handler) clusterDatabaseGet(w http.ResponseWriter, r *http.Request, p h
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if len(dbServers) == 0 {
-		return nil, trace.NotFound("database %q not found", databaseName)
-	}
 	aggregateStatus := types.AggregateHealthStatus(func(yield func(types.TargetHealthStatus) bool) {
 		for _, srv := range dbServers {
-			if !yield(types.TargetHealthStatus(srv.GetTargetHealth().Status)) {
+			if !yield(srv.GetTargetHealthStatus()) {
 				return
 			}
 		}
 	})
-	health := dbServers[0].GetTargetHealth()
-	health.Status = string(aggregateStatus)
-	dbServers[0].SetTargetHealth(health)
+	dbServers[0].SetTargetHealthStatus(aggregateStatus)
 
 	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -323,7 +323,7 @@ type Database struct {
 	// extract db from it:
 	// - webapi/sites/:site/databases/:database (singular)
 	// - webapi/sites/:site/resources (unified resources)
-	TargetHealth types.TargetHealth `json:"targetHealth,omitempty"`
+	TargetHealth types.TargetHealth `json:"targetHealth,omitzero"`
 }
 
 // AWS contains AWS specific fields.


### PR DESCRIPTION
Part of:
- #20544

This should also fix:
- https://github.com/gravitational/teleport/issues/46937

Web UI and Teleterm will be updated in separate PRs to leverage the URC change and fetch all health statuses.

The health status for a resource with multiple servers, as in a database proxied by multiple agents, will now be aggregated in the unified resource cache.
If there are multiple statuses and the statuses are not all the same, then the aggregate status will be set to "mixed".
It is then the client's responsibility to list the servers for a "mixed" status resource if they want details about individual resource server health.

The purpose is to allow the web ui to efficiently fetch all health statuses for all resources in the unified resources view.