### PR TITLE
scoped role/assignment validation and backend service

### DIFF
--- a/lib/scopes/doc.go
+++ b/lib/scopes/doc.go
@@ -30,7 +30,7 @@
 //
 //   - When reading in a scope value from an external source (user input, identity provider, etc) check it with [StrongValidate].
 //   - When reading in a scope value from a trusted source (control-plane, backend, etc) check it with [WeakValidate].
-//   - When constructing a scope from component strings (e.g. during string interpolation), call [ValidateSegment] on each segment in addition to calling [StrongValidate] on the final scope.
+//   - When constructing a scope from component strings (e.g. during string interpolation), call [StrongValidateSegment] on each segment in addition to calling [StrongValidate] on the final scope.
 //   - If you have a resource at a given scope and want to filter for applicable policies/permissions, use [ResourceScope].
 //   - If you have a policy/permission at a given scope and want to filter for subject resources, use [PolicyScope].
 //   - Avoid using [Compare] and the associated [Relationship] type directly in access-control logic.

--- a/lib/scopes/roles/roles.go
+++ b/lib/scopes/roles/roles.go
@@ -1,0 +1,307 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package roles
+
+import (
+	"iter"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+const (
+	// MaxRolesPerAssignment is the maximum number of roles@scope assignments that a given scoped role assignment
+	// resource may contain. This value is so low because our backend limits the number of keys that can be associated
+	// with a single atomic operation. Any significant increase to this value would necessitate a change to the
+	// scoped role backend model.
+	MaxRolesPerAssignment = 16
+
+	// KindScopedRole is the kind of a scoped role resource.
+	KindScopedRole = "scoped_role"
+
+	// KindScopedRoleAssignment is the kind of a scoped role assignment resource.
+	KindScopedRoleAssignment = "scoped_role_assignment"
+
+	// maxAssignableScopes is the maximum number of assignable scopes that a given scoped role resource may contain. Note that
+	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
+	// to avoid excess resource size and to keep our options open for the future.
+	maxAssignableScopes = 16
+)
+
+// RoleIsAssignableAtScope checks if the given role is assignable at the given scope.
+func RoleIsAssignableAtScope(role *srpb.ScopedRole, scope string) bool {
+	for assignableScope := range WeakValidatedAssignableScopes(role) {
+		if scopes.Glob(assignableScope).Matches(scope) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// WeakValidatedAssignableScopes is a helper for iterating all well formed assignable scopes for a given role.
+func WeakValidatedAssignableScopes(role *srpb.ScopedRole) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, assignableScope := range role.GetSpec().GetAssignableScopes() {
+			if err := scopes.WeakValidateGlob(assignableScope); err != nil {
+				// ignore invalid assignable scopes
+				continue
+			}
+
+			if !scopes.Glob(assignableScope).IsSubjectToPolicyResourceScope(role.GetScope()) {
+				// ignore assignable scopes that do not conform to assignment subjugation rules
+				continue
+			}
+
+			if !yield(assignableScope) {
+				return
+			}
+		}
+	}
+}
+
+// WeakValidateRole valides a role to ensure it is free of obvious issues that would render it unusable and/or
+// induce serious unintended behavior. Prefer using this function for validating roles loaded from "internal" sources
+// (e.g. backend/control-plane), and [StrongValidateRole] for validating roles loaded from "external" sources (e.g. user input).
+func WeakValidateRole(role *srpb.ScopedRole) error {
+	if err := commonValidateRole(role); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := scopes.WeakValidate(role.GetScope()); err != nil {
+		return trace.BadParameter("scoped role %q has invalid scope: %v", role.GetMetadata().GetName(), err)
+	}
+
+	// NOTE: in strong validation, this is where we'd check that the assignable scopes are valid. In weak validation
+	// we don't do that and instead rely on invalid assignable scopes being filtered out
+	// and excluded during runtime assignment validation checks. This helps us ensure that outdated agents continue
+	// to be able to understand and process the subset of assignments that they are able to reason about.
+
+	return nil
+}
+
+// StrongValidateRole performs robust validation of a role to ensure it complies with all expected constraints. Prefer
+// using this function for validating roles loaded from "external" sources (e.g. user input), and [WeakValidateRole] for
+// validating roles loaded from "internal" sources (e.g. backend/control-plane).
+func StrongValidateRole(role *srpb.ScopedRole) error {
+	if err := commonValidateRole(role); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateRoleName(role.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped role name %q does not conform to segment naming rules: %v", role.GetMetadata().GetName(), err)
+	}
+
+	if err := scopes.StrongValidate(role.GetScope()); err != nil {
+		return trace.BadParameter("scoped role %q has invalid scope: %v", role.GetMetadata().GetName(), err)
+	}
+
+	if len(role.GetSpec().GetAssignableScopes()) == 0 {
+		return trace.BadParameter("scoped role %q does not have any assignable scopes", role.GetMetadata().GetName())
+	}
+
+	if len(role.GetSpec().GetAssignableScopes()) > maxAssignableScopes {
+		return trace.BadParameter("scoped role %q has too many assignable scopes (max %d)", role.GetMetadata().GetName(), maxAssignableScopes)
+	}
+
+	for _, scopeGlob := range role.GetSpec().GetAssignableScopes() {
+		if err := scopes.StrongValidateGlob(scopeGlob); err != nil {
+			return trace.BadParameter("scoped role %q has invalid assignable scope %q: %v", role.GetMetadata().GetName(), scopeGlob, err)
+		}
+
+		if !scopes.Glob(scopeGlob).IsSubjectToPolicyResourceScope(role.GetScope()) {
+			return trace.BadParameter("scoped role %q has assignable scope %q that is not a sub-scope of the role's scope %q", role.GetMetadata().GetName(), scopeGlob, role.GetScope())
+		}
+	}
+
+	return nil
+}
+
+func validateRoleName(name string) error {
+	// note: having the scope name be validated as a segment name is a bit of an arbitrary choice, but its basically
+	// equivalent to what we would want from a standalone name requirement, and there may even be some future benefit
+	// if we ever need to encode a role assignment as a scope-like name.
+	return trace.Wrap(scopes.StrongValidateSegment(name))
+}
+
+// commonValidateRole performs the subset of role validation common to both weak and strong validation.
+func commonValidateRole(role *srpb.ScopedRole) error {
+	if role.GetMetadata().GetName() == "" {
+		return trace.BadParameter("scoped role is missing metadata.name")
+	}
+
+	if role.GetKind() == "" {
+		return trace.BadParameter("scoped role %q is missing kind", role.GetMetadata().GetName())
+	}
+
+	if role.GetKind() != KindScopedRole {
+		return trace.BadParameter("scoped role %q has invalid kind %q, expected %q", role.GetMetadata().GetName(), role.GetKind(), KindScopedRole)
+	}
+
+	if role.GetSubKind() != "" {
+		return trace.BadParameter("scoped role %q has unknown sub_kind %q", role.GetMetadata().GetName(), role.GetSubKind())
+	}
+
+	if role.GetVersion() == "" {
+		return trace.BadParameter("scoped role %q is missing version", role.GetMetadata().GetName())
+	}
+
+	if role.GetVersion() != types.V1 {
+		return trace.BadParameter("scoped role %q has unsupported version %q (expected %q)", role.GetMetadata().GetName(), role.GetVersion(), types.V1)
+	}
+
+	if role.GetScope() == "" {
+		return trace.BadParameter("scoped role %q is missing scope", role.GetMetadata().GetName())
+	}
+
+	return nil
+}
+
+// WeakValidatedSubAssignments is a helper for iterating all well formed sub-assignments within a given assignment. Note that the concept
+// of a well-formed sub-assignment is distinct from wether or not an assignment is "boken/invalidated" in the sense used when
+// deciding wether or not an access-control check can be performed for a given scope. The only thing that is being filtered out
+// by this iterator is sub-assignments that are so obviously misconfigured that we can't reason about them at all. Sub-assignments
+// returned by this iterator may still be broken because they assign a nonexistent role, or to a scope that the target role is not
+// assignable to.
+func WeakValidatedSubAssignments(assignment *srpb.ScopedRoleAssignment) iter.Seq[*srpb.Assignment] {
+	return func(yield func(*srpb.Assignment) bool) {
+		for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+			if subAssignment.GetRole() == "" {
+				// ignore sub-assignments with missing role
+				continue
+			}
+
+			if err := scopes.WeakValidate(subAssignment.GetScope()); err != nil {
+				// ignore sub-assignments with invalid scopes
+				continue
+			}
+
+			if !scopes.PolicyAssignmentScope(subAssignment.GetScope()).IsSubjectToPolicyResourceScope(assignment.GetScope()) {
+				// ignore sub-assignments with scopes that do not conform to assignment subjugation rules
+				continue
+			}
+
+			if !yield(subAssignment) {
+				return
+			}
+		}
+	}
+}
+
+// WeakValidateAssignment validates an assignment to ensure it is free of obvious issues that would render it unusable and/or
+// induce serious unintended behavior. Prefer using this function for validating assignments loaded from "internal" sources
+// (e.g. backend/control-plane), and [StrongValidateAssignment] for validating assignments loaded from "external" sources (e.g. user input).
+func WeakValidateAssignment(assignment *srpb.ScopedRoleAssignment) error {
+	if err := commonValidateAssignment(assignment); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := scopes.WeakValidate(assignment.GetScope()); err != nil {
+		return trace.BadParameter("scoped role assignment %q has invalid scope: %v", assignment.GetMetadata().GetName(), err)
+	}
+
+	// NOTE: in strong validation, this is where we'd check that the sub-assignments are valid. In weak validation
+	// we don't do that and instead rely on invalid sub-assignments being filtered out and excluded during runtime
+	// assignment resolution.
+
+	return nil
+}
+
+// StrongValidateAssignment performs robust validation of an assignment to ensure it complies with all expected constraints. Prefer
+// using this function for validating assignments loaded from "external" sources (e.g. user input), and [WeakValidateAssignment] for
+// validating assignments loaded from "internal" sources (e.g. backend/control-plane).
+func StrongValidateAssignment(assignment *srpb.ScopedRoleAssignment) error {
+	if err := commonValidateAssignment(assignment); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := uuid.Parse(assignment.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped role assignment %q has invalid name (must be uuid): %v", assignment.GetMetadata().GetName(), err)
+	}
+
+	if err := scopes.StrongValidate(assignment.GetScope()); err != nil {
+		return trace.BadParameter("scoped role assignment %q has invalid scope: %v", assignment.GetMetadata().GetName(), err)
+	}
+
+	if len(assignment.GetSpec().GetAssignments()) == 0 {
+		return trace.BadParameter("scoped role assignment %q does not assign any roles", assignment.GetMetadata().GetName())
+	}
+
+	if len(assignment.GetSpec().GetAssignments()) > MaxRolesPerAssignment {
+		return trace.BadParameter("scoped role assignment %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), MaxRolesPerAssignment)
+	}
+
+	for i, subAssignment := range assignment.GetSpec().GetAssignments() {
+		if subAssignment.GetRole() == "" {
+			return trace.BadParameter("scoped role assignment %q is missing role in sub-assignment %d", assignment.GetMetadata().GetName(), i)
+		}
+
+		if err := validateRoleName(subAssignment.GetRole()); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid role name in sub-assignment %d: %v", assignment.GetMetadata().GetName(), i, err)
+		}
+
+		if err := scopes.StrongValidate(subAssignment.GetScope()); err != nil {
+			return trace.BadParameter("scoped role assignment %q has invalid scope in sub-assignment %d: %v", assignment.GetMetadata().GetName(), i, err)
+		}
+
+		if !scopes.PolicyAssignmentScope(subAssignment.GetScope()).IsSubjectToPolicyResourceScope(assignment.GetScope()) {
+			return trace.BadParameter("scoped role assignment %q has sub-assignment %d with scope %q that is not a sub-scope of the assignment's scope %q", assignment.GetMetadata().GetName(), i, subAssignment.GetScope(), assignment.GetScope())
+		}
+	}
+
+	return nil
+}
+
+func commonValidateAssignment(assignment *srpb.ScopedRoleAssignment) error {
+	if assignment.GetMetadata().GetName() == "" {
+		return trace.BadParameter("scoped role assignment is missing metadata.name")
+	}
+
+	if assignment.GetKind() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing kind", assignment.GetMetadata().GetName())
+	}
+
+	if assignment.GetKind() != KindScopedRoleAssignment {
+		return trace.BadParameter("scoped role assignment %q has invalid kind %q, expected %q", assignment.GetMetadata().GetName(), assignment.GetKind(), KindScopedRoleAssignment)
+	}
+
+	if assignment.GetSubKind() != "" {
+		return trace.BadParameter("scoped role assignment %q has unknown sub_kind %q", assignment.GetMetadata().GetName(), assignment.GetSubKind())
+	}
+
+	if assignment.GetVersion() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing version", assignment.GetMetadata().GetName())
+	}
+
+	if assignment.GetVersion() != types.V1 {
+		return trace.BadParameter("scoped role assignment %q has unsupported version %q (expected %q)", assignment.GetMetadata().GetName(), assignment.GetVersion(), types.V1)
+	}
+
+	if assignment.GetScope() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing scope", assignment.GetMetadata().GetName())
+	}
+
+	if assignment.GetSpec().GetUser() == "" {
+		return trace.BadParameter("scoped role assignment %q is missing spec.user", assignment.GetMetadata().GetName())
+	}
+
+	return nil
+}

