### PR TITLE
[v17] Prevent unsanitized user input from affecting the PKINIT auth flow

### DIFF
--- a/lib/srv/db/common/kerberos/client_test.go
+++ b/lib/srv/db/common/kerberos/client_test.go
@@ -46,8 +46,29 @@ type staticCache struct {
 	pass bool
 }
 
+func getCachePath(t *testing.T, args ...string) string {
+	if len(args) != 8 {
+		t.Fatalf("Unexpected args (%v): %v", len(args), args)
+	}
+	// example arguments:
+	// [-X X509_anchors=FILE:/tmp/kinit3779395068/userca.pem -X X509_user_identity=FILE:/tmp/kinit3779395068/cert.pem,/tmp/kinit3779395068/key.pem -c /tmp/kinit3779395068/krb5.cache -- alice]
+	if args[0] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[0], args)
+	}
+	if args[2] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[2], args)
+	}
+	if args[4] != "-c" {
+		t.Fatalf("Unexpected args (%v): %v", args[4], args)
+	}
+	if args[6] != "--" {
+		t.Fatalf("Unexpected args (%v): %v", args[6], args)
+	}
+	return args[5]
+}
+
 func (s *staticCache) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	cachePath := args[len(args)-1]
+	cachePath := getCachePath(s.t, args...)
 	require.NotEmpty(s.t, cachePath)
 	err := os.WriteFile(cachePath, cacheData, 0664)
 	require.NoError(s.t, err)
