### PR TITLE
[v16] Prevent unsanitized user input from affecting the PKINIT auth flow

### DIFF
--- a/lib/srv/db/sqlserver/auth.go
+++ b/lib/srv/db/sqlserver/auth.go
@@ -69,7 +69,7 @@ func (c *connector) keytabClient(session *common.Session) (*client.Client, error
 }
 
 // kinitClient returns a kerberos client using a kinit ccache
-func (c *connector) kinitClient(ctx context.Context, session *common.Session, auth windows.AuthInterface, dataDir string) (*client.Client, error) {
+func (c *connector) kinitClient(ctx context.Context, session *common.Session, auth windows.AuthInterface) (*client.Client, error) {
 	ldapPem, _ := pem.Decode([]byte(session.Database.GetAD().LDAPCert))
 
 	if ldapPem == nil {
@@ -98,7 +98,6 @@ func (c *connector) kinitClient(ctx context.Context, session *common.Session, au
 			Realm:       realmName,
 			KDCHost:     session.Database.GetAD().KDCHostName,
 			AdminServer: session.Database.GetAD().Domain,
-			DataDir:     dataDir,
 			LDAPCA:      cert,
 			LDAPCAPEM:   session.Database.GetAD().LDAPCert,
 			Command:     c.kinitCommandGenerator,

--- a/lib/srv/db/sqlserver/connect.go
+++ b/lib/srv/db/sqlserver/connect.go
@@ -58,8 +58,6 @@ type connector struct {
 	DBAuth common.Auth
 	// AuthClient is the teleport client
 	AuthClient windows.AuthInterface
-	// DataDir is the Teleport data directory
-	DataDir string
 
 	kinitCommandGenerator kinit.CommandGenerator
 }
@@ -75,7 +73,7 @@ func (c *connector) getKerberosClient(ctx context.Context, sessionCtx *common.Se
 		}
 		return kt, nil
 	case sessionCtx.Database.GetAD().KDCHostName != "" && sessionCtx.Database.GetAD().LDAPCert != "":
-		kt, err := c.kinitClient(ctx, sessionCtx, c.AuthClient, c.DataDir)
+		kt, err := c.kinitClient(ctx, sessionCtx, c.AuthClient)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/sqlserver/connect_test.go
+++ b/lib/srv/db/sqlserver/connect_test.go
@@ -154,8 +154,29 @@ type staticCache struct {
 	pass bool
 }
 
+func getCachePath(t *testing.T, args ...string) string {
+	if len(args) != 8 {
+		t.Fatalf("Unexpected args (%v): %v", len(args), args)
+	}
+	// example arguments:
+	// [-X X509_anchors=FILE:/tmp/kinit3779395068/userca.pem -X X509_user_identity=FILE:/tmp/kinit3779395068/cert.pem,/tmp/kinit3779395068/key.pem -c /tmp/kinit3779395068/krb5.cache -- alice]
+	if args[0] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[0], args)
+	}
+	if args[2] != "-X" {
+		t.Fatalf("Unexpected args (%v): %v", args[2], args)
+	}
+	if args[4] != "-c" {
+		t.Fatalf("Unexpected args (%v): %v", args[4], args)
+	}
+	if args[6] != "--" {
+		t.Fatalf("Unexpected args (%v): %v", args[6], args)
+	}
+	return args[5]
+}
+
 func (s *staticCache) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	cachePath := args[len(args)-1]
+	cachePath := getCachePath(s.t, args...)
 	require.NotEmpty(s.t, cachePath)
 	err := os.WriteFile(cachePath, cacheData, 0664)
 	require.NoError(s.t, err)
@@ -315,7 +336,6 @@ func TestConnectorKInitClient(t *testing.T) {
 
 			databaseUser := "alice"
 			databaseName := database.GetName()
-			connector.DataDir = dir
 
 			connectorCtx, cancel := context.WithCancel(ctx)
 			// we want to pass the canceled context

--- a/lib/srv/db/sqlserver/engine.go
+++ b/lib/srv/db/sqlserver/engine.go
@@ -41,7 +41,6 @@ func NewEngine(ec common.EngineConfig) common.Engine {
 		Connector: &connector{
 			DBAuth:     ec.Auth,
 			AuthClient: ec.AuthClient,
-			DataDir:    ec.DataDir,
 		},
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/55141 on `v16` branch.

Changelog: Fix the impact of malicious `--db-user` values on PKINIT flow.