--- a/lib/scopes/roles/roles_test.go
+++ b/lib/scopes/roles/roles_test.go
@@ -1,0 +1,796 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package roles
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestValidateRole verifies basic functionality of strong and weak role validation functions.
+func TestValidateRole(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		role     *srpb.ScopedRole
+		strongOk bool
+		weakOk   bool
+	}{
+		{
+			name: "basic",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "unknown sub_kind",
+			role: &srpb.ScopedRole{
+				Kind:    KindScopedRole,
+				SubKind: "unknown",
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing name",
+			role: &srpb.ScopedRole{
+				Kind:     KindScopedRole,
+				Metadata: &headerpb.Metadata{},
+				Scope:    "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing kind",
+			role: &srpb.ScopedRole{
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing version",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "malformed name",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "foo/bar",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "malformed kind",
+			role: &srpb.ScopedRole{
+				Kind: "role",
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "slightly malformed scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "foo/bar",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo/bar"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "siginifcantly malformed scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "foo@bar",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo/bar"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing assignable scopes",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope:   "/",
+				Spec:    &srpb.ScopedRoleSpec{},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "slightly malformed assignable scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"foo/bar"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "siginifcantly malformed assignable scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"foo@bar"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true, // invalid assignable scopes are totally ignored, even if they don't pass weak validation rules
+		},
+		{
+			name: "impermissable assignable scope",
+			role: &srpb.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerpb.Metadata{
+					Name: "test",
+				},
+				Scope: "/foo/bar",
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo"},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StrongValidateRole(tt.role)
+			if tt.strongOk {
+				require.NoError(t, err, "strong validation should not fail")
+			} else {
+				require.Error(t, err, "strong validation should fail")
+			}
+
+			err = WeakValidateRole(tt.role)
+			if tt.weakOk {
+				require.NoError(t, err, "weak validation should not fail")
+			} else {
+				require.Error(t, err, "weak validation should fail")
+			}
+		})
+	}
+}
+
+func TestValidateAsssignment(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name       string
+		assignment *srpb.ScopedRoleAssignment
+		strongOk   bool
+		weakOk     bool
+	}{
+		{
+			name: "basic",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+		{
+			name: "unknown sub_kind",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind:    KindScopedRoleAssignment,
+				SubKind: "unknown",
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing name",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind:     KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{},
+				Scope:    "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing kind",
+			assignment: &srpb.ScopedRoleAssignment{
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing scope",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "missing version",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "malformed name",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: "not-a-uuid",
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "malformed kind",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: "not_scoped_role_assignment",
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "slightly malformed scope",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "foo",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "significantly malformed scope",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "foo@bar",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   false,
+		},
+		{
+			name: "impermissable assigned scope",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/foo/bar",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "malformed assigned scope",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name: "basic",
+			assignment: &srpb.ScopedRoleAssignment{
+				Kind: KindScopedRoleAssignment,
+				Metadata: &headerpb.Metadata{
+					Name: uuid.New().String(),
+				},
+				Scope: "/",
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*srpb.Assignment{
+						{
+							Role:  "test",
+							Scope: "/foo",
+						},
+					},
+				},
+				Version: types.V1,
+			},
+			strongOk: true,
+			weakOk:   true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StrongValidateAssignment(tt.assignment)
+			if tt.strongOk {
+				require.NoError(t, err, "strong validation should not fail")
+			} else {
+				require.Error(t, err, "strong validation should fail")
+			}
+
+			err = WeakValidateAssignment(tt.assignment)
+			if tt.weakOk {
+				require.NoError(t, err, "weak validation should not fail")
+			} else {
+				require.Error(t, err, "weak validation should fail")
+			}
+		})
+	}
+}
+
+func TestWeakValidatedAssignableScopes(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name             string
+		scope            string
+		assignableScopes []string
+		expect           []string
+	}{
+		{
+			name:             "basic",
+			scope:            "/foo",
+			assignableScopes: []string{"/foo/bar", "/foo/baz"},
+			expect:           []string{"/foo/bar", "/foo/baz"},
+		},
+		{
+			name:             "empty",
+			scope:            "/foo",
+			assignableScopes: nil,
+			expect:           nil,
+		},
+		{
+			name:             "mildly malformed",
+			scope:            "/foo",
+			assignableScopes: []string{"foo/bar", "foo/baz"},
+			expect:           []string{"foo/bar", "foo/baz"},
+		},
+		{
+			name:             "significantly malformed",
+			scope:            "/foo",
+			assignableScopes: []string{"foo@bar", "foo@baz"},
+			expect:           nil,
+		},
+		{
+			name:             "impermissible",
+			scope:            "/foo/bar",
+			assignableScopes: []string{"/foo", "/foo/bar"},
+			expect:           []string{"/foo/bar"},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			result := slices.Collect(WeakValidatedAssignableScopes(&srpb.ScopedRole{
+				Scope: tt.scope,
+				Spec: &srpb.ScopedRoleSpec{
+					AssignableScopes: tt.assignableScopes,
+				},
+			}))
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestWeakValidatedSubAssignments(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name        string
+		scope       string
+		assignments []*srpb.Assignment
+		expect      []*srpb.Assignment
+	}{
+		{
+			name:  "basic",
+			scope: "/foo",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+		},
+		{
+			name:  "mildly malformed scope",
+			scope: "/foo",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "foo/bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "foo/bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+		},
+		{
+			name:  "significantly malformed scope",
+			scope: "/foo",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "foo@bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+		},
+		{
+			name:  "impermissible scope",
+			scope: "/foo/bar",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+			},
+		},
+		{
+			name:  "missing scope",
+			scope: "/foo",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "",
+				},
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/baz",
+				},
+			},
+		},
+		{
+			name:  "missing role",
+			scope: "/foo",
+			assignments: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "",
+					Scope: "/foo/baz",
+				},
+			},
+			expect: []*srpb.Assignment{
+				{
+					Role:  "test",
+					Scope: "/foo/bar",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			result := slices.Collect(WeakValidatedSubAssignments(&srpb.ScopedRoleAssignment{
+				Scope: tt.scope,
+				Spec: &srpb.ScopedRoleAssignmentSpec{
+					Assignments: tt.assignments,
+				},
+			}))
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -23,7 +23,6 @@ import (
 	"iter"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"github.com/gravitational/trace"
 )
@@ -37,10 +36,14 @@ const (
 	// separator is the character used to separate segments in a scope and is the the value of the root scope.
 	separator = "/"
 
+	// exclusiveChildGlobSegment is the string used to indicate a wildcard match for child segments, used to construct
+	// the exclusive child glob suffix.
+	exclusiveChildGlobSegment = "**"
+
 	// exclusiveChildGlobSuffix is a special suffix used in roles to indicate that the role can be
 	// assigned to any *child* of a given scope, but not to the scope itself (e.g. an assignable scope of
 	// `/aa/**` allows assignment to `/aa/bb`, but not to `/aa`).
-	exclusiveChildGlobSuffix = separator + "**"
+	exclusiveChildGlobSuffix = separator + exclusiveChildGlobSegment
 
 	// maxScopeSize is the maximum size of a scope, including separators.
 	maxScopeSize = 64
@@ -55,33 +58,8 @@ const (
 	// members even when performing looser/weaker validation. This it intended to be an additional
 	// guardrail against erroneous interpretation of future extensions to scope syntax by outdated
 	// agents in the event of improper cross-version compat logic.
-	breakingChars = "\\@(){}\"'%*?#$!+=|<>,;~`&[]"
+	breakingChars = "\\@(){}\"'%*?#$!+=|<>,;~`&[]/"
 )
-
-// ValidateSegment checks if a given scope segment is valid. Generally, one of either [StrongValidate] or
-// [WeakValidate] should be called against the entire scope, but this function is useful for validating segments
-// prior to performing variable interpolation or other operations that involve building scopes from
-// external input. Among other things, using this function in that context is an easy way to prevent
-// multi-segment injection in places where a single segment is expected.
-func ValidateSegment(segment string) error {
-	if segment == "" {
-		return trace.BadParameter("segment is empty")
-	}
-
-	if len(segment) < minSegmentSize {
-		return trace.BadParameter("segment %q is too short (min characters %d)", segment, minSegmentSize)
-	}
-
-	if !segmentRegexp.MatchString(segment) {
-		return trace.BadParameter("segment %q is malformed", segment)
-	}
-
-	if len(segment) > maxSegmentSize {
-		return trace.BadParameter("segment %q is too long (max characters %d)", segment, maxSegmentSize)
-	}
-
-	return nil
-}
 
 // StrongValidate checks if the scope is valid according to all scope formatting rules. This function
 // *must* be called on all scope values received from user input and/or cluster-external sources (e.g.
@@ -102,13 +80,21 @@ func StrongValidate(scope string) error {
 	}
 
 	for segment := range DescendingSegments(scope) {
-		if err := ValidateSegment(segment); err != nil {
+		if err := StrongValidateSegment(segment); err != nil {
 			return trace.BadParameter("scope %q is invalid: %v", scope, err)
 		}
 	}
 
 	if len(scope) > maxScopeSize {
 		return trace.BadParameter("scope %q is too long (max characters %d)", scope, maxScopeSize)
+	}
+
+	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
+	// construct a weak check that rejects something that would otherwise pass a strong check. strong
+	// validation is not used in perf-critical paths, so there isn't any real downside to a little
+	// defensiveness here.
+	if err := WeakValidate(scope); err != nil {
+		return trace.BadParameter("scope would not pass weak validation: %v", err)
 	}
 
 	return nil
@@ -119,28 +105,90 @@ func StrongValidate(scope string) error {
 // about them (e.g. due to significant version drift). Prefer using [StrongValidate] for scopes received from
 // external sources (e.g. user input or identity provider).
 func WeakValidate(scope string) error {
-	for segment := range DescendingSegments(scope) {
-		// check for spaces and control characters
-		for _, r := range segment {
-			if unicode.IsSpace(r) || unicode.IsControl(r) {
-				return trace.BadParameter("scope %q contains invalid segment %q (whitespace or control character)", scope, segment)
-			}
-		}
+	if scope == "" {
+		return trace.BadParameter("scope is empty")
+	}
 
-		// check for breaking characters
-		if strings.ContainsAny(segment, breakingChars) {
-			return trace.BadParameter("scope %q contains invalid segment %q (invalid character)", scope, segment)
+	for segment := range DescendingSegments(scope) {
+		if err := WeakValidateSegment(segment); err != nil {
+			return trace.BadParameter("scope %q is invalid: %v", scope, err)
 		}
 	}
 
 	return nil
 }
 
-// ValidateGlob checks if a scope glob is valid. A scope glob is a special type of scope that
-// may be either a literal or a very simplistic matcher.
-func ValidateGlob(scope string) error {
+// StrongValidateSegment checks if the scope segment is valid according to all scope formatting rules. This function
+// *must* be called on all scope segment values received from user input and/or cluster-external sources (e.g.
+// an identity provider). Use of this function should be avoided when checking the validity of segments
+// from the control-plane in logic that may be run agent-side. Prefer [WeakValidateSegment] in those cases, which
+// is more forgiving of changes to scope formatting rules.
+func StrongValidateSegment(segment string) error {
+	if segment == "" {
+		return trace.BadParameter("segment is empty")
+	}
+
+	if len(segment) < minSegmentSize {
+		return trace.BadParameter("segment %q is too short (min characters %d)", segment, minSegmentSize)
+	}
+
+	if !segmentRegexp.MatchString(segment) {
+		return trace.BadParameter("segment %q is malformed", segment)
+	}
+
+	if len(segment) > maxSegmentSize {
+		return trace.BadParameter("segment %q is too long (max characters %d)", segment, maxSegmentSize)
+	}
+
+	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
+	// construct a weak check that rejects something that would otherwise pass a strong check. strong
+	// validation is not used in perf-critical paths, so there isn't any real downside to a little
+	// defensiveness here.
+	if err := WeakValidateSegment(segment); err != nil {
+		return trace.BadParameter("segment would not pass weak validation: %v", err)
+	}
+
+	return nil
+}
+
+// WeakValidateSegment performs a weak form of validation on a scope segment. This is useful primarily for ensuring
+// that segments received from trusted sources haven't been altered beyond our ability to reason effectively
+// about them (e.g. due to significant version drift). Prefer using [StrongValidateSegment] for segments received from
+// external sources (e.g. user input or identity provider).
+func WeakValidateSegment(segment string) error {
+	// check for spaces and control characters
+	for _, b := range []byte(segment) {
+		if !isNonSpacePrintableASCII(b) {
+			return trace.BadParameter("segment %q contains invalid character", segment)
+		}
+	}
+
+	// check for breaking characters
+	if strings.ContainsAny(segment, breakingChars) {
+		return trace.BadParameter("segment %q contains invalid character", segment)
+	}
+
+	return nil
+}
+
+// isNonSpacePrintableASCII checks if a byte is a non-space printable ASCII character (i.e. a byte in the range
+// [33, 126] inclusive). This is used for weak validation of scope segments and globs.
+func isNonSpacePrintableASCII(b byte) bool {
+	if b < 33 || b > 126 {
+		return false
+	}
+
+	return true
+}
+
+// StrongValidateGlob checks if the scope glob is valid according to all scope formatting rules. This function
+// *must* be called on all scope glob values received from user input and/or cluster-external sources (e.g.
+// an identity provider). Use of this function should be avoided when checking the validity of scope globs
+// from the control-plane in logic that may be run agent-side. Prefer [WeakValidateGlob] in those cases, which
+// is more forgiving of changes to scope glob formatting rules.
+func StrongValidateGlob(scope string) error {
 	if scope == "" {
-		return trace.BadParameter("scope is empty")
+		return trace.BadParameter("scope glob is empty")
 	}
 
 	if scope == exclusiveChildGlobSuffix {
@@ -148,7 +196,41 @@ func ValidateGlob(scope string) error {
 		return nil
 	}
 
-	return StrongValidate(strings.TrimSuffix(scope, exclusiveChildGlobSuffix))
+	if err := StrongValidate(strings.TrimSuffix(scope, exclusiveChildGlobSuffix)); err != nil {
+		return trace.BadParameter("scope glob %q is invalid: %v", scope, err)
+	}
+
+	// as an extra precaution, also run all weak checks just to be certain we didn't accidentally
+	// construct a weak check that rejects something that would otherwise pass a strong check. strong
+	// validation is not used in perf-critical paths, so there isn't any real downside to a little
+	// defensiveness here.
+	if err := WeakValidateGlob(scope); err != nil {
+		return trace.BadParameter("scope glob would not pass weak validation: %v", err)
+	}
+
+	return nil
+}
+
+// WeakValidateGlob is a weaker form of validation for scope globs. This is useful primarily for ensuring
+// that scope globs received from trusted sources haven't been altered beyond our ability to reason effectively
+// about them (e.g. due to significant version drift). Prefer using [StrongValidateGlob] for globs received from
+// external sources (e.g. user input or identity provider).
+func WeakValidateGlob(scope string) error {
+	if scope == "" {
+		return trace.BadParameter("scope glob is empty")
+	}
+
+	for segment := range DescendingSegments(scope) {
+		if segment == exclusiveChildGlobSegment {
+			continue
+		}
+
+		if err := WeakValidateSegment(segment); err != nil {
+			return trace.BadParameter("scope glob %q is invalid: %v", scope, err)
+		}
+	}
+
+	return nil
 }
 
 // DescendingSegments produces an iterator over the segments of a scope in descending order.
@@ -244,6 +326,11 @@ func (rel Relationship) String() string {
 // Note that this function does not perform validation, and may return unexpected results when
 // called against invalid scope values.
 func Compare(lhs, rhs string) Relationship {
+	if lhs == "" || rhs == "" {
+		// empty scopes are always orthogonal, including to one-another
+		return Orthogonal
+	}
+
 	lNext, lStop := iter.Pull(DescendingSegments(lhs))
 	defer lStop()
 
@@ -306,6 +393,23 @@ func (s ResourceScope) IsSubjectToPolicyScope(scope string) bool {
 	return rel == Equivalent || rel == Ancestor
 }
 
+// PolicyAssignmentScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
+//
+//	if scopes.PolicyAssignmentScope(subAssignment.Scope).IsSubjectToPolicyResourceScope(assignment.Scope) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid scope values.
+type PolicyAssignmentScope string
+
+// IsSubjectToPolicyResourceScope checks if this policy assignment scope is subject to the specified policy resource
+// scope. This is used to validate that the individual assignments within a resource conform to the scoping of the
+// overall assignment resource.
+func (s PolicyAssignmentScope) IsSubjectToPolicyResourceScope(scope string) bool {
+	rel := Compare(string(s), scope)
+	return rel == Equivalent || rel == Ancestor
+}
+
 // Glob is a helper for matching scope globs against scopes. This is currently used to support exactly
 // one piece of special syntax, the use of `/component/**` to indicate that a role can be assigned to any child of
 // the specified scope, but not to the scope itself. Ex:
@@ -318,17 +422,104 @@ type Glob string
 
 // Matches checks if the given scope matches this scope glob.
 func (s Glob) Matches(scope string) bool {
-	glob := string(s)
-	var exclusiveChildMatcher bool
-	if strings.HasSuffix(glob, exclusiveChildGlobSuffix) {
-		glob = strings.TrimSuffix(glob, exclusiveChildGlobSuffix)
-		exclusiveChildMatcher = true
+	return matchGlob(string(s), scope)
+}
+
+// IsSubjectToPolicyResourceScope checks if this glob exclusively matches scopes that would be subject to the
+// specified policy resource scope. This is used to validate that the assignable scope globs of a role only
+// permit assignment of that role to scopes that could permissibly be subject to the policies defined by that role.
+func (s Glob) IsSubjectToPolicyResourceScope(scope string) bool {
+	return globIsSubjectToPolicyResourceScope(string(s), scope)
+}
+
+// matchGlob implements glob matching. note that this function technically supports some limited
+// matching behaviors that we don't actually currently allow the use of. e.g. `/foo/**/bar` would match
+// `/foo/baz/bar` (but not  `/foo/baz/bin/bar` or `/foo/bar/`), but we only permit the use of the double-wildcard
+// syntax in the trailing segment for simplicity's sake.
+func matchGlob(glob string, scope string) bool {
+	if glob == "" || scope == "" {
+		return false
 	}
 
-	rel := Compare(glob, scope)
-	if exclusiveChildMatcher {
-		return rel == Descendant
-	} else {
-		return rel == Equivalent
+	gNext, gStop := iter.Pull(DescendingSegments(glob))
+	defer gStop()
+
+	sNext, sStop := iter.Pull(DescendingSegments(scope))
+	defer sStop()
+
+	for {
+		gVal, gOk := gNext()
+		sVal, sOk := sNext()
+
+		switch {
+		case gOk && sOk:
+			// both values have segments left to compare
+			if gVal == sVal {
+				// segments are equivalent, descend into the next segment
+				continue
+			}
+			if gVal == exclusiveChildGlobSegment {
+				// double-wildcard matches any segment, continue
+				continue
+			}
+			// scopes have diverged
+			return false
+		case gOk && !sOk:
+			// the scope is an ancestor of the glob
+			return false
+		case !gOk && sOk:
+			// the glob is an ancestor of the scope
+			return true
+		case !gOk && !sOk:
+			// literal match
+			return true
+		}
+	}
+}
+
+// globIsSubjectToPolicyResourceScope checks if the glob is subject to the specified policy resource scope.
+func globIsSubjectToPolicyResourceScope(glob string, scope string) bool {
+	if glob == "" || scope == "" {
+		return false
+	}
+
+	gNext, gStop := iter.Pull(DescendingSegments(glob))
+	defer gStop()
+
+	sNext, sStop := iter.Pull(DescendingSegments(scope))
+	defer sStop()
+
+	for {
+		gVal, gOk := gNext()
+		sVal, sOk := sNext()
+
+		switch {
+		case gOk && sOk:
+			// both values have segments left to compare
+			if gVal == sVal {
+				// segments are equivalent, descend into the next segment
+				continue
+			}
+			if gVal == exclusiveChildGlobSegment {
+				// we've hit the first wildcard segment and are still descending
+				// through the segments of the scope. this means that the glob may
+				// match a scope orthogonal to the resource scope and therefore does
+				// not conform to subjugation rules.
+				return false
+			}
+			// scopes have diverged
+			return false
+		case gOk && !sOk:
+			// the scope is an ancestor of the glob, anything the glob matches
+			// will be subject to the scope.
+			return true
+		case !gOk && sOk:
+			// the glob is an ancestor of the scope, and is therefore trivially not
+			// subject to the scope.
+			return false
+		case !gOk && !sOk:
+			// literal match, the glob is subject by equivalence to the scope.
+			return true
+		}
 	}
 }

--- a/lib/services/local/scoped_roles.go
+++ b/lib/services/local/scoped_roles.go
@@ -1,0 +1,760 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/gravitational/teleport"
+	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// scoped role and assignment state is modeled with the following key ranges:
+//
+//  - `/scoped_role/role/<role-name>`             (the location of the role resource, stored at author-chosen name)
+//  - `/scoped_role/assignment/<assignment-name>` (the assignment resource itself, always stored at a random UUID)
+//  - `/scoped_role/user_lock/<username>`         (a value that is randomized each time associated user's assignments are modified)
+//  - `/scoped_role/role_lock/<role-name>`        (a value that is randomized each time associated role's assignments are modified)
+//
+// These four key ranges allow for efficient management of roles and assignmments atomically. Assignments are stored homogenously,
+// but the provided lock values make it easy for backend operations to assert that the assignments related to a given user/role
+// are not concurrently changed, indepdnent of the total number of assignments or the number of roles they effect (each assignment
+// may assign multiple roles). Cleanup of role locks is the responsibility of the DeleteScopedRole operation, and cleanup of user locks
+// is the responsibility of the DeleteScopedRoleAssignment operation.
+//
+// NOTE: this model does not provide means of making one assignment invalidate another (e.g. in the case of OIDC assignments,
+// for which only one should be valid at a time), and does not invalidate assignments on user deletion.
+
+const (
+	scopedRolePrefix              = "scoped_role"
+	scopedRoleRoleComponent       = "role"
+	scopedRoleAssignmentComponent = "assignment"
+	userAssignmentLockComponent   = "user_lock"
+	roleAssignmentLockComponent   = "role_lock"
+)
+
+// ScopedRoleService manages backend state for the ScopedRole and ScopedRoleAssignment types.
+type ScopedRoleService struct {
+	bk     backend.Backend
+	logger *slog.Logger
+}
+
+// NewScopedRoleService creates a new ScopedRoleService for the specified backend.
+func NewScopedRoleService(bk backend.Backend) *ScopedRoleService {
+	return &ScopedRoleService{
+		bk:     bk,
+		logger: slog.With(teleport.ComponentKey, "scopedrole"),
+	}
+}
+
+func (s *ScopedRoleService) GetScopedRole(ctx context.Context, req *srpb.GetScopedRoleRequest) (*srpb.GetScopedRoleResponse, error) {
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("missing scoped role name in get request")
+	}
+
+	item, err := s.bk.Get(ctx, scopedRoleKey(req.GetName()))
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("scoped role %q not found", req.GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	role, err := scopedRoleFromItem(item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := sr.WeakValidateRole(role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.GetScopedRoleResponse{
+		Role: role,
+	}, nil
+}
+
+// StreamScopedRoles returns a stream of all scoped roles in the backend. Malformed roles are skipped. Returned roles
+// have had weak validation applied.
+func (s *ScopedRoleService) StreamScopedRoles(ctx context.Context) stream.Stream[*srpb.ScopedRole] {
+	return func(yield func(*srpb.ScopedRole, error) bool) {
+		startKey := scopedRoleKey("")
+		params := backend.ItemsParams{
+			StartKey: startKey,
+			EndKey:   backend.RangeEnd(startKey),
+		}
+
+		for item, err := range s.bk.Items(ctx, params) {
+			if err != nil {
+				// backend errors terminate the stream
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			role, err := scopedRoleFromItem(&item)
+			if err != nil {
+				// per-role errors are logged and skipped
+				s.logger.WarnContext(ctx, "skipping scoped role due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				continue
+			}
+
+			if err := sr.WeakValidateRole(role); err != nil {
+				// per-role errors are logged and skipped
+				s.logger.WarnContext(ctx, "skipping scoped role due to validation error", "error", err, "key", logutils.StringerAttr(item.Key))
+				continue
+			}
+
+			if !yield(role, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (s *ScopedRoleService) CreateScopedRole(ctx context.Context, req *srpb.CreateScopedRoleRequest) (*srpb.CreateScopedRoleResponse, error) {
+	role := req.GetRole()
+	if role == nil {
+		return nil, trace.BadParameter("missing scoped role in create request")
+	}
+
+	if err := sr.StrongValidateRole(role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	item, err := scopedRoleToItem(role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// we make efforts elsewhere to ensure that roles cannot be deleted s.t. they leave behind dangling assignments,
+	// but it is best to be absolutely certain about that.
+	lockItem, err := s.bk.Get(ctx, roleAssignmentLockKey(role.GetMetadata().GetName()))
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		lockItem = nil
+	}
+
+	lockCondition := backend.NotExists()
+	if lockItem != nil {
+		lockCondition = backend.Revision(lockItem.Revision)
+		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+				if subAssignment.GetRole() != role.GetMetadata().GetName() {
+					continue
+				}
+
+				// an assignment already exists referencing this role, we need to check if that is because
+				// a role with this name exists, or because the assignment is dangling.
+				_, err = s.bk.Get(ctx, scopedRoleKey(role.GetMetadata().GetName()))
+				if err != nil {
+					if !trace.IsNotFound(err) {
+						return nil, trace.Wrap(err)
+					}
+					// this is a dangling assignment, we need to return an error
+					return nil, trace.CompareFailed("cannot create scoped role %q while extant assignment %q references it", role.GetMetadata().GetName(), assignment.GetMetadata().GetName())
+				}
+				return nil, trace.CompareFailed("scoped role %q already exists", role.GetMetadata().GetName())
+			}
+		}
+	}
+
+	revision, err := s.bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       item.Key,
+			Condition: backend.NotExists(),
+			Action:    backend.Put(item),
+		},
+		{
+			Key:       roleAssignmentLockKey(role.GetMetadata().GetName()),
+			Condition: lockCondition,
+			Action:    backend.Nop(), // assignments update the lock, roles just assert that it is unchanged
+		},
+	})
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.CompareFailed("scoped role %q or an associated assignment already exist", role.GetMetadata().GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.CreateScopedRoleResponse{
+		Role: scopedRoleWithRevision(role, revision),
+	}, nil
+}
+
+func (s *ScopedRoleService) UpdateScopedRole(ctx context.Context, req *srpb.UpdateScopedRoleRequest) (*srpb.UpdateScopedRoleResponse, error) {
+	role := req.GetRole()
+	if role == nil {
+		return nil, trace.BadParameter("missing scoped role in update request")
+	}
+
+	if err := sr.StrongValidateRole(role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	extant, err := s.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+		Name: role.GetMetadata().GetName(),
+	})
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		return nil, trace.CompareFailed("scoped role %q was deleted", role.GetMetadata().GetName())
+	}
+
+	if role.GetMetadata().GetRevision() != "" && role.GetMetadata().GetRevision() != extant.GetRole().GetMetadata().GetRevision() {
+		return nil, trace.CompareFailed("scoped role %q has been concurrently modified", role.GetMetadata().GetName())
+	}
+
+	// disallow change of resource scope via update. use of scopes.Compare directly is generally discouraged,
+	// but that is due to ease of misuse, which isn't really a concern for a simple equivalence check.
+	if scopes.Compare(role.GetScope(), extant.GetRole().GetScope()) != scopes.Equivalent {
+		return nil, trace.BadParameter("cannot modify the resource scope of scoped role %q (%q -> %q)", role.GetMetadata().GetName(), extant.GetRole().GetScope(), role.GetScope())
+	}
+
+	// acquire the assignment lock and verify that the update doesn't validate any extant assignments
+	lockItem, err := s.bk.Get(ctx, roleAssignmentLockKey(role.GetMetadata().GetName()))
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		lockItem = nil
+	}
+
+	lockCondition := backend.NotExists()
+	if lockItem != nil {
+		lockCondition = backend.Revision(lockItem.Revision)
+		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+				if subAssignment.GetRole() != role.GetMetadata().GetName() {
+					continue
+				}
+
+				if !sr.RoleIsAssignableAtScope(extant.GetRole(), subAssignment.GetScope()) {
+					// theoretically, we prevent broken assignments. in practice, its best to
+					// assume they may exist and to not allow them to prevent an otherwsie
+					// valid update. We will still force all broken assignments to be
+					// removed at the time of role deletion.
+					continue
+				}
+
+				if !sr.RoleIsAssignableAtScope(role, subAssignment.GetScope()) {
+					return nil, trace.BadParameter("update of scoped role %q would invalidate assignment %q which assigns it to user %q at scope %q", role.GetMetadata().GetName(), assignment.GetMetadata().GetName(), assignment.GetSpec().GetUser(), subAssignment.GetScope())
+				}
+			}
+		}
+	}
+
+	item, err := scopedRoleToItem(role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	revision, err := s.bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       item.Key,
+			Condition: backend.Revision(item.Revision),
+			Action:    backend.Put(item),
+		},
+		{
+			Key:       roleAssignmentLockKey(role.GetMetadata().GetName()),
+			Condition: lockCondition,
+			Action:    backend.Nop(),
+		},
+	})
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.CompareFailed("scoped role %q or an associated assignment was concurrently modified", role.GetMetadata().GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.UpdateScopedRoleResponse{
+		Role: scopedRoleWithRevision(role, revision),
+	}, nil
+}
+
+func (s *ScopedRoleService) DeleteScopedRole(ctx context.Context, req *srpb.DeleteScopedRoleRequest) (*srpb.DeleteScopedRoleResponse, error) {
+	roleName := req.GetName()
+	if roleName == "" {
+		return nil, trace.BadParameter("missing scoped role name in delete request")
+	}
+
+	lockItem, err := s.bk.Get(ctx, roleAssignmentLockKey(roleName))
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		lockItem = nil
+	}
+
+	lockCondition := backend.NotExists()
+	if lockItem != nil {
+		lockCondition = backend.Revision(lockItem.Revision)
+	}
+
+	// now that we have a lock condition established, we can read all assignments with a "happens after" relationship
+	// to the current lock value and verify that no assignments target this role.
+	for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+			if subAssignment.GetRole() == roleName {
+				return nil, trace.CompareFailed("cannot delete scoped role %q while assignment %q assigns it to a user", roleName, assignment.GetMetadata().GetName())
+			}
+		}
+	}
+
+	roleCondition := backend.Exists()
+	if rev := req.GetRevision(); rev != "" {
+		roleCondition = backend.Revision(rev)
+	}
+
+	// atomically delete the role and its associated assignment lock while asserting that no assignments
+	// have been concurrently applied that target this role.
+	_, err = s.bk.AtomicWrite(ctx, []backend.ConditionalAction{
+		{
+			Key:       scopedRoleKey(roleName),
+			Condition: roleCondition,
+			Action:    backend.Delete(),
+		},
+		{
+			Key:       roleAssignmentLockKey(roleName),
+			Condition: lockCondition,
+			Action:    backend.Delete(),
+		},
+	})
+
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.CompareFailed("scoped role %q has been concurrently modified and/or assigned", roleName)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.DeleteScopedRoleResponse{}, nil
+}
+
+func (s *ScopedRoleService) GetScopedRoleAssignment(ctx context.Context, req *srpb.GetScopedRoleAssignmentRequest) (*srpb.GetScopedRoleAssignmentResponse, error) {
+	assignmentName := req.GetName()
+	if assignmentName == "" {
+		return nil, trace.BadParameter("missing scoped role assignment name in get request")
+	}
+
+	item, err := s.bk.Get(ctx, scopedRoleAssignmentKey(assignmentName))
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("scoped role assignment %q not found", assignmentName)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	assignment, err := scopedRoleAssignmentFromItem(item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := sr.WeakValidateAssignment(assignment); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.GetScopedRoleAssignmentResponse{
+		Assignment: assignment,
+	}, nil
+}
+
+// StreamScopedRoleAssignments returns a stream of all scoped role assignments in the backend. Malformed assignments are skipped.
+// Returned assignments have had weak validation applied.
+func (s *ScopedRoleService) StreamScopedRoleAssignments(ctx context.Context) stream.Stream[*srpb.ScopedRoleAssignment] {
+	return func(yield func(*srpb.ScopedRoleAssignment, error) bool) {
+		startKey := scopedRoleAssignmentKey("")
+		params := backend.ItemsParams{
+			StartKey: startKey,
+			EndKey:   backend.RangeEnd(startKey),
+		}
+
+		for item, err := range s.bk.Items(ctx, params) {
+			if err != nil {
+				// backend errors terminate the stream
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			assignment, err := scopedRoleAssignmentFromItem(&item)
+			if err != nil {
+				// per-assignment errors are logged and skipped
+				s.logger.WarnContext(ctx, "skipping scoped role assignment due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				continue
+			}
+
+			if err := sr.WeakValidateAssignment(assignment); err != nil {
+				// per-assignment errors are logged and skipped
+				s.logger.WarnContext(ctx, "skipping scoped role assignment due to validation error", "error", err, "key", logutils.StringerAttr(item.Key))
+				continue
+			}
+
+			if !yield(assignment, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (s *ScopedRoleService) CreateScopedRoleAssignment(ctx context.Context, req *srpb.CreateScopedRoleAssignmentRequest) (*srpb.CreateScopedRoleAssignmentResponse, error) {
+	assignment := req.GetAssignment()
+	if assignment == nil {
+		return nil, trace.BadParameter("missing scoped role assignment in create request")
+	}
+
+	if err := sr.StrongValidateAssignment(assignment); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// independently enforce the max number of roles per assignment limit here since not all validation
+	// may necessarily enforce it, but it is a hard-limit for the backend impl.
+	if len(assignment.GetSpec().GetAssignments()) > sr.MaxRolesPerAssignment {
+		return nil, trace.BadParameter("scoped role assignment resource %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), sr.MaxRolesPerAssignment)
+	}
+
+	item, err := scopedRoleAssignmentToItem(assignment)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// set up conditional actions for assignment and user lock
+	condacts := []backend.ConditionalAction{
+		{
+			Key:       item.Key,
+			Condition: backend.NotExists(),
+			Action:    backend.Put(item),
+		},
+		{
+			Key:       userAssignmentLockKey(assignment.GetSpec().GetUser()),
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: newUserAssignmentLockVal(assignment.GetSpec().GetUser()),
+			}),
+		},
+	}
+
+	// set up conditional actions for each assigned role lock
+	for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+		// operation must verify that all associated roles have not been concurrently modified
+		// as such modification could theoretically invalidate prior access-control checks.
+		roleRevision, ok := req.GetRoleRevisions()[subAssignment.GetRole()]
+		if !ok {
+			// this is a bug in the API layer, we should never be missing a role revision as it should be
+			// filled in with the revision of the role used for the access-control check.
+			return nil, trace.BadParameter("missing role revision for role %q in backend create (this is a bug)", subAssignment.GetRole())
+		}
+
+		rrsp, err := s.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+			Name: subAssignment.GetRole(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if rrsp.GetRole().GetMetadata().GetRevision() != roleRevision {
+			return nil, trace.CompareFailed("scoped role %q has been concurrently modified", subAssignment.GetRole())
+		}
+
+		// verify that the role is scoped to the same resource scope as the assignment itself
+		// NOTE: this restriction may eventually be relaxed in favor of something more flexible,
+		// but as of right now we haven't decided what that should look like.
+		if scopes.Compare(rrsp.GetRole().GetScope(), assignment.GetScope()) != scopes.Equivalent {
+			return nil, trace.BadParameter("role %q is not scoped to the same resource scope as assignment %q (%q -> %q)", subAssignment.GetRole(), assignment.GetMetadata().GetName(), rrsp.GetRole().GetScope(), subAssignment.GetScope())
+		}
+
+		// verify that the role is assignable at the specified scope
+		if !sr.RoleIsAssignableAtScope(rrsp.GetRole(), subAssignment.GetScope()) {
+			return nil, trace.BadParameter("scoped role %q is not configured to be assignable at scope %q", subAssignment.GetRole(), subAssignment.GetScope())
+		}
+
+		// assert that role is unchanged and modify associated role lock so that role modifications can
+		// detect concurrent modifications to their assignments.
+		condacts = append(condacts, []backend.ConditionalAction{
+			{
+				Key:       scopedRoleKey(subAssignment.GetRole()),
+				Condition: backend.Revision(roleRevision),
+				Action:    backend.Nop(),
+			},
+			{
+				Key:       roleAssignmentLockKey(subAssignment.GetRole()),
+				Condition: backend.Whatever(),
+				Action: backend.Put(backend.Item{
+					Value: newRoleAssignmentLockVal(subAssignment.GetRole()),
+				}),
+			},
+		}...)
+	}
+
+	revision, err := s.bk.AtomicWrite(ctx, condacts)
+	if err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			// return a general concurrent-modification error since it isn't clear which condition faile
+			return nil, trace.CompareFailed("scoped role assignment %q failed due to concurrent modification of associated resources", assignment.GetMetadata().GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.CreateScopedRoleAssignmentResponse{
+		Assignment: scopedRoleAssignmentWithRevision(assignment, revision),
+	}, nil
+}
+
+func (s *ScopedRoleService) DeleteScopedRoleAssignment(ctx context.Context, req *srpb.DeleteScopedRoleAssignmentRequest) (*srpb.DeleteScopedRoleAssignmentResponse, error) {
+	assignmentName := req.GetName()
+	if assignmentName == "" {
+		return nil, trace.BadParameter("missing scoped role assignment name in delete request")
+	}
+
+	extant, err := s.GetScopedRoleAssignment(ctx, &srpb.GetScopedRoleAssignmentRequest{
+		Name: assignmentName,
+	})
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.CompareFailed("scoped role assignment %q was concurrently delete", assignmentName)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	if rev := req.GetRevision(); rev != "" && rev != extant.Assignment.GetMetadata().GetRevision() {
+		return nil, trace.CompareFailed("scoped role assignment %q has been concurrently modified", assignmentName)
+	}
+
+	// check to see if we have a lock on the user. if so, we need to check to see if we're the last assignment
+	// relying on the lock. if we are, we can delete it.
+	userLockItem, err := s.bk.Get(ctx, userAssignmentLockKey(extant.Assignment.GetSpec().GetUser()))
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+		userLockItem = nil
+	}
+
+	// start with initial condition assuming non-existence. note that this really should never happen unless
+	// we have a bug somewhere else, but there isn't really a downside to being resilient to it.
+	userLockCondition := backend.NotExists()
+	userLockAction := backend.Nop()
+	if userLockItem != nil {
+		userLockCondition = backend.Revision(userLockItem.Revision)
+		userLockAction = backend.Put(backend.Item{
+			Value: newUserAssignmentLockVal(extant.Assignment.GetSpec().GetUser()),
+		})
+
+		// check to see if we're the last assignment relying on the user lock. if so, we should delete it.
+		var hasOtherAssignments bool
+		for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if assignment.GetSpec().GetUser() != extant.Assignment.GetSpec().GetUser() {
+				// skip assignments related to other users
+				continue
+			}
+			if assignment.GetMetadata().GetName() == extant.Assignment.GetMetadata().GetName() {
+				// skip the assignment we're currently deleting
+				continue
+			}
+
+			// found another assignment for the same user
+			hasOtherAssignments = true
+			break
+		}
+
+		if !hasOtherAssignments {
+			// no other assignments for this user, we can delete the lock
+			userLockAction = backend.Delete()
+		}
+	}
+
+	condacts := []backend.ConditionalAction{
+		{
+			Key:       scopedRoleAssignmentKey(assignmentName),
+			Condition: backend.Revision(extant.Assignment.GetMetadata().GetRevision()),
+			Action:    backend.Delete(),
+		},
+		{
+			Key:       userAssignmentLockKey(extant.Assignment.GetSpec().GetUser()),
+			Condition: userLockCondition,
+			Action:    userLockAction,
+		},
+	}
+
+	for _, subAssignment := range extant.Assignment.GetSpec().GetAssignments() {
+		// operation must modify all associated role locks to ensure that role operations can
+		// efficiently assert that no assigment related to the role has changed.
+		condacts = append(condacts, backend.ConditionalAction{
+			Key:       roleAssignmentLockKey(subAssignment.GetRole()),
+			Condition: backend.Whatever(),
+			Action: backend.Put(backend.Item{
+				Value: newRoleAssignmentLockVal(subAssignment.GetRole()),
+			}),
+		})
+	}
+
+	if _, err := s.bk.AtomicWrite(ctx, condacts); err != nil {
+		if errors.Is(err, backend.ErrConditionFailed) {
+			return nil, trace.CompareFailed("scoped role assignment %q or another related assignment was concurrently modified", assignmentName)
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return &srpb.DeleteScopedRoleAssignmentResponse{}, nil
+}
+
+func scopedRoleKey(roleName string) backend.Key {
+	return backend.NewKey(scopedRolePrefix, scopedRoleRoleComponent, roleName)
+}
+
+func scopedRoleAssignmentKey(assignmentID string) backend.Key {
+	return backend.NewKey(scopedRolePrefix, scopedRoleAssignmentComponent, assignmentID)
+}
+
+func userAssignmentLockKey(username string) backend.Key {
+	return backend.NewKey(scopedRolePrefix, userAssignmentLockComponent, username)
+}
+
+func roleAssignmentLockKey(roleName string) backend.Key {
+	return backend.NewKey(scopedRolePrefix, roleAssignmentLockComponent, roleName)
+}
+
+// newUserAssignmentLockVal generates a new user assignment lock value for the specified username. A random
+// element is used to ensure that the lock value changes for each operation that changes assignments.
+func newUserAssignmentLockVal(username string) []byte {
+	return []byte(rand.Text() + "-" + username)
+}
+
+// newRoleAssignmentLockVal generates a new role assignment lock value for the specified role name. A random
+// element is used to ensure that the lock value changes for each operation that changes assignments.
+func newRoleAssignmentLockVal(roleName string) []byte {
+	return []byte(rand.Text() + "-" + roleName)
+}
+
+func scopedRoleFromItem(item *backend.Item) (*srpb.ScopedRole, error) {
+	var role srpb.ScopedRole
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, &role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if role.GetMetadata() == nil {
+		return nil, trace.BadParameter("role at %q is critically malformed (missing metadata)", item.Key)
+	}
+
+	role.Metadata.Revision = item.Revision
+	role.Metadata.Expires = utils.TimeIntoProto(item.Expires)
+	return &role, nil
+}
+
+func scopedRoleToItem(role *srpb.ScopedRole) (backend.Item, error) {
+	if role.GetMetadata() == nil {
+		return backend.Item{}, trace.BadParameter("missing metadata in scoped role")
+	}
+
+	if role.GetMetadata().Expires != nil {
+		return backend.Item{}, trace.BadParameter("scoped roles do not support expiration")
+	}
+
+	data, err := protojson.Marshal(role)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
+	return backend.Item{
+		Key:      scopedRoleKey(role.GetMetadata().GetName()),
+		Value:    data,
+		Revision: role.GetMetadata().GetRevision(),
+	}, nil
+}
+
+func scopedRoleAssignmentFromItem(item *backend.Item) (*srpb.ScopedRoleAssignment, error) {
+	var assignment srpb.ScopedRoleAssignment
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, &assignment); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if assignment.GetMetadata() == nil {
+		return nil, trace.BadParameter("assignment at %q is critically malformed (missing metadata)", item.Key)
+	}
+
+	assignment.Metadata.Revision = item.Revision
+	assignment.Metadata.Expires = utils.TimeIntoProto(item.Expires)
+	return &assignment, nil
+}
+
+func scopedRoleAssignmentToItem(assignment *srpb.ScopedRoleAssignment) (backend.Item, error) {
+	if assignment.GetMetadata() == nil {
+		return backend.Item{}, trace.BadParameter("missing metadata in scoped role assignment")
+	}
+
+	if assignment.GetMetadata().Expires != nil {
+		return backend.Item{}, trace.BadParameter("scoped role assignments do not support expiration")
+	}
+
+	data, err := protojson.Marshal(assignment)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+
+	return backend.Item{
+		Key:      scopedRoleAssignmentKey(assignment.GetMetadata().GetName()),
+		Value:    data,
+		Revision: assignment.GetMetadata().GetRevision(),
+	}, nil
+}
+
+// scopedRoleWithRevision creates a copy of the provided role with an updated revision.
+func scopedRoleWithRevision(role *srpb.ScopedRole, revision string) *srpb.ScopedRole {
+	role = apiutils.CloneProtoMsg(role)
+	role.Metadata.Revision = revision
+	return role
+}
+
+// scopedRoleAssignmentWithRevision creates a shallow copy of the provided assignment with an updated revision.
+func scopedRoleAssignmentWithRevision(assignment *srpb.ScopedRoleAssignment, revision string) *srpb.ScopedRoleAssignment {
+	assignment = apiutils.CloneProtoMsg(assignment)
+	assignment.Metadata.Revision = revision
+	return assignment
+}

--- a/lib/services/local/scoped_roles_test.go
+++ b/lib/services/local/scoped_roles_test.go
@@ -1,0 +1,641 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+)
+
+// TestScopedRoleBasicCRUD tests the basic CRUD operations of the ScopedRoleService, excluding the more non-trivial
+// scenarios involving roles with active assignments, which are tested separately.
+func TestScopedRoleBasicCRUD(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	defer backend.Close()
+
+	service := NewScopedRoleService(backend)
+
+	basicRoles := []*srpb.ScopedRole{
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "basic-01",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "basic-02",
+			},
+			Scope: "/bar",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/bar/**"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "basic-03",
+			},
+			Scope: "/baz",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/baz/**"},
+			},
+			Version: types.V1,
+		},
+	}
+
+	var revisions []string
+
+	// verify the expected behavior of CreateScopedRole
+	for _, role := range basicRoles {
+		crsp, err := service.CreateScopedRole(ctx, &srpb.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, crsp.Role.Metadata.Revision)
+		require.Empty(t, cmp.Diff(role, crsp.Role, protocmp.Transform(), protocmp.IgnoreFields(&headerpb.Metadata{}, "revision")))
+
+		// Check that the role can be retrieved.
+		grsp, err := service.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+			Name: role.Metadata.Name,
+		})
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(crsp.Role, grsp.Role, protocmp.Transform() /* deliberately not ignoring revision */))
+
+		revisions = append(revisions, grsp.Role.Metadata.Revision)
+	}
+
+	require.Len(t, revisions, len(basicRoles))
+
+	// verify that create fails if the role already exists
+	_, err = service.CreateScopedRole(ctx, &srpb.CreateScopedRoleRequest{
+		Role: basicRoles[0],
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify a basic allowable update
+	basic01Mod := apiutils.CloneProtoMsg(basicRoles[0])
+	basic01Mod.Spec.AssignableScopes = []string{"/foo", "/bar"}
+	basic01Mod.Metadata.Revision = revisions[0]
+
+	ursp, err := service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: basic01Mod,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, ursp.Role.Metadata.Revision)
+	require.Empty(t, cmp.Diff(basic01Mod, ursp.Role, protocmp.Transform(), protocmp.IgnoreFields(&headerpb.Metadata{}, "revision")))
+
+	// verify that update really happened
+	grsp, err := service.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+		Name: basic01Mod.Metadata.Name,
+	})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(ursp.Role, grsp.Role, protocmp.Transform() /* deliberately not ignoring revision */))
+
+	// verify that update fails if the revision is wrong
+	_, err = service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: basic01Mod,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that update is rejected if the role's scope is changed
+	basic01Mod = apiutils.CloneProtoMsg(ursp.Role)
+	basic01Mod.Scope = "/foo"
+
+	_, err = service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: basic01Mod,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// verify that update fails if the role does not exist
+	_, err = service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: &srpb.ScopedRole{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name:     "non-existent",
+				Revision: revisions[0],
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that delete fails if the role does not exist
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name: "non-existent",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that delete fails if the revision does not match
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name:     basicRoles[0].Metadata.Name,
+		Revision: revisions[0],
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify successful unconditional delete
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name: basicRoles[0].Metadata.Name,
+	})
+	require.NoError(t, err)
+
+	// verify that the role is gone
+	_, err = service.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+		Name: basicRoles[0].Metadata.Name,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
+	// verify successful conditional delete
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name:     basicRoles[1].Metadata.Name,
+		Revision: revisions[1],
+	})
+	require.NoError(t, err)
+
+	// verify that the role is gone
+	_, err = service.GetScopedRole(ctx, &srpb.GetScopedRoleRequest{
+		Name: basicRoles[1].Metadata.Name,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+}
+
+// TestScopedRoleAssignmentBasicCRD tests the basic CRD operations of the ScopedRoleAssignmentService, excluding the more non-trivial
+// scenarios involving roles with active assignments, which are tested separately.
+func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	defer backend.Close()
+
+	service := NewScopedRoleService(backend)
+
+	roles := []*srpb.ScopedRole{
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-01",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-02",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-03",
+			},
+			Scope: "/foo",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		},
+	}
+
+	var roleRevisions []string
+
+	// Create the roles.
+	for _, role := range roles {
+		rsp, err := service.CreateScopedRole(ctx, &srpb.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+
+		roleRevisions = append(roleRevisions, rsp.Role.Metadata.Revision)
+	}
+
+	// basic root assignment to test standard CRD operations with (initially invalid,
+	// will be modified later to be valid)
+	assignment01 := &srpb.ScopedRoleAssignment{
+		Kind: sr.KindScopedRoleAssignment,
+		Metadata: &headerpb.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/",
+		Spec: &srpb.ScopedRoleAssignmentSpec{
+			User: "alice",
+			Assignments: []*srpb.Assignment{
+				{
+					Role:  "role-02", // not assignable to root
+					Scope: "/",
+				},
+			},
+		},
+		Version: types.V1,
+	}
+
+	// check that assignment to root fails since the target role is only assignable to /foo
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-02": roleRevisions[1],
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// check that assignment with an invalid resource scope fails
+	assignment01.Spec.Assignments[0].Role = "role-01" // fix role to be assignable to root
+	assignment01.Scope = "/foo"                       // invalid scope for root assignment
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// check that assignment of correct role still fails if revision is incorrect
+	assignment01.Scope = "/" // fix scope to be valid for root assignment
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[1], // revision of role-02, not role-01
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// check that assignment of correct role with correct revision works
+	crsp, err := service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, crsp.Assignment.Metadata.Revision)
+	require.Empty(t, cmp.Diff(crsp.Assignment, assignment01, protocmp.Transform(), protocmp.IgnoreFields(&headerpb.Metadata{}, "revision")))
+
+	// Check that the assignment can be retrieved.
+	grsp, err := service.GetScopedRoleAssignment(ctx, &srpb.GetScopedRoleAssignmentRequest{
+		Name: assignment01.Metadata.Name,
+	})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(crsp.Assignment, grsp.Assignment, protocmp.Transform() /* deliberately not ignoring revision */))
+
+	// verify that create fails if the assignment already exists
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that delete of assignment with incorrect revision fails
+	_, err = service.DeleteScopedRoleAssignment(ctx, &srpb.DeleteScopedRoleAssignmentRequest{
+		Name:     assignment01.Metadata.Name,
+		Revision: roleRevisions[0],
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that delete of assignment with correct revision works
+	_, err = service.DeleteScopedRoleAssignment(ctx, &srpb.DeleteScopedRoleAssignmentRequest{
+		Name:     assignment01.Metadata.Name,
+		Revision: crsp.Assignment.Metadata.Revision,
+	})
+	require.NoError(t, err)
+
+	// verify that the assignment is gone
+	_, err = service.GetScopedRoleAssignment(ctx, &srpb.GetScopedRoleAssignmentRequest{
+		Name: assignment01.Metadata.Name,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
+	// set up a more non-trivial assignment with multiple sub-assignments
+	assignment02 := &srpb.ScopedRoleAssignment{
+		Kind: sr.KindScopedRoleAssignment,
+		Metadata: &headerpb.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/",
+		Spec: &srpb.ScopedRoleAssignmentSpec{
+			User: "bob",
+			Assignments: []*srpb.Assignment{
+				{
+					Role:  "role-01",
+					Scope: "/foo",
+				},
+				{
+					Role:  "role-02",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "role-03", // role-03 cannot by assigned to by an assignment in the root resource scope
+					Scope: "/foo",
+				},
+			},
+		},
+		Version: types.V1,
+	}
+
+	// verify that assignment with a mix of conflicting and correct resource scopes fails
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment02,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			"role-02": roleRevisions[1],
+			"role-03": roleRevisions[2],
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// verify that a mix of valid and invalid role revisions fails
+	assignment02.Spec.Assignments = assignment02.Spec.Assignments[:2] // remove role-03 assignment
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment02,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			"role-02": roleRevisions[2], // revision of role-03, not role-02
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// verify that assignment with some but not all of the role revisions fails
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment02,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			// role-02 is missing
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// verify that assignment with all of the role revisions works
+	crsp, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment02,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			"role-02": roleRevisions[1],
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, crsp.Assignment.Metadata.Revision)
+	require.Empty(t, cmp.Diff(crsp.Assignment, assignment02, protocmp.Transform(), protocmp.IgnoreFields(&headerpb.Metadata{}, "revision")))
+
+	// Check that the assignment can be retrieved
+	grsp, err = service.GetScopedRoleAssignment(ctx, &srpb.GetScopedRoleAssignmentRequest{
+		Name: assignment02.Metadata.Name,
+	})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(crsp.Assignment, grsp.Assignment, protocmp.Transform() /* deliberately not ignoring revision */))
+}
+
+// TestScopedRoleAssignmentInteraction verifies the expected interaction rules between scoped roles and
+// scoped role assignments.
+func TestScopedRoleAssignmentInteraction(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	defer backend.Close()
+
+	service := NewScopedRoleService(backend)
+
+	roles := []*srpb.ScopedRole{
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-01",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-02",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-03",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/bar"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "role-04",
+			},
+			Scope: "/",
+			Spec: &srpb.ScopedRoleSpec{
+				AssignableScopes: []string{"/bin"},
+			},
+			Version: types.V1,
+		},
+	}
+
+	var roleRevisions []string
+
+	// Create the roles.
+	for _, role := range roles {
+		rsp, err := service.CreateScopedRole(ctx, &srpb.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+
+		roleRevisions = append(roleRevisions, rsp.Role.Metadata.Revision)
+	}
+
+	// set up a non-trivial assignment with multiple sub-assignments
+	assignment01 := &srpb.ScopedRoleAssignment{
+		Kind: sr.KindScopedRoleAssignment,
+		Metadata: &headerpb.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/",
+		Spec: &srpb.ScopedRoleAssignmentSpec{
+			User: "alice",
+			Assignments: []*srpb.Assignment{
+				{
+					Role:  "role-01",
+					Scope: "/foo",
+				},
+				{
+					Role:  "role-02",
+					Scope: "/foo/bar",
+				},
+				{
+					Role:  "role-03",
+					Scope: "/bar",
+				},
+			},
+		},
+		Version: types.V1,
+	}
+
+	crsp, err := service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			"role-02": roleRevisions[1],
+			"role-03": roleRevisions[2],
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, crsp.Assignment.Metadata.Revision)
+	require.Empty(t, cmp.Diff(crsp.Assignment, assignment01, protocmp.Transform(), protocmp.IgnoreFields(&headerpb.Metadata{}, "revision")))
+
+	// check that unrelated role can be deleted
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name:     "role-04",
+		Revision: roleRevisions[3],
+	})
+	require.NoError(t, err)
+
+	// check that deleting a role referenced by an assignment fails
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name:     "role-01",
+		Revision: roleRevisions[0],
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// check that updated a role s.t. it would invalidate an assignment fails
+	updatedRole := apiutils.CloneProtoMsg(roles[1])
+	updatedRole.Spec.AssignableScopes = []string{"/bin"} // role-02 is now assignable to /bin, not /foo
+	updatedRole.Metadata.Revision = roleRevisions[1]
+	_, err = service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: updatedRole,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+
+	// check that deletion of a role s.t. it would invalidate an assignment fails
+	_, err = service.DeleteScopedRole(ctx, &srpb.DeleteScopedRoleRequest{
+		Name:     "role-02",
+		Revision: roleRevisions[1],
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
+
+	// delete the assignment
+	_, err = service.DeleteScopedRoleAssignment(ctx, &srpb.DeleteScopedRoleAssignmentRequest{
+		Name:     assignment01.Metadata.Name,
+		Revision: crsp.Assignment.Metadata.Revision,
+	})
+	require.NoError(t, err)
+
+	// check that update of role now succeeds
+	urrsp, err := service.UpdateScopedRole(ctx, &srpb.UpdateScopedRoleRequest{
+		Role: updatedRole,
+	})
+	require.NoError(t, err)
+
+	// check that recreate of assignment would now fail due to conflicting role
+	_, err = service.CreateScopedRoleAssignment(ctx, &srpb.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment01,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+			"role-02": urrsp.Role.Metadata.Revision, // revision of updated role-02
+			"role-03": roleRevisions[2],
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+}

--- a/lib/utils/time.go
+++ b/lib/utils/time.go
@@ -22,7 +22,33 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// TimeFromProto converts a protobuf Timestamp to a Go time.Time, preserving
+// the zero value across the conversion boundary (standard go/proto timestamp
+// conversion doesn't preserve "zeroness").
+func TimeFromProto(t *timestamppb.Timestamp) time.Time {
+	// use the zero time to represent the nil timestamp. note that this is conceptually distinct
+	// from using t.GetSeconds() == 0 && t.GetNanos() == 0. a timstampb that happens to be created
+	// targeting the unix epoch isn't necessarily equivalent to a zero go timestamp, since the zero
+	// value for the go timestamp isn't the unix epoch.
+	if t == nil {
+		return time.Time{}
+	}
+
+	return t.AsTime()
+}
+
+// TimeIntoProto converts a Go time.Time to a protobuf Timestamp, preserving
+// the zero value across the conversion boundary (standard go/proto timestamp
+// conversion doesn't preserve "zeroness").
+func TimeIntoProto(t time.Time) *timestamppb.Timestamp {
+	if t.IsZero() {
+		return nil
+	}
+	return timestamppb.New(t)
+}
 
 // MinTTL selects the smallest non-zero duration from a and b.
 func MinTTL(a, b time.Duration) time.Duration {

--- a/lib/utils/time_test.go
+++ b/lib/utils/time_test.go
@@ -1,0 +1,59 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+// TestTimeProtoConv verified the expected behavior of our zero-preserving
+// proto timestamp conversion helpers.
+func TestTimeProtoConv(t *testing.T) {
+	t.Parallel()
+
+	// verify the stated purpose of the conversion functions, preservation
+	// of zeroness across the conversion boundary.
+	require.Nil(t, TimeIntoProto(time.Time{}))
+	require.True(t, TimeFromProto(nil).IsZero())
+	require.Nil(t, TimeIntoProto(TimeFromProto(nil)))
+	require.True(t, TimeFromProto(TimeIntoProto(time.Time{})).IsZero())
+
+	// verify some relatively trivial examples. our conversion functions are
+	// thin wrappers around the standard go/proto conversion functions, so
+	// we aren't trying to robustly validate them, just add a sanity-check
+	// against mistakes.
+	tts := []time.Time{
+		time.Unix(0, 0).UTC(),
+		time.Unix(0, 1).UTC(),
+		time.Unix(1, 0).UTC(),
+		time.Unix(1, 1).UTC(),
+		time.Now().UTC(),
+	}
+
+	for i, tt := range tts {
+		protott := TimeIntoProto(tt)
+		require.True(t, tt.Equal(TimeFromProto(protott)), "index %d", i)
+		require.Empty(t, cmp.Diff(protott, TimeIntoProto(TimeFromProto(protott)), protocmp.Transform()))
+	}
+}


### PR DESCRIPTION
Implements validation and backend logic for the `ScopedRole` and `ScopedRoleAssignment` types.

Given the current high churn in scopes, all validation was added to `lib` rather than `api`.  Some elements may be moved to `api` once scopes are a bit more flushed out.

The backend implementation was deliberately set up to be more opinionated than we probably want in the long run.  Due to the prototype/mvp nature of scopes and the fast intended development pace, I'm trying to leave our options open as much as possible for future changes/extensions, which will be a lot easier if the initial backend impl is highly opinionated.  Some notable restrictions include:

- Roles cannot be deleted if an assignment references them.
- Roles cannot be edited to change their resource scope.
- Role cannot be edited s.t. the edit might invalidate an extant assignment.
- Assignment resources cannot be created that contain an invalid role-assignment.
- Assignments cannot be created for nonexistent roles.
- Assignment creation requests cannot be created without revision assertions for all assigned roles.
- An assignment's resource scope must exactly match the resource scope of the role(s) it assigns.
- No mechanism of editing assignments is provided.
- Role/assignments do not support expiry.

One notable omission from this work is a system for ensuring that role assignments created by identity provider logins are atomically overwritten by new logins. That design work has been deliberately deferred in order to land the core impl sooner.

The scope validation logic `lib/scopes` (originally introduced in https://github.com/gravitational/teleport/pull/54616) has been slightly modified. The original implementation treated `""` and `"/"` interchangeably for the purposes of comparisons.  This was because _resource_ scopes are implicitly root if they are not defined, and policy scopes are green field so the individual policy types can enforce scope presence.  During my work on validation/backend logic I found it was too easy to make potentially risky mistakes with this behavior.  Scope comparison was updated to treat `""` as `Orthogonal` to all other values, meaning that a bug leading to a policy assigned at an unspecified scope would lead to the policy applying to nothing, which is a safer failure mode.  The glob-related matching and validation logic in `lib/scopes` has also been improved to better handle the more flexible syntax expected by the `Weak*` family of validators.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).