### PR TITLE
Add tests for role v7/v8 around kubernetes rbac

### DIFF
--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -25,6 +25,7 @@ import (
 	"mime"
 	"net/http"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	restclientwatch "k8s.io/client-go/rest/watch"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1752,6 +1754,1214 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 	}
 }
 
+func TestV8JailedNamespaceListRBAC(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+
+	newTestUser := newTestUserFactory(t, testCtx, "", types.V8)
+
+	tests := []struct {
+		name string
+		user types.User
+		ns   string
+		want []string
+	}{
+		{
+			name: "full default access",
+			user: newTestUser(nil, nil),
+			ns:   "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "full wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "namespaced wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "^" + types.Wildcard + "$",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "clusterwide wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				// pods.
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "single wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// NOTE: Wildcard kind with namespace means no access to global resources.
+				// namespaces.
+				"default",
+			},
+		},
+		{
+			name: "wildcard single namespace access default",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+				{
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// namespaces.
+				"default",
+			},
+		},
+		{
+			name: "wildcard single namespace access dev",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "dev",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+				{
+					Kind:  "namespaces",
+					Name:  "dev",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "dev",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-2",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				// clusterroles.
+				// namespaces.
+				"dev",
+			},
+		},
+		{
+			name: "regular namespace all access by name",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespaces",
+					Name:  types.Wildcard,
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				// pods.
+				// clusterroles.
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "regular namespace all access by namespace",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      "namespaces",
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				// pods.
+				// clusterroles.
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "regular namespace single access by name default",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespaces",
+					Name:  "default",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				// pods.
+				// clusterroles.
+				// namespaces.
+				"default",
+			},
+		},
+		{
+			name: "regular namespace single access by name dev",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespaces",
+					Name:  "dev",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "dev",
+			want: []string{
+				// teleportroles.
+				// pods.
+				// clusterroles.
+				// namespaces.
+				"dev",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a kube dynClient with user certs for auth.
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+
+			// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
+			got := []string{}
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestV7JailedNamespaceListRBAC(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+
+	newTestUser := newTestUserFactory(t, testCtx, "", types.V7)
+
+	tests := []struct {
+		name string
+		user types.User
+		ns   string
+		want []string
+	}{
+		{
+			name: "full default access",
+			user: newTestUser(nil, nil),
+			ns:   "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "full wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "namespaced wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      "namespace",
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "single wildcard access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				"cr-nginx-1",
+				"cr-nginx-2",
+				"cr-test",
+				// namespaces.
+				"default",
+			},
+		},
+		{
+			name: "regular namespace all access by name",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  types.Wildcard,
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// namespaces.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "regular namespace single access by name default",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  "default",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "default",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-1",
+				"telerole-2",
+				"telerole-test",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				"test",
+				// clusterroles.
+				// namespaces.
+				"default",
+			},
+		},
+		{
+			name: "regular namespace single access by name dev",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  "dev",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			ns: "dev",
+			want: []string{
+				// teleportroles.
+				"telerole-1",
+				"telerole-2",
+				// pods.
+				"nginx-1",
+				"nginx-2",
+				// clusterroles.
+				// namespaces.
+				"dev",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a kube dynClient with user certs for auth.
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+
+			// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
+			got := []string{}
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Test role equivalence between v7 and v8.
+// Assert the same result from both roles.
+func TestV7V8Match(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+
+	// Create a factory to generate users in various role versions.
+	newV7TestUser := newTestUserFactory(t, testCtx, "v7v8", types.V7)
+	newV8TestUser := newTestUserFactory(t, testCtx, "v7v8", types.V8)
+
+	fullV7Access := []types.KubernetesResource{
+		{
+			Kind:      types.Wildcard,
+			Name:      types.Wildcard,
+			Namespace: types.Wildcard,
+			Verbs:     []string{types.Wildcard},
+		},
+	}
+
+	// Define the well-known state to test against.
+	fullV8Access := []types.KubernetesResource{
+		{
+			Kind:      types.Wildcard,
+			APIGroup:  types.Wildcard,
+			Name:      types.Wildcard,
+			Namespace: types.Wildcard,
+			Verbs:     []string{types.Wildcard},
+		},
+		{
+			Kind:      types.Wildcard,
+			APIGroup:  types.Wildcard,
+			Name:      types.Wildcard,
+			Namespace: "",
+			Verbs:     []string{types.Wildcard},
+		},
+	}
+
+	agg := func(in ...[]string) []string {
+		var out []string
+		for _, elem := range in {
+			out = append(out, elem...)
+		}
+		return out
+	}
+	nsDefault := []string{
+		// teleportroles.
+		"telerole-1",
+		"telerole-1",
+		"telerole-2",
+		"telerole-test",
+		// pods.
+		"nginx-1",
+		"nginx-2",
+		"test",
+	}
+	nsDev := []string{
+		// teleportroles.
+		"telerole-1",
+		"telerole-2",
+		// pods.
+		"nginx-1",
+		"nginx-2",
+	}
+	globals := []string{
+		// clusterroles.
+		"cr-nginx-1",
+		"cr-nginx-2",
+		"cr-test",
+	}
+	namespaces := []string{
+		// namespaces.
+		"default",
+		"test",
+		"dev",
+		"prod",
+	}
+	fullDefaultResult := agg(nsDefault, globals, namespaces)
+	fullDevResult := agg(nsDev, globals, namespaces)
+
+	tests := []struct {
+		name         string
+		user7, user8 types.User
+		ns           string
+		want         []string
+	}{
+		{
+			name:  "default role all",
+			user7: newV7TestUser(nil, nil),
+			user8: newV8TestUser(nil, nil),
+			ns:    "",
+			want:  agg(nsDefault, nsDev, globals, namespaces),
+		},
+		{
+			name:  "default role default",
+			user7: newV7TestUser(nil, nil),
+			user8: newV8TestUser(nil, nil),
+			ns:    "default",
+			want:  fullDefaultResult,
+		},
+		{
+			name:  "default role dev",
+			user7: newV7TestUser(nil, nil),
+			user8: newV8TestUser(nil, nil),
+			ns:    "dev",
+			want:  fullDevResult,
+		},
+		{
+			name:  "full access",
+			user7: newV7TestUser(fullV7Access, nil),
+			user8: newV8TestUser(fullV8Access, nil),
+			ns:    "default",
+			want:  fullDefaultResult,
+		},
+		{
+			name:  "no access all",
+			user7: newV7TestUser(fullV7Access, fullV7Access),
+			user8: newV8TestUser(fullV8Access, fullV8Access),
+			ns:    "",
+			want:  []string{},
+		},
+		{
+			name:  "no access default",
+			user7: newV7TestUser(fullV7Access, fullV7Access),
+			user8: newV8TestUser(fullV8Access, fullV8Access),
+			ns:    "default",
+			want:  []string{},
+		},
+		{
+			name: "all namespaced resources all namespaces all",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  types.Wildcard,
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "^" + types.Wildcard + "$",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "",
+			want: agg(nsDefault, nsDev, namespaces),
+		},
+		{
+			name: "all namespaced resources all namespaces default",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  types.Wildcard,
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "^" + types.Wildcard + "$",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "default",
+			want: agg(nsDefault, namespaces),
+		},
+		{
+			name: "all namespaced resources all namespaces dev",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  types.Wildcard,
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "^" + types.Wildcard + "$",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "dev",
+			want: agg(nsDev, namespaces),
+		},
+		{
+			name: "all namespaced resources single namespaces default",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  "default",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "default",
+			want: agg(nsDefault, []string{"default"}),
+		},
+		{
+			name: "all namespaced resources single namespaces dev",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:  "namespace",
+					Name:  "dev",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "dev",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "dev",
+			want: agg(nsDev, []string{"dev"}),
+		},
+		{
+			name: "wildcard kind all namespaces default",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      "*test*",
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      "*test*",
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "default",
+			want: agg([]string{"cr-test", "telerole-test", "test"}, namespaces),
+		},
+		{
+			name: "wildcard kind all namespaces dev",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      "*test*",
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      "*test*",
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			ns:   "dev",
+			want: agg([]string{"cr-test"}, namespaces),
+		},
+		{
+			name: "clusterwide access all",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "doest-not-exist",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, []types.KubernetesResource{
+				{
+					Kind:      "namespaces",
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}),
+			ns:   "",
+			want: agg(globals),
+		},
+		{
+			name: "clusterwide access dev",
+			user7: newV7TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "doest-not-exist",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, nil),
+			user8: newV8TestUser([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					APIGroup:  types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "",
+					Verbs:     []string{types.Wildcard},
+				},
+			}, []types.KubernetesResource{
+				{
+					Kind:      "namespaces",
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}),
+			ns:   "dev",
+			want: agg(globals),
+		},
+	}
+	for _, tt := range tests {
+		sort.Strings(tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			run := func(t *testing.T, userName string) {
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, userName, kubeCluster)
+
+				// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
+				got := []string{}
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/pods")).Namespace(tt.ns))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("rbac.authorization.k8s.io/v1/clusterroles")))...)
+				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+				sort.Strings(got)
+				require.Equal(t, tt.want, got)
+			}
+
+			t.Run("v7", func(t *testing.T) { run(t, tt.user7.GetName()) })
+			t.Run("v8", func(t *testing.T) { run(t, tt.user8.GetName()) })
+		})
+	}
+}
+
+func TestNamespaceListRBAC(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+
+	newTestUser := newTestUserFactory(t, testCtx, "nslist", types.V8)
+
+	commonResources := []types.KubernetesResource{
+		{
+			Kind:      "teleportroles",
+			Name:      types.Wildcard,
+			Namespace: "test",
+			Verbs:     []string{types.Wildcard},
+			APIGroup:  "resources.teleport.dev",
+		},
+		{
+			Kind:     "clusterroles",
+			Name:     types.Wildcard,
+			Verbs:    []string{types.Wildcard},
+			APIGroup: types.Wildcard,
+		},
+		{
+			Kind:      "pods",
+			Name:      types.Wildcard,
+			Namespace: "pr*",
+			Verbs:     []string{types.Wildcard},
+			APIGroup:  "",
+		},
+	}
+
+	tests := []struct {
+		name string
+		user types.User
+		want []string
+	}{
+		{
+			name: "common resources",
+			user: newTestUser(commonResources, nil),
+			want: []string{
+				"test",
+				"prod",
+			},
+		},
+		{
+			name: "common resources with deny",
+			user: newTestUser(commonResources, []types.KubernetesResource{
+				{
+					Kind:      "teleportroles",
+					Name:      types.Wildcard,
+					Namespace: "dev",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  "resources.teleport.dev",
+				},
+				{
+					Kind:      "pods",
+					Name:      types.Wildcard,
+					Namespace: "prod",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  "",
+				},
+			}),
+			want: []string{
+				"test",
+				"prod",
+			},
+		},
+		{
+			name: "full wildcard access",
+			user: newTestUser(append(commonResources, types.KubernetesResource{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			}), nil),
+			want: []string{
+				// All namespaces because of the wildcard.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "single wildcard access",
+			user: newTestUser(append(commonResources, types.KubernetesResource{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: "dev",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			}), nil),
+			want: []string{
+				//  test and prod from common resources, dev from main one.
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "reg ns access",
+			user: newTestUser(append(commonResources, types.KubernetesResource{
+				Kind:  "namespaces",
+				Name:  "dev",
+				Verbs: []string{types.Wildcard},
+			}), nil),
+			want: []string{
+				//  test and prod from common resources, dev from main one.
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "ns wildcard access",
+			user: newTestUser(append(commonResources, types.KubernetesResource{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: types.Wildcard,
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			}), nil),
+			want: []string{
+				// All namespaces because of the wildcard.
+				"default",
+				"test",
+				"dev",
+				"prod",
+			},
+		},
+		{
+			name: "wildcard ns single access",
+			user: newTestUser(append(commonResources, types.KubernetesResource{
+				Kind:      types.Wildcard,
+				Name:      types.Wildcard,
+				Namespace: "test",
+				Verbs:     []string{types.Wildcard},
+				APIGroup:  types.Wildcard,
+			}), nil),
+			want: []string{
+				// test and prod from the common resources, test from main one.
+				"test",
+				"prod",
+			},
+		},
+		{
+			name: "jailed and reg ns single access",
+			user: newTestUser([]types.KubernetesResource{
+				{
+					Kind:     "namespaces",
+					Name:     "default",
+					Verbs:    []string{types.Wildcard},
+					APIGroup: types.Wildcard,
+				},
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "test",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+				{
+					Kind:      "pods",
+					Name:      types.Wildcard,
+					Namespace: "dev",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			want: []string{
+				"default",
+				"test",
+				"dev",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a kube dynClient with user certs for auth.
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+
+			got := []string{}
+			got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, tkm.WithTeleportRoleCRD)
+
+	newTestUser := newTestUserFactory(t, testCtx, "fullnsnodelete", types.V8)
+
+	tests := []struct {
+		name string
+		user types.User
+		ns   string
+	}{
+		{
+			name: "wildcard access",
+			user: newTestUser(
+				[]types.KubernetesResource{
+					{
+						Kind:      types.Wildcard,
+						Name:      types.Wildcard,
+						Namespace: "dev",
+						Verbs:     []string{types.Wildcard},
+						APIGroup:  types.Wildcard,
+					},
+				},
+				[]types.KubernetesResource{
+					{
+						Kind:  "namespaces",
+						Name:  "dev",
+						Verbs: []string{"delete"},
+					},
+				},
+			),
+			ns: "dev",
+		},
+		{
+			name: "wildcard ns access",
+			user: newTestUser(
+				[]types.KubernetesResource{
+					{
+						Kind:      types.Wildcard,
+						Name:      types.Wildcard,
+						Namespace: "dev",
+						Verbs:     []string{types.Wildcard},
+						APIGroup:  types.Wildcard,
+					},
+					{
+						Kind:  "namespaces",
+						Name:  "dev",
+						Verbs: []string{types.Wildcard},
+					},
+				},
+				[]types.KubernetesResource{
+					{
+						Kind:  "namespaces",
+						Name:  "dev",
+						Verbs: []string{"delete"},
+					},
+				},
+			),
+			ns: "dev",
+		},
+		{
+			name: "regular access",
+			user: newTestUser(
+				[]types.KubernetesResource{
+					{
+						Kind:      "pods",
+						Name:      types.Wildcard,
+						Namespace: "dev",
+						Verbs:     []string{types.Wildcard},
+					},
+					{
+						Kind:      "secrets",
+						Name:      types.Wildcard,
+						Namespace: "dev",
+						Verbs:     []string{types.Wildcard},
+					},
+					{
+						Kind:      "namespaces",
+						Name:      types.Wildcard,
+						Namespace: "dev",
+						Verbs:     []string{types.Wildcard},
+					},
+				},
+				[]types.KubernetesResource{
+					{
+						Kind:  "namespaces",
+						Name:  "dev",
+						Verbs: []string{"delete"},
+					},
+				},
+			),
+			ns: "dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a kube dynClient with user certs for auth.
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+
+			require.NoError(t, dynClient.Resource(gvr("v1/pods")).DeleteCollection(testCtx.Context, metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.NoError(t, dynClient.Resource(gvr("v1/secrets")).DeleteCollection(testCtx.Context, metav1.DeleteOptions{}, metav1.ListOptions{}))
+			require.Error(t, dynClient.Resource(gvr("v1/namespaces")).Delete(testCtx.Context, tt.ns, metav1.DeleteOptions{}))
+		})
+	}
+}
+
 func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *TestContext) {
 	t.Helper()
 
@@ -1779,6 +2989,68 @@ func newTestKubeCRDMock(t *testing.T, opts ...tkm.Option) (*runtime.Scheme, *Tes
 	t.Cleanup(func() { assert.NoError(t, testCtx.Close()) })
 
 	return kubeScheme, testCtx
+}
+
+func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion string) func(allow, deny []types.KubernetesResource) types.User {
+	count := 0
+	if prefix == "" {
+		prefix = "test"
+	}
+	return func(allow, deny []types.KubernetesResource) types.User {
+		t.Helper()
+		count++
+		name := fmt.Sprintf("%s-user-%s-%d", prefix, roleVersion, count)
+		user, _ := testCtx.CreateUserAndRoleVersion(
+			testCtx.Context,
+			t,
+			name,
+			roleVersion,
+			RoleSpec{
+				Name:       name,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, allow)
+					r.SetKubeResources(types.Deny, deny)
+				},
+			},
+		)
+		return user
+	}
+}
+
+func unstructuredListNames(items *unstructured.UnstructuredList) []string {
+	if items == nil {
+		return nil
+	}
+	names := make([]string, 0, len(items.Items))
+	for _, item := range items.Items {
+		names = append(names, item.GetName())
+	}
+	return names
+}
+
+func gvr(in string) schema.GroupVersionResource {
+	pars := strings.Split(in, "/")
+	if len(pars) == 2 {
+		return schema.GroupVersionResource{
+			Group:    "",
+			Version:  pars[0],
+			Resource: pars[1],
+		}
+	}
+	return schema.GroupVersionResource{
+		Group:    pars[0],
+		Version:  pars[1],
+		Resource: pars[2],
+	}
+}
+
+// dynList fetches the list for the given resource. Returns the names of the found resources.
+// Ignores the error if any.
+func dynList(ctx context.Context, r dynamic.ResourceInterface) []string {
+	roles, _ := r.List(ctx, metav1.ListOptions{})
+	return unstructuredListNames(roles)
 }
 
 // Test cases:


### PR DESCRIPTION
Add tests for #54938, split off to avoid triggering the large PR bot. While not complex, the tests are a bit verbose and have many lines.
The vast majority of the content being like

```
					{
						Kind:      types.Wildcard,
						Name:      types.Wildcard,
						Namespace: "dev",
						Verbs:     []string{types.Wildcard},
						APIGroup:  types.Wildcard,
					},
```