### PR TITLE
Swap columns in text VNet diag report, make setter of usePersistedState stable

### DIFF
--- a/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
+++ b/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
@@ -12,10 +12,10 @@ DNS zones: teleport.example.com, company.test
 ---
 ⚠️ There are network routes in conflict with VNet.
 
-| Conflicting destination | VNet destination | Interface | Set up by |
-| ----------------------- | ---------------- | --------- | --------- |
-| 100.64.0.0/10 | 100.64.0.1 | utun5 | VPN: Foobar |
-| 0.0.0.0/1 | 100.64.0.0/10 | utun6 | unknown |
+| VNet destination | Conflicting destination | Interface | Set up by |
+| ---------------- | ----------------------- | --------- | --------- |
+| 100.64.0.1 | 100.64.0.0/10 | utun5 | VPN: Foobar |
+| 100.64.0.0/10 | 0.0.0.0/1 | utun6 | unknown |
 
 \`\`\`
 $ netstat -rn -f inet

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -139,13 +139,13 @@ function routeConflictReportToText({
   const tableRows = report.routeConflictReport.routeConflicts
     .map(
       routeConflict =>
-        `| ${routeConflict.dest} | ${routeConflict.vnetDest} | ${routeConflict.interfaceName} | ${routeConflict.interfaceApp || 'unknown'} |`
+        `| ${routeConflict.vnetDest} | ${routeConflict.dest} | ${routeConflict.interfaceName} | ${routeConflict.interfaceApp || 'unknown'} |`
     )
     .join('\n');
 
   return `⚠️ There are network routes in conflict with VNet.
 
-| Conflicting destination | VNet destination | Interface | Set up by |
-| ----------------------- | ---------------- | --------- | --------- |
+| VNet destination | Conflicting destination | Interface | Set up by |
+| ---------------- | ----------------------- | --------- | --------- |
 ${tableRows}`;
 }

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -350,8 +350,8 @@ function CheckReportRouteConflict({
         emptyText=""
         data={routeConflicts}
         columns={[
-          { key: 'dest', headerText: 'Conflicting destination' },
           { key: 'vnetDest', headerText: 'VNet destination' },
+          { key: 'dest', headerText: 'Conflicting destination' },
           { key: 'interfaceName', headerText: 'Interface' },
           {
             key: 'interfaceApp',

--- a/web/packages/teleterm/src/ui/hooks/usePersistedState.test.tsx
+++ b/web/packages/teleterm/src/ui/hooks/usePersistedState.test.tsx
@@ -148,6 +148,28 @@ it('properly handles existing state when given a function to setState', () => {
   expect(state).toEqual({ foo: 3, bar: 1 });
 });
 
+it('keeps the identity of the setter stable', () => {
+  const { result } = renderHook(
+    () =>
+      usePersistedState<'counters', { counters: { foo: number } }>('counters', {
+        foo: 1,
+      }),
+    { wrapper: MockAppContextProvider }
+  );
+
+  let [, setState] = result.current;
+  const originalSetState = setState;
+  act(() => {
+    setState({ foo: 5 });
+  });
+  expect(result.current[1]).toBe(originalSetState);
+
+  act(() => {
+    setState(state => ({ ...state, foo: state.foo + 1 }));
+  });
+  expect(result.current[1]).toBe(originalSetState);
+});
+
 type TestState = { counter: number; boolean: boolean };
 
 const Counter = () => {


### PR DESCRIPTION
## Swapped columns

Earlier today I read a VNet diag report that starts like this:

```
VNet Diagnostic Report

Created at: 2025-05-26 12:53:47 (Mon, 26 May 2025 11:53:47 GMT)
Network interface: utun5
IPv4 CIDR ranges: 100.64.0.0/10
IPv6 prefix: fd5b:e7f2:8b59::
DNS zones: <some domain>

---
⚠️ There are network routes in conflict with VNet.

| Conflicting destination | VNet destination | Interface | Set up by |
| ----------------------- | ---------------- | --------- | --------- |
| 100.64.0.0/10 | 100.64.0.1 | utun4 | unknown |
```

When I was reading the table, I was a bit confused (and I'm the person who wrote it lol). Is VNet set up on utun4 or is it the other software? Then I noticed that at the top there's "Network interface: utun5", so it must mean that utun4 is the other software that's conflicting with VNet.

I realized that it'd have been easier to interpret if the destination columns were swapped:

```
VNet Diagnostic Report

Created at: 2025-05-26 12:53:47 (Mon, 26 May 2025 11:53:47 GMT)
Network interface: utun5
IPv4 CIDR ranges: 100.64.0.0/10
IPv6 prefix: fd5b:e7f2:8b59::
DNS zones: <some domain>

---
⚠️ There are network routes in conflict with VNet.

| VNet destination | Conflicting destination | Interface | Set up by |
| ---------------- | ----------------------- | --------- | --------- |
| 100.64.0.1 | 100.64.0.0/10 | utun4 | unknown |
```

## Stable setter of `usePersistedState`

To verify the change with the columns, I went to open the story, but it wouldn't render. It seemed to get into an endless loop. At first I thought it was caused by the effect in the story that updates the doc, but after commenting it out, it turned out that the faulty line was the one with `stop` in this effect:

https://github.com/gravitational/teleport/blob/a73613d257b4c9d599764a7b6a2a54fa256a6612/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx#L239-L249

Bisecting pointed to #53623 as the faulty PR. In that PR, I modified the setter of `usePersistedState` to depend on the value of the state which made the setter unstable between updates. `usePersistedState` is our bespoke 🧐 hook to access state from a service that persists state to disk.

https://github.com/gravitational/teleport/blob/a73613d257b4c9d599764a7b6a2a54fa256a6612/web/packages/teleterm/src/ui/hooks/usePersistedState.ts#L97-L116

`stop` from the VNet context depends on `setAppState` which is a setter from `usePersistedState`. So on the first cleanup, the effect would enter an infinite loop where each execution of `setAppState` would update its identity.