### PR TITLE
Add autoupdate agent report commands

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2982,6 +2982,18 @@ func (c *Client) ListAutoUpdateAgentReports(ctx context.Context, pageSize int, p
 	return resp.GetAutoupdateAgentReports(), resp.GetNextKey(), nil
 }
 
+// UpsertAutoUpdateAgentReport upserts an AutoUpdateAgentReport resource.
+func (c *Client) UpsertAutoUpdateAgentReport(ctx context.Context, report *autoupdatev1pb.AutoUpdateAgentReport) (*autoupdatev1pb.AutoUpdateAgentReport, error) {
+	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
+	resp, err := client.UpsertAutoUpdateAgentReport(ctx, &autoupdatev1pb.UpsertAutoUpdateAgentReportRequest{
+		AutoupdateAgentReport: report,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
 // GetClusterAccessGraphConfig retrieves the Cluster Access Graph configuration from Auth server.
 func (c *Client) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
 	rsp, err := c.ClusterConfigClient().GetClusterAccessGraphConfig(ctx, &clusterconfigpb.GetClusterAccessGraphConfigRequest{})
@@ -2991,7 +3003,7 @@ func (c *Client) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfi
 	return rsp.AccessGraph, nil
 }
 
-// GetInstaller gets all installer script resources
+// GetInstallers gets all installer script resources
 func (c *Client) GetInstallers(ctx context.Context) ([]types.Installer, error) {
 	resp, err := c.grpc.GetInstallers(ctx, &emptypb.Empty{})
 	if err != nil {

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -274,6 +274,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAutoUpdateVersion, nil
 	case types.KindAutoUpdateAgentRollout:
 		return types.KindAutoUpdateAgentRollout, nil
+	case types.KindAutoUpdateAgentReport:
+		return types.KindAutoUpdateAgentReport, nil
 	case types.KindGitServer, types.KindGitServer + "s":
 		return types.KindGitServer, nil
 	case types.KindWorkloadIdentityX509Revocation, types.KindWorkloadIdentityX509Revocation + "s":

--- a/tool/tctl/common/autoupdate_command.go
+++ b/tool/tctl/common/autoupdate_command.go
@@ -22,7 +22,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,6 +58,7 @@ type AutoUpdateCommand struct {
 	toolsDisableCmd      *kingpin.CmdClause
 	toolsStatusCmd       *kingpin.CmdClause
 	agentsStatusCmd      *kingpin.CmdClause
+	agentsReportCmd      *kingpin.CmdClause
 	agentsStartUpdateCmd *kingpin.CmdClause
 	agentsMarkDoneCmd    *kingpin.CmdClause
 	agentsRollbackCmd    *kingpin.CmdClause
@@ -65,6 +69,9 @@ type AutoUpdateCommand struct {
 	groups             []string
 
 	clear bool
+
+	// used for testing purposes
+	now func() time.Time
 
 	// stdout allows to switch standard output source for resource command. Used in tests.
 	stdout io.Writer
@@ -91,6 +98,7 @@ func (c *AutoUpdateCommand) Initialize(app *kingpin.Application, ccf *tctlcfg.Gl
 
 	agentsCmd := autoUpdateCmd.Command("agents", "Manage agents auto update configuration.")
 	c.agentsStatusCmd = agentsCmd.Command("status", "Prints agents auto update status.")
+	c.agentsReportCmd = agentsCmd.Command("report", "Aggregates the agent autoupdate reports and displays agent count per version and per update group.")
 	c.agentsStartUpdateCmd = agentsCmd.Command("start-update", "Starts updating one or many groups.")
 	c.agentsStartUpdateCmd.Arg("groups", "Groups to start updating.").StringsVar(&c.groups)
 	c.agentsMarkDoneCmd = agentsCmd.Command("mark-done", "Marks one or many groups as done updating.")
@@ -100,6 +108,10 @@ func (c *AutoUpdateCommand) Initialize(app *kingpin.Application, ccf *tctlcfg.Gl
 
 	if c.stdout == nil {
 		c.stdout = os.Stdout
+	}
+
+	if c.now == nil {
+		c.now = time.Now
 	}
 }
 
@@ -120,6 +132,8 @@ func (c *AutoUpdateCommand) TryRun(ctx context.Context, cmd string, clientFunc c
 		return true, trace.Wrap(err)
 	case cmd == c.agentsStatusCmd.FullCommand():
 		commandFunc = c.agentsStatusCommand
+	case cmd == c.agentsReportCmd.FullCommand():
+		commandFunc = c.agentsReportCommand
 	case cmd == c.agentsStartUpdateCmd.FullCommand():
 		commandFunc = c.agentsStartUpdateCommand
 	case cmd == c.agentsMarkDoneCmd.FullCommand():
@@ -201,6 +215,7 @@ type autoupdateClient interface {
 	TriggerAutoUpdateAgentGroup(ctx context.Context, groups []string, state autoupdatev1pb.AutoUpdateAgentGroupState) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
 	ForceAutoUpdateAgentGroup(ctx context.Context, groups []string) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
 	RollbackAutoUpdateAgentGroup(ctx context.Context, groups []string, allStartedGroups bool) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
+	ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdatev1pb.AutoUpdateAgentReport, string, error)
 }
 
 func (c *AutoUpdateCommand) agentsStatusCommand(ctx context.Context, client autoupdateClient) error {
@@ -242,18 +257,174 @@ func (c *AutoUpdateCommand) agentsStatusCommand(ctx context.Context, client auto
 	return nil
 }
 
+func (c *AutoUpdateCommand) agentsReportCommand(ctx context.Context, client autoupdateClient) error {
+	now := c.now()
+	reports, err := getAllReports(ctx, client)
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return trace.Wrap(err, "listing reports")
+		}
+
+		fmt.Fprintln(c.stdout, "No autoupdate_agent_report found.")
+		if c.ccf != nil && len(c.ccf.AuthServerAddr) > 0 && !strings.Contains(c.ccf.AuthServerAddr[0], "teleport.sh") {
+			fmt.Fprintln(c.stdout, "Managed Updates agent reports require enabling Managed Updates v2 by creating the autoupdate_version resource.")
+			fmt.Fprintln(c.stdout, "See: https://goteleport.com/docs/upgrading/agent-managed-updates/#configuring-managed-agent-updates")
+		}
+		return trace.Wrap(err)
+	}
+
+	if len(reports) == 0 {
+		return trace.BadParameter("no reports returned, but the server did not return a NotFoundError, this ia a bug")
+	}
+
+	validReports := filterValidReports(reports, now)
+
+	if len(validReports) == 0 {
+		fmt.Fprintf(c.stdout, "Read %d reports, but they are expired. If you just (re)deployed the Auth service, you might want to retry after 60 seconds.\n", len(reports))
+		return trace.CompareFailed("reports expired")
+	}
+
+	fmt.Fprintf(c.stdout, "%d autoupdate agent reports aggregated\n\n", len(validReports))
+
+	groupSet := make(map[string]any)
+	versionsSet := make(map[string]any)
+	for _, report := range validReports {
+		for groupName, group := range report.GetSpec().GetGroups() {
+			groupSet[groupName] = struct{}{}
+			for versionName, _ := range group.GetVersions() {
+				versionsSet[versionName] = struct{}{}
+			}
+		}
+	}
+
+	groupNames := slices.Collect(maps.Keys(groupSet))
+	versionNames := slices.Collect(maps.Keys(versionsSet))
+	slices.Sort(groupNames)
+	slices.Sort(versionNames)
+
+	if len(groupNames) == 0 || len(versionNames) == 0 {
+		fmt.Fprintln(c.stdout, "Reports contain no agents.")
+	} else {
+		t := asciitable.MakeTable(append([]string{"Agent Version"}, groupNames...))
+		for _, versionName := range versionNames {
+			row := make([]string, len(groupNames)+1)
+			row[0] = versionName
+			for j, groupName := range groupNames {
+				var count int
+				for _, report := range validReports {
+					count += int(report.GetSpec().GetGroups()[groupName].GetVersions()[versionName].GetCount())
+				}
+				row[j+1] = strconv.Itoa(count)
+			}
+			t.AddRow(row)
+		}
+
+		_, err = t.AsBuffer().WriteTo(c.stdout)
+	}
+
+	fmt.Fprint(c.stdout, c.omittedSummary(validReports))
+
+	return trace.Wrap(err)
+}
+
+func filterValidReports(reports []*autoupdatev1pb.AutoUpdateAgentReport, now time.Time) []*autoupdatev1pb.AutoUpdateAgentReport {
+	var validReports []*autoupdatev1pb.AutoUpdateAgentReport
+	for _, report := range reports {
+		if now.Sub(report.GetSpec().GetTimestamp().AsTime()) <= time.Minute {
+			validReports = append(validReports, report)
+		}
+	}
+	return validReports
+}
+
+func (c *AutoUpdateCommand) omittedSummary(reports []*autoupdatev1pb.AutoUpdateAgentReport) string {
+	aggregated := make(map[string]int)
+	var totalOmitted int
+	for _, report := range reports {
+		for _, omitted := range report.GetSpec().GetOmitted() {
+			totalOmitted += int(omitted.GetCount())
+			aggregated[omitted.GetReason()] += int(omitted.GetCount())
+		}
+	}
+
+	if totalOmitted == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteRune('\n')
+	sb.WriteString(fmt.Sprintf("%d agents were omitted from the reports:\n", totalOmitted))
+	// We sort reasons alphabetically as this ensures the output is consistent
+	// And makes snapshot testing easier.
+	for _, reason := range slices.Sorted(maps.Keys(aggregated)) {
+		sb.WriteString(fmt.Sprintf("- %d omitted because: %s\n", aggregated[reason], reason))
+	}
+	return sb.String()
+}
+
+func getAllReports(ctx context.Context, client autoupdateClient) ([]*autoupdatev1pb.AutoUpdateAgentReport, error) {
+	const pageSize = 50
+	var pageToken string
+	var reports []*autoupdatev1pb.AutoUpdateAgentReport
+	for {
+		page, nextToken, err := client.ListAutoUpdateAgentReports(ctx, pageSize, pageToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		reports = append(reports, page...)
+		if nextToken == "" {
+			return reports, nil
+		}
+		pageToken = nextToken
+	}
+}
+
+func rolloutHasAgentCounters(rollout *autoupdatev1pb.AutoUpdateAgentRollout) bool {
+	for _, group := range rollout.GetStatus().GetGroups() {
+		if group.PresentCount != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func rolloutGroupTable(rollout *autoupdatev1pb.AutoUpdateAgentRollout, writer io.Writer) {
-	if groups := rollout.GetStatus().GetGroups(); len(groups) > 0 {
+	groups := rollout.GetStatus().GetGroups()
+	switch {
+	case len(groups) != 0 && rolloutHasAgentCounters(rollout):
+		headers := []string{"Group Name", "State", "Start Time", "State Reason", "Agent Count", "Up-to-date"}
+		table := asciitable.MakeTable(headers)
+		for i, group := range groups {
+			groupName := group.GetName()
+			groupCount := group.PresentCount
+			groupUpToDate := group.UpToDateCount
+			if i == len(groups)-1 {
+				groupName = groupName + " (catch-all)"
+			}
+			table.AddRow([]string{
+				groupName,
+				userFriendlyState(group.GetState()),
+				formatTimeIfNotEmpty(group.GetStartTime().AsTime(), time.DateTime),
+				group.GetLastUpdateReason(),
+				strconv.FormatUint(groupCount, 10),
+				strconv.FormatUint(groupUpToDate, 10),
+			})
+		}
+		writer.Write(table.AsBuffer().Bytes())
+
+	case len(groups) != 0:
 		headers := []string{"Group Name", "State", "Start Time", "State Reason"}
 		table := asciitable.MakeTable(headers)
 		for _, group := range groups {
+			groupName := group.GetName()
 			table.AddRow([]string{
-				group.GetName(),
+				groupName,
 				userFriendlyState(group.GetState()),
 				formatTimeIfNotEmpty(group.GetStartTime().AsTime(), time.DateTime),
 				group.GetLastUpdateReason()})
 		}
 		writer.Write(table.AsBuffer().Bytes())
+	default:
 	}
 }
 

--- a/tool/tctl/common/autoupdate_command.go
+++ b/tool/tctl/common/autoupdate_command.go
@@ -266,7 +266,7 @@ func (c *AutoUpdateCommand) agentsReportCommand(ctx context.Context, client auto
 		}
 
 		fmt.Fprintln(c.stdout, "No autoupdate_agent_report found.")
-		if c.ccf != nil && len(c.ccf.AuthServerAddr) > 0 && !strings.Contains(c.ccf.AuthServerAddr[0], "teleport.sh") {
+		if c.ccf != nil && len(c.ccf.AuthServerAddr) > 0 && !strings.HasSuffix(c.ccf.AuthServerAddr[0], ".teleport.sh") {
 			fmt.Fprintln(c.stdout, "Managed Updates agent reports require enabling Managed Updates v2 by creating the autoupdate_version resource.")
 			fmt.Fprintln(c.stdout, "See: https://goteleport.com/docs/upgrading/agent-managed-updates/#configuring-managed-agent-updates")
 		}
@@ -286,12 +286,12 @@ func (c *AutoUpdateCommand) agentsReportCommand(ctx context.Context, client auto
 
 	fmt.Fprintf(c.stdout, "%d autoupdate agent reports aggregated\n\n", len(validReports))
 
-	groupSet := make(map[string]any)
-	versionsSet := make(map[string]any)
+	groupSet := make(map[string]struct{})
+	versionsSet := make(map[string]struct{})
 	for _, report := range validReports {
 		for groupName, group := range report.GetSpec().GetGroups() {
 			groupSet[groupName] = struct{}{}
-			for versionName, _ := range group.GetVersions() {
+			for versionName := range group.GetVersions() {
 				versionsSet[versionName] = struct{}{}
 			}
 		}

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -21,7 +21,6 @@ package common
 import (
 	"bytes"
 	"context"
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"testing"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -21,6 +21,7 @@ package common
 import (
 	"bytes"
 	"context"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"testing"
 	"time"
 
@@ -123,18 +124,24 @@ func runAutoUpdateCommand(t *testing.T, client *authclient.Client, args []string
 	return &stdoutBuff, err
 }
 
-type mockRolloutClient struct {
+type mockAutoUpdateClient struct {
 	authclient.Client
 	mock.Mock
 }
 
-func (m *mockRolloutClient) GetAutoUpdateAgentRollout(_ context.Context) (*autoupdatepb.AutoUpdateAgentRollout, error) {
+func (m *mockAutoUpdateClient) GetAutoUpdateAgentRollout(_ context.Context) (*autoupdatepb.AutoUpdateAgentRollout, error) {
 	args := m.Called()
 	return args.Get(0).(*autoupdatepb.AutoUpdateAgentRollout), args.Error(1)
 }
 
+func (m *mockAutoUpdateClient) ListAutoUpdateAgentReports(_ context.Context, pageSize int, nextKey string) ([]*autoupdatepb.AutoUpdateAgentReport, string, error) {
+	args := m.Called()
+	return args.Get(0).([]*autoupdatepb.AutoUpdateAgentReport), "", args.Error(1)
+}
+
 func TestAutoUpdateAgentStatusCommand(t *testing.T) {
 	ctx := context.Background()
+	now := time.Now()
 
 	tests := []struct {
 		name           string
@@ -280,19 +287,271 @@ stage      Active    2025-01-15 14:00:00 in_window
 prod       Unstarted                     outside_window 
 `,
 		},
+		{
+			name: "rollout regular schedule halt-on-error with progress",
+			fixture: &autoupdatepb.AutoUpdateAgentRollout{
+				Spec: &autoupdatepb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleRegular,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+					Strategy:       autoupdate.AgentsStrategyHaltOnError,
+				},
+				Status: &autoupdatepb.AutoUpdateAgentRolloutStatus{
+					Groups: []*autoupdatepb.AutoUpdateAgentRolloutStatusGroup{
+						{
+							Name:             "dev",
+							StartTime:        timestamppb.New(time.Date(2025, 1, 15, 12, 00, 0, 0, time.UTC)),
+							State:            autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+							LastUpdateTime:   nil,
+							LastUpdateReason: "outside_window",
+							ConfigDays:       []string{"Mon", "Tue", "Wed", "Thu", "Fri"},
+							ConfigStartHour:  8,
+							PresentCount:     1023,
+							UpToDateCount:    567,
+							InitialCount:     1012,
+						},
+						{
+							Name:             "stage",
+							StartTime:        timestamppb.New(time.Date(2025, 1, 15, 14, 00, 0, 0, time.UTC)),
+							State:            autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+							LastUpdateReason: "in_window",
+							ConfigDays:       []string{"Mon", "Tue", "Wed", "Thu", "Fri"},
+							ConfigStartHour:  14,
+						},
+						{
+							Name:             "prod",
+							StartTime:        nil,
+							State:            autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+							LastUpdateReason: "outside_window",
+							ConfigDays:       []string{"Mon", "Tue", "Wed", "Thu", "Fri"},
+							ConfigStartHour:  18,
+							PresentCount:     789,
+						},
+					},
+					State:        autoupdatepb.AutoUpdateAgentRolloutState_AUTO_UPDATE_AGENT_ROLLOUT_STATE_ACTIVE,
+					StartTime:    timestamppb.New(time.Date(2025, 1, 15, 2, 0, 0, 0, time.UTC)),
+					TimeOverride: nil,
+				},
+			},
+			expectedOutput: `Agent autoupdate mode: enabled
+Rollout creation date: 2025-01-15 02:00:00
+Start version: 1.2.3
+Target version: 1.2.4
+Rollout state: Active
+Strategy: halt-on-error
+
+Group Name       State     Start Time          State Reason   Agent Count Up-to-date 
+---------------- --------- ------------------- -------------- ----------- ---------- 
+dev              Done      2025-01-15 12:00:00 outside_window 1023        567        
+stage            Active    2025-01-15 14:00:00 in_window      0           0          
+prod (catch-all) Unstarted                     outside_window 789         0          
+`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test setup: create mock client and load fixtures.
-			clt := &mockRolloutClient{}
+			clt := &mockAutoUpdateClient{}
 			clt.On("GetAutoUpdateAgentRollout", mock.Anything).Return(tt.fixture, tt.fixtureErr).Once()
 
 			// Test execution: run command.
 			output := &bytes.Buffer{}
-			cmd := AutoUpdateCommand{stdout: output}
+			cmd := AutoUpdateCommand{stdout: output, now: func() time.Time { return now }}
 			err := cmd.agentsStatusCommand(ctx, clt)
 			require.NoError(t, err)
+
+			// Test validation: check the command output.
+			require.Equal(t, tt.expectedOutput, output.String())
+
+			// Test validation: check that the mock received the expected calls.
+			clt.AssertExpectations(t)
+		})
+	}
+
+}
+
+func TestAutoUpdateAgentReportCommand(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	fewSecondsAgo := now.Add(-5 * time.Second)
+	fewMinutesAgo := now.Add(-5 * time.Minute)
+
+	tests := []struct {
+		name           string
+		fixtures       []*autoupdatepb.AutoUpdateAgentReport
+		fixturesErr    error
+		expectedOutput string
+		expectErr      require.ErrorAssertionFunc
+	}{
+		{
+			name:           "no agent report",
+			fixtures:       nil,
+			fixturesErr:    trace.NotFound("no agent report"),
+			expectedOutput: "No autoupdate_agent_report found.\n",
+			expectErr:      require.Error,
+		},
+		{
+			name: "only expired agent reports",
+			fixtures: []*autoupdatepb.AutoUpdateAgentReport{
+				{
+					Metadata: &headerv1.Metadata{Name: "auth1"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewMinutesAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 123},
+									"1.2.4": {Count: 234},
+								},
+							},
+						},
+					},
+				},
+				{
+					Metadata: &headerv1.Metadata{Name: "auth2"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewMinutesAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 456},
+									"1.2.4": {Count: 567},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: "Read 2 reports, but they are expired. If you just (re)deployed the Auth service, you might want to retry after 60 seconds.\n",
+			expectErr:      require.Error,
+		},
+		{
+			name: "valid reports",
+			fixtures: []*autoupdatepb.AutoUpdateAgentReport{
+				{
+					Metadata: &headerv1.Metadata{Name: "auth1"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewSecondsAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 123},
+									"1.2.4": {Count: 234},
+								},
+							},
+							"stage": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 123},
+								},
+							},
+						},
+					},
+				},
+				{
+					Metadata: &headerv1.Metadata{Name: "auth2"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewSecondsAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 456},
+									"1.2.4": {Count: 567},
+								},
+							},
+							"prod": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 789},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: require.NoError,
+			expectedOutput: `2 autoupdate agent reports aggregated
+
+Agent Version dev  prod stage 
+------------- ---  ---- ----- 
+1.2.3         579  789  123   
+1.2.4         801  0    0     
+`,
+		},
+		{
+			name: "valid reports with omissions",
+			fixtures: []*autoupdatepb.AutoUpdateAgentReport{
+				{
+					Metadata: &headerv1.Metadata{Name: "auth1"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewSecondsAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 123},
+									"1.2.4": {Count: 234},
+								},
+							},
+							"stage": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 123},
+								},
+							},
+						},
+						Omitted: []*autoupdatepb.AutoUpdateAgentReportSpecOmitted{
+							{Reason: "agent is too old", Count: 2},
+						},
+					},
+				},
+				{
+					Metadata: &headerv1.Metadata{Name: "auth2"},
+					Spec: &autoupdatepb.AutoUpdateAgentReportSpec{
+						Timestamp: timestamppb.New(fewSecondsAgo),
+						Groups: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroup{
+							"dev": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 456},
+									"1.2.4": {Count: 567},
+								},
+							},
+							"prod": {
+								Versions: map[string]*autoupdatepb.AutoUpdateAgentReportSpecGroupVersion{
+									"1.2.3": {Count: 789},
+								},
+							},
+						},
+						Omitted: []*autoupdatepb.AutoUpdateAgentReportSpecOmitted{
+							{Reason: "updater is disabled", Count: 5},
+						},
+					},
+				},
+			},
+			expectErr: require.NoError,
+			expectedOutput: `2 autoupdate agent reports aggregated
+
+Agent Version dev  prod stage 
+------------- ---  ---- ----- 
+1.2.3         579  789  123   
+1.2.4         801  0    0     
+
+7 agents were omitted from the reports:
+- 2 omitted because: agent is too old
+- 5 omitted because: updater is disabled
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test setup: create mock client and load fixtures.
+			clt := &mockAutoUpdateClient{}
+			clt.On("ListAutoUpdateAgentReports", mock.Anything, mock.Anything, mock.Anything).Return(tt.fixtures, tt.fixturesErr).Once()
+
+			// Test execution: run command.
+			output := &bytes.Buffer{}
+			cmd := AutoUpdateCommand{stdout: output, now: func() time.Time { return now }}
+			err := cmd.agentsReportCommand(ctx, clt)
+			tt.expectErr(t, err)
 
 			// Test validation: check the command output.
 			require.Equal(t, tt.expectedOutput, output.String())

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -2055,7 +2055,7 @@ func (c *autoUpdateAgentReportCollection) writeText(w io.Writer, verbose bool) e
 	for _, report := range c.reports {
 		for groupName, group := range report.GetSpec().GetGroups() {
 			groupSet[groupName] = struct{}{}
-			for versionName, _ := range group.GetVersions() {
+			for versionName := range group.GetVersions() {
 				versionsSet[versionName] = struct{}{}
 			}
 		}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"sort"
 	"strconv"
@@ -2032,6 +2033,54 @@ func (c *autoUpdateAgentRolloutCollection) writeText(w io.Writer, verbose bool) 
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetSchedule()),
 		fmt.Sprintf("%v", c.rollout.GetSpec().GetStrategy()),
 	})
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type autoUpdateAgentReportCollection struct {
+	reports []*autoupdatev1pb.AutoUpdateAgentReport
+}
+
+func (c *autoUpdateAgentReportCollection) resources() []types.Resource {
+	resources := make([]types.Resource, len(c.reports))
+	for i, report := range c.reports {
+		resources[i] = types.ProtoResource153ToLegacy(report)
+	}
+	return resources
+}
+
+func (c *autoUpdateAgentReportCollection) writeText(w io.Writer, verbose bool) error {
+	groupSet := make(map[string]any)
+	versionsSet := make(map[string]any)
+	for _, report := range c.reports {
+		for groupName, group := range report.GetSpec().GetGroups() {
+			groupSet[groupName] = struct{}{}
+			for versionName, _ := range group.GetVersions() {
+				versionsSet[versionName] = struct{}{}
+			}
+		}
+	}
+
+	groupNames := slices.Collect(maps.Keys(groupSet))
+	versionNames := slices.Collect(maps.Keys(versionsSet))
+	slices.Sort(groupNames)
+	slices.Sort(versionNames)
+
+	t := asciitable.MakeTable(append([]string{"Auth Server ID", "Agent Version"}, groupNames...))
+	for _, report := range c.reports {
+		for i, versionName := range versionNames {
+			row := make([]string, len(groupNames)+2)
+			if i == 0 {
+				row[0] = report.GetMetadata().GetName()
+			}
+			row[1] = versionName
+			for j, groupName := range groupNames {
+				row[j+2] = strconv.Itoa(int(report.GetSpec().GetGroups()[groupName].GetVersions()[versionName].GetCount()))
+			}
+			t.AddRow(row)
+		}
+		t.AddRow(make([]string, len(versionNames)+2))
+	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -185,6 +185,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindAutoUpdateVersion:                  rc.createAutoUpdateVersion,
 		types.KindGitServer:                          rc.createGitServer,
 		types.KindAutoUpdateAgentRollout:             rc.createAutoUpdateAgentRollout,
+		types.KindAutoUpdateAgentReport:              rc.upsertAutoUpdateAgentReport,
 		types.KindWorkloadIdentityX509IssuerOverride: rc.createWorkloadIdentityX509IssuerOverride,
 		types.KindSigstorePolicy:                     rc.createSigstorePolicy,
 		types.KindHealthCheckConfig:                  rc.createHealthCheckConfig,
@@ -210,6 +211,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindDynamicWindowsDesktop:              rc.updateDynamicWindowsDesktop,
 		types.KindGitServer:                          rc.updateGitServer,
 		types.KindAutoUpdateAgentRollout:             rc.updateAutoUpdateAgentRollout,
+		types.KindAutoUpdateAgentReport:              rc.upsertAutoUpdateAgentReport,
 		types.KindWorkloadIdentityX509IssuerOverride: rc.updateWorkloadIdentityX509IssuerOverride,
 		types.KindSigstorePolicy:                     rc.updateSigstorePolicy,
 		types.KindHealthCheckConfig:                  rc.updateHealthCheckConfig,
@@ -3533,6 +3535,29 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &autoUpdateAgentRolloutCollection{version}, nil
+	case types.KindAutoUpdateAgentReport:
+		if rc.ref.Name != "" {
+			report, err := client.GetAutoUpdateAgentReport(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &autoUpdateAgentReportCollection{reports: []*autoupdatev1pb.AutoUpdateAgentReport{report}}, nil
+		}
+
+		var reports []*autoupdatev1pb.AutoUpdateAgentReport
+		var nextToken string
+		for {
+			resp, token, err := client.ListAutoUpdateAgentReports(ctx, 0, nextToken)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			reports = append(reports, resp...)
+			if token == "" {
+				break
+			}
+			nextToken = token
+		}
+		return &autoUpdateAgentReportCollection{reports: reports}, nil
 	case types.KindAccessMonitoringRule:
 		if rc.ref.Name != "" {
 			rule, err := client.AccessMonitoringRuleClient().GetAccessMonitoringRule(ctx, rc.ref.Name)
@@ -4146,6 +4171,21 @@ func (rc *ResourceCommand) createAutoUpdateAgentRollout(ctx context.Context, cli
 	}
 
 	fmt.Println("autoupdate_agent_rollout has been created")
+	return nil
+}
+
+func (rc *ResourceCommand) upsertAutoUpdateAgentReport(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	report, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateAgentReport](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.UpsertAutoUpdateAgentReport(ctx, report)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Println("autoupdate_agent_report has been created")
 	return nil
 }
 


### PR DESCRIPTION
This PR adds 3 tctl changes:
- Add `tctl autoupdate agents report` that aggregates every agent report and shows the version/group/agents matrix
- Add tctl resource support for `autoupdate_agent_report`:
  - `tctl get autoudpate_agent_report`
  - `tctl create autoupdate_agent_report` (only useful for tests)
- Add progress tracking to `tctl autoupdate agents status`

Examples:
```
$ ./tctl -c teleport.yaml autoupdate agents report
2 autoupdate agent reports found

Agent Version dev  prod stage
------------- ---  ---- -----
1.2.3         15   0    15
1.2.4         2    0    125
1.2.5         34   1543 0

174 agents were omitted from the reports:
- 120 omitted because: version is pinned
- 12 omitted because: managed update v1 updater does not support agent reports
- 42 omitted because: updater version predates agent report

$ ./tctl -c teleport.yaml autoupdate agents status
Agent autoupdate mode: enabled
Rollout creation date: 2025-05-20 20:41:14
Start version: 1.2.4
Target version: 1.2.5
Rollout state: Done
Strategy: halt-on-error

Group Name       State Start Time          State Reason    Agent Count Up-to-date
---------------- ----- ------------------- --------------- ----------- ----------
dev              Done  2025-05-21 12:14:17 update_complete 51          34
stage            Done  2025-05-21 16:00:25 update_complete 140         0
prod (catch-all) Done  2025-05-21 18:00:29 update_complete 1543        1543
```

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856