### PR TITLE
Web: Remove fn component assignment in features

### DIFF
--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -294,7 +294,7 @@ export class FeatureAddBots implements TeleportFeature {
     title: 'Bot',
     path: cfg.routes.botsNew,
     exact: true,
-    component: () => <AddBots />,
+    component: AddBots,
   };
 
   hasAccess(flags: FeatureFlags) {
@@ -467,7 +467,7 @@ export class FeatureIntegrations implements TeleportFeature {
     title: 'Manage Integrations',
     path: cfg.routes.integrations,
     exact: true,
-    component: () => <Integrations />,
+    component: Integrations,
   };
 
   navigationItem = {
@@ -492,7 +492,7 @@ export class FeatureIntegrationEnroll implements TeleportFeature {
     title: 'Integration',
     path: cfg.routes.integrationEnroll,
     exact: false,
-    component: () => <IntegrationEnroll />,
+    component: IntegrationEnroll,
   };
 
   hasAccess(flags: FeatureFlags) {


### PR DESCRIPTION
The function component assignment can cause problems like component re-mounting unnecessarily per route change, which can cause [flickering](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1747928103675509), or undesired affect eg. using [history.replace](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1725391285311419) unexpectedly causing a remount

Wasn't planning on backporting since it's not really causing any bugs, but let me know.