### PR TITLE
Add `scutil --dns` to VNet diag report

### DIFF
--- a/lib/vnet/diag/routeconflict_darwin.go
+++ b/lib/vnet/diag/routeconflict_darwin.go
@@ -129,5 +129,6 @@ func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (str
 func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
 	return []*exec.Cmd{
 		exec.CommandContext(ctx, "netstat", "-rn", "-f", "inet"),
+		exec.CommandContext(ctx, "scutil", "--dns"),
 	}
 }


### PR DESCRIPTION
`scutil --dns` is a macOS command that shows the DNS configuration of the system. It is helpful in situations where some other VPN software sets up a DNS nameserver that conflicts with VNet's and captures DNS queries "meant" for VNet.

idk why I didn't include this originally when I was working on the diag report. I think I assumed I'd add it to the DNS diag check which ultimately got tabled (#52553). Still, the output of the command is very useful to have even if the diag report doesn't run any DNS checks yet. It'd have saved me a back and forth with a customer who did include the output of the diag report (see [the Zendesk ticket](https://gravitational.zendesk.com/agent/tickets/14130)).

No UI changes are needed as the UI already handles an arbitrary number of extra diag commands:

<img width="1280" alt="vnet-diag-report-scutil" src="https://github.com/user-attachments/assets/81e90397-ae1c-4d07-8d29-5c7e977ced2a" />
