### PR TITLE
Fix incorrect package import for `assert` in e2e test

### DIFF
--- a/e2e/web_e2e_test.go
+++ b/e2e/web_e2e_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/assert"
 )
 
 // TestSignup sets up a test instance of Teleport and runs a playwright test against it to test the signup flow.

--- a/go.mod
+++ b/go.mod
@@ -261,8 +261,6 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.5.0
 )
 
-require github.com/zeebo/assert v1.3.0
-
 require (
 	cel.dev/expr v0.20.0 // indirect
 	cloud.google.com/go v0.120.0 // indirect


### PR DESCRIPTION
## Purpose

This PR removes the import for `github.com/zeebo/assert` which was mistakenly added to `web_e2e_test.go` and replaces it with `github.com/stretchr/testify/assert`

See [this comment ](https://github.com/gravitational/teleport/pull/54094#discussion_r2098776833)