@@ -131,7 +152,7 @@ func TestConnectorKInitClient(t *testing.T) {
 
 	dir := t.TempDir()
 
-	provider := newClientProvider(&mockAuth{}, dir)
+	provider := newClientProvider(&mockAuth{})
 	provider.kinitCommandGenerator = &staticCache{t: t, pass: true}
 
 	krbConfPath := filepath.Join(dir, "krb5.conf")

--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 
@@ -94,8 +95,6 @@ type CommandConfig struct {
 	KDCHost string
 	// AdminServer is the administration server hostname (usually AD server)
 	AdminServer string
-	// DataDir is the Teleport Data Directory
-	DataDir string
 	// LDAPCA is the Windows LDAP Certificate for client signing
 	LDAPCA *x509.Certificate
 	// LDAPCAPEM contains the same certificate as LDAPCA but in PEM format. It
@@ -114,13 +113,9 @@ func NewCommandLineInitializer(config CommandConfig) *CommandLineInitializer {
 	cmd := &CommandLineInitializer{
 		auth:               config.AuthClient,
 		userName:           config.User,
-		cacheName:          fmt.Sprintf("%s@%s", config.User, config.Realm),
 		RealmName:          config.Realm,
 		KDCHostName:        config.KDCHost,
 		AdminServerName:    config.AdminServer,
-		dataDir:            config.DataDir,
-		certPath:           fmt.Sprintf("%s.pem", config.User),
-		keyPath:            fmt.Sprintf("%s-key.pem", config.User),
 		binary:             kinitBinary,
 		command:            config.Command,
 		certGetter:         config.CertGetter,
@@ -160,13 +155,9 @@ type CommandLineInitializer struct {
 	// AdminServerName is the admin server Name (usually AD host)
 	AdminServerName string
 
-	dataDir   string
-	userName  string
-	cacheName string
+	userName string
 
-	certPath string
-	keyPath  string
-	binary   string
+	binary string
 
 	command    CommandGenerator
 	certGetter CertGetter
@@ -242,18 +233,10 @@ func (k *CommandLineInitializer) UseOrCreateCredentials(ctx context.Context) (*c
 		}
 	}()
 
-	certPath := filepath.Join(tmp, fmt.Sprintf("%s.pem", k.userName))
-	keyPath := filepath.Join(tmp, fmt.Sprintf("%s-key.pem", k.userName))
+	certPath := filepath.Join(tmp, "cert.pem")
+	keyPath := filepath.Join(tmp, "key.pem")
 	userCAPath := filepath.Join(tmp, "userca.pem")
-
-	cacheDir := filepath.Join(k.dataDir, "krb5_cache")
-
-	err = os.MkdirAll(cacheDir, os.ModePerm)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	cachePath := filepath.Join(cacheDir, k.cacheName)
+	cachePath := filepath.Join(tmp, "krb5.cache")
 
 	wca, err := k.certGetter.GetCertificateBytes(ctx)
 	if err != nil {
@@ -261,22 +244,22 @@ func (k *CommandLineInitializer) UseOrCreateCredentials(ctx context.Context) (*c
 	}
 
 	// store files in temp dir
-	err = os.WriteFile(certPath, wca.certPEM, 0644)
+	err = os.WriteFile(certPath, wca.certPEM, 0600)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	err = os.WriteFile(keyPath, wca.keyPEM, 0644)
+	err = os.WriteFile(keyPath, wca.keyPEM, 0600)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	err = os.WriteFile(userCAPath, k.buildAnchorsFileContents(wca.caCert), 0644)
+	err = os.WriteFile(userCAPath, k.buildAnchorsFileContents(wca.caCert), 0600)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	krbConfPath := filepath.Join(tmp, fmt.Sprintf("krb_%s", k.userName))
+	krbConfPath := filepath.Join(tmp, "krb5.conf")
 	err = k.WriteKRB5Config(krbConfPath)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -290,14 +273,18 @@ func (k *CommandLineInitializer) UseOrCreateCredentials(ctx context.Context) (*c
 	cmd := k.command.CommandContext(ctx,
 		k.binary,
 		"-X", fmt.Sprintf("X509_anchors=FILE:%s", userCAPath),
-		"-X", fmt.Sprintf("X509_user_identity=FILE:%s,%s", certPath, keyPath), k.userName,
-		"-c", cachePath)
-
+		"-X", fmt.Sprintf("X509_user_identity=FILE:%s,%s", certPath, keyPath),
+		"-c", cachePath,
+		"--", k.userName,
+	)
 	if cmd.Err != nil {
 		return nil, nil, trace.Wrap(cmd.Err)
 	}
 
 	cmd.Env = append(cmd.Env, []string{fmt.Sprintf("%s=%s", krb5ConfigEnv, krbConfPath)}...)
+
+	k.log.Debugf("Running command: %v %v %s", strings.Join(cmd.Env, " "), cmd.Path, strings.Join(cmd.Args, " "))
+
 	kinitOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		k.log.Errorf("Failed to authenticate with KDC: %s", kinitOutput)

--- a/lib/srv/db/common/kerberos/kinit/kinit_test.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit_test.go
@@ -43,8 +43,29 @@ type badCache struct {
 	t *testing.T
 }
 
+func getCachePath(t *testing.T, args ...string) string {
+	if len(args) != 8 {
+		t.Fatalf("Unexpected args (%v): %v", len(args), args)
+	}
+	// example arguments:
+	// [-X X509_anchors=FILE:/tmp/kinit3779395068/userca.pem -X X509_user_identity=FILE:/tmp/kinit3779395068/cert.pem,/tmp/kinit3779395068/key.pem -c /tmp/kinit3779395068/krb5.cache -- alice]
+	if args[0] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[0], args)
+	}
+	if args[2] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[2], args)
+	}
+	if args[4] != "-c" {
+		t.Fatalf("Unexpected args (%v): %v", args[4], args)
+	}
+	if args[6] != "--" {
+		t.Fatalf("Unexpected args (%v): %v", args[6], args)
+	}
+	return args[5]
+}
+
 func (b *badCache) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	cachePath := args[len(args)-1]
+	cachePath := getCachePath(b.t, args...)
 	require.NotEmpty(b.t, cachePath)
 	err := os.WriteFile(cachePath, badCacheData, 0664)
 	require.NoError(b.t, err)
@@ -53,7 +74,7 @@ func (b *badCache) CommandContext(ctx context.Context, name string, args ...stri
 }
 
 func (s *staticCache) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	cachePath := args[len(args)-1]
+	cachePath := getCachePath(s.t, args...)
 	require.NotEmpty(s.t, cachePath)
 	err := os.WriteFile(cachePath, cacheData, 0664)
 	require.NoError(s.t, err)
@@ -64,7 +85,6 @@ func (s *staticCache) CommandContext(ctx context.Context, name string, args ...s
 	cmd := exec.Command("")
 	cmd.Err = errors.New("bad command")
 	return cmd
-
 }
 
 type testCertGetter struct {
@@ -90,11 +110,6 @@ type testCase struct {
 func step(t *testing.T, name string, cg CommandGenerator, c *testCertGetter, expectErr require.ErrorAssertionFunc, expectNil require.ValueAssertionFunc) *testCase {
 	t.Helper()
 
-	dir := t.TempDir()
-	var err error
-	dir, err = os.MkdirTemp(dir, "krb5_cache")
-	require.NoError(t, err)
-
 	return &testCase{
 		name: name,
 		initializer: New(NewCommandLineInitializer(
@@ -103,7 +118,6 @@ func step(t *testing.T, name string, cg CommandGenerator, c *testCertGetter, exp
 				Realm:       "example.com",
 				KDCHost:     "host.example.com",
 				AdminServer: "host.example.com",
-				DataDir:     dir,
 				Command:     cg,
 				CertGetter:  c,
 			})),
@@ -183,7 +197,6 @@ func TestKRBConfString(t *testing.T) {
 			AdminServer: "host.example.com",
 			Command:     &staticCache{t: t, pass: true},
 			CertGetter:  &testCertGetter{pass: true},
-			DataDir:     t.TempDir(),
 		})
 
 	tmp := t.TempDir()

--- a/lib/srv/db/sqlserver/engine.go
+++ b/lib/srv/db/sqlserver/engine.go
@@ -42,7 +42,7 @@ func NewEngine(ec common.EngineConfig) common.Engine {
 		Connector: &connector{
 			DBAuth: ec.Auth,
 
-			kerberos: kerberos.NewClientProvider(ec.AuthClient, ec.DataDir),
+			kerberos: kerberos.NewClientProvider(ec.AuthClient),
 		},
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/55141 on `v17` branch.

Changelog: Fix the impact of malicious `--db-user` values on PKINIT flow.