### PR TITLE
Fix IP address check in state.Identity

### DIFF
--- a/lib/auth/state/identity_test.go
+++ b/lib/auth/state/identity_test.go
@@ -1,0 +1,80 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"crypto/x509"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasDNSNames(t *testing.T) {
+	require.False(t, (&Identity{XCert: nil}).HasDNSNames(nil))
+
+	type testCase struct {
+		dnsNames    []string
+		ipAddresses []net.IP
+
+		requested []string
+		check     require.BoolAssertionFunc
+	}
+
+	testCases := []testCase{
+		{
+			dnsNames:    []string{},
+			ipAddresses: []net.IP{},
+			requested:   []string{},
+			check:       require.True,
+		},
+		{
+			dnsNames:    nil,
+			ipAddresses: nil,
+			requested:   []string{},
+			check:       require.True,
+		},
+		{
+			dnsNames:    []string{"foo", "bar"},
+			ipAddresses: []net.IP{},
+			requested:   []string{"foo"},
+			check:       require.True,
+		},
+		{
+			dnsNames:    []string{"foo", "bar"},
+			ipAddresses: []net.IP{},
+			requested:   []string{"foo", "1.2.3.4"},
+			check:       require.False,
+		},
+		{
+			dnsNames:    []string{"foo", "bar"},
+			ipAddresses: []net.IP{net.IPv4(1, 2, 3, 4)},
+			requested:   []string{"foo", "1.2.3.4"},
+			check:       require.True,
+		},
+	}
+	for _, tc := range testCases {
+		identity := &Identity{
+			XCert: &x509.Certificate{
+				DNSNames:    tc.dnsNames,
+				IPAddresses: tc.ipAddresses,
+			},
+		}
+		tc.check(t, identity.HasDNSNames(tc.requested))
+	}
+
+}


### PR DESCRIPTION
Currently, a Teleport agent requesting some IP addresses as part of the "dns names" of its identity will correctly get an X.509 certificate with those addresses as IP SANs, but the check at start time (and at rotation time) for whether or not the current credentials should be reissued will ignore the IP SANs, so the agent will do a cert reissue at every restart. This PR fixes the test so that any expected IP addresses are correctly checked for in the IP SANs.