### PR TITLE
Make k8s namespaces addressable individually in RBAC

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1450,12 +1450,11 @@ var KubernetesResourcesV7KindGroups = map[string]string{
 // to their kubernetes name.
 // Used to upgrade roles <=v7 as well as to support existing access request
 // format.
-// TODO(@creack): Remove this, find a better way to handle the mapping.
+// NOTE: Namespace having a different behavior between versions, it is omitted from this map.
 var KubernetesResourcesKindsPlurals = map[string]string{
 	KindKubePod:                       "pods",
 	KindKubeSecret:                    "secrets",
 	KindKubeConfigmap:                 "configmaps",
-	KindKubeNamespace:                 "namespaces",
 	KindKubeService:                   "services",
 	KindKubeServiceAccount:            "serviceaccounts",
 	KindKubeNode:                      "nodes",
@@ -1521,7 +1520,7 @@ var KubernetesVerbs = []string{
 
 // KubernetesClusterWideResourceKinds is the list of supported Kubernetes cluster resource kinds
 // that are not namespaced.
-// TODO(@creack): Remove in favor of proper lookup.
+// Needed to maintain backward compatibility.
 var KubernetesClusterWideResourceKinds = []string{
 	KindKubeNamespace,
 	KindKubeNode,

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -302,13 +302,16 @@ type Role interface {
 	Clone() Role
 }
 
+// DefaultRoleVersion for NewRole() and test helpers.
+// When incrementing the role version, make sure to update the
+// role version in the asset file used by the UI.
+// See: web/packages/teleport/src/Roles/templates/role.yaml
+const DefaultRoleVersion = V8
+
 // NewRole constructs new standard V8 role.
 // This creates a V8 role with V4+ RBAC semantics.
 func NewRole(name string, spec RoleSpecV6) (Role, error) {
-	// When incrementing the role version, make sure to update the
-	// role version in the asset file used by the UI.
-	// See: web/packages/teleport/src/Roles/templates/role.yaml
-	role, err := NewRoleWithVersion(name, V8, spec)
+	role, err := NewRoleWithVersion(name, DefaultRoleVersion, spec)
 	return role, trace.Wrap(err)
 }
 
@@ -463,38 +466,82 @@ func (r *RoleV6) GetKubeResources(rct RoleConditionType) []KubernetesResource {
 	if rct == Allow {
 		return r.convertAllowKubernetesResourcesBetweenRoleVersions(r.Spec.Allow.KubernetesResources)
 	}
-	return r.convertDenyKubernetesResourcesBetweenRoleVersions(r.Spec.Deny.KubernetesResources)
+	return r.convertKubernetesResourcesBetweenRoleVersions(r.Spec.Deny.KubernetesResources)
 }
 
-// convertDenyKubernetesResourcesBetweenRoleVersions converts Kubernetes resources between role versions.
+// convertKubernetesResourcesBetweenRoleVersions converts Kubernetes resources between role versions.
 // This is required to keep compatibility between role versions to avoid breaking changes
 // when using an older role version.
 //
 // For roles v8, it returns the list as it is.
 //
 // For roles <=v7, it maps the legacy teleport Kinds to k8s plurals and sets the APIGroup to wildcard.
-func (r *RoleV6) convertDenyKubernetesResourcesBetweenRoleVersions(resources []KubernetesResource) []KubernetesResource {
+func (r *RoleV6) convertKubernetesResourcesBetweenRoleVersions(resources []KubernetesResource) []KubernetesResource {
 	switch r.Version {
 	case V8:
 		return resources
 	default:
 		v7resources := slices.Clone(resources)
+		var extraResources []KubernetesResource
 		for i, r := range v7resources {
+			// "namespace" kind used to mean "namespaces" and all resources in the namespace.
+			// It is now represented by 'namespaces' for the resource itself and wildcard for
+			// all resources in the namespace.
+			if r.Kind == KindKubeNamespace {
+				r.Kind = Wildcard
+				if r.Name == Wildcard {
+					r.Namespace = "^" + Wildcard + "$"
+				} else {
+					r.Namespace = r.Name
+				}
+				r.Name = Wildcard
+				r.APIGroup = Wildcard
+				v7resources[i] = r
+				extraResources = append(extraResources, KubernetesResource{
+					Kind:  "namespaces",
+					Name:  r.Namespace,
+					Verbs: r.Verbs,
+				})
+				continue
+			}
+			// The namespace field was ignored in v7 for global resources.
+			if r.Namespace != "" && slices.Contains(KubernetesClusterWideResourceKinds, r.Kind) {
+				r.Namespace = ""
+			}
 			if k, ok := KubernetesResourcesKindsPlurals[r.Kind]; ok { // Can be empty if the kind is a wildcard.
 				r.Kind = k
 			}
 			r.APIGroup = Wildcard
 			v7resources[i] = r
+			if r.Kind == Wildcard { // If we have a wildcard, inject the clusterwide resources.
+				for _, elem := range KubernetesClusterWideResourceKinds {
+					if elem == KindKubeNamespace { // Namespace is handled separately.
+						continue
+					}
+					extraResources = append(extraResources, KubernetesResource{
+						Kind:     KubernetesResourcesKindsPlurals[elem],
+						Name:     r.Name,
+						Verbs:    r.Verbs,
+						APIGroup: Wildcard,
+					})
+				}
+			}
 		}
-		return v7resources
+		return append(v7resources, extraResources...)
 	}
 }
 
-// convertKubeResourcesBetweenRoleVersions converts Kubernetes resources between role versions.
+// convertAllowKubeResourcesBetweenRoleVersions converts Kubernetes resources between role versions.
 // This is required to keep compatibility between role versions to avoid breaking changes
 // when using an older role version.
 //
 // For roles v8, it returns the list as it is.
+//
+// For roles v7, if we have a Wildcard kind, add the v7 cluster-wide resources to maintain
+// the existing behavior as in Teleport <=v17, those resources ignored the namespace value
+// of the rbac entry. Earlier roles didn't support wildcard so it is not a concern.
+//
+// For roles v7, if we have a "namespace" kind, map it to a wildcard + namespaces kind.
 //
 // For roles <=v7, it sets the APIGroup to wildcard for all resources and maps the legacy
 // teleport Kinds to k8s plurals.
@@ -507,18 +554,9 @@ func (r *RoleV6) convertDenyKubernetesResourcesBetweenRoleVersions(resources []K
 // and append the other supported resources - KubernetesResourcesKinds - for Role v8.
 func (r *RoleV6) convertAllowKubernetesResourcesBetweenRoleVersions(resources []KubernetesResource) []KubernetesResource {
 	switch r.Version {
-	case V8:
-		return resources
-	case V7:
-		v7resources := slices.Clone(resources)
-		for i, r := range v7resources {
-			if k, ok := KubernetesResourcesKindsPlurals[r.Kind]; ok { // Can be empty if the kind is a wildcard.
-				r.Kind = k
-			}
-			r.APIGroup = Wildcard
-			v7resources[i] = r
-		}
-		return v7resources
+	case V7, V8:
+		// V7 and v8 uses the same logic for allow and deny.
+		return r.convertKubernetesResourcesBetweenRoleVersions(resources)
 	// Teleport does not support role versions < v3.
 	case V6, V5, V4, V3:
 		switch {
@@ -1232,9 +1270,10 @@ func (r *RoleV6) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 	case V7:
-		// Kubernetes resources default to {kind:*, name:*, namespace:*} for v7 and v8 roles.
+		// Kubernetes resources default to {kind:*, name:*, namespace:*, verbs:[*]} for v7 roles.
 		if len(r.Spec.Allow.KubernetesResources) == 0 && r.HasLabelMatchers(Allow, KindKubernetesCluster) {
 			r.Spec.Allow.KubernetesResources = []KubernetesResource{
+				// Full access to everything.
 				{
 					Kind:      Wildcard,
 					Namespace: Wildcard,
@@ -1247,9 +1286,10 @@ func (r *RoleV6) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 	case V8:
-		// Kubernetes resources default to {kind:*, name:*, namespace:*, group:*} for v7 and v8 roles.
+		// Kubernetes resources default to {kind:*, name:*, namespace:*, api_group:*, verbs:[*]} for v8 roles.
 		if len(r.Spec.Allow.KubernetesResources) == 0 && r.HasLabelMatchers(Allow, KindKubernetesCluster) {
 			r.Spec.Allow.KubernetesResources = []KubernetesResource{
+				// Full access to everything.
 				{
 					Kind:      Wildcard,
 					Namespace: Wildcard,
@@ -1956,17 +1996,17 @@ func validateKubeResources(roleVersion string, kubeResources []KubernetesResourc
 			fallthrough
 		case V7:
 			if kubeResource.APIGroup != "" {
-				return trace.BadParameter("Group %q is not supported in role version %q. Upgrade the role version to %q", kubeResource.APIGroup, roleVersion, V8)
+				return trace.BadParameter("API Group %q is not supported in role version %q. Upgrade the role version to %q", kubeResource.APIGroup, roleVersion, V8)
 			}
 			if kubeResource.Kind != Wildcard && !slices.Contains(KubernetesResourcesKinds, kubeResource.Kind) {
 				return trace.BadParameter("KubernetesResource kind %q is invalid or unsupported; Supported: %v", kubeResource.Kind, append([]string{Wildcard}, KubernetesResourcesKinds...))
 			}
 			if kubeResource.Namespace == "" && !slices.Contains(KubernetesClusterWideResourceKinds, kubeResource.Kind) {
-				return trace.BadParameter("KubernetesResource must include Namespace")
+				return trace.BadParameter("KubernetesResource kind %q must include Namespace", kubeResource.Kind)
 			}
 		case V8:
 			if kubeResource.Kind == "" {
-				return trace.BadParameter("KubernetesResource kind is required in role version %q", roleVersion)
+				return trace.BadParameter("KubernetesResource kind %q is required in role version %q", kubeResource.Kind, roleVersion)
 			}
 			// If we have a kind that match a role v7 one, check the api group.
 			if slices.Contains(KubernetesResourcesKinds, kubeResource.Kind) {

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -358,6 +358,182 @@ func TestRole_GetKubeResources(t *testing.T) {
 			},
 		},
 		{
+			name: "v7 with allow wildcard kind",
+			args: args{
+				version: V7,
+				labels:  kubeLabels,
+				resources: []KubernetesResource{
+					{
+						// rolev7 ignored the namespace field for global resources.
+						Kind:      Wildcard,
+						Namespace: "default",
+						Name:      Wildcard,
+						Verbs:     []string{Wildcard},
+					},
+				},
+			},
+			assertErrorCreation: require.NoError,
+			wantAllow: []KubernetesResource{
+				// Expect the main resource to match namespaced resources.
+				{
+					Kind:      Wildcard,
+					Namespace: "default",
+					Name:      Wildcard,
+					Verbs:     []string{Wildcard},
+					APIGroup:  Wildcard,
+				},
+				// Expect injected global resources to maintain v7 behavior.
+				{
+					Kind:     "nodes",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "persistentvolumes",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "clusterroles",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "clusterrolebindings",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "certificatesigningrequests",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+			},
+		},
+		{
+			name: "v7 with deny wildcard kind",
+			args: args{
+				version: V7,
+				labels:  kubeLabels,
+				resources: []KubernetesResource{
+					{
+						// rolev7 ignored the namespace field for global resources.
+						Kind:      Wildcard,
+						Namespace: "default",
+						Name:      Wildcard,
+						Verbs:     []string{Wildcard},
+					},
+				},
+			},
+			assertErrorCreation: require.NoError,
+			wantDeny: []KubernetesResource{
+				// Expect the main resource to match namespaced resources.
+				{
+					Kind:      Wildcard,
+					Namespace: "default",
+					Name:      Wildcard,
+					Verbs:     []string{Wildcard},
+					APIGroup:  Wildcard,
+				},
+				// Expect injected global resources to maintain v7 behavior.
+				{
+					Kind:     "nodes",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "persistentvolumes",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "clusterroles",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "clusterrolebindings",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+				{
+					Kind:     "certificatesigningrequests",
+					Name:     Wildcard,
+					Verbs:    []string{Wildcard},
+					APIGroup: Wildcard,
+				},
+			},
+		},
+		{
+			name: "v7 with allow namespace",
+			args: args{
+				version: V7,
+				labels:  kubeLabels,
+				resources: []KubernetesResource{
+					{
+						Kind:  KindKubeNamespace,
+						Name:  "default",
+						Verbs: []string{Wildcard},
+					},
+				},
+			},
+			assertErrorCreation: require.NoError,
+			wantAllow: []KubernetesResource{
+				{
+					Kind:      Wildcard,
+					Namespace: "default",
+					Name:      Wildcard,
+					Verbs:     []string{Wildcard},
+					APIGroup:  Wildcard,
+				},
+				{
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{Wildcard},
+				},
+			},
+		},
+
+		{
+			name: "v7 with deny namespace",
+			args: args{
+				version: V7,
+				labels:  kubeLabels,
+				resources: []KubernetesResource{
+					{
+						Kind:  KindKubeNamespace,
+						Name:  "default",
+						Verbs: []string{Wildcard},
+					},
+				},
+			},
+			assertErrorCreation: require.NoError,
+			wantDeny: []KubernetesResource{
+				{
+					Kind:      Wildcard,
+					Namespace: "default",
+					Name:      Wildcard,
+					Verbs:     []string{Wildcard},
+					APIGroup:  Wildcard,
+				},
+				{
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{Wildcard},
+				},
+			},
+		},
+
+		{
 			name: "v6 without wildcard; labels expression",
 			args: args{
 				version:          V6,

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5373,13 +5373,6 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 					APIGroup:  types.Wildcard,
 				},
 				{
-					Kind:      types.Wildcard,
-					Name:      types.Wildcard,
-					Namespace: types.Wildcard,
-					Verbs:     []string{types.Wildcard},
-					APIGroup:  types.Wildcard,
-				},
-				{
 					Kind:      "ingresses",
 					Name:      types.Wildcard,
 					Namespace: types.Wildcard,
@@ -5399,13 +5392,6 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 			KubernetesResources: []types.KubernetesResource{
 				{
 					Kind:      "pods",
-					Name:      types.Wildcard,
-					Namespace: types.Wildcard,
-					Verbs:     []string{types.Wildcard},
-					APIGroup:  types.Wildcard,
-				},
-				{
-					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
 					Namespace: types.Wildcard,
 					Verbs:     []string{types.Wildcard},
@@ -5454,6 +5440,43 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 					Name:      types.Wildcard,
 					Namespace: types.Wildcard,
 					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			},
+		},
+	})
+	downgradev7incompatibleNamespace := newRole("downgrade_v7_incompatible_namespace", types.V8, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind:  "namespaces",
+					Name:  "foo",
+					Verbs: []string{types.Wildcard},
+				},
+			},
+		},
+	})
+	downgradev7incompatibleNamespacedWildcard := newRole("downgrade_v7_incompatible_namespaced_wildcard", types.V8, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      "foo",
+					Namespace: "bar",
+					Verbs:     []string{"get"},
+					APIGroup:  types.Wildcard,
+				},
+			},
+		},
+	})
+	downgradev7incompatibleClusterWideWildcard := newRole("downgrade_v7_incompatible_cluster_wide_wildcard", types.V8, types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      "bar",
+					Namespace: "", // Cluster wide.
+					Verbs:     []string{"get"},
 					APIGroup:  types.Wildcard,
 				},
 			},
@@ -5515,6 +5538,9 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 		testRole1,
 		downgradev7comptibleK8sResourcesRole,
 		downgradev7incompatibleK8sResourcesRole,
+		downgradev7incompatibleNamespace,
+		downgradev7incompatibleNamespacedWildcard,
+		downgradev7incompatibleClusterWideWildcard,
 		downgradev7mixedK8sResourcesRole,
 	)
 	require.NoError(t, err)
@@ -5553,12 +5579,6 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 							Verbs:     []string{types.Wildcard},
 						},
 						{
-							Kind:      types.Wildcard,
-							Name:      types.Wildcard,
-							Namespace: types.Wildcard,
-							Verbs:     []string{types.Wildcard},
-						},
-						{
 							Kind:      types.KindKubeIngress,
 							Name:      types.Wildcard,
 							Namespace: types.Wildcard,
@@ -5576,12 +5596,6 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 					KubernetesResources: []types.KubernetesResource{
 						{
 							Kind:      types.KindKubePod,
-							Name:      types.Wildcard,
-							Namespace: types.Wildcard,
-							Verbs:     []string{types.Wildcard},
-						},
-						{
-							Kind:      types.Wildcard,
 							Name:      types.Wildcard,
 							Namespace: types.Wildcard,
 							Verbs:     []string{types.Wildcard},
@@ -5617,6 +5631,105 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 			},
 			inputRole: downgradev7incompatibleK8sResourcesRole,
 			expectedRole: newRole(downgradev7incompatibleK8sResourcesRole.GetName(), types.V7, types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					KubernetesResources: nil,
+				},
+				Deny: types.RoleConditions{
+					KubernetesLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					KubernetesResources: []types.KubernetesResource{
+						{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+						},
+					},
+				},
+				Options: types.RoleOptions{
+					IDP: &types.IdPOptions{
+						SAML: &types.IdPSAMLOptions{
+							Enabled: types.NewBoolOption(false),
+						},
+					},
+				},
+			}),
+			expectDowngraded: true,
+		},
+		{
+			desc: "downgrade v7 incompatible k8s namespaces kind",
+			clientVersions: []string{
+				"17.2.7",
+			},
+			inputRole: downgradev7incompatibleNamespace,
+			expectedRole: newRole(downgradev7incompatibleNamespace.GetName(), types.V7, types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					KubernetesResources: nil,
+				},
+				Deny: types.RoleConditions{
+					KubernetesLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					KubernetesResources: []types.KubernetesResource{
+						{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+						},
+					},
+				},
+				Options: types.RoleOptions{
+					IDP: &types.IdPOptions{
+						SAML: &types.IdPSAMLOptions{
+							Enabled: types.NewBoolOption(false),
+						},
+					},
+				},
+			}),
+			expectDowngraded: true,
+		},
+		{
+			desc: "downgrade v7 incompatible k8s namespaced wildcard kind",
+			clientVersions: []string{
+				"17.2.7",
+			},
+			inputRole: downgradev7incompatibleNamespacedWildcard,
+			expectedRole: newRole(downgradev7incompatibleNamespacedWildcard.GetName(), types.V7, types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					KubernetesResources: nil,
+				},
+				Deny: types.RoleConditions{
+					KubernetesLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					KubernetesResources: []types.KubernetesResource{
+						{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+						},
+					},
+				},
+				Options: types.RoleOptions{
+					IDP: &types.IdPOptions{
+						SAML: &types.IdPSAMLOptions{
+							Enabled: types.NewBoolOption(false),
+						},
+					},
+				},
+			}),
+			expectDowngraded: true,
+		},
+		{
+			desc: "downgrade v7 incompatible k8s cluster wide wildcard kind",
+			clientVersions: []string{
+				"17.2.7",
+			},
+			inputRole: downgradev7incompatibleClusterWideWildcard,
+			expectedRole: newRole(downgradev7incompatibleClusterWideWildcard.GetName(), types.V7, types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					KubernetesResources: nil,
 				},

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -1395,10 +1395,18 @@ func CreateUser(ctx context.Context, clt clt, username string, roles ...types.Ro
 type createUserAndRoleOptions struct {
 	mutateUser []func(user types.User)
 	mutateRole []func(role types.Role)
+	version    string
 }
 
 // CreateUserAndRoleOption is a functional option for CreateUserAndRole
 type CreateUserAndRoleOption func(*createUserAndRoleOptions)
+
+// WithRoleVersion sets the version of the role to be created.
+func WithRoleVersion(version string) CreateUserAndRoleOption {
+	return func(o *createUserAndRoleOptions) {
+		o.version = version
+	}
+}
 
 // WithUserMutator sets a function that will be called to mutate the user before it is created
 func WithUserMutator(mutate ...func(user types.User)) CreateUserAndRoleOption {
@@ -1419,7 +1427,9 @@ func WithRoleMutator(mutate ...func(role types.Role)) CreateUserAndRoleOption {
 // If allowRules is not-nil, then the rules associated with the role will be
 // replaced with those specified.
 func CreateUserAndRole(clt clt, username string, allowedLogins []string, allowRules []types.Rule, opts ...CreateUserAndRoleOption) (types.User, types.Role, error) {
-	o := createUserAndRoleOptions{}
+	o := createUserAndRoleOptions{
+		version: types.DefaultRoleVersion,
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -1429,7 +1439,7 @@ func CreateUserAndRole(clt clt, username string, allowedLogins []string, allowRu
 		return nil, nil, trace.Wrap(err)
 	}
 
-	role := services.RoleForUser(user)
+	role := services.RoleWithVersionForUser(user, o.version)
 	role.SetLogins(types.Allow, allowedLogins)
 	if allowRules != nil {
 		role.SetRules(types.Allow, allowRules)

--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -90,7 +90,15 @@ func TestListKubernetesResources(t *testing.T) {
 				// override the role to allow access to all kube resources.
 				r.SetKubeResources(
 					types.Allow,
-					[]types.KubernetesResource{{Kind: types.Wildcard, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}, APIGroup: types.Wildcard}},
+					[]types.KubernetesResource{
+						{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+							APIGroup:  types.Wildcard,
+						},
+					},
 				)
 			},
 		},
@@ -555,7 +563,7 @@ func TestListKubernetesResources(t *testing.T) {
 						Kind:    types.KindKubeClusterRole,
 						Version: "v1",
 						Metadata: types.Metadata{
-							Name:      "nginx-1",
+							Name:      "cr-nginx-1",
 							Namespace: "default",
 						},
 						Spec: types.KubernetesResourceSpecV1{},
@@ -564,7 +572,7 @@ func TestListKubernetesResources(t *testing.T) {
 						Kind:    types.KindKubeClusterRole,
 						Version: "v1",
 						Metadata: types.Metadata{
-							Name:      "nginx-2",
+							Name:      "cr-nginx-2",
 							Namespace: "default",
 						},
 						Spec: types.KubernetesResourceSpecV1{},
@@ -573,7 +581,7 @@ func TestListKubernetesResources(t *testing.T) {
 						Kind:    types.KindKubeClusterRole,
 						Version: "v1",
 						Metadata: types.Metadata{
-							Name:      "test",
+							Name:      "cr-test",
 							Namespace: "default",
 						},
 						Spec: types.KubernetesResourceSpecV1{},

--- a/lib/kube/proxy/resource_filters.go
+++ b/lib/kube/proxy/resource_filters.go
@@ -75,6 +75,7 @@ func newResourceFilterer(kind, group, verb string, isClusterWideResource bool, c
 // wildcardFilter is a filter that matches all pods.
 var wildcardFilter = types.KubernetesResource{
 	Kind:      types.Wildcard,
+	APIGroup:  types.Wildcard,
 	Namespace: types.Wildcard,
 	Name:      types.Wildcard,
 	Verbs:     []string{types.Wildcard},
@@ -84,6 +85,7 @@ var wildcardFilter = types.KubernetesResource{
 func containsWildcard(resources []types.KubernetesResource) bool {
 	for _, r := range resources {
 		if r.Kind == wildcardFilter.Kind &&
+			r.APIGroup == wildcardFilter.APIGroup &&
 			r.Name == wildcardFilter.Name &&
 			r.Namespace == wildcardFilter.Namespace &&
 			len(r.Verbs) == 1 && r.Verbs[0] == wildcardFilter.Verbs[0] {

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -29,6 +29,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -168,7 +169,6 @@ type KubeUpgradeRequests struct {
 }
 
 type KubeMockServer struct {
-	router               *httprouter.Router
 	log                  *slog.Logger
 	server               *httptest.Server
 	TLS                  *tls.Config
@@ -197,7 +197,6 @@ type KubeMockServer struct {
 // TODO(tigrato): add support for other endpoints
 func NewKubeAPIMock(opts ...Option) (*KubeMockServer, error) {
 	s := &KubeMockServer{
-		router:           httprouter.New(),
 		log:              slog.Default(),
 		deletedResources: make(map[deletedResource][]string),
 		version: &apimachineryversion.Info{
@@ -230,46 +229,53 @@ func NewKubeAPIMock(opts ...Option) (*KubeMockServer, error) {
 }
 
 func (s *KubeMockServer) setup() {
-	s.router.UseRawPath = true
-	s.router.POST("/api/:ver/namespaces/:namespace/pods/:name/exec", s.withWriter(s.exec))
-	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name/exec", s.withWriter(s.exec))
-	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name/portforward", s.withWriter(s.portforward))
-	s.router.POST("/api/:ver/namespaces/:namespace/pods/:name/portforward", s.withWriter(s.portforward))
+	// NOTE: We use stdlib because the gravitational/httplib package doesn't support k8s patterns,
+	// it panics due to overlapping routes.
+	router := http.NewServeMux()
 
-	s.router.GET("/apis/rbac.authorization.k8s.io/:ver/clusterroles", s.withWriter(s.listClusterRoles))
-	s.router.GET("/apis/rbac.authorization.k8s.io/:ver/clusterroles/:name", s.withWriter(s.getClusterRole))
-	s.router.DELETE("/apis/rbac.authorization.k8s.io/:ver/clusterroles/:name", s.withWriter(s.deleteClusterRole))
-	s.router.GET("/apis/rbac.authorization.k8s.io/:ver", s.withWriter(s.discoveryEndpoint))
+	router.Handle("POST /api/{ver}/namespaces/{namespace}/pods/{name}/exec", s.withWriter(s.exec))
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/pods/{name}/exec", s.withWriter(s.exec))
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/pods/{name}/portforward", s.withWriter(s.portforward))
+	router.Handle("POST /api/{ver}/namespaces/{namespace}/pods/{name}/portforward", s.withWriter(s.portforward))
 
-	s.router.GET("/api/:ver/namespaces/:namespace/pods", s.withWriter(s.listPods))
-	s.router.GET("/api/:ver/pods", s.withWriter(s.listPods))
-	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name", s.withWriter(s.getPod))
-	s.router.DELETE("/api/:ver/namespaces/:namespace/pods/:name", s.withWriter(s.deletePod))
+	router.Handle("GET /apis/rbac.authorization.k8s.io/{ver}/clusterroles", s.withWriter(s.listClusterRoles))
+	router.Handle("GET /apis/rbac.authorization.k8s.io/{ver}/clusterroles/{name}", s.withWriter(s.getClusterRole))
+	router.Handle("DELETE /apis/rbac.authorization.k8s.io/{ver}/clusterroles/{name}", s.withWriter(s.deleteClusterRole))
+	router.Handle("GET /apis/rbac.authorization.k8s.io/{ver}", s.withWriter(s.discoveryEndpoint))
 
-	s.router.GET("/api/:ver/namespaces/:namespace/secrets", s.withWriter(s.listSecrets))
-	s.router.GET("/api/:ver/secrets", s.withWriter(s.listSecrets))
-	s.router.GET("/api/:ver/namespaces/:namespace/secrets/:name", s.withWriter(s.getSecret))
-	s.router.DELETE("/api/:ver/namespaces/:namespace/secrets/:name", s.withWriter(s.deleteSecret))
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/pods", s.withWriter(s.listPods))
+	router.Handle("GET /api/{ver}/pods", s.withWriter(s.listPods))
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/pods/{name}", s.withWriter(s.getPod))
+	router.Handle("DELETE /api/{ver}/namespaces/{namespace}/pods/{name}", s.withWriter(s.deletePod))
 
-	s.router.POST("/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", s.withWriter(s.selfSubjectAccessReviews))
+	router.Handle("GET /api/{ver}/namespaces", s.withWriter(s.listNamespaces))
+	router.Handle("GET /api/{ver}/namespaces/{name}", s.withWriter(s.getNamespace))
+	router.Handle("DELETE /api/v1/namespaces/{name}", s.withWriter(s.deleteNamespace))
+
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/secrets", s.withWriter(s.listSecrets))
+	router.Handle("GET /api/{ver}/secrets", s.withWriter(s.listSecrets))
+	router.Handle("GET /api/{ver}/namespaces/{namespace}/secrets/{name}", s.withWriter(s.getSecret))
+	router.Handle("DELETE /api/{ver}/namespaces/{namespace}/secrets/{name}", s.withWriter(s.deleteSecret))
+
+	router.Handle("POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews", s.withWriter(s.selfSubjectAccessReviews))
 
 	for k, crd := range s.crds {
-		s.router.GET("/apis/"+k.group+"/"+k.version+"/namespaces/:namespace/"+k.plural, s.withWriter(s.listCRDs(crd)))
-		s.router.GET("/apis/"+k.group+"/"+k.version+"/"+k.plural, s.withWriter(s.listCRDs(crd)))
-		s.router.GET("/apis/"+k.group+"/"+k.version+"/namespaces/:namespace/"+k.plural+"/:name", s.withWriter(s.getCRD(crd)))
-		s.router.DELETE("/apis/"+k.group+"/"+k.version+"/namespaces/:namespace/"+k.plural+"/:name", s.withWriter(s.deleteCRD(crd)))
+		router.Handle("GET /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural, s.withWriter(s.listCRDs(crd)))
+		router.Handle("GET /apis/"+k.group+"/"+k.version+"/"+k.plural, s.withWriter(s.listCRDs(crd)))
+		router.Handle("GET /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural+"/{name}", s.withWriter(s.getCRD(crd)))
+		router.Handle("DELETE /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural+"/{name}", s.withWriter(s.deleteCRD(crd)))
 	}
 
-	s.router.GET("/version", s.withWriter(s.versionEndpoint))
+	router.Handle("GET /version", s.withWriter(s.versionEndpoint))
 
-	for _, endpoint := range []string{"/api", "/api/:ver", "/apis"} {
-		s.router.GET(endpoint, s.withWriter(s.discoveryEndpoint))
+	for _, endpoint := range []string{"/api", "/api/{ver}", "/apis"} {
+		router.Handle("GET "+endpoint, s.withWriter(s.discoveryEndpoint))
 	}
 	for k, v := range s.crds {
-		s.router.GET("/apis/"+k.group+"/"+k.version, s.withWriter(crdDiscovery(v)))
+		router.Handle("GET /apis/"+k.group+"/"+k.version, s.withWriter(crdDiscovery(v)))
 	}
 
-	s.server = httptest.NewUnstartedServer(s.router)
+	s.server = httptest.NewUnstartedServer(router)
 	s.server.EnableHTTP2 = true
 }
 
@@ -301,8 +307,20 @@ func (s *KubeMockServer) Close() error {
 	return nil
 }
 
-func (s *KubeMockServer) withWriter(handler httplib.HandlerFunc) httprouter.Handle {
-	return httplib.MakeHandlerWithErrorWriter(handler, s.formatResponseError)
+var routerRe = regexp.MustCompile(`\{([^}]+)\}`)
+
+// withWriter handles the glue to support stdlib handler.
+func (s *KubeMockServer) withWriter(handler httplib.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		matches := routerRe.FindAllStringSubmatch(r.Pattern, -1)
+
+		p := httprouter.Params{}
+		for _, elem := range matches {
+			p = append(p, httprouter.Param{Key: elem[1], Value: r.PathValue(elem[1])})
+		}
+
+		httplib.MakeHandlerWithErrorWriter(handler, s.formatResponseError)(w, r, p)
+	}
 }
 
 func (s *KubeMockServer) formatResponseError(rw http.ResponseWriter, respErr error) {

--- a/lib/kube/proxy/testing/kube_server/namespaces.go
+++ b/lib/kube/proxy/testing/kube_server/namespaces.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -24,32 +24,33 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
-	authv1 "k8s.io/api/rbac/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
 )
 
-var clusterRoleList = authv1.ClusterRoleList{
+var namespaceList = corev1.NamespaceList{
 	TypeMeta: metav1.TypeMeta{
-		Kind:       "ClusterRoleList",
-		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "NamespaceList",
+		APIVersion: "v1",
 	},
 	ListMeta: metav1.ListMeta{
 		ResourceVersion: "1231415",
 	},
-	Items: []authv1.ClusterRole{
-		newClusterRole("cr-nginx-1"),
-		newClusterRole("cr-nginx-2"),
-		newClusterRole("cr-test"),
+	Items: []corev1.Namespace{
+		newNamespace("default"),
+		newNamespace("test"),
+		newNamespace("dev"),
+		newNamespace("prod"),
 	},
 }
 
-func newClusterRole(name string) authv1.ClusterRole {
-	return authv1.ClusterRole{
+func newNamespace(name string) corev1.Namespace {
+	return corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Namespace",
+			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -57,25 +58,27 @@ func newClusterRole(name string) authv1.ClusterRole {
 	}
 }
 
-func (s *KubeMockServer) listClusterRoles(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
-	return &clusterRoleList, nil
+func (s *KubeMockServer) listNamespaces(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+	list := namespaceList.DeepCopy()
+	return list, nil
 }
 
-func (s *KubeMockServer) getClusterRole(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+func (s *KubeMockServer) getNamespace(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	name := p.ByName("name")
-	filter := func(role authv1.ClusterRole) bool {
+	filter := func(role corev1.Namespace) bool {
 		return role.Name == name
 	}
-	for _, role := range clusterRoleList.Items {
+	for _, role := range namespaceList.Items {
 		if filter(role) {
 			return role, nil
 		}
 	}
-	return nil, trace.NotFound("cluster role %q not found", name)
+	return nil, trace.NotFound("namespace %q not found", name)
 }
 
-func (s *KubeMockServer) deleteClusterRole(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+func (s *KubeMockServer) deleteNamespace(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	name := p.ByName("name")
+
 	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -84,24 +87,24 @@ func (s *KubeMockServer) deleteClusterRole(w http.ResponseWriter, req *http.Requ
 	if deleteOpts.Preconditions != nil && deleteOpts.Preconditions.UID != nil {
 		reqID = string(*deleteOpts.Preconditions.UID)
 	}
-	filter := func(role authv1.ClusterRole) bool {
+	filter := func(role corev1.Namespace) bool {
 		return role.Name == name
 	}
-	for _, role := range clusterRoleList.Items {
+	for _, role := range namespaceList.Items {
 		if filter(role) {
 			s.mu.Lock()
-			key := deletedResource{reqID, types.KindKubeClusterRole}
+			key := deletedResource{reqID, types.KindKubeNamespace}
 			s.deletedResources[key] = append(s.deletedResources[key], name)
 			s.mu.Unlock()
 			return role, nil
 		}
 	}
-	return nil, trace.NotFound("cluster %q not found", name)
+	return nil, trace.NotFound("namespace %q not found", name)
 }
 
-func (s *KubeMockServer) DeletedClusterRoles(reqID string) []string {
+func (s *KubeMockServer) Deletednamespaces(reqID string) []string {
 	s.mu.Lock()
-	key := deletedResource{reqID, types.KindKubeClusterRole}
+	key := deletedResource{reqID, types.KindKubeNamespace}
 	deleted := make([]string, len(s.deletedResources[key]))
 	copy(deleted, s.deletedResources[key])
 	s.mu.Unlock()

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -40,13 +40,14 @@ type metaResource struct {
 	resourceDefinition *metav1.APIResource // Resource definition data from the schema.
 	requestedResource  apiResource         // User input, based on URL.
 	verb               string              // Verb of the user request.
+	isClusterWide      bool                // TODO(@creack): Remove this in favor of resourceDefinition.Namespaced.
 }
 
 func (mr *metaResource) isClusterWideResource() bool {
-	if mr == nil || mr.resourceDefinition == nil {
+	if mr == nil {
 		return false
 	}
-	return !mr.resourceDefinition.Namespaced
+	return mr.isClusterWide || (mr.resourceDefinition != nil && !mr.resourceDefinition.Namespaced)
 }
 
 func (mr *metaResource) rbacResource() *types.KubernetesResource {
@@ -236,6 +237,7 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 		// If the resource is not supported, return nil.
 		return out, nil
 	}
+	out.isClusterWide = !resource.Namespaced
 
 	if apiResource.resourceName == "" && out.verb != types.KubeVerbCreate {
 		// if the resource is supported but the resource name is not present and not a create request,

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -451,6 +451,10 @@ type RoleSpec struct {
 
 // CreateUserWithTraitsAndRole creates Teleport user and role with specified names
 func (c *TestContext) CreateUserWithTraitsAndRole(ctx context.Context, t *testing.T, username string, userTraits map[string][]string, roleSpec RoleSpec) (types.User, types.Role) {
+	return c.CreateUserWithTraitsAndRoleVersion(ctx, t, username, userTraits, types.DefaultRoleVersion, roleSpec)
+}
+
+func (c *TestContext) CreateUserWithTraitsAndRoleVersion(ctx context.Context, t *testing.T, username string, userTraits map[string][]string, roleVersion string, roleSpec RoleSpec) (types.User, types.Role) {
 	user, role, err := auth.CreateUserAndRole(
 		c.TLSServer.Auth(),
 		username,
@@ -459,6 +463,7 @@ func (c *TestContext) CreateUserWithTraitsAndRole(ctx context.Context, t *testin
 		auth.WithUserMutator(func(user types.User) {
 			user.SetTraits(userTraits)
 		}),
+		auth.WithRoleVersion(roleVersion),
 	)
 	require.NoError(t, err)
 	role.SetKubeUsers(types.Allow, roleSpec.KubeUsers)
@@ -478,7 +483,12 @@ func (c *TestContext) CreateUserWithTraitsAndRole(ctx context.Context, t *testin
 
 // CreateUserAndRole creates Teleport user and role with specified names
 func (c *TestContext) CreateUserAndRole(ctx context.Context, t *testing.T, username string, roleSpec RoleSpec) (types.User, types.Role) {
-	return c.CreateUserWithTraitsAndRole(ctx, t, username, nil, roleSpec)
+	return c.CreateUserAndRoleVersion(ctx, t, username, types.DefaultRoleVersion, roleSpec)
+}
+
+// CreateUserAndRoleVersion creates Teleport user and role with specified names and role version.
+func (c *TestContext) CreateUserAndRoleVersion(ctx context.Context, t *testing.T, username, roleVersion string, roleSpec RoleSpec) (types.User, types.Role) {
+	return c.CreateUserWithTraitsAndRoleVersion(ctx, t, username, nil, roleVersion, roleSpec)
 }
 
 func newKubeConfigFile(t *testing.T, clusters ...KubeClusterConfig) string {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -508,11 +508,26 @@ func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, de
 	}
 	var err error
 	rolesAllowed, rolesDenied := a.RoleSet.GetKubeResources(cluster, a.info.Traits)
+
+	// If we have a legacy 'namespace' in the allowedResourceIDs, we need to add the new 'namespaces' one.
+	// The old one will get mapped to wildcard later.
+	allowedResourceIDs := slices.Clone(a.info.AllowedResourceIDs)
+	for _, elem := range a.info.AllowedResourceIDs {
+		if elem.Kind == types.KindKubeNamespace {
+			allowedResourceIDs = append(allowedResourceIDs, types.ResourceID{
+				ClusterName:     elem.ClusterName,
+				Kind:            "namespaces",
+				SubResourceName: elem.SubResourceName,
+				Name:            elem.Name,
+			})
+		}
+	}
+
 	// Allways append the denied resources from the roles. This is because
 	// the denied resources from the roles take precedence over the allowed
 	// resources from the certificate.
 	denied = rolesDenied
-	for _, r := range a.info.AllowedResourceIDs {
+	for _, r := range allowedResourceIDs {
 		if r.Name != cluster.GetName() || r.ClusterName != a.localCluster {
 			continue
 		}
@@ -520,6 +535,7 @@ func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, de
 		case slices.Contains(types.KubernetesResourcesKinds, r.Kind):
 			namespace := ""
 			name := ""
+			// TODO(@creack): Make sure this gets handled in the AccessRequest PR.
 			if slices.Contains(types.KubernetesClusterWideResourceKinds, r.Kind) {
 				// Cluster wide resources do not have a namespace.
 				name = r.SubResourceName
@@ -539,6 +555,16 @@ func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, de
 			kind := types.KubernetesResourcesKindsPlurals[r.Kind]
 			if kind == "" {
 				kind = r.Kind
+			}
+			// NOTE: The 'namespace' behavior changed, to maintain backwards compatibility,
+			// map the legacy value to wildcard.
+			if r.Kind == types.KindKubeNamespace {
+				kind = types.Wildcard
+				namespace = name
+				if namespace == types.Wildcard {
+					namespace = "^" + types.Wildcard + "$"
+				}
+				name = types.Wildcard
 			}
 			r := types.KubernetesResource{
 				Kind:      kind,

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -2391,6 +2391,7 @@ func getKubeResourcesFromResourceIDs(resourceIDs []types.ResourceID, clusterName
 				kind = resourceID.Kind
 			}
 			switch {
+			// TODO(@creack): Make sure this is handled in the AccessRequest PR.
 			case slices.Contains(types.KubernetesClusterWideResourceKinds, resourceID.Kind):
 				kubernetesResources = append(kubernetesResources, types.KubernetesResource{
 					Kind: kind,

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2948,7 +2948,7 @@ func TestValidate_WithAllowRequestKubernetesResources(t *testing.T) {
 					"*": {"*"},
 				},
 				KubernetesResources: []types.KubernetesResource{
-					{Kind: "namespaces", Namespace: "*", Name: "*", Verbs: []string{"*"}, APIGroup: "*"},
+					{Kind: "*", Namespace: "*", Name: "*", Verbs: []string{"*"}, APIGroup: "*"},
 				},
 			},
 		},

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -151,7 +151,14 @@ func NewImplicitRole() types.Role {
 //
 // Used in tests only.
 func RoleForUser(u types.User) types.Role {
-	role, _ := types.NewRole(RoleNameForUser(u.GetName()), types.RoleSpecV6{
+	return RoleWithVersionForUser(u, types.DefaultRoleVersion)
+}
+
+// RoleWithVersionForUser creates an admin role for a services.User.
+//
+// Used in tests only.
+func RoleWithVersionForUser(u types.User, v string) types.Role {
+	role, _ := types.NewRoleWithVersion(RoleNameForUser(u.GetName()), v, types.RoleSpecV6{
 		Options: types.RoleOptions{
 			CertificateFormat: constants.CertificateFormatStandard,
 			MaxSessionTTL:     types.NewDuration(defaults.MaxCertDuration),

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -187,7 +187,7 @@ func TestRoleParse(t *testing.T) {
 					}
 				}`,
 			error:        trace.BadParameter(""),
-			matchMessage: "KubernetesResource must include Namespace",
+			matchMessage: "KubernetesResource kind \"pod\" must include Namespace",
 		},
 		{
 			name: "validation error, invalid kubernetes_resources kind",

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -233,7 +233,15 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
 					Namespace: types.Wildcard,
+					Name:      types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Namespace: "",
 					Name:      types.Wildcard,
 					Verbs:     []string{types.Wildcard},
 				},
@@ -472,16 +480,18 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 		{
 			name: "list clusterrole with resource",
 			input: types.KubernetesResource{
-				Kind:  "clusterroles",
-				Name:  "clusterrole",
-				Verbs: []string{types.KubeVerbGet},
+				Kind:     "clusterroles",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     "clusterrole",
+				Verbs:    []string{types.KubeVerbGet},
 			},
 			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
-					Kind:  "clusterroles",
-					Name:  "clusterrole",
-					Verbs: []string{types.Wildcard},
+					Kind:     "clusterroles",
+					APIGroup: "rbac.authorization.k8s.io",
+					Name:     "clusterrole",
+					Verbs:    []string{types.Wildcard},
 				},
 			},
 			assert:  require.NoError,
@@ -491,16 +501,18 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 		{
 			name: "list clusterrole with wildcard",
 			input: types.KubernetesResource{
-				Kind:  "clusterroles",
-				Name:  "clusterrole",
-				Verbs: []string{types.KubeVerbGet},
+				Kind:     "clusterroles",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     "clusterrole",
+				Verbs:    []string{types.KubeVerbGet},
 			},
 			isClusterWide: true,
 			resources: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
 					Name:      types.Wildcard,
-					Namespace: types.Wildcard,
+					Namespace: "",
 					Verbs:     []string{types.Wildcard},
 				},
 			},
@@ -571,7 +583,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 		},
 
 		{
-			name: "namespace granting read access to pod",
+			name: "jailed namespace granting read access to pod",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "default",
@@ -584,13 +596,20 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{types.KubeVerbGet},
 				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbGet},
+				},
 			},
 			assert:  require.NoError,
 			action:  types.Allow,
 			matches: true,
 		},
 		{
-			name: "namespace denying update access to pod",
+			name: "jailed namespace denying update access to pod",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "default",
@@ -603,13 +622,20 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{types.KubeVerbGet},
 				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbGet},
+				},
 			},
 			assert:  require.NoError,
 			action:  types.Allow,
 			matches: false,
 		},
 		{
-			name: "namespace granting read access to custom resource",
+			name: "jailed namespace granting read access to custom resource",
 			input: types.KubernetesResource{
 				Kind:      "mycustomresources",
 				Namespace: "default",
@@ -619,10 +645,16 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			},
 			resources: []types.KubernetesResource{
 				{
-					Kind:     "namespaces",
-					Name:     "default",
-					Verbs:    []string{types.KubeVerbGet},
-					APIGroup: "*",
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{types.KubeVerbGet},
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbGet},
 				},
 			},
 			assert:  require.NoError,
@@ -640,10 +672,9 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			},
 			resources: []types.KubernetesResource{
 				{
-					Kind:     "namespaces",
-					Name:     "default",
-					Verbs:    []string{types.KubeVerbGet},
-					APIGroup: "*",
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{types.KubeVerbGet},
 				},
 			},
 			assert:  require.NoError,
@@ -665,13 +696,11 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 					Namespace: "default",
 					Name:      "name",
 					Verbs:     []string{types.KubeVerbGet},
-					APIGroup:  "*",
 				},
 				{
-					Kind:     "namespaces",
-					Name:     "diffnamespace",
-					Verbs:    []string{types.KubeVerbGet},
-					APIGroup: "*",
+					Kind:  "namespaces",
+					Name:  "diffnamespace",
+					Verbs: []string{types.KubeVerbGet},
 				},
 			},
 			assert:  require.NoError,
@@ -699,7 +728,7 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			matches: true,
 		},
 		{
-			name: "global custom resource with namespaced wildcard",
+			name: "global custom resource with jailed namespaced wildcard",
 			input: types.KubernetesResource{
 				Kind:     "mycustomresources",
 				Name:     "name",
@@ -708,10 +737,16 @@ func TestKubeResourceMatchesRegex(t *testing.T) {
 			},
 			resources: []types.KubernetesResource{
 				{
-					Kind:     "namespaces",
-					Name:     "*",
-					Verbs:    []string{types.KubeVerbGet},
-					APIGroup: "*",
+					Kind:  "namespaces",
+					Name:  types.Wildcard,
+					Verbs: []string{types.KubeVerbGet},
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbGet},
 				},
 			},
 			assert:  require.NoError,
@@ -1269,7 +1304,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 		},
 
 		{
-			name: "namespace granting read access to pod",
+			name: "jailed namespace granting read access to pod",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "default",
@@ -1281,31 +1316,20 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{types.KubeVerbGet},
 				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbGet},
+				},
 			},
 			assert:  require.NoError,
 			matches: true,
 			action:  types.Allow,
 		},
 		{
-			name: "namespace denying update access to pod",
-			input: types.KubernetesResource{
-				Kind:      "pods",
-				Namespace: "default",
-				Verbs:     []string{types.KubeVerbList},
-			},
-			resources: []types.KubernetesResource{
-				{
-					Kind:  "namespaces",
-					Name:  "default",
-					Verbs: []string{types.KubeVerbList},
-				},
-			},
-			assert:  require.NoError,
-			matches: false,
-			action:  types.Deny,
-		},
-		{
-			name: "namespace denying list access to pod with different namespace",
+			name: "jailed namespace denying list access to pod with different namespace",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "default2",
@@ -1313,9 +1337,16 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 			},
 			resources: []types.KubernetesResource{
 				{
-					Kind:  "namespaces",
+					Kind:  "names",
 					Name:  "default",
 					Verbs: []string{types.KubeVerbList},
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbList},
 				},
 			},
 			assert:  require.NoError,
@@ -1323,7 +1354,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 			action:  types.Deny,
 		},
 		{
-			name: "namespace denying list access to pod in all namespaces doesnt match deny",
+			name: "jailed namespace denying list access to pod in all namespaces doesnt match deny",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "",
@@ -1335,13 +1366,20 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{types.KubeVerbList},
 				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbList},
+				},
 			},
 			assert:  require.NoError,
 			matches: false,
 			action:  types.Deny,
 		},
 		{
-			name: "namespace denying update access to pod in all namespaces matches allow",
+			name: "jailed namespace denying update access to pod in all namespaces matches allow",
 			input: types.KubernetesResource{
 				Kind:      "pods",
 				Namespace: "",
@@ -1352,29 +1390,18 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 					Kind:  "namespaces",
 					Name:  "default",
 					Verbs: []string{types.KubeVerbList},
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					APIGroup:  types.Wildcard,
+					Verbs:     []string{types.KubeVerbList},
 				},
 			},
 			assert:  require.NoError,
 			matches: true,
 			action:  types.Allow,
-		},
-		{
-			name: "namespace denying update access to pod deny matches all namespaces",
-			input: types.KubernetesResource{
-				Kind:      "pods",
-				Namespace: "",
-				Verbs:     []string{types.KubeVerbList},
-			},
-			resources: []types.KubernetesResource{
-				{
-					Kind:  "namespaces",
-					Name:  types.Wildcard,
-					Verbs: []string{types.KubeVerbList},
-				},
-			},
-			assert:  require.NoError,
-			matches: true,
-			action:  types.Deny,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Change the behavior of 'namespaces' for rolev8. It used to mean 'namespaces' and all resources, now it just means 'namespaces'.

This v7 behavior can still be achieved

```
- kind: namespace
  name: foo
```

with this in v8:

```
- kind: '*'
  name: '*'
  namespace: 'foo'
  api_group: '*'
- kind: namespaces
  name: foo
```

Requested by customers and caused for confusion for many. Creating this new kind should simplify and clarify a lot.

NOTE: It changes the behavior of the wildcard from rolev7. In rolev7, the namespace field was ignored for global resources, resulting in unexpected access being granted, with this change, global resources match only if the namespace is empty.
While it may grant unexpected permissions, to avoid breaking changes, when using rolev7, the behavior is maintained. The new behavior only applies to rolev8.

Separate PR for docs: https://github.com/gravitational/teleport/pull/55127

changelog: Make the namespaces k8s kind stand alone instead of meaning namesapce and all resources.