### PR TITLE
Add `wasm-unsafe-eval` to Connect CSP

### DIFF
--- a/web/packages/teleterm/csp.ts
+++ b/web/packages/teleterm/csp.ts
@@ -22,21 +22,22 @@ export function getConnectCsp(development: boolean) {
     ? 'https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod'
     : 'https://usage.teleport.dev';
 
-  let csp = `
+  const scriptEval = development
+    ? // Required to make source maps work in dev mode.
+      "'unsafe-eval' 'unsafe-inline'"
+    : // Enables WASM initialization with a safer alternative to 'unsafe-eval'.
+      // This source expression applies specifically to WASM.
+      "'wasm-unsafe-eval'";
+
+  return `
 default-src 'self';
 connect-src 'self' ${feedbackAddress};
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob:;
 object-src 'none';
 font-src 'self' data:;
+script-src 'self' ${scriptEval};
 `
     .replaceAll('\n', ' ')
     .trim();
-
-  if (development) {
-    // Required to make source maps work in dev mode.
-    csp += " script-src 'self' 'unsafe-eval' 'unsafe-inline';";
-  }
-
-  return csp;
 }


### PR DESCRIPTION
To initialize a WASM code, the content security policy[ must be extended](https://www.w3.org/TR/CSP3/#directive-script-src) with `wasm-unsafe-eval`, otherwise WASM won't work: 

<img width="572" alt="wasm" src="https://github.com/user-attachments/assets/b2d6aebc-bd7d-4879-bbb9-f35284f33723" />

This is done in Web UI too. 
I haven't noticed it initially because the app in dev mode sets 'unsafe-eval' so everything worked.