### PR TITLE
Mark Azure DevOps RFD implemented

### DIFF
--- a/rfd/0211-azure-devops-joining.md
+++ b/rfd/0211-azure-devops-joining.md
@@ -1,6 +1,6 @@
 ---
 authors: Noah Stride (noah@goteleport.com)
-state: draft
+state: implemented (v17.5.0)
 ---
 <!--- cslint:disable -->
 # RFD 211 - Azure DevOps Joining


### PR DESCRIPTION
Now that the final PRs have been merged down for Azure DevOps joining, we can mark this RFD as implemented in the next v17 release.