### PR TITLE
Test batch exporting in BulkExporter

### DIFF
--- a/lib/events/export/exporter_test.go
+++ b/lib/events/export/exporter_test.go
@@ -102,8 +102,8 @@ func TestExporterBasics(t *testing.T) {
 // and returns the generated events for comparison.
 func addEvents(t *testing.T, clt *fakeClient, date time.Time, chunks, eventsPerChunk int) []*auditlogpb.ExportEventUnstructured {
 	var allEvents []*auditlogpb.ExportEventUnstructured
-	for i := 0; i < chunks; i++ {
-		chunk := makeEventChunk(t, date, eventsPerChunk)
+	for range chunks {
+		chunk, _ := makeEventChunk(t, date, eventsPerChunk)
 		allEvents = append(allEvents, chunk...)
 		clt.addChunk(date.Format(time.DateOnly), uuid.NewString(), chunk)
 	}


### PR DESCRIPTION
Use clockwork to make BulkExporter more testable from implementations in teleport-ent.

Use existing test infrastructure to also test BatchExport in DateExporter.

---

I don't think I've updated this in @fspmarshall style or interest, sorry. 
I'm happy to take pointers.
