### PR TITLE
MCP access part 5: Claude desktop config parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,8 @@ require (
 	github.com/spiffe/aws-spiffe-workload-helper v0.0.1-rc.8
 	github.com/spiffe/go-spiffe/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0
+	github.com/tidwall/pretty v1.2.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb
 	github.com/vulcand/predicate v1.2.0 // replaced
 	github.com/yusufpapurcu/wmi v1.2.4
@@ -531,6 +533,8 @@ require (
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.0.2 // indirect
+	github.com/tidwall/gjson v1.14.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2227,7 +2227,15 @@ github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qv
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
 github.com/theupdateframework/go-tuf/v2 v2.0.2 h1:PyNnjV9BJNzN1ZE6BcWK+5JbF+if370jjzO84SS+Ebo=
 github.com/theupdateframework/go-tuf/v2 v2.0.2/go.mod h1:baB22nBHeHBCeuGZcIlctNq4P61PcOdyARlplg5xmLA=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/lib/client/mcp/claude/config.go
+++ b/lib/client/mcp/claude/config.go
@@ -1,0 +1,211 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package claude
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/gravitational/trace"
+)
+
+// Config represents the Claude Desktop config.
+type Config struct {
+	// MCPServers specifies a list of MCP servers.
+	MCPServers map[string]MCPServer `json:"mcpServers,omitempty"`
+	// AllFields preserves all fields of the config.
+	AllFields map[string]any `json:"-"`
+}
+
+// AddMCPServer adds a new MCP server to the config.
+func (c *Config) AddMCPServer(name string, mcpServer MCPServer) {
+	if c.MCPServers == nil {
+		c.MCPServers = make(map[string]MCPServer)
+	}
+	c.MCPServers[name] = mcpServer
+}
+
+// MarshalJSON implements json.Marshaler.
+func (c Config) MarshalJSON() ([]byte, error) {
+	// Shallow copy.
+	c.AllFields = maps.Clone(c.AllFields)
+	c.updateFields()
+	data, err := json.Marshal(c.AllFields)
+	return data, trace.Wrap(err)
+}
+
+func (c *Config) updateFields() {
+	if c.AllFields == nil {
+		c.AllFields = make(map[string]any)
+	}
+	if len(c.MCPServers) != 0 {
+		c.AllFields["mcpServers"] = c.MCPServers
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type Alias Config
+	if err := json.Unmarshal(data, (*Alias)(c)); err != nil {
+		return trace.Wrap(err)
+	}
+	var allFields map[string]any
+	if err := json.Unmarshal(data, &allFields); err != nil {
+		return trace.Wrap(err)
+	}
+	c.AllFields = allFields
+	c.updateFields()
+	return nil
+}
+
+// MCPServer contains details to launch a MCP server.
+type MCPServer struct {
+	// Command specifies the command to execute.
+	Command string `json:"command"`
+	// Args specifies the arguments for the command.
+	Args []string `json:"args,omitempty"`
+	// Envs specifies extra environment variable.
+	Envs map[string]string `json:"env,omitempty"`
+	// AllFields preserves all fields of the MCPServer.
+	AllFields map[string]any `json:"-"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s MCPServer) MarshalJSON() ([]byte, error) {
+	// Shallow copy.
+	s.AllFields = maps.Clone(s.AllFields)
+	s.updateFields()
+	data, err := json.Marshal(s.AllFields)
+	return data, trace.Wrap(err)
+}
+
+func (s *MCPServer) updateFields() {
+	if s.AllFields == nil {
+		s.AllFields = make(map[string]any)
+	}
+	s.AllFields["command"] = s.Command
+	if len(s.Args) > 0 {
+		s.AllFields["args"] = s.Args
+	}
+	if len(s.Envs) > 0 {
+		s.AllFields["env"] = s.Envs
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *MCPServer) UnmarshalJSON(data []byte) error {
+	type Alias MCPServer
+	if err := json.Unmarshal(data, (*Alias)(s)); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var allFields map[string]any
+	if err := json.Unmarshal(data, &allFields); err != nil {
+		return trace.Wrap(err)
+	}
+	s.AllFields = allFields
+	s.updateFields()
+	return nil
+}
+
+// LoadConfigFromDefaultPath loads the Claude Desktop's config from the default
+// path.
+func LoadConfigFromDefaultPath() (*Config, error) {
+	configPath, err := DefaultConfigPath()
+	if err != nil {
+		return nil, trace.Wrap(err, "finding Claude Desktop config path")
+	}
+	config, err := LoadConfig(configPath)
+	return config, trace.Wrap(err)
+}
+
+// LoadConfig loads the Claude Desktop's config from the provided path.
+func LoadConfig(configPath string) (*Config, error) {
+	var config Config
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, trace.Wrap(err, "reading Claude Desktop config")
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, trace.Wrap(err, "parsing Claude Desktop config")
+	}
+	return &config, nil
+}
+
+// SaveConfigToDefaultPath saves the Claude Desk config to the default path.
+func SaveConfigToDefaultPath(config *Config) error {
+	configPath, err := DefaultConfigPath()
+	if err != nil {
+		return trace.Wrap(err, "finding Claude Desktop config path")
+	}
+
+	return trace.Wrap(SaveConfig(config, configPath))
+}
+
+// SaveConfig saves the Claude Desktop config to specified path.
+func SaveConfig(config *Config, configPath string) error {
+	if config == nil {
+		return trace.BadParameter("config is nil")
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return trace.Wrap(err, "marshalling Claude Desktop config")
+	}
+	// Claude Desktop creates the config with 0644.
+	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return trace.Wrap(err, "opening Claude Desktop config")
+	}
+	defer file.Close()
+	if _, err := file.Write(data); err != nil {
+		return trace.Wrap(err, "writing Claude Desktop config")
+	}
+	return nil
+}
+
+// DefaultConfigPath returns the default path for the Claude Desktop config.
+// https://modelcontextprotocol.io/quickstart/user
+//
+// Windows: %APPDATA%\Claude\claude_desktop_config.json
+func DefaultConfigPath() (string, error) {
+	switch runtime.GOOS {
+	// macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
+	case "darwin":
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return filepath.Join(userHome, "Library", "Application Support", "Claude", "claude_desktop_config.json"), nil
+
+	// windows: %APPDATA%\Claude\claude_desktop_config.json
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", trace.BadParameter("APPDATA environment variable not found")
+		}
+
+		return filepath.Join(appData, "Claude", "claude_desktop_config.json"), nil
+
+	default:
+		return "", trace.NotImplemented("Claude Desktop is not supported on OS %s", runtime.GOOS)
+	}
+}

--- a/lib/client/mcp/claude/config_test.go
+++ b/lib/client/mcp/claude/config_test.go
@@ -1,0 +1,146 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleConfigJSON = `{
+  "someUnknownField": "someUnknownValue",
+  "mcpServers": {
+    "Puppeteer": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-puppeteer"
+      ],
+      "someUnknownField": "someUnknownValue"
+    },
+    "teleport-my-mcp": {
+      "command": "tsh",
+      "args": [
+        "mcp",
+        "connect",
+        "my-mcp"
+      ],
+      "env": {
+        "TELEPORT_HOME": "/tsh-home/"
+      }
+    }
+  }
+}
+`
+
+var sampleConfig = Config{
+	MCPServers: map[string]MCPServer{
+		"Puppeteer": {
+			Command: "npx",
+			Args:    []string{"-y", "@modelcontextprotocol/server-puppeteer"},
+		},
+		"teleport-my-mcp": {
+			Command: "tsh",
+			Args:    []string{"mcp", "connect", "my-mcp"},
+			Envs: map[string]string{
+				"TELEPORT_HOME": "/tsh-home/",
+			},
+		},
+	},
+}
+
+func TestConfig_marshaling(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantConfig Config
+	}{
+		{
+			name:       "empty",
+			input:      "{}",
+			wantConfig: Config{},
+		},
+		{
+			name:       "sample",
+			input:      sampleConfigJSON,
+			wantConfig: sampleConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config Config
+			err := json.Unmarshal([]byte(tt.input), &config)
+			require.NoError(t, err)
+
+			require.Empty(t, diffConfig(&tt.wantConfig, &config))
+
+			output, err := json.Marshal(config)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.input, string(output))
+		})
+	}
+}
+
+func TestConfig_file(t *testing.T) {
+	dir := t.TempDir()
+	orgPath := filepath.Join(dir, "config_org.json")
+	require.NoError(t, os.WriteFile(orgPath, []byte(sampleConfigJSON), 0600))
+	savePath := filepath.Join(dir, "config_save.json")
+
+	t.Run("LoadConfig no file exists", func(t *testing.T) {
+		_, err := LoadConfig("no_exist.json")
+		require.Error(t, err)
+	})
+
+	var config *Config
+	t.Run("LoadConfig", func(t *testing.T) {
+		var err error
+		config, err = LoadConfig(orgPath)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.Empty(t, diffConfig(&sampleConfig, config))
+	})
+
+	t.Run("SaveConfig", func(t *testing.T) {
+		err := SaveConfig(config, savePath)
+		require.NoError(t, err)
+
+		// Double check all fields are preserved.
+		orgData, err := os.ReadFile(orgPath)
+		require.NoError(t, err)
+		savedData, err := os.ReadFile(savePath)
+		require.NoError(t, err)
+		require.JSONEq(t, string(orgData), string(savedData))
+	})
+}
+
+func diffConfig(a, b *Config) string {
+	return cmp.Diff(a, b,
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(Config{}, "AllFields"),
+		cmpopts.IgnoreFields(MCPServer{}, "AllFields"),
+	)
+}

--- a/lib/client/mcp/claude/config_test.go
+++ b/lib/client/mcp/claude/config_test.go
@@ -133,8 +133,7 @@ func TestFileConfig_sampleFile(t *testing.T) {
 }
 
 func TestConfig_Write(t *testing.T) {
-	config, err := NewConfig()
-	require.NoError(t, err)
+	config := NewConfig()
 
 	require.NoError(t, config.PutMCPServer("test", MCPServer{
 		Command: "command",


### PR DESCRIPTION
Related:
- #54705

Doing a small separate PR for parser so it can be shared for `tsh mcp db`