### PR TITLE
[v15] docs: Fix mangled summary tags

### DIFF
--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -38,7 +38,7 @@ $ tsh device asset-tag
 ```
 
 <details>
-<summary>Manually retrieving device serial" close</summary>
+<summary>Manually retrieving device serial</summary>
   <Tabs>
   <TabItem label="macOS">
     The serial number is visible under Apple menu -> "About This Mac" -> "Serial number".

--- a/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
@@ -62,7 +62,7 @@ Create a readonly Jamf user for inventory sync.
   Teleport Cloud users can quickly get started with Jamf integration by using
   the hosted Jamf plugin in the Web UI.
   <details>
-  <summary>Configure Jamf hosted plugin" min="13.2" close</summary>
+  <summary>Configure Jamf hosted plugin</summary>
     Select the Jamf plugin:
     ![Select Jamf plugin](../../../../img/access-controls/device-trust/select-jamf.png)
     Fill in the required information and click "Connect Jamf" button:

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -745,7 +745,7 @@ then begin to forward traffic to the target host and port. The client can then
 make an SSH connection.
 
 <details>
-<summary>Example in Python (Paramiko)" close</summary>
+<summary>Example in Python (Paramiko)</summary>
 ```python
 import os
 import paramiko
@@ -788,7 +788,7 @@ print(stdout.read().decode())
 </details>
 
 <details>
-<summary>Example in Go" close</summary>
+<summary>Example in Go</summary>
 ```go
 package main
 


### PR DESCRIPTION
Backport #54915

`docs/pages/admin-guides/access-controls/device-trust/device-management.mdx` on this release branch doesn't have that fragment about the `--os` flag hence the change in it wasn't backported.