### PR TITLE
Warmup hardware key touch before login

### DIFF
--- a/api/utils/keys/piv/service.go
+++ b/api/utils/keys/piv/service.go
@@ -118,6 +118,8 @@ func (s *YubiKeyService) NewPrivateKey(ctx context.Context, config hardwarekey.P
 	}
 
 	// If PIN is required, check that PIN and PUK are not the defaults.
+	// This also caches the PIN in the PIV connection, similar to a call
+	// to [hardwarekey.Signer.WarmupHardwareKey].
 	if config.Policy.PINRequired {
 		if err := y.checkOrSetPIN(ctx, s.getPrompt(), config.ContextualKeyInfo, config.PINCacheTTL); err != nil {
 			return nil, trace.Wrap(err)
@@ -129,7 +131,18 @@ func (s *YubiKeyService) NewPrivateKey(ctx context.Context, config hardwarekey.P
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return hardwarekey.NewSigner(s, ref, config.ContextualKeyInfo), nil
+
+		signer := hardwarekey.NewSigner(s, ref, config.ContextualKeyInfo)
+		if config.Policy.TouchRequired {
+			// Warmup the hardware key with a touch prompt now rather than later. This is intended
+			// to avoid prompting for PIV touch directly after a WebAuthn touch prompt, which
+			// can delay the PIV signature and beyond the expected [sigsignTouchPromptDelay].
+			if err := signer.WarmupHardwareKey(ctx); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+
+		return signer, nil
 	}
 
 	// If a custom slot was not specified, check for a key in the
@@ -177,7 +190,17 @@ func (s *YubiKeyService) NewPrivateKey(ctx context.Context, config hardwarekey.P
 		return generatePrivateKey()
 	}
 
-	return hardwarekey.NewSigner(s, keyRef, config.ContextualKeyInfo), nil
+	signer := hardwarekey.NewSigner(s, keyRef, config.ContextualKeyInfo)
+	if config.Policy.TouchRequired {
+		// Warmup the hardware key with a touch prompt now rather than later. This is intended
+		// to avoid prompting for PIV touch directly after a WebAuthn touch prompt, which
+		// can delay the PIV signature and beyond the expected [sigsignTouchPromptDelay].
+		if err := signer.WarmupHardwareKey(ctx); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return signer, nil
 }
 
 // Sign performs a cryptographic signature using the specified hardware


### PR DESCRIPTION
Warm up hardware key touch before login, while preparing the client key, so that the PIV touch occurs before the WebAuthn touch. Both PIV and Webauthn claim the YubiKey's resources and don't release them for a couple seconds after a successful touch. However, Webauthn is better equipped to handle this delay in resource acquisition than PIV, as we don't have a way to actually control the PIV touch prompt (Note: this may be an issue with the upstream piv-go library not providing some functionality, or it may be an actual PIV limitation - I haven't taken the time to investigate deeply).

This ensures that when the PIV signature method is called, and a touch prompt is issued by the Teleport client after 200ms, the YubiKey is actually ready to prompt (green flashes).

I also expect this to resolve https://github.com/gravitational/teleport/issues/20384, but can't say for certain as I haven't been able to reproduce the issue.

Note: I don't think this is worth adding to the changelog.
 
Closes https://github.com/gravitational/teleport/issues/20384