### PR TITLE
docs: include sudo for install systemd examples

### DIFF
--- a/docs/pages/admin-guides/management/diagnostics/logging.mdx
+++ b/docs/pages/admin-guides/management/diagnostics/logging.mdx
@@ -41,9 +41,9 @@ Format `extra_fields` defines additional fields which must be added to the log o
 On systemd-based distributions you can watch the log output by running the following command:
 
 ```code
-$ teleport install systemd -o /etc/systemd/system/teleport.service
-$ systemctl enable teleport
-$ journalctl -fu teleport
+$ sudo teleport install systemd -o /etc/systemd/system/teleport.service
+$ sudo systemctl enable teleport
+$ sudo journalctl -fu teleport
 ```
 
 ## Log rotation support

--- a/docs/pages/includes/machine-id/daemon.mdx
+++ b/docs/pages/includes/machine-id/daemon.mdx
@@ -7,7 +7,7 @@ compatible with all common alternatives.
 Use `tbot install systemd` to generate a systemd service file:
 
 ```code
-$ tbot install systemd \
+$ sudo tbot install systemd \
    --write \
    --config /etc/tbot.yaml \
    --user teleport \


### PR DESCRIPTION
Includes `sudo` which matches with other examples of installing a systemd service.