### PR TITLE
[web] Add `RequestKind` toggle to Access Requests in web ui

### DIFF
--- a/web/packages/design/src/Alert/Alert.story.tsx
+++ b/web/packages/design/src/Alert/Alert.story.tsx
@@ -20,7 +20,7 @@ import { action } from 'storybook/actions';
 
 import { Restore } from 'design/Icon';
 
-import { Box } from '..';
+import { Box, Flex, Text } from '..';
 import { Alert, AlertProps, Banner } from './Alert';
 
 export default {
@@ -36,6 +36,49 @@ export const Simple = () => (
     <Alert kind="success">This is success</Alert>
     <Alert kind="neutral" icon={Restore}>
       Alert with a custom icon
+    </Alert>
+  </Box>
+);
+
+export const Wrapping = () => (
+  <Box maxWidth="300px">
+    <Alert kind="neutral" wrapContents>
+      <Flex flexDirection="column" gap={1}>
+        <Text>Some neutral message</Text>
+        <Text typography="body2" bold={false}>
+          Some more information or extended description, which may be long
+          enough to wrap to multiple lines. Note how the icon stays aligned with
+          the top despite this.
+        </Text>
+      </Flex>
+    </Alert>
+    <Alert
+      kind="warning"
+      primaryAction={{ content: 'Okay', onClick: () => {} }}
+      wrapContents
+    >
+      <Flex flexDirection="column" gap={1}>
+        <Text>Some warning</Text>
+        <Text typography="body2" bold={false}>
+          This is a warning message with an action button. When the text wraps
+          here, the button should stay centre-aligned as well.
+        </Text>
+      </Flex>
+    </Alert>
+    <Alert
+      kind="danger"
+      primaryAction={{ content: 'Action', onClick: () => {} }}
+      wrapContents
+    >
+      Some error alert with an action
+    </Alert>
+    <Alert
+      kind="danger"
+      primaryAction={{ content: 'Action', onClick: () => {} }}
+      secondaryAction={{ content: 'Cancel', onClick: () => {} }}
+      wrapContents
+    >
+      Some error alert with two actions
     </Alert>
   </Box>
 );

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -26,6 +26,7 @@ export function Toggle({
   disabled,
   className,
   size = 'small',
+  ref,
 }: {
   isToggled: boolean;
   onToggle: () => void;
@@ -33,9 +34,10 @@ export function Toggle({
   disabled?: boolean;
   className?: string;
   size?: 'small' | 'large';
+  ref?: React.ForwardedRef<HTMLLabelElement>;
 }) {
   return (
-    <StyledWrapper disabled={disabled} className={className}>
+    <StyledWrapper disabled={disabled} className={className} ref={ref}>
       <StyledInput
         checked={isToggled}
         onChange={onToggle}

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm.tsx
@@ -1,0 +1,264 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Alert } from 'design/Alert';
+import Flex from 'design/Flex';
+import Text from 'design/Text';
+import {
+  PendingListItem,
+  RequestCheckoutProps,
+} from 'shared/components/AccessRequests/NewRequest';
+import {
+  AccessRequest,
+  LongTermResourceGrouping,
+  RequestKind,
+} from 'shared/services/accessRequests';
+
+// LongTermGroupingErrors displays any errors related to long-term
+// resource grouping, such as uncovered or incompatible resources.
+export const LongTermGroupingErrors = <
+  T extends PendingListItem = PendingListItem,
+>({
+  grouping,
+  toggleResources,
+  pendingAccessRequests,
+}: {
+  grouping: LongTermResourceGrouping;
+  toggleResources?: RequestCheckoutProps<T>['toggleResources'];
+  pendingAccessRequests: T[];
+}) => {
+  if (
+    !grouping?.accessListToResources?.[grouping?.recommendedAccessList]?.length
+  ) {
+    return (
+      <Alert kind="danger" wrapContents>
+        <Flex flexDirection="column" gap={1}>
+          <Text>Long-term access unavailable</Text>
+          <Text typography="body2" bold={false}>
+            {grouping.validationMessage ||
+              'No resources are available for long-term access.'}
+          </Text>
+        </Flex>
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      <UncoveredResourcesError
+        grouping={grouping}
+        pendingAccessRequests={pendingAccessRequests}
+        toggleResources={toggleResources}
+      />
+      <IncompatibleResourcesError
+        grouping={grouping}
+        pendingAccessRequests={pendingAccessRequests}
+        toggleResources={toggleResources}
+      />
+    </>
+  );
+};
+
+const UncoveredResourcesError = <T extends PendingListItem = PendingListItem>({
+  grouping,
+  pendingAccessRequests,
+  toggleResources,
+}: {
+  grouping: LongTermResourceGrouping;
+  pendingAccessRequests: T[];
+  toggleResources?: RequestCheckoutProps<T>['toggleResources'];
+}) => {
+  const uncoveredResources = findUncoveredLongTermResources(
+    grouping,
+    pendingAccessRequests
+  );
+  if (!uncoveredResources.length) {
+    return null;
+  }
+
+  const plural = uncoveredResources.length > 1;
+  const message = `${joinResourceNames(uncoveredResources)} ${plural ? 'are' : 'is'} not available for long-term access. Remove ${plural ? 'them' : 'it'} or switch to a short-term request.`;
+
+  return (
+    <Alert
+      kind="danger"
+      primaryAction={{
+        content: `Remove incompatible ${plural ? 'resources' : 'resource'}`,
+        onClick: () =>
+          toggleResources(
+            uncoveredResources.map(i => ({
+              resourceName: i.name,
+              resourceId: i.id,
+              kind: i.kind,
+            }))
+          ),
+      }}
+      wrapContents
+    >
+      <Flex flexDirection="column" gap={1}>
+        <Text>
+          Long-term access is not available for{' '}
+          {plural ? 'some selected resources' : 'a selected resource'}
+        </Text>
+        <Text typography="body2" bold={false}>
+          {message}
+        </Text>
+      </Flex>
+    </Alert>
+  );
+};
+
+const IncompatibleResourcesError = <
+  T extends PendingListItem = PendingListItem,
+>({
+  grouping,
+  pendingAccessRequests,
+  toggleResources,
+}: {
+  grouping: LongTermResourceGrouping;
+  pendingAccessRequests: T[];
+  toggleResources?: RequestCheckoutProps<T>['toggleResources'];
+}) => {
+  const incompatibleResources = findIncompatibleLongTermResources(
+    grouping,
+    pendingAccessRequests
+  );
+  if (!incompatibleResources.length) {
+    return null;
+  }
+
+  const plural = incompatibleResources.length > 1;
+  const message = `Remove ${joinResourceNames(incompatibleResources)} and request ${plural ? 'them' : 'it'} separately, or switch to a short-term request.`;
+
+  return (
+    <Alert
+      kind="warning"
+      primaryAction={{
+        content: `Remove incompatible ${plural ? 'resources' : 'resource'}`,
+        onClick: () =>
+          toggleResources(
+            incompatibleResources.map(i => ({
+              resourceName: i.name,
+              resourceId: i.id,
+              kind: i.kind,
+            }))
+          ),
+      }}
+      wrapContents
+    >
+      <Flex flexDirection="column" gap={1}>
+        <Text>
+          {plural ? 'Resources' : 'Resource'} cannot be grouped for long-term
+          access
+        </Text>
+        <Text typography="body2" bold={false}>
+          {message}
+        </Text>
+      </Flex>
+    </Alert>
+  );
+};
+
+// joinResourceNames takes a list of resources and returns a
+// human-readable string of their names, formatted
+// as a list with commas and "and" for the last item.
+const joinResourceNames = <T extends PendingListItem = PendingListItem>(
+  resources: T[]
+) => {
+  const names = resources.map(r => r.name);
+  if (names.length <= 1) return names[0] || '';
+  if (names.length === 2) return names.join(' and ');
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+};
+
+// findIncompatibleLongTermResources iterates through the
+// pendingRequests and returns a list of resources
+// that are incompatible with the optimal grouping.
+const findIncompatibleLongTermResources = <
+  T extends PendingListItem = PendingListItem,
+>(
+  grouping: LongTermResourceGrouping,
+  pendingRequests: T[]
+) => {
+  const optimalGrouping =
+    grouping.accessListToResources?.[grouping.recommendedAccessList];
+  if (!optimalGrouping?.length) {
+    return [];
+  }
+
+  // Don't include uncovered resources, so we avoid duplicate errs
+  const uncoveredResources = findUncoveredLongTermResources(
+    grouping,
+    pendingRequests
+  );
+
+  return pendingRequests.filter(
+    item =>
+      item.kind !== 'namespace' &&
+      !uncoveredResources.some(i => item.id === i.id) &&
+      !optimalGrouping.some(i => item.id === i.name)
+  );
+};
+
+// findUncoveredLongTermResources iterates through the
+// pendingAccessRequests and returns a list of resources
+// that are not covered by any grouping.
+const findUncoveredLongTermResources = <
+  T extends PendingListItem = PendingListItem,
+>(
+  grouping: LongTermResourceGrouping,
+  pendingRequests: T[]
+) => {
+  const groupings = Object.values(grouping.accessListToResources || {}).flat();
+
+  return pendingRequests.filter(
+    item =>
+      item.kind !== 'namespace' && !groupings.some(i => item.id === i.name)
+  );
+};
+
+// shouldShowLongTermGroupingErrors checks if the current dryRunResponse is
+// up-to-date with the current pendingAccessRequests and requestKind,
+// intended for use before rendering any LongTermGrouping errors.
+export const shouldShowLongTermGroupingErrors = <
+  T extends PendingListItem = PendingListItem,
+>({
+  requestKind,
+  pendingAccessRequests,
+  dryRunResponse,
+}: {
+  requestKind: RequestKind;
+  pendingAccessRequests: T[];
+  dryRunResponse: AccessRequest;
+}) => {
+  if (
+    requestKind !== RequestKind.LongTerm ||
+    !dryRunResponse ||
+    dryRunResponse.requestKind !== requestKind
+  ) {
+    return false;
+  }
+
+  const responseResourceKeys = new Set(
+    dryRunResponse.resources.map(res => `${res.id.kind}:${res.id.name}`)
+  );
+  return pendingAccessRequests.every(r => {
+    if (r.kind === 'namespace') return true;
+    const key = `${r.kind}:${r.id}`;
+    return responseResourceKeys.has(key);
+  });
+};

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -21,6 +21,7 @@ import { Link, MemoryRouter } from 'react-router-dom';
 
 import { Box, ButtonPrimary, ButtonText } from 'design';
 import { Option } from 'shared/components/Select';
+import { RequestKind } from 'shared/services/accessRequests';
 
 import { dryRunResponse } from '../../fixtures';
 import { useSpecifiableFields } from '../useSpecifiableFields';
@@ -249,6 +250,7 @@ const baseProps: RequestCheckoutWithSliderProps = {
   clearAttempt: () => null,
   onClose: () => null,
   toggleResource: () => null,
+  toggleResources: () => null,
   reset: () => null,
   transitionState: 'entered',
   numRequestedResources: 4,
@@ -264,5 +266,7 @@ const baseProps: RequestCheckoutWithSliderProps = {
   pendingRequestTtlOptions: [],
   dryRunResponse,
   startTime: null,
+  requestKind: RequestKind.ShortTerm,
+  setRequestKind: () => null,
   onStartTimeChange: () => null,
 };

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -20,12 +20,14 @@ import { useState } from 'react';
 import { Link, MemoryRouter } from 'react-router-dom';
 
 import { Box, ButtonPrimary, ButtonText } from 'design';
+import { UNSUPPORTED_KINDS } from 'shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm';
 import { Option } from 'shared/components/Select';
-import { RequestKind } from 'shared/services/accessRequests';
+import { AccessRequest, RequestKind } from 'shared/services/accessRequests';
 
 import { dryRunResponse } from '../../fixtures';
 import { useSpecifiableFields } from '../useSpecifiableFields';
 import {
+  PendingListItem,
   RequestCheckoutWithSlider,
   RequestCheckoutWithSliderProps,
 } from './RequestCheckout';
@@ -128,6 +130,143 @@ export const LoadedResourceRequest = () => {
   );
 };
 
+export const LoadedLongTermRequest = () => {
+  const dryRunResponseWithLongTerm = {
+    ...dryRunResponse,
+    requestKind: RequestKind.LongTerm,
+    longTermResourceGrouping: {
+      accessListToResources: {
+        'some-list-uuid': baseProps.pendingAccessRequests
+          .filter(r => !UNSUPPORTED_KINDS.includes(r.kind))
+          .map(r => ({
+            kind: r.kind,
+            name: r.id,
+            clusterName: 'cluster-name',
+          })),
+      },
+      canProceed: true,
+      recommendedAccessList: 'some-list-uuid',
+      validationMessage: '',
+    },
+  } satisfies AccessRequest;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        pendingAccessRequests={baseProps.pendingAccessRequests.filter(
+          r => r.kind !== 'windows_desktop'
+        )}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        requestKind={RequestKind.LongTerm}
+        dryRunResponse={dryRunResponseWithLongTerm}
+      />
+    </MemoryRouter>
+  );
+};
+
+export const LoadedLongTermRequestWithGroupingErrors = () => {
+  const dryRunResponseWithLongTermGroupingErrors = {
+    ...dryRunResponse,
+    requestKind: RequestKind.LongTerm,
+    longTermResourceGrouping: {
+      accessListToResources: {
+        'some-list-uuid': baseProps.pendingAccessRequests
+          .slice(0, 3)
+          .map(r => ({
+            kind: r.kind,
+            name: r.id,
+            clusterName: 'cluster-name',
+          })),
+        'another-list-uuid': baseProps.pendingAccessRequests
+          .slice(3)
+          .map(r => ({
+            kind: r.kind,
+            name: r.id,
+            clusterName: 'cluster-name',
+          })),
+      },
+      canProceed: false,
+      recommendedAccessList: 'some-list-uuid',
+      validationMessage:
+        'Selected resources cannot be grouped for long-term access',
+    },
+  } satisfies AccessRequest;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        requestKind={RequestKind.LongTerm}
+        dryRunResponse={dryRunResponseWithLongTermGroupingErrors}
+      />
+    </MemoryRouter>
+  );
+};
+
+export const LoadedLongTermRequestWithUnsupportedResources = () => {
+  const unsupportedResources = [
+    {
+      kind: 'windows_desktop',
+      name: 'desktop-name',
+      id: 'desktop-id',
+    },
+    {
+      kind: 'namespace',
+      name: 'kube-name',
+      id: 'kube-id',
+      subResourceName: 'kube-namespace-name',
+    },
+  ] satisfies PendingListItem[];
+
+  const dryRunResponseWithLongTermAndUnsupportedResources = {
+    ...dryRunResponse,
+    requestKind: RequestKind.LongTerm,
+    resources: [
+      ...baseProps.pendingAccessRequests.map(r => ({
+        id: { ...r, clusterName: 'cluster-name' },
+      })),
+      ...unsupportedResources.map(r => ({
+        id: { ...r, clusterName: 'cluster-name' },
+      })),
+    ],
+    longTermResourceGrouping: {
+      accessListToResources: {
+        'list-uuid': baseProps.pendingAccessRequests
+          .filter(r => !UNSUPPORTED_KINDS.includes(r.kind))
+          .map(r => ({
+            kind: r.kind,
+            name: r.id,
+            clusterName: 'cluster-name',
+          })),
+      },
+      canProceed: false,
+      recommendedAccessList: 'list-uuid',
+      validationMessage:
+        'Long-term access is not available for some selected resources',
+    },
+  } satisfies AccessRequest;
+
+  return (
+    <MemoryRouter>
+      <RequestCheckoutWithSlider
+        {...baseProps}
+        isResourceRequest={true}
+        pendingAccessRequests={[
+          ...baseProps.pendingAccessRequests,
+          ...unsupportedResources,
+        ]}
+        fetchResourceRequestRolesAttempt={{ status: 'success' }}
+        requestKind={RequestKind.LongTerm}
+        dryRunResponse={dryRunResponseWithLongTermAndUnsupportedResources}
+      />
+    </MemoryRouter>
+  );
+};
+
 export const ProcessingResourceRequest = () => (
   <MemoryRouter>
     <RequestCheckoutWithSlider
@@ -214,37 +353,37 @@ const baseProps: RequestCheckoutWithSliderProps = {
     {
       kind: 'app',
       name: 'app-name',
-      id: 'app-name',
+      id: 'app-id',
     },
     {
       kind: 'db',
-      name: 'app-name',
-      id: 'app-name',
+      name: 'db-name',
+      id: 'db-id',
     },
     {
       kind: 'kube_cluster',
       name: 'kube-name',
-      id: 'app-name',
+      id: 'kube-id',
     },
     {
       kind: 'user_group',
       name: 'user-group-name',
-      id: 'app-name',
+      id: 'user-group-id',
     },
     {
       kind: 'windows_desktop',
       name: 'desktop-name',
-      id: 'app-name',
+      id: 'desktop-id',
     },
     {
       kind: 'saml_idp_service_provider',
       name: 'app-saml',
-      id: 'app-name',
+      id: 'saml-id',
     },
     {
       kind: 'aws_ic_account_assignment',
       name: 'account1',
-      id: 'admin-on-account1',
+      id: 'aws-id',
     },
   ],
   clearAttempt: () => null,

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -226,14 +226,18 @@ export function RequestCheckout<T extends PendingListItem>({
       pendingAccessRequests.length === 0 ||
       createAttempt.status === 'processing' ||
       isInvalidRoleSelection
-    )
+    ) {
       return true;
+    }
     if (
       fetchResourceRequestRolesAttempt.status === 'failed' &&
       hasUnsupporteKubeResourceKinds
-    )
+    ) {
       return true;
-    if (fetchResourceRequestRolesAttempt.status === 'processing') return true;
+    }
+    if (fetchResourceRequestRolesAttempt.status === 'processing') {
+      return true;
+    }
     if (isLongTerm) {
       return !dryRunResponse?.longTermResourceGrouping?.canProceed;
     }
@@ -300,8 +304,22 @@ export function RequestCheckout<T extends PendingListItem>({
 
   function customRow(item: T) {
     if (item.kind === 'kube_cluster') {
+      const unsupported =
+        requestKind === RequestKind.LongTerm &&
+        !!isKubeClusterWithNamespaces(item, pendingAccessRequests);
+
       return (
-        <td colSpan={showClusterNameColumn ? 4 : 3}>
+        <td
+          colSpan={showClusterNameColumn ? 4 : 3}
+          style={
+            unsupported
+              ? {
+                  background: theme.colors.interactive.tonal.danger[0],
+                  borderTopColor: theme.colors.interactive.tonal.danger[2],
+                }
+              : {}
+          }
+        >
           <Flex>
             <Flex flexWrap="wrap">
               <Flex
@@ -541,10 +559,6 @@ export function RequestCheckout<T extends PendingListItem>({
                               )
                             }
                             disabled={longTermDisabled}
-                            css={
-                              longTermDisabled &&
-                              `cursor: not-allowed !important;`
-                            }
                           >
                             <Flex flexDirection="column" ml={3}>
                               <Text>Long-Term Access</Text>
@@ -568,7 +582,7 @@ export function RequestCheckout<T extends PendingListItem>({
                   )}
                   {/* Selecting reviewers not available for long-term requests */}
                   {!isLongTerm && (
-                    <Box mt={4}>
+                    <Box my={4}>
                       <SelectReviewers
                         reviewers={
                           dryRunResponse?.reviewers.map(r => r.name) ?? []

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -52,6 +52,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import {
   LongTermGroupingErrors,
   shouldShowLongTermGroupingErrors,
+  UNSUPPORTED_KINDS,
 } from 'shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm';
 import { RequestableResourceKind } from 'shared/components/AccessRequests/NewRequest/resource';
 import { FieldCheckbox } from 'shared/components/FieldCheckbox';
@@ -360,9 +361,7 @@ export function RequestCheckout<T extends PendingListItem>({
           requestKind,
           pendingAccessRequests,
           dryRunResponse,
-        }) ||
-        !dryRunResponse?.longTermResourceGrouping ||
-        dryRunResponse.longTermResourceGrouping.canProceed
+        })
       ) {
         return;
       }
@@ -377,7 +376,7 @@ export function RequestCheckout<T extends PendingListItem>({
 
       const isInOptimalGrouping = grouping.some(i => i.name === item.id);
 
-      if (!isInAnyGrouping) {
+      if (!isInAnyGrouping || UNSUPPORTED_KINDS.includes(item.kind)) {
         return {
           background: theme.colors.interactive.tonal.danger[0],
           borderTopColor: theme.colors.interactive.tonal.danger[2],
@@ -448,12 +447,20 @@ export function RequestCheckout<T extends PendingListItem>({
               </Box>
             </Alert>
           )}
-          {fetchStatus === 'loading' && (
-            <Box mt={5} textAlign="center">
+          {fetchStatus === 'loading' ? (
+            <Box
+              textAlign="center"
+              // roughly align with the 'normal' height of the side-panel
+              // and prevent jitter from Indicator sub-pixel rendering
+              css={`
+                min-height: 30vh;
+                display: grid;
+                place-items: center;
+              `}
+            >
               <Indicator delay="none" />
             </Box>
-          )}
-          {fetchStatus === 'loaded' && (
+          ) : (
             <div>
               {createAttempt.status === 'success' ? (
                 <>

--- a/web/packages/shared/components/AccessRequests/NewRequest/useSpecifiableFields.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/useSpecifiableFields.ts
@@ -23,7 +23,7 @@ import {
   ReviewerOption,
 } from 'shared/components/AccessRequests/NewRequest';
 import { Option } from 'shared/components/Select';
-import { AccessRequest } from 'shared/services/accessRequests';
+import { AccessRequest, RequestKind } from 'shared/services/accessRequests';
 
 import {
   getDurationOptionIndexClosestToOneWeek,
@@ -87,6 +87,10 @@ export function useSpecifiableFields() {
    */
   let maxDurationOptions: Option<number>[] = [];
 
+  const [requestKind, setRequestKind] = useState<RequestKind>(
+    RequestKind.ShortTerm
+  );
+
   if (dryRunResponse) {
     pendingRequestTtlOptions = getPendingRequestDurationOptions(
       dryRunResponse.created,
@@ -106,6 +110,7 @@ export function useSpecifiableFields() {
     setStartTime(null);
     setMaxDuration(null);
     setPendingRequestTtl(null);
+    setRequestKind(RequestKind.ShortTerm);
   }
 
   function preselectPendingRequestTtlOption(
@@ -198,6 +203,8 @@ export function useSpecifiableFields() {
     pendingRequestTtlOptions,
     dryRunResponse,
     startTime,
+    requestKind,
+    setRequestKind,
     onStartTimeChange,
     onDryRunChange,
     reset,

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.tsx
@@ -29,7 +29,11 @@ import { Option } from 'shared/components/Select';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { Attempt } from 'shared/hooks/useAsync';
-import { AccessRequest, RequestState } from 'shared/services/accessRequests';
+import {
+  AccessRequest,
+  RequestKind,
+  RequestState,
+} from 'shared/services/accessRequests';
 
 import { AccessDurationReview } from '../../../AccessDuration';
 import { AssumeStartTime } from '../../../AssumeStartTime/AssumeStartTime';
@@ -298,9 +302,13 @@ function makeReviewStateOptions(
     );
   }
 
-  return [
+  const opts: ReviewStateOption[] = [
     { value: 'DENIED', label: <>Reject request</> },
-    {
+  ];
+
+  // Don't allow approving short-term access for long-term requests.
+  if (request.requestKind !== RequestKind.LongTerm) {
+    opts.push({
       value: 'APPROVED',
       label: (
         <>
@@ -308,16 +316,19 @@ function makeReviewStateOptions(
           {shortTermDuration ? ` (${shortTermDuration})` : ''}
         </>
       ),
-    },
-    {
-      value: 'PROMOTED',
-      disabled:
-        fetchSuggestedAccessListsAttempt.status === 'error' ||
-        (fetchSuggestedAccessListsAttempt.status === 'success' &&
-          fetchSuggestedAccessListsAttempt.data.length === 0),
-      label: <>{promotedContent}</>,
-    },
-  ];
+    });
+  }
+
+  opts.push({
+    value: 'PROMOTED',
+    disabled:
+      fetchSuggestedAccessListsAttempt.status === 'error' ||
+      (fetchSuggestedAccessListsAttempt.status === 'success' &&
+        fetchSuggestedAccessListsAttempt.data.length === 0),
+    label: <>{promotedContent}</>,
+  });
+
+  return opts;
 }
 
 const TextMutedNoEllipsis = styled.div`

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -42,12 +42,14 @@ import {
 import { LabelKind } from 'design/LabelState/LabelState';
 import { TeleportGearIcon } from 'design/SVGIcon';
 import { HoverTooltip } from 'design/Tooltip';
+import ResourcesRequested from 'shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested';
 import { Attempt, hasFinished } from 'shared/hooks/useAsync';
 import {
   AccessRequest,
   AccessRequestReview,
   AccessRequestReviewer,
   canAssumeNow,
+  RequestKind,
   RequestState,
   Resource,
 } from 'shared/services/accessRequests';
@@ -224,20 +226,38 @@ export function RequestView({
                     >
                       {request.user}
                     </Text>
-                    <Text
-                      mr={2}
-                      typography="body3"
-                      style={{
-                        flexShrink: 0,
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      is requesting roles:
-                    </Text>
-                    <RolesRequested roles={request.roles} />
-                    <Text typography="body3">
-                      for {requestedAccessTime}, starting {startingTime}
-                    </Text>
+                    {request.requestKind === RequestKind.LongTerm ? (
+                      <>
+                        <Text
+                          mr={2}
+                          typography="body3"
+                          style={{
+                            flexShrink: 0,
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          is requesting long-term access to resources:
+                        </Text>
+                        <ResourcesRequested resources={request.resources} />
+                      </>
+                    ) : (
+                      <>
+                        <Text
+                          mr={2}
+                          typography="body3"
+                          style={{
+                            flexShrink: 0,
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          is requesting roles:
+                        </Text>
+                        <RolesRequested roles={request.roles} />
+                        <Text typography="body3">
+                          for {requestedAccessTime}, starting {startingTime}
+                        </Text>
+                      </>
+                    )}
                   </Flex>
                 </H3>
               </Flex>

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/ResourcesRequested.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,17 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type { Option } from 'shared/components/Select';
-import type { RequestKind } from 'shared/services/accessRequests';
+import { Box, Label } from 'design';
+import { formattedName } from 'shared/components/AccessRequests/ReviewRequests';
+import type { Resource } from 'shared/services/accessRequests';
 
-export type TimeOption = Option<Date>;
+export default function ResourcesRequested({
+  resources,
+}: {
+  resources: Resource[];
+}) {
+  const $resources = resources.map(resource => (
+    <Label mr={1} key={resource.id.name} kind="secondary">
+      {resource.details.friendlyName || formattedName(resource)}
+    </Label>
+  ));
 
-export type CreateRequest = {
-  reason?: string;
-  start?: Date;
-  suggestedReviewers?: string[];
-  maxDuration?: Date;
-  requestTTL?: Date;
-  dryRun?: boolean;
-  requestKind?: RequestKind;
-};
+  return <Box>{$resources}</Box>;
+}

--- a/web/packages/shared/services/accessRequests/accessRequests.ts
+++ b/web/packages/shared/services/accessRequests/accessRequests.ts
@@ -27,6 +27,39 @@ export type RequestState =
   | 'PROMOTED'
   | '';
 
+export enum RequestKind {
+  Undefined = 0,
+  ShortTerm = 1,
+  LongTerm = 2,
+}
+
+/**
+ * LongTermResourceGrouping contains information about how resources can be grouped
+ * for long-term Access Requests.
+ */
+export interface LongTermResourceGrouping {
+  /**
+   * canProceed represents the validity of the long-term request. If all requested
+   * resources cannot be grouped together, this will be false.
+   */
+  canProceed: boolean;
+  /**
+   * validationMessage is a user-friendly message explaining any grouping error if `canProceed` is false
+   */
+  validationMessage?: string;
+  /**
+   * recommendedAccessList is the name of the Access List that would provide
+   * access to the most resources. If multiple Access Lists provide the same
+   * number of resources, the first one found will be used.
+   */
+  recommendedAccessList?: string;
+  /**
+   * accessListToResources maps applicable Access List names to the resources they can grant,
+   * including the optimal grouping.
+   */
+  accessListToResources: { [key: string]: ResourceId[] };
+}
+
 export interface AccessRequest {
   id: string;
   state: RequestState;
@@ -53,6 +86,8 @@ export interface AccessRequest {
   assumeStartTimeDuration?: string;
   reasonMode: string;
   reasonPrompts: string[];
+  requestKind?: RequestKind;
+  longTermResourceGrouping?: LongTermResourceGrouping;
 }
 
 export interface AccessRequestReview {

--- a/web/packages/shared/services/accessRequests/makeAccessRequest.ts
+++ b/web/packages/shared/services/accessRequests/makeAccessRequest.ts
@@ -22,6 +22,7 @@ import {
   AccessRequest,
   AccessRequestReview,
   AccessRequestReviewer,
+  RequestKind,
 } from './accessRequests';
 
 // TODO(gzdunek): This function should live in the Web UI.
@@ -72,7 +73,20 @@ export function makeAccessRequest(json?): AccessRequest {
     assumeStartTimeDuration: getAssumeStartDurationText(json.assumeStartTime),
     reasonMode: json.reasonMode || 'optional',
     reasonPrompts: json.reasonPrompts || [],
+    requestKind: getRequestKind(json.requestKind),
+    longTermResourceGrouping: json.longTermResourceGrouping,
   };
+}
+
+function getRequestKind(jsonKind: unknown): RequestKind {
+  if (typeof jsonKind !== 'number') {
+    return RequestKind.Undefined;
+  }
+  return jsonKind === RequestKind.LongTerm
+    ? RequestKind.LongTerm
+    : jsonKind === RequestKind.ShortTerm
+      ? RequestKind.ShortTerm
+      : RequestKind.Undefined;
 }
 
 function makeReviews(jsonReviews): AccessRequestReview[] {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { AccessRequest as TshdAccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
-import { AccessRequest } from 'shared/services/accessRequests';
+import { AccessRequest, RequestKind } from 'shared/services/accessRequests';
 
 import { makeUiAccessRequest } from './useAccessRequests';
 
@@ -159,6 +159,8 @@ test('makeUiAccessRequest', async () => {
     assumeStartTimeDuration: 'now',
     reasonMode: 'optional',
     reasonPrompts: [],
+    requestKind: RequestKind.Undefined,
+    longTermResourceGrouping: undefined,
   };
 
   expect(makeUiAccessRequest(request)).toStrictEqual(processedRequest);


### PR DESCRIPTION
## Summary
- Add Long-Term toggle to Access Request checkout in web ui
- Format/display validation errors when resources can't be granted long-term under a single Access List (or at all)

Related to [#5846](https://github.com/gravitational/teleport.e/issues/5846).
Requires [#54978](https://github.com/gravitational/teleport/pull/54978), [#6554](https://github.com/gravitational/teleport.e/pull/6554).

changelog: Add toggle to Access Request checkout for request kind (long/short-term) in web ui
