### PR TITLE
MWI: Wrap `tbot`'s gRPC connection to support late initialization

### DIFF
--- a/lib/tbot/grpcconn/grpcconn.go
+++ b/lib/tbot/grpcconn/grpcconn.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package grpcconn
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// errUninitialized is returned when neither a connection or error has been set
+// on the ClientConn. It's the "default" state of an uninitialized connection.
+var errUninitialized = status.Error(codes.Unavailable, "gRPC client connection is uninitialized")
+
+// ClientConn wraps a *grpc.ClientConn to make it possible to create and pass
+// around gRPC client stubs before the connection has been properly established.
+//
+// This is useful in cases where we weren't able to connect and authenticate
+// with the auth server on-startup (e.g. due to a network partition) but might
+// be able to in the future, and it's more useful for tbot to run in a "degraded"
+// state than to exit completely.
+//
+// The zero-value of a ClientConn returns an error with a gRPC Unavailable
+// status code on each RPC.
+type ClientConn struct {
+	mu       sync.RWMutex
+	err      error
+	realConn *grpc.ClientConn
+}
+
+// WithConnection creates a ClientConn that will use the given connection for
+// each RPC.
+func WithConnection(conn *grpc.ClientConn) *ClientConn {
+	return &ClientConn{realConn: conn}
+}
+
+// WithError creates ClientConn that will return the given error on each RPC
+// until the the connection is set with SetConnection.
+func WithError(err error) *ClientConn {
+	return &ClientConn{err: err}
+}
+
+// SetConnection sets the connection that will be used for each RPC and discards
+// any previously-set error.
+func (c *ClientConn) SetConnection(conn *grpc.ClientConn) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.realConn = conn
+	c.err = nil
+}
+
+// SetError sets the error that will be returned from each RPC and discards any
+// previously-set client.
+func (c *ClientConn) SetError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.realConn = nil
+	c.err = err
+}
+
+// Invoke implements grpc.ClientConnInterface.
+func (c *ClientConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.realConn != nil {
+		return c.realConn.Invoke(ctx, method, args, reply, opts...)
+	}
+
+	if c.err != nil {
+		return c.err
+	}
+
+	return errUninitialized
+}
+
+// NewStream implements grpc.ClientConnInterface.
+func (c *ClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.realConn != nil {
+		return c.realConn.NewStream(ctx, desc, method, opts...)
+	}
+
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	return nil, errUninitialized
+}
+
+var _ grpc.ClientConnInterface = (*ClientConn)(nil)

--- a/lib/tbot/grpcconn/grpcconn_test.go
+++ b/lib/tbot/grpcconn/grpcconn_test.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package grpcconn_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/gravitational/teleport/lib/tbot/grpcconn"
+)
+
+func TestUninitialized(t *testing.T) {
+	conn := new(grpcconn.ClientConn)
+	client := healthpb.NewHealthClient(conn)
+
+	_, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.ErrorContains(t, err, "connection is uninitialized")
+	require.Equal(t, codes.Unavailable.String(), status.Code(err).String())
+
+	_, err = client.Watch(context.Background(), &healthpb.HealthCheckRequest{})
+	require.ErrorContains(t, err, "connection is uninitialized")
+	require.Equal(t, codes.Unavailable.String(), status.Code(err).String())
+}
+
+func TestWithError(t *testing.T) {
+	conn := grpcconn.WithError(errors.New("KABOOM"))
+	client := healthpb.NewHealthClient(conn)
+
+	_, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.ErrorContains(t, err, "KABOOM")
+
+	_, err = client.Watch(context.Background(), &healthpb.HealthCheckRequest{})
+	require.ErrorContains(t, err, "KABOOM")
+}
+
+func TestWithConnection(t *testing.T) {
+	conn := grpcconn.WithConnection(dialRealConnection(t))
+	client := healthpb.NewHealthClient(conn)
+
+	_, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.CloseSend()) })
+}
+
+func TestEndToEnd(t *testing.T) {
+	conn := new(grpcconn.ClientConn)
+	client := healthpb.NewHealthClient(conn)
+
+	conn.SetError(errors.New("KABOOM"))
+
+	_, err := client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.ErrorContains(t, err, "KABOOM")
+
+	realConn := dialRealConnection(t)
+	conn.SetConnection(realConn)
+
+	_, err = client.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+}
+
+func dialRealConnection(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(100)
+	t.Cleanup(func() {
+		assert.NoError(t, lis.Close())
+	})
+
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, testHealthService{})
+
+	t.Cleanup(srv.Stop)
+	go func() { require.NoError(t, srv.Serve(lis)) }()
+
+	realConn, err := grpc.NewClient(
+		"127.0.0.0", // Avoid DNS resolution.
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		realConn.Close()
+	})
+
+	return realConn
+}
+
+type testHealthService struct {
+	healthpb.UnimplementedHealthServer
+}
+
+func (testHealthService) Check(context.Context, *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	return &healthpb.HealthCheckResponse{
+		Status: healthpb.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (testHealthService) Watch(*healthpb.HealthCheckRequest, grpc.ServerStreamingServer[healthpb.HealthCheckResponse]) error {
+	return nil
+}

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/grpcconn"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -62,6 +63,8 @@ type identityService struct {
 	cfg               *config.BotConfig
 	resolver          reversetunnelclient.Resolver
 
+	conn grpcconn.ClientConn
+
 	mu     sync.Mutex
 	client *authclient.Client
 	facade *identity.Facade
@@ -72,6 +75,11 @@ func (s *identityService) GetIdentity() *identity.Identity {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.facade.Get()
+}
+
+// GetConnection returns the gRPC client connection.
+func (s *identityService) GetConnection() *grpcconn.ClientConn {
+	return &s.conn
 }
 
 // GetClient returns the facaded client for the Bot identity for use by other
@@ -235,6 +243,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 	}
 	s.mu.Lock()
 	s.client = c
+	s.conn.SetConnection(c.GetConnection())
 	s.facade = facade
 	s.mu.Unlock()
 


### PR DESCRIPTION
This PR is the first part of #53711.

It introduces a new implementation of `grpc.ClientConnInterface` which makes it possible to create gRPC client stubs before the connection is properly established, which will make it possible for us to continue running if we're unable to reach the auth server on startup (and retry the connection in the background).

The next PR(s) will replace direct dependencies on `*authclient.Client` with gRPC client stubs.
