### PR TITLE
AutomaticReview: Handle conflicting review rules

### DIFF
--- a/lib/accessmonitoring/review/review.go
+++ b/lib/accessmonitoring/review/review.go
@@ -202,7 +202,7 @@ func (handler *Handler) onPendingRequest(ctx context.Context, req types.AccessRe
 	}
 
 	env := getAccessRequestExpressionEnv(req, user.GetTraits())
-	reviewRule := handler.selectMatchingRule(ctx, env)
+	reviewRule := handler.getMatchingRule(ctx, env)
 	if reviewRule == nil {
 		// This access request does not match any access monitoring rules.
 		return nil
@@ -233,10 +233,10 @@ func (handler *Handler) onPendingRequest(ctx context.Context, req types.AccessRe
 	return nil
 }
 
-// selectMatchingRule returns the first access monitoring rule that matches the
+// getMatchingRule returns the first access monitoring rule that matches the
 // given access request environment. If multiple rules match, `DENIED` rules
 // take precedence.
-func (handler *Handler) selectMatchingRule(
+func (handler *Handler) getMatchingRule(
 	ctx context.Context,
 	env accessmonitoring.AccessRequestExpressionEnv,
 ) *accessmonitoringrulesv1.AccessMonitoringRule {

--- a/lib/accessmonitoring/review/review.go
+++ b/lib/accessmonitoring/review/review.go
@@ -34,11 +34,6 @@ import (
 	"github.com/gravitational/teleport/lib/accessmonitoring"
 )
 
-const (
-	// componentName specifies the access review handler component name used for debugging.
-	componentName = "access_review_handler"
-)
-
 // Client aggregates the parts of Teleport API client interface
 // (as implemented by github.com/gravitational/teleport/api/client.Client)
 // that are used by the access review handler.
@@ -288,7 +283,7 @@ func newAccessReview(userName, ruleName, state string) (types.AccessReview, erro
 		ProposedState: proposedState,
 		Reason: fmt.Sprintf("Access request has been automatically %[4]s by %[1]q. "+
 			"User %[2]q is %[4]s by access_monitoring_rule %[3]q.",
-			componentName, userName, ruleName, strings.ToLower(state)),
+			teleport.SystemAccessApproverUserName, userName, ruleName, strings.ToLower(state)),
 		Created: time.Now(),
 	}, nil
 }

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -141,7 +141,7 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.Empty(t, cache.Get())
 }
 
-// TestConflictingRules verifies that when there are mutliple matching rules
+// TestConflictingRules verifies that when there are multiple matching rules
 // with conflicting review decisions, the `DENIED` rule will take precedence.
 func TestConflictingRules(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -141,6 +141,8 @@ func TestHandleAccessMonitoringRule(t *testing.T) {
 	require.Empty(t, cache.Get())
 }
 
+// TestConflictingRules verifies that when there are mutliple matching rules
+// with conflicting review decisions, the `DENIED` rule will take precedence.
 func TestConflictingRules(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)
@@ -148,12 +150,14 @@ func TestConflictingRules(t *testing.T) {
 	testReqID := uuid.New().String()
 	withSecretsFalse := false
 	requesterUserName := "requester"
+	approvedRule := newApprovedRule("approved-rule", "true")
+	deniedRule := newDeniedRule("denied-rule", "true")
 
 	// Configure both an approved and denied rule.
 	cache := accessmonitoring.NewCache()
 	cache.Put([]*accessmonitoringrulesv1.AccessMonitoringRule{
-		newApprovedRule("approved-rule", "true"),
-		newDeniedRule("denied-rule", "true"),
+		approvedRule,
+		deniedRule,
 	})
 
 	requester, err := types.NewUser(requesterUserName)
@@ -162,6 +166,18 @@ func TestConflictingRules(t *testing.T) {
 	client := &mockClient{}
 	client.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
 		Return(requester, nil)
+
+	review, err := newAccessReview(
+		requesterUserName,
+		deniedRule.GetMetadata().GetName(),
+		deniedRule.GetSpec().GetAutomaticReview().GetDecision())
+	require.NoError(t, err)
+	review.Created = time.Time{}
+
+	client.On("SubmitAccessReview", mock.Anything, types.AccessReviewSubmission{
+		RequestID: testReqID,
+		Review:    review,
+	}).Return(mock.Anything, nil)
 
 	handler, err := NewHandler(Config{
 		HandlerName: handlerName,
@@ -177,8 +193,7 @@ func TestConflictingRules(t *testing.T) {
 		Type:     types.OpPut,
 		Resource: req,
 	}
-	require.ErrorContains(t, handler.HandleAccessRequest(ctx, event),
-		"conflicting access review rule")
+	require.NoError(t, handler.HandleAccessRequest(ctx, event))
 }
 
 func TestResourceRequest(t *testing.T) {


### PR DESCRIPTION
Currently, if an access request matches multiple rules with conflicting review decisions, no review is submitted. This behavior is not very user-friendly, as users are given no indication of why an automatic review was not submitted. The only way to troubleshoot the issue is to manually list and inspect all automatic review rules.

This PR changes that behavior so that if an access request matches multiple rules with conflicting review decisions, `DENIED` rules take precedence. This should provide a better user experience and aligns with how Teleport's RBAC system typically handles similar scenarios.

This PR also makes a minor change to the automatic review reason message. The message no longer uses the obscure  `access_review_handler` component name.

Changelog: Denied rules take precedence when conflicting automatic review rules are configured