### PR TITLE
[iac] Implement AWS CloudTrail log ingestion for Access Graph

### DIFF
--- a/api/types/discoveryconfig/discoveryconfig_test.go
+++ b/api/types/discoveryconfig/discoveryconfig_test.go
@@ -246,6 +246,84 @@ func TestNewDiscoveryConfig(t *testing.T) {
 			errCheck: require.NoError,
 		},
 		{
+			name: "tag aws sync with cloudtrail logs",
+			inMetadata: header.Metadata{
+				Name: "my-first-dc",
+			},
+			inSpec: Spec{
+				DiscoveryGroup: "dg1",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Integration: "1234",
+							AssumeRole: &types.AssumeRole{
+								RoleARN: "arn:aws:iam::123456789012:role/teleport",
+							},
+							Regions: []string{"us-west-2"},
+							CloudTrailLogs: &types.AccessGraphAWSSyncCloudTrailLogs{
+								SQSQueue: "sqs-queue",
+								Region:   "us-west-2",
+							},
+						},
+					},
+				},
+			},
+			expected: &DiscoveryConfig{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    types.KindDiscoveryConfig,
+					Version: types.V1,
+					Metadata: header.Metadata{
+						Name: "my-first-dc",
+					},
+				},
+				Spec: Spec{
+					DiscoveryGroup: "dg1",
+					AWS:            make([]types.AWSMatcher, 0),
+					Azure:          make([]types.AzureMatcher, 0),
+					GCP:            make([]types.GCPMatcher, 0),
+					Kube:           []types.KubernetesMatcher{},
+					AccessGraph: &types.AccessGraphSync{
+						AWS: []*types.AccessGraphAWSSync{
+							{
+								Integration: "1234",
+								AssumeRole: &types.AssumeRole{
+									RoleARN: "arn:aws:iam::123456789012:role/teleport",
+								},
+								Regions: []string{"us-west-2"},
+								CloudTrailLogs: &types.AccessGraphAWSSyncCloudTrailLogs{
+									SQSQueue: "sqs-queue",
+									Region:   "us-west-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			errCheck: require.NoError,
+		},
+		{
+			name: "tag aws sync with missing cloudtrail logs fields",
+			inMetadata: header.Metadata{
+				Name: "my-first-dc",
+			},
+			inSpec: Spec{
+				DiscoveryGroup: "dg1",
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{
+							Integration: "1234",
+							AssumeRole: &types.AssumeRole{
+								RoleARN: "arn:aws:iam::123456789012:role/teleport",
+							},
+							Regions:        []string{"us-west-2"},
+							CloudTrailLogs: &types.AccessGraphAWSSyncCloudTrailLogs{},
+						},
+					},
+				},
+			},
+			errCheck: require.Error,
+		},
+		{
 			name: "tag aws sync with invalid region",
 			inMetadata: header.Metadata{
 				Name: "my-first-dc",

--- a/api/types/matchers_accessgraph.go
+++ b/api/types/matchers_accessgraph.go
@@ -42,5 +42,15 @@ func (a *AccessGraphAWSSync) CheckAndSetDefaults() error {
 			return trace.BadParameter("discovery service does not support region %q", region)
 		}
 	}
+
+	if a.CloudTrailLogs != nil {
+		if a.CloudTrailLogs.SQSQueue == "" {
+			return trace.BadParameter("discovery service requires SQS queue for CloudTrail logs")
+		}
+		if a.CloudTrailLogs.Region == "" {
+			return trace.BadParameter("discovery service requires Region for CloudTrail logs")
+		}
+	}
+
 	return nil
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1638,9 +1638,18 @@ kubernetes matchers are present`)
 					ExternalID: awsMatcher.ExternalID,
 				}
 			}
+			var cloudTrailLogs *types.AccessGraphAWSSyncCloudTrailLogs
+			if awsMatcher.SQSPolling != nil {
+				cloudTrailLogs = &types.AccessGraphAWSSyncCloudTrailLogs{
+					SQSQueue: awsMatcher.SQSPolling.QueueURL,
+					Region:   awsMatcher.SQSPolling.QueueRegion,
+				}
+			}
+
 			tMatcher.AWS = append(tMatcher.AWS, &types.AccessGraphAWSSync{
-				Regions:    regions,
-				AssumeRole: assumeRole,
+				Regions:        regions,
+				AssumeRole:     assumeRole,
+				CloudTrailLogs: cloudTrailLogs,
 			})
 		}
 		for _, azureMatcher := range fc.Discovery.AccessGraph.Azure {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1639,10 +1639,10 @@ kubernetes matchers are present`)
 				}
 			}
 			var cloudTrailLogs *types.AccessGraphAWSSyncCloudTrailLogs
