### PR TITLE
docs: updated linux demo video link

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
@@ -1,7 +1,7 @@
 ---
 title: Run a Self-Hosted Demo Cluster 
 description: This tutorial will guide you through the steps needed to install and run Teleport on a Linux server
-videoBanner: BJWbSqiDLeU
+videoBanner: O0YOPpWsn8M
 tocDepth: 3
 ---
 


### PR DESCRIPTION
Updated the video link on the [Run a Self-Hosted Demo Cluster](https://goteleport.com/docs/admin-guides/deploy-a-cluster/linux-demo/) page to the newest video tutorial.