### PR TITLE
Fix Okta service proto

### DIFF
--- a/api/gen/proto/go/teleport/okta/v1/okta_service.pb.go
+++ b/api/gen/proto/go/teleport/okta/v1/okta_service.pb.go
@@ -415,8 +415,10 @@ type UpdateIntegrationRequest struct {
 	// in turn will disable JIT Access Requests. Makes sense only when apps and groups sync is
 	// enabled.
 	EnableBidirectionalSync bool `protobuf:"varint,10,opt,name=enable_bidirectional_sync,json=enableBidirectionalSync,proto3" json:"enable_bidirectional_sync,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Enable Okta system log export.
+	EnableSystemLogExport bool `protobuf:"varint,11,opt,name=enable_system_log_export,json=enableSystemLogExport,proto3" json:"enable_system_log_export,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *UpdateIntegrationRequest) Reset() {
@@ -494,6 +496,13 @@ func (x *UpdateIntegrationRequest) GetAccessListSettings() *AccessListSettings {
 func (x *UpdateIntegrationRequest) GetEnableBidirectionalSync() bool {
 	if x != nil {
 		return x.EnableBidirectionalSync
+	}
+	return false
+}
+
+func (x *UpdateIntegrationRequest) GetEnableSystemLogExport() bool {
+	if x != nil {
+		return x.EnableSystemLogExport
 	}
 	return false
 }
@@ -1795,7 +1804,7 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x10sso_metadata_url\x18\t \x01(\tR\x0essoMetadataUrl\x12:\n" +
 	"\x19enable_bidirectional_sync\x18\n" +
 	" \x01(\bR\x17enableBidirectionalSync\x127\n" +
-	"\x18enable_system_log_export\x18\v \x01(\bR\x15enableSystemLogExport\"\xdf\x03\n" +
+	"\x18enable_system_log_export\x18\v \x01(\bR\x15enableSystemLogExport\"\x98\x04\n" +
 	"\x18UpdateIntegrationRequest\x12M\n" +
 	"\x0fapi_credentials\x18\x02 \x01(\v2$.teleport.okta.v1.OktaAPICredentialsR\x0eapiCredentials\x12\x1d\n" +
 	"\n" +
@@ -1805,7 +1814,8 @@ const file_teleport_okta_v1_okta_service_proto_rawDesc = "" +
 	"\x15enable_app_group_sync\x18\x06 \x01(\bR\x12enableAppGroupSync\x12V\n" +
 	"\x14access_list_settings\x18\a \x01(\v2$.teleport.okta.v1.AccessListSettingsR\x12accessListSettings\x12:\n" +
 	"\x19enable_bidirectional_sync\x18\n" +
-	" \x01(\bR\x17enableBidirectionalSyncJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	" \x01(\bR\x17enableBidirectionalSync\x127\n" +
+	"\x18enable_system_log_export\x18\v \x01(\bR\x15enableSystemLogExportJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"R\x0freuse_connectorR\x10sso_metadata_url\"\x7f\n" +
 	"\x12AccessListSettings\x12#\n" +
 	"\rgroup_filters\x18\x02 \x03(\tR\fgroupFilters\x12\x1f\n" +

--- a/api/proto/teleport/okta/v1/okta_service.proto
+++ b/api/proto/teleport/okta/v1/okta_service.proto
@@ -160,6 +160,8 @@ message UpdateIntegrationRequest {
   // in turn will disable JIT Access Requests. Makes sense only when apps and groups sync is
   // enabled.
   bool enable_bidirectional_sync = 10;
+  // Enable Okta system log export.
+  bool enable_system_log_export = 11;
 }
 
 // AccessListSettings contains the settings for access list synchronization.


### PR DESCRIPTION
Fix Okta service proto to include field `enable_system_log_export` for the Update request. This mirrors the behaviour of the Create request message and fixes an initial oversight.