-			if awsMatcher.SQSPolling != nil {
+			if awsMatcher.CloudTrailLogs != nil {
 				cloudTrailLogs = &types.AccessGraphAWSSyncCloudTrailLogs{
-					SQSQueue: awsMatcher.SQSPolling.QueueURL,
-					Region:   awsMatcher.SQSPolling.QueueRegion,
+					SQSQueue: awsMatcher.CloudTrailLogs.QueueURL,
+					Region:   awsMatcher.CloudTrailLogs.QueueRegion,
 				}
 			}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1618,9 +1618,10 @@ type AccessGraphAWSSync struct {
 	AssumeRoleARN string `yaml:"assume_role_arn,omitempty"`
 	// ExternalID is the AWS external ID to use when assuming a role for
 	// database discovery in an external AWS account.
-	ExternalID              string                        `yaml:"external_id,omitempty"`
-	EnableCloudTrailPolling bool                          `yaml:"cloud_trail_polling,omitempty"`
-	SQSPolling              *AccessGraphAWSSyncSQSPolling `yaml:"sqs_polling,omitempty"`
+	ExternalID string `yaml:"external_id,omitempty"`
+	// CloudTrailLogs is the configuration for the SQS queue to poll for
+	// CloudTrail logs.
+	CloudTrailLogs *AccessGraphAWSSyncSQSPolling `yaml:"cloud_trail_logs,omitempty"`
 }
 
 // AccessGraphAzureSync represents the configuration for the Azure AccessGraph Sync service.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1603,7 +1603,9 @@ type AccessGraphSync struct {
 	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 
-type AccessGraphAWSSyncSQSPolling struct {
+// AccessGraphAWSSyncCloudTrailLogs represents the configuration for the SQS queue
+// to poll for CloudTrail notifications.
+type AccessGraphAWSSyncCloudTrailLogs struct {
 	// QueueURL is the URL of the SQS queue to poll for AWS resources.
 	QueueURL string `yaml:"queue_url,omitempty"`
 	// QueueRegion is the AWS region of the SQS queue to poll for AWS resources.
@@ -1621,7 +1623,7 @@ type AccessGraphAWSSync struct {
 	ExternalID string `yaml:"external_id,omitempty"`
 	// CloudTrailLogs is the configuration for the SQS queue to poll for
 	// CloudTrail logs.
-	CloudTrailLogs *AccessGraphAWSSyncSQSPolling `yaml:"cloud_trail_logs,omitempty"`
+	CloudTrailLogs *AccessGraphAWSSyncCloudTrailLogs `yaml:"cloud_trail_logs,omitempty"`
 }
 
 // AccessGraphAzureSync represents the configuration for the Azure AccessGraph Sync service.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1603,6 +1603,13 @@ type AccessGraphSync struct {
 	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 
+type AccessGraphAWSSyncSQSPolling struct {
+	// QueueURL is the URL of the SQS queue to poll for AWS resources.
+	QueueURL string `yaml:"queue_url,omitempty"`
+	// QueueRegion is the AWS region of the SQS queue to poll for AWS resources.
+	QueueRegion string `yaml:"queue_region,omitempty"`
+}
+
 // AccessGraphAWSSync represents the configuration for the AWS AccessGraph Sync service.
 type AccessGraphAWSSync struct {
 	// Regions are AWS regions to poll for resources.
@@ -1611,7 +1618,9 @@ type AccessGraphAWSSync struct {
 	AssumeRoleARN string `yaml:"assume_role_arn,omitempty"`
 	// ExternalID is the AWS external ID to use when assuming a role for
 	// database discovery in an external AWS account.
-	ExternalID string `yaml:"external_id,omitempty"`
+	ExternalID              string                        `yaml:"external_id,omitempty"`
+	EnableCloudTrailPolling bool                          `yaml:"cloud_trail_polling,omitempty"`
+	SQSPolling              *AccessGraphAWSSyncSQSPolling `yaml:"sqs_polling,omitempty"`
 }
 
 // AccessGraphAzureSync represents the configuration for the Azure AccessGraph Sync service.

--- a/lib/srv/discovery/access_graph_aws_test.go
+++ b/lib/srv/discovery/access_graph_aws_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/srv/discovery/access_graph_aws_test.go
+++ b/lib/srv/discovery/access_graph_aws_test.go
@@ -34,10 +34,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestSQSPollEvents(t *testing.T) {
@@ -102,7 +103,7 @@ func TestSQSPollEvents(t *testing.T) {
 	publish("bucket2", "messageID2", "key2", "key3")
 	publish("bucket3", "messageID3", "key4")
 	var messages [][]byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		select {
 		case <-ctx.Done():
 			cancel()
@@ -113,6 +114,8 @@ func TestSQSPollEvents(t *testing.T) {
 			messages = append(messages, msg.payload)
 		}
 	}
+
+	require.Len(t, messages, 3)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.ElementsMatch(t, []string{"messageID1", "messageID2", "messageID3"}, fakeSQSQueue.getDeletedMessages())

--- a/lib/srv/discovery/access_graph_aws_test.go
+++ b/lib/srv/discovery/access_graph_aws_test.go
@@ -1,0 +1,262 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQSPollEvents(t *testing.T) {
+	t.Parallel()
+
+	fakeSQSQueue := newFakeQueue()
+	fakeS3Bucket := newFakeS3Bucket(
+		"bucket4/key3",
+	)
+	s := &Server{
+		Config: &Config{
+			Log: slog.Default(),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan payloadChannelMessage)
+	errC := make(chan error, 1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := s.pollEventsFromSQSFilesImpl(
+			ctx,
+			"accountID",
+			fakeSQSQueue,
+			fakeS3Bucket,
+			&types.AccessGraphAWSSyncCloudTrailLogs{
+				SQSQueue: "queueURL",
+				Region:   "us-east-1",
+			},
+			eventsC,
+		)
+		errC <- err
+	}()
+
+	publish := func(bucket, id string, keys ...string) {
+		err := fakeSQSQueue.Publish(ctx, sqsFileEvent{
+			S3Bucket:    bucket,
+			S3ObjectKey: keys,
+		}, id)
+		require.NoError(t, err)
+	}
+
+	publish("bucket1", "messageID1", "key1")
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return
+	case err := <-errC:
+		require.Fail(t, "unexpected error", err)
+	case msg := <-eventsC:
+		require.Equal(t, []byte("bucket1/key1"), msg.payload)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.ElementsMatch(t, []string{"messageID1"}, fakeSQSQueue.getDeletedMessages())
+	}, time.Second*5, time.Millisecond, "expected all messages to be deleted")
+
+	publish("bucket2", "messageID2", "key2", "key3")
+	publish("bucket3", "messageID3", "key4")
+	var messages [][]byte
+	for i := 0; i < 3; i++ {
+		select {
+		case <-ctx.Done():
+			cancel()
+			return
+		case err := <-errC:
+			require.Fail(t, "unexpected error", err)
+		case msg := <-eventsC:
+			messages = append(messages, msg.payload)
+		}
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.ElementsMatch(t, []string{"messageID1", "messageID2", "messageID3"}, fakeSQSQueue.getDeletedMessages())
+	}, time.Second*5, time.Millisecond, "expected all messages to be deleted")
+
+	// Simulate a failure to get an object from S3 if only one key fails.
+	//The message shouldn't be deleted from the queue.
+	publish("bucket4", "messageID4", "key1", "key2", "key3")
+
+	// Check that the files were downloaded.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for _, file := range []string{"bucket4/key1", "bucket4/key2", "bucket4/key3"} {
+			assert.Contains(t, fakeS3Bucket.getDownloadedFiles(), file)
+		}
+	}, time.Second*5, time.Millisecond, "expected all files to be downloaded")
+
+	require.Never(t, func() bool {
+		// Check that the message is not deleted from the queue.
+		return slices.Contains(fakeSQSQueue.getDeletedMessages(), "messageID4")
+	}, time.Second*2, time.Millisecond, "expected message to not be deleted from the queue")
+
+	// Clean up the goroutine.
+	cancel()
+	wg.Wait()
+}
+
+// fakeQueue is used to fake SNS+SQS combination on AWS.
+type fakeQueue struct {
+	// publishErrors is chain of error returns on Publish method.
+	// Errors are returned from start to end and removed, one-by-one, on each
+	// invocation of the Publish method.
+	// If the slice is empty, Publish runs normally.
+	publishErrors   []error
+	mu              sync.Mutex
+	msgs            []fakeQueueMessage
+	deletedMessages []string
+}
+
+type fakeQueueMessage struct {
+	payload   string
+	messageID string
+}
+
+func newFakeQueue() *fakeQueue {
+	return &fakeQueue{}
+}
+
+func (f *fakeQueue) Publish(ctx context.Context, payload sqsFileEvent, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.publishErrors) > 0 {
+		err := f.publishErrors[0]
+		f.publishErrors = f.publishErrors[1:]
+		return err
+	}
+
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	f.msgs = append(f.msgs, fakeQueueMessage{
+		payload:   string(jsonBody),
+		messageID: id,
+	})
+	return nil
+}
+
+func (f *fakeQueue) ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+	msgs := f.dequeue()
+	if len(msgs) == 0 {
+		return &sqs.ReceiveMessageOutput{}, nil
+	}
+	out := make([]sqstypes.Message, 0, len(msgs))
+	for _, msg := range msgs {
+		out = append(out, sqstypes.Message{
+			Body:          &msg.payload,
+			ReceiptHandle: aws.String(msg.messageID),
+		})
+	}
+	return &sqs.ReceiveMessageOutput{
+		Messages: out,
+	}, nil
+}
+
+func (f *fakeQueue) DeleteMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedMessages = append(f.deletedMessages, *params.ReceiptHandle)
+	return &sqs.DeleteMessageOutput{}, nil
+}
+
+func (f *fakeQueue) getDeletedMessages() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.deletedMessages)
+}
+
+func (f *fakeQueue) dequeue() []fakeQueueMessage {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	batchSize := 10
+	if len(f.msgs) == 0 {
+		return nil
+	}
+	if len(f.msgs) < batchSize {
+		batchSize = len(f.msgs)
+	}
+	items := f.msgs[:batchSize]
+	f.msgs = f.msgs[batchSize:]
+	return items
+}
+
+type fakeS3Bucket struct {
+	filesWithErr    map[string]struct{}
+	mu              sync.Mutex
+	downloadedFiles []string
+}
+
+func newFakeS3Bucket(filesWithErr ...string) *fakeS3Bucket {
+	fileErrsMap := make(map[string]struct{}, len(filesWithErr))
+	for _, fileErr := range filesWithErr {
+		fileErrsMap[fileErr] = struct{}{}
+	}
+	return &fakeS3Bucket{
+		filesWithErr: fileErrsMap,
+	}
+}
+
+func (f *fakeS3Bucket) getDownloadedFiles() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.downloadedFiles)
+}
+
+func (f *fakeS3Bucket) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	file := filepath.Join(*params.Bucket, *params.Key)
+	f.downloadedFiles = append(f.downloadedFiles, file)
+	if _, ok := f.filesWithErr[file]; ok {
+		return nil, trace.BadParameter("fake error")
+	}
+	b := io.NopCloser(bytes.NewBufferString(file))
+	return &s3.GetObjectOutput{
+		Body: b,
+	}, nil
+}


