### PR TITLE
[v16] [17.4.10] Bump cloud docs version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "17.4.9",
+      "version": "17.4.10",
       "major_version": "17",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Backport #55103 to branch/v16