### PR TITLE
Set the agent count when reconciling time-based rollouts

### DIFF
--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -660,7 +660,7 @@ func (s *Service) DeleteAutoUpdateAgentRollout(ctx context.Context, req *autoupd
 }
 
 func (s *Service) getAllReports(ctx context.Context) ([]*autoupdate.AutoUpdateAgentReport, error) {
-	reports := make([]*autoupdate.AutoUpdateAgentReport, 0)
+	var reports []*autoupdate.AutoUpdateAgentReport
 
 	// this is an in-memory client, we go for the default page size
 	const pageSize = 0

--- a/lib/autoupdate/rollout/controller.go
+++ b/lib/autoupdate/rollout/controller.go
@@ -77,7 +77,7 @@ func NewController(client Client, log *slog.Logger, clock clockwork.Clock, perio
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to initialize halt-on-error strategy")
 	}
-	timeBased, err := newTimeBasedStrategy(log)
+	timeBased, err := newTimeBasedStrategy(log, client)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to initialize time-based strategy")
 	}

--- a/lib/autoupdate/rollout/strategy_haltonerror.go
+++ b/lib/autoupdate/rollout/strategy_haltonerror.go
@@ -215,9 +215,9 @@ func countUpToDate(
 	for _, report := range reports {
 		for group, groupCount := range report.GetSpec().GetGroups() {
 			for version, versionCount := range groupCount.GetVersions() {
-				countByGroup[group] = countByGroup[group] + int(versionCount.GetCount())
+				countByGroup[group] += int(versionCount.GetCount())
 				if version == targetVersion {
-					upToDateByGroup[group] = upToDateByGroup[group] + int(versionCount.GetCount())
+					upToDateByGroup[group] += int(versionCount.GetCount())
 				}
 			}
 		}
@@ -234,7 +234,7 @@ func countCatchAll(rolloutStatus *autoupdate.AutoUpdateAgentRolloutStatus, count
 		return 0, 0
 	}
 
-	rolloutGroups := make([]string, 0, len(rolloutStatus.GetGroups()))
+	rolloutGroups := make([]string, 0, len(rolloutStatus.GetGroups())-1)
 	// We don't count the last group as it is the default one
 	for _, group := range rolloutStatus.GetGroups()[:len(rolloutStatus.GetGroups())-1] {
 		rolloutGroups = append(rolloutGroups, group.GetName())


### PR DESCRIPTION
This PR makes the time-based strategy count agents and report the result in the rollout, like halt-on-error does.

Depends on: https://github.com/gravitational/teleport/pull/55116
Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)
Goal (internal): https://github.com/gravitational/cloud/issues/11856