### PR TITLE
[vnet] feat: TCP dial to SSH targets

### DIFF
--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -649,9 +649,14 @@ type MatchedCluster struct {
 	Ipv4CidrRange string `protobuf:"bytes,1,opt,name=ipv4_cidr_range,json=ipv4CidrRange,proto3" json:"ipv4_cidr_range,omitempty"`
 	// WebProxyAddr is the web proxy address of the root cluster that matched the
 	// query.
-	WebProxyAddr  string `protobuf:"bytes,2,opt,name=web_proxy_addr,json=webProxyAddr,proto3" json:"web_proxy_addr,omitempty"`
-	Profile       string `protobuf:"bytes,3,opt,name=profile,proto3" json:"profile,omitempty"`
-	RootCluster   string `protobuf:"bytes,4,opt,name=root_cluster,json=rootCluster,proto3" json:"root_cluster,omitempty"`
+	WebProxyAddr string `protobuf:"bytes,2,opt,name=web_proxy_addr,json=webProxyAddr,proto3" json:"web_proxy_addr,omitempty"`
+	// Profile is the profile the matched cluster was found in.
+	Profile string `protobuf:"bytes,3,opt,name=profile,proto3" json:"profile,omitempty"`
+	// RootCluster will always be set to the name of the root cluster that matched
+	// the query.
+	RootCluster string `protobuf:"bytes,4,opt,name=root_cluster,json=rootCluster,proto3" json:"root_cluster,omitempty"`
+	// LeafCluster will be set only when the query matched a leaf cluster of
+	// RootCluster, or else it will be empty.
 	LeafCluster   string `protobuf:"bytes,5,opt,name=leaf_cluster,json=leafCluster,proto3" json:"leaf_cluster,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -650,6 +650,9 @@ type MatchedCluster struct {
 	// WebProxyAddr is the web proxy address of the root cluster that matched the
 	// query.
 	WebProxyAddr  string `protobuf:"bytes,2,opt,name=web_proxy_addr,json=webProxyAddr,proto3" json:"web_proxy_addr,omitempty"`
+	Profile       string `protobuf:"bytes,3,opt,name=profile,proto3" json:"profile,omitempty"`
+	RootCluster   string `protobuf:"bytes,4,opt,name=root_cluster,json=rootCluster,proto3" json:"root_cluster,omitempty"`
+	LeafCluster   string `protobuf:"bytes,5,opt,name=leaf_cluster,json=leafCluster,proto3" json:"leaf_cluster,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -694,6 +697,27 @@ func (x *MatchedCluster) GetIpv4CidrRange() string {
 func (x *MatchedCluster) GetWebProxyAddr() string {
 	if x != nil {
 		return x.WebProxyAddr
+	}
+	return ""
+}
+
+func (x *MatchedCluster) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
+func (x *MatchedCluster) GetRootCluster() string {
+	if x != nil {
+		return x.RootCluster
+	}
+	return ""
+}
+
+func (x *MatchedCluster) GetLeafCluster() string {
+	if x != nil {
+		return x.LeafCluster
 	}
 	return ""
 }
@@ -860,8 +884,10 @@ type DialOptions struct {
 	Sni string `protobuf:"bytes,3,opt,name=sni,proto3" json:"sni,omitempty"`
 	// InsecureSkipVerify turns off verification for x509 upstream ALPN proxy service certificate.
 	InsecureSkipVerify bool `protobuf:"varint,4,opt,name=insecure_skip_verify,json=insecureSkipVerify,proto3" json:"insecure_skip_verify,omitempty"`
-	// RootClusterCaCertPool overrides the x509 certificate pool used to verify the server.
-	// It is a PEM-encoded X509 certificate pool.
+	// RootClusterCaCertPool is the host CA TLS certificate pool for the root
+	// cluster. It is a PEM-encoded X509 certificate pool. It should be used when
+	// dialing the proxy and AlpnConnUpgradeRequired is true or when dialing the
+	// transport service.
 	RootClusterCaCertPool []byte `protobuf:"bytes,5,opt,name=root_cluster_ca_cert_pool,json=rootClusterCaCertPool,proto3" json:"root_cluster_ca_cert_pool,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
@@ -1048,13 +1074,8 @@ type SignForAppRequest struct {
 	// TargetPort of a previous successful call to ReissueAppCert for an app
 	// matching AppKey.
 	TargetPort uint32 `protobuf:"varint,2,opt,name=target_port,json=targetPort,proto3" json:"target_port,omitempty"`
-	// Digest is the bytes to sign.
-	Digest []byte `protobuf:"bytes,3,opt,name=digest,proto3" json:"digest,omitempty"`
-	// Hash is the hash function used to compute digest.
-	Hash Hash `protobuf:"varint,4,opt,name=hash,proto3,enum=teleport.lib.vnet.v1.Hash" json:"hash,omitempty"`
-	// PssSaltLength specifies the length of the salt added to the digest before a
-	// signature. Only used and required for RSA PSS signatures.
-	PssSaltLength *int32 `protobuf:"varint,5,opt,name=pss_salt_length,json=pssSaltLength,proto3,oneof" json:"pss_salt_length,omitempty"`
+	// Sign holds signature request details.
+	Sign          *SignRequest `protobuf:"bytes,6,opt,name=sign,proto3" json:"sign,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1103,21 +1124,72 @@ func (x *SignForAppRequest) GetTargetPort() uint32 {
 	return 0
 }
 
-func (x *SignForAppRequest) GetDigest() []byte {
+func (x *SignForAppRequest) GetSign() *SignRequest {
+	if x != nil {
+		return x.Sign
+	}
+	return nil
+}
+
+// SignRequest holds signature request details.
+type SignRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Digest is the bytes to sign.
+	Digest []byte `protobuf:"bytes,1,opt,name=digest,proto3" json:"digest,omitempty"`
+	// Hash is the hash function used to compute digest.
+	Hash Hash `protobuf:"varint,2,opt,name=hash,proto3,enum=teleport.lib.vnet.v1.Hash" json:"hash,omitempty"`
+	// PssSaltLength specifies the length of the salt added to the digest before a
+	// signature. Only used and required for RSA PSS signatures.
+	PssSaltLength *int32 `protobuf:"varint,3,opt,name=pss_salt_length,json=pssSaltLength,proto3,oneof" json:"pss_salt_length,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignRequest) Reset() {
+	*x = SignRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignRequest) ProtoMessage() {}
+
+func (x *SignRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignRequest.ProtoReflect.Descriptor instead.
+func (*SignRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *SignRequest) GetDigest() []byte {
 	if x != nil {
 		return x.Digest
 	}
 	return nil
 }
 
-func (x *SignForAppRequest) GetHash() Hash {
+func (x *SignRequest) GetHash() Hash {
 	if x != nil {
 		return x.Hash
 	}
 	return Hash_HASH_UNSPECIFIED
 }
 
-func (x *SignForAppRequest) GetPssSaltLength() int32 {
+func (x *SignRequest) GetPssSaltLength() int32 {
 	if x != nil && x.PssSaltLength != nil {
 		return *x.PssSaltLength
 	}
@@ -1135,7 +1207,7 @@ type SignForAppResponse struct {
 
 func (x *SignForAppResponse) Reset() {
 	*x = SignForAppResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1147,7 +1219,7 @@ func (x *SignForAppResponse) String() string {
 func (*SignForAppResponse) ProtoMessage() {}
 
 func (x *SignForAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1160,7 +1232,7 @@ func (x *SignForAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignForAppResponse.ProtoReflect.Descriptor instead.
 func (*SignForAppResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{18}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SignForAppResponse) GetSignature() []byte {
@@ -1181,7 +1253,7 @@ type OnNewConnectionRequest struct {
 
 func (x *OnNewConnectionRequest) Reset() {
 	*x = OnNewConnectionRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1193,7 +1265,7 @@ func (x *OnNewConnectionRequest) String() string {
 func (*OnNewConnectionRequest) ProtoMessage() {}
 
 func (x *OnNewConnectionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1206,7 +1278,7 @@ func (x *OnNewConnectionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnNewConnectionRequest.ProtoReflect.Descriptor instead.
 func (*OnNewConnectionRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{19}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *OnNewConnectionRequest) GetAppKey() *AppKey {
@@ -1225,7 +1297,7 @@ type OnNewConnectionResponse struct {
 
 func (x *OnNewConnectionResponse) Reset() {
 	*x = OnNewConnectionResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1237,7 +1309,7 @@ func (x *OnNewConnectionResponse) String() string {
 func (*OnNewConnectionResponse) ProtoMessage() {}
 
 func (x *OnNewConnectionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1250,7 +1322,7 @@ func (x *OnNewConnectionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnNewConnectionResponse.ProtoReflect.Descriptor instead.
 func (*OnNewConnectionResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{20}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{21}
 }
 
 // OnInvalidLocalPortRequest is a request for OnInvalidLocalPort.
@@ -1269,7 +1341,7 @@ type OnInvalidLocalPortRequest struct {
 
 func (x *OnInvalidLocalPortRequest) Reset() {
 	*x = OnInvalidLocalPortRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1281,7 +1353,7 @@ func (x *OnInvalidLocalPortRequest) String() string {
 func (*OnInvalidLocalPortRequest) ProtoMessage() {}
 
 func (x *OnInvalidLocalPortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1294,7 +1366,7 @@ func (x *OnInvalidLocalPortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnInvalidLocalPortRequest.ProtoReflect.Descriptor instead.
 func (*OnInvalidLocalPortRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{21}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *OnInvalidLocalPortRequest) GetAppInfo() *AppInfo {
@@ -1320,7 +1392,7 @@ type OnInvalidLocalPortResponse struct {
 
 func (x *OnInvalidLocalPortResponse) Reset() {
 	*x = OnInvalidLocalPortResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1332,7 +1404,7 @@ func (x *OnInvalidLocalPortResponse) String() string {
 func (*OnInvalidLocalPortResponse) ProtoMessage() {}
 
 func (x *OnInvalidLocalPortResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1345,7 +1417,7 @@ func (x *OnInvalidLocalPortResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnInvalidLocalPortResponse.ProtoReflect.Descriptor instead.
 func (*OnInvalidLocalPortResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{22}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{23}
 }
 
 // GetTargetOSConfigurationRequest is a request for the target host OS configuration.
@@ -1357,7 +1429,7 @@ type GetTargetOSConfigurationRequest struct {
 
 func (x *GetTargetOSConfigurationRequest) Reset() {
 	*x = GetTargetOSConfigurationRequest{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1369,7 +1441,7 @@ func (x *GetTargetOSConfigurationRequest) String() string {
 func (*GetTargetOSConfigurationRequest) ProtoMessage() {}
 
 func (x *GetTargetOSConfigurationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[23]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1382,7 +1454,7 @@ func (x *GetTargetOSConfigurationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTargetOSConfigurationRequest.ProtoReflect.Descriptor instead.
 func (*GetTargetOSConfigurationRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{23}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{24}
 }
 
 // GetTargetOSConfigurationResponse is a response including the target host OS configuration.
@@ -1396,7 +1468,7 @@ type GetTargetOSConfigurationResponse struct {
 
 func (x *GetTargetOSConfigurationResponse) Reset() {
 	*x = GetTargetOSConfigurationResponse{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1408,7 +1480,7 @@ func (x *GetTargetOSConfigurationResponse) String() string {
 func (*GetTargetOSConfigurationResponse) ProtoMessage() {}
 
 func (x *GetTargetOSConfigurationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[24]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1421,7 +1493,7 @@ func (x *GetTargetOSConfigurationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTargetOSConfigurationResponse.ProtoReflect.Descriptor instead.
 func (*GetTargetOSConfigurationResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{24}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetTargetOSConfigurationResponse) GetTargetOsConfiguration() *TargetOSConfiguration {
@@ -1451,7 +1523,7 @@ type TargetOSConfiguration struct {
 
 func (x *TargetOSConfiguration) Reset() {
 	*x = TargetOSConfiguration{}
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1463,7 +1535,7 @@ func (x *TargetOSConfiguration) String() string {
 func (*TargetOSConfiguration) ProtoMessage() {}
 
 func (x *TargetOSConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[25]
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1476,7 +1548,7 @@ func (x *TargetOSConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetOSConfiguration.ProtoReflect.Descriptor instead.
 func (*TargetOSConfiguration) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{25}
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TargetOSConfiguration) GetDnsZones() []string {
@@ -1489,6 +1561,209 @@ func (x *TargetOSConfiguration) GetDnsZones() []string {
 func (x *TargetOSConfiguration) GetIpv4CidrRanges() []string {
 	if x != nil {
 		return x.Ipv4CidrRanges
+	}
+	return nil
+}
+
+// UserTLSCertRequest is a request for UserTLSCert.
+type UserTLSCertRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Profile is the profile to retrieve the certificate for.
+	Profile       string `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserTLSCertRequest) Reset() {
+	*x = UserTLSCertRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserTLSCertRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserTLSCertRequest) ProtoMessage() {}
+
+func (x *UserTLSCertRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserTLSCertRequest.ProtoReflect.Descriptor instead.
+func (*UserTLSCertRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *UserTLSCertRequest) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
+// UserTLSCertResponse is a response for UserTLSCert.
+type UserTLSCertResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Cert is the user TLS certificate in X.509 ASN.1 DER format.
+	Cert []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	// DialOptions holds options that should be used when dialing the root cluster
+	// proxy.
+	DialOptions   *DialOptions `protobuf:"bytes,2,opt,name=dial_options,json=dialOptions,proto3" json:"dial_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserTLSCertResponse) Reset() {
+	*x = UserTLSCertResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserTLSCertResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserTLSCertResponse) ProtoMessage() {}
+
+func (x *UserTLSCertResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserTLSCertResponse.ProtoReflect.Descriptor instead.
+func (*UserTLSCertResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *UserTLSCertResponse) GetCert() []byte {
+	if x != nil {
+		return x.Cert
+	}
+	return nil
+}
+
+func (x *UserTLSCertResponse) GetDialOptions() *DialOptions {
+	if x != nil {
+		return x.DialOptions
+	}
+	return nil
+}
+
+// SignForUserTLSRequest is a request for SignForUserTLS.
+type SignForUserTLSRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Profile is the user profile to sign for.
+	Profile string `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	// Sign holds signature request details.
+	Sign          *SignRequest `protobuf:"bytes,2,opt,name=sign,proto3" json:"sign,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForUserTLSRequest) Reset() {
+	*x = SignForUserTLSRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForUserTLSRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForUserTLSRequest) ProtoMessage() {}
+
+func (x *SignForUserTLSRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForUserTLSRequest.ProtoReflect.Descriptor instead.
+func (*SignForUserTLSRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *SignForUserTLSRequest) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
+func (x *SignForUserTLSRequest) GetSign() *SignRequest {
+	if x != nil {
+		return x.Sign
+	}
+	return nil
+}
+
+// SignForUserTLSResponse is a response for SignForUserTLS.
+type SignForUserTLSResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Signature is the signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForUserTLSResponse) Reset() {
+	*x = SignForUserTLSResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForUserTLSResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForUserTLSResponse) ProtoMessage() {}
+
+func (x *SignForUserTLSResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForUserTLSResponse.ProtoReflect.Descriptor instead.
+func (*SignForUserTLSResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *SignForUserTLSResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
 	}
 	return nil
 }
@@ -1521,10 +1796,13 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x05match\"I\n" +
 	"\rMatchedTCPApp\x128\n" +
 	"\bapp_info\x18\x01 \x01(\v2\x1d.teleport.lib.vnet.v1.AppInfoR\aappInfo\"\x0f\n" +
-	"\rMatchedWebApp\"^\n" +
+	"\rMatchedWebApp\"\xbe\x01\n" +
 	"\x0eMatchedCluster\x12&\n" +
 	"\x0fipv4_cidr_range\x18\x01 \x01(\tR\ripv4CidrRange\x12$\n" +
-	"\x0eweb_proxy_addr\x18\x02 \x01(\tR\fwebProxyAddr\"\xe8\x01\n" +
+	"\x0eweb_proxy_addr\x18\x02 \x01(\tR\fwebProxyAddr\x12\x18\n" +
+	"\aprofile\x18\x03 \x01(\tR\aprofile\x12!\n" +
+	"\froot_cluster\x18\x04 \x01(\tR\vrootCluster\x12!\n" +
+	"\fleaf_cluster\x18\x05 \x01(\tR\vleafCluster\"\xe8\x01\n" +
 	"\aAppInfo\x125\n" +
 	"\aapp_key\x18\x01 \x01(\v2\x1c.teleport.lib.vnet.v1.AppKeyR\x06appKey\x12\x18\n" +
 	"\acluster\x18\x02 \x01(\tR\acluster\x12\x1e\n" +
@@ -1546,14 +1824,16 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\vtarget_port\x18\x02 \x01(\rR\n" +
 	"targetPort\",\n" +
 	"\x16ReissueAppCertResponse\x12\x12\n" +
-	"\x04cert\x18\x01 \x01(\fR\x04cert\"\xf4\x01\n" +
+	"\x04cert\x18\x01 \x01(\fR\x04cert\"\xd3\x01\n" +
 	"\x11SignForAppRequest\x125\n" +
 	"\aapp_key\x18\x01 \x01(\v2\x1c.teleport.lib.vnet.v1.AppKeyR\x06appKey\x12\x1f\n" +
 	"\vtarget_port\x18\x02 \x01(\rR\n" +
-	"targetPort\x12\x16\n" +
-	"\x06digest\x18\x03 \x01(\fR\x06digest\x12.\n" +
-	"\x04hash\x18\x04 \x01(\x0e2\x1a.teleport.lib.vnet.v1.HashR\x04hash\x12+\n" +
-	"\x0fpss_salt_length\x18\x05 \x01(\x05H\x00R\rpssSaltLength\x88\x01\x01B\x12\n" +
+	"targetPort\x125\n" +
+	"\x04sign\x18\x06 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04signJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x06digestR\x04hashR\x0fpss_salt_length\"\x96\x01\n" +
+	"\vSignRequest\x12\x16\n" +
+	"\x06digest\x18\x01 \x01(\fR\x06digest\x12.\n" +
+	"\x04hash\x18\x02 \x01(\x0e2\x1a.teleport.lib.vnet.v1.HashR\x04hash\x12+\n" +
+	"\x0fpss_salt_length\x18\x03 \x01(\x05H\x00R\rpssSaltLength\x88\x01\x01B\x12\n" +
 	"\x10_pss_salt_length\"2\n" +
 	"\x12SignForAppResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\fR\tsignature\"O\n" +
@@ -1570,11 +1850,21 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x17target_os_configuration\x18\x01 \x01(\v2+.teleport.lib.vnet.v1.TargetOSConfigurationR\x15targetOsConfiguration\"^\n" +
 	"\x15TargetOSConfiguration\x12\x1b\n" +
 	"\tdns_zones\x18\x01 \x03(\tR\bdnsZones\x12(\n" +
-	"\x10ipv4_cidr_ranges\x18\x02 \x03(\tR\x0eipv4CidrRanges*<\n" +
+	"\x10ipv4_cidr_ranges\x18\x02 \x03(\tR\x0eipv4CidrRanges\".\n" +
+	"\x12UserTLSCertRequest\x12\x18\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\"o\n" +
+	"\x13UserTLSCertResponse\x12\x12\n" +
+	"\x04cert\x18\x01 \x01(\fR\x04cert\x12D\n" +
+	"\fdial_options\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.DialOptionsR\vdialOptions\"h\n" +
+	"\x15SignForUserTLSRequest\x12\x18\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\x125\n" +
+	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"6\n" +
+	"\x16SignForUserTLSResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature*<\n" +
 	"\x04Hash\x12\x14\n" +
 	"\x10HASH_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tHASH_NONE\x10\x01\x12\x0f\n" +
-	"\vHASH_SHA256\x10\x022\x92\b\n" +
+	"\vHASH_SHA256\x10\x022\xe3\t\n" +
 	"\x18ClientApplicationService\x12z\n" +
 	"\x13AuthenticateProcess\x120.teleport.lib.vnet.v1.AuthenticateProcessRequest\x1a1.teleport.lib.vnet.v1.AuthenticateProcessResponse\x12\x83\x01\n" +
 	"\x16ReportNetworkStackInfo\x123.teleport.lib.vnet.v1.ReportNetworkStackInfoRequest\x1a4.teleport.lib.vnet.v1.ReportNetworkStackInfoResponse\x12M\n" +
@@ -1585,7 +1875,9 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"SignForApp\x12'.teleport.lib.vnet.v1.SignForAppRequest\x1a(.teleport.lib.vnet.v1.SignForAppResponse\x12n\n" +
 	"\x0fOnNewConnection\x12,.teleport.lib.vnet.v1.OnNewConnectionRequest\x1a-.teleport.lib.vnet.v1.OnNewConnectionResponse\x12w\n" +
 	"\x12OnInvalidLocalPort\x12/.teleport.lib.vnet.v1.OnInvalidLocalPortRequest\x1a0.teleport.lib.vnet.v1.OnInvalidLocalPortResponse\x12\x89\x01\n" +
-	"\x18GetTargetOSConfiguration\x125.teleport.lib.vnet.v1.GetTargetOSConfigurationRequest\x1a6.teleport.lib.vnet.v1.GetTargetOSConfigurationResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
+	"\x18GetTargetOSConfiguration\x125.teleport.lib.vnet.v1.GetTargetOSConfigurationRequest\x1a6.teleport.lib.vnet.v1.GetTargetOSConfigurationResponse\x12b\n" +
+	"\vUserTLSCert\x12(.teleport.lib.vnet.v1.UserTLSCertRequest\x1a).teleport.lib.vnet.v1.UserTLSCertResponse\x12k\n" +
+	"\x0eSignForUserTLS\x12+.teleport.lib.vnet.v1.SignForUserTLSRequest\x1a,.teleport.lib.vnet.v1.SignForUserTLSResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
 
 var (
 	file_teleport_lib_vnet_v1_client_application_service_proto_rawDescOnce sync.Once
@@ -1600,7 +1892,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP() []
 }
 
 var file_teleport_lib_vnet_v1_client_application_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(Hash)(0),                                // 0: teleport.lib.vnet.v1.Hash
 	(*AuthenticateProcessRequest)(nil),       // 1: teleport.lib.vnet.v1.AuthenticateProcessRequest
@@ -1621,15 +1913,20 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(*ReissueAppCertRequest)(nil),            // 16: teleport.lib.vnet.v1.ReissueAppCertRequest
 	(*ReissueAppCertResponse)(nil),           // 17: teleport.lib.vnet.v1.ReissueAppCertResponse
 	(*SignForAppRequest)(nil),                // 18: teleport.lib.vnet.v1.SignForAppRequest
-	(*SignForAppResponse)(nil),               // 19: teleport.lib.vnet.v1.SignForAppResponse
-	(*OnNewConnectionRequest)(nil),           // 20: teleport.lib.vnet.v1.OnNewConnectionRequest
-	(*OnNewConnectionResponse)(nil),          // 21: teleport.lib.vnet.v1.OnNewConnectionResponse
-	(*OnInvalidLocalPortRequest)(nil),        // 22: teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	(*OnInvalidLocalPortResponse)(nil),       // 23: teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	(*GetTargetOSConfigurationRequest)(nil),  // 24: teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	(*GetTargetOSConfigurationResponse)(nil), // 25: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	(*TargetOSConfiguration)(nil),            // 26: teleport.lib.vnet.v1.TargetOSConfiguration
-	(*types.AppV3)(nil),                      // 27: types.AppV3
+	(*SignRequest)(nil),                      // 19: teleport.lib.vnet.v1.SignRequest
+	(*SignForAppResponse)(nil),               // 20: teleport.lib.vnet.v1.SignForAppResponse
+	(*OnNewConnectionRequest)(nil),           // 21: teleport.lib.vnet.v1.OnNewConnectionRequest
+	(*OnNewConnectionResponse)(nil),          // 22: teleport.lib.vnet.v1.OnNewConnectionResponse
+	(*OnInvalidLocalPortRequest)(nil),        // 23: teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	(*OnInvalidLocalPortResponse)(nil),       // 24: teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	(*GetTargetOSConfigurationRequest)(nil),  // 25: teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	(*GetTargetOSConfigurationResponse)(nil), // 26: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	(*TargetOSConfiguration)(nil),            // 27: teleport.lib.vnet.v1.TargetOSConfiguration
+	(*UserTLSCertRequest)(nil),               // 28: teleport.lib.vnet.v1.UserTLSCertRequest
+	(*UserTLSCertResponse)(nil),              // 29: teleport.lib.vnet.v1.UserTLSCertResponse
+	(*SignForUserTLSRequest)(nil),            // 30: teleport.lib.vnet.v1.SignForUserTLSRequest
+	(*SignForUserTLSResponse)(nil),           // 31: teleport.lib.vnet.v1.SignForUserTLSResponse
+	(*types.AppV3)(nil),                      // 32: types.AppV3
 }
 var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32{
 	4,  // 0: teleport.lib.vnet.v1.ReportNetworkStackInfoRequest.network_stack_info:type_name -> teleport.lib.vnet.v1.NetworkStackInfo
@@ -1638,37 +1935,44 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32
 	12, // 3: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_cluster:type_name -> teleport.lib.vnet.v1.MatchedCluster
 	13, // 4: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 5: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	27, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
+	32, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
 	15, // 7: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
 	13, // 8: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 9: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	0,  // 10: teleport.lib.vnet.v1.SignForAppRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
-	14, // 11: teleport.lib.vnet.v1.OnNewConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	13, // 12: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
-	26, // 13: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
-	1,  // 14: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
-	3,  // 15: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
-	6,  // 16: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
-	8,  // 17: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
-	16, // 18: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
-	18, // 19: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
-	20, // 20: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
-	22, // 21: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	24, // 22: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	2,  // 23: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
-	5,  // 24: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
-	7,  // 25: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
-	9,  // 26: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
-	17, // 27: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
-	19, // 28: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
-	21, // 29: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
-	23, // 30: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	25, // 31: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	23, // [23:32] is the sub-list for method output_type
-	14, // [14:23] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	19, // 10: teleport.lib.vnet.v1.SignForAppRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	0,  // 11: teleport.lib.vnet.v1.SignRequest.hash:type_name -> teleport.lib.vnet.v1.Hash
+	14, // 12: teleport.lib.vnet.v1.OnNewConnectionRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
+	13, // 13: teleport.lib.vnet.v1.OnInvalidLocalPortRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
+	27, // 14: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
+	15, // 15: teleport.lib.vnet.v1.UserTLSCertResponse.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
+	19, // 16: teleport.lib.vnet.v1.SignForUserTLSRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	1,  // 17: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
+	3,  // 18: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
+	6,  // 19: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
+	8,  // 20: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
+	16, // 21: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
+	18, // 22: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
+	21, // 23: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
+	23, // 24: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	25, // 25: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	28, // 26: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:input_type -> teleport.lib.vnet.v1.UserTLSCertRequest
+	30, // 27: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
+	2,  // 28: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
+	5,  // 29: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
+	7,  // 30: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
+	9,  // 31: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
+	17, // 32: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
+	20, // 33: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
+	22, // 34: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
+	24, // 35: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	26, // 36: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	29, // 37: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
+	31, // 38: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
+	28, // [28:39] is the sub-list for method output_type
+	17, // [17:28] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_v1_client_application_service_proto_init() }
@@ -1681,14 +1985,14 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 		(*ResolveFQDNResponse_MatchedWebApp)(nil),
 		(*ResolveFQDNResponse_MatchedCluster)(nil),
 	}
-	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[17].OneofWrappers = []any{}
+	file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[18].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc), len(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   26,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
@@ -44,6 +44,8 @@ const (
 	ClientApplicationService_OnNewConnection_FullMethodName          = "/teleport.lib.vnet.v1.ClientApplicationService/OnNewConnection"
 	ClientApplicationService_OnInvalidLocalPort_FullMethodName       = "/teleport.lib.vnet.v1.ClientApplicationService/OnInvalidLocalPort"
 	ClientApplicationService_GetTargetOSConfiguration_FullMethodName = "/teleport.lib.vnet.v1.ClientApplicationService/GetTargetOSConfiguration"
+	ClientApplicationService_UserTLSCert_FullMethodName              = "/teleport.lib.vnet.v1.ClientApplicationService/UserTLSCert"
+	ClientApplicationService_SignForUserTLS_FullMethodName           = "/teleport.lib.vnet.v1.ClientApplicationService/SignForUserTLS"
 )
 
 // ClientApplicationServiceClient is the client API for ClientApplicationService service.
@@ -81,6 +83,10 @@ type ClientApplicationServiceClient interface {
 	OnInvalidLocalPort(ctx context.Context, in *OnInvalidLocalPortRequest, opts ...grpc.CallOption) (*OnInvalidLocalPortResponse, error)
 	// GetTargetOSConfiguration gets the target OS configuration.
 	GetTargetOSConfiguration(ctx context.Context, in *GetTargetOSConfigurationRequest, opts ...grpc.CallOption) (*GetTargetOSConfigurationResponse, error)
+	// UserTLSCert returns the user TLS certificate for a specific profile.
+	UserTLSCert(ctx context.Context, in *UserTLSCertRequest, opts ...grpc.CallOption) (*UserTLSCertResponse, error)
+	// SignForUserTLS signs a digest with the user TLS private key.
+	SignForUserTLS(ctx context.Context, in *SignForUserTLSRequest, opts ...grpc.CallOption) (*SignForUserTLSResponse, error)
 }
 
 type clientApplicationServiceClient struct {
@@ -181,6 +187,26 @@ func (c *clientApplicationServiceClient) GetTargetOSConfiguration(ctx context.Co
 	return out, nil
 }
 
+func (c *clientApplicationServiceClient) UserTLSCert(ctx context.Context, in *UserTLSCertRequest, opts ...grpc.CallOption) (*UserTLSCertResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UserTLSCertResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_UserTLSCert_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clientApplicationServiceClient) SignForUserTLS(ctx context.Context, in *SignForUserTLSRequest, opts ...grpc.CallOption) (*SignForUserTLSResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignForUserTLSResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_SignForUserTLS_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ClientApplicationServiceServer is the server API for ClientApplicationService service.
 // All implementations must embed UnimplementedClientApplicationServiceServer
 // for forward compatibility.
@@ -216,6 +242,10 @@ type ClientApplicationServiceServer interface {
 	OnInvalidLocalPort(context.Context, *OnInvalidLocalPortRequest) (*OnInvalidLocalPortResponse, error)
 	// GetTargetOSConfiguration gets the target OS configuration.
 	GetTargetOSConfiguration(context.Context, *GetTargetOSConfigurationRequest) (*GetTargetOSConfigurationResponse, error)
+	// UserTLSCert returns the user TLS certificate for a specific profile.
+	UserTLSCert(context.Context, *UserTLSCertRequest) (*UserTLSCertResponse, error)
+	// SignForUserTLS signs a digest with the user TLS private key.
+	SignForUserTLS(context.Context, *SignForUserTLSRequest) (*SignForUserTLSResponse, error)
 	mustEmbedUnimplementedClientApplicationServiceServer()
 }
 
@@ -252,6 +282,12 @@ func (UnimplementedClientApplicationServiceServer) OnInvalidLocalPort(context.Co
 }
 func (UnimplementedClientApplicationServiceServer) GetTargetOSConfiguration(context.Context, *GetTargetOSConfigurationRequest) (*GetTargetOSConfigurationResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTargetOSConfiguration not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) UserTLSCert(context.Context, *UserTLSCertRequest) (*UserTLSCertResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UserTLSCert not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) SignForUserTLS(context.Context, *SignForUserTLSRequest) (*SignForUserTLSResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignForUserTLS not implemented")
 }
 func (UnimplementedClientApplicationServiceServer) mustEmbedUnimplementedClientApplicationServiceServer() {
 }
@@ -437,6 +473,42 @@ func _ClientApplicationService_GetTargetOSConfiguration_Handler(srv interface{},
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ClientApplicationService_UserTLSCert_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UserTLSCertRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).UserTLSCert(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_UserTLSCert_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).UserTLSCert(ctx, req.(*UserTLSCertRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ClientApplicationService_SignForUserTLS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignForUserTLSRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).SignForUserTLS(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_SignForUserTLS_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).SignForUserTLS(ctx, req.(*SignForUserTLSRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ClientApplicationService_ServiceDesc is the grpc.ServiceDesc for ClientApplicationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -479,6 +551,14 @@ var ClientApplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTargetOSConfiguration",
 			Handler:    _ClientApplicationService_GetTargetOSConfiguration_Handler,
+		},
+		{
+			MethodName: "UserTLSCert",
+			Handler:    _ClientApplicationService_UserTLSCert_Handler,
+		},
+		{
+			MethodName: "SignForUserTLS",
+			Handler:    _ClientApplicationService_SignForUserTLS_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lib/vnet/admin_process_common.go
+++ b/lib/vnet/admin_process_common.go
@@ -22,9 +22,11 @@ import (
 )
 
 func newNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
+	sshProvider := newSSHProvider(sshProviderConfig{clt: clt})
 	tcpHandlerResolver := newTCPHandlerResolver(&tcpHandlerResolverConfig{
 		clt:         clt,
 		appProvider: newAppProvider(clt),
+		sshProvider: sshProvider,
 		clock:       clockwork.NewRealClock(),
 	})
 	ipv6Prefix, err := newIPv6Prefix()

--- a/lib/vnet/app_provider.go
+++ b/lib/vnet/app_provider.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 
@@ -57,7 +56,7 @@ func (p *appProvider) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInf
 	return tlsCert, nil
 }
 
-func (p *appProvider) newAppCertSigner(cert []byte, appKey *vnetv1.AppKey, targetPort uint16) (crypto.Signer, error) {
+func (p *appProvider) newAppCertSigner(cert []byte, appKey *vnetv1.AppKey, targetPort uint16) (*rpcSigner, error) {
 	x509Cert, err := x509.ParseCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing x509 certificate")

--- a/lib/vnet/app_provider.go
+++ b/lib/vnet/app_provider.go
@@ -19,10 +19,8 @@ package vnet
 import (
 	"context"
 	"crypto"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"io"
 
 	"github.com/gravitational/trace"
 
@@ -59,59 +57,22 @@ func (p *appProvider) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInf
 	return tlsCert, nil
 }
 
-func (p *appProvider) newAppCertSigner(cert []byte, appKey *vnetv1.AppKey, targetPort uint16) (*rpcAppCertSigner, error) {
+func (p *appProvider) newAppCertSigner(cert []byte, appKey *vnetv1.AppKey, targetPort uint16) (crypto.Signer, error) {
 	x509Cert, err := x509.ParseCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing x509 certificate")
 	}
-	return &rpcAppCertSigner{
-		clt:        p.clt,
-		pub:        x509Cert.PublicKey,
-		appKey:     appKey,
-		targetPort: targetPort,
+	pub := x509Cert.PublicKey
+	return &rpcSigner{
+		pub: pub,
+		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
+			return p.clt.SignForApp(context.TODO(), &vnetv1.SignForAppRequest{
+				AppKey:     appKey,
+				TargetPort: uint32(targetPort),
+				Sign:       req,
+			})
+		},
 	}, nil
-}
-
-// rpcAppCertSigner implements [crypto.Signer] for app TLS signatures that are
-// issued by the client application over gRPC.
-type rpcAppCertSigner struct {
-	clt        *clientApplicationServiceClient
-	pub        crypto.PublicKey
-	appKey     *vnetv1.AppKey
-	targetPort uint16
-}
-
-// Public implements [crypto.Signer.Public] and returns the public key
-// associated with the signer.
-func (s *rpcAppCertSigner) Public() crypto.PublicKey {
-	return s.pub
-}
-
-// Sign implements [crypto.Signer.Sign] and issues a signature over digest for
-// the associated app.
-func (s *rpcAppCertSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	req := &vnetv1.SignForAppRequest{
-		AppKey:     s.appKey,
-		TargetPort: uint32(s.targetPort),
-		Digest:     digest,
-	}
-	switch opts.HashFunc() {
-	case 0:
-		req.Hash = vnetv1.Hash_HASH_NONE
-	case crypto.SHA256:
-		req.Hash = vnetv1.Hash_HASH_SHA256
-	default:
-		return nil, trace.BadParameter("unsupported signature hash func %v", opts.HashFunc())
-	}
-	if pssOpts, ok := opts.(*rsa.PSSOptions); ok {
-		saltLen := int32(pssOpts.SaltLength)
-		req.PssSaltLength = &saltLen
-	}
-	signature, err := s.clt.SignForApp(context.TODO(), req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return signature, nil
 }
 
 // OnNewConnection reports a new TCP connection to the target app.

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -246,6 +246,9 @@ func (s *clientApplicationService) UserTLSCert(ctx context.Context, req *vnetv1.
 	if err != nil {
 		return nil, trace.Wrap(err, "getting user TLS cert")
 	}
+	if len(tlsCert.Certificate) == 0 {
+		return nil, trace.Errorf("user TLS cert has no certificate")
+	}
 	dialOpts, err := s.cfg.clientApplication.GetDialOptions(ctx, req.GetProfile())
 	if err != nil {
 		return nil, trace.Wrap(err, "getting TLS dial options")

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -132,29 +132,14 @@ func (s *clientApplicationService) ReissueAppCert(ctx context.Context, req *vnet
 // It uses a cached signer for the requested app, which must have previously
 // been issued a certificate via [clientApplicationService.ReissueAppCert].
 func (s *clientApplicationService) SignForApp(ctx context.Context, req *vnetv1.SignForAppRequest) (*vnetv1.SignForAppResponse, error) {
+	signReq := req.GetSign()
 	log.DebugContext(ctx, "Got SignForApp request",
 		"app", req.GetAppKey(),
-		"hash", req.GetHash(),
-		"is_rsa_pss", req.PssSaltLength != nil,
-		"pss_salt_len", req.GetPssSaltLength(),
-		"digest_len", len(req.GetDigest()),
+		"hash", signReq.GetHash(),
+		"is_rsa_pss", signReq.PssSaltLength != nil,
+		"pss_salt_len", signReq.GetPssSaltLength(),
+		"digest_len", len(signReq.GetDigest()),
 	)
-	var hash crypto.Hash
-	switch req.GetHash() {
-	case vnetv1.Hash_HASH_NONE:
-		hash = crypto.Hash(0)
-	case vnetv1.Hash_HASH_SHA256:
-		hash = crypto.SHA256
-	default:
-		return nil, trace.BadParameter("unsupported hash %v", req.GetHash())
-	}
-	opts := crypto.SignerOpts(hash)
-	if req.PssSaltLength != nil {
-		opts = &rsa.PSSOptions{
-			Hash:       hash,
-			SaltLength: int(*req.PssSaltLength),
-		}
-	}
 
 	appKey := req.GetAppKey()
 	if err := checkAppKey(appKey); err != nil {
@@ -165,13 +150,34 @@ func (s *clientApplicationService) SignForApp(ctx context.Context, req *vnetv1.S
 		return nil, trace.BadParameter("no signer for app %v", appKey)
 	}
 
-	signature, err := signer.Sign(rand.Reader, req.GetDigest(), opts)
+	signature, err := sign(signer, signReq)
 	if err != nil {
 		return nil, trace.Wrap(err, "signing for app %v", appKey)
 	}
 	return &vnetv1.SignForAppResponse{
 		Signature: signature,
 	}, nil
+}
+
+func sign(signer crypto.Signer, signReq *vnetv1.SignRequest) ([]byte, error) {
+	var hash crypto.Hash
+	switch signReq.GetHash() {
+	case vnetv1.Hash_HASH_NONE:
+		hash = crypto.Hash(0)
+	case vnetv1.Hash_HASH_SHA256:
+		hash = crypto.SHA256
+	default:
+		return nil, trace.BadParameter("unsupported hash %v", signReq.GetHash())
+	}
+	opts := crypto.SignerOpts(hash)
+	if signReq.PssSaltLength != nil {
+		opts = &rsa.PSSOptions{
+			Hash:       hash,
+			SaltLength: int(*signReq.PssSaltLength),
+		}
+	}
+	signature, err := signer.Sign(rand.Reader, signReq.GetDigest(), opts)
+	return signature, trace.Wrap(err)
 }
 
 func (s *clientApplicationService) setSignerForApp(appKey *vnetv1.AppKey, targetPort uint16, signer crypto.Signer) {
@@ -231,6 +237,41 @@ func (s *clientApplicationService) GetTargetOSConfiguration(ctx context.Context,
 	}
 	return &vnetv1.GetTargetOSConfigurationResponse{
 		TargetOsConfiguration: targetConfig,
+	}, nil
+}
+
+// UserTLSCert returns the user TLS certificate for a specific profile.
+func (s *clientApplicationService) UserTLSCert(ctx context.Context, req *vnetv1.UserTLSCertRequest) (*vnetv1.UserTLSCertResponse, error) {
+	tlsCert, err := s.cfg.clientApplication.UserTLSCert(ctx, req.GetProfile())
+	if err != nil {
+		return nil, trace.Wrap(err, "getting user TLS cert")
+	}
+	dialOpts, err := s.cfg.clientApplication.GetDialOptions(ctx, req.GetProfile())
+	if err != nil {
+		return nil, trace.Wrap(err, "getting TLS dial options")
+	}
+	return &vnetv1.UserTLSCertResponse{
+		Cert:        tlsCert.Certificate[0],
+		DialOptions: dialOpts,
+	}, nil
+}
+
+// SignForUserTLS signs a digest with the user TLS private key.
+func (s *clientApplicationService) SignForUserTLS(ctx context.Context, req *vnetv1.SignForUserTLSRequest) (*vnetv1.SignForUserTLSResponse, error) {
+	tlsCert, err := s.cfg.clientApplication.UserTLSCert(ctx, req.GetProfile())
+	if err != nil {
+		return nil, trace.Wrap(err, "getting user TLS config")
+	}
+	signer, ok := tlsCert.PrivateKey.(crypto.Signer)
+	if !ok {
+		return nil, trace.Errorf("user TLS private key does not implement crypto.Signer")
+	}
+	signature, err := sign(signer, req.GetSign())
+	if err != nil {
+		return nil, trace.Wrap(err, "signing for user TLS certificate")
+	}
+	return &vnetv1.SignForUserTLSResponse{
+		Signature: signature,
 	}, nil
 }
 

--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -275,6 +275,9 @@ func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string,
 					MatchedCluster: &vnetv1.MatchedCluster{
 						WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
 						Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+						Profile:       profileName,
+						RootCluster:   rootClusterName,
+						LeafCluster:   leafClusterName,
 					},
 				},
 			}, nil
@@ -292,6 +295,8 @@ func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string,
 				MatchedCluster: &vnetv1.MatchedCluster{
 					WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
 					Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+					Profile:       profileName,
+					RootCluster:   rootClusterName,
 				},
 			},
 		}, nil

--- a/lib/vnet/ssh_handler.go
+++ b/lib/vnet/ssh_handler.go
@@ -1,0 +1,73 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+)
+
+// sshHandler handles incoming VNet SSH connections.
+type sshHandler struct {
+	cfg sshHandlerConfig
+}
+
+type sshHandlerConfig struct {
+	sshProvider *sshProvider
+	target      dialTarget
+}
+
+func newSSHHandler(cfg sshHandlerConfig) *sshHandler {
+	return &sshHandler{
+		cfg: cfg,
+	}
+}
+
+// handleTCPConnector handles an incoming TCP connection from VNet and proxies
+// the connection to a target SSH node.
+func (h *sshHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
+	if localPort != 22 {
+		return trace.BadParameter("SSH is only handled on port 22")
+	}
+	targetConn, err := h.cfg.sshProvider.dial(ctx, h.cfg.target)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer targetConn.Close()
+	return trace.Wrap(h.handleTCPConnectorWithTargetConn(ctx, localPort, connector, targetConn))
+}
+
+// handleTCPConnectorWithTargetTCPConn handles an incoming TCP connection from
+// VNet when a TCP connection to the target host has already been established.
+func (h *sshHandler) handleTCPConnectorWithTargetConn(
+	ctx context.Context,
+	localPort uint16,
+	connector func() (net.Conn, error),
+	targetConn net.Conn,
+) error {
+	// For now we accept the incoming TCP conn to indicate that the node exists,
+	// but SSH connection forwarding is not implemented yet so we immediately
+	// close it.
+	localConn, err := connector()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	localConn.Close()
+	return trace.NotImplemented("VNet SSH connection forwarding is not yet implemented")
+}

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -1,0 +1,182 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	proxyclient "github.com/gravitational/teleport/api/client/proxy"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// sshProvider provides methods necessary for VNet SSH access.
+type sshProvider struct {
+	cfg sshProviderConfig
+}
+
+type sshProviderConfig struct {
+	clt *clientApplicationServiceClient
+	// overrideNodeDialer can be used in tests to dial SSH nodes with the real
+	// TLS configuration but without setting up the proxy transport service.
+	overrideNodeDialer func(
+		ctx context.Context,
+		target dialTarget,
+		tlsConfig *tls.Config,
+		dialOpts *vnetv1.DialOptions,
+	) (net.Conn, error)
+}
+
+func newSSHProvider(cfg sshProviderConfig) *sshProvider {
+	return &sshProvider{
+		cfg: cfg,
+	}
+}
+
+// dial dials the target SSH host.
+func (p *sshProvider) dial(ctx context.Context, target dialTarget) (net.Conn, error) {
+	userTLSCertResp, err := p.cfg.clt.UserTLSCert(ctx, target.profile)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rawCert := userTLSCertResp.GetCert()
+	dialOpts := userTLSCertResp.GetDialOptions()
+	tlsConfig, err := p.userTLSConfig(ctx, target.profile, rawCert, dialOpts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if p.cfg.overrideNodeDialer != nil {
+		return p.cfg.overrideNodeDialer(ctx, target, tlsConfig, dialOpts)
+	}
+	return p.dialViaProxy(ctx, target, tlsConfig, dialOpts)
+}
+
+// dialViaProxy dials the target SSH host via the proxy transport service.
+func (p *sshProvider) dialViaProxy(
+	ctx context.Context,
+	target dialTarget,
+	tlsConfig *tls.Config,
+	dialOpts *vnetv1.DialOptions,
+) (net.Conn, error) {
+	// TODO(nklaassen): consider reusing proxy clients, need to figure out when
+	// it's necessary to make a new client e.g. if the user's TLS credentials
+	// are replaced by a relogin. For now it's simpler to make a new client for
+	// every SSH dial.
+	pclt, err := proxyclient.NewClient(ctx, proxyclient.ClientConfig{
+		ProxyAddress:            dialOpts.GetWebProxyAddr(),
+		TLSConfigFunc:           func(cluster string) (*tls.Config, error) { return tlsConfig, nil },
+		ALPNConnUpgradeRequired: dialOpts.GetAlpnConnUpgradeRequired(),
+		InsecureSkipVerify:      dialOpts.GetInsecureSkipVerify(),
+		// This empty SSH client config should never be used, we dial to the
+		// proxy over TLS only.
+		SSHConfig: &ssh.ClientConfig{},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "building proxy client")
+	}
+	// TODO(nklaassen): pass an SSH keyring to support proxy recording mode.
+	conn, _, err := pclt.DialHost(ctx, target.host, target.cluster, nil /*keyRing*/)
+	if err != nil {
+		pclt.Close()
+		return nil, trace.Wrap(err, "dialing target via proxy")
+	}
+	// Make sure to close the proxy client, but not until we're done with the
+	// target connection or else it would close the underlying gRPC stream.
+	conn = newConnWithExtraCloser(conn, pclt.Close)
+	return conn, nil
+}
+
+func (p *sshProvider) userTLSConfig(
+	ctx context.Context,
+	profile string,
+	rawCert []byte,
+	dialOpts *vnetv1.DialOptions,
+) (*tls.Config, error) {
+	parsedCert, err := x509.ParseCertificate(rawCert)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing user TLS certificate")
+	}
+	signer := &rpcSigner{
+		pub: parsedCert.PublicKey,
+		sendRequest: func(req *vnetv1.SignRequest) ([]byte, error) {
+			return p.cfg.clt.SignForUserTLS(ctx, &vnetv1.SignForUserTLSRequest{
+				Profile: profile,
+				Sign:    req,
+			})
+		},
+	}
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{rawCert},
+		PrivateKey:  signer,
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(dialOpts.GetRootClusterCaCertPool()) {
+		return nil, trace.Errorf("failed to parse root cluster CA cert pool")
+	}
+	return &tls.Config{
+		Certificates:       []tls.Certificate{tlsCert},
+		RootCAs:            caPool,
+		ServerName:         dialOpts.GetSni(),
+		InsecureSkipVerify: dialOpts.GetInsecureSkipVerify(),
+	}, nil
+}
+
+type dialTarget struct {
+	profile, cluster, host string
+}
+
+func computeDialTarget(matchedCluster *vnetv1.MatchedCluster, fqdn string) dialTarget {
+	targetProfile := matchedCluster.GetProfile()
+	targetCluster := matchedCluster.GetRootCluster()
+	targetHost := strings.TrimSuffix(fqdn, "."+matchedCluster.GetRootCluster()+".")
+	if leafCluster := matchedCluster.GetLeafCluster(); leafCluster != "" {
+		targetCluster = leafCluster
+		targetHost = strings.TrimSuffix(targetHost, "."+leafCluster)
+	}
+	targetHost = targetHost + ":0"
+	return dialTarget{
+		profile: targetProfile,
+		cluster: targetCluster,
+		host:    targetHost,
+	}
+}
+
+// connWithExtraCloser embeds a net.Conn and overrides the Close method to close
+// an extra closer. Useful when the lifetime of a client providing the net.Conn
+// must be tied to the lifetime of the Conn.
+type connWithExtraCloser struct {
+	net.Conn
+	extraCloser func() error
+}
+
+func newConnWithExtraCloser(conn net.Conn, extraCloser func() error) *connWithExtraCloser {
+	return &connWithExtraCloser{
+		Conn:        conn,
+		extraCloser: extraCloser,
+	}
+}
+
+// Close closes the net.Conn and the extra closer.
+func (c *connWithExtraCloser) Close() error {
+	return trace.NewAggregate(c.Conn.Close(), c.extraCloser())
+}

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -37,9 +37,11 @@ type tcpHandlerResolver struct {
 }
 
 type tcpHandlerResolverConfig struct {
-	clt         *clientApplicationServiceClient
-	appProvider *appProvider
-	clock       clockwork.Clock
+	clt                      *clientApplicationServiceClient
+	appProvider              *appProvider
+	sshProvider              *sshProvider
+	clock                    clockwork.Clock
+	alwaysTrustRootClusterCA bool
 }
 
 func newTCPHandlerResolver(cfg *tcpHandlerResolverConfig) *tcpHandlerResolver {
@@ -67,9 +69,10 @@ func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string)
 		return &tcpHandlerSpec{
 			ipv4CIDRRange: appInfo.GetIpv4CidrRange(),
 			tcpHandler: newTCPAppHandler(&tcpAppHandlerConfig{
-				appInfo:     appInfo,
-				appProvider: r.cfg.appProvider,
-				clock:       r.cfg.clock,
+				appInfo:                  appInfo,
+				appProvider:              r.cfg.appProvider,
+				clock:                    r.cfg.clock,
+				alwaysTrustRootClusterCA: r.cfg.alwaysTrustRootClusterCA,
 			}),
 		}, nil
 	}
@@ -85,11 +88,9 @@ func (r *tcpHandlerResolver) resolveTCPHandler(ctx context.Context, fqdn string)
 		// TCP connection if this may match an SSH node or an app that may be
 		// added later so we return an undecidedHandler.
 		handler, err := newUndecidedHandler(&undecidedHandlerConfig{
-			clt:          r.cfg.clt,
-			appProvider:  r.cfg.appProvider,
-			clock:        r.cfg.clock,
-			fqdn:         fqdn,
-			webProxyAddr: matchedCluster.GetWebProxyAddr(),
+			tcpHandlerResolverConfig: r.cfg,
+			fqdn:                     fqdn,
+			webProxyAddr:             matchedCluster.GetWebProxyAddr(),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -118,9 +119,7 @@ type undecidedHandler struct {
 }
 
 type undecidedHandlerConfig struct {
-	clt          *clientApplicationServiceClient
-	appProvider  *appProvider
-	clock        clockwork.Clock
+	*tcpHandlerResolverConfig
 	fqdn         string
 	webProxyAddr string
 }
@@ -168,9 +167,10 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		// and all subsequent connections to this address.
 		log.DebugContext(ctx, "Resolved FQDN to a matched TCP app", "fqdn", h.cfg.fqdn)
 		tcpAppHandler := newTCPAppHandler(&tcpAppHandlerConfig{
-			appInfo:     matchedTCPApp.GetAppInfo(),
-			appProvider: h.cfg.appProvider,
-			clock:       h.cfg.clock,
+			appInfo:                  matchedTCPApp.GetAppInfo(),
+			appProvider:              h.cfg.appProvider,
+			clock:                    h.cfg.clock,
+			alwaysTrustRootClusterCA: h.cfg.alwaysTrustRootClusterCA,
 		})
 		h.setDecidedHandler(tcpAppHandler)
 		return tcpAppHandler.handleTCPConnector(ctx, localPort, connector)
@@ -184,7 +184,32 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		return webAppHandler.handleTCPConnector(ctx, localPort, connector)
 	}
 	if matchedCluster := resp.GetMatchedCluster(); matchedCluster != nil && localPort == 22 {
-		return trace.NotImplemented("SSH connection forwarding not yet implemented")
+		// Matched a cluster, this FQDN could potentially match an SSH node.
+		log.DebugContext(ctx, "Resolved FQDN to a matched cluster", "fqdn", h.cfg.fqdn)
+		// Attempt a dial to the target SSH node to see if it exists.
+		target := computeDialTarget(matchedCluster, h.cfg.fqdn)
+		targetConn, err := h.cfg.sshProvider.dial(ctx, target)
+		if err != nil {
+			if trace.IsConnectionProblem(err) {
+				log.DebugContext(ctx, "Failed TCP dial to target, node probably doesn't exist",
+					"fqdn", h.cfg.fqdn)
+				return nil
+			}
+			return trace.Wrap(err, "unexpected error TCP dialing to target node at %s", h.cfg.fqdn)
+		}
+		defer targetConn.Close()
+		log.DebugContext(ctx, "TCP dial to target SSH node succeeded", "fqdn", h.cfg.fqdn)
+		// Now that we know there is a matching SSH node, this handler will
+		// permanently handle SSH connections at this address and avoid app
+		// queries on subsequent connections.
+		sshHandler := newSSHHandler(sshHandlerConfig{
+			sshProvider: h.cfg.sshProvider,
+			target:      target,
+		})
+		h.setDecidedHandler(sshHandler)
+		// Handle the incoming connection with the TCP connection to the target
+		// SSH node that has already been established.
+		return sshHandler.handleTCPConnectorWithTargetConn(ctx, localPort, connector, targetConn)
 	}
 	return trace.Errorf("rejecting connection to %s:%d", h.cfg.fqdn, localPort)
 }

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -45,6 +45,9 @@ type ClientApplication interface {
 	// ReissueAppCert issues a new cert for the target app.
 	ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) (tls.Certificate, error)
 
+	// UserTLSCert returns the user TLS certificate for the given profile.
+	UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error)
+
 	// GetDialOptions returns ALPN dial options for the profile.
 	GetDialOptions(ctx context.Context, profileName string) (*vnetv1.DialOptions, error)
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -52,6 +52,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -144,10 +145,16 @@ func newTestPack(t *testing.T, ctx context.Context, cfg testPackConfig) *testPac
 	// interface with fakeClientApp via the gRPC client.
 	clt := runTestClientApplicationService(t, ctx, cfg.clock, cfg.fakeClientApp)
 	appProvider := newAppProvider(clt)
+	sshProvider := newSSHProvider(sshProviderConfig{
+		clt:                clt,
+		overrideNodeDialer: cfg.fakeClientApp.dialSSHNode,
+	})
 	tcpHandlerResolver := newTCPHandlerResolver(&tcpHandlerResolverConfig{
-		clt:         clt,
-		appProvider: appProvider,
-		clock:       cfg.clock,
+		clt:                      clt,
+		appProvider:              appProvider,
+		sshProvider:              sshProvider,
+		clock:                    cfg.clock,
+		alwaysTrustRootClusterCA: true,
 	})
 
 	// Create the VNet and connect it to the other side of the TUN.
@@ -318,8 +325,11 @@ type appSpec struct {
 	tcpPorts   []*types.PortRange
 }
 
+type nodeSpec struct{}
+
 type testClusterSpec struct {
 	apps           []appSpec
+	nodes          map[string]nodeSpec
 	cidrRange      string
 	customDNSZones []string
 	leafClusters   map[string]testClusterSpec
@@ -328,8 +338,9 @@ type testClusterSpec struct {
 type fakeClientApp struct {
 	cfg *fakeClientAppConfig
 
-	tlsCA    tls.Certificate
-	dialOpts *vnetv1.DialOptions
+	tlsCA       tls.Certificate
+	userTLSCert tls.Certificate
+	dialOpts    *vnetv1.DialOptions
 
 	onNewConnectionCallCount    atomic.Uint32
 	onInvalidLocalPortCallCount atomic.Uint32
@@ -351,9 +362,17 @@ type fakeClientAppConfig struct {
 func newFakeClientApp(ctx context.Context, t *testing.T, cfg *fakeClientAppConfig) *fakeClientApp {
 	tlsCA := newSelfSignedCA(t)
 	dialOpts := mustStartFakeWebProxy(ctx, t, tlsCA, cfg.clock, cfg.signatureAlgorithmSuite)
+	userTLSCert, err := newClientCert(ctx,
+		tlsCA,
+		"testuser",
+		cfg.clock.Now().Add(defaults.CertDuration),
+		cfg.signatureAlgorithmSuite,
+		cryptosuites.UserTLS)
+	require.NoError(t, err)
 	return &fakeClientApp{
 		cfg:                  cfg,
 		tlsCA:                tlsCA,
+		userTLSCert:          userTLSCert,
 		dialOpts:             dialOpts,
 		requestedRouteToApps: make(map[string][]*proto.RouteToApp),
 	}
@@ -407,6 +426,10 @@ func (p *fakeClientApp) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppI
 		p.cfg.clock.Now().Add(appCertLifetime),
 		p.cfg.signatureAlgorithmSuite,
 		cryptosuites.UserTLS)
+}
+
+func (p *fakeClientApp) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
+	return p.userTLSCert, nil
 }
 
 func (p *fakeClientApp) RequestedRouteToApps(publicAddr string) []*proto.RouteToApp {
@@ -482,6 +505,30 @@ func (p *fakeClientApp) OnNewConnection(_ context.Context, _ *vnetv1.AppKey) err
 
 func (p *fakeClientApp) OnInvalidLocalPort(_ context.Context, _ *vnetv1.AppInfo, _ uint16) {
 	p.onInvalidLocalPortCallCount.Add(1)
+}
+
+func (p *fakeClientApp) dialSSHNode(
+	ctx context.Context,
+	target dialTarget,
+	tlsConfig *tls.Config,
+	dialOpts *vnetv1.DialOptions,
+) (net.Conn, error) {
+	targetCluster, ok := p.cfg.clusters[target.profile]
+	if !ok {
+		return nil, trace.NotFound("no such profile")
+	}
+	if target.cluster != target.profile {
+		targetCluster, ok = targetCluster.leafClusters[target.cluster]
+		if !ok {
+			return nil, trace.NotFound("no such cluster")
+		}
+	}
+	if _, ok := targetCluster.nodes[strings.TrimSuffix(target.host, ":0")]; !ok {
+		return nil, trace.NotFound("no such host")
+	}
+	// For now just let it dial the fake web proxy, later we'll need to set up a
+	// fake SSH server for the test to dial to.
+	return tls.Dial("tcp", dialOpts.GetWebProxyAddr(), tlsConfig)
 }
 
 type fakeClusterClient struct {
@@ -1010,17 +1057,29 @@ func TestSSH(t *testing.T) {
 		clusters: map[string]testClusterSpec{
 			"root1.example.com": {
 				cidrRange: root1CIDR,
+				nodes: map[string]nodeSpec{
+					"node": {},
+				},
 				leafClusters: map[string]testClusterSpec{
 					"leaf1.example.com": {
 						cidrRange: leaf1CIDR,
+						nodes: map[string]nodeSpec{
+							"node": {},
+						},
 					},
 				},
 			},
 			"root2.example.com": {
 				cidrRange: root2CIDR,
+				nodes: map[string]nodeSpec{
+					"node": {},
+				},
 				leafClusters: map[string]testClusterSpec{
 					"leaf2.example.com": {
 						cidrRange: leaf2CIDR,
+						nodes: map[string]nodeSpec{
+							"node": {},
+						},
 					},
 				},
 			},
@@ -1035,32 +1094,67 @@ func TestSSH(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		addr       string
-		expectCIDR string
+		dialAddr           string
+		dialPort           int
+		expectCIDR         string
+		expectLookupToFail bool
+		expectDialToFail   bool
 	}{
 		{
-			addr:       "node.root1.example.com",
+			dialAddr:   "node.root1.example.com",
+			dialPort:   22,
 			expectCIDR: root1CIDR,
 		},
 		{
-			addr:       "node.leaf1.example.com.root1.example.com",
+			// Dial should fail on non-standard SSH port.
+			dialAddr:         "node.root1.example.com",
+			dialPort:         23,
+			expectCIDR:       root1CIDR,
+			expectDialToFail: true,
+		},
+		{
+			dialAddr:   "node.leaf1.example.com.root1.example.com",
+			dialPort:   22,
 			expectCIDR: leaf1CIDR,
 		},
 		{
-			addr:       "node.root2.example.com",
+			dialAddr:   "node.root2.example.com",
+			dialPort:   22,
 			expectCIDR: root2CIDR,
 		},
 		{
-			addr:       "node.leaf2.example.com.root2.example.com",
+			dialAddr:   "node.leaf2.example.com.root2.example.com",
+			dialPort:   22,
 			expectCIDR: leaf2CIDR,
 		},
+		{
+			// DNS lookup should fail if the FQDN doesn't match any cluster.
+			dialAddr:           "node.bogus.example.com.",
+			dialPort:           22,
+			expectLookupToFail: true,
+		},
+		{
+			// If the FQDN matches a cluster but no node, the DNS lookup should
+			// succeed but the TCP dial should fail.
+			dialAddr:         "bogus.root1.example.com",
+			dialPort:         22,
+			expectCIDR:       root1CIDR,
+			expectDialToFail: true,
+		},
 	} {
-		t.Run(tc.addr, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s:%d", tc.dialAddr, tc.dialPort), func(t *testing.T) {
 			t.Parallel()
+
+			lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
 			// SSH access isn't fully implemented yet, at this point the DNS
 			// lookup for *.<cluster-name> should resolve to an IP in the
 			// expected CIDR range for the cluster.
-			resolvedAddrs, err := p.lookupHost(ctx, tc.addr)
+			resolvedAddrs, err := p.lookupHost(lookupCtx, tc.dialAddr)
+			if tc.expectLookupToFail {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			_, expectNet, err := net.ParseCIDR(tc.expectCIDR)
@@ -1076,10 +1170,15 @@ func TestSSH(t *testing.T) {
 					"expected CIDR range %s does not include resolved IP %s", expectNet, resolvedIPSuffix)
 			}
 
-			// Actually dialing the address should still fail until VNet SSH is
-			// implemented.
-			_, err = p.dialHost(ctx, tc.addr, 22)
-			require.Error(t, err)
+			dialCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+			conn, err := p.dialHost(dialCtx, tc.dialAddr, tc.dialPort)
+			if tc.expectDialToFail {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			conn.Close()
 		})
 	}
 }

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -135,8 +135,13 @@ message MatchedCluster {
   // WebProxyAddr is the web proxy address of the root cluster that matched the
   // query.
   string web_proxy_addr = 2;
+  // Profile is the profile the matched cluster was found in.
   string profile = 3;
+  // RootCluster will always be set to the name of the root cluster that matched
+  // the query.
   string root_cluster = 4;
+  // LeafCluster will be set only when the query matched a leaf cluster of
+  // RootCluster, or else it will be empty.
   string leaf_cluster = 5;
 }
 

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -53,6 +53,10 @@ service ClientApplicationService {
   rpc OnInvalidLocalPort(OnInvalidLocalPortRequest) returns (OnInvalidLocalPortResponse);
   // GetTargetOSConfiguration gets the target OS configuration.
   rpc GetTargetOSConfiguration(GetTargetOSConfigurationRequest) returns (GetTargetOSConfigurationResponse);
+  // UserTLSCert returns the user TLS certificate for a specific profile.
+  rpc UserTLSCert(UserTLSCertRequest) returns (UserTLSCertResponse);
+  // SignForUserTLS signs a digest with the user TLS private key.
+  rpc SignForUserTLS(SignForUserTLSRequest) returns (SignForUserTLSResponse);
 }
 
 // AuthenticateProcessRequest is a request for AuthenticateProcess.
@@ -131,6 +135,9 @@ message MatchedCluster {
   // WebProxyAddr is the web proxy address of the root cluster that matched the
   // query.
   string web_proxy_addr = 2;
+  string profile = 3;
+  string root_cluster = 4;
+  string leaf_cluster = 5;
 }
 
 // AppInfo holds all necessary info for making connections to VNet TCP apps.
@@ -172,8 +179,10 @@ message DialOptions {
   string sni = 3;
   // InsecureSkipVerify turns off verification for x509 upstream ALPN proxy service certificate.
   bool insecure_skip_verify = 4;
-  // RootClusterCaCertPool overrides the x509 certificate pool used to verify the server.
-  // It is a PEM-encoded X509 certificate pool.
+  // RootClusterCaCertPool is the host CA TLS certificate pool for the root
+  // cluster. It is a PEM-encoded X509 certificate pool. It should be used when
+  // dialing the proxy and AlpnConnUpgradeRequired is true or when dialing the
+  // transport service.
   bytes root_cluster_ca_cert_pool = 5;
 }
 
@@ -198,6 +207,8 @@ message ReissueAppCertResponse {
 // ReissueAppCert. The private key used for the signature will match the subject
 // public key of the issued x509 certificate.
 message SignForAppRequest {
+  reserved 3, 4, 5;
+  reserved "digest", "hash", "pss_salt_length";
   // AppKey uniquely identifies a TCP app, it must match the key of an app from
   // a previous successful call to ReissueAppCert.
   AppKey app_key = 1;
@@ -205,13 +216,19 @@ message SignForAppRequest {
   // TargetPort of a previous successful call to ReissueAppCert for an app
   // matching AppKey.
   uint32 target_port = 2;
+  // Sign holds signature request details.
+  SignRequest sign = 6;
+}
+
+// SignRequest holds signature request details.
+message SignRequest {
   // Digest is the bytes to sign.
-  bytes digest = 3;
+  bytes digest = 1;
   // Hash is the hash function used to compute digest.
-  Hash hash = 4;
+  Hash hash = 2;
   // PssSaltLength specifies the length of the salt added to the digest before a
   // signature. Only used and required for RSA PSS signatures.
-  optional int32 pss_salt_length = 5;
+  optional int32 pss_salt_length = 3;
 }
 
 // Hash specifies a cryptographic hash function.
@@ -277,4 +294,33 @@ message TargetOSConfiguration {
   // is logged in to, and if any cluster does not configure a custom range it
   // should also include the default range.
   repeated string ipv4_cidr_ranges = 2;
+}
+
+// UserTLSCertRequest is a request for UserTLSCert.
+message UserTLSCertRequest {
+  // Profile is the profile to retrieve the certificate for.
+  string profile = 1;
+}
+
+// UserTLSCertResponse is a response for UserTLSCert.
+message UserTLSCertResponse {
+  // Cert is the user TLS certificate in X.509 ASN.1 DER format.
+  bytes cert = 1;
+  // DialOptions holds options that should be used when dialing the root cluster
+  // proxy.
+  DialOptions dial_options = 2;
+}
+
+// SignForUserTLSRequest is a request for SignForUserTLS.
+message SignForUserTLSRequest {
+  // Profile is the user profile to sign for.
+  string profile = 1;
+  // Sign holds signature request details.
+  SignRequest sign = 2;
+}
+
+// SignForUserTLSResponse is a response for SignForUserTLS.
+message SignForUserTLSResponse {
+  // Signature is the signature.
+  bytes signature = 1;
 }

--- a/tool/tsh/common/vnet_client_application.go
+++ b/tool/tsh/common/vnet_client_application.go
@@ -100,6 +100,22 @@ func (p *vnetClientApplication) ReissueAppCert(ctx context.Context, appInfo *vne
 	return cert, trace.Wrap(err)
 }
 
+// UserTLSCert returns the user TLS certificate for the given profile.
+func (p *vnetClientApplication) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
+	profile, err := p.clientStore.GetProfile(profileName)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "loading user profile %s", profileName)
+	}
+	tlsConfig, err := profile.TLSConfig()
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err, "loading TLS config for profile")
+	}
+	if len(tlsConfig.Certificates) == 0 {
+		return tls.Certificate{}, trace.Errorf("user tls config has no certificates")
+	}
+	return tlsConfig.Certificates[0], nil
+}
+
 // GetDialOptions returns ALPN dial options for the profile.
 func (p *vnetClientApplication) GetDialOptions(ctx context.Context, profileName string) (*vnetv1.DialOptions, error) {
 	profile, err := p.clientStore.GetProfile(profileName)
@@ -111,11 +127,9 @@ func (p *vnetClientApplication) GetDialOptions(ctx context.Context, profileName 
 		AlpnConnUpgradeRequired: profile.TLSRoutingConnUpgradeRequired,
 		InsecureSkipVerify:      p.cf.InsecureSkipVerify,
 	}
-	if dialOpts.AlpnConnUpgradeRequired {
-		dialOpts.RootClusterCaCertPool, err = p.getRootClusterCACertPoolPEM(ctx, profileName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	dialOpts.RootClusterCaCertPool, err = p.getRootClusterCACertPoolPEM(ctx, profileName)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return dialOpts, nil
 }


### PR DESCRIPTION
This PR is the next step in the implementation of VNet SSH ([RFD](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md)).

According to the design in the RFD, when VNet receives a TCP connection on port 22 at an address that matches a cluster name, it attempts to dial the SSH node to see if it exists. If it does exist, the handler at that IP address is assigned to handle SSH connections. In a later PR it will actually handle proxying the SSH connection to the target node, for now it only completes the TCP dial.

At this point you can try it out by attempting connections to real or fake node addresses with netcat, if the node exists the TCP dial connection will be accepted, otherwise it will be rejected.
```
$ nc -v node-iot.one.private 22
Connection to node-iot.one.private port 22 [tcp/ssh] succeeded!
$ nc -v bogus.one.private 22
nc: connectx to bogus.one.private port 22 (tcp) failed: Connection refused
$ nc -v two-auth.two-prod.one.private 22
Connection to two-auth.two-prod.one.private port 22 [tcp/ssh] succeeded!
$ nc -v bogus.two-prod.one.private 22
nc: connectx to bogus.two-prod.one.private port 22 (tcp) failed: Connection refused
$ nc -v node-iot.one.private 33
nc: connectx to node-iot.one.private port 33 (tcp) failed: Connection refused
```

Child PR: https://github.com/gravitational/teleport/pull/55155