### PR TITLE
Add agent counters to autoupdate_agent_rollout proto

### DIFF
--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -1087,8 +1087,26 @@ type AutoUpdateAgentRolloutStatusGroup struct {
 	// config_wait_hours after last group succeeds before this group can run. This can only be used when the strategy is "halt-on-failure".
 	// This field must be positive.
 	ConfigWaitHours int32 `protobuf:"varint,9,opt,name=config_wait_hours,json=configWaitHours,proto3" json:"config_wait_hours,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// initial_count of nodes when the group transitioned to the active phase. This is computed by aggregating
+	// autoupdate_agent_reports.
+	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+	// to the done state if:
+	// - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
+	InitialCount int64 `protobuf:"varint,10,opt,name=initial_count,json=initialCount,proto3" json:"initial_count,omitempty"`
+	// present_count represents the nodes currently connected to the cluster according to autoupdate_agent_reports.
+	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+	// to the done state if:
+	// - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
+	// - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
+	PresentCount int64 `protobuf:"varint,11,opt,name=present_count,json=presentCount,proto3" json:"present_count,omitempty"`
+	// up_to_date_count represents the nodes currently connected and running the target_version according to
+	// autoupdate_agent_reports.
+	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+	// to the done state if:
+	// - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
+	UpToDateCount int64 `protobuf:"varint,12,opt,name=up_to_date_count,json=upToDateCount,proto3" json:"up_to_date_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AutoUpdateAgentRolloutStatusGroup) Reset() {
@@ -1173,6 +1191,27 @@ func (x *AutoUpdateAgentRolloutStatusGroup) GetConfigStartHour() int32 {
 func (x *AutoUpdateAgentRolloutStatusGroup) GetConfigWaitHours() int32 {
 	if x != nil {
 		return x.ConfigWaitHours
+	}
+	return 0
+}
+
+func (x *AutoUpdateAgentRolloutStatusGroup) GetInitialCount() int64 {
+	if x != nil {
+		return x.InitialCount
+	}
+	return 0
+}
+
+func (x *AutoUpdateAgentRolloutStatusGroup) GetPresentCount() int64 {
+	if x != nil {
+		return x.PresentCount
+	}
+	return 0
+}
+
+func (x *AutoUpdateAgentRolloutStatusGroup) GetUpToDateCount() int64 {
+	if x != nil {
+		return x.UpToDateCount
 	}
 	return 0
 }
@@ -1530,7 +1569,7 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"\x05state\x18\x02 \x01(\x0e23.teleport.autoupdate.v1.AutoUpdateAgentRolloutStateR\x05state\x129\n" +
 	"\n" +
 	"start_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x12?\n" +
-	"\rtime_override\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ftimeOverride\"\xc0\x03\n" +
+	"\rtime_override\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ftimeOverride\"\xb3\x04\n" +
 	"!AutoUpdateAgentRolloutStatusGroup\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
 	"\n" +
@@ -1541,7 +1580,11 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"\vconfig_days\x18\x06 \x03(\tR\n" +
 	"configDays\x12*\n" +
 	"\x11config_start_hour\x18\a \x01(\x05R\x0fconfigStartHour\x12*\n" +
-	"\x11config_wait_hours\x18\t \x01(\x05R\x0fconfigWaitHoursJ\x04\b\b\x10\tR\x10config_wait_days\"\xe1\x01\n" +
+	"\x11config_wait_hours\x18\t \x01(\x05R\x0fconfigWaitHours\x12#\n" +
+	"\rinitial_count\x18\n" +
+	" \x01(\x03R\finitialCount\x12#\n" +
+	"\rpresent_count\x18\v \x01(\x03R\fpresentCount\x12'\n" +
+	"\x10up_to_date_count\x18\f \x01(\x03R\rupToDateCountJ\x04\b\b\x10\tR\x10config_wait_days\"\xe1\x01\n" +
 	"\x15AutoUpdateAgentReport\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +

--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -1092,19 +1092,19 @@ type AutoUpdateAgentRolloutStatusGroup struct {
 	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
 	// to the done state if:
 	// - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
-	InitialCount int64 `protobuf:"varint,10,opt,name=initial_count,json=initialCount,proto3" json:"initial_count,omitempty"`
+	InitialCount uint64 `protobuf:"varint,10,opt,name=initial_count,json=initialCount,proto3" json:"initial_count,omitempty"`
 	// present_count represents the nodes currently connected to the cluster according to autoupdate_agent_reports.
 	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
 	// to the done state if:
 	// - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
 	// - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
-	PresentCount int64 `protobuf:"varint,11,opt,name=present_count,json=presentCount,proto3" json:"present_count,omitempty"`
+	PresentCount uint64 `protobuf:"varint,11,opt,name=present_count,json=presentCount,proto3" json:"present_count,omitempty"`
 	// up_to_date_count represents the nodes currently connected and running the target_version according to
 	// autoupdate_agent_reports.
 	// In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
 	// to the done state if:
 	// - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
-	UpToDateCount int64 `protobuf:"varint,12,opt,name=up_to_date_count,json=upToDateCount,proto3" json:"up_to_date_count,omitempty"`
+	UpToDateCount uint64 `protobuf:"varint,12,opt,name=up_to_date_count,json=upToDateCount,proto3" json:"up_to_date_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1195,21 +1195,21 @@ func (x *AutoUpdateAgentRolloutStatusGroup) GetConfigWaitHours() int32 {
 	return 0
 }
 
-func (x *AutoUpdateAgentRolloutStatusGroup) GetInitialCount() int64 {
+func (x *AutoUpdateAgentRolloutStatusGroup) GetInitialCount() uint64 {
 	if x != nil {
 		return x.InitialCount
 	}
 	return 0
 }
 
-func (x *AutoUpdateAgentRolloutStatusGroup) GetPresentCount() int64 {
+func (x *AutoUpdateAgentRolloutStatusGroup) GetPresentCount() uint64 {
 	if x != nil {
 		return x.PresentCount
 	}
 	return 0
 }
 
-func (x *AutoUpdateAgentRolloutStatusGroup) GetUpToDateCount() int64 {
+func (x *AutoUpdateAgentRolloutStatusGroup) GetUpToDateCount() uint64 {
 	if x != nil {
 		return x.UpToDateCount
 	}
@@ -1582,9 +1582,9 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"\x11config_start_hour\x18\a \x01(\x05R\x0fconfigStartHour\x12*\n" +
 	"\x11config_wait_hours\x18\t \x01(\x05R\x0fconfigWaitHours\x12#\n" +
 	"\rinitial_count\x18\n" +
-	" \x01(\x03R\finitialCount\x12#\n" +
-	"\rpresent_count\x18\v \x01(\x03R\fpresentCount\x12'\n" +
-	"\x10up_to_date_count\x18\f \x01(\x03R\rupToDateCountJ\x04\b\b\x10\tR\x10config_wait_days\"\xe1\x01\n" +
+	" \x01(\x04R\finitialCount\x12#\n" +
+	"\rpresent_count\x18\v \x01(\x04R\fpresentCount\x12'\n" +
+	"\x10up_to_date_count\x18\f \x01(\x04R\rupToDateCountJ\x04\b\b\x10\tR\x10config_wait_days\"\xe1\x01\n" +
 	"\x15AutoUpdateAgentReport\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -212,6 +212,24 @@ message AutoUpdateAgentRolloutStatusGroup {
   // config_wait_hours after last group succeeds before this group can run. This can only be used when the strategy is "halt-on-failure".
   // This field must be positive.
   int32 config_wait_hours = 9;
+  // initial_count of nodes when the group transitioned to the active phase. This is computed by aggregating
+  // autoupdate_agent_reports.
+  // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+  // to the done state if:
+  // - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
+  int64 initial_count = 10;
+  // present_count represents the nodes currently connected to the cluster according to autoupdate_agent_reports.
+  // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+  // to the done state if:
+  // - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
+  // - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
+  int64 present_count = 11;
+  // up_to_date_count represents the nodes currently connected and running the target_version according to
+  // autoupdate_agent_reports.
+  // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
+  // to the done state if:
+  // - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
+  int64 up_to_date_count = 12;
 }
 
 // AutoUpdateAgentGroupState represents the agent group state. This state controls whether the agents from this group

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -217,19 +217,19 @@ message AutoUpdateAgentRolloutStatusGroup {
   // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
   // to the done state if:
   // - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
-  int64 initial_count = 10;
+  uint64 initial_count = 10;
   // present_count represents the nodes currently connected to the cluster according to autoupdate_agent_reports.
   // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
   // to the done state if:
   // - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
   // - the ratio up_to_date_count/present_count is above 0.9 (at least 90% of the nodes are running the desired version)
-  int64 present_count = 11;
+  uint64 present_count = 11;
   // up_to_date_count represents the nodes currently connected and running the target_version according to
   // autoupdate_agent_reports.
   // In halt-on-error strategy, if a group is active and initial_count is set, the group will only transition
   // to the done state if:
   // - the ratio present_count/initial_count is above 0.9 (no more than 10% of the nodes dropped during update)
-  int64 up_to_date_count = 12;
+  uint64 up_to_date_count = 12;
 }
 
 // AutoUpdateAgentGroupState represents the agent group state. This state controls whether the agents from this group


### PR DESCRIPTION
This PR adds the agent counters to the `autoupdate_agent_rollout` proto message. Those counters are used to track:
- how many agents were connected when we started to update the group
- how many agents are currently connected
- how many agents are currently up-to-date

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856