### PR TITLE
[v17] fix: preserve saml idp redirect on device trust web auth

### DIFF
--- a/lib/web/device_trust.go
+++ b/lib/web/device_trust.go
@@ -82,30 +82,38 @@ func (h *Handler) deviceWebConfirm(w http.ResponseWriter, r *http.Request, _ htt
 	// Always redirect back to the dashboard, regardless of outcome.
 	app.SetRedirectPageHeaders(w.Header(), "" /* nonce */)
 
-	redirectTo, err := h.getRedirectPath(unsafeRedirectURI)
+	redirectTo, err := h.getRedirectURL(r.Host, unsafeRedirectURI)
 	if err != nil {
 		h.log.
 			WithError(err).
 			WithField("redirect_uri", unsafeRedirectURI).
 			Debug("Unable to parse redirectURI")
+		http.Error(w, http.StatusText(trace.ErrorToCode(err)), trace.ErrorToCode(err))
+		return nil, nil
 	}
 	http.Redirect(w, r, redirectTo, http.StatusSeeOther)
 
 	return nil, nil
 }
 
-// getRedirectPath tries to parse the given redirectURI. It will always return a redirect url
-// even if the parse fails (in case of failture, the returned string is "/web")
-func (h *Handler) getRedirectPath(redirectURI string) (string, error) {
-	const basePath = "/web"
+// getRedirectPath tries to parse the given unsafeRedirectURI.
+// It returns a full URL if the unsafeRedirectURI points to SAML IdP SSO endpoint.
+// In any other case, as long as the redirect URL is parsable, it returns
+// a path ensuring its prefixed with "/web".
+func (h *Handler) getRedirectURL(host, unsafeRedirectURI string) (string, error) {
+	const (
+		basePath                = "/web"
+		samlSPInitiatedSSOPath  = "/enterprise/saml-idp/sso"
+		samlIDPInitiatedSSOPath = "/enterprise/saml-idp/login"
+	)
 
-	if redirectURI == "" {
+	if unsafeRedirectURI == "" {
 		return basePath, nil
 	}
 
-	parsedURL, err := url.Parse(redirectURI)
+	parsedURL, err := url.Parse(unsafeRedirectURI)
 	if err != nil {
-		return basePath, trace.Wrap(err)
+		return basePath, trace.BadParameter("invalid redirect URL")
 	}
 
 	cleanPath := path.Clean(parsedURL.Path)
@@ -114,6 +122,25 @@ func (h *Handler) getRedirectPath(redirectURI string) (string, error) {
 		cleanPath = "/"
 	} else if !strings.HasPrefix(cleanPath, "/") {
 		cleanPath = "/" + cleanPath
+	}
+
+	// IDP initiated SSO path format: "/enterprise/saml-idp/login/<service provider name>"
+	isIdpInitiatedSSOPath := strings.HasPrefix(cleanPath, samlIDPInitiatedSSOPath) && len(strings.Split(cleanPath, "/")) == 5
+	if cleanPath == samlSPInitiatedSSOPath || isIdpInitiatedSSOPath {
+		if parsedURL.Host != host {
+			return "", trace.BadParameter("host mismatch")
+		}
+		path := samlSPInitiatedSSOPath
+		if isIdpInitiatedSSOPath {
+			path = cleanPath
+		}
+		ensuredURL := &url.URL{
+			Scheme:   "https",
+			Host:     host,
+			Path:     path,
+			RawQuery: parsedURL.RawQuery,
+		}
+		return ensuredURL.String(), nil
 	}
 
 	// Prepend "/web" only if it's not already present

--- a/web/packages/shared/redirects/processRedirectUri.test.ts
+++ b/web/packages/shared/redirects/processRedirectUri.test.ts
@@ -71,6 +71,23 @@ describe('processRedirectURI', () => {
         input: '/web/existing/path',
         expected: '/web/existing/path',
       },
+      {
+        name: 'saml idp service provider initiated SSO URL',
+        input:
+          'https://example.com/enterprise/saml-idp/sso?SAMLRequest=example-authn-request',
+        expected: '/enterprise/saml-idp/sso?SAMLRequest=example-authn-request',
+      },
+      {
+        name: 'malformed URL',
+        input:
+          'https://example.//attacker.com/enterprise/saml-idp/sso?SAMLRequest=example-authn-request',
+        expected: '/web//attacker.com/enterprise/saml-idp/sso',
+      },
+      {
+        name: 'saml idp identity provider initiated SSO URL',
+        input: 'https://example.com/enterprise/saml-idp/login/example-app',
+        expected: '/enterprise/saml-idp/login/example-app',
+      },
     ];
 
   test.each(tests)('$name', ({ input, expected }) => {

--- a/web/packages/shared/redirects/processRedirectUri.ts
+++ b/web/packages/shared/redirects/processRedirectUri.ts
@@ -17,6 +17,8 @@
  */
 
 const BASE_PATH = '/web';
+const SAML_SP_INITIATED_SSO_PATH = '/enterprise/saml-idp/sso';
+const SAML_IDP_INITIATED_SSO_PATH = '/enterprise/saml-idp/login';
 
 /**
  * Processes a redirect URI to ensure it's valid and follows the expected format.
@@ -33,12 +35,11 @@ const BASE_PATH = '/web';
  * @returns A processed URI string that always starts with the basePath, unless it's an invalid input.
  *
  * @example
- * processRedirectURI('/web', null) // returns '/web'
- * processRedirectURI('/web', 'https://example.com/path') // returns '/web/path'
- * processRedirectURI('/web', '/custom/path') // returns '/web/custom/path'
- * processRedirectURI('/web', '/web/existing/path') // returns '/web/existing/path'
- * processRedirectURI('/web', 'invalid://url') // returns '/web'
- * processRedirectURI('/app', 'https://example.com/path') // returns '/app/path'
+ * processRedirectURI(null) // returns '/web'
+ * processRedirectURI('https://example.com/path') // returns '/web/path'
+ * processRedirectURI('/custom/path') // returns '/web/custom/path'
+ * processRedirectURI('/web/existing/path') // returns '/web/existing/path'
+ * processRedirectURI('invalid://url') // returns '/web'
  */
 export function processRedirectUri(redirectUri: string | null): string {
   // should be equal to cfg.routes.root
@@ -51,6 +52,13 @@ export function processRedirectUri(redirectUri: string | null): string {
     // If it already starts with basePath, return as is
     if (path.startsWith(BASE_PATH)) {
       return path;
+    }
+
+    if (
+      path.startsWith(SAML_IDP_INITIATED_SSO_PATH) ||
+      path.startsWith(SAML_SP_INITIATED_SSO_PATH)
+    ) {
+      return path + url.search;
     }
 
     if (path === '/') {


### PR DESCRIPTION
Backports #54530 to branch/v17

Fixes https://github.com/gravitational/teleport/issues/54121

changelog: Fixed an issue with Device Trust web authentication redirection that lost the original encoding of SAML authentication data during service provider initiated SAML login.