### PR TITLE
Bump preset roles to v8

### DIFF
--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1,7 +1,7 @@
 {
   "access": {
     "kind": "role",
-    "version": "v7",
+    "version": "v8",
     "metadata": {
       "name": "access",
       "description": "Access cluster resources",
@@ -25,11 +25,6 @@
         "desktop_directory_sharing": true,
         "pin_source_ip": false,
         "ssh_file_copy": true,
-        "idp": {
-          "saml": {
-            "enabled": true
-          }
-        },
         "create_desktop_user": false,
         "create_db_user": false,
         "ssh_port_forwarding": {
@@ -127,7 +122,8 @@
             "name": "*",
             "verbs": [
               "*"
-            ]
+            ],
+            "api_group": "*"
           }
         ],
         "gcp_service_accounts": [
@@ -152,7 +148,7 @@
   },
   "auditor": {
     "kind": "role",
-    "version": "v7",
+    "version": "v8",
     "metadata": {
       "name": "auditor",
       "description": "Review cluster events and replay sessions",
@@ -176,11 +172,6 @@
         "desktop_directory_sharing": true,
         "pin_source_ip": false,
         "ssh_file_copy": true,
-        "idp": {
-          "saml": {
-            "enabled": true
-          }
-        },
         "create_desktop_user": false,
         "create_db_user": false
       },
@@ -276,7 +267,7 @@
   },
   "editor": {
     "kind": "role",
-    "version": "v7",
+    "version": "v8",
     "metadata": {
       "name": "editor",
       "description": "Edit cluster configuration",
@@ -300,11 +291,6 @@
         "desktop_directory_sharing": true,
         "pin_source_ip": false,
         "ssh_file_copy": true,
-        "idp": {
-          "saml": {
-            "enabled": true
-          }
-        },
         "create_desktop_user": false,
         "create_db_user": false,
         "ssh_port_forwarding": {

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -47,7 +47,7 @@ func NewSystemAutomaticAccessApproverRole() types.Role {
 	}
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.SystemAutomaticAccessApprovalRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -113,7 +113,7 @@ func NewPresetEditorRole() types.Role {
 	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetEditorRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -234,7 +234,7 @@ func NewPresetAccessRole() types.Role {
 	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetAccessRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -284,7 +284,7 @@ func NewPresetAccessRole() types.Role {
 						Namespace: types.Wildcard,
 						Name:      types.Wildcard,
 						Verbs:     []string{types.Wildcard},
-						APIGroup:  "",
+						APIGroup:  types.Wildcard,
 					},
 				},
 				GitHubPermissions: []types.GitHubPermission{{
@@ -327,7 +327,7 @@ func NewPresetAuditorRole() types.Role {
 	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetAuditorRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -372,7 +372,7 @@ func NewPresetReviewerRole() types.Role {
 
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetReviewerRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -399,7 +399,7 @@ func NewPresetRequesterRole() types.Role {
 
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetRequesterRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -426,7 +426,7 @@ func NewPresetGroupAccessRole() types.Role {
 
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetGroupAccessRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -460,7 +460,7 @@ func NewPresetDeviceAdminRole() types.Role {
 
 	return &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetDeviceAdminRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -489,7 +489,7 @@ func NewPresetDeviceEnrollRole() types.Role {
 
 	return &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetDeviceEnrollRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -519,7 +519,7 @@ func NewPresetRequireTrustedDeviceRole() types.Role {
 
 	return &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetRequireTrustedDeviceRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -567,7 +567,7 @@ func NewPresetRequireTrustedDeviceRole() types.Role {
 func NewPresetWildcardWorkloadIdentityIssuerRole() types.Role {
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetWildcardWorkloadIdentityIssuerRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -600,7 +600,7 @@ func NewSystemOktaAccessRole() types.Role {
 
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.SystemOktaAccessRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -636,7 +636,7 @@ func NewSystemOktaRequesterRole() types.Role {
 
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.SystemOktaRequesterRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -663,7 +663,7 @@ func NewSystemIdentityCenterAccessRole() types.Role {
 	}
 	return &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.SystemIdentityCenterAccessRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -690,7 +690,7 @@ func NewSystemIdentityCenterAccessRole() types.Role {
 func NewPresetTerraformProviderRole() types.Role {
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
-		Version: types.V7,
+		Version: types.V8,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetTerraformProviderRoleName,
 			Namespace:   apidefaults.Namespace,


### PR DESCRIPTION
Reverted to allow PRs to pass the merge queue check. Brought back here.

Was reverted in https://github.com/gravitational/teleport/pull/54760