### PR TITLE
Align SCIM plugin validation

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -754,14 +754,9 @@ func (c *PluginEntraIDSettings) Validate() error {
 }
 
 func (c *PluginSCIMSettings) CheckAndSetDefaults() error {
-	if c.DefaultRole == "" {
-		return trace.BadParameter("default_role must be set")
-	}
-
 	if c.SamlConnectorName == "" {
 		return trace.BadParameter("saml_connector_name must be set")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### What

Currently, the Plugin SCIM is not in use. The generic SCIM functionality requires that an Access List be created in advance, which will then be mapped to the SCIM group. Given this setup, the DefaultRole option does not appear to be applicable  in the generic SCIM flow.