### PR TITLE
[v17] Okta: Fix creating Access Requests for legacy okta_service resources

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5571,15 +5571,24 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 	// 7. Run tests
 
 	t.Run("requesting okta resources but no okta plugin", func(t *testing.T) {
-		// Note: Okta-originated resources present in the cluster and no Okta plugin
-		// configured is the situation where the plugin was freshly deleted and the
-		// heartbeats for the Okta apps haven't expired yet. This is an edge-case so the
-		// error is a bit confusing.
+		// v18+ version:
+		/*
+			// Note: Okta-originated resources present in the cluster and no Okta plugin
+			// configured is the situation where the plugin was freshly deleted and the
+			// heartbeats for the Okta apps haven't expired yet. This is an edge-case so the
+			// error is a bit confusing.
+			for _, accessRequest := range testAccessRequests {
+				_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err))
+				require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error())
+			}
+		*/
+
+		// v17 only - we need to support okta_service where no plugin exists:
 		for _, accessRequest := range testAccessRequests {
 			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
-			require.Error(t, err)
-			require.True(t, trace.IsBadParameter(err))
-			require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error())
+			require.NoError(t, err)
 		}
 	})
 

--- a/lib/auth/okta/auth.go
+++ b/lib/auth/okta/auth.go
@@ -102,7 +102,14 @@ func CheckAccess(authzCtx *authz.Context, existingResource types.ResourceWithLab
 func BidirectionalSyncEnabled(ctx context.Context, plugins services.Plugins) (bool, error) {
 	plugin, err := oktaplugin.Get(ctx, plugins, false /* withSecrets */)
 	if trace.IsNotFound(err) {
-		return false, nil
+		// v17 only: since we still support the legacy okta_service configuration there is
+		// a chance someone will configure app & groups sync and will create roles allowing
+		// Access Requests. If this is false then resources allowed by search_as_roles
+		// won't be allowed because the access checker will think this is a RO integration
+		// because for okta_service configuration there is no plugin in the backend.
+		// The support for okta_service is dropped in v18 so we should return false there.
+		trueInV17 := true
+		return trueInV17, nil
 	} else if err != nil {
 		return false, trace.Wrap(err, "getting Okta plugin")
 	}


### PR DESCRIPTION
With https://github.com/gravitational/teleport/pull/53697 no plugin in the backend is interpreted as read-only integration (i.e. bidirectional sync disabled). In read-only  mode we:

- don't list Okta-originated resources for Access Requests
- don't allow Access Requests for Okta-originated resources

This PR changes that so missing plugin is NOT interpreted as read-only. This allows creating Access Requests for Okta-originated resources in the legacy setup with okta_service.

changelog: Okta: Fix creating Access Requests for Okta-originated resources in the legacy okta_service setup.