### PR TITLE
docs: Fix mangled summary tags

### DIFF
--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -42,7 +42,7 @@ $ tsh device asset-tag
 ```
 
 <details>
-<summary>Manually retrieving device serial" close</summary>
+<summary>Manually retrieving device serial</summary>
   <Tabs>
   <TabItem label="macOS">
     The serial number is visible under Apple menu -> "About This Mac" -> "Serial number".
@@ -68,10 +68,9 @@ $ tsh device asset-tag
 </details>
 
 
-Replace 
-<Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/> 
-with the serial number of the device you wish to enroll and
-<Var name="macos" /> with your operating system. Run the `tctl devices add` command:
+Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/>
+with the serial number of the device you wish to enroll and <Var name="macos" /> with your operating
+system. Run the `tctl devices add` command:
 
 ```code
 $ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'

--- a/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
@@ -82,7 +82,7 @@ try to recreate your API client.
   Teleport Cloud users can quickly get started with Jamf integration by using
   the hosted Jamf plugin in the Web UI.
   <details>
-  <summary>Configure Jamf hosted plugin" min="13.2" close</summary>
+  <summary>Configure Jamf hosted plugin</summary>
     Select the Jamf plugin:
     ![Select Jamf plugin](../../../../img/access-controls/device-trust/select-jamf.png)
     Fill in the required information and click "Connect Jamf" button:

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -1057,7 +1057,7 @@ then begin to forward traffic to the target host and port. The client can then
 make an SSH connection.
 
 <details>
-<summary>Example in Python (Paramiko)" close</summary>
+<summary>Example in Python (Paramiko)</summary>
 ```python
 import os
 import paramiko
@@ -1100,7 +1100,7 @@ print(stdout.read().decode())
 </details>
 
 <details>
-<summary>Example in Go" close</summary>
+<summary>Example in Go</summary>
 ```go
 package main
 


### PR DESCRIPTION
#53009 migrated the docs from a custom `<Details>` component to a standard `<details>` supported by Docusaurus. While reading Device Trust docs, I noticed that one `<summary>` tag was mangled, likely by some kind of project-wide search & replace.

I grepped the project for other instances of `" close` and fixed them accordingly, based on the diff from #53009.