### PR TITLE
text and yaml format for `tsh play` with a file

### DIFF
--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -103,12 +103,11 @@ func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat str
 					return trace.ConvertSystemError(err)
 				}
 			case teleport.YAML:
-				_, err := fmt.Println("---")
+				_, err := fmt.Fprintln(w, "---")
 				if err != nil {
 					return trace.ConvertSystemError(err)
 				}
-				err = utils.WriteYAML(w, event)
-				if err != nil {
+				if err := utils.WriteYAML(w, event); err != nil {
 					return trace.ConvertSystemError(err)
 				}
 			case teleport.Text:
@@ -117,8 +116,7 @@ func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat str
 					continue
 				}
 				// write bytes to writer
-				_, err := w.Write(printEvent.Data)
-				if err != nil {
+				if _, err := w.Write(printEvent.Data); err != nil {
 					return trace.ConvertSystemError(err)
 				}
 			default:

--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -24,12 +24,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	apievents "github.com/gravitational/teleport/api/types/events"
 	"io"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/utils"
 )
 


### PR DESCRIPTION
Before, the `text` and `yaml` formats for `tsh play` only work when streaming the event from a Teleport backend. Trying to use those formats would fail with a local file:

```
% tsh play -f text ./f180dc60-0b82-2623-da7b-5d200e1c06b8.tar             
ERROR: unsupported format "text", "json" is the only supported format
```

This PR adds support for those formats with a session recording file.

Closes #54320
Closes #53960