### PR TITLE
[v16] build: Force installation of wasm-* tools, fix version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1723,10 +1723,10 @@ BIN_JQ = $(shell which jq 2>/dev/null)
 CARGO_GET_VERSION = $(if $(BIN_JQ),$(CARGO_GET_VERSION_JQ),$(CARGO_GET_VERSION_AWK))
 
 ensure-wasm-pack: NEED_VERSION = $(shell $(MAKE) --no-print-directory -s -C build.assets print-wasm-pack-version)
-ensure-wasm-pack: INSTALLED_VERSION = $(lastword $(shell wasm-pack --version 2>/dev/null))
+ensure-wasm-pack: INSTALLED_VERSION = $(word 2,$(shell wasm-pack --version 2>/dev/null))
 ensure-wasm-pack:
 	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
-		cargo install wasm-pack --locked --version "$(NEED_VERSION)", \
+		cargo install wasm-pack --force --locked --version "$(NEED_VERSION)", \
 		@echo wasm-pack up-to-date: $(INSTALLED_VERSION) \
 	)
 
@@ -1734,16 +1734,19 @@ ensure-wasm-pack:
 #       On 386 Arch, calling the variable produces a malformed command that fails the build.
 #ensure-wasm-bindgen: NEED_VERSION = $(shell $(call CARGO_GET_VERSION,wasm-bindgen))
 ensure-wasm-bindgen: NEED_VERSION = 0.2.95
-ensure-wasm-bindgen: INSTALLED_VERSION = $(lastword $(shell wasm-bindgen --version 2>/dev/null))
+ensure-wasm-bindgen: INSTALLED_VERSION = $(word 2,$(shell wasm-bindgen --version 2>/dev/null))
 ensure-wasm-bindgen:
-ifeq ($(CI),true)
+ifneq ($(CI)$(FORCE),)
 	@: $(or $(NEED_VERSION),$(error Unknown wasm-bindgen version. Is it in Cargo.lock?))
 	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
-		cargo install wasm-bindgen-cli --locked --version "$(NEED_VERSION)", \
+		cargo install wasm-bindgen-cli --force --locked --version "$(NEED_VERSION)", \
 		@echo wasm-bindgen-cli up-to-date: $(INSTALLED_VERSION) \
 	)
 else
-	@echo Skipping ensure-wasm-bindgen, to run set CI=true
+	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
+		@echo "Wrong wasm-bindgen version. Want $(NEED_VERSION) have $(INSTALLED_VERSION)"; \
+		echo "Run 'make $@ FORCE=true' to force installation." \
+	)
 endif
 endif
 


### PR DESCRIPTION
Use `--force` when running `cargo install` to build and install
`wasm-pack` and `wasm-bindgen` as if they already exist but are the
wrong version, `cargo` will still not build/install it, saying it's
already installed.

Fix the version check for the tools. The version is the second field
from the output of running them with `--version`. That was the last
field when I last ran it, but sometimes it adds a hash to the end, so we
need to explicitly take the second field, not the last field.

Allow `make ensure-wasm-bindgen` to do something locally when `FORCE` is
set rather than `CI` as `CI` may have other undesirable side-effects.
Only output the message if there is a version mismatch and include an
exact command to run to get the right version installed.

Backport: https://github.com/gravitational/teleport/pull/54824
