### PR TITLE
[vnet] feat: forward SSH connections to target

### DIFF
--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -1773,6 +1773,258 @@ func (x *SignForUserTLSResponse) GetSignature() []byte {
 	return nil
 }
 
+// SessionSSHConfigRequest is a request for SessionSSHConfig.
+type SessionSSHConfigRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Profile is the profile in which the SSH server is found.
+	Profile string `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	// RootCluster is the cluster in which the SSH server is found.
+	RootCluster string `protobuf:"bytes,2,opt,name=root_cluster,json=rootCluster,proto3" json:"root_cluster,omitempty"`
+	// LeafCluster is the leaf cluster in which the SSH server is found.
+	// If empty, the SSH server is in the root cluster.
+	LeafCluster string `protobuf:"bytes,3,opt,name=leaf_cluster,json=leafCluster,proto3" json:"leaf_cluster,omitempty"`
+	// Address is the address of the SSH server.
+	Address string `protobuf:"bytes,4,opt,name=address,proto3" json:"address,omitempty"`
+	// User is the SSH user the session is for.
+	User          string `protobuf:"bytes,5,opt,name=user,proto3" json:"user,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionSSHConfigRequest) Reset() {
+	*x = SessionSSHConfigRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionSSHConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionSSHConfigRequest) ProtoMessage() {}
+
+func (x *SessionSSHConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionSSHConfigRequest.ProtoReflect.Descriptor instead.
+func (*SessionSSHConfigRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *SessionSSHConfigRequest) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
+func (x *SessionSSHConfigRequest) GetRootCluster() string {
+	if x != nil {
+		return x.RootCluster
+	}
+	return ""
+}
+
+func (x *SessionSSHConfigRequest) GetLeafCluster() string {
+	if x != nil {
+		return x.LeafCluster
+	}
+	return ""
+}
+
+func (x *SessionSSHConfigRequest) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *SessionSSHConfigRequest) GetUser() string {
+	if x != nil {
+		return x.User
+	}
+	return ""
+}
+
+// SessionSSHConfigResponse is a response for SessionSSHConfig.
+type SessionSSHConfigResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SessionId is an opaque identifier for the session, it should be passed to
+	// SignForSSHSession to issue signatures with the private key associated with
+	// the session.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Cert is the session SSH certificate in SSH wire format.
+	Cert []byte `protobuf:"bytes,2,opt,name=cert,proto3" json:"cert,omitempty"`
+	// TrustedCas is a list of trusted SSH certificate authorities in SSH wire
+	// format.
+	TrustedCas    [][]byte `protobuf:"bytes,3,rep,name=trusted_cas,json=trustedCas,proto3" json:"trusted_cas,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionSSHConfigResponse) Reset() {
+	*x = SessionSSHConfigResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionSSHConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionSSHConfigResponse) ProtoMessage() {}
+
+func (x *SessionSSHConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionSSHConfigResponse.ProtoReflect.Descriptor instead.
+func (*SessionSSHConfigResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *SessionSSHConfigResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *SessionSSHConfigResponse) GetCert() []byte {
+	if x != nil {
+		return x.Cert
+	}
+	return nil
+}
+
+func (x *SessionSSHConfigResponse) GetTrustedCas() [][]byte {
+	if x != nil {
+		return x.TrustedCas
+	}
+	return nil
+}
+
+// SignForSSHSessionRequest is a request for SignForSSHSession.
+type SignForSSHSessionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SessionId is an opaque identifier for the session returned from a previous
+	// call to SessionSSHConfig.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Sign holds signature request details.
+	Sign          *SignRequest `protobuf:"bytes,2,opt,name=sign,proto3" json:"sign,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForSSHSessionRequest) Reset() {
+	*x = SignForSSHSessionRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForSSHSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForSSHSessionRequest) ProtoMessage() {}
+
+func (x *SignForSSHSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForSSHSessionRequest.ProtoReflect.Descriptor instead.
+func (*SignForSSHSessionRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *SignForSSHSessionRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *SignForSSHSessionRequest) GetSign() *SignRequest {
+	if x != nil {
+		return x.Sign
+	}
+	return nil
+}
+
+// SignForSSHSessionResponse is a response for SignForSSHSession.
+type SignForSSHSessionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Signature is the signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignForSSHSessionResponse) Reset() {
+	*x = SignForSSHSessionResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignForSSHSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignForSSHSessionResponse) ProtoMessage() {}
+
+func (x *SignForSSHSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignForSSHSessionResponse.ProtoReflect.Descriptor instead.
+func (*SignForSSHSessionResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *SignForSSHSessionResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 var File_teleport_lib_vnet_v1_client_application_service_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
@@ -1865,11 +2117,29 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\aprofile\x18\x01 \x01(\tR\aprofile\x125\n" +
 	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"6\n" +
 	"\x16SignForUserTLSResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"\xa7\x01\n" +
+	"\x17SessionSSHConfigRequest\x12\x18\n" +
+	"\aprofile\x18\x01 \x01(\tR\aprofile\x12!\n" +
+	"\froot_cluster\x18\x02 \x01(\tR\vrootCluster\x12!\n" +
+	"\fleaf_cluster\x18\x03 \x01(\tR\vleafCluster\x12\x18\n" +
+	"\aaddress\x18\x04 \x01(\tR\aaddress\x12\x12\n" +
+	"\x04user\x18\x05 \x01(\tR\x04user\"n\n" +
+	"\x18SessionSSHConfigResponse\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
+	"\x04cert\x18\x02 \x01(\fR\x04cert\x12\x1f\n" +
+	"\vtrusted_cas\x18\x03 \x03(\fR\n" +
+	"trustedCas\"p\n" +
+	"\x18SignForSSHSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x125\n" +
+	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"9\n" +
+	"\x19SignForSSHSessionResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\fR\tsignature*<\n" +
 	"\x04Hash\x12\x14\n" +
 	"\x10HASH_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tHASH_NONE\x10\x01\x12\x0f\n" +
-	"\vHASH_SHA256\x10\x022\xe3\t\n" +
+	"\vHASH_SHA256\x10\x022\xcc\v\n" +
 	"\x18ClientApplicationService\x12z\n" +
 	"\x13AuthenticateProcess\x120.teleport.lib.vnet.v1.AuthenticateProcessRequest\x1a1.teleport.lib.vnet.v1.AuthenticateProcessResponse\x12\x83\x01\n" +
 	"\x16ReportNetworkStackInfo\x123.teleport.lib.vnet.v1.ReportNetworkStackInfoRequest\x1a4.teleport.lib.vnet.v1.ReportNetworkStackInfoResponse\x12M\n" +
@@ -1882,7 +2152,9 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\x12OnInvalidLocalPort\x12/.teleport.lib.vnet.v1.OnInvalidLocalPortRequest\x1a0.teleport.lib.vnet.v1.OnInvalidLocalPortResponse\x12\x89\x01\n" +
 	"\x18GetTargetOSConfiguration\x125.teleport.lib.vnet.v1.GetTargetOSConfigurationRequest\x1a6.teleport.lib.vnet.v1.GetTargetOSConfigurationResponse\x12b\n" +
 	"\vUserTLSCert\x12(.teleport.lib.vnet.v1.UserTLSCertRequest\x1a).teleport.lib.vnet.v1.UserTLSCertResponse\x12k\n" +
-	"\x0eSignForUserTLS\x12+.teleport.lib.vnet.v1.SignForUserTLSRequest\x1a,.teleport.lib.vnet.v1.SignForUserTLSResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
+	"\x0eSignForUserTLS\x12+.teleport.lib.vnet.v1.SignForUserTLSRequest\x1a,.teleport.lib.vnet.v1.SignForUserTLSResponse\x12q\n" +
+	"\x10SessionSSHConfig\x12-.teleport.lib.vnet.v1.SessionSSHConfigRequest\x1a..teleport.lib.vnet.v1.SessionSSHConfigResponse\x12t\n" +
+	"\x11SignForSSHSession\x12..teleport.lib.vnet.v1.SignForSSHSessionRequest\x1a/.teleport.lib.vnet.v1.SignForSSHSessionResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
 
 var (
 	file_teleport_lib_vnet_v1_client_application_service_proto_rawDescOnce sync.Once
@@ -1897,7 +2169,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP() []
 }
 
 var file_teleport_lib_vnet_v1_client_application_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(Hash)(0),                                // 0: teleport.lib.vnet.v1.Hash
 	(*AuthenticateProcessRequest)(nil),       // 1: teleport.lib.vnet.v1.AuthenticateProcessRequest
@@ -1931,7 +2203,11 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(*UserTLSCertResponse)(nil),              // 29: teleport.lib.vnet.v1.UserTLSCertResponse
 	(*SignForUserTLSRequest)(nil),            // 30: teleport.lib.vnet.v1.SignForUserTLSRequest
 	(*SignForUserTLSResponse)(nil),           // 31: teleport.lib.vnet.v1.SignForUserTLSResponse
-	(*types.AppV3)(nil),                      // 32: types.AppV3
+	(*SessionSSHConfigRequest)(nil),          // 32: teleport.lib.vnet.v1.SessionSSHConfigRequest
+	(*SessionSSHConfigResponse)(nil),         // 33: teleport.lib.vnet.v1.SessionSSHConfigResponse
+	(*SignForSSHSessionRequest)(nil),         // 34: teleport.lib.vnet.v1.SignForSSHSessionRequest
+	(*SignForSSHSessionResponse)(nil),        // 35: teleport.lib.vnet.v1.SignForSSHSessionResponse
+	(*types.AppV3)(nil),                      // 36: types.AppV3
 }
 var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32{
 	4,  // 0: teleport.lib.vnet.v1.ReportNetworkStackInfoRequest.network_stack_info:type_name -> teleport.lib.vnet.v1.NetworkStackInfo
@@ -1940,7 +2216,7 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32
 	12, // 3: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_cluster:type_name -> teleport.lib.vnet.v1.MatchedCluster
 	13, // 4: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 5: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	32, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
+	36, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
 	15, // 7: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
 	13, // 8: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 9: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
@@ -1951,33 +2227,38 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32
 	27, // 14: teleport.lib.vnet.v1.GetTargetOSConfigurationResponse.target_os_configuration:type_name -> teleport.lib.vnet.v1.TargetOSConfiguration
 	15, // 15: teleport.lib.vnet.v1.UserTLSCertResponse.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
 	19, // 16: teleport.lib.vnet.v1.SignForUserTLSRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
-	1,  // 17: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
-	3,  // 18: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
-	6,  // 19: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
-	8,  // 20: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
-	16, // 21: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
-	18, // 22: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
-	21, // 23: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
-	23, // 24: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
-	25, // 25: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
-	28, // 26: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:input_type -> teleport.lib.vnet.v1.UserTLSCertRequest
-	30, // 27: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
-	2,  // 28: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
-	5,  // 29: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
-	7,  // 30: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
-	9,  // 31: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
-	17, // 32: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
-	20, // 33: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
-	22, // 34: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
-	24, // 35: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	26, // 36: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	29, // 37: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
-	31, // 38: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
-	28, // [28:39] is the sub-list for method output_type
-	17, // [17:28] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	19, // 17: teleport.lib.vnet.v1.SignForSSHSessionRequest.sign:type_name -> teleport.lib.vnet.v1.SignRequest
+	1,  // 18: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:input_type -> teleport.lib.vnet.v1.AuthenticateProcessRequest
+	3,  // 19: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:input_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoRequest
+	6,  // 20: teleport.lib.vnet.v1.ClientApplicationService.Ping:input_type -> teleport.lib.vnet.v1.PingRequest
+	8,  // 21: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:input_type -> teleport.lib.vnet.v1.ResolveFQDNRequest
+	16, // 22: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:input_type -> teleport.lib.vnet.v1.ReissueAppCertRequest
+	18, // 23: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:input_type -> teleport.lib.vnet.v1.SignForAppRequest
+	21, // 24: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:input_type -> teleport.lib.vnet.v1.OnNewConnectionRequest
+	23, // 25: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:input_type -> teleport.lib.vnet.v1.OnInvalidLocalPortRequest
+	25, // 26: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:input_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationRequest
+	28, // 27: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:input_type -> teleport.lib.vnet.v1.UserTLSCertRequest
+	30, // 28: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
+	32, // 29: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:input_type -> teleport.lib.vnet.v1.SessionSSHConfigRequest
+	34, // 30: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:input_type -> teleport.lib.vnet.v1.SignForSSHSessionRequest
+	2,  // 31: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
+	5,  // 32: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
+	7,  // 33: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
+	9,  // 34: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
+	17, // 35: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
+	20, // 36: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
+	22, // 37: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
+	24, // 38: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	26, // 39: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	29, // 40: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
+	31, // 41: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
+	33, // 42: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:output_type -> teleport.lib.vnet.v1.SessionSSHConfigResponse
+	35, // 43: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:output_type -> teleport.lib.vnet.v1.SignForSSHSessionResponse
+	31, // [31:44] is the sub-list for method output_type
+	18, // [18:31] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_v1_client_application_service_proto_init() }
@@ -1997,7 +2278,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc), len(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   31,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
@@ -46,6 +46,8 @@ const (
 	ClientApplicationService_GetTargetOSConfiguration_FullMethodName = "/teleport.lib.vnet.v1.ClientApplicationService/GetTargetOSConfiguration"
 	ClientApplicationService_UserTLSCert_FullMethodName              = "/teleport.lib.vnet.v1.ClientApplicationService/UserTLSCert"
 	ClientApplicationService_SignForUserTLS_FullMethodName           = "/teleport.lib.vnet.v1.ClientApplicationService/SignForUserTLS"
+	ClientApplicationService_SessionSSHConfig_FullMethodName         = "/teleport.lib.vnet.v1.ClientApplicationService/SessionSSHConfig"
+	ClientApplicationService_SignForSSHSession_FullMethodName        = "/teleport.lib.vnet.v1.ClientApplicationService/SignForSSHSession"
 )
 
 // ClientApplicationServiceClient is the client API for ClientApplicationService service.
@@ -87,6 +89,11 @@ type ClientApplicationServiceClient interface {
 	UserTLSCert(ctx context.Context, in *UserTLSCertRequest, opts ...grpc.CallOption) (*UserTLSCertResponse, error)
 	// SignForUserTLS signs a digest with the user TLS private key.
 	SignForUserTLS(ctx context.Context, in *SignForUserTLSRequest, opts ...grpc.CallOption) (*SignForUserTLSResponse, error)
+	// SessionSSHConfig returns the user SSH configuration for an SSH session.
+	SessionSSHConfig(ctx context.Context, in *SessionSSHConfigRequest, opts ...grpc.CallOption) (*SessionSSHConfigResponse, error)
+	// SignForSSHSession signs a digest with the SSH private key associated with the
+	// session from a previous call to SessionSSHConfig.
+	SignForSSHSession(ctx context.Context, in *SignForSSHSessionRequest, opts ...grpc.CallOption) (*SignForSSHSessionResponse, error)
 }
 
 type clientApplicationServiceClient struct {
@@ -207,6 +214,26 @@ func (c *clientApplicationServiceClient) SignForUserTLS(ctx context.Context, in 
 	return out, nil
 }
 
+func (c *clientApplicationServiceClient) SessionSSHConfig(ctx context.Context, in *SessionSSHConfigRequest, opts ...grpc.CallOption) (*SessionSSHConfigResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SessionSSHConfigResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_SessionSSHConfig_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clientApplicationServiceClient) SignForSSHSession(ctx context.Context, in *SignForSSHSessionRequest, opts ...grpc.CallOption) (*SignForSSHSessionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignForSSHSessionResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_SignForSSHSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ClientApplicationServiceServer is the server API for ClientApplicationService service.
 // All implementations must embed UnimplementedClientApplicationServiceServer
 // for forward compatibility.
@@ -246,6 +273,11 @@ type ClientApplicationServiceServer interface {
 	UserTLSCert(context.Context, *UserTLSCertRequest) (*UserTLSCertResponse, error)
 	// SignForUserTLS signs a digest with the user TLS private key.
 	SignForUserTLS(context.Context, *SignForUserTLSRequest) (*SignForUserTLSResponse, error)
+	// SessionSSHConfig returns the user SSH configuration for an SSH session.
+	SessionSSHConfig(context.Context, *SessionSSHConfigRequest) (*SessionSSHConfigResponse, error)
+	// SignForSSHSession signs a digest with the SSH private key associated with the
+	// session from a previous call to SessionSSHConfig.
+	SignForSSHSession(context.Context, *SignForSSHSessionRequest) (*SignForSSHSessionResponse, error)
 	mustEmbedUnimplementedClientApplicationServiceServer()
 }
 
@@ -288,6 +320,12 @@ func (UnimplementedClientApplicationServiceServer) UserTLSCert(context.Context, 
 }
 func (UnimplementedClientApplicationServiceServer) SignForUserTLS(context.Context, *SignForUserTLSRequest) (*SignForUserTLSResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SignForUserTLS not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) SessionSSHConfig(context.Context, *SessionSSHConfigRequest) (*SessionSSHConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SessionSSHConfig not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) SignForSSHSession(context.Context, *SignForSSHSessionRequest) (*SignForSSHSessionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignForSSHSession not implemented")
 }
 func (UnimplementedClientApplicationServiceServer) mustEmbedUnimplementedClientApplicationServiceServer() {
 }
@@ -509,6 +547,42 @@ func _ClientApplicationService_SignForUserTLS_Handler(srv interface{}, ctx conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ClientApplicationService_SessionSSHConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SessionSSHConfigRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).SessionSSHConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_SessionSSHConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).SessionSSHConfig(ctx, req.(*SessionSSHConfigRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ClientApplicationService_SignForSSHSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignForSSHSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).SignForSSHSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_SignForSSHSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).SignForSSHSession(ctx, req.(*SignForSSHSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ClientApplicationService_ServiceDesc is the grpc.ServiceDesc for ClientApplicationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -559,6 +633,14 @@ var ClientApplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SignForUserTLS",
 			Handler:    _ClientApplicationService_SignForUserTLS_Handler,
+		},
+		{
+			MethodName: "SessionSSHConfig",
+			Handler:    _ClientApplicationService_SessionSSHConfig_Handler,
+		},
+		{
+			MethodName: "SignForSSHSession",
+			Handler:    _ClientApplicationService_SignForSSHSession_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -282,28 +282,66 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 		return sshConfig, nil
 	}
 
-	keyRing, err := c.tc.localAgent.GetKeyRing(target.Cluster, WithAllCerts...)
+	newKeyRing, completedMFA, err := c.SessionSSHKeyRing(ctx, user, target)
 	if err != nil {
-		return nil, trace.Wrap(MFARequiredUnknown(err))
+		return nil, trace.Wrap(err)
+	}
+	if !completedMFA {
+		// The caller relies on this function returning an error if
+		// target.MFACheck is nil and session MFA was not actually required.
+		return nil, trace.Wrap(services.ErrSessionMFANotRequired)
+	}
+
+	am, err := newKeyRing.AsAuthMethod()
+	if err != nil {
+		return nil, trace.Wrap(ceremonyFailedErr{err})
+	}
+
+	sshConfig.Auth = []ssh.AuthMethod{am}
+	return sshConfig, nil
+}
+
+// SessionSSHKeyRing returns a KeyRing valid for an SSH session to the target.
+// If per session MFA is required to establish the connection, then the MFA
+// ceremony will be performed. If per session MFA is not required, the user's
+// base KeyRing for the cluster will be returned.
+func (c *ClusterClient) SessionSSHKeyRing(ctx context.Context, user string, target NodeDetails) (keyRing *KeyRing, completedMFA bool, err error) {
+	ctx, span := c.Tracer.Start(
+		ctx,
+		"clusterClient/SessionSSHKeyRing",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			attribute.String("cluster", c.tc.SiteName),
+		),
+	)
+	defer span.End()
+
+	baseKeyRing, err := c.tc.localAgent.GetKeyRing(target.Cluster, WithSSHCerts{})
+	if err != nil {
+		return nil, false, trace.Wrap(MFARequiredUnknown(err))
+	}
+
+	if target.MFACheck != nil && !target.MFACheck.Required {
+		return baseKeyRing, false, nil
 	}
 
 	// Always connect to root for getting new credentials, but attempt to reuse
 	// the existing client if possible.
-	rootClusterName, err := keyRing.RootClusterName()
+	rootClusterName, err := baseKeyRing.RootClusterName()
 	if err != nil {
-		return nil, trace.Wrap(MFARequiredUnknown(err))
+		return nil, false, trace.Wrap(MFARequiredUnknown(err))
 	}
 
 	mfaClt := c
 	if target.Cluster != rootClusterName {
 		cfg, err := c.ProxyClient.ClientConfig(ctx, rootClusterName)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, false, trace.Wrap(err)
 		}
 
 		authClient, err := authclient.NewClient(cfg)
 		if err != nil {
-			return nil, trace.Wrap(MFARequiredUnknown(err))
+			return nil, false, trace.Wrap(MFARequiredUnknown(err))
 		}
 
 		mfaClt = &ClusterClient{
@@ -326,20 +364,19 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 			RouteToCluster: target.Cluster,
 			MFACheck:       target.MFACheck,
 		},
-		keyRing,
+		baseKeyRing.Copy(),
 	)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		if errors.Is(err, services.ErrSessionMFANotRequired) {
+			log.DebugContext(ctx, "Session MFA was not required, returning original KeyRing")
+			return baseKeyRing, false, nil
+		}
+		log.DebugContext(ctx, "Error performing session MFA ceremony", "error", err)
+		return nil, false, trace.Wrap(err)
 	}
 
 	log.DebugContext(ctx, "Issued single-use user certificate after an MFA check")
-	am, err := result.KeyRing.AsAuthMethod()
-	if err != nil {
-		return nil, trace.Wrap(ceremonyFailedErr{err})
-	}
-
-	sshConfig.Auth = []ssh.AuthMethod{am}
-	return sshConfig, nil
+	return result.KeyRing, true, nil
 }
 
 // prepareUserCertsRequest creates a [proto.UserCertsRequest] with the fields

--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -187,6 +187,31 @@ func (c *clientApplicationServiceClient) SignForUserTLS(ctx context.Context, req
 	return resp.GetSignature(), nil
 }
 
+// SessionSSHConfig returns user SSH configuration values for an SSH session.
+func (c *clientApplicationServiceClient) SessionSSHConfig(ctx context.Context, target dialTarget, user string) (*vnetv1.SessionSSHConfigResponse, error) {
+	resp, err := c.clt.SessionSSHConfig(ctx, &vnetv1.SessionSSHConfigRequest{
+		Profile:     target.profile,
+		RootCluster: target.rootCluster,
+		LeafCluster: target.leafCluster,
+		Address:     target.addr,
+		User:        user,
+	})
+	return resp, trace.Wrap(err, "calling SessionSSHConfig rpc")
+}
+
+// SignForSSHSession signs a digest with the SSH private key associated with the
+// session from a previous call to SessionSSHConfig.
+func (c *clientApplicationServiceClient) SignForSSHSession(ctx context.Context, sessionID string, sign *vnetv1.SignRequest) ([]byte, error) {
+	resp, err := c.clt.SignForSSHSession(ctx, &vnetv1.SignForSSHSessionRequest{
+		SessionId: sessionID,
+		Sign:      sign,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "calling SignForSSHSession rpc")
+	}
+	return resp.GetSignature(), nil
+}
+
 // rpcSigner implements [crypto.Signer] for signatures that are issued by the
 // client application over gRPC.
 type rpcSigner struct {

--- a/lib/vnet/ssh_proxy_test.go
+++ b/lib/vnet/ssh_proxy_test.go
@@ -103,6 +103,11 @@ func testSSHConnection(t *testing.T, dial dialer) {
 	sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, "localhost", clientConfig)
 	require.NoError(t, err)
 	defer sshConn.Close()
+
+	testConnectionToSshEchoServer(t, sshConn, chans, reqs)
+}
+
+func testConnectionToSshEchoServer(t *testing.T, sshConn ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) {
 	go ssh.DiscardRequests(reqs)
 	go func() {
 		for newChan := range chans {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -62,7 +62,9 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -277,11 +279,13 @@ func runTestClientApplicationService(t *testing.T, ctx context.Context, clock cl
 		clusterConfigCache: clusterConfigCache,
 		leafClusterCache:   leafClusterCache,
 	})
-	clientApplicationService := newClientApplicationService(&clientApplicationServiceConfig{
+	clientApplicationService, err := newClientApplicationService(&clientApplicationServiceConfig{
 		clientApplication:     clientApp,
 		fqdnResolver:          fqdnResolver,
 		localOSConfigProvider: nil, // OS configuration is not needed in tests.
+		clock:                 clock,
 	})
+	require.NoError(t, err)
 
 	ipcCredentials, err := newIPCCredentials()
 	require.NoError(t, err)
@@ -333,7 +337,9 @@ type appSpec struct {
 	tcpPorts   []*types.PortRange
 }
 
-type nodeSpec struct{}
+type nodeSpec struct {
+	denyAccess bool
+}
 
 type testClusterSpec struct {
 	apps           []appSpec
@@ -346,9 +352,15 @@ type testClusterSpec struct {
 type fakeClientApp struct {
 	cfg *fakeClientAppConfig
 
-	tlsCA       tls.Certificate
-	userTLSCert tls.Certificate
-	dialOpts    *vnetv1.DialOptions
+	tlsCA    tls.Certificate
+	dialOpts *vnetv1.DialOptions
+
+	userTLSCertMu      sync.Mutex
+	userTLSCert        tls.Certificate
+	userTLSCertExpires time.Time
+
+	teleportHostCA ssh.Signer
+	teleportUserCA ssh.Signer
 
 	onNewConnectionCallCount    atomic.Uint32
 	onInvalidLocalPortCallCount atomic.Uint32
@@ -368,20 +380,31 @@ type fakeClientAppConfig struct {
 // able to run with any implementation of [ClientApplication] and little to no
 // other configuration.
 func newFakeClientApp(ctx context.Context, t *testing.T, cfg *fakeClientAppConfig) *fakeClientApp {
-	tlsCA := newSelfSignedCA(t)
-	dialOpts := mustStartFakeWebProxy(ctx, t, tlsCA, cfg.clock, cfg.signatureAlgorithmSuite)
-	userTLSCert, err := newClientCert(ctx,
-		tlsCA,
-		"testuser",
-		cfg.clock.Now().Add(defaults.CertDuration),
-		cfg.signatureAlgorithmSuite,
-		cryptosuites.UserTLS)
+	teleportHostCAKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
 	require.NoError(t, err)
+	teleportHostCA, err := ssh.NewSignerFromSigner(teleportHostCAKey)
+	require.NoError(t, err)
+
+	teleportUserCAKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
+	require.NoError(t, err)
+	teleportUserCA, err := ssh.NewSignerFromSigner(teleportUserCAKey)
+	require.NoError(t, err)
+
+	tlsCA := newSelfSignedCA(t)
+	dialOpts := mustStartFakeWebProxy(ctx, t, fakeWebProxyConfig{
+		tlsCA:  tlsCA,
+		hostCA: teleportHostCA,
+		userCA: teleportUserCA,
+		clock:  cfg.clock,
+		suite:  cfg.signatureAlgorithmSuite,
+	})
+
 	return &fakeClientApp{
 		cfg:                  cfg,
 		tlsCA:                tlsCA,
-		userTLSCert:          userTLSCert,
 		dialOpts:             dialOpts,
+		teleportHostCA:       teleportHostCA,
+		teleportUserCA:       teleportUserCA,
 		requestedRouteToApps: make(map[string][]*proto.RouteToApp),
 	}
 }
@@ -406,6 +429,10 @@ func (p *fakeClientApp) GetCachedClient(ctx context.Context, profileName, leafCl
 				clusterName:     profileName,
 				rootClusterName: profileName,
 			},
+			clusterSpec:    &rootCluster,
+			teleportHostCA: p.teleportHostCA,
+			teleportUserCA: p.teleportUserCA,
+			clock:          p.cfg.clock,
 		}, nil
 	}
 	leafCluster, ok := rootCluster.leafClusters[leafClusterName]
@@ -418,6 +445,10 @@ func (p *fakeClientApp) GetCachedClient(ctx context.Context, profileName, leafCl
 			clusterName:     leafClusterName,
 			rootClusterName: profileName,
 		},
+		clusterSpec:    &leafCluster,
+		teleportHostCA: p.teleportHostCA,
+		teleportUserCA: p.teleportUserCA,
+		clock:          p.cfg.clock,
 	}, nil
 }
 
@@ -437,7 +468,26 @@ func (p *fakeClientApp) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppI
 }
 
 func (p *fakeClientApp) UserTLSCert(ctx context.Context, profileName string) (tls.Certificate, error) {
-	return p.userTLSCert, nil
+	p.userTLSCertMu.Lock()
+	defer p.userTLSCertMu.Unlock()
+
+	now := p.cfg.clock.Now()
+	if now.Before(p.userTLSCertExpires) {
+		return p.userTLSCert, nil
+	}
+	expiry := now.Add(defaults.CertDuration)
+	userTLSCert, err := newClientCert(ctx,
+		p.tlsCA,
+		"testuser",
+		expiry,
+		p.cfg.signatureAlgorithmSuite,
+		cryptosuites.UserTLS)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+	p.userTLSCert = userTLSCert
+	p.userTLSCertExpires = expiry
+	return userTLSCert, nil
 }
 
 func (p *fakeClientApp) RequestedRouteToApps(publicAddr string) []*proto.RouteToApp {
@@ -531,16 +581,19 @@ func (p *fakeClientApp) dialSSHNode(
 			return nil, trace.NotFound("no such cluster")
 		}
 	}
-	if _, ok := targetCluster.nodes[strings.TrimSuffix(target.host, ":0")]; !ok {
+	if _, ok := targetCluster.nodes[target.hostname]; !ok {
 		return nil, trace.NotFound("no such host")
 	}
-	// For now just let it dial the fake web proxy, later we'll need to set up a
-	// fake SSH server for the test to dial to.
+	tlsConfig.NextProtos = []string{string(alpncommon.ProtocolProxySSH)}
 	return tls.Dial("tcp", dialOpts.GetWebProxyAddr(), tlsConfig)
 }
 
 type fakeClusterClient struct {
-	authClient *fakeAuthClient
+	authClient     *fakeAuthClient
+	clusterSpec    *testClusterSpec
+	teleportHostCA ssh.Signer
+	teleportUserCA ssh.Signer
+	clock          clockwork.Clock
 }
 
 func (c *fakeClusterClient) CurrentCluster() authclient.ClientI {
@@ -553,6 +606,52 @@ func (c *fakeClusterClient) ClusterName() string {
 
 func (c *fakeClusterClient) RootClusterName() string {
 	return c.authClient.rootClusterName
+}
+
+func (c *fakeClusterClient) SessionSSHKeyRing(ctx context.Context, user string, target client.NodeDetails) (*client.KeyRing, bool, error) {
+	targetHost, _, err := net.SplitHostPort(target.Addr)
+	if err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+	nodeSpec, ok := c.clusterSpec.nodes[targetHost]
+	if !ok {
+		return nil, false, trace.NotFound("no such node")
+	}
+	if nodeSpec.denyAccess {
+		return nil, false, trace.AccessDenied("access denied to %s", targetHost)
+	}
+	userSSHKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.Ed25519)
+	if err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+	userSSHSigner, err := ssh.NewSignerFromSigner(userSSHKey)
+	if err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+	now := c.clock.Now()
+	cert := &ssh.Certificate{
+		Key:             userSSHSigner.PublicKey(),
+		Serial:          1,
+		CertType:        ssh.UserCert,
+		ValidPrincipals: []string{user},
+		ValidAfter:      uint64(now.Add(-1 * time.Minute).Unix()),
+		ValidBefore:     uint64(now.Add(time.Minute).Unix()),
+	}
+	if err := cert.SignCert(rand.Reader, c.teleportUserCA); err != nil {
+		return nil, false, trace.Wrap(err)
+	}
+	trustedCert := ssh.MarshalAuthorizedKey(c.teleportHostCA.PublicKey())
+	k := &client.KeyRing{
+		SSHPrivateKey: userSSHKey,
+		Cert:          ssh.MarshalAuthorizedKey(cert),
+		TrustedCerts: []authclient.TrustedCerts{
+			{
+				ClusterName:    c.ClusterName(),
+				AuthorizedKeys: [][]byte{trustedCert},
+			},
+		},
+	}
+	return k, false, nil
 }
 
 // fakeAuthClient is a fake auth client that answers GetResources requests with a static list of apps and
@@ -1066,7 +1165,8 @@ func TestSSH(t *testing.T) {
 			"root1.example.com": {
 				cidrRange: root1CIDR,
 				nodes: map[string]nodeSpec{
-					"node": {},
+					"node":     {},
+					"denynode": {denyAccess: true},
 				},
 				leafClusters: map[string]testClusterSpec{
 					"leaf1.example.com": {
@@ -1127,8 +1227,10 @@ func TestSSH(t *testing.T) {
 		sshUser                  string
 		sshUserSigner            ssh.Signer
 		expectSSHHandshakeToFail bool
+		expectBannerMessages     []string
 	}{
 		{
+			// Connection to node in root cluster should work.
 			dialAddr:      "node.root1.example.com",
 			dialPort:      22,
 			expectCIDR:    root1CIDR,
@@ -1151,6 +1253,7 @@ func TestSSH(t *testing.T) {
 			expectDialToFail: true,
 		},
 		{
+			// SSH handshake should fail if using the wrong user key.
 			dialAddr:                 "node.root1.example.com",
 			dialPort:                 22,
 			expectCIDR:               root1CIDR,
@@ -1159,6 +1262,32 @@ func TestSSH(t *testing.T) {
 			expectSSHHandshakeToFail: true,
 		},
 		{
+			// Access to denied node should be denied with appropriate banner
+			// messages.
+			dialAddr:      "denynode.root1.example.com",
+			dialPort:      22,
+			expectCIDR:    root1CIDR,
+			sshUser:       "testuser",
+			sshUserSigner: sshUserSigner,
+			expectBannerMessages: []string{
+				"VNet: building SSH client config\n\tcalling SessionSSHConfig rpc\n\t\tgetting KeyRing for SSH session\n\taccess denied to denynode\n",
+			},
+			expectSSHHandshakeToFail: true,
+		},
+		{
+			// username "denyuser" is hardcoded to be denied.
+			dialAddr:      "node.root1.example.com",
+			dialPort:      22,
+			expectCIDR:    root1CIDR,
+			sshUser:       "denyuser",
+			sshUserSigner: sshUserSigner,
+			expectBannerMessages: []string{
+				"VNet: access denied to denyuser connecting to node\n",
+			},
+			expectSSHHandshakeToFail: true,
+		},
+		{
+			// Connection to node in leaf cluster should work.
 			dialAddr:      "node.leaf1.example.com.root1.example.com",
 			dialPort:      22,
 			expectCIDR:    leaf1CIDR,
@@ -1166,6 +1295,8 @@ func TestSSH(t *testing.T) {
 			sshUserSigner: sshUserSigner,
 		},
 		{
+			// Connection to node in root cluster in alternate profile should
+			// work.
 			dialAddr:      "node.root2.example.com",
 			dialPort:      22,
 			expectCIDR:    root2CIDR,
@@ -1173,6 +1304,8 @@ func TestSSH(t *testing.T) {
 			sshUserSigner: sshUserSigner,
 		},
 		{
+			// Connection to node in leaf cluster in alternate profile should
+			// work.
 			dialAddr:      "node.leaf2.example.com.root2.example.com",
 			dialPort:      22,
 			expectCIDR:    leaf2CIDR,
@@ -1243,18 +1376,26 @@ func TestSSH(t *testing.T) {
 				},
 				Clock: clock.Now,
 			}
+			var bannerMessages []string
 			clientConfig := &ssh.ClientConfig{
 				User:            tc.sshUser,
 				Auth:            []ssh.AuthMethod{ssh.PublicKeys(tc.sshUserSigner)},
 				HostKeyCallback: certChecker.CheckHostKey,
+				BannerCallback: func(msg string) error {
+					bannerMessages = append(bannerMessages, msg)
+					return nil
+				},
 			}
-			sshConn, _, _, err := ssh.NewClientConn(conn, fmt.Sprintf("%s:%d", tc.dialAddr, tc.dialPort), clientConfig)
+			sshConn, chans, reqs, err := ssh.NewClientConn(conn, fmt.Sprintf("%s:%d", tc.dialAddr, tc.dialPort), clientConfig)
+			assert.Equal(t, tc.expectBannerMessages, bannerMessages, "actual banner messages did not match the expected")
 			if tc.expectSSHHandshakeToFail {
-				require.Error(t, err, "expected SSH handshake to fail")
+				assert.Error(t, err, "expected SSH handshake to fail")
 				return
 			}
 			require.NoError(t, err)
 			defer sshConn.Close()
+
+			testConnectionToSshEchoServer(t, sshConn, chans, reqs)
 		})
 	}
 
@@ -1456,27 +1597,33 @@ func newLeafCert(
 	}, nil
 }
 
+type fakeWebProxyConfig struct {
+	tlsCA  tls.Certificate
+	hostCA ssh.Signer
+	userCA ssh.Signer
+	clock  clockwork.Clock
+	suite  types.SignatureAlgorithmSuite
+}
+
 func mustStartFakeWebProxy(
 	ctx context.Context,
 	t *testing.T,
-	ca tls.Certificate,
-	clock clockwork.Clock,
-	suite types.SignatureAlgorithmSuite,
+	cfg fakeWebProxyConfig,
 ) *vnetv1.DialOptions {
 	t.Helper()
 
 	roots := x509.NewCertPool()
-	caX509, err := x509.ParseCertificate(ca.Certificate[0])
+	caX509, err := x509.ParseCertificate(cfg.tlsCA.Certificate[0])
 	require.NoError(t, err)
 	roots.AddCert(caX509)
 
 	const proxyCN = "testproxy"
 	proxyCert, err := newServerCert(
 		ctx,
-		ca,
+		cfg.tlsCA,
 		proxyCN,
-		clock.Now().Add(365*24*time.Hour),
-		suite,
+		cfg.clock.Now().Add(365*24*time.Hour),
+		cfg.suite,
 		cryptosuites.HostIdentity,
 	)
 	require.NoError(t, err)
@@ -1485,12 +1632,56 @@ func mustStartFakeWebProxy(
 		Certificates: []tls.Certificate{proxyCert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		ClientCAs:    roots,
+		NextProtos: []string{
+			string(alpncommon.ProtocolProxySSH),
+			string(alpncommon.ProtocolTCP),
+		},
+	}
+
+	tcpAppHandler := func(conn net.Conn) error {
+		// All fake TCP apps for the tests get routed to this handler which
+		// simply echos any input back on the tcp connection.
+		_, err := io.Copy(conn, conn)
+		return trace.Wrap(err, "io.Copy error in proxy echo server")
+	}
+	sshHandler := func(conn net.Conn) error {
+		// All fake SSH nodes for the tests get routed to this handler which
+		// terminates the incoming SSH connection with an ephemeral host cert.
+		// It trusts cfg.userCA for incoming SSH connections but always denies
+		// access for SSH users named "denyuser". After completing the handshake
+		// it runs a test "echo" SSH server implemented in
+		// runTestSSHServerInstance.
+		hostCert, err := newHostCert("node", cfg.hostCA)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		certChecker := ssh.CertChecker{
+			IsUserAuthority: func(auth ssh.PublicKey) bool {
+				return sshutils.KeysEqual(auth, cfg.userCA.PublicKey())
+			},
+			Clock: cfg.clock.Now,
+		}
+		serverConfig := &ssh.ServerConfig{
+			PublicKeyCallback: func(conn ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+				if conn.User() == "denyuser" {
+					return nil, trace.AccessDenied("access denied for denyuser")
+				}
+				return certChecker.Authenticate(conn, pubKey)
+			},
+		}
+		serverConfig.AddHostKey(hostCert)
+		return trace.Wrap(runTestSSHServerInstance(conn, serverConfig))
+	}
+
+	// Run a simplified TLS router for the test.
+	protocolHandlers := map[alpncommon.Protocol]func(net.Conn) error{
+		alpncommon.ProtocolTCP:      tcpAppHandler,
+		alpncommon.ProtocolProxySSH: sshHandler,
 	}
 
 	listener, err := tls.Listen("tcp", "localhost:0", proxyTLSConfig)
 	require.NoError(t, err)
 
-	// Run a fake web proxy that will accept any client connection and echo the input back.
 	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
 		Name: "web proxy",
 		Task: func(ctx context.Context) error {
@@ -1526,14 +1717,19 @@ func mustStartFakeWebProxy(
 					// It's important that the fake clock is never far behind the real clock, and that the
 					// cert NotBefore is always at/before the real current time, so the TLS library is
 					// satisfied.
-					if clock.Now().After(clientCerts[0].NotAfter) {
-						t.Logf("client cert is expired: currentTime=%s expiry=%s", clock.Now(), clientCerts[0].NotAfter)
+					if cfg.clock.Now().After(clientCerts[0].NotAfter) {
+						t.Logf("client cert is expired: currentTime=%s expiry=%s", cfg.clock.Now(), clientCerts[0].NotAfter)
 						return
 					}
 
-					_, err := io.Copy(conn, conn)
-					if err != nil && !utils.IsOKNetworkError(err) {
-						t.Logf("error in io.Copy for echo proxy server: %v", err)
+					protocol := tlsConn.ConnectionState().NegotiatedProtocol
+					handler, ok := protocolHandlers[alpncommon.Protocol(protocol)]
+					if !ok {
+						t.Logf("unhandled proxy protocol %s", protocol)
+						return
+					}
+					if err := handler(conn); err != nil {
+						t.Logf("error in protocol handler: %v", err)
 					}
 				}()
 			}

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -57,6 +57,11 @@ service ClientApplicationService {
   rpc UserTLSCert(UserTLSCertRequest) returns (UserTLSCertResponse);
   // SignForUserTLS signs a digest with the user TLS private key.
   rpc SignForUserTLS(SignForUserTLSRequest) returns (SignForUserTLSResponse);
+  // SessionSSHConfig returns the user SSH configuration for an SSH session.
+  rpc SessionSSHConfig(SessionSSHConfigRequest) returns (SessionSSHConfigResponse);
+  // SignForSSHSession signs a digest with the SSH private key associated with the
+  // session from a previous call to SessionSSHConfig.
+  rpc SignForSSHSession(SignForSSHSessionRequest) returns (SignForSSHSessionResponse);
 }
 
 // AuthenticateProcessRequest is a request for AuthenticateProcess.
@@ -326,6 +331,49 @@ message SignForUserTLSRequest {
 
 // SignForUserTLSResponse is a response for SignForUserTLS.
 message SignForUserTLSResponse {
+  // Signature is the signature.
+  bytes signature = 1;
+}
+
+// SessionSSHConfigRequest is a request for SessionSSHConfig.
+message SessionSSHConfigRequest {
+  // Profile is the profile in which the SSH server is found.
+  string profile = 1;
+  // RootCluster is the cluster in which the SSH server is found.
+  string root_cluster = 2;
+  // LeafCluster is the leaf cluster in which the SSH server is found.
+  // If empty, the SSH server is in the root cluster.
+  string leaf_cluster = 3;
+  // Address is the address of the SSH server.
+  string address = 4;
+  // User is the SSH user the session is for.
+  string user = 5;
+}
+
+// SessionSSHConfigResponse is a response for SessionSSHConfig.
+message SessionSSHConfigResponse {
+  // SessionId is an opaque identifier for the session, it should be passed to
+  // SignForSSHSession to issue signatures with the private key associated with
+  // the session.
+  string session_id = 1;
+  // Cert is the session SSH certificate in SSH wire format.
+  bytes cert = 2;
+  // TrustedCas is a list of trusted SSH certificate authorities in SSH wire
+  // format.
+  repeated bytes trusted_cas = 3;
+}
+
+// SignForSSHSessionRequest is a request for SignForSSHSession.
+message SignForSSHSessionRequest {
+  // SessionId is an opaque identifier for the session returned from a previous
+  // call to SessionSSHConfig.
+  string session_id = 1;
+  // Sign holds signature request details.
+  SignRequest sign = 2;
+}
+
+// SignForSSHSessionResponse is a response for SignForSSHSession.
+message SignForSSHSessionResponse {
   // Signature is the signature.
   bytes signature = 1;
 }


### PR DESCRIPTION
This PR is the next step in the implementation of VNet SSH ([RFD](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md)).

This PR implements forwarding the incoming SSH connection to the target server. The bulk of the new logic is about getting an ssh.ClientConfig that can initiate an SSH connection to the target over the TCP connection that was already established in a [previous PR](https://github.com/gravitational/teleport/pull/55087). This implementation works whether or not per-session MFA is required.

If you comment out the line that checks the user SSH key, you can now test VNet SSH with a real SSH client as long as you configure it to trust any host key. At this point the connection to the target host 100% works, you can run commands, the session will be recorded, and per-session MFA works fine.
```
Nics-MacBook-Pro:teleport nic$ ssh nic@node-iot.one.private
Warning: Permanently added 'node-iot.one.private' (ED25519) to the list of known hosts.
Nics-MacBook-Pro:~ nic$ date
Mon 26 May 2025 18:01:51 PDT
Nics-MacBook-Pro:~ nic$ exit
logout
Connection to node-iot.one.private closed.
```

Subsequent PRs will automatically configure SSH clients to use and trust the correct keys so that this works seamlessly.

Parent PR: https://github.com/gravitational/teleport/pull/55155
Child PR: https://github.com/gravitational/teleport/pull/55228