### PR TITLE
Do not send client keyboard layout in desktop player

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -57,8 +57,8 @@ export default meta;
 const fakeClient = () => {
   const client = new TdpClient(() => null, new BrowserFileSystem());
   // Don't try to connect to a websocket.
-  client.connect = async (keyboardLayout: number, spec: ClientScreenSpec) => {
-    emitFrame(client, spec);
+  client.connect = async options => {
+    emitFrame(client, options.screenSpec);
   };
   return client;
 };
@@ -171,8 +171,8 @@ export const SharingDisabledRbac = () => (
 
 export const Alerts = () => {
   const client = fakeClient();
-  client.connect = async (keyboardLayout: number, spec: ClientScreenSpec) => {
-    emitFrame(client, spec);
+  client.connect = async options => {
+    emitFrame(client, options.screenSpec);
     client.emit(
       TdpClientEvent.TDP_WARNING,
       'Potential performance issues detected. Expect possible lag or instability.'

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -246,7 +246,10 @@ export function DesktopSession({
     if (!shouldConnect) {
       return;
     }
-    void client.connect(keyboardLayout, canvasRendererRef.current.getSize());
+    void client.connect({
+      keyboardLayout,
+      screenSpec: canvasRendererRef.current.getSize(),
+    });
     return () => {
       client.shutdown();
     };

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -149,15 +149,23 @@ export class TdpClient extends EventEmitter<EventMap> {
     this.codec = new Codec();
   }
 
-  /**
-   * Connects to the transport and registers event handlers.
-   * Include a screen spec in cases where the client should determine the screen size
-   * (e.g. in a desktop session). Leave the screen spec undefined in cases where the server determines
-   * the screen size (e.g. in a recording playback session). In that case, the client will
-   * set the internal screen size when it receives the screen spec from the server
-   * (see PlayerClient.handleClientScreenSpec).
-   */
-  async connect(keyboardLayout: number = 0, spec?: ClientScreenSpec) {
+  /** Connects to the transport and registers event handlers. */
+  async connect(
+    options: {
+      /**
+       * Client keyboard layout.
+       * This should be provided only for a desktop session
+       * (desktop player doesn't allow this parameter).
+       */
+      keyboardLayout?: number;
+      /**
+       * Client screen size.
+       * This should be provided only for a desktop session
+       * (desktop player doesn't allow this parameter).
+       */
+      screenSpec?: ClientScreenSpec;
+    } = {}
+  ) {
     this.transportAbortController = new AbortController();
     if (!wasmReady) {
       wasmReady = this.initWasm();
@@ -174,11 +182,13 @@ export class TdpClient extends EventEmitter<EventMap> {
     }
 
     this.emit(TdpClientEvent.TRANSPORT_OPEN);
-    if (spec) {
-      this.sendClientScreenSpec(spec);
+    if (options.screenSpec) {
+      this.sendClientScreenSpec(options.screenSpec);
     }
 
-    this.sendClientKeyboardLayout(keyboardLayout);
+    if (options.keyboardLayout !== undefined) {
+      this.sendClientKeyboardLayout(options.keyboardLayout);
+    }
 
     let processingError: Error | undefined;
     let connectionError: Error | undefined;


### PR DESCRIPTION
The desktop player stopped working after https://github.com/gravitational/teleport/pull/55119 was merged.
This happens because the playback handler expects all incoming messages to be in JSON format. When it receives a TDP message instead, it fails to parse it, resulting in the connection being terminated.

https://github.com/gravitational/teleport/blob/6b80477a14a0d7ee69ea78bee64b0b381a322d42/lib/web/desktop/playback.go#L78-L84