### PR TITLE
Add `workload_identity_x509_issuer_override` to preset `editor` role

### DIFF
--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1078,6 +1078,30 @@
               "update",
               "delete"
             ]
+          },
+          {
+            "resources": [
+              "workload_identity_x509_issuer_override"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
+          },
+          {
+            "resources": [
+              "workload_identity_x509_issuer_override_csr"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
           }
         ]
       },

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -216,6 +216,8 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindWorkloadIdentityX509Revocation, RW()),
 					types.NewRule(types.KindHealthCheckConfig, RW()),
 					types.NewRule(types.KindSigstorePolicy, RW()),
+					types.NewRule(types.KindWorkloadIdentityX509IssuerOverride, RW()),
+					types.NewRule(types.KindWorkloadIdentityX509IssuerOverrideCSR, RW()),
 				},
 			},
 		},


### PR DESCRIPTION
changelog: Added `workload_identity_x509_issuer_override` kind to `editor` preset role.