### PR TITLE
[v16] Skip active desktop session prompt when per-session MFA is enabled

### DIFF
--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -30,6 +30,7 @@ import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 import { adaptWebSocketToTdpTransport } from 'teleport/lib/tdp';
 import useWebAuthn, { WebAuthnState } from 'teleport/lib/useWebAuthn';
 import { getHostName } from 'teleport/services/api';
+import auth from 'teleport/services/auth';
 
 export function DesktopSession() {
   const ctx = useTeleport();
@@ -63,10 +64,29 @@ export function DesktopSession() {
     }, [ctx.userService])
   );
 
-  const hasAnotherSession = useCallback(
-    () => ctx.desktopService.checkDesktopIsActive(clusterId, desktopName),
-    [clusterId, ctx.desktopService, desktopName]
-  );
+  // Returns an active session only if per-session MFA is disabled.
+  // This improves the user experience by preventing multiple confirmation prompts:
+  // - one from the active desktop alert,
+  // - another from the per-session MFA prompt.
+  // The check for another session was added to prevent a situation where a user could be tricked
+  // into clicking a link that would DOS another user's active session.
+  // https://github.com/gravitational/webapps/pull/1297
+  // Showing only the MFA prompt is enough for security.
+  const hasAnotherSession = useCallback(async (): Promise<boolean> => {
+    const [mfaRequiredResponse, desktopActive] = await Promise.all([
+      auth.checkMfaRequired(clusterId, {
+        windows_desktop: {
+          desktop_name: desktopName,
+          login: username,
+        },
+      }),
+      ctx.desktopService.checkDesktopIsActive(clusterId, desktopName),
+    ]);
+    if (mfaRequiredResponse.required) {
+      return false;
+    }
+    return desktopActive;
+  }, [clusterId, ctx.desktopService, desktopName, username]);
 
   useEffect(() => {
     fetchAcl();

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/useConnectionDiagnostic.ts
@@ -73,7 +73,7 @@ export function useConnectionDiagnostic() {
     try {
       if (!mfaAuthnResponse) {
         const mfaReq = getMfaRequest(req, resourceSpec);
-        const sessionMfa = await auth.checkMfaRequired(mfaReq);
+        const sessionMfa = await auth.checkMfaRequired(undefined, mfaReq);
         if (sessionMfa.required) {
           setShowMfaDialog(true);
           return { mfaRequired: true };

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -326,6 +326,7 @@ const auth = {
     if (isMfaRequiredRequest) {
       try {
         const isMFARequired = await checkMfaRequired(
+          undefined,
           isMfaRequiredRequest,
           abortSignal
         );
@@ -372,9 +373,11 @@ const auth = {
   },
 };
 
+// When clusterId is undefined, the check is run against the root cluster.
 function checkMfaRequired(
+  clusterId: string | undefined,
   params: IsMfaRequiredRequest,
-  abortSignal?
+  abortSignal?: AbortSignal
 ): Promise<IsMfaRequiredResponse> {
   const appParams = params as IsMfaRequiredApp;
   if (appParams?.app?.cluster_name) {
@@ -384,7 +387,7 @@ function checkMfaRequired(
       abortSignal
     );
   }
-  return api.post(cfg.getMfaRequiredUrl(), params, abortSignal);
+  return api.post(cfg.getMfaRequiredUrl(clusterId), params, abortSignal);
 }
 
 function base64EncodeUnicode(str: string) {


### PR DESCRIPTION
Backport #54848 to branch/v16

There are some differences vs the original PR because of changes in this backport https://github.com/gravitational/teleport/pull/51854.

changelog: Disabled the "another session is active" prompt when per-session MFA is enabled, since MFA already enforces user confirmation when starting a desktop session