### PR TITLE
Add children to sync stamp

### DIFF
--- a/web/packages/design/src/SyncStamp/SyncStamp.story.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.story.tsx
@@ -16,10 +16,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { IconTooltip } from '../Tooltip';
 import { SyncStamp } from './SyncStamp';
 
 export default {
   title: 'Design/SyncStamp',
 };
 
-export const Story = () => <SyncStamp date={new Date()} />;
+export const Story = () => (
+  <>
+    <SyncStamp date={new Date()} />
+    <SyncStamp date={new Date('2019-08-30T00:00:00.00Z')} />
+    <SyncStamp date={new Date()}>
+      <IconTooltip kind="error">Failed</IconTooltip>
+    </SyncStamp>
+  </>
+);

--- a/web/packages/design/src/SyncStamp/SyncStamp.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.tsx
@@ -17,21 +17,27 @@
  */
 
 import { formatDistanceToNowStrict } from 'date-fns';
+import { PropsWithChildren } from 'react';
 
 import Flex from 'design/Flex';
 import { SyncAlt } from 'design/Icon';
 import { P3 } from 'design/Text';
 
-export function SyncStamp({ date }: { date?: Date }) {
+export function SyncStamp({
+  date,
+  children,
+}: PropsWithChildren<{ date?: Date }>) {
   let content = 'N/A';
   if (date && date.getTime() >= 0) {
     content = formatDistanceToNowStrict(date, { addSuffix: true });
   }
 
   return (
-    <Flex data-testid="sync">
+    <Flex data-testid="sync" alignItems="center">
       <SyncAlt color="text.muted" size="small" mr={1} />
-      <P3 color="text.muted">Last Sync: {content}</P3>
+      <P3 color="text.muted">
+        Last Sync: {content} {children}
+      </P3>
     </Flex>
   );
 }


### PR DESCRIPTION
Adds children prop to SyncStamp, which will enable us to use this shared component in our `/e` components `OktaStatusDetails/AppGroupSyncDetails.tsx` & `IntegrationStatus/OktaStatusDetails/UserSyncDetails.tsx`