### PR TITLE
Remove / prefix from ListUserGroups next token

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7314,7 +7314,7 @@ func (a *ServerWithRoles) ListUserGroups(ctx context.Context, pageSize int, next
 		return filteredUserGroups, "", nil
 	}
 
-	return filteredUserGroups[:pageSize], backend.NextPaginationKey(filteredUserGroups[pageSize-1]), nil
+	return filteredUserGroups[:pageSize], filteredUserGroups[pageSize-1].GetName(), nil
 }
 
 // GetUserGroup returns the specified user group resources.

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -356,20 +356,6 @@ type KeyedItem interface {
 	GetName() string
 }
 
-// NextPaginationKey returns the next pagination key.
-// For items that implement HostID, the next key will also
-// have the HostID part.
-func NextPaginationKey(ki KeyedItem) string {
-	var key Key
-	if h, ok := ki.(HostID); ok {
-		key = internalKey(h.GetHostID(), h.GetName())
-	} else {
-		key = NewKey(ki.GetName())
-	}
-
-	return nextKey(key).String()
-}
-
 // GetPaginationKey returns the pagination key given item.
 // For items that implement HostID, the next key will also
 // have the HostID part.

--- a/lib/cache/user_group.go
+++ b/lib/cache/user_group.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -88,6 +89,9 @@ func (c *Cache) ListUserGroups(ctx context.Context, pageSize int, nextKey string
 		group, nextKey, err := c.Config.UserGroups.ListUserGroups(ctx, pageSize, nextKey)
 		return group, nextKey, trace.Wrap(err)
 	}
+
+	// TODO(tross): DELETE IN V20.0.0
+	nextKey = strings.TrimPrefix(nextKey, "/")
 
 	// Adjust page size, so it can't be too large.
 	if pageSize <= 0 || pageSize > local.GroupMaxPageSize {

--- a/lib/cache/user_group_test.go
+++ b/lib/cache/user_group_test.go
@@ -18,7 +18,14 @@ package cache
 
 import (
 	"context"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -52,4 +59,63 @@ func TestUserGroups(t *testing.T) {
 		update:    p.userGroups.UpdateUserGroup,
 		deleteAll: p.userGroups.DeleteAllUserGroups,
 	})
+
+	require.NoError(t, p.userGroups.DeleteAllUserGroups(t.Context()))
+
+	var expected []types.UserGroup
+	for i := 0; i < 500; i++ {
+		ug, err := types.NewUserGroup(
+			types.Metadata{
+				Name: "ug-" + strconv.Itoa(i+1),
+			}, types.UserGroupSpecV1{})
+		require.NoError(t, err)
+
+		require.NoError(t, p.userGroups.CreateUserGroup(t.Context(), ug))
+
+		ug, err = p.userGroups.GetUserGroup(t.Context(), ug.GetName())
+		require.NoError(t, err)
+		expected = append(expected, ug)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Equal(t, 500, p.cache.collections.userGroups.store.len())
+	}, 10*time.Second, 100*time.Millisecond)
+
+	var out []types.UserGroup
+	var start string
+	for {
+		g, next, err := p.cache.ListUserGroups(t.Context(), 0, start)
+		require.NoError(t, err)
+
+		out = append(out, g...)
+		if next == "" {
+			break
+		}
+
+		// The /<token> here is to test an edge case that cause infinite listing. The
+		// gPRC layer injected a / in the response which is not consumed by the new
+		// cache collection, but was handled by the legacy local service.
+		next = "/" + next
+		start = next
+	}
+
+	assert.Len(t, out, len(expected))
+	require.Empty(t, cmp.Diff(expected, out, cmpopts.SortSlices(func(x, y types.UserGroup) bool { return x.GetName() < y.GetName() })))
+
+	out = nil
+	start = ""
+	for {
+		g, next, err := p.cache.ListUserGroups(t.Context(), 0, start)
+		require.NoError(t, err)
+
+		out = append(out, g...)
+		if next == "" {
+			break
+		}
+
+		start = next
+	}
+
+	assert.Len(t, out, len(expected))
+	require.Empty(t, cmp.Diff(expected, out, cmpopts.SortSlices(func(x, y types.UserGroup) bool { return x.GetName() < y.GetName() })))
 }

--- a/lib/services/local/usergroup_test.go
+++ b/lib/services/local/usergroup_test.go
@@ -96,6 +96,26 @@ func TestUserGroupCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+	numPages = 0
+	nextToken = ""
+	paginatedOut = make([]types.UserGroup, 0, 2)
+	for {
+		numPages++
+		out, nextToken, err = service.ListUserGroups(ctx, 1, nextToken)
+		require.NoError(t, err)
+
+		paginatedOut = append(paginatedOut, out...)
+		if nextToken == "" {
+			break
+		}
+		nextToken = "/" + nextToken
+	}
+
+	require.Equal(t, 2, numPages)
+	require.Empty(t, cmp.Diff([]types.UserGroup{g1, g2}, paginatedOut,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
 	// Fetch a specific user group.
 	sp, err := service.GetUserGroup(ctx, g2.GetName())
 	require.NoError(t, err)


### PR DESCRIPTION
`(ServerWithRoles) ListUserGroups` was returning the next page token with a / preceeding the name of the group. When switching over to the new cache collection, the cache was not accounting for this and would result in an infinite loop. The prefix was a result of calling backend.NextPaginationKey instead of providing the unique group name.

This was not a problem in the past because the local UserGroup storage service was joining the next token with the key prefix which correctly built the key `/user_groups/<next>`. The new cache collection is now trimming the `/` prefix to prevent the infinite looping.

The AuthServer implementation was also updated to no longer include the prefix, which should be backward compatible because of the way the local services are constructing the backend key. Additionally, tests were added to both the new caching layer and local storage layer to validate both work if the nextKey provided has a `/` prefix or not.

`backend.NextPaginationKey` was also removed since it was no longer being used.