### PR TITLE
Update GKE Auto-Discovery IAM permissions

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -79,6 +79,7 @@ title: GKE Cluster Access Manager
 description: "Manage access to GKE clusters"
 stage: GA
 includedPermissions:
+- container.clusters.connect
 - container.clusters.get
 - container.clusters.impersonate
 - container.pods.get
@@ -367,7 +368,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: <Var name="teleport.example.com" />:443    
+  proxy_server: <Var name="teleport.example.com" />:443
 auth_service:
   enabled: false
 proxy_service:
@@ -389,7 +390,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: <Var name="teleport.example.com" />:443    
+  proxy_server: <Var name="teleport.example.com" />:443
 auth_service:
   enabled: false
 proxy_service:


### PR DESCRIPTION
The DNS-based endpoint that Google recently introduced requires an additional permission of `container.clusters.connect` that was not present in the documentation.