### PR DESCRIPTION
Ingest AWS CloudTrail logs into Access Graph. Poll SQS queues for
notifications of new CloudTrail log files in S3, download these files,
and stream their raw contents to the Access Graph service via a new
gRPC stream.

Add configuration to enable SQS-based AWS CloudTrail log polling for
Access Graph AWS sync matchers. Specify SQS queue URL and region
for notifications.

In `lib/srv/discovery/access_graph_aws.go`:
- Orchestrate CloudTrail log ingestion using a new `startCloudtrailPoller` function.
    - Ensure singleton poller execution with a semaphore lock (`access_graph_aws_cloudtrail_sync`).
    - Stream log data to Access Graph via a new `AWSCloudTrailStream` gRPC stream.
    - Exchange initial configuration and resume state with the server.
    - Dynamically manage polling routines per AWS matcher using a `GenericReconciler`.
- Poll SQS queues for CloudTrail S3 object notifications in `pollEventsFromSQSFiles`.
    - Download raw CloudTrail log files from S3.
    - Stream S3 file payloads and AWS Account ID (from STS) to Access Graph.
    - Delete SQS messages post-transmission.
- Filter AWS sync configurations for CloudTrail polling.
- Increase accessGraphClient gRPC message size limits to 50MB.

Improve concurrency safety in `lib/srv/discovery/discovery.go` by adding an `RWMutex`
to protect the `dynamicDiscoveryConfig` map.

I did not write the code of this PR. It has been rebased and pulled over 
from the iac PoC (see #54626).

Related-pull-request: https://github.com/gravitational/teleport/pull/54626
Co-authored-by: Tiago Silva <tiago.silva@goteleport.com>
Co-authored-by: Matt Brock <matthew.brock@goteleport.com>
