### PR TITLE
Disallow deleting enum reservations in buf breaking

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -80,12 +80,6 @@ breaking:
   use:
     - ENUM_VALUE_NO_DELETE
     - WIRE_JSON
-  except:
-    - FIELD_SAME_DEFAULT
   ignore:
     # TODO(codingllama): Remove ignore once the PDP API is stable.
     - api/proto/teleport/decision/v1alpha1
-  ignore_only:
-    RESERVED_ENUM_NO_DELETE:
-      - api/proto/teleport/legacy/types/types.proto
-      - proto/teleport/legacy/types/types.proto


### PR DESCRIPTION
This PR removes an exception added in #36248 to allow fixing an incompatibility in #35803, as well as removing an exception added by the buf v2 config migration (which doesn't apply to us anyway, default values are only in proto2 and editions but not in proto3).