### PR TITLE
Remove Teleport v14 references from the docs

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx
@@ -12,10 +12,9 @@ custom resources. The Teleport Kubernetes Operator watches for those resources a
 reach the desired state.  
 
 Since Teleport version 15, the operator can be deployed both:
-- alongside self-hosted Teleport clusters deployed with the `teleport-cluster` Helm chart.
-  This deployment method differs from version 14. In version 15 and above, the operator
-  is no longer deployed as a sidecar. An operator outage cannot affect Teleport's availability.
-- against a remote Teleport instance (such as Teleport Cloud or deployed with Terraform)
+- Alongside self-hosted Teleport clusters deployed with the `teleport-cluster` Helm chart.
+  An operator outage cannot affect Teleport's availability.
+- Against a remote Teleport instance (such as Teleport Cloud or deployed with Terraform)
 
 The operator supports multiple replicas within a single cluster by electing a
 leader with a Kubernetes lease.

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -19,7 +19,8 @@ You will learn how to:
 
 - A client machine running Windows 10 or higher. You can only use `tsh` to save PuTTY sessions on Windows.
 
-- The Teleport `tsh.exe` client, version 14.0.3 or higher. To download the `tsh.exe` client, run the following command:
+- The Teleport `tsh.exe` client. To download the `tsh.exe` client, run the
+  following command:
 
   ```code
   $ curl.exe -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -60,22 +60,6 @@ In this setup, the Teleport SSH Service performs RBAC checks as well as audits a
   Teleport Proxy Service host.
 - (!docs/pages/includes/tctl.mdx!)
 
-### Upgrading to v14 from legacy OpenSSH nodes
-
-  If you have previously configured OpenSSH nodes to trust a Teleport CA without
-  registering them and you upgrade your Teleport cluster to Teleport 14, you won't
-  be able to connect to them anymore by default. This is because open dialing to
-  OpenSSH servers not registered with the cluster is no longer allowed in Teleport 14.
-  To ensure that you will retain access to your OpenSSH nodes you will need to follow
-  this guide to register every OpenSSH node with Teleport that you previously
-  configured. This must be done *before* your Teleport cluster is upgraded to Teleport 14.
-
-  If you are having issues registering OpenSSH nodes or need to upgrade your
-  Teleport cluster to Teleport 14 before registering all of your OpenSSH nodes, you can
-  pass the `TELEPORT_UNSTABLE_UNLISTED_AGENT_DIALING` environment variable to your
-  Proxy Service and set it to `yes`. This will allow connections to unregistered
-  OpenSSH nodes but will be removed in Teleport v15.
-
 ## Step 1/3. Configure `sshd`
 
 Teleport only allows access to resources in your infrastructure via Teleport

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -58,23 +58,6 @@ In this setup, the Teleport SSH Service performs RBAC checks as well as audits a
   Teleport Proxy Service host.
 - (!docs/pages/includes/tctl.mdx!)
 
-### Upgrading to v14 from legacy OpenSSH nodes
-
-  If you have previously configured OpenSSH nodes to trust a Teleport CA without
-  registering them and you upgrade your Teleport cluster to Teleport 14, you won't
-  be able to connect to them anymore by default. This is because open dialing to
-  OpenSSH servers not registered with the cluster is no longer allowed in Teleport 14.
-  To ensure that you will retain access to your OpenSSH nodes you will need to follow
-  this guide to register every OpenSSH node with Teleport that you previously
-  configured. This must be done *before* your Teleport cluster is upgraded to Teleport 14.
-
-  If you are having issues registering OpenSSH nodes or need to upgrade your
-  Teleport cluster to Teleport 14 before registering all of your OpenSSH nodes, you can
-  pass the `TELEPORT_UNSTABLE_UNLISTED_AGENT_DIALING` environment variable to your
-  Proxy Service and set it to `yes`. This will allow connections to unregistered
-  OpenSSH nodes but will be removed in Teleport v15.
-
-
 ## Step 1/5. Add a node resource to your Teleport cluster
 
 When you request an SSH connection to a OpenSSH node, Teleport needs to be able

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1002,7 +1002,6 @@ the following Terraform script:
 
 To configure Teleport to use Athena:
 
-- Make sure you are using **Teleport version 14.0.0** or newer.
 - Prepare infrastructure
 - Specify an Athena URL inside the `audit_events_uri` array in your Teleport
   configuration file:

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -417,8 +417,6 @@ This join method works by exporting the public Kubernetes signing keys and using
 them to validate Kubernetes SA token signatures. The signature validation can be
 performed by an Auth Service without access to the Kubernetes.
 
-The Kubernetes JWKS join method is available in Teleport 14+.
-
 (!docs/pages/includes/provision-token/kubernetes-jwks-spec.mdx!)
 
 <Admonition type="warning">

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -20,8 +20,6 @@ artifacts include configuration files, certificates, and cryptographic key
 material. Usually, artifacts are files, but this term is explicitly avoided
 because a destination isn't required to be a filesystem.
 
-From Teleport 14, `tbot` supports the v2 configuration version.
-
 ```yaml
 # version specifies the version of the configuration file in use. `v2` is the
 # most recent and should be used for all new bots. The rest of this example

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -59,7 +59,7 @@ The code that aggregates and anonymizes this data can be found in our [GitHub
 repository](https://github.com/gravitational/teleport/tree/master/lib/usagereporter/teleport/aggregating).
 
 For a restricted network environment you can configure Teleport Auth Service instances
-to send usage data through a proxy for version 16.0.4/15.4.7/14.3.21 or later.
+to send usage data through a proxy for version 16.0.4/15.4.7 or later.
 Set the `TELEPORT_REPORTING_HTTPS_PROXY` and `TELEPORT_REPORTING_HTTP_PROXY`
 environment variables to your proxy address. That will apply as the HTTP connect
 proxy setting overriding `HTTPS_PROXY` and `HTTP_PROXY` just for outbound usage reporting.


### PR DESCRIPTION
When we release v18, v15 will be EOL. Per the docs test plan, we remove all mentions of the version before the newly EOL version.