### PR TITLE
Always send update group in agent hello

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -34,6 +34,11 @@ import (
 )
 
 const (
+	// defaultSetting is used to represent the default value for updater config.
+	defaultSetting = "default"
+)
+
+const (
 	// updateConfigName specifies the name of the file inside versionsDirName containing configuration for the teleport update.
 	updateConfigName = "update.yaml"
 
@@ -228,7 +233,7 @@ func overrideOptional(orig, override string) string {
 	switch override {
 	case "":
 		return orig
-	case "default":
+	case defaultSetting:
 		return ""
 	default:
 		return override

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -199,6 +199,9 @@ func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string
 	}
 
 	info.UpdateGroup = cfg.Spec.Group
+	if info.UpdateGroup == "" {
+		info.UpdateGroup = defaultSetting
+	}
 	if p := cfg.Status.IDFile; p != "" {
 		machineID, err := os.ReadFile(systemdMachineIDFile)
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -878,7 +878,7 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig, id string) (FindR
 	}
 	group := cfg.Spec.Group
 	if group == "" {
-		group = "default"
+		group = defaultSetting
 	}
 	resp, err := webclient.Find(&webclient.Config{
 		Context:     ctx,


### PR DESCRIPTION
This PR ensures that the update group sent via the agent hello always matches the group used by `teleport-update` to query the desired version. This ensures accurate tracking of update state in each group.

---

changelog: teleport-update: always send update group in agent hello

---

The `teleport-update` binary is used to enable, disable, and trigger automatic Teleport agent updates. The new Managed Updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856