### PR TITLE
docs: Pin Terraform major version to Teleport major version

### DIFF
--- a/docs/pages/reference/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider/terraform-provider.mdx
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> 15.0"
+      version = "~> (=teleport.major_version=).0"
     }
   }
 }
@@ -61,7 +61,7 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> 15.0"
+      version = "~> (=cloud.major_version=).0"
     }
   }
 }

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -40,7 +40,7 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> 15.0"
+      version = "~> (=teleport.major_version=).0"
     }
   }
 }
@@ -61,7 +61,7 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> 15.0"
+      version = "~> (=cloud.major_version=).0"
     }
   }
 }


### PR DESCRIPTION
v16 and v17 Terraform provider docs were still using `~> 15.0` as the version constraint, meaning anyone following them will get the latest and greatest v15 Terraform provider, rather than the latest v16 or v17 provider that they should surely be using to match their cluster's major version.

This PR updates the version to be dynamically sourced from the major version variables for self-hosted and Cloud instead so we don't run into this pickle again.

As per [Terraform docs](https://developer.hashicorp.com/terraform/language/expressions/version-constraints):

`~>` - allows only the right-most version component to increment. Examples:
- `~> 1.0.4`: Allows Terraform to install 1.0.5 and 1.0.10 but not 1.1.0
- `~> 1.1`: Allows Terraform to install 1.2 and 1.10 but not 2.0




