### PR TITLE
[vnet] cache leaf cluster lookups

### DIFF
--- a/lib/vnet/leafclustercache.go
+++ b/lib/vnet/leafclustercache.go
@@ -1,0 +1,68 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type leafClusterCache struct {
+	fnCache *utils.FnCache
+}
+
+func newLeafClusterCache(clock clockwork.Clock) (*leafClusterCache, error) {
+	fnCache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL:         5 * time.Minute,
+		Clock:       clock,
+		ReloadOnErr: true,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &leafClusterCache{
+		fnCache: fnCache,
+	}, nil
+}
+
+func (c *leafClusterCache) getLeafClusters(ctx context.Context, rootClient ClusterClient) ([]string, error) {
+	return utils.FnCacheGet(ctx, c.fnCache, rootClient.ClusterName(), func(ctx context.Context) ([]string, error) {
+		return c.getLeafClustersUncached(ctx, rootClient)
+	})
+}
+
+func (c *leafClusterCache) getLeafClustersUncached(ctx context.Context, rootClient ClusterClient) ([]string, error) {
+	var leafClusters []string
+	nextPage := ""
+	for {
+		remoteClusters, nextPage, err := rootClient.CurrentCluster().ListRemoteClusters(ctx, 0, nextPage)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, rc := range remoteClusters {
+			leafClusters = append(leafClusters, rc.GetName())
+		}
+		if nextPage == "" {
+			return leafClusters, nil
+		}
+	}
+}

--- a/lib/vnet/local_fqdn_resolver.go
+++ b/lib/vnet/local_fqdn_resolver.go
@@ -41,6 +41,7 @@ type localFQDNResolver struct {
 type localFQDNResolverConfig struct {
 	clientApplication  ClientApplication
 	clusterConfigCache *ClusterConfigCache
+	leafClusterCache   *leafClusterCache
 }
 
 func newLocalFQDNResolver(cfg *localFQDNResolverConfig) *localFQDNResolver {
@@ -127,7 +128,7 @@ func (r *localFQDNResolver) clusterClientForAppFQDN(ctx context.Context, profile
 		return rootClient, nil
 	}
 
-	leafClusters, err := getLeafClusters(ctx, rootClient)
+	leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
 	if err != nil {
 		// Good chance we're here because the user is not logged in to the profile.
 		log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
@@ -245,7 +246,7 @@ func (r *localFQDNResolver) tryResolveSSH(ctx context.Context, profileNames []st
 		if !isDescendantSubdomain(fqdn, rootClusterName) {
 			continue
 		}
-		leafClusters, err := getLeafClusters(ctx, rootClient)
+		leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
 		if err != nil {
 			// Good chance we're here because the user is not logged in to the profile.
 			log.ErrorContext(ctx, "Failed to list leaf clusters, SSH nodes in this cluster will not be resolved", "error", err)

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -84,9 +84,14 @@ type ClusterClient interface {
 func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*UserProcess, error) {
 	clock := clockwork.NewRealClock()
 	clusterConfigCache := NewClusterConfigCache(clock)
+	leafClusterCache, err := newLeafClusterCache(clock)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	localResolver := newLocalFQDNResolver(&localFQDNResolverConfig{
 		clientApplication:  clientApplication,
 		clusterConfigCache: clusterConfigCache,
+		leafClusterCache:   leafClusterCache,
 	})
 	appProvider := newLocalAppProvider(&localAppProviderConfig{
 		clientApplication: clientApplication,
@@ -94,6 +99,7 @@ func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*
 	osConfigProvider := NewLocalOSConfigProvider(&LocalOSConfigProviderConfig{
 		clientApplication:  clientApplication,
 		clusterConfigCache: clusterConfigCache,
+		leafClusterCache:   leafClusterCache,
 	})
 	clientApplicationService := newClientApplicationService(&clientApplicationServiceConfig{
 		localResolver:         localResolver,

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -588,11 +588,14 @@ func TestDialFakeApp(t *testing.T) {
 	}, dialOpts, reissueClientCert, clock)
 
 	clusterConfigCache := NewClusterConfigCache(clock)
+	leafClusterCache, err := newLeafClusterCache(clock)
+	require.NoError(t, err)
 	p := newTestPack(t, ctx, testPackConfig{
 		clock: clock,
 		fqdnResolver: newLocalFQDNResolver(&localFQDNResolverConfig{
 			clientApplication:  clientApp,
 			clusterConfigCache: clusterConfigCache,
+			leafClusterCache:   leafClusterCache,
 		}),
 		appProvider: newLocalAppProvider(&localAppProviderConfig{
 			clientApplication: clientApp,
@@ -859,11 +862,14 @@ func TestOnNewConnection(t *testing.T) {
 	invalidAppName := "not.an.app.example.com."
 
 	clusterConfigCache := NewClusterConfigCache(clock)
+	leafClusterCache, err := newLeafClusterCache(clock)
+	require.NoError(t, err)
 	p := newTestPack(t, ctx, testPackConfig{
 		clock: clock,
 		fqdnResolver: newLocalFQDNResolver(&localFQDNResolverConfig{
 			clientApplication:  clientApp,
 			clusterConfigCache: clusterConfigCache,
+			leafClusterCache:   leafClusterCache,
 		}),
 		appProvider: newLocalAppProvider(&localAppProviderConfig{
 			clientApplication: clientApp,
@@ -874,7 +880,7 @@ func TestOnNewConnection(t *testing.T) {
 	// called.
 	lookupCtx, lookupCtxCancel := context.WithTimeout(ctx, 200*time.Millisecond)
 	defer lookupCtxCancel()
-	_, err := p.lookupHost(lookupCtx, invalidAppName)
+	_, err = p.lookupHost(lookupCtx, invalidAppName)
 	require.Error(t, err, "Expected lookup of an invalid app to fail")
 	require.Equal(t, uint32(0), clientApp.onNewConnectionCallCount.Load())
 
@@ -943,9 +949,12 @@ func testRemoteAppProvider(t *testing.T, alg cryptosuites.Algorithm) {
 		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
 	)
 	clusterConfigCache := NewClusterConfigCache(clock)
+	leafClusterCache, err := newLeafClusterCache(clock)
+	require.NoError(t, err)
 	localResolver := newLocalFQDNResolver(&localFQDNResolverConfig{
 		clientApplication:  clientApp,
 		clusterConfigCache: clusterConfigCache,
+		leafClusterCache:   leafClusterCache,
 	})
 	appProvider := newLocalAppProvider(&localAppProviderConfig{
 		clientApplication: clientApp,


### PR DESCRIPTION
This commit adds a cache for leaf clusters to we don't query the list from each root cluster one or more times per DNS query.