### PR TITLE
[v15] Fix an issue database discovery fails when there are more than 5 OpenSearch domains

### DIFF
--- a/lib/cloud/mocks/aws_opensearch.go
+++ b/lib/cloud/mocks/aws_opensearch.go
@@ -56,6 +56,11 @@ func (o *OpenSearchMock) DescribeDomainsWithContext(_ aws.Context, input *opense
 	if o.Unauth {
 		return nil, trace.AccessDenied("unauthorized")
 	}
+	// The real API only allows 5 domains at a time:
+	// https://github.com/gravitational/teleport/issues/38651
+	if len(input.DomainNames) > 5 {
+		return nil, trace.BadParameter("Please provide a maximum of 5 domain names to describe.")
+	}
 	out := &opensearchservice.DescribeDomainsOutput{}
 	for _, domain := range o.Domains {
 		if slices.ContainsFunc(input.DomainNames, func(other *string) bool {

--- a/lib/srv/discovery/fetchers/db/aws_opensearch_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_opensearch_test.go
@@ -19,6 +19,7 @@
 package db
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,17 +47,23 @@ func TestOpenSearchFetcher(t *testing.T) {
 
 	test, testDBs := makeOpenSearchDomain(t, tags, "os5", "us-east-1", "test")
 
+	// Make a few more.
+	os6, os6DBs := makeOpenSearchDomain(t, tags, "os6", "us-east-1", "test")
+	os7, os7DBs := makeOpenSearchDomain(t, tags, "os7", "us-east-1", "test")
+	os8, os8DBs := makeOpenSearchDomain(t, tags, "os8", "us-east-1", "test")
+	os9, os9DBs := makeOpenSearchDomain(t, tags, "os9", "us-east-1", "test")
+
 	tests := []awsFetcherTest{
 		{
 			name: "fetch all",
 			inputClients: &cloud.TestCloudClients{
 				OpenSearch: &mocks.OpenSearchMock{
-					Domains:   []*opensearchservice.DomainStatus{prod, test},
+					Domains:   []*opensearchservice.DomainStatus{prod, test, os6, os7, os8, os9},
 					TagsByARN: tags,
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherOpenSearch, "us-east-1", wildcardLabels),
-			wantDatabases: append(append(types.Databases{}, prodDBs...), testDBs...),
+			wantDatabases: slices.Concat(prodDBs, testDBs, os6DBs, os7DBs, os8DBs, os9DBs),
 		},
 		{
 			name: "fetch prod",


### PR DESCRIPTION
backport of #55024 to branch/v15

changelog: Fix an issue database discovery fails when there are more than 5 OpenSearch domains.