### PR TITLE
Adding recording encryption and playback for `sync` modes

### DIFF
--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -33,6 +33,7 @@ require (
 	cloud.google.com/go/resourcemanager v1.10.6 // indirect
 	connectrpc.com/connect v1.18.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	filippo.io/age v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.121.1 h1:S3kTQSydxmu1JfLRLpKtxRPA7rSrYPRPEUmL/PavVUw=
 cloud.google.com/go v0.121.1/go.mod h1:nRFlrHq39MNVWu+zESP2PosMWA0ryJw8KUBZ2iZpxbw=
 cloud.google.com/go/auth v0.16.1 h1:XrXauHMd30LhQYVRHLGvJiYeczweKQXZxsTbV9TiguU=
@@ -22,6 +24,8 @@ connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -37,6 +37,7 @@ require (
 	code.dny.dev/ssrf v0.2.0 // indirect
 	connectrpc.com/connect v1.18.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	filippo.io/age v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -43,6 +45,8 @@ connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -34,6 +34,7 @@ require (
 	code.dny.dev/ssrf v0.2.0 // indirect
 	connectrpc.com/connect v1.18.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	filippo.io/age v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -68,6 +70,8 @@ connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2pr
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -91,6 +91,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
 	"github.com/gravitational/teleport/lib/auth/okta"
+	"github.com/gravitational/teleport/lib/auth/recordingencryption"
 	"github.com/gravitational/teleport/lib/auth/userloginstate"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -221,6 +222,57 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err)
 		}
 		cfg.ClusterConfiguration = clusterConfig
+	}
+	if cfg.KeyStore == nil {
+		keystoreOpts := &keystore.Options{
+			HostUUID:             cfg.HostUUID,
+			ClusterName:          cfg.ClusterName,
+			AuthPreferenceGetter: cfg.ClusterConfiguration,
+			FIPS:                 cfg.FIPS,
+		}
+		if cfg.KeyStoreConfig.PKCS11 != (servicecfg.PKCS11Config{}) {
+			if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+				return nil, fmt.Errorf("PKCS11 HSM support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
+			}
+		} else if cfg.KeyStoreConfig.GCPKMS != (servicecfg.GCPKMSConfig{}) {
+			if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+				return nil, fmt.Errorf("GCP KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
+			}
+		} else if cfg.KeyStoreConfig.AWSKMS != nil {
+			if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+				return nil, fmt.Errorf("AWS KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
+			}
+		}
+		cfg.KeyStore, err = keystore.NewManager(context.Background(), &cfg.KeyStoreConfig, keystoreOpts)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	if cfg.RecordingEncryption == nil {
+		localRecordingEncryption, err := local.NewRecordingEncryptionService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		recordingEncryptionManager, err := recordingencryption.NewManager(recordingencryption.ManagerConfig{
+			Backend:       localRecordingEncryption,
+			ClusterConfig: cfg.ClusterConfiguration,
+			KeyStore:      cfg.KeyStore,
+			Logger:        cfg.Logger,
+			LockConfig: backend.RunWhileLockedConfig{
+				LockConfiguration: backend.LockConfiguration{
+					Backend:            cfg.Backend,
+					TTL:                time.Second * 30,
+					LockNameComponents: []string{"recording_encryption"},
+				},
+			},
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		cfg.RecordingEncryption = recordingEncryptionManager
+		cfg.ClusterConfiguration = recordingEncryptionManager
 	}
 	if cfg.AutoUpdateService == nil {
 		cfg.AutoUpdateService, err = local.NewAutoUpdateService(cfg.Backend)
@@ -465,30 +517,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 
 	limiter := limiter.NewConnectionsLimiter(defaults.LimiterMaxConcurrentSignatures)
 
-	keystoreOpts := &keystore.Options{
-		HostUUID:             cfg.HostUUID,
-		ClusterName:          cfg.ClusterName,
-		AuthPreferenceGetter: cfg.ClusterConfiguration,
-		FIPS:                 cfg.FIPS,
-	}
-	if cfg.KeyStoreConfig.PKCS11 != (servicecfg.PKCS11Config{}) {
-		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
-			return nil, fmt.Errorf("PKCS11 HSM support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
-		}
-	} else if cfg.KeyStoreConfig.GCPKMS != (servicecfg.GCPKMSConfig{}) {
-		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
-			return nil, fmt.Errorf("GCP KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
-		}
-	} else if cfg.KeyStoreConfig.AWSKMS != nil {
-		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
-			return nil, fmt.Errorf("AWS KMS support requires a license with the HSM feature enabled: %w", ErrRequiresEnterprise)
-		}
-	}
-	keyStore, err := keystore.NewManager(context.Background(), &cfg.KeyStoreConfig, keystoreOpts)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	if cfg.KubeWaitingContainers == nil {
 		cfg.KubeWaitingContainers, err = local.NewKubeWaitingContainerService(cfg.Backend)
 		if err != nil {
@@ -566,6 +594,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		HealthCheckConfig:               cfg.HealthCheckConfig,
 		BackendInfoService:              cfg.BackendInfo,
 		VnetConfigService:               cfg.VnetConfigService,
+		RecordingEncryptionManager:      cfg.RecordingEncryption,
 	}
 
 	as := Server{
@@ -582,7 +611,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		Unstable:                local.NewUnstableService(cfg.Backend, cfg.AssertionReplayService),
 		Services:                services,
 		Cache:                   services,
-		keyStore:                keyStore,
+		keyStore:                cfg.KeyStore,
 		traceClient:             cfg.TraceClient,
 		fips:                    cfg.FIPS,
 		loadAllCAs:              cfg.LoadAllCAs,
@@ -805,6 +834,7 @@ type Services struct {
 	services.HealthCheckConfig
 	services.BackendInfoService
 	services.VnetConfigService
+	RecordingEncryptionManager
 }
 
 // GetWebSession returns existing web session described by req.

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/migration"
+	"github.com/gravitational/teleport/lib/auth/recordingencryption"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -85,6 +86,13 @@ type VersionStorage interface {
 	DeleteTeleportVersion(ctx context.Context) error
 }
 
+// RecordingEncryptionManager wraps a RecordingEncryption backend service with higher level
+// operations.
+type RecordingEncryptionManager interface {
+	services.RecordingEncryption
+	recordingencryption.DecryptionKeyFinder
+}
+
 // InitConfig is auth server init config
 type InitConfig struct {
 	// Backend is auth backend to use
@@ -99,6 +107,10 @@ type InitConfig struct {
 	// KeyStoreConfig is the config for the KeyStore which handles private CA
 	// keys that may be held in an HSM.
 	KeyStoreConfig servicecfg.KeystoreConfig
+
+	// KeyStore which handles private CA keys and encryption keys that may be
+	// held in an HSM.
+	KeyStore *keystore.Manager
 
 	// HostUUID is a UUID of this host
 	HostUUID string
@@ -366,6 +378,9 @@ type InitConfig struct {
 
 	// BackendInfo is a service of backend information.
 	BackendInfo services.BackendInfoService
+
+	// RecordingEncryption manages state for encrypted session recording.
+	RecordingEncryption RecordingEncryptionManager
 
 	// SkipVersionCheck skips version check during major version upgrade/downgrade.
 	SkipVersionCheck bool

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -108,8 +108,8 @@ type InitConfig struct {
 	// keys that may be held in an HSM.
 	KeyStoreConfig servicecfg.KeystoreConfig
 
-	// KeyStore which handles private CA keys and encryption keys that may be
-	// held in an HSM.
+	// KeyStore handles private CA keys and encryption keys that may be held
+	// in an HSM.
 	KeyStore *keystore.Manager
 
 	// HostUUID is a UUID of this host

--- a/lib/auth/recordingencryption/encryptedio.go
+++ b/lib/auth/recordingencryption/encryptedio.go
@@ -1,0 +1,146 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recordingencryption
+
+import (
+	"context"
+	"io"
+
+	"filippo.io/age"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// SessionRecordingConfigGetter returns the types.SessionRecordingConfig used to determine if
+// encryption is enabled and retrieve the encryption keys to use
+type SessionRecordingConfigGetter interface {
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
+}
+
+// EncryptedIO wraps a SessionRecordingConfigGetter and a recordingencryption.DecryptionKeyFinder in order
+// to provide encryption and decryption wrapping backed by cluster resources
+type EncryptedIO struct {
+	srcGetter SessionRecordingConfigGetter
+	keyFinder DecryptionKeyFinder
+}
+
+// NewEncryptedIO returns an EncryptedIO configured with the given SessionRecordingConfigGetter and
+// recordingencryption.DecryptionKeyFinder
+func NewEncryptedIO(srcgetter SessionRecordingConfigGetter, decryptionKeyGetter DecryptionKeyFinder) *EncryptedIO {
+	return &EncryptedIO{
+		srcGetter: srcgetter,
+		keyFinder: decryptionKeyGetter,
+	}
+}
+
+// WithEncryption wraps the given io.WriteCloser with encryption using the keys present in the
+// retrieved types.SessionRecordingConfig
+func (e *EncryptedIO) WithEncryption(ctx context.Context, writer io.WriteCloser) (io.WriteCloser, error) {
+	if e.srcGetter == nil {
+		return writer, nil
+	}
+
+	src, err := e.srcGetter.GetSessionRecordingConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	encrypter := NewEncryptionWrapper(src)
+	w, err := encrypter.WithEncryption(ctx, writer)
+	return w, trace.Wrap(err)
+}
+
+// WithDecryption wraps the given io.Reader with decryption using the recordingencryption.RecordingIdentity. This
+// will dynamically search for an accessible decryption key using the provided recordingencryption.DecryptionKeyFinder
+// in order to perform decryption
+func (e *EncryptedIO) WithDecryption(ctx context.Context, reader io.Reader) (io.Reader, error) {
+	if e.keyFinder == nil {
+		return reader, nil
+	}
+
+	ident := NewRecordingIdentity(ctx, e.keyFinder)
+	r, err := age.Decrypt(reader, ident)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return r, nil
+}
+
+// EncryptionWrapper provides a wrapper for recording data using the keys present in the given
+// types.SessionRecordingConfig
+type EncryptionWrapper struct {
+	config types.SessionRecordingConfig
+}
+
+// NewEncryptionWrapper returns a new EncryptionWrapper backed by the given types.SessionRecordingConfig
+func NewEncryptionWrapper(sessionRecordingConfig types.SessionRecordingConfig) *EncryptionWrapper {
+	return &EncryptionWrapper{
+		config: sessionRecordingConfig,
+	}
+}
+
+// WithEncryption wraps the given io.WriteCloser with encryption using the keys present in the
+// configured types.SessionRecordingConfig
+func (s *EncryptionWrapper) WithEncryption(ctx context.Context, writer io.WriteCloser) (io.WriteCloser, error) {
+	if !s.config.GetEncrypted() {
+		return writer, nil
+	}
+
+	var recipients []age.Recipient
+	for _, key := range s.config.GetEncryptionKeys() {
+		recipient, err := ParseRecordingRecipient(string(key.PublicKey))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		recipients = append(recipients, recipient)
+	}
+
+	return &ageWriter{
+		w:          writer,
+		recipients: recipients,
+	}, nil
+}
+
+// ageWriter defers initializing the age encrypter to the first write so we can
+// prevent age from immediately writing the header
+type ageWriter struct {
+	w           io.WriteCloser
+	recipients  []age.Recipient
+	initialized bool
+}
+
+// Write data using age encryption, initializing the encrypter if needed
+func (a *ageWriter) Write(data []byte) (int, error) {
+	if !a.initialized {
+		w, err := age.Encrypt(a.w, a.recipients...)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		a.w = w
+		a.initialized = true
+	}
+
+	return a.w.Write(data)
+}
+
+// Close flushes any buffered encrypted data and closes the underlying io.WriteCloser
+func (a *ageWriter) Close() error {
+	return a.w.Close()
+}

--- a/lib/auth/recordingencryption/encryptedio.go
+++ b/lib/auth/recordingencryption/encryptedio.go
@@ -64,12 +64,15 @@ func (e *EncryptedIO) WithEncryption(ctx context.Context, writer io.WriteCloser)
 	return w, trace.Wrap(err)
 }
 
+// ErrDecryptionDisabled signals that there's no key finder configured to facilitate decryption
+var ErrDecryptionDisabled = &trace.BadParameterError{Message: "missing key finder required for decryption"}
+
 // WithDecryption wraps the given io.Reader with decryption using the recordingencryption.RecordingIdentity. This
 // will dynamically search for an accessible decryption key using the provided recordingencryption.DecryptionKeyFinder
 // in order to perform decryption
 func (e *EncryptedIO) WithDecryption(ctx context.Context, reader io.Reader) (io.Reader, error) {
 	if e.keyFinder == nil {
-		return reader, nil
+		return nil, trace.Wrap(ErrDecryptionDisabled)
 	}
 
 	ident := NewRecordingIdentity(ctx, e.keyFinder)
@@ -101,7 +104,7 @@ var ErrEncryptionDisabled = &trace.BadParameterError{Message: "session_recording
 // configured types.SessionRecordingConfig
 func (s *EncryptionWrapper) WithEncryption(ctx context.Context, writer io.WriteCloser) (io.WriteCloser, error) {
 	if !s.config.GetEncrypted() {
-		return nil, ErrEncryptionDisabled
+		return nil, trace.Wrap(ErrEncryptionDisabled)
 	}
 
 	var recipients []age.Recipient

--- a/lib/auth/recordingencryption/encryptedio_test.go
+++ b/lib/auth/recordingencryption/encryptedio_test.go
@@ -65,22 +65,20 @@ func TestEncryptedIO(t *testing.T) {
 
 	require.Equal(t, msg, plaintext)
 
-	// creating an EncryptedIO without a SessionRecordingConfigGetter should be an error
+	// creating an EncryptedIO without a SessionRecordingConfigGetter or keyfinder should be an error
 	_, err = recordingencryption.NewEncryptedIO(nil, nil)
+	require.Error(t, err)
+	_, err = recordingencryption.NewEncryptedIO(srcGetter, nil)
 	require.Error(t, err)
 
 	// wrapping encryption when encryption is disabled should return an ErrEncryptionDisabled
 	srcGetter, err = newFakeSRCGetter(false, nil)
 	require.NoError(t, err)
-	encryptedIO, err = recordingencryption.NewEncryptedIO(srcGetter, nil)
+	encryptedIO, err = recordingencryption.NewEncryptedIO(srcGetter, keyFinder)
 	require.NoError(t, err)
 
 	_, err = encryptedIO.WithEncryption(ctx, &writeCloser{Writer: out})
 	require.ErrorIs(t, err, recordingencryption.ErrEncryptionDisabled)
-
-	// wrapping decryption with a nil keyFinder should return an ErrDecryptionDisabled
-	_, err = encryptedIO.WithDecryption(ctx, out)
-	require.ErrorIs(t, err, recordingencryption.ErrDecryptionDisabled)
 }
 
 type fakeSRCGetter struct {

--- a/lib/auth/recordingencryption/encryptedio_test.go
+++ b/lib/auth/recordingencryption/encryptedio_test.go
@@ -77,6 +77,10 @@ func TestEncryptedIO(t *testing.T) {
 
 	_, err = encryptedIO.WithEncryption(ctx, &writeCloser{Writer: out})
 	require.ErrorIs(t, err, recordingencryption.ErrEncryptionDisabled)
+
+	// wrapping decryption with a nil keyFinder should return an ErrDecryptionDisabled
+	_, err = encryptedIO.WithDecryption(ctx, out)
+	require.ErrorIs(t, err, recordingencryption.ErrDecryptionDisabled)
 }
 
 type fakeSRCGetter struct {

--- a/lib/auth/recordingencryption/encryptedio_test.go
+++ b/lib/auth/recordingencryption/encryptedio_test.go
@@ -1,0 +1,101 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recordingencryption_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/recordingencryption"
+)
+
+func TestEncryptedIO(t *testing.T) {
+	ctx := context.Background()
+	keyFinder := newFakeKeyFinder()
+	ident, err := keyFinder.generateIdentity()
+	require.NoError(t, err)
+
+	srcGetter, err := newFakeSRCGetter(true, []*types.AgeEncryptionKey{
+		{
+			PublicKey: []byte(ident.Recipient().String()),
+		},
+	})
+	require.NoError(t, err)
+
+	encryptedIO := recordingencryption.NewEncryptedIO(srcGetter, keyFinder)
+
+	out := bytes.NewBuffer(nil)
+	writer, err := encryptedIO.WithEncryption(ctx, &writeCloser{Writer: out})
+	require.NoError(t, err)
+
+	msg := []byte("testing encrypted IO")
+	_, err = writer.Write(msg)
+	require.NoError(t, err)
+
+	// writer must be closed to ensure data is flushed
+	err = writer.Close()
+	require.NoError(t, err)
+
+	reader, err := encryptedIO.WithDecryption(ctx, out)
+	require.NoError(t, err)
+
+	plaintext, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	require.Equal(t, msg, plaintext)
+}
+
+type fakeSRCGetter struct {
+	config types.SessionRecordingConfig
+}
+
+func newFakeSRCGetter(encrypted bool, keys []*types.AgeEncryptionKey) (*fakeSRCGetter, error) {
+	spec := types.SessionRecordingConfigSpecV2{
+		Encryption: &types.SessionRecordingEncryptionConfig{
+			Enabled: true,
+		},
+	}
+
+	config, err := types.NewSessionRecordingConfigFromConfigFile(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	config.SetEncryptionKeys(slices.Values(keys))
+
+	return &fakeSRCGetter{
+		config: config,
+	}, nil
+}
+
+func (f *fakeSRCGetter) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
+	return f.config, nil
+}
+
+type writeCloser struct {
+	io.Writer
+}
+
+func (w *writeCloser) Close() error {
+	return nil
+}

--- a/lib/client/player.go
+++ b/lib/client/player.go
@@ -51,7 +51,8 @@ func (p *playFromFileStreamer) StreamSessionEvents(
 		}
 		defer f.Close()
 
-		pr := events.NewProtoReader(f)
+		pr := events.NewProtoReader(f, nil)
+
 		for i := int64(0); ; i++ {
 			evt, err := pr.Read(ctx)
 			if err != nil {

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -203,6 +203,9 @@ type AuditLog struct {
 	// localLog is a local events log used
 	// to emit audit events if no external log has been specified
 	localLog *FileLog
+
+	// decrypter wraps session replay with decryption
+	decrypter DecryptionWrapper
 }
 
 // AuditLogConfig specifies configuration for AuditLog server
@@ -247,6 +250,9 @@ type AuditLogConfig struct {
 
 	// Context is audit log context
 	Context context.Context
+
+	// Decrypter wraps session replay with decryption
+	Decrypter DecryptionWrapper
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -304,6 +310,7 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 		activeDownloads: make(map[string]context.Context),
 		ctx:             ctx,
 		cancel:          cancel,
+		decrypter:       cfg.Decrypter,
 	}
 	// create a directory for audit logs, audit log does not create
 	// session logs before migrations are run in case if the directory
@@ -589,7 +596,7 @@ func (l *AuditLog) StreamSessionEvents(ctx context.Context, sessionID session.ID
 			return
 		}
 
-		protoReader := NewProtoReader(rawSession)
+		protoReader := NewProtoReader(rawSession, l.decrypter)
 		defer protoReader.Close()
 
 		firstEvent := true

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -107,7 +107,7 @@ func TestProtoStreamer(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, part := range parts {
-				reader := events.NewProtoReader(bytes.NewReader(part))
+				reader := events.NewProtoReader(bytes.NewReader(part), nil)
 				out, err := reader.ReadAll(ctx)
 				require.NoError(t, err, "part crash %#v", part)
 				outEvents = append(outEvents, out...)
@@ -255,7 +255,7 @@ func TestExport(t *testing.T) {
 		_, err := f.Write(part)
 		require.NoError(t, err)
 	}
-	reader := events.NewProtoReader(io.MultiReader(readers...))
+	reader := events.NewProtoReader(io.MultiReader(readers...), nil)
 	outEvents, err := reader.ReadAll(ctx)
 	require.NoError(t, err)
 

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -439,9 +439,10 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 		return trace.Wrap(err, "uploader could not acquire file lock for %q", sessionFilePath)
 	}
 
+	protoReader := events.NewProtoReader(sessionFile, nil)
 	upload := &upload{
 		sessionID:    sessionID,
-		reader:       events.NewProtoReader(sessionFile),
+		reader:       protoReader,
 		file:         sessionFile,
 		fileUnlockFn: unlock,
 	}

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -121,7 +121,7 @@ func TestChaosUpload(t *testing.T) {
 	go uploader.Serve(ctx)
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir)
+	fileStreamer, err := NewStreamer(scanDir, nil)
 	require.NoError(t, err)
 
 	parallelStreams := 20

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -121,7 +121,7 @@ func TestChaosUpload(t *testing.T) {
 	go uploader.Serve(ctx)
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir, nil)
+	fileStreamer, err := NewStreamer(scanDir)
 	require.NoError(t, err)
 
 	parallelStreams := 20

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -47,7 +47,7 @@ func TestUploadOK(t *testing.T) {
 	// wait until uploader blocks on the clock
 	p.clock.BlockUntil(1)
 
-	fileStreamer, err := NewStreamer(p.scanDir)
+	fileStreamer, err := NewStreamer(p.scanDir, nil)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -85,7 +85,7 @@ func TestUploadParallel(t *testing.T) {
 	sessions := make(map[string][]apievents.AuditEvent)
 
 	for range 5 {
-		fileStreamer, err := NewStreamer(p.scanDir)
+		fileStreamer, err := NewStreamer(p.scanDir, nil)
 		require.NoError(t, err)
 
 		sessionEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -382,7 +382,7 @@ func TestUploadBackoff(t *testing.T) {
 	// wait until uploader blocks on the clock before creating the stream
 	p.clock.BlockUntil(1)
 
-	fileStreamer, err := NewStreamer(p.scanDir)
+	fileStreamer, err := NewStreamer(p.scanDir, nil)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 4096})
@@ -589,7 +589,7 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir)
+	fileStreamer, err := NewStreamer(scanDir, nil)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -669,7 +669,7 @@ func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *ev
 	var reader *events.ProtoReader
 	for i, part := range parts {
 		if i == 0 {
-			reader = events.NewProtoReader(bytes.NewReader(part))
+			reader = events.NewProtoReader(bytes.NewReader(part), nil)
 		} else {
 			err := reader.Reset(bytes.NewReader(part))
 			require.NoError(t, err)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -47,7 +47,7 @@ func TestUploadOK(t *testing.T) {
 	// wait until uploader blocks on the clock
 	p.clock.BlockUntil(1)
 
-	fileStreamer, err := NewStreamer(p.scanDir, nil)
+	fileStreamer, err := NewStreamer(p.scanDir)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -85,7 +85,7 @@ func TestUploadParallel(t *testing.T) {
 	sessions := make(map[string][]apievents.AuditEvent)
 
 	for range 5 {
-		fileStreamer, err := NewStreamer(p.scanDir, nil)
+		fileStreamer, err := NewStreamer(p.scanDir)
 		require.NoError(t, err)
 
 		sessionEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -382,7 +382,7 @@ func TestUploadBackoff(t *testing.T) {
 	// wait until uploader blocks on the clock before creating the stream
 	p.clock.BlockUntil(1)
 
-	fileStreamer, err := NewStreamer(p.scanDir, nil)
+	fileStreamer, err := NewStreamer(p.scanDir)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 4096})
@@ -589,7 +589,7 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir, nil)
+	fileStreamer, err := NewStreamer(scanDir)
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})

--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -53,7 +53,7 @@ func DetectFormat(r io.ReadSeeker) (*Header, error) {
 		return nil, trace.ConvertSystemError(err)
 	}
 	protocolVersion := binary.BigEndian.Uint64(version)
-	if protocolVersion == ProtoStreamV1 {
+	if protocolVersion >= ProtoStreamV1 && protocolVersion <= ProtoStreamV2 {
 		return &Header{
 			Proto:        true,
 			ProtoVersion: int64(protocolVersion),
@@ -83,7 +83,7 @@ func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat str
 	}
 	switch {
 	case format.Proto:
-		protoReader := NewProtoReader(rs)
+		protoReader := NewProtoReader(rs, nil)
 		for {
 			event, err := protoReader.Read(ctx)
 			if err != nil {

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -74,7 +74,7 @@ func TestSessionWriter(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, part := range parts {
-			reader := events.NewProtoReader(bytes.NewReader(part))
+			reader := events.NewProtoReader(bytes.NewReader(part), nil)
 			out, err := reader.ReadAll(test.ctx)
 			require.NoError(t, err, "part crash %#v", part)
 			outEvents = append(outEvents, out...)
@@ -420,7 +420,7 @@ func (a *sessionWriterTest) collectEvents(t *testing.T) []apievents.AuditEvent {
 	for _, part := range parts {
 		readers = append(readers, bytes.NewReader(part))
 	}
-	reader := events.NewProtoReader(io.MultiReader(readers...))
+	reader := events.NewProtoReader(io.MultiReader(readers...), nil)
 	outEvents, err := reader.ReadAll(a.ctx)
 	require.NoError(t, err, "failed to read")
 	t.Logf("Reader stats :%v", reader.GetStats().ToFields())

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -41,6 +41,16 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// ProtoStreamFlag is a bit flag containing options that were used to record the stream, such as whether or not the
+// stream was encrypted. It appears in the header of v2+ proto streams and should be used to construct the correct
+// ProtoReader configuration.
+type ProtoStreamFlag = uint8
+
+const (
+	// ProtoStreamFlagEncrypted flags whether or not a stream was encrypted during recording.
+	ProtoStreamFlagEncrypted = 1 << iota
+)
+
 const (
 	// Int32Size is a constant for 32 bit integer byte size
 	Int32Size = 4
@@ -62,12 +72,23 @@ const (
 	// ProtoStreamV1 is a version of the binary protocol
 	ProtoStreamV1 = 1
 
+	// ProtoStreamV2 is a version of the binary protocol
+	ProtoStreamV2 = 2
+
 	// ProtoStreamV1PartHeaderSize is the size of the part of the protocol stream
 	// on disk format, it consists of
 	// * 8 bytes for the format version
 	// * 8 bytes for meaningful size of the part
 	// * 8 bytes for optional padding size at the end of the slice
 	ProtoStreamV1PartHeaderSize = Int64Size * 3
+
+	// ProtoStreamV2PartHeaderSize is the size of the part of the protocol stream
+	// on disk format, it consists of
+	// * 8 bytes for the format version
+	// * 8 bytes for meaningful size of the part
+	// * 8 bytes for optional padding size at the end of the slice
+	// * 8 bytes for 1 byte flags and 7 bytes of zero padding reserved for future
+	ProtoStreamV2PartHeaderSize = Int64Size * 4
 
 	// ProtoStreamV1RecordHeaderSize is the size of the header
 	// of the record header, it consists of the record length
@@ -77,6 +98,16 @@ const (
 	// `ReserveUploadPart` fails.
 	uploaderReservePartErrorMessage = "uploader failed to reserve upload part"
 )
+
+// An EncryptionWrapper wraps a given io.WriteCloser with encryption.
+type EncryptionWrapper interface {
+	WithEncryption(context.Context, io.WriteCloser) (io.WriteCloser, error)
+}
+
+// A DecryptionWrapper wraps a given io.Reader with decryption.
+type DecryptionWrapper interface {
+	WithDecryption(context.Context, io.Reader) (io.Reader, error)
+}
 
 // ProtoStreamerConfig specifies configuration for the part
 type ProtoStreamerConfig struct {
@@ -92,6 +123,8 @@ type ProtoStreamerConfig struct {
 	ForceFlush chan struct{}
 	// RetryConfig defines how to retry on a failed upload
 	RetryConfig *retryutils.LinearConfig
+	// Encrypter wraps the final gzip writer with encryption.
+	Encrypter EncryptionWrapper
 }
 
 // CheckAndSetDefaults checks and sets streamer defaults
@@ -142,6 +175,7 @@ func (s *ProtoStreamer) CreateAuditStreamForUpload(ctx context.Context, sid sess
 		ConcurrentUploads: s.cfg.ConcurrentUploads,
 		ForceFlush:        s.cfg.ForceFlush,
 		RetryConfig:       s.cfg.RetryConfig,
+		Encrypter:         s.cfg.Encrypter,
 	})
 }
 
@@ -171,6 +205,7 @@ func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, u
 		MinUploadBytes: s.cfg.MinUploadBytes,
 		CompletedParts: parts,
 		RetryConfig:    s.cfg.RetryConfig,
+		Encrypter:      s.cfg.Encrypter,
 	})
 }
 
@@ -203,6 +238,8 @@ type ProtoStreamConfig struct {
 	ConcurrentUploads int
 	// RetryConfig defines how to retry on a failed upload
 	RetryConfig *retryutils.LinearConfig
+	// Encrypter wraps the final gzip writer with encryption.
+	Encrypter EncryptionWrapper
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -297,6 +334,7 @@ func NewProtoStream(cfg ProtoStreamConfig) (*ProtoStream, error) {
 		semUploads:        make(chan struct{}, cfg.ConcurrentUploads),
 		lastPartNumber:    0,
 		retryConfig:       *cfg.RetryConfig,
+		encrypter:         cfg.Encrypter,
 	}
 	if len(cfg.CompletedParts) > 0 {
 		// skip 2 extra parts as a protection from accidental overwrites.
@@ -501,9 +539,11 @@ type sliceWriter struct {
 	completedParts []StreamPart
 	// emptyHeader is used to write empty header
 	// to preserve some bytes
-	emptyHeader [ProtoStreamV1PartHeaderSize]byte
+	emptyHeader [ProtoStreamV2PartHeaderSize]byte
 	// retryConfig  defines how to retry on a failed upload
 	retryConfig retryutils.LinearConfig
+	// encrypter wraps writes with encryption
+	encrypter EncryptionWrapper
 }
 
 func (w *sliceWriter) updateCompletedParts(part StreamPart, lastEventIndex int64) {
@@ -650,20 +690,39 @@ func (w *sliceWriter) newSlice() (*slice, error) {
 	// This buffer will be returned to the pool by slice.Close
 	buffer := w.proto.cfg.BufferPool.Get()
 	buffer.Reset()
+
+	var encrypted bool
+	var writer io.WriteCloser = &bufferCloser{Buffer: buffer}
+	if w.encrypter != nil {
+		// we want to encrypt after compression, so gzip needs to be the outermost layer
+		encryptedWriter, err := w.encrypter.WithEncryption(w.proto.completeCtx, writer)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		encrypted = writer != encryptedWriter
+		writer = encryptedWriter
+	}
+
 	// reserve bytes for version header
-	buffer.Write(w.emptyHeader[:])
+	headerSize := ProtoStreamV1PartHeaderSize
+	if encrypted {
+		headerSize = ProtoStreamV2PartHeaderSize
+	}
+	buffer.Write(w.emptyHeader[:headerSize])
 
 	err := w.proto.cfg.Uploader.ReserveUploadPart(w.proto.cancelCtx, w.proto.cfg.Upload, w.lastPartNumber)
 	if err != nil {
 		// Return the unused buffer to the pool.
 		w.proto.cfg.BufferPool.Put(buffer)
+		writer.Close()
 		return nil, trace.ConnectionProblem(err, uploaderReservePartErrorMessage)
 	}
 
 	return &slice{
-		proto:  w.proto,
-		buffer: buffer,
-		writer: newGzipWriter(&bufferCloser{Buffer: buffer}),
+		proto:     w.proto,
+		buffer:    buffer,
+		writer:    newGzipWriter(writer),
+		encrypted: encrypted,
 	}, nil
 }
 
@@ -853,11 +912,12 @@ func (a *activeUpload) getPart() (*StreamPart, error) {
 // slice contains serialized protobuf messages
 type slice struct {
 	proto          *ProtoStream
-	writer         *gzipWriter
+	writer         io.WriteCloser
 	buffer         *bytes.Buffer
 	isLast         bool
 	lastEventIndex int64
 	eventCount     uint64
+	encrypted      bool
 }
 
 // reader returns a reader for the bytes written, no writes should be done after this
@@ -878,11 +938,22 @@ func (s *slice) reader() (io.ReadSeeker, error) {
 		s.buffer.Write(padding)
 	}
 	data := s.buffer.Bytes()
+	var streamVersion uint64 = ProtoStreamV1
+	var headerSize int64 = ProtoStreamV1PartHeaderSize
+	if s.encrypted {
+		streamVersion = ProtoStreamV2
+		headerSize = ProtoStreamV2PartHeaderSize
+	}
 	// when the slice was created, the first bytes were reserved
 	// for the protocol version number and size of the slice in bytes
-	binary.BigEndian.PutUint64(data[0:], ProtoStreamV1)
-	binary.BigEndian.PutUint64(data[Int64Size:], uint64(wroteBytes-ProtoStreamV1PartHeaderSize))
+	binary.BigEndian.PutUint64(data[0:], streamVersion)
+	binary.BigEndian.PutUint64(data[Int64Size:], uint64(wroteBytes-headerSize))
 	binary.BigEndian.PutUint64(data[Int64Size*2:], uint64(paddingBytes))
+	if s.encrypted {
+		binary.BigEndian.PutUint64(data[Int64Size*3:], 0)
+		data[Int64Size*3] |= ProtoStreamFlagEncrypted
+	}
+
 	return bytes.NewReader(data), nil
 }
 
@@ -940,10 +1011,11 @@ func (s *slice) recordEvent(event protoEvent) error {
 }
 
 // NewProtoReader returns a new proto reader with slice pool
-func NewProtoReader(r io.Reader) *ProtoReader {
+func NewProtoReader(r io.Reader, decrypter DecryptionWrapper) *ProtoReader {
 	return &ProtoReader{
 		reader:    r,
 		lastIndex: -1,
+		decrypter: decrypter,
 	}
 }
 
@@ -978,6 +1050,7 @@ type ProtoReader struct {
 	error        error
 	lastIndex    int64
 	stats        ProtoReaderStats
+	decrypter    DecryptionWrapper
 }
 
 // ProtoReaderStats contains some reader statistics
@@ -1067,8 +1140,7 @@ func (r *ProtoReader) Read(ctx context.Context) (apievents.AuditEvent, error) {
 		case protoReaderStateInit:
 			// read the part header that consists of the protocol version
 			// and the part size (for the V1 version of the protocol)
-			_, err := io.ReadFull(r.reader, r.sizeBytes[:Int64Size])
-			if err != nil {
+			if _, err := io.ReadFull(r.reader, r.sizeBytes[:Int64Size]); err != nil {
 				// reached the end of the stream
 				if errors.Is(err, io.EOF) {
 					r.state = protoReaderStateEOF
@@ -1077,25 +1149,47 @@ func (r *ProtoReader) Read(ctx context.Context) (apievents.AuditEvent, error) {
 				return nil, r.setError(trace.ConvertSystemError(err))
 			}
 			protocolVersion := binary.BigEndian.Uint64(r.sizeBytes[:Int64Size])
-			if protocolVersion != ProtoStreamV1 {
+			if protocolVersion > ProtoStreamV2 {
 				return nil, trace.BadParameter("unsupported protocol version %v", protocolVersion)
 			}
 			// read size of this gzipped part as encoded by V1 protocol version
-			_, err = io.ReadFull(r.reader, r.sizeBytes[:Int64Size])
-			if err != nil {
+			if _, err := io.ReadFull(r.reader, r.sizeBytes[:Int64Size]); err != nil {
 				return nil, r.setError(trace.ConvertSystemError(err))
 			}
 			partSize := binary.BigEndian.Uint64(r.sizeBytes[:Int64Size])
 			// read padding size (could be 0)
-			_, err = io.ReadFull(r.reader, r.sizeBytes[:Int64Size])
-			if err != nil {
+			if _, err := io.ReadFull(r.reader, r.sizeBytes[:Int64Size]); err != nil {
 				return nil, r.setError(trace.ConvertSystemError(err))
 			}
 			r.padding = int64(binary.BigEndian.Uint64(r.sizeBytes[:Int64Size]))
-			gzipReader, err := newGzipReader(io.NopCloser(io.LimitReader(r.reader, int64(partSize))))
+
+			var encrypted bool
+			if protocolVersion > 1 {
+				if _, err := io.ReadFull(r.reader, r.sizeBytes[:Int64Size]); err != nil {
+					return nil, r.setError(trace.ConvertSystemError(err))
+				}
+				flags := r.sizeBytes[0]
+				encrypted = flags&ProtoStreamFlagEncrypted != 0
+			}
+
+			reader := r.reader
+			if encrypted {
+				if r.decrypter == nil {
+					return nil, r.setError(trace.Errorf("reading encrypted protos without decrypter"))
+				}
+
+				var err error
+				reader, err = r.decrypter.WithDecryption(ctx, r.reader)
+				if err != nil {
+					return nil, r.setError(trace.Wrap(err))
+				}
+			}
+
+			gzipReader, err := newGzipReader(io.NopCloser(io.LimitReader(reader, int64(partSize))))
 			if err != nil {
 				return nil, r.setError(trace.Wrap(err))
 			}
+
 			r.gzipReader = gzipReader
 			r.state = protoReaderStateCurrent
 			continue

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -227,7 +227,7 @@ func TestReadCorruptedRecording(t *testing.T) {
 }
 
 func TestEncryptedRecordingIO(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	uploader := eventstest.NewMemoryUploader()

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -19,8 +19,11 @@
 package events_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -29,6 +32,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -212,7 +216,7 @@ func TestReadCorruptedRecording(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	reader := events.NewProtoReader(f)
+	reader := events.NewProtoReader(f, nil)
 	defer reader.Close()
 
 	events, err := reader.ReadAll(ctx)
@@ -220,6 +224,68 @@ func TestReadCorruptedRecording(t *testing.T) {
 
 	// verify that the expected number of events are extracted
 	require.Len(t, events, 12)
+}
+
+func TestEncryptedRecordingIO(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	uploader := eventstest.NewMemoryUploader()
+	encryptedIO := &fakeEncryptedIO{}
+	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader:  uploader,
+		Encrypter: encryptedIO,
+	})
+	require.NoError(t, err)
+
+	const eventCount = 10
+	evts := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: eventCount})
+	sid := session.ID(evts[0].(events.SessionMetadataGetter).GetSessionID())
+	stream, err := streamer.CreateAuditStream(ctx, sid)
+	require.NoError(t, err)
+
+	preparer, err := events.NewPreparer(events.PreparerConfig{
+		SessionID:   sid,
+		Namespace:   apidefaults.Namespace,
+		ClusterName: "cluster",
+	})
+	require.NoError(t, err)
+
+	for _, evt := range evts {
+		preparedEvent, err := preparer.PrepareSessionEvent(evt)
+		require.NoError(t, err)
+
+		err = stream.RecordEvent(ctx, preparedEvent)
+		require.NoError(t, err)
+	}
+
+	err = stream.Complete(ctx)
+	require.NoError(t, err)
+
+	doneC := make(chan struct{})
+	go func() {
+		defer close(doneC)
+		stream.Complete(ctx)
+		stream.Close(ctx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for emitter to complete")
+	case <-doneC:
+	}
+
+	out := fakeWriterAt{
+		buf: &bytes.Buffer{},
+	}
+	err = uploader.Download(ctx, sid, out)
+	require.NoError(t, err)
+
+	reader := events.NewProtoReader(out.buf, encryptedIO)
+
+	decryptedEvents, err := reader.ReadAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, decryptedEvents, eventCount+2)
 }
 
 func makeQueryEvent(id string, query string) *apievents.DatabaseSessionQuery {
@@ -240,4 +306,48 @@ func makeAccessRequestEvent(id string, in string) *apievents.AccessRequestDelete
 		},
 		RequestID: in,
 	}
+}
+
+// encryptedIO is really just a reversible transform, so we fake encryption by encoding/decoding as hex
+type fakeEncryptedIO struct {
+	err error
+}
+
+type fakeEncrypter struct {
+	inner  io.WriteCloser
+	writer io.Writer
+}
+
+func (f *fakeEncrypter) Write(out []byte) (int, error) {
+	return f.writer.Write(out)
+}
+
+func (f *fakeEncrypter) Close() error {
+	return f.inner.Close()
+}
+
+func (f *fakeEncryptedIO) WithEncryption(ctx context.Context, writer io.WriteCloser) (io.WriteCloser, error) {
+	hexWriter := hex.NewEncoder(writer)
+	encrypter := &fakeEncrypter{
+		inner:  writer,
+		writer: hexWriter,
+	}
+
+	return encrypter, f.err
+}
+
+func (f *fakeEncryptedIO) WithDecryption(ctx context.Context, reader io.Reader) (io.Reader, error) {
+	return hex.NewDecoder(reader), f.err
+}
+
+type fakeWriterAt struct {
+	buf *bytes.Buffer
+}
+
+func (f fakeWriterAt) Write(p []byte) (int, error) {
+	return f.buf.Write(p)
+}
+
+func (f fakeWriterAt) WriteAt(p []byte, offset int64) (int, error) {
+	return f.Write(p)
 }

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -255,7 +255,8 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 	_, err = f.Seek(0, 0)
 	require.NoError(t, err)
 
-	reader := events.NewProtoReader(f)
+	reader := events.NewProtoReader(f, nil)
+
 	out, err := reader.ReadAll(ctx)
 	require.NoError(t, err)
 
@@ -326,7 +327,8 @@ func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, p
 	_, err = f.Seek(0, 0)
 	require.NoError(t, err)
 
-	reader := events.NewProtoReader(f)
+	reader := events.NewProtoReader(f, nil)
+
 	out, err := reader.ReadAll(ctx)
 	require.NoError(t, err)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -85,6 +85,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auditd"
@@ -92,7 +93,9 @@ import (
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/keygen"
+	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
+	"github.com/gravitational/teleport/lib/auth/recordingencryption"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/authz"
@@ -2062,6 +2065,7 @@ func (process *TeleportProcess) initAuthExternalAuditLog(auditConfig types.Clust
 func (process *TeleportProcess) initAuthService() error {
 	var err error
 	cfg := process.Config
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id))
 
 	// Initialize the storage back-ends for keys, events and records
 	b, err := process.initAuthStorage()
@@ -2070,10 +2074,83 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 	process.backend = b
 
+	clusterName := cfg.Auth.ClusterName.GetClusterName()
+	ident, err := process.storage.ReadIdentity(state.IdentityCurrent, types.RoleAdmin)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	if ident != nil {
+		clusterName = ident.ClusterName
+	}
+
+	cn, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: clusterName,
+	})
+
+	clusterConfig := cfg.ClusterConfiguration
+	if clusterConfig == nil {
+		clusterConfig, err = local.NewClusterConfigurationService(b)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	// create keystore
+	keystoreOpts := &keystore.Options{
+		HostUUID:             cfg.HostUUID,
+		ClusterName:          cn,
+		AuthPreferenceGetter: clusterConfig,
+		FIPS:                 cfg.FIPS,
+	}
+
+	switch {
+	case cfg.Auth.KeyStore.PKCS11 != servicecfg.PKCS11Config{}:
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+			return trace.Errorf("PKCS11 HSM support requires a license with the HSM feature enabled: %w", auth.ErrRequiresEnterprise)
+		}
+	case cfg.Auth.KeyStore.GCPKMS != servicecfg.GCPKMSConfig{}:
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+			return trace.Errorf("GCP KMS support requires a license with the HSM feature enabled: %w", auth.ErrRequiresEnterprise)
+		}
+	case cfg.Auth.KeyStore.AWSKMS != nil:
+		if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
+			return trace.Errorf("AWS KMS support requires a license with the HSM feature enabled: %w", auth.ErrRequiresEnterprise)
+		}
+	}
+
+	keyStore, err := keystore.NewManager(process.GracefulExitContext(), &cfg.Auth.KeyStore, keystoreOpts)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	localRecordingEncryption, err := local.NewRecordingEncryptionService(b)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	recordingEncryptionManager, err := recordingencryption.NewManager(recordingencryption.ManagerConfig{
+		Backend:       localRecordingEncryption,
+		KeyStore:      keyStore,
+		Logger:        logger,
+		ClusterConfig: clusterConfig,
+		LockConfig: backend.RunWhileLockedConfig{
+			LockConfiguration: backend.LockConfiguration{
+				Backend:            process.backend,
+				TTL:                time.Second * 30,
+				LockNameComponents: []string{"recording_encryption"},
+			},
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	clusterConfig = recordingEncryptionManager
 	var emitter apievents.Emitter
 	var streamer events.Streamer
 	var uploadHandler events.MultipartHandler
 	var externalAuditStorage *externalauditstorage.Configurator
+	encryptedIO := recordingencryption.NewEncryptedIO(clusterConfig, recordingEncryptionManager)
 
 	// create the audit log, which will be consuming (and recording) all events
 	// and recording all sessions.
@@ -2112,7 +2189,8 @@ func (process *TeleportProcess) initAuthService() error {
 			}
 		}
 		streamer, err = events.NewProtoStreamer(events.ProtoStreamerConfig{
-			Uploader: uploadHandler,
+			Uploader:  uploadHandler,
+			Encrypter: encryptedIO,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -2133,6 +2211,7 @@ func (process *TeleportProcess) initAuthService() error {
 			ServerID:      cfg.HostUUID,
 			UploadHandler: uploadHandler,
 			ExternalLog:   externalLog,
+			Decrypter:     encryptedIO,
 		}
 		auditServiceConfig.UID, auditServiceConfig.GID, err = adminCreds()
 		if err != nil {
@@ -2152,15 +2231,6 @@ func (process *TeleportProcess) initAuthService() error {
 		} else {
 			emitter = localLog
 		}
-	}
-
-	clusterName := cfg.Auth.ClusterName.GetClusterName()
-	ident, err := process.storage.ReadIdentity(state.IdentityCurrent, types.RoleAdmin)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	if ident != nil {
-		clusterName = ident.ClusterName
 	}
 
 	checkingEmitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
@@ -2188,14 +2258,6 @@ func (process *TeleportProcess) initAuthService() error {
 		traceClt = clt
 	}
 
-	cn, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
-		ClusterName: clusterName,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id))
 	// Environment variable for disabling the check major version upgrade check and overrides
 	// latest known version in backend.
 	skipVersionCheckFromEnv := os.Getenv("TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK") != ""
@@ -2208,7 +2270,7 @@ func (process *TeleportProcess) initAuthService() error {
 			VersionStorage:          process.storage,
 			SkipVersionCheck:        cfg.SkipVersionCheck || skipVersionCheckFromEnv,
 			Authority:               cfg.Keygen,
-			ClusterConfiguration:    cfg.ClusterConfiguration,
+			ClusterConfiguration:    clusterConfig,
 			AutoUpdateService:       cfg.AutoUpdateService,
 			ClusterAuditConfig:      cfg.Auth.AuditConfig,
 			ClusterNetworkingConfig: cfg.Auth.NetworkingConfig,
@@ -2234,6 +2296,7 @@ func (process *TeleportProcess) initAuthService() error {
 			OIDCConnectors:          cfg.OIDCConnectors,
 			AuditLog:                process.auditLog,
 			CipherSuites:            cfg.CipherSuites,
+			KeyStore:                keyStore,
 			KeyStoreConfig:          cfg.Auth.KeyStore,
 			Emitter:                 checkingEmitter,
 			Streamer:                events.NewReportingStreamer(streamer, process.Config.Testing.UploadEventsC),
@@ -2243,6 +2306,7 @@ func (process *TeleportProcess) initAuthService() error {
 			AccessMonitoringEnabled: cfg.Auth.IsAccessMonitoringEnabled(),
 			Clock:                   cfg.Clock,
 			HTTPClientForAWSSTS:     cfg.Auth.HTTPClientForAWSSTS,
+			RecordingEncryption:     recordingEncryptionManager,
 			Tracer:                  process.TracingProvider.Tracer(teleport.ComponentAuth),
 			Logger:                  logger,
 		}, func(as *auth.Server) error {
@@ -2617,6 +2681,10 @@ func (process *TeleportProcess) initAuthService() error {
 			logger.ErrorContext(process.GracefulExitContext(), "expiry starting", "error", err)
 		}
 		return trace.Wrap(err)
+	})
+
+	process.RegisterFunc("auth.recording_encryption_resolver", func() error {
+		return trace.Wrap(recordingEncryptionManager.Watch(process.GracefulExitContext(), authServer.Services))
 	})
 
 	// execute this when process is asked to exit:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2150,7 +2150,10 @@ func (process *TeleportProcess) initAuthService() error {
 	var streamer events.Streamer
 	var uploadHandler events.MultipartHandler
 	var externalAuditStorage *externalauditstorage.Configurator
-	encryptedIO := recordingencryption.NewEncryptedIO(clusterConfig, recordingEncryptionManager)
+	encryptedIO, err := recordingencryption.NewEncryptedIO(clusterConfig, recordingEncryptionManager)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	// create the audit log, which will be consuming (and recording) all events
 	// and recording all sessions.

--- a/lib/services/local/recording_encryption.go
+++ b/lib/services/local/recording_encryption.go
@@ -67,6 +67,7 @@ func (s *RecordingEncryptionService) CreateRecordingEncryption(ctx context.Conte
 		encryption.Metadata = &headerv1.Metadata{}
 	}
 	encryption.Metadata.Name = types.MetaNameRecordingEncryption
+	encryption.Kind = types.KindRecordingEncryption
 	created, err := s.encryption.CreateResource(ctx, encryption)
 	return created, trace.Wrap(err)
 }
@@ -77,6 +78,7 @@ func (s *RecordingEncryptionService) UpdateRecordingEncryption(ctx context.Conte
 		encryption.Metadata = &headerv1.Metadata{}
 	}
 	encryption.Metadata.Name = types.MetaNameRecordingEncryption
+	encryption.Kind = types.KindRecordingEncryption
 	updated, err := s.encryption.ConditionalUpdateResource(ctx, encryption)
 	return updated, trace.Wrap(err)
 }

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -166,6 +166,7 @@ func SetUpSuite(t *testing.T) *Suite {
 
 func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	s := &Suite{}
+	s.closeContext, s.closeFunc = context.WithCancel(t.Context())
 
 	s.clock = clockwork.NewFakeClock()
 	s.dataDir = t.TempDir()
@@ -229,8 +230,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	// Create user for regular tests.
 	s.user, err = auth.CreateUser(context.Background(), s.tlsServer.Auth(), "foo", s.role)
 	require.NoError(t, err)
-
-	s.closeContext, s.closeFunc = context.WithCancel(context.Background())
 
 	// Create a in-memory HTTP server that will respond with a UUID. This value
 	// will be checked in the client later to ensure a connection was made.


### PR DESCRIPTION
This PR is in support of the [encrypted session recordings RFD](https://github.com/gravitational/teleport/blob/eriktate/rfd-encrypted-session-recording/rfd/0127-encrypted-session-recordings.md). It adds encrypted session recording with decrypted playback for `sync` recording modes. It can be enabled by using `tctl` to set `encryption.enabled: true` in your `session_recording_config`:
```yml
spec:
  encryption:
    enabled: true
```
It will use whichever CA keystore is configured in order to provision the necessary key encryption keys, which by default uses software keys