### PR TITLE
Adds recording encryption manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	cloud.google.com/go/storage v1.53.0
 	code.dny.dev/ssrf v0.2.0
 	connectrpc.com/connect v1.18.1
+	filippo.io/age v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -641,6 +643,8 @@ cuelang.org/go v0.12.1/go.mod h1:B4+kjvGGQnbkz+GuAv1dq/R308gTkp0sO28FdMrJ2Kw=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=

--- a/lib/auth/recordingencryption/manager.go
+++ b/lib/auth/recordingencryption/manager.go
@@ -1,0 +1,533 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recordingencryption
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"iter"
+	"log/slog"
+	"slices"
+	"time"
+
+	"filippo.io/age"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// KeyStore provides methods for interacting with encryption keys.
+type KeyStore interface {
+	NewEncryptionKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.EncryptionKeyPair, error)
+	GetDecrypter(ctx context.Context, keyPair *types.EncryptionKeyPair) (crypto.Decrypter, error)
+}
+
+// ManagerConfig captures all of the dependencies required to instantiate a Manager.
+type ManagerConfig struct {
+	Backend       services.RecordingEncryption
+	ClusterConfig services.ClusterConfigurationInternal
+	KeyStore      KeyStore
+	Logger        *slog.Logger
+	LockConfig    backend.RunWhileLockedConfig
+}
+
+// NewManager returns a new Manager using the given ManagerConfig.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	switch {
+	case cfg.Backend == nil:
+		return nil, trace.BadParameter("backend is required")
+	case cfg.ClusterConfig == nil:
+		return nil, trace.BadParameter("cluster config is required")
+	case cfg.KeyStore == nil:
+		return nil, trace.BadParameter("key store is required")
+	}
+
+	if cfg.Logger == nil {
+		cfg.Logger = slog.With(teleport.ComponentKey, "recording-encryption-manager")
+	}
+
+	return &Manager{
+		RecordingEncryption:          cfg.Backend,
+		ClusterConfigurationInternal: cfg.ClusterConfig,
+
+		keyStore:   cfg.KeyStore,
+		lockConfig: cfg.LockConfig,
+		logger:     cfg.Logger,
+	}, nil
+}
+
+// A Manager wraps a services.RecordingEncryption and KeyStore in order to provide more complex operations
+// than the CRUD methods exposed by services.RecordingEncryption. It primarily handles resolving RecordingEncryption
+// state and searching for accessible decryption keys.
+type Manager struct {
+	services.RecordingEncryption
+	services.ClusterConfigurationInternal
+
+	logger     *slog.Logger
+	lockConfig backend.RunWhileLockedConfig
+	keyStore   KeyStore
+}
+
+// CreateSessionRecordingConfig creates a new session recording configuration. If encryption is enabled then the
+// recording encryption resource will also be resolved.
+func (m *Manager) CreateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (sessionRecordingConfig types.SessionRecordingConfig, err error) {
+	err = backend.RunWhileLocked(ctx, m.lockConfig, func(ctx context.Context) error {
+		if cfg.GetEncrypted() {
+			encryption, err := m.resolveRecordingEncryption(ctx)
+			if err != nil {
+				return err
+			}
+
+			_ = cfg.SetEncryptionKeys(getAgeEncryptionKeys(encryption.GetSpec().ActiveKeys))
+		}
+
+		sessionRecordingConfig, err = m.ClusterConfigurationInternal.CreateSessionRecordingConfig(ctx, cfg)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	})
+
+	return sessionRecordingConfig, trace.Wrap(err)
+}
+
+// UpdateSessionRecordingConfig updates an existing session recording configuration. If encryption is enabled then
+// the recording encryption resource will also be resolved.
+func (m *Manager) UpdateSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (sessionRecordingConfig types.SessionRecordingConfig, err error) {
+	err = backend.RunWhileLocked(ctx, m.lockConfig, func(ctx context.Context) error {
+		if cfg.GetEncrypted() {
+			encryption, err := m.resolveRecordingEncryption(ctx)
+			if err != nil {
+				return err
+			}
+
+			_ = cfg.SetEncryptionKeys(getAgeEncryptionKeys(encryption.GetSpec().ActiveKeys))
+		}
+
+		sessionRecordingConfig, err = m.ClusterConfigurationInternal.UpdateSessionRecordingConfig(ctx, cfg)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	})
+
+	return sessionRecordingConfig, trace.Wrap(err)
+}
+
+// UpsertSessionRecordingConfig creates a new session recording configuration or overwrites an existing one. If
+// encryption is enabled then the recording encryption resource will also be resolved.
+func (m *Manager) UpsertSessionRecordingConfig(ctx context.Context, cfg types.SessionRecordingConfig) (sessionRecordingConfig types.SessionRecordingConfig, err error) {
+	err = backend.RunWhileLocked(ctx, m.lockConfig, func(ctx context.Context) error {
+		if cfg.GetEncrypted() {
+			encryption, err := m.resolveRecordingEncryption(ctx)
+			if err != nil {
+				return err
+			}
+
+			_ = cfg.SetEncryptionKeys(getAgeEncryptionKeys(encryption.GetSpec().ActiveKeys))
+		}
+
+		sessionRecordingConfig, err = m.ClusterConfigurationInternal.UpsertSessionRecordingConfig(ctx, cfg)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
+	})
+
+	return sessionRecordingConfig, trace.Wrap(err)
+}
+
+// ensureActiveRecordingEncryption returns the configured RecordingEncryption resource if it exists with active keys. If it does not,
+// then the resource will be created or updated with a new active keypair. The bool return value indicates whether or not
+// a new pair was provisioned.
+func (m *Manager) ensureActiveRecordingEncryption(ctx context.Context) (*recordingencryptionv1.RecordingEncryption, bool, error) {
+	persistFn := m.RecordingEncryption.UpdateRecordingEncryption
+	encryption, err := m.RecordingEncryption.GetRecordingEncryption(ctx)
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return encryption, false, trace.Wrap(err)
+		}
+		encryption = &recordingencryptionv1.RecordingEncryption{
+			Spec: &recordingencryptionv1.RecordingEncryptionSpec{},
+		}
+		persistFn = m.RecordingEncryption.CreateRecordingEncryption
+	}
+
+	activeKeys := encryption.GetSpec().ActiveKeys
+
+	// no keys present, need to generate the initial active keypair
+	if len(activeKeys) > 0 {
+		return encryption, false, nil
+	}
+
+	keyEncryptionPair, err := m.keyStore.NewEncryptionKeyPair(ctx, cryptosuites.RecordingKeyWrapping)
+	if err != nil {
+		return encryption, false, trace.Wrap(err, "generating wrapping key")
+	}
+
+	ident, err := age.GenerateX25519Identity()
+	if err != nil {
+		return encryption, false, trace.Wrap(err, "generating age encryption key")
+	}
+
+	encryptedIdent, err := keyEncryptionPair.EncryptOAEP([]byte(ident.String()))
+	if err != nil {
+		return encryption, false, trace.Wrap(err, "wrapping encryption key")
+	}
+
+	wrappedKey := recordingencryptionv1.WrappedKey{
+		KeyEncryptionPair: keyEncryptionPair,
+		RecordingEncryptionPair: &types.EncryptionKeyPair{
+			PrivateKeyType: types.PrivateKeyType_RAW,
+			PrivateKey:     encryptedIdent,
+			PublicKey:      []byte(ident.Recipient().String()),
+		},
+	}
+	encryption.Spec.ActiveKeys = []*recordingencryptionv1.WrappedKey{&wrappedKey}
+	encryption, err = persistFn(ctx, encryption)
+	if err != nil {
+		return encryption, false, trace.Wrap(err)
+	}
+	fp := sha256.Sum256(wrappedKey.RecordingEncryptionPair.PublicKey)
+	m.logger.InfoContext(ctx, "no active keys, generated initial recording encryption pair", "public_fingerprint", hex.EncodeToString(fp[:]))
+	return encryption, true, nil
+}
+
+var errWaitingForKey = errors.New("waiting for key to be fulfilled")
+
+// getRecordingEncryptionKey returns the first active recording encryption key accessible to the configured key store.
+func (m *Manager) getRecordingEncryptionKeyPair(ctx context.Context, keys []*recordingencryptionv1.WrappedKey) (*types.EncryptionKeyPair, error) {
+	var foundUnfulfilledKey bool
+	for _, key := range keys {
+		decrypter, err := m.keyStore.GetDecrypter(ctx, key.KeyEncryptionPair)
+		if err != nil {
+			continue
+		}
+
+		// if we make it to this section the key is accessible to the current auth server
+		if key.RecordingEncryptionPair == nil {
+			foundUnfulfilledKey = true
+			continue
+		}
+
+		decryptionKey, err := decrypter.Decrypt(rand.Reader, key.RecordingEncryptionPair.PrivateKey, nil)
+		if err != nil {
+			return nil, trace.Wrap(err, "decrypting known key")
+		}
+
+		return &types.EncryptionKeyPair{
+			PrivateKey: decryptionKey,
+			PublicKey:  key.RecordingEncryptionPair.PublicKey,
+		}, nil
+	}
+
+	if foundUnfulfilledKey {
+		return nil, trace.Wrap(errWaitingForKey)
+	}
+
+	return nil, trace.NotFound("no accessible recording encryption pair found")
+}
+
+// resolveRecordingEncryption examines the current state of the RescordingEncryption resource and advances it to the
+// next state on behalf of the current auth server.
+//
+// When no active recording encryption key pairs exist, the first pair will be generated and wrapped using a new key
+// encryption pair generated by the Manager's keystore.
+//
+// When at least one active keypair exists but none are accessible to the Manager's keystore, a new key encryption pair
+// will be generated and saved without a key encryption pair. This is an unfulfilled key that some other instance of
+// Manager on another auth server will need to fulfill asynchronously.
+//
+// If at least one active key is accessible to the Manager's keystore, then unfulfilled keys (identified by missing
+// recording encryption key pairs) will be fulfilled using their public key encryption keys.
+//
+// If there are no unfulfilled keys present, then nothing should be done.
+func (m *Manager) resolveRecordingEncryption(ctx context.Context) (*recordingencryptionv1.RecordingEncryption, error) {
+	encryption, generatedKey, err := m.ensureActiveRecordingEncryption(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if generatedKey {
+		m.logger.DebugContext(ctx, "created initial recording encryption key")
+		return encryption, nil
+	}
+
+	activeKeys := encryption.GetSpec().ActiveKeys
+	recordingEncryptionPair, err := m.getRecordingEncryptionKeyPair(ctx, activeKeys)
+	if err != nil {
+		if errors.Is(err, errWaitingForKey) {
+			// do nothing
+			return encryption, nil
+		}
+
+		if trace.IsNotFound(err) {
+			m.logger.InfoContext(ctx, "no accessible recording encryption keys, posting new key to be fulfilled")
+			keypair, err := m.keyStore.NewEncryptionKeyPair(ctx, cryptosuites.RecordingKeyWrapping)
+			if err != nil {
+				return nil, trace.Wrap(err, "generating keypair for new wrapped key")
+			}
+			encryption.GetSpec().ActiveKeys = append(activeKeys, &recordingencryptionv1.WrappedKey{
+				KeyEncryptionPair: keypair,
+			})
+
+			encryption, err = m.RecordingEncryption.UpdateRecordingEncryption(ctx, encryption)
+			return encryption, trace.Wrap(err, "updating session recording config")
+		}
+
+		return nil, trace.Wrap(err)
+	}
+
+	var shouldUpdate bool
+	for _, key := range activeKeys {
+		if key.RecordingEncryptionPair != nil {
+			continue
+		}
+
+		encryptedKey, err := key.KeyEncryptionPair.EncryptOAEP(recordingEncryptionPair.PrivateKey)
+		if err != nil {
+			return encryption, trace.Wrap(err, "reencrypting decryption key")
+		}
+
+		key.RecordingEncryptionPair = &types.EncryptionKeyPair{
+			PrivateKey: encryptedKey,
+			PublicKey:  recordingEncryptionPair.PublicKey,
+		}
+
+		shouldUpdate = true
+	}
+
+	if shouldUpdate {
+		m.logger.DebugContext(ctx, "fulfilling empty keys")
+		encryption, err = m.RecordingEncryption.UpdateRecordingEncryption(ctx, encryption)
+		if err != nil {
+			return encryption, trace.Wrap(err, "updating session recording config")
+		}
+	}
+
+	return encryption, nil
+}
+
+func (m *Manager) searchActiveKeys(ctx context.Context, activeKeys []*recordingencryptionv1.WrappedKey, publicKey []byte) (*types.EncryptionKeyPair, error) {
+	for _, key := range activeKeys {
+		if key.GetRecordingEncryptionPair() == nil {
+			continue
+		}
+
+		if !slices.Equal(key.RecordingEncryptionPair.PublicKey, publicKey) {
+			continue
+		}
+
+		decrypter, err := m.keyStore.GetDecrypter(ctx, key.KeyEncryptionPair)
+		if err != nil {
+			continue
+		}
+
+		privateKey, err := decrypter.Decrypt(rand.Reader, key.RecordingEncryptionPair.PrivateKey, nil)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &types.EncryptionKeyPair{
+			PrivateKey:     privateKey,
+			PublicKey:      key.RecordingEncryptionPair.PublicKey,
+			PrivateKeyType: key.RecordingEncryptionPair.PrivateKeyType,
+		}, nil
+	}
+
+	return nil, trace.NotFound("no accessible decryption key found")
+}
+
+// FindDecryptionKey returns the first accessible decryption key that matches one of the given public keys.
+func (m *Manager) FindDecryptionKey(ctx context.Context, publicKeys ...[]byte) (*types.EncryptionKeyPair, error) {
+	encryption, err := m.RecordingEncryption.GetRecordingEncryption(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO (eriktate): search rotated keys as well once rotation is implemented
+	activeKeys := encryption.GetSpec().ActiveKeys
+	if len(publicKeys) == 0 {
+		return m.searchActiveKeys(ctx, activeKeys, nil)
+	}
+
+	for _, publicKey := range publicKeys {
+		found, err := m.searchActiveKeys(ctx, activeKeys, publicKey)
+		if err != nil {
+			if trace.IsNotFound(err) {
+				continue
+			}
+
+			if !slices.Equal(found.PublicKey, publicKey) {
+				continue
+			}
+
+			decrypter, err := m.keyStore.GetDecrypter(ctx, found)
+			if err != nil {
+				if !trace.IsNotFound(err) {
+					m.logger.ErrorContext(ctx, "could not get decrypter from key store", "error", err)
+				}
+				continue
+			}
+
+			privateKey, err := decrypter.Decrypt(rand.Reader, found.PrivateKey, nil)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return &types.EncryptionKeyPair{
+				PrivateKey:     privateKey,
+				PublicKey:      found.PublicKey,
+				PrivateKeyType: found.PrivateKeyType,
+			}, nil
+		}
+
+		return found, nil
+	}
+
+	return nil, trace.NotFound("no accessible decryption key found")
+}
+
+func (m *Manager) Watch(ctx context.Context, events types.Events) (err error) {
+	// shouldRetryAfterJitterFn waits at most 5 seconds and returns a bool specifying whether or not
+	// execution should continue
+	shouldRetryAfterJitterFn := func() bool {
+		select {
+		case <-time.After(retryutils.SeventhJitter(time.Second * 5)):
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	defer func() {
+		m.logger.InfoContext(ctx, "stopping encryption watcher", "error", err)
+	}()
+
+	for {
+		watch, err := events.NewWatcher(ctx, types.Watch{
+			Name: "recording_encryption_watcher",
+			Kinds: []types.WatchKind{
+				{
+					Kind: types.KindRecordingEncryption,
+				},
+			},
+		})
+		if err != nil {
+			m.logger.ErrorContext(ctx, "failed to create watcher, retrying", "error", err)
+			if !shouldRetryAfterJitterFn() {
+				return nil
+			}
+			continue
+		}
+		defer watch.Close()
+
+	HandleEvents:
+		for {
+			select {
+			case ev := <-watch.Events():
+				if err := m.handleEvent(ctx, ev, shouldRetryAfterJitterFn); err != nil {
+					m.logger.ErrorContext(ctx, "failure handling recording encryption event", "kind", ev.Resource.GetKind(), "error", err)
+				}
+			case <-watch.Done():
+				if err := watch.Error(); err == nil {
+					return nil
+				}
+
+				m.logger.ErrorContext(ctx, "watcher failed, retrying", "error", err)
+				if !shouldRetryAfterJitterFn() {
+					return nil
+				}
+				break HandleEvents
+			case <-ctx.Done():
+				return nil
+			}
+
+		}
+	}
+}
+
+func (m *Manager) handleEvent(ctx context.Context, ev types.Event, shouldRetryFn func() bool) error {
+	if ev.Type != types.OpPut {
+		return nil
+	}
+
+	if ev.Resource.GetKind() != types.KindRecordingEncryption {
+		return nil
+	}
+
+	const retries = 3
+	for retry := range retries {
+		err := backend.RunWhileLocked(ctx, m.lockConfig, func(ctx context.Context) error {
+			sessionRecordingConfig, err := m.GetSessionRecordingConfig(ctx)
+			if err != nil {
+				m.logger.ErrorContext(ctx, "failed to retrieve session_recording_config, retrying", "error", err)
+				return err
+			}
+
+			if !sessionRecordingConfig.GetEncrypted() {
+				return nil
+			}
+
+			if _, err := m.resolveRecordingEncryption(ctx); err != nil {
+				m.logger.ErrorContext(ctx, "failed to resolve recording encryption keys, retrying", "retry", retry, "retries_left", retries-retry, "error", err)
+
+				return err
+			}
+
+			return nil
+		})
+		if err != nil && shouldRetryFn() {
+			continue
+		}
+
+		return nil
+	}
+
+	return trace.LimitExceeded("resolving recording encryption exceeded max retries")
+}
+
+// getAgeEncryptionKeys returns an iterator of AgeEncryptionKeys from a list of WrappedKeys. This is for use in
+// populating the EncryptionKeys field of SessionRecordingConfigStatus.
+func getAgeEncryptionKeys(keys []*recordingencryptionv1.WrappedKey) iter.Seq[*types.AgeEncryptionKey] {
+	return func(yield func(*types.AgeEncryptionKey) bool) {
+		for _, key := range keys {
+			if key.RecordingEncryptionPair == nil {
+				continue
+			}
+
+			if !yield(&types.AgeEncryptionKey{
+				PublicKey: key.RecordingEncryptionPair.PublicKey,
+			}) {
+				return
+			}
+		}
+	}
+}

--- a/lib/auth/recordingencryption/manager_test.go
+++ b/lib/auth/recordingencryption/manager_test.go
@@ -1,0 +1,402 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package recordingencryption_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/recordingencryption"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type oaepDecrypter struct {
+	crypto.Decrypter
+	hash crypto.Hash
+}
+
+func (d oaepDecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
+	return d.Decrypter.Decrypt(rand, msg, &rsa.OAEPOptions{
+		Hash: d.hash,
+	})
+}
+
+type fakeKeyStore struct {
+	keyType types.PrivateKeyType // abusing this field as a way to simulate different auth servers
+}
+
+func (f *fakeKeyStore) NewEncryptionKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.EncryptionKeyPair, error) {
+	decrypter, err := cryptosuites.GenerateDecrypterWithAlgorithm(cryptosuites.RSA2048)
+	if err != nil {
+		return nil, err
+	}
+
+	private, ok := decrypter.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("expected RSA private key")
+	}
+
+	privatePEM := pem.EncodeToMemory(&pem.Block{
+		Type:  keys.PKCS1PrivateKeyType,
+		Bytes: x509.MarshalPKCS1PrivateKey(private),
+	})
+
+	publicPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  keys.PKCS1PublicKeyType,
+		Bytes: x509.MarshalPKCS1PublicKey(&private.PublicKey),
+	})
+
+	return &types.EncryptionKeyPair{
+		PrivateKey:     privatePEM,
+		PublicKey:      publicPEM,
+		PrivateKeyType: f.keyType,
+		Hash:           uint32(crypto.SHA256),
+	}, nil
+}
+
+func (f *fakeKeyStore) GetDecrypter(ctx context.Context, keyPair *types.EncryptionKeyPair) (crypto.Decrypter, error) {
+	if keyPair.PrivateKeyType != f.keyType {
+		return nil, errors.New("could not access decrypter")
+	}
+
+	block, _ := pem.Decode(keyPair.PrivateKey)
+
+	private, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return oaepDecrypter{Decrypter: private, hash: crypto.Hash(keyPair.Hash)}, nil
+}
+
+func newLocalBackend(
+	t *testing.T,
+) (context.Context, backend.Backend) {
+	t.Parallel()
+	ctx := t.Context()
+	clock := clockwork.NewRealClock()
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	bk := backend.NewSanitizer(mem)
+	return ctx, bk
+}
+
+func newManagerConfig(t *testing.T, bk backend.Backend, keyType types.PrivateKeyType) recordingencryption.ManagerConfig {
+	recordingEncryptionService, err := local.NewRecordingEncryptionService(bk)
+	require.NoError(t, err)
+
+	clusterConfigService, err := local.NewClusterConfigurationService(bk)
+	require.NoError(t, err)
+
+	src := &types.SessionRecordingConfigV2{}
+	require.NoError(t, src.CheckAndSetDefaults())
+	src.Spec.Encryption = &types.SessionRecordingEncryptionConfig{
+		Enabled: true,
+	}
+
+	return recordingencryption.ManagerConfig{
+		Backend:       recordingEncryptionService,
+		ClusterConfig: clusterConfigService,
+		KeyStore:      &fakeKeyStore{keyType: keyType},
+		Logger:        utils.NewSlogLoggerForTests(),
+		LockConfig: backend.RunWhileLockedConfig{
+			LockConfiguration: backend.LockConfiguration{
+				Backend:            bk,
+				LockNameComponents: []string{"recording_encryption"},
+				TTL:                5 * time.Second,
+				RetryInterval:      10 * time.Millisecond,
+			},
+		},
+	}
+}
+
+// resolve is a proxy to Manager.resolveRecordingEncryption through calling UpsertSessionRecordingConfig
+func resolve(ctx context.Context, service services.RecordingEncryption, manager *recordingencryption.Manager) (*recordingencryptionv1.RecordingEncryption, types.SessionRecordingConfig, error) {
+	req := types.SessionRecordingConfigV2{
+		Spec: types.SessionRecordingConfigSpecV2{
+			Encryption: &types.SessionRecordingEncryptionConfig{
+				Enabled: true,
+			},
+		},
+	}
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	src, err := manager.UpsertSessionRecordingConfig(ctx, &req)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	encryption, err := service.GetRecordingEncryption(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return encryption, src, nil
+}
+
+func TestCreateUpdateSessionRecordingConfig(t *testing.T) {
+	ctx, bk := newLocalBackend(t)
+
+	config := newManagerConfig(t, bk, types.PrivateKeyType_RAW)
+	manager, err := recordingencryption.NewManager(config)
+	require.NoError(t, err)
+
+	req := &types.SessionRecordingConfigV2{}
+	require.NoError(t, req.CheckAndSetDefaults())
+	req.Spec.Encryption = &types.SessionRecordingEncryptionConfig{
+		Enabled: true,
+	}
+
+	// create should provision initial keypair and write public key to SRC
+	src, err := manager.CreateSessionRecordingConfig(ctx, req)
+	require.NoError(t, err)
+	encryptionKeys := src.GetEncryptionKeys()
+	require.Len(t, encryptionKeys, 1)
+
+	encryption, err := config.Backend.GetRecordingEncryption(ctx)
+	require.NoError(t, err)
+	activeKeys := encryption.GetSpec().GetActiveKeys()
+	require.Len(t, activeKeys, 1)
+	require.NotNil(t, activeKeys[0].RecordingEncryptionPair)
+	require.NotEmpty(t, activeKeys[0].RecordingEncryptionPair.PrivateKey)
+	require.NotEmpty(t, activeKeys[0].RecordingEncryptionPair.PublicKey)
+	require.NotNil(t, activeKeys[0].KeyEncryptionPair)
+	require.NotEmpty(t, activeKeys[0].KeyEncryptionPair.PrivateKey)
+	require.NotEmpty(t, activeKeys[0].KeyEncryptionPair.PublicKey)
+
+	// update should change nothing
+	src, err = manager.UpdateSessionRecordingConfig(ctx, src)
+	require.NoError(t, err)
+	newEncryptionKeys := src.GetEncryptionKeys()
+	require.ElementsMatch(t, newEncryptionKeys, encryptionKeys)
+
+	encryption, err = config.Backend.GetRecordingEncryption(ctx)
+	require.NoError(t, err)
+	newActiveKeys := encryption.GetSpec().GetActiveKeys()
+	require.ElementsMatch(t, newActiveKeys, activeKeys)
+}
+
+func TestResolveRecordingEncryption(t *testing.T) {
+	// SETUP
+	ctx, bk := newLocalBackend(t)
+
+	managerAType := types.PrivateKeyType_RAW
+	managerBType := types.PrivateKeyType_AWS_KMS
+
+	configA := newManagerConfig(t, bk, managerAType)
+	configB := configA
+	configB.KeyStore = &fakeKeyStore{managerBType}
+
+	managerA, err := recordingencryption.NewManager(configA)
+	require.NoError(t, err)
+
+	managerB, err := recordingencryption.NewManager(configB)
+	require.NoError(t, err)
+
+	service := configA.Backend
+
+	// TEST
+	// CASE: service A first evaluation initializes recording encryption resource
+	encryption, src, err := resolve(ctx, service, managerA)
+	require.NoError(t, err)
+	activeKeys := encryption.GetSpec().GetActiveKeys()
+
+	require.Len(t, activeKeys, 1)
+	require.Len(t, src.GetEncryptionKeys(), 1)
+	firstKey := activeKeys[0]
+
+	// should generate a wrapped key with the initial recording encryption pair
+	require.NotNil(t, firstKey.KeyEncryptionPair)
+	require.NotNil(t, firstKey.RecordingEncryptionPair)
+
+	// CASE: service B should generate an unfulfilled key since there's an existing recording encryption resource
+	encryption, src, err = resolve(ctx, service, managerB)
+	require.NoError(t, err)
+
+	activeKeys = encryption.GetSpec().ActiveKeys
+	require.Len(t, activeKeys, 2)
+	require.Len(t, src.GetEncryptionKeys(), 1)
+	for _, key := range activeKeys {
+		require.NotNil(t, key.KeyEncryptionPair)
+		if key.KeyEncryptionPair.PrivateKeyType == managerAType {
+			require.NotNil(t, key.RecordingEncryptionPair)
+		} else {
+			require.Nil(t, key.RecordingEncryptionPair)
+		}
+	}
+
+	// service B re-evaluting with an unfulfilled key should do nothing
+	encryption, src, err = resolve(ctx, service, managerB)
+	require.NoError(t, err)
+	activeKeys = encryption.GetSpec().ActiveKeys
+	require.Len(t, activeKeys, 2)
+	require.Len(t, src.GetEncryptionKeys(), 1)
+	for _, key := range activeKeys {
+		require.NotNil(t, key.KeyEncryptionPair)
+		if key.KeyEncryptionPair.PrivateKeyType == managerAType {
+			require.NotNil(t, key.RecordingEncryptionPair)
+		} else {
+			require.Nil(t, key.RecordingEncryptionPair)
+		}
+	}
+
+	// CASE: service A evaluation should fulfill service B's key
+	encryption, src, err = resolve(ctx, service, managerA)
+	require.NoError(t, err)
+	activeKeys = encryption.GetSpec().ActiveKeys
+	require.Len(t, activeKeys, 2)
+	require.Len(t, src.GetEncryptionKeys(), 1)
+	for _, key := range activeKeys {
+		require.NotNil(t, key.KeyEncryptionPair)
+		require.NotNil(t, key.RecordingEncryptionPair)
+	}
+}
+
+func TestResolveRecordingEncryptionConcurrent(t *testing.T) {
+	// SETUP
+	ctx, bk := newLocalBackend(t)
+
+	managerAType := types.PrivateKeyType_RAW
+	managerBType := types.PrivateKeyType_AWS_KMS
+	serviceCType := types.PrivateKeyType_GCP_KMS
+
+	configA := newManagerConfig(t, bk, managerAType)
+	configB := configA
+	configB.KeyStore = &fakeKeyStore{managerBType}
+	configC := configA
+	configC.KeyStore = &fakeKeyStore{serviceCType}
+	recordingEncryptionService := configA.Backend
+	managerA, err := recordingencryption.NewManager(configA)
+	require.NoError(t, err)
+
+	managerB, err := recordingencryption.NewManager(configB)
+	require.NoError(t, err)
+
+	serviceC, err := recordingencryption.NewManager(configC)
+	require.NoError(t, err)
+
+	service := configA.Backend
+	resolveFn := func(manager *recordingencryption.Manager, wg *sync.WaitGroup) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resolve(ctx, service, manager)
+			require.NoError(t, err)
+		}()
+	}
+
+	wg := sync.WaitGroup{}
+	resolveFn(managerA, &wg)
+	resolveFn(managerB, &wg)
+	resolveFn(serviceC, &wg)
+	wg.Wait()
+
+	encryption, err := recordingEncryptionService.GetRecordingEncryption(ctx)
+	require.NoError(t, err)
+
+	activeKeys := encryption.GetSpec().ActiveKeys
+	// each service should have an active wrapped key
+	require.Len(t, activeKeys, 3)
+	var fulfilledKeys int
+	for _, key := range activeKeys {
+		// all wrapped keys should have KeyEncryptionPairs
+		require.NotNil(t, key.KeyEncryptionPair)
+		require.NotEmpty(t, key.KeyEncryptionPair.PublicKey)
+		require.NotEmpty(t, key.KeyEncryptionPair.PrivateKey)
+
+		if key.RecordingEncryptionPair != nil {
+			fulfilledKeys += 1
+		}
+	}
+
+	// only the first service to run should have a fulfilled wrapped key
+	require.Equal(t, 1, fulfilledKeys)
+}
+
+func TestFindDecryptionKeyFromActiveKeys(t *testing.T) {
+	// SETUP
+	ctx, bk := newLocalBackend(t)
+	keyTypeA := types.PrivateKeyType_RAW
+	keyTypeB := types.PrivateKeyType_AWS_KMS
+
+	configA := newManagerConfig(t, bk, keyTypeA)
+	configB := configA
+	configB.KeyStore = &fakeKeyStore{keyTypeB}
+	managerA, err := recordingencryption.NewManager(configA)
+	require.NoError(t, err)
+
+	managerB, err := recordingencryption.NewManager(configB)
+	require.NoError(t, err)
+
+	service := configA.Backend
+	_, _, err = resolve(ctx, service, managerA)
+	require.NoError(t, err)
+
+	encryption, _, err := resolve(ctx, service, managerB)
+	require.NoError(t, err)
+
+	activeKeys := encryption.GetSpec().ActiveKeys
+	require.Len(t, activeKeys, 2)
+	pubKey := activeKeys[0].RecordingEncryptionPair.PublicKey
+
+	// fail to find private key for manager B because it is waiting for key fulfillment
+	_, err = managerB.FindDecryptionKey(ctx, pubKey)
+	require.Error(t, err)
+
+	_, _, err = resolve(ctx, service, managerA)
+	require.NoError(t, err)
+
+	// find private key for manager A because it provisioned the key
+	decryptionPair, err := managerA.FindDecryptionKey(ctx, pubKey)
+	require.NoError(t, err)
+	ident, err := age.ParseX25519Identity(string(decryptionPair.PrivateKey))
+	require.NoError(t, err)
+	require.Equal(t, ident.Recipient().String(), string(pubKey))
+
+	// find private key for manager B after fulfillment
+	decryptionPair, err = managerB.FindDecryptionKey(ctx, pubKey)
+	require.NoError(t, err)
+	ident, err = age.ParseX25519Identity(string(decryptionPair.PrivateKey))
+	require.NoError(t, err)
+	require.Equal(t, ident.Recipient().String(), string(pubKey))
+}


### PR DESCRIPTION
This PR adds a `Manager` struct responsible for higher level `RecordingEncryption` operations such as resolving state in order to facilitate cooperation between auth servers. It also includes the implementation for a watcher that will automatically attempt to resolve `RecordingEncryption` state whenever the resource is modified.