### PR TITLE
Update sessions config for multi-region blueprint

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -81,7 +81,8 @@ This section describes this setup in more detail.
   - on-prem, MinIO supports [multi-site bucket replication](https://min.io/docs/minio/linux/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.html)
   - on AWS, you can [set up two-way-replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mrap-create-two-way-replication-rules.html)
     between S3 buckets.
-- Setup [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
+- Set up IAM to allow access to the object storage. See [S3 docs](../reference/backends.mdx#s3-iam-policy) for the reference.
+- Set up [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
 
 ### Teleport backend configuration
 
@@ -174,7 +175,7 @@ auth:
         conn_string: postgres://teleport@cockroachdb-public.<region>.svc.cluster.local:26257/teleport_backend?sslmode=verify-full&pool_max_conns=20
         audit_events_uri:
           - "postgres://teleport@cockroachdb-public.<region>.svc.cluster.local:26257/teleport_audit?sslmode=verify-full"
-        # replace this with the URI of your regional object storage (S3, GCS, MinIO)
+        # replace this with the URI of your regional object storage (S3, GCS, MinIO) and IAM role configured for the object storage access
         # set complete_initiators param to ensure Teleport will only complete uploads initiated by itself
         audit_sessions_uri: "uri://to-your-regional-bucket?complete_initiators=<teleport-iam-role>"
         ttl_job_cron: '*/20 * * * *'

--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -175,7 +175,8 @@ auth:
         audit_events_uri:
           - "postgres://teleport@cockroachdb-public.<region>.svc.cluster.local:26257/teleport_audit?sslmode=verify-full"
         # replace this with the URI of your regional object storage (S3, GCS, MinIO)
-        audit_sessions_uri: "uri://to-your-regional-bucket"
+        # set complete_initiators param to ensure Teleport will only complete uploads initiated by itself
+        audit_sessions_uri: "uri://to-your-regional-bucket?complete_initiators=<teleport-iam-role>"
         ttl_job_cron: '*/20 * * * *'
     
     # Configure proxy peering

--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -81,7 +81,7 @@ This section describes this setup in more detail.
   - on-prem, MinIO supports [multi-site bucket replication](https://min.io/docs/minio/linux/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.html)
   - on AWS, you can [set up two-way-replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mrap-create-two-way-replication-rules.html)
     between S3 buckets.
-- Set up IAM to allow access to the object storage. See [S3 docs](../reference/backends.mdx#s3-iam-policy) for the reference.
+- Set up IAM to allow access to the object storage. See [S3 docs](../../reference/backends.mdx#s3-iam-policy) for the reference.
 - Set up [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
 
 ### Teleport backend configuration

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -659,7 +659,7 @@ Service reads these parameters to configure its interactions with S3:
 initiated by the specified set of initiators. This is helpful in scenarios where
 software other than Teleport is initiating multipart uploads in the recordings
 bucket. This should be set to the display name of the initiator(s) you want to
-ignore.
+allow.
 
 ### S3 IAM policy
 


### PR DESCRIPTION
Updating multi-region blueprint to include recently added `complete_initiators` param.

The parameter is supported in versions 17.4.6+, 16.5.5+, 15.5.0+.