### PR TITLE
Convert Identity Center Accounts to Apps in the UnifiedResourceCache

### DIFF
--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -247,6 +247,14 @@ type resource153ToResourceWithLabelsAdapter[T Resource153] struct {
 	resource153ToLegacyAdapter[T]
 }
 
+// UnwrapT is an escape hatch for Resource153 instances that are piped down into
+// the codebase as a legacy Resource.
+//
+// Ideally you shouldn't depend on this.
+func (r *resource153ToResourceWithLabelsAdapter[T]) UnwrapT() T {
+	return r.inner
+}
+
 // Origin implements ResourceWithLabels for the adapter.
 func (r *resource153ToResourceWithLabelsAdapter[T]) Origin() string {
 	m := r.inner.GetMetadata()
@@ -307,46 +315,6 @@ func (r *resource153ToResourceWithLabelsAdapter[T]) MatchSearch(searchValues []s
 	}
 	fieldVals := append(utils.MapToStrings(r.GetAllLabels()), r.GetName())
 	return MatchSearch(fieldVals, searchValues, nil)
-}
-
-// ClonableResource153 adds a restriction on [Resource153] such that implementors
-// must have a CloneResource() method.
-type ClonableResource153 interface {
-	Resource153
-	CloneResource() ClonableResource153
-}
-
-// UnifiedResource represents the combined set of interfaces that a resource
-// must implement to be used with the Teleport Unified Resource Cache
-type UnifiedResource interface {
-	ResourceWithLabels
-	CloneResource() ResourceWithLabels
-}
-
-// Resource153ToUnifiedResource wraps an RFD153-style resource in a type that
-// implements the legacy [ResourceWithLabels] interface and is suitable for use
-// with the Teleport Unified Resources Cache.
-//
-// The same caveats that apply to [Resource153ToLegacy] apply.
-func Resource153ToUnifiedResource[T ClonableResource153](r T) UnifiedResource {
-	return &resource153ToUnifiedResourceAdapter[T]{
-		resource153ToResourceWithLabelsAdapter: resource153ToResourceWithLabelsAdapter[T]{
-			resource153ToLegacyAdapter[T]{
-				inner: r,
-			},
-		},
-	}
-}
-
-// resource153ToUnifiedResourceAdapter wraps a [resource153ToLegacyAdapter] to
-// provide an implementation of [UnifiedResource]
-type resource153ToUnifiedResourceAdapter[T ClonableResource153] struct {
-	resource153ToResourceWithLabelsAdapter[T]
-}
-
-// CloneResource clones the underlying resource and wraps it in
-func (r *resource153ToUnifiedResourceAdapter[T]) CloneResource() ResourceWithLabels {
-	return Resource153ToUnifiedResource(r.inner.CloneResource().(T))
 }
 
 // ProtoResource153 is a Resource153 implemented by a protobuf-generated struct.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1427,7 +1427,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 	}
 
-	paginatedResources, err := services.MakePaginatedResources(ctx, types.KindUnifiedResource, unifiedResources, resourceLister.requestableMap)
+	paginatedResources, err := services.MakePaginatedResources(types.KindUnifiedResource, unifiedResources, resourceLister.requestableMap)
 	if err != nil {
 		return nil, trace.Wrap(err, "making paginated unified resources")
 	}
@@ -1833,8 +1833,6 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		types.KindWindowsDesktopService,
 		types.KindUserGroup,
 		types.KindSAMLIdPServiceProvider,
-		types.KindIdentityCenterAccount,
-		types.KindIdentityCenterAccountAssignment,
 		types.KindGitServer:
 
 	default:
@@ -1946,6 +1944,10 @@ func (r *resourceChecker) CanAccess(resource types.ResourceWithLabels) error {
 	state := services.AccessState{MFAVerified: true}
 	switch rr := resource.(type) {
 	case types.AppServer:
+		if rr.GetSubKind() == types.KindIdentityCenterAccount {
+			return r.CheckAccess(rr.GetApp(), state, services.NewIdentityCenterAppMatcher(rr.GetApp()))
+		}
+
 		return r.CheckAccess(rr.GetApp(), state)
 	case types.KubeServer:
 		return r.CheckAccess(rr.GetCluster(), state)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6122,279 +6122,165 @@ func TestUnifiedResources_IdentityCenter(t *testing.T) {
 	withMatchingAccountAssignment := withAccountAssignment(types.Allow,
 		validAccountID, validPermissionSetARN)
 
-	testCases := []struct {
-		name string
-		kind string
-		init func(*testing.T)
-	}{
-		{
-			name: "account",
-			kind: types.KindIdentityCenterAccount,
-			init: func(subtestT *testing.T) {
-				acct, err := srv.Auth().CreateIdentityCenterAccount(ctx, services.IdentityCenterAccount{
-					Account: &identitycenterv1.Account{
-						Kind:    types.KindIdentityCenterAccount,
-						Version: types.V1,
-						Metadata: &headerv1.Metadata{
-							Name: "test-account",
-							Labels: map[string]string{
-								types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-							},
-						},
-						Spec: &identitycenterv1.AccountSpec{
-							Id:   validAccountID,
-							Arn:  "some:account:arn",
-							Name: "Test Account",
-						},
-					},
-				})
-				require.NoError(subtestT, err)
-				subtestT.Cleanup(func() {
-					srv.Auth().DeleteIdentityCenterAccount(ctx,
-						services.IdentityCenterAccountID(acct.GetMetadata().GetName()))
-				})
-
-				inlineEventually(subtestT,
-					func() bool {
-						accounts, _, err := srv.Auth().ListIdentityCenterAccounts(
-							ctx, 100, &pagination.PageRequestToken{})
-						require.NoError(t, err)
-						return len(accounts) == 1
-					},
-					5*time.Second, 200*time.Millisecond,
-					"Target resource missing from cache")
+	acct, err := srv.Auth().CreateIdentityCenterAccount(ctx, services.IdentityCenterAccount{
+		Account: &identitycenterv1.Account{
+			Kind:    types.KindIdentityCenterAccount,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-account",
+				Labels: map[string]string{
+					types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+				},
+			},
+			Spec: &identitycenterv1.AccountSpec{
+				Id:   validAccountID,
+				Arn:  "some:account:arn",
+				Name: "Test Account",
 			},
 		},
-		{
-			name: "account assignment",
-			kind: types.KindIdentityCenterAccountAssignment,
-			init: func(subtestT *testing.T) {
-				asmt, err := srv.Auth().CreateAccountAssignment(ctx, services.IdentityCenterAccountAssignment{
-					AccountAssignment: &identitycenterv1.AccountAssignment{
-						Kind:    types.KindIdentityCenterAccountAssignment,
-						Version: types.V1,
-						Metadata: &headerv1.Metadata{
-							Name: "test-account",
-							Labels: map[string]string{
-								types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-							},
-						},
-						Spec: &identitycenterv1.AccountAssignmentSpec{
-							AccountId: validAccountID,
-							Display:   "Test Account Assignment",
-							PermissionSet: &identitycenterv1.PermissionSetInfo{
-								Arn:          validPermissionSetARN,
-								Name:         "Test permission set",
-								AssignmentId: "Test Assignment on Test Account",
-							},
-						},
-					},
-				})
-				require.NoError(subtestT, err)
-				subtestT.Cleanup(func() {
-					srv.Auth().DeleteAccountAssignment(ctx,
-						services.IdentityCenterAccountAssignmentID(asmt.GetMetadata().GetName()))
-				})
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		srv.Auth().DeleteIdentityCenterAccount(ctx,
+			services.IdentityCenterAccountID(acct.GetMetadata().GetName()))
+	})
 
-				inlineEventually(subtestT,
-					func() bool {
-						testAssignments, _, err := srv.Auth().ListAccountAssignments(
-							ctx, 100, &pagination.PageRequestToken{})
-						require.NoError(t, err)
-						return len(testAssignments) == 1
-					},
-					5*time.Second, 200*time.Millisecond,
-					"Target resource missing from cache")
-			},
+	inlineEventually(t,
+		func() bool {
+			accounts, _, err := srv.Auth().ListIdentityCenterAccounts(
+				ctx, 100, &pagination.PageRequestToken{})
+			require.NoError(t, err)
+			return len(accounts) == 1
 		},
+		5*time.Second, 200*time.Millisecond,
+		"Target resource missing from cache")
+	allowBySpecificKind := []types.Rule{
+		types.NewRule(types.KindIdentityCenterAccount, services.RO()),
 	}
 
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			test.init(t)
+	t.Run("no access", func(t *testing.T) {
+		userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access", nil, nil)
+		require.NoError(t, err)
 
-			allowBySpecificKind := []types.Rule{
-				types.NewRule(test.kind, services.RO()),
-			}
+		identity := TestUser(userNoAccess.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
 
-			t.Run("no access", func(t *testing.T) {
-				userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access", nil, nil)
-				require.NoError(t, err)
-
-				identity := TestUser(userNoAccess.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Empty(t, resp.Resources)
-			})
-
-			t.Run("no access via no matching account condition ", func(t *testing.T) {
-				userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access-account-mismatch", nil,
-					allowByGenericKind,
-					withAccountAssignment(types.Allow, "22222222", validPermissionSetARN))
-				require.NoError(t, err)
-
-				identity := TestUser(userNoAccess.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Empty(t, resp.Resources)
-			})
-
-			t.Run("access denied by account deny condition", func(t *testing.T) {
-				userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access-account-mismatch", nil,
-					allowBySpecificKind,
-					withMatchingAccountAssignment,
-					withAccountAssignment(types.Deny, validAccountID, "*"))
-				require.NoError(t, err)
-
-				identity := TestUser(userNoAccess.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Empty(t, resp.Resources)
-			})
-
-			t.Run("access via generic kind", func(t *testing.T) {
-				user, _, err := CreateUserAndRole(srv.Auth(), "read-generic", nil,
-					allowByGenericKind,
-					withMatchingAccountAssignment)
-				require.NoError(t, err)
-
-				identity := TestUser(user.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Len(t, resp.Resources, 1)
-			})
-
-			t.Run("access via specific kind", func(t *testing.T) {
-				user, _, err := CreateUserAndRole(srv.Auth(), "read-specific", nil,
-					allowBySpecificKind,
-					withMatchingAccountAssignment)
-				require.NoError(t, err)
-
-				identity := TestUser(user.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-				})
-				require.NoError(t, err)
-				require.Len(t, resp.Resources, 1)
-			})
-
-			t.Run("access denied via specific kind beats allow via generic kind", func(t *testing.T) {
-				user, _, err := CreateUserAndRole(srv.Auth(), "specific-beats-generic", nil,
-					allowByGenericKind,
-					withMatchingAccountAssignment,
-					WithRoleMutator(func(r types.Role) {
-						r.SetRules(types.Deny, []types.Rule{
-							types.NewRule(test.kind, services.RO()),
-						})
-					}))
-				require.NoError(t, err)
-
-				identity := TestUser(user.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				_, err = clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-				})
-				require.True(t, trace.IsAccessDenied(err),
-					"Expected Access Denied, got %v", err)
-			})
-
-			// The tests below this point are only applicable to Identity Center
-			// Account assignments
-			if test.kind == types.KindIdentityCenterAccount {
-				return
-			}
-
-			// Asserts that a role ALLOW condition with a matching Account ID but
-			// nonmatching PermissionSet ARN does not allow access
-			t.Run("no access via no matching allow permission set condition", func(t *testing.T) {
-				userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access-allow-ps-mismatch", nil,
-					allowByGenericKind,
-					withAccountAssignment(types.Allow, validAccountID, "some:other:ps:arn"))
-				require.NoError(t, err)
-
-				identity := TestUser(userNoAccess.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Empty(t, resp.Resources)
-			})
-
-			// Asserts that a role DENY condition with a matching Account ID but
-			// nonmatching PermissionSet ARN does not block access
-			t.Run("access via no matching deny permission set condition", func(t *testing.T) {
-				userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "access-deny-ps-mismatch", nil,
-					allowByGenericKind,
-					withMatchingAccountAssignment,
-					withAccountAssignment(types.Deny, "*", "some:other:ps"))
-				require.NoError(t, err)
-
-				identity := TestUser(userNoAccess.GetName())
-				clt, err := srv.NewClient(identity)
-				require.NoError(t, err)
-				defer clt.Close()
-
-				resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
-					ResourceType: test.kind,
-					Labels: map[string]string{
-						types.OriginLabel: apicommon.OriginAWSIdentityCenter,
-					},
-				})
-				require.NoError(t, err)
-				require.Len(t, resp.Resources, 1)
-			})
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+			Labels: map[string]string{
+				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+			},
 		})
-	}
+		require.NoError(t, err)
+		require.Empty(t, resp.Resources)
+	})
+
+	t.Run("no access via no matching account condition ", func(t *testing.T) {
+		userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access-account-mismatch", nil,
+			allowByGenericKind,
+			withAccountAssignment(types.Allow, "22222222", validPermissionSetARN))
+		require.NoError(t, err)
+
+		identity := TestUser(userNoAccess.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+			Labels: map[string]string{
+				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Resources)
+	})
+
+	t.Run("access denied by account deny condition", func(t *testing.T) {
+		userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access-account-mismatch", nil,
+			allowBySpecificKind,
+			withMatchingAccountAssignment,
+			withAccountAssignment(types.Deny, validAccountID, "*"))
+		require.NoError(t, err)
+
+		identity := TestUser(userNoAccess.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+			Labels: map[string]string{
+				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Resources)
+	})
+
+	t.Run("access via generic kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "read-generic", nil,
+			allowByGenericKind,
+			withMatchingAccountAssignment)
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+			Labels: map[string]string{
+				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 1)
+	})
+
+	t.Run("access via specific kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "read-specific", nil,
+			allowBySpecificKind,
+			withMatchingAccountAssignment)
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 1)
+	})
+
+	t.Run("access denied via specific kind beats allow via generic kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "specific-beats-generic", nil,
+			allowByGenericKind,
+			withMatchingAccountAssignment,
+			WithRoleMutator(func(r types.Role) {
+				r.SetRules(types.Deny, []types.Rule{
+					types.NewRule(types.KindIdentityCenterAccount, services.RO()),
+				})
+			}))
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		_, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindIdentityCenterAccount},
+		})
+		require.True(t, trace.IsAccessDenied(err),
+			"Expected Access Denied, got %v", err)
+	})
 }
 
 func BenchmarkListUnifiedResourcesFilter(b *testing.B) {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4325,7 +4325,7 @@ func (g *GRPCServer) ListResources(ctx context.Context, req *authpb.ListResource
 		return nil, trace.Wrap(err)
 	}
 
-	paginatedResources, err := services.MakePaginatedResources(ctx, req.ResourceType, resp.Resources, nil /* requestable map */)
+	paginatedResources, err := services.MakePaginatedResources(req.ResourceType, resp.Resources, nil /* requestable map */)
 	if err != nil {
 		return nil, trace.Wrap(err, "making paginated resources")
 	}

--- a/lib/services/identitycenter_test.go
+++ b/lib/services/identitycenter_test.go
@@ -21,80 +21,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
 )
-
-func TestIdentityCenterAccountClone(t *testing.T) {
-	// GIVEN an Account Record
-	src := IdentityCenterAccount{
-		Account: &identitycenterv1.Account{
-			Kind:     types.KindIdentityCenterAccount,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{Name: "some-account"},
-			Spec: &identitycenterv1.AccountSpec{
-				Id:          "aws-account-id",
-				Arn:         "arn:aws:sso::account-id:",
-				Description: "Test account",
-				PermissionSetInfo: []*identitycenterv1.PermissionSetInfo{
-					{
-						Name: "original value",
-						Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
-					},
-				},
-			},
-		},
-	}
-
-	// WHEN I clone the resource
-	dst := src.CloneResource().(IdentityCenterAccount)
-
-	// EXPECT that the resulting clone compares equally
-	require.Equal(t, src, dst)
-
-	// WHEN I modify the source object in a way that would be shared with a
-	// shallow copy
-	src.Spec.PermissionSetInfo[0].Name = "some new value"
-
-	// EXPECT that the cloned object DOES NOT inherit the update
-	require.NotEqual(t, src, dst)
-	require.Equal(t, "original value", dst.Spec.PermissionSetInfo[0].Name)
-}
-
-func TestIdentityCenterAccountAssignmentClone(t *testing.T) {
-	// GIVEN an Account Assignment Record
-	src := IdentityCenterAccountAssignment{
-		AccountAssignment: &identitycenterv1.AccountAssignment{
-			Kind:     types.KindIdentityCenterAccountAssignment,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{Name: "u-test@example.com"},
-			Spec: &identitycenterv1.AccountAssignmentSpec{
-				Display: "Some-Permission-set on Some-AWS-account",
-				PermissionSet: &identitycenterv1.PermissionSetInfo{
-					Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
-					Name: "original name",
-				},
-				AccountName: "Some Account Name",
-				AccountId:   "some account id",
-			},
-		},
-	}
-
-	// WHEN I clone the resource
-	dst := src.CloneResource().(IdentityCenterAccountAssignment)
-
-	// EXPECT that the resulting clone compares equally
-	require.Equal(t, src, dst)
-
-	// WHEN I modify the source object in a way that would be shared with a
-	// shallow copy
-	src.Spec.PermissionSet.Name = "some new name"
-
-	// EXPECT that the cloned object DOES NOT inherit the update
-	require.NotEqual(t, src, dst)
-	require.Equal(t, "original name", dst.Spec.PermissionSet.Name)
-}
 
 func TestIdentityCenterAccountMatcher(t *testing.T) {
 	testCases := []struct {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
-	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -1264,12 +1263,6 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	case types.KindUserGroup:
 		keyPrefix = []string{userGroupPrefix}
 		unmarshalItemFunc = backendItemToUserGroup
-	case types.KindIdentityCenterAccount:
-		keyPrefix = []string{awsResourcePrefix, awsAccountPrefix}
-		unmarshalItemFunc = backendItemToIdentityCenterAccount
-	case types.KindIdentityCenterAccountAssignment:
-		keyPrefix = []string{awsResourcePrefix, awsAccountAssignmentPrefix}
-		unmarshalItemFunc = backendItemToIdentityCenterAccountAssignment
 	case types.KindGitServer:
 		keyPrefix = []string{gitServerPrefix}
 		unmarshalItemFunc = backendItemToServer(types.KindGitServer)
@@ -1659,35 +1652,6 @@ func backendItemToUserGroup(item backend.Item) (types.ResourceWithLabels, error)
 		services.WithExpires(item.Expires),
 		services.WithRevision(item.Revision),
 	)
-}
-
-func backendItemToIdentityCenterAccount(item backend.Item) (types.ResourceWithLabels, error) {
-	assignment, err := services.UnmarshalProtoResource[*identitycenterv1.Account](
-		item.Value,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	resource := types.Resource153ToUnifiedResource(
-		services.IdentityCenterAccount{Account: assignment},
-	)
-	return resource.(types.ResourceWithLabels), nil
-}
-
-func backendItemToIdentityCenterAccountAssignment(item backend.Item) (types.ResourceWithLabels, error) {
-	assignment, err := services.UnmarshalProtoResource[*identitycenterv1.AccountAssignment](
-		item.Value,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return types.Resource153ToUnifiedResource(
-		services.IdentityCenterAccountAssignment{AccountAssignment: assignment},
-	), nil
 }
 
 const (

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2577,6 +2577,7 @@ func (l kubernetesClusterLabelMatcher) getKubeLabelMatchers(role types.Role, typ
 // AccessCheckable is the subset of types.Resource required for the RBAC checks.
 type AccessCheckable interface {
 	GetKind() string
+	GetSubKind() string
 	GetName() string
 	GetMetadata() types.Metadata
 	GetLabel(key string) (value string, ok bool)
@@ -2594,7 +2595,10 @@ func resourceRequiresLabelMatching(r AccessCheckable) bool {
 	switch r.GetKind() {
 	case types.KindIdentityCenterAccount, types.KindIdentityCenterAccountAssignment:
 		return false
+	case types.KindApp, types.KindAppServer:
+		return r.GetSubKind() != types.KindIdentityCenterAccount
 	}
+
 	return true
 }
 

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -35,7 +35,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -343,48 +342,6 @@ func (c *UnifiedResourceCache) SAMLIdPServiceProviders(ctx context.Context, para
 	return iterateUnifiedResourceCache(ctx, c, params, types.KindSAMLIdPServiceProvider, types.SAMLIdPServiceProvider.Copy)
 }
 
-// IdentityCenterAccounts iterates over all cached identity center accounts starting from the provided key.
-func (c *UnifiedResourceCache) IdentityCenterAccounts(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[*identitycenterv1.Account, error] {
-	// cloning is performed on the concrete resource below instead of
-	// on the wrapper type.
-	cloneFn := func(account types.Resource153UnwrapperT[IdentityCenterAccount]) types.Resource153UnwrapperT[IdentityCenterAccount] {
-		return account
-	}
-	return func(yield func(*identitycenterv1.Account, error) bool) {
-		for account, err := range iterateUnifiedResourceCache(ctx, c, params, types.KindIdentityCenterAccount, cloneFn) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			if !yield(apiutils.CloneProtoMsg(account.UnwrapT().Account), nil) {
-				return
-			}
-		}
-	}
-}
-
-// IdentityCenterAccountAssignments iterates over all cached identity center account assignments starting from the provided key.
-func (c *UnifiedResourceCache) IdentityCenterAccountAssignments(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[*identitycenterv1.AccountAssignment, error] {
-	// cloning is performed on the concrete resource below instead of
-	// on the wrapper type.
-	cloneFn := func(account types.Resource153UnwrapperT[IdentityCenterAccountAssignment]) types.Resource153UnwrapperT[IdentityCenterAccountAssignment] {
-		return account
-	}
-	return func(yield func(*identitycenterv1.AccountAssignment, error) bool) {
-		for assignment, err := range iterateUnifiedResourceCache(ctx, c, params, types.KindIdentityCenterAccountAssignment, cloneFn) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
-			if !yield(apiutils.CloneProtoMsg(assignment.UnwrapT().AccountAssignment), nil) {
-				return
-			}
-		}
-	}
-}
-
 func iterateUnifiedResourceCache[T any](ctx context.Context, c *UnifiedResourceCache, params UnifiedResourcesIterateParams, kind string, cloneFn func(T) T) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
 		sortBy := types.SortBy{IsDesc: params.Descending, Field: SortByName}
@@ -433,7 +390,6 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 	switch r.GetKind() {
 	case types.KindNode,
 		types.KindWindowsDesktop,
-		types.KindIdentityCenterAccountAssignment,
 		types.KindGitServer,
 		types.KindDatabase,
 		types.KindKubernetesCluster:
@@ -475,6 +431,12 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 		_, ok := kinds[types.KindSAMLIdPServiceProvider]
 		return ok
 	case types.KindAppServer:
+		if r.GetSubKind() == types.KindIdentityCenterAccount {
+			if _, ok := kinds[types.KindIdentityCenterAccount]; ok {
+				return ok
+			}
+		}
+
 		if _, ok := kinds[types.KindApp]; ok {
 			return ok
 		}
@@ -539,7 +501,6 @@ type ResourceGetter interface {
 	KubernetesServerGetter
 	SAMLIdpServiceProviderGetter
 	IdentityCenterAccountGetter
-	IdentityCenterAccountAssignmentGetter
 	GitServerGetter
 }
 
@@ -656,11 +617,6 @@ func (c *UnifiedResourceCache) getResourcesAndUpdateCurrent(ctx context.Context)
 		return trace.Wrap(err)
 	}
 
-	newICAccountAssignments, err := c.getIdentityCenterAccountAssignments(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	newGitServers, err := c.getGitServers(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -675,15 +631,14 @@ func (c *UnifiedResourceCache) getResourcesAndUpdateCurrent(ctx context.Context)
 	// c.resources = make(map[string]resource)
 	clear(c.resources)
 
-	putResources[types.Server](c, newNodes)
-	putResources[types.DatabaseServer](c, newDbs)
-	putResources[types.AppServer](c, newApps)
-	putResources[types.KubeServer](c, newKubes)
-	putResources[types.SAMLIdPServiceProvider](c, newSAMLApps)
-	putResources[types.WindowsDesktop](c, newDesktops)
-	putResources[resource](c, newICAccounts)
-	putResources[resource](c, newICAccountAssignments)
-	putResources[types.Server](c, newGitServers)
+	putResources(c, newNodes)
+	putResources(c, newDbs)
+	putResources(c, newApps)
+	putResources(c, newKubes)
+	putResources(c, newSAMLApps)
+	putResources(c, newDesktops)
+	putResources(c, newICAccounts)
+	putResources(c, newGitServers)
 	c.stale = false
 	c.defineCollectorAsInitialized()
 	return nil
@@ -801,28 +756,8 @@ func (c *UnifiedResourceCache) getIdentityCenterAccounts(ctx context.Context) ([
 		if err != nil {
 			return nil, trace.Wrap(err, "getting AWS Identity Center accounts for resource watcher")
 		}
-		for _, a := range resultsPage {
-			accounts = append(accounts, types.Resource153ToUnifiedResource(a))
-		}
-
-		if nextPage == pagination.EndOfList {
-			break
-		}
-		pageRequest.Update(nextPage)
-	}
-	return accounts, nil
-}
-
-func (c *UnifiedResourceCache) getIdentityCenterAccountAssignments(ctx context.Context) ([]resource, error) {
-	var accounts []resource
-	var pageRequest pagination.PageRequestToken
-	for {
-		resultsPage, nextPage, err := c.ListAccountAssignments(ctx, apidefaults.DefaultChunkSize, &pageRequest)
-		if err != nil {
-			return nil, trace.Wrap(err, "getting AWS Identity Center accounts for resource watcher")
-		}
-		for _, a := range resultsPage {
-			accounts = append(accounts, types.Resource153ToUnifiedResource(a))
+		for _, acct := range resultsPage {
+			accounts = append(accounts, IdentityCenterAccountToAppServer(acct.Account))
 		}
 
 		if nextPage == pagination.EndOfList {
@@ -941,15 +876,23 @@ func (c *UnifiedResourceCache) processEventsAndUpdateCurrent(ctx context.Context
 
 		switch event.Type {
 		case types.OpDelete:
-			c.deleteLocked(event.Resource)
+			switch event.Resource.GetKind() {
+			case types.KindIdentityCenterAccount:
+				c.deleteLocked(&types.ResourceHeader{
+					Kind: types.KindAppServer,
+					Metadata: types.Metadata{
+						Name: event.Resource.GetName(),
+					},
+				})
+			default:
+				c.deleteLocked(event.Resource)
+			}
 		case types.OpPut:
 			switch r := event.Resource.(type) {
 			case resource:
 				c.putLocked(r)
 			case types.Resource153UnwrapperT[*identitycenterv1.Account]:
-				c.putLocked(types.Resource153ToUnifiedResource(IdentityCenterAccount{Account: r.UnwrapT()}))
-			case types.Resource153UnwrapperT[*identitycenterv1.AccountAssignment]:
-				c.putLocked(types.Resource153ToUnifiedResource(IdentityCenterAccountAssignment{AccountAssignment: r.UnwrapT()}))
+				c.putLocked(IdentityCenterAccountToAppServer(r.UnwrapT()))
 			default:
 				c.logger.WarnContext(ctx, "unsupported Resource type", "resource_type", logutils.TypeAttr(r))
 			}
@@ -970,7 +913,6 @@ func (c *UnifiedResourceCache) resourceKinds() []types.WatchKind {
 		{Kind: types.KindWindowsDesktop},
 		{Kind: types.KindSAMLIdPServiceProvider},
 		{Kind: types.KindIdentityCenterAccount},
-		{Kind: types.KindIdentityCenterAccountAssignment},
 		{Kind: types.KindGitServer},
 	}
 }
@@ -1013,7 +955,7 @@ const (
 )
 
 // MakePaginatedResource converts a resource into a paginated proto representation.
-func MakePaginatedResource(ctx context.Context, requestType string, r types.ResourceWithLabels, requiresRequest bool) (*proto.PaginatedResource, error) {
+func MakePaginatedResource(requestType string, r types.ResourceWithLabels, requiresRequest bool) (*proto.PaginatedResource, error) {
 	var protoResource *proto.PaginatedResource
 	resourceKind := requestType
 	if requestType == types.KindUnifiedResource {
@@ -1103,25 +1045,6 @@ func MakePaginatedResource(ctx context.Context, requestType string, r types.Reso
 			},
 			RequiresRequest: requiresRequest,
 		}
-
-	case types.KindIdentityCenterAccount:
-		var err error
-		protoResource, err = makePaginatedIdentityCenterAccount(resourceKind, resource, requiresRequest)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-	case types.KindIdentityCenterAccountAssignment:
-		unwrapper, ok := resource.(types.Resource153UnwrapperT[IdentityCenterAccountAssignment])
-		if !ok {
-			return nil, trace.BadParameter("%s has invalid type %T", resourceKind, resource)
-		}
-		assignment := unwrapper.UnwrapT()
-		protoResource = &proto.PaginatedResource{
-			Resource:        proto.PackICAccountAssignment(assignment.AccountAssignment),
-			RequiresRequest: requiresRequest,
-		}
-
 	case types.KindGitServer:
 		server, ok := resource.(*types.ServerV2)
 		if !ok {
@@ -1134,7 +1057,6 @@ func MakePaginatedResource(ctx context.Context, requestType string, r types.Reso
 			},
 			RequiresRequest: requiresRequest,
 		}
-
 	default:
 		return nil, trace.NotImplemented("resource type %s doesn't support pagination", resource.GetKind())
 	}
@@ -1142,66 +1064,12 @@ func MakePaginatedResource(ctx context.Context, requestType string, r types.Reso
 	return protoResource, nil
 }
 
-// makePaginatedIdentityCenterAccount returns a representation of the supplied
-// Identity Center account as an App.
-func makePaginatedIdentityCenterAccount(resourceKind string, resource types.ResourceWithLabels, requiresRequest bool) (*proto.PaginatedResource, error) {
-	unwrapper, ok := resource.(types.Resource153UnwrapperT[IdentityCenterAccount])
-	if !ok {
-		return nil, trace.BadParameter("%s has invalid type %T", resourceKind, resource)
-	}
-	acct := unwrapper.UnwrapT()
-	srcPSs := acct.GetSpec().GetPermissionSetInfo()
-	pss := make([]*types.IdentityCenterPermissionSet, len(srcPSs))
-	for i, ps := range acct.GetSpec().GetPermissionSetInfo() {
-		pss[i] = &types.IdentityCenterPermissionSet{
-			ARN:          ps.Arn,
-			Name:         ps.Name,
-			AssignmentID: ps.AssignmentId,
-		}
-	}
-
-	appServer := &types.AppServerV3{
-		Kind:     types.KindAppServer,
-		Version:  types.V3,
-		Metadata: resource.GetMetadata(),
-		Spec: types.AppServerSpecV3{
-			App: &types.AppV3{
-				Kind:     types.KindApp,
-				SubKind:  types.KindIdentityCenterAccount,
-				Version:  types.V3,
-				Metadata: types.Metadata153ToLegacy(acct.Metadata),
-				Spec: types.AppSpecV3{
-					URI:        acct.Spec.StartUrl,
-					PublicAddr: acct.Spec.StartUrl,
-					AWS: &types.AppAWS{
-						ExternalID: acct.Spec.Id,
-					},
-					IdentityCenter: &types.AppIdentityCenter{
-						AccountID:      acct.Spec.Id,
-						PermissionSets: pss,
-					},
-				},
-			},
-		},
-	}
-	appServer.Metadata.Description = acct.Spec.Name
-
-	protoResource := &proto.PaginatedResource{
-		Resource: &proto.PaginatedResource_AppServer{
-			AppServer: appServer,
-		},
-		RequiresRequest: requiresRequest,
-	}
-
-	return protoResource, nil
-}
-
 // MakePaginatedResources converts a list of resources into a list of paginated proto representations.
-func MakePaginatedResources(ctx context.Context, requestType string, resources []types.ResourceWithLabels, requestableMap map[string]struct{}) ([]*proto.PaginatedResource, error) {
+func MakePaginatedResources(requestType string, resources []types.ResourceWithLabels, requestableMap map[string]struct{}) ([]*proto.PaginatedResource, error) {
 	paginatedResources := make([]*proto.PaginatedResource, 0, len(resources))
 	for _, r := range resources {
 		_, requiresRequest := requestableMap[r.GetName()]
-		protoResource, err := MakePaginatedResource(ctx, requestType, r, requiresRequest)
+		protoResource, err := MakePaginatedResource(requestType, r, requiresRequest)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -55,7 +55,6 @@ type client struct {
 	services.SAMLIdPServiceProviders
 	services.GitServers
 	services.IdentityCenterAccounts
-	services.IdentityCenterAccountAssignments
 	types.Events
 }
 
@@ -75,14 +74,13 @@ func newClient(t *testing.T) *client {
 	require.NoError(t, err)
 
 	return &client{
-		bk:                               bk,
-		Presence:                         local.NewPresenceService(bk),
-		WindowsDesktops:                  local.NewWindowsDesktopService(bk),
-		SAMLIdPServiceProviders:          samlService,
-		Events:                           local.NewEventsService(bk),
-		GitServers:                       gitService,
-		IdentityCenterAccounts:           icService,
-		IdentityCenterAccountAssignments: icService,
+		bk:                      bk,
+		Presence:                local.NewPresenceService(bk),
+		WindowsDesktops:         local.NewWindowsDesktopService(bk),
+		SAMLIdPServiceProviders: samlService,
+		Events:                  local.NewEventsService(bk),
+		GitServers:              gitService,
+		IdentityCenterAccounts:  icService,
 	}
 }
 
@@ -176,13 +174,11 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	icAcct := newICAccount(t, ctx, clt)
-	icAcctAssignment := newICAccountAssignment(t, ctx, clt)
 
 	// we expect each of the resources above to exist
 	expectedRes := []types.ResourceWithLabels{node, app, samlapp, dbServer, win,
 		gitServer, gitServer2,
-		types.Resource153ToUnifiedResource(icAcct),
-		types.Resource153ToUnifiedResource(icAcctAssignment),
+		services.IdentityCenterAccountToAppServer(icAcct),
 	}
 	assert.Eventually(t, func() bool {
 		res, err = w.GetUnifiedResources(ctx)
@@ -196,25 +192,6 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
 		// Ignore order.
 		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
-
-		cmp.Transformer("Unwrap.IdentityCenterAccountAssignment",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccountAssignment]) services.IdentityCenterAccountAssignment {
-				return t.UnwrapT()
-			}),
-
-		cmp.Transformer("Unwrap.IdentityCenterAccount",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccount]) services.IdentityCenterAccount {
-				return t.UnwrapT()
-			}),
-
-		// Ignore unexported values in RFD153-style resources
-		cmpopts.IgnoreUnexported(
-			headerv1.Metadata{},
-			identitycenterv1.Account{},
-			identitycenterv1.AccountSpec{},
-			identitycenterv1.PermissionSetInfo{},
-			identitycenterv1.AccountAssignment{},
-			identitycenterv1.AccountAssignmentSpec{}),
 	))
 
 	// // Update and remove some resources.
@@ -227,8 +204,8 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	// this should include the updated node, and shouldn't have any apps included
 	expectedRes = []types.ResourceWithLabels{nodeUpdated, samlapp, dbServer, win,
 		gitServer, gitServer2,
-		types.Resource153ToUnifiedResource(icAcct),
-		types.Resource153ToUnifiedResource(icAcctAssignment)}
+		services.IdentityCenterAccountToAppServer(icAcct),
+	}
 
 	assert.Eventually(t, func() bool {
 		res, err = w.GetUnifiedResources(ctx)
@@ -245,26 +222,6 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
-
-		// Allow comparison of the wrapped values inside a Resource153ToLegacyAdapter
-		cmp.Transformer("Unwrap.IdentityCenterAccountAssignment",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccountAssignment]) services.IdentityCenterAccountAssignment {
-				return t.UnwrapT()
-			}),
-
-		cmp.Transformer("Unwrap.IdentityCenterAccount",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccount]) services.IdentityCenterAccount {
-				return t.UnwrapT()
-			}),
-
-		// Ignore unexported values in RFD153-style resources
-		cmpopts.IgnoreUnexported(
-			headerv1.Metadata{},
-			identitycenterv1.Account{},
-			identitycenterv1.AccountSpec{},
-			identitycenterv1.PermissionSetInfo{},
-			identitycenterv1.AccountAssignment{},
-			identitycenterv1.AccountAssignmentSpec{}),
 
 		// Ignore order.
 		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
@@ -345,7 +302,6 @@ func TestUnifiedResourceCacheIterateResources(t *testing.T) {
 	require.NoError(t, err)
 
 	icAcct := newICAccount(t, ctx, clt)
-	icAcctAssignment := newICAccountAssignment(t, ctx, clt)
 
 	w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
@@ -364,39 +320,19 @@ func TestUnifiedResourceCacheIterateResources(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
 
-		cmp.Transformer("Unwrap.IdentityCenterAccountAssignment",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccountAssignment]) services.IdentityCenterAccountAssignment {
-				return t.UnwrapT()
-			}),
-
-		cmp.Transformer("Unwrap.IdentityCenterAccount",
-			func(t types.Resource153UnwrapperT[services.IdentityCenterAccount]) services.IdentityCenterAccount {
-				return t.UnwrapT()
-			}),
-
-		// Ignore unexported values in RFD153-style resources
-		cmpopts.IgnoreUnexported(
-			headerv1.Metadata{},
-			identitycenterv1.Account{},
-			identitycenterv1.AccountSpec{},
-			identitycenterv1.PermissionSetInfo{},
-			identitycenterv1.AccountAssignment{},
-			identitycenterv1.AccountAssignmentSpec{}),
-
 		// Ignore order.
 		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
 	}
 
 	expected := map[string]types.ResourceWithLabels{
-		types.KindApp:                             app,
-		types.KindDatabase:                        dbServer,
-		types.KindNode:                            node,
-		types.KindWindowsDesktop:                  win,
-		types.KindKubernetesCluster:               kubeServer,
-		types.KindSAMLIdPServiceProvider:          samlapp,
-		types.KindGitServer:                       gitServer,
-		types.KindIdentityCenterAccount:           types.Resource153ToUnifiedResource(icAcct),
-		types.KindIdentityCenterAccountAssignment: types.Resource153ToUnifiedResource(icAcctAssignment),
+		types.KindApp:                    app,
+		types.KindDatabase:               dbServer,
+		types.KindNode:                   node,
+		types.KindWindowsDesktop:         win,
+		types.KindKubernetesCluster:      kubeServer,
+		types.KindSAMLIdPServiceProvider: samlapp,
+		types.KindGitServer:              gitServer,
+		types.KindIdentityCenterAccount:  services.IdentityCenterAccountToAppServer(icAcct),
 	}
 
 	for r, err := range w.Resources(ctx, "", types.SortBy{Field: services.SortByKind}) {
@@ -406,6 +342,9 @@ func TestUnifiedResourceCacheIterateResources(t *testing.T) {
 		switch kind {
 		case types.KindAppServer:
 			kind = types.KindApp
+			if r.GetSubKind() == types.KindIdentityCenterAccount {
+				kind = types.KindIdentityCenterAccount
+			}
 		case types.KindDatabaseServer:
 			kind = types.KindDatabase
 		case types.KindKubeServer:
@@ -432,6 +371,9 @@ func TestUnifiedResourceCacheIterateResources(t *testing.T) {
 			switch kind {
 			case types.KindAppServer:
 				kind = types.KindApp
+				if r.GetSubKind() == types.KindIdentityCenterAccount {
+					kind = types.KindIdentityCenterAccount
+				}
 			case types.KindDatabaseServer:
 				kind = types.KindDatabase
 			case types.KindKubeServer:
@@ -698,94 +640,6 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 						}
 
 						if !yield(n, nil) {
-							return
-						}
-					}
-				}
-			},
-		},
-		{
-			name: "identity center account",
-			createResource: func(name string, c *client) error {
-				_, err := c.CreateIdentityCenterAccount(ctx, services.IdentityCenterAccount{
-					Account: &identitycenterv1.Account{
-						Kind:    types.KindIdentityCenterAccount,
-						Version: types.V1,
-						Metadata: &headerv1.Metadata{
-							Name: name,
-							Labels: map[string]string{
-								types.OriginLabel: common.OriginAWSIdentityCenter,
-							},
-						},
-						Spec: &identitycenterv1.AccountSpec{
-							Id:          name,
-							Arn:         "arn:aws:sso:::account/" + name,
-							Name:        "Test AWS Account",
-							Description: "Used for testing",
-							PermissionSetInfo: []*identitycenterv1.PermissionSetInfo{
-								{
-									Name: "Alpha",
-									Arn:  "arn:aws:sso:::permissionSet/ssoins-1234567890/ps-alpha",
-								},
-								{
-									Name: "Beta",
-									Arn:  "arn:aws:sso:::permissionSet/ssoins-1234567890/ps-beta",
-								},
-							},
-						},
-					}})
-				return err
-			},
-			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
-				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.IdentityCenterAccounts(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
-						if err != nil {
-							yield(nil, err)
-							return
-						}
-
-						if !yield(types.Resource153ToResourceWithLabels(n), nil) {
-							return
-						}
-					}
-				}
-			},
-		},
-		{
-			name: "identity center account assignment",
-			createResource: func(name string, c *client) error {
-				_, err := c.CreateAccountAssignment(ctx, services.IdentityCenterAccountAssignment{
-					AccountAssignment: &identitycenterv1.AccountAssignment{
-						Kind:    types.KindIdentityCenterAccountAssignment,
-						Version: types.V1,
-						Metadata: &headerv1.Metadata{
-							Name: name,
-							Labels: map[string]string{
-								types.OriginLabel: common.OriginAWSIdentityCenter,
-							},
-						},
-						Spec: &identitycenterv1.AccountAssignmentSpec{
-							Display: "Admin access on Production",
-							PermissionSet: &identitycenterv1.PermissionSetInfo{
-								Arn:          "arn:aws::::ps-Admin",
-								Name:         "Admin",
-								AssignmentId: "production--admin",
-							},
-							AccountName: "Production",
-							AccountId:   "99999999",
-						},
-					}})
-				return err
-			},
-			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
-				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.IdentityCenterAccountAssignments(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
-						if err != nil {
-							yield(nil, err)
-							return
-						}
-
-						if !yield(types.Resource153ToResourceWithLabels(n), nil) {
 							return
 						}
 					}
@@ -1108,7 +962,7 @@ const testEntityDescriptor = `<?xml version="1.0" encoding="UTF-8"?>
 </md:EntityDescriptor>
 `
 
-func newICAccount(t *testing.T, ctx context.Context, svc services.IdentityCenterAccounts) services.IdentityCenterAccount {
+func newICAccount(t *testing.T, ctx context.Context, svc services.IdentityCenterAccounts) *identitycenterv1.Account {
 	t.Helper()
 
 	accountID := t.Name()
@@ -1141,35 +995,7 @@ func newICAccount(t *testing.T, ctx context.Context, svc services.IdentityCenter
 			},
 		}})
 	require.NoError(t, err, "creating Identity Center Account")
-	return icAcct
-}
-
-func newICAccountAssignment(t *testing.T, ctx context.Context, svc services.IdentityCenterAccountAssignments) services.IdentityCenterAccountAssignment {
-	t.Helper()
-
-	assignment, err := svc.CreateAccountAssignment(ctx, services.IdentityCenterAccountAssignment{
-		AccountAssignment: &identitycenterv1.AccountAssignment{
-			Kind:    types.KindIdentityCenterAccountAssignment,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: t.Name(),
-				Labels: map[string]string{
-					types.OriginLabel: common.OriginAWSIdentityCenter,
-				},
-			},
-			Spec: &identitycenterv1.AccountAssignmentSpec{
-				Display: "Admin access on Production",
-				PermissionSet: &identitycenterv1.PermissionSetInfo{
-					Arn:          "arn:aws::::ps-Admin",
-					Name:         "Admin",
-					AssignmentId: "production--admin",
-				},
-				AccountName: "Production",
-				AccountId:   "99999999",
-			},
-		}})
-	require.NoError(t, err, "creating Identity Center Account Assignment")
-	return assignment
+	return icAcct.Account
 }
 
 func TestOktaAppServers(t *testing.T) {


### PR DESCRIPTION
The resources are only ever presented to the UI as Apps so there is room to simplify the special handling of Identity Center Accounts stored in the URC. The extra machinery needed to convert the `identitycenterv1.Account` into a `types.ResourceWithLabels` is no longer needed and is removed. The `IdentityCenterAccountMatcher` was extended to allow being created from a `types.AppServer` so that RBAC is still enforced appropriately on any `types.AppServer`s that are an IC Account.

The IdentityCenterAccountAssignments were also removed entirely from the unified resource cache because they were never consumed. Additionally the resources were exposed via `ListResources` but never consumed and should be made available in their own distinct `ListIdentityCenterAccountAssignments` and `IdentityCenterAccounts` instead of piggybacking on to `ListResources`.



Depends on https://github.com/gravitational/teleport.e/pull/6542.