### PR TITLE
MWI: Spike running the AWS RA service when auth server unavailable

### DIFF
--- a/lib/tbot/client.go
+++ b/lib/tbot/client.go
@@ -1,0 +1,246 @@
+package tbot
+
+import (
+	"context"
+	"sync"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	trustv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"google.golang.org/grpc"
+)
+
+type Client interface {
+	Close() error
+	GenerateHostCert(ctx context.Context, in *trustv1.GenerateHostCertRequest, opts ...grpc.CallOption) (*trustv1.GenerateHostCertResponse, error)
+	GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
+	GetAuthPreference(context.Context) (types.AuthPreference, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error)
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, includeSigningKeys bool) (types.CertAuthority, error)
+	GetClusterCACert(ctx context.Context) (*proto.GetClusterCACertResponse, error)
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
+	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
+	GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error)
+	GetRole(ctx context.Context, name string) (types.Role, error)
+	GetTrustCertAuthority(ctx context.Context, in *trustv1.GetCertAuthorityRequest, opts ...grpc.CallOption) (*types.CertAuthorityV2, error)
+	IssueWorkloadIdentities(ctx context.Context, in *workloadidentityv1pb.IssueWorkloadIdentitiesRequest, opts ...grpc.CallOption) (*workloadidentityv1pb.IssueWorkloadIdentitiesResponse, error)
+	IssueWorkloadIdentity(ctx context.Context, in *workloadidentityv1pb.IssueWorkloadIdentityRequest, opts ...grpc.CallOption) (*workloadidentityv1pb.IssueWorkloadIdentityResponse, error)
+	ListSPIFFEFederations(ctx context.Context, in *machineidv1pb.ListSPIFFEFederationsRequest, opts ...grpc.CallOption) (*machineidv1pb.ListSPIFFEFederationsResponse, error)
+	ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error)
+	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
+	Ping(ctx context.Context) (proto.PingResponse, error)
+	ResolveSSHTarget(ctx context.Context, req *proto.ResolveSSHTargetRequest) (*proto.ResolveSSHTargetResponse, error)
+	SignJWTSVIDs(ctx context.Context, in *machineidv1pb.SignJWTSVIDsRequest, opts ...grpc.CallOption) (*machineidv1pb.SignJWTSVIDsResponse, error)
+	SignX509SVIDs(ctx context.Context, in *machineidv1pb.SignX509SVIDsRequest, opts ...grpc.CallOption) (*machineidv1pb.SignX509SVIDsResponse, error)
+	StreamSignedCRL(ctx context.Context, in *workloadidentityv1pb.StreamSignedCRLRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[workloadidentityv1pb.StreamSignedCRLResponse], error)
+	SubmitHeartbeat(ctx context.Context, in *machineidv1pb.SubmitHeartbeatRequest, opts ...grpc.CallOption) (*machineidv1pb.SubmitHeartbeatResponse, error)
+}
+
+type fallableClient struct {
+	mu     sync.Mutex
+	client *apiclient.Client
+	err    error
+}
+
+var _ Client = (*fallableClient)(nil)
+
+func (f *fallableClient) setClient(client *apiclient.Client) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.client = client
+	f.err = nil
+}
+
+func (f *fallableClient) getClient() (*apiclient.Client, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.client, f.err
+}
+
+func (c *fallableClient) Close() error {
+	if client, _ := c.getClient(); client != nil {
+		return client.Close()
+	}
+	return nil
+}
+
+func (c *fallableClient) GenerateHostCert(ctx context.Context, in *trustv1.GenerateHostCertRequest, opts ...grpc.CallOption) (*trustv1.GenerateHostCertResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.TrustClient().GenerateHostCert(ctx, in, opts...)
+}
+
+func (c *fallableClient) GenerateUserCerts(ctx context.Context, in proto.UserCertsRequest) (*proto.Certs, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GenerateUserCerts(ctx, in)
+}
+
+func (c *fallableClient) GetAuthPreference(ctx context.Context) (types.AuthPreference, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetAuthPreference(ctx)
+}
+
+func (c *fallableClient) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetCertAuthorities(ctx, caType, loadKeys)
+}
+
+func (c *fallableClient) GetCertAuthority(ctx context.Context, id types.CertAuthID, includeSigningKeys bool) (types.CertAuthority, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetCertAuthority(ctx, id, includeSigningKeys)
+}
+
+func (c *fallableClient) GetClusterCACert(ctx context.Context) (*proto.GetClusterCACertResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetClusterCACert(ctx)
+}
+
+func (c *fallableClient) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetClusterNetworkingConfig(ctx)
+}
+
+func (c *fallableClient) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetRemoteClusters(ctx)
+}
+
+func (c *fallableClient) GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetResources(ctx, req)
+}
+
+func (c *fallableClient) GetRole(ctx context.Context, name string) (types.Role, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.GetRole(ctx, name)
+}
+
+func (c *fallableClient) GetTrustCertAuthority(ctx context.Context, in *trustv1.GetCertAuthorityRequest, opts ...grpc.CallOption) (*types.CertAuthorityV2, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.TrustClient().GetCertAuthority(ctx, in, opts...)
+}
+
+func (c *fallableClient) IssueWorkloadIdentities(ctx context.Context, in *workloadidentityv1pb.IssueWorkloadIdentitiesRequest, opts ...grpc.CallOption) (*workloadidentityv1pb.IssueWorkloadIdentitiesResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.WorkloadIdentityIssuanceClient().IssueWorkloadIdentities(ctx, in, opts...)
+}
+
+func (c *fallableClient) IssueWorkloadIdentity(ctx context.Context, in *workloadidentityv1pb.IssueWorkloadIdentityRequest, opts ...grpc.CallOption) (*workloadidentityv1pb.IssueWorkloadIdentityResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.WorkloadIdentityIssuanceClient().IssueWorkloadIdentity(ctx, in, opts...)
+}
+
+func (c *fallableClient) ListSPIFFEFederations(ctx context.Context, in *machineidv1pb.ListSPIFFEFederationsRequest, opts ...grpc.CallOption) (*machineidv1pb.ListSPIFFEFederationsResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.SPIFFEFederationServiceClient().ListSPIFFEFederations(ctx, in, opts...)
+}
+
+func (c *fallableClient) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.ListUnifiedResources(ctx, req)
+}
+
+func (c *fallableClient) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.NewWatcher(ctx, watch)
+}
+
+func (c *fallableClient) Ping(ctx context.Context) (proto.PingResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return proto.PingResponse{}, err
+	}
+	return client.Ping(ctx)
+}
+
+func (c *fallableClient) ResolveSSHTarget(ctx context.Context, req *proto.ResolveSSHTargetRequest) (*proto.ResolveSSHTargetResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.ResolveSSHTarget(ctx, req)
+}
+
+func (c *fallableClient) SignJWTSVIDs(ctx context.Context, in *machineidv1pb.SignJWTSVIDsRequest, opts ...grpc.CallOption) (*machineidv1pb.SignJWTSVIDsResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.WorkloadIdentityServiceClient().SignJWTSVIDs(ctx, in, opts...)
+}
+
+func (c *fallableClient) SignX509SVIDs(ctx context.Context, in *machineidv1pb.SignX509SVIDsRequest, opts ...grpc.CallOption) (*machineidv1pb.SignX509SVIDsResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.WorkloadIdentityServiceClient().SignX509SVIDs(ctx, in, opts...)
+}
+
+func (c *fallableClient) StreamSignedCRL(ctx context.Context, in *workloadidentityv1pb.StreamSignedCRLRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[workloadidentityv1pb.StreamSignedCRLResponse], error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.WorkloadIdentityRevocationServiceClient().StreamSignedCRL(ctx, in, opts...)
+}
+
+func (c *fallableClient) SubmitHeartbeat(ctx context.Context, in *machineidv1pb.SubmitHeartbeatRequest, opts ...grpc.CallOption) (*machineidv1pb.SubmitHeartbeatResponse, error) {
+	client, err := c.getClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.BotInstanceServiceClient().SubmitHeartbeat(ctx, in, opts...)
+}

--- a/lib/tbot/config/output.go
+++ b/lib/tbot/config/output.go
@@ -34,8 +34,12 @@ import (
 // If there's no destination in the provided yaml node, then this will return
 // nil, nil.
 func extractOutputDestination(node *yaml.Node) (bot.Destination, error) {
+	return extractDestinationField(node, "destination")
+}
+
+func extractDestinationField(node *yaml.Node, name string) (bot.Destination, error) {
 	for i, subNode := range node.Content {
-		if subNode.Value == "destination" {
+		if subNode.Value == name {
 			// Next node will be the contents
 			dest, err := unmarshalDestination(node.Content[i+1])
 			if err != nil {

--- a/lib/tbot/database_access.go
+++ b/lib/tbot/database_access.go
@@ -28,11 +28,10 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 )
 
-func getDatabase(ctx context.Context, clt *authclient.Client, name string) (types.Database, error) {
+func getDatabase(ctx context.Context, clt Client, name string) (types.Database, error) {
 	ctx, span := tracer.Start(ctx, "getDatabase")
 	defer span.End()
 
@@ -59,7 +58,7 @@ func getDatabase(ctx context.Context, clt *authclient.Client, name string) (type
 func getRouteToDatabase(
 	ctx context.Context,
 	log *slog.Logger,
-	client *authclient.Client,
+	client Client,
 	service string,
 	username string,
 	database string,

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -288,7 +288,7 @@ type identityConfigurator = func(req *proto.UserCertsRequest)
 // certs.
 func generateIdentity(
 	ctx context.Context,
-	client *authclient.Client,
+	client Client,
 	currentIdentity *identity.Identity,
 	roles []string,
 	ttl time.Duration,

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -39,7 +38,7 @@ import (
 // ApplicationOutputService generates the artifacts necessary to connect to a
 // HTTP or TCP application using Teleport.
 type ApplicationOutputService struct {
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.ApplicationOutput
 	getBotIdentity    getBotIdentityFn
@@ -115,7 +114,7 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -210,7 +209,7 @@ func (s *ApplicationOutputService) render(
 func getRouteToApp(
 	ctx context.Context,
 	botIdentity *identity.Identity,
-	client *authclient.Client,
+	client Client,
 	appName string,
 ) (proto.RouteToApp, types.Application, error) {
 	ctx, span := tracer.Start(ctx, "getRouteToApp")
@@ -233,7 +232,7 @@ func getRouteToApp(
 	return routeToApp, app, nil
 }
 
-func getApp(ctx context.Context, clt *authclient.Client, appName string) (types.Application, error) {
+func getApp(ctx context.Context, clt Client, appName string) (types.Application, error) {
 	ctx, span := tracer.Start(ctx, "getApp")
 	defer span.End()
 

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -49,7 +48,7 @@ type ApplicationTunnelService struct {
 	proxyPingCache *proxyPingCache
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
-	botClient      *authclient.Client
+	botClient      Client
 	getBotIdentity getBotIdentityFn
 }
 
@@ -208,7 +207,7 @@ func (s *ApplicationTunnelService) issueCert(
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	impersonatedClient, err := clientForFacade(
+	impersonatedClient, err := temporaryClient(
 		ctx,
 		s.log,
 		s.botCfg,

--- a/lib/tbot/service_ca_rotation.go
+++ b/lib/tbot/service_ca_rotation.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 // debouncer accepts a duration, and a function. When `attempt` is called on
@@ -129,7 +128,7 @@ const caRotationRetryBackoff = time.Second * 2
 type caRotationService struct {
 	log               *slog.Logger
 	reloadBroadcaster *channelBroadcaster
-	botClient         *authclient.Client
+	botClient         Client
 	getBotIdentity    getBotIdentityFn
 }
 

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -34,7 +33,7 @@ type ClientCredentialOutputService struct {
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.UnstableClientCredentialOutput
 	getBotIdentity    getBotIdentityFn

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -39,7 +38,7 @@ import (
 // DatabaseOutputService generates the artifacts necessary to connect to a
 // database using Teleport.
 type DatabaseOutputService struct {
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.DatabaseOutput
 	getBotIdentity    getBotIdentityFn
@@ -115,7 +114,7 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -69,7 +68,7 @@ type DatabaseTunnelService struct {
 	proxyPingCache *proxyPingCache
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
-	botClient      *authclient.Client
+	botClient      Client
 	getBotIdentity getBotIdentityFn
 }
 
@@ -248,7 +247,7 @@ func (s *DatabaseTunnelService) getRouteToDatabaseWithImpersonation(ctx context.
 		return proto.RouteToDatabase{}, trace.Wrap(err)
 	}
 
-	impersonatedClient, err := clientForFacade(
+	impersonatedClient, err := temporaryClient(
 		ctx,
 		s.log,
 		s.botCfg,

--- a/lib/tbot/service_heartbeat.go
+++ b/lib/tbot/service_heartbeat.go
@@ -83,12 +83,15 @@ func (s *heartbeatService) heartbeat(ctx context.Context, isStartup bool) error 
 
 func (s *heartbeatService) OneShot(ctx context.Context) error {
 	err := s.heartbeat(ctx, true)
-	// Ignore not implemented as this is likely confusing.
-	// TODO(noah): Remove NotImplemented check at V18 assuming V17 first major
-	// with heartbeating.
-	if err != nil && !trace.IsNotImplemented(err) {
-		return trace.Wrap(err)
+
+	if trace.IsNotImplemented(err) {
+		// Ignore not implemented as this is likely confusing.
+		// TODO(noah): Remove NotImplemented check at V18 assuming V17 first major
+		// with heartbeating.
+		return nil
 	}
+
+	s.log.ErrorContext(ctx, "Failed to submit heartbeat", "error", err)
 	return nil
 }
 

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/config/openssh"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -48,7 +47,7 @@ type IdentityOutputService struct {
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.IdentityOutput
 	getBotIdentity    getBotIdentityFn
@@ -132,7 +131,7 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -412,7 +411,7 @@ func renderSSHConfig(
 }
 
 func getClusterNames(
-	ctx context.Context, client *authclient.Client, connectedClusterName string,
+	ctx context.Context, client Client, connectedClusterName string,
 ) ([]string, error) {
 	allClusterNames := []string{connectedClusterName}
 

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -54,7 +53,7 @@ type KubernetesOutputService struct {
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.KubernetesOutput
 	getBotIdentity    getBotIdentityFn
@@ -134,7 +133,7 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -53,7 +52,7 @@ type KubernetesV2OutputService struct {
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
-	botAuthClient     *authclient.Client
+	botAuthClient     Client
 	botCfg            *config.BotConfig
 	cfg               *config.KubernetesV2Output
 	getBotIdentity    getBotIdentityFn
@@ -132,7 +131,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -52,7 +52,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -83,7 +82,7 @@ type SPIFFEWorkloadAPIService struct {
 	trustBundleCache *workloadidentity.TrustBundleCache
 
 	// client holds the impersonated client for the service
-	client           *authclient.Client
+	client           Client
 	attestor         *workloadattest.Attestor
 	localTrustDomain spiffeid.TrustDomain
 }
@@ -107,7 +106,7 @@ func (s *SPIFFEWorkloadAPIService) setup(ctx context.Context) (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	client, err := clientForFacade(
+	client, err := temporaryClient(
 		ctx, s.log, s.botCfg, facade, s.resolver,
 	)
 	if err != nil {
@@ -776,7 +775,7 @@ func (s *SPIFFEWorkloadAPIService) FetchJWTSVID(
 		})
 	}
 
-	res, err := s.client.WorkloadIdentityServiceClient().SignJWTSVIDs(ctx, &machineidv1pb.SignJWTSVIDsRequest{
+	res, err := s.client.SignJWTSVIDs(ctx, &machineidv1pb.SignJWTSVIDsRequest{
 		Svids: reqs,
 	})
 	if err != nil {

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -43,7 +43,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -75,7 +74,7 @@ type WorkloadIdentityAPIService struct {
 	crlCache         *workloadidentity.CRLCache
 
 	// client holds the impersonated client for the service
-	client           *authclient.Client
+	client           Client
 	attestor         *workloadattest.Attestor
 	localTrustDomain spiffeid.TrustDomain
 }
@@ -99,7 +98,7 @@ func (s *WorkloadIdentityAPIService) setup(ctx context.Context) (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	client, err := clientForFacade(
+	client, err := temporaryClient(
 		ctx, s.log, s.botCfg, facade, s.resolver,
 	)
 	if err != nil {

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -28,7 +28,6 @@ import (
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -38,7 +37,7 @@ import (
 // WorkloadIdentityJWTService is a service that retrieves JWT workload identity
 // credentials for WorkloadIdentity resources.
 type WorkloadIdentityJWTService struct {
-	botAuthClient  *authclient.Client
+	botAuthClient  Client
 	botCfg         *config.BotConfig
 	cfg            *config.WorkloadIdentityJWTService
 	getBotIdentity getBotIdentityFn
@@ -167,7 +166,7 @@ func (s *WorkloadIdentityJWTService) requestJWTSVID(
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := temporaryClient(ctx, s.log, s.botCfg, facade, s.resolver)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/ssh_proxy.go
+++ b/lib/tbot/ssh_proxy.go
@@ -215,13 +215,13 @@ func resolveTargetHost(ctx context.Context, cfg client.Config, search, query str
 	}
 	defer apiClient.Close()
 
-	return resolveTargetHostWithClient(ctx, apiClient, search, query)
+	return resolveTargetHostWithClient(ctx, &fallableClient{client: apiClient}, search, query)
 }
 
 // resolveTargetHostWithClient resolves the target host using the provided
 // client and search and query parameters.
 func resolveTargetHostWithClient(
-	ctx context.Context, clt *client.Client, search, query string,
+	ctx context.Context, clt Client, search, query string,
 ) (types.Server, error) {
 	resp, err := clt.ResolveSSHTarget(ctx, &proto.ResolveSSHTargetRequest{
 		SearchKeywords:      libclient.ParseSearchKeywords(search, ','),

--- a/lib/tbot/workloadidentity/issue.go
+++ b/lib/tbot/workloadidentity/issue.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/attrs"
@@ -70,7 +69,7 @@ func WorkloadIdentitiesLogValue(credentials []*workloadidentityv1pb.Credential) 
 }
 
 type authClient interface {
-	WorkloadIdentityIssuanceClient() workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient
+	workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient
 	cryptosuites.AuthPreferenceGetter
 }
 
@@ -110,7 +109,7 @@ func IssueX509WorkloadIdentity(
 		)
 		// When using the "name" based selector, we either get a single WIC back,
 		// or an error. We don't need to worry about selecting the right one.
-		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentity(ctx,
+		res, err := clt.IssueWorkloadIdentity(ctx,
 			&workloadidentityv1pb.IssueWorkloadIdentityRequest{
 				Name: workloadIdentity.Name,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentityRequest_X509SvidParams{
@@ -139,7 +138,7 @@ func IssueX509WorkloadIdentity(
 			"Requesting issuance of X509 workload identity credentials using labels",
 			"labels", labelSelectors,
 		)
-		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentities(ctx,
+		res, err := clt.IssueWorkloadIdentities(ctx,
 			&workloadidentityv1pb.IssueWorkloadIdentitiesRequest{
 				LabelSelectors: labelSelectors,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentitiesRequest_X509SvidParams{
@@ -182,7 +181,7 @@ func labelsToSelectors(in map[string][]string) []*workloadidentityv1pb.LabelSele
 func IssueJWTWorkloadIdentity(
 	ctx context.Context,
 	log *slog.Logger,
-	clt *authclient.Client,
+	clt workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient,
 	workloadIdentity config.WorkloadIdentitySelector,
 	audiences []string,
 	ttl time.Duration,
@@ -207,7 +206,7 @@ func IssueJWTWorkloadIdentity(
 		)
 		// When using the "name" based selector, we either get a single WIC back,
 		// or an error. We don't need to worry about selecting the right one.
-		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentity(ctx,
+		res, err := clt.IssueWorkloadIdentity(ctx,
 			&workloadidentityv1pb.IssueWorkloadIdentityRequest{
 				Name: workloadIdentity.Name,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentityRequest_JwtSvidParams{
@@ -235,7 +234,7 @@ func IssueJWTWorkloadIdentity(
 			"Requesting issuance of JWT workload identity credentials using labels",
 			"labels", labelSelectors,
 		)
-		res, err := clt.WorkloadIdentityIssuanceClient().IssueWorkloadIdentities(ctx,
+		res, err := clt.IssueWorkloadIdentities(ctx,
 			&workloadidentityv1pb.IssueWorkloadIdentitiesRequest{
 				LabelSelectors: labelSelectors,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentitiesRequest_JwtSvidParams{


### PR DESCRIPTION
This is a spike of a possible solution for #53711.

#### How it works

Rather than depending on `*authclient.Client` or `client.Client` directly, we now pass around our own wrapper struct. If the bot identity service initialization fails but there is an old identity on-disk, it'll return "successfully" but the client wrapper will be rigged to return an error on each RPC.

This effectively allows `tbot` to run in a "degraded" state without a functioning API client, while the bot identity service's `Run` method retries the initialization in the background.

The roles anywhere service now writes its SVID to a "cache" destination (in-memory by default, but can be configured to on-disk) and if the client returns an error because initialization fails, it'll fall back to using the cached SVID for the exchange.

I've tested this manually by running `tbot` once with the following configuration, killing it, stopping the auth server, restarting `tbot`, and then restarting the auth server.

```yaml
version: v2
proxy_server: <address>
onboarding:
  join_method: token
  token: <token>
storage:
  type: directory
  path: /Users/dan/Desktop/tbot/internal
services:
  - type: workload-identity-aws-roles-anywhere
    destination:
      type: directory
      path: /Users/dan/Desktop/tbot/aws-ra
    cache:
      type: directory
      path: /Users/dan/Desktop/tbot/aws-ra-cache
    role_arn: <arn>
    profile_arn:  <arn>
    trust_anchor_arn: <arn>
    region: eu-west-2
    selector:
      name: aws-ra-workload-identity

```