### PR TITLE
[kube] add support for teleport.dev/description in app discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -873,6 +873,8 @@ const (
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
 	DiscoveryAppNameLabel = TeleportNamespace + "/name"
+	// DiscoveryAppDescriptionLabelKey Key used to pass a human-friendly description through labels.
+	DiscoveryAppDescriptionLabelKey = TeleportNamespace + "/description"
 	// DiscoveryPathLabel optionally specifies a context path for apps created from Kubernetes services.
 	DiscoveryPathLabel = TeleportNamespace + "/path"
 	// DiscoveryAppInsecureSkipVerify specifies the TLS verification enforcement for a discovered app created from Kubernetes service.

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -873,8 +873,9 @@ const (
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
 	DiscoveryAppNameLabel = TeleportNamespace + "/name"
-	// DiscoveryAppDescriptionLabelKey Key used to pass a human-friendly description through labels.
-	DiscoveryAppDescriptionLabelKey = TeleportNamespace + "/description"
+	// DiscoveryAppDescriptionLabel specifies a human-friendly description
+	// for apps created from Kubernetes Services.
+	DiscoveryAppDescriptionLabel = TeleportNamespace + "/description"
 	// DiscoveryPathLabel optionally specifies a context path for apps created from Kubernetes services.
 	DiscoveryPathLabel = TeleportNamespace + "/path"
 	// DiscoveryAppInsecureSkipVerify specifies the TLS verification enforcement for a discovered app created from Kubernetes service.

--- a/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
@@ -102,6 +102,14 @@ Controls resulting app name. If present it will override default app name patter
 as a suffix to the annotation value, as `$APP_NAME-$PORT1_NAME`, `$APP_NAME-$PORT2_NAME` etc, where `$APP_NAME` is the name
 set by the annotation.
 
+### `teleport.dev/description`
+
+Controls the **description** that will appear for the imported Teleport application.
+```yaml
+annotations:
+  teleport.dev/description: "Internal Grafana dashboard"
+```
+
 ### `teleport.dev/insecure-skip-verify`
 
 Controls whether TLS certificate verification should be skipped for this app.

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -182,9 +182,16 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 		return nil, trace.Wrap(err, "could not get labels for the service")
 	}
 
+	description := fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName)
+	if desc, ok := service.GetAnnotations()[types.DiscoveryAppDescriptionLabelKey]; ok {
+		if strings.TrimSpace(desc) != "" {
+			description = desc
+		}
+	}
+
 	app, err := types.NewAppV3(types.Metadata{
 		Name:        appName,
-		Description: fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName),
+		Description: description,
 		Labels:      labels,
 	}, types.AppSpecV3{
 		URI:                appURI,

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -184,8 +184,8 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 
 	description := fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName)
 	if desc, ok := service.GetAnnotations()[types.DiscoveryAppDescriptionLabelKey]; ok {
-		if strings.TrimSpace(desc) != "" {
-			description = desc
+		if d := strings.TrimSpace(desc); d != "" {
+			description = d
 		}
 	}
 


### PR DESCRIPTION
### Summary

Adds first-class support for the `teleport.dev/description` annotation when discovering Kubernetes Services and converting them into Teleport `Application` resources.

### Why

* **Consistency:** Brings the description path in line with the existing name customisation (`teleport.dev/name`).
* **Usability:** Allows operators to surface friendly, human-readable descriptions in the Teleport UI without renaming resources.
