### PR TITLE
[v16] Use protojson in tctl for marshaling BotInstance resource

### DIFF
--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -562,7 +562,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 	}
 
 	if c.format == teleport.JSON {
-		// Wrap resource type so the correct protojson marshalling is used for
+		// Wrap resource type so the correct protojson marshaling is used for
 		// timestamp fields.
 		wrappedInstances := make([]types.Resource, 0, len(instances))
 		for _, instance := range instances {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -562,7 +562,15 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 	}
 
 	if c.format == teleport.JSON {
-		err := utils.WriteJSONArray(c.stdout, instances)
+		// Wrap resource type so the correct protojson marshalling is used for
+		// timestamp fields.
+		wrappedInstances := make([]types.Resource, 0, len(instances))
+		for _, instance := range instances {
+			wrappedInstances = append(
+				wrappedInstances, types.ProtoResource153ToLegacy(instance),
+			)
+		}
+		err := utils.WriteJSONArray(c.stdout, wrappedInstances)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal bot instances")
 		}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1686,7 +1686,7 @@ type botInstanceCollection struct {
 func (c *botInstanceCollection) resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
-		r = append(r, types.Resource153ToLegacy(resource))
+		r = append(r, types.ProtoResource153ToLegacy(resource))
 	}
 	return r
 }


### PR DESCRIPTION
Backport #55093 to branch/v16

changelog: Fixed `tctl` rendering of timestamps in BotInstance resource YAML
