### PR TITLE
Use the correct label for new cache metrics

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -521,9 +521,9 @@ func (c *Cache) setInitError(err error) {
 	})
 
 	if err == nil {
-		cacheHealth.WithLabelValues(c.Component).Set(1.0)
+		cacheHealth.WithLabelValues(c.target).Set(1.0)
 	} else {
-		cacheHealth.WithLabelValues(c.Component).Set(0.0)
+		cacheHealth.WithLabelValues(c.target).Set(0.0)
 	}
 }
 
@@ -1098,7 +1098,7 @@ func (c *Cache) notify(ctx context.Context, event Event) {
 //	we assume that this cache will eventually end up in a correct state
 //	potentially lagging behind the state of the database.
 func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry, timer *time.Timer) error {
-	cacheLastReset.WithLabelValues(c.Component).SetToCurrentTime()
+	cacheLastReset.WithLabelValues(c.target).SetToCurrentTime()
 	requestKinds := c.Config.Watches
 	watcher, err := c.Events.NewWatcher(c.ctx, types.Watch{
 		Name:                c.Component,


### PR DESCRIPTION
The new cache metrics `teleport_cache_health` and `teleport_cache_last_reset_seconds` and added in #54776 are using a label for `cache_component` of the form `auth:1:cache`, matching the label used for logging rather than the one used for the previously existing metrics. This PR changes the label to use `c.target` to match the other two cache metrics.