### PR TITLE
Allow unknown ListUnifiedResourceRequest.Kinds

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1289,7 +1289,9 @@ var (
 
 func (a *ServerWithRoles) checkKindAccess(kind string) error {
 	if _, ok := supportedUnifiedResourceKinds[kind]; !ok {
-		return trace.BadParameter("unsupported kind %q requested", kind)
+		// Treat unknown kinds as an access denied error instead of a bad parameter
+		// to prevent rejecting the request if users have access to other kinds requested.
+		return trace.AccessDenied("unsupported kind %q requested", kind)
 	}
 	switch kind {
 	case types.KindNode:


### PR DESCRIPTION
Unknown kinds resulted in the request erroring out and returning an error about unknown kinds. This causes compatibility issues when new kinds are added, i.e. git_server in v17 with a v16 leaf cluster will prevent the leaf cluster resources page from loading in the root web ui.

The errors are now treated as if access for unknown kinds are denied which will filter them out and allow any known resources to still be processed and returned.

Changelog: Prevent unknown resource kinds from rendering errors in the web UI