### PR TITLE
AWS Roles Anywhere: sync profiles as AWS Apps

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -879,6 +879,15 @@ const (
 	// KubernetesClusterLabel indicates name of the kubernetes cluster for auto-discovered services inside kubernetes.
 	KubernetesClusterLabel = TeleportNamespace + "/kubernetes-cluster"
 
+	// AWSRolesAnywhereProfileNameOverrideLabel indicates the name of the AWS IAM Roles Anywhere Profile's tag key
+	// that Teleport will use to override the name of the discovered profile.
+	// Ensure this name is unique and valid DNS label.
+	AWSRolesAnywhereProfileNameOverrideLabel = "TeleportApplicationName"
+
+	// AWSRolesAnywhereProfileARNLabel is the label key to store the Profile ARN when creating an Application
+	// resource from an AWS IAM Roles Anywhere Profile.
+	AWSRolesAnywhereProfileARNLabel = TeleportNamespace + "/aws-roles-anywhere-profile-arn"
+
 	// DiscoveryTypeLabel specifies type of discovered service that should be created from Kubernetes service.
 	// Also added by discovery service to indicate the type of discovered
 	// resource, e.g. "rds" for RDS databases, "eks" for EKS kube clusters, etc.

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -250,9 +250,10 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 		if err := s.createGitHubCredentials(ctx, req.Integration); err != nil {
 			return nil, trace.Wrap(err)
 		}
-	case types.IntegrationSubKindAWSOIDC:
-		// AWS OIDC Integration can be used as source of credentials to access AWS Web/CLI.
-		// This creates a new AppServer whose endpoint is <integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
+	case types.IntegrationSubKindAWSOIDC, types.IntegrationSubKindAWSRolesAnywhere:
+		// AWS OIDC and Roles Anywhere Integrations can be used as source of credentials to access AWS Web/CLI.
+		// For OIDC, this creates a new AppServer whose endpoint is <integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
+		// For Roles Anywhere, this creates a AppServers for each Roles Anywhere Profile whose endpoint is <profileName>-<integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
 		// Instead of failing when the integration is already created, it fails at creation time.
 		if errs := validation.IsDNS1035Label(req.GetIntegration().GetName()); len(errs) > 0 {
 			return nil, trace.BadParameter("integration name %q must be a lower case valid DNS subdomain so that it can be used to allow Web/CLI access", req.GetIntegration().GetName())

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -1,0 +1,420 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// AWSRolesAnywherProfileSyncerParams contains the parameters for the AWS Roles Anywhere Profile Syncer.
+type AWSRolesAnywherProfileSyncerParams struct {
+	// Clock is used to calculate the expiration time of the AppServers.
+	Clock clockwork.Clock
+
+	// Logger is used to log messages.
+	Logger *slog.Logger
+
+	// KeyStoreManager grants access to the AWS Roles Anywhere signer.
+	KeyStoreManager KeyStoreManager
+
+	// Cache is used to get the current cluster name and cert authority keys.
+	Cache SyncerCache
+
+	// AppServerUpserter is used to upsert AppServers.
+	AppServerUpserter AppServerUpserter
+
+	// HostUUID is the Host UUID to assign to the AppServers.
+	HostUUID string
+
+	// SyncPollInterval is the interval at which to poll for new profiles.
+	// Default is 5 minutes.
+	SyncPollInterval time.Duration
+
+	// subjectName is the name of the subject to use when generating AWS credentials.
+	subjectName string
+
+	// rolesAnywhereClient is the AWS Roles Anywhere client used to interact with the AWS IAM Roles Anywhere service.
+	// Should only be set for testing purposes.
+	rolesAnywhereClient RolesAnywhereClient
+
+	// createSession is the API used to create a session with AWS IAM Roles Anywhere.
+	// This is used to mock the CreateSession API in tests.
+	createSession func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error)
+}
+
+// SyncerCache is the subset of the cached resources that the syncer service queries.
+type SyncerCache interface {
+	// GetCertAuthority returns cert authority by id
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
+	// GetClusterName returns the current cluster name.
+	GetClusterName(ctx context.Context) (types.ClusterName, error)
+	// GetProxies returns a list of proxy servers registered in the cluster
+	GetProxies() ([]types.Server, error)
+	// ListIntegrations returns a paginated list of all integration resources.
+	ListIntegrations(ctx context.Context, pageSize int, nextKey string) ([]types.Integration, string, error)
+}
+
+// RolesAnywhereClient is an interface that defines methods to interact with the AWS IAM Roles Anywhere service.
+type RolesAnywhereClient interface {
+	// Lists all profiles in the authenticated account and Amazon Web Services Region.
+	ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error)
+
+	// Lists the tags attached to the resource.
+	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
+}
+
+func (p *AWSRolesAnywherProfileSyncerParams) checkAndSetDefaults() error {
+	if p.KeyStoreManager == nil {
+		return trace.BadParameter("key store manager is required")
+	}
+
+	if p.Cache == nil {
+		return trace.BadParameter("cache client is required")
+	}
+
+	if p.AppServerUpserter == nil {
+		return trace.BadParameter("app server upserter is required")
+	}
+
+	if p.SyncPollInterval == 0 {
+		p.SyncPollInterval = 5 * time.Minute
+	}
+
+	if p.Logger == nil {
+		p.Logger = slog.Default()
+	}
+
+	if p.Clock == nil {
+		p.Clock = clockwork.NewRealClock()
+	}
+
+	if p.HostUUID == "" {
+		p.HostUUID = uuid.NewString()
+	}
+
+	p.subjectName = "teleport-roles-anywhere-profile-sync"
+
+	return nil
+}
+
+// AppServerUpserter is an interface that defines methods for upserting application servers.
+type AppServerUpserter interface {
+	// UpsertApplicationServer registers an application server.
+	UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error)
+}
+
+// RunAWSRolesAnywherProfileSyncer starts the AWS Roles Anywhere Profile Syncer.
+// It will iterate over all AWS IAM Roles Anywhere integrations, and for each one:
+// 1. Check if the Profile Sync is enabled.
+// 2. Generate AWS credentials using the integration.
+// 3. List all profiles in the AWS IAM Roles Anywhere service.
+// 4. For each profile, check if it is enabled and has associated roles.
+// 5. Create an AppServer for each profile, using the profile name as the AppServer name.
+// AppServer name can be overridden by the `TeleportApplicationName` tag on the Profile.
+func RunAWSRolesAnywherProfileSyncer(ctx context.Context, params AWSRolesAnywherProfileSyncerParams) error {
+	if err := params.checkAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for {
+		integrations, err := integrationsWithProfileSyncEnabled(ctx, params.Cache)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		proxyPublicAddr, err := fetchProxyPublicAddr(params.Cache)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		for _, integration := range integrations {
+			if err := syncProfileForIntegration(ctx, params, integration, proxyPublicAddr); err != nil {
+				params.Logger.ErrorContext(ctx, "failed to sync AWS Roles Anywhere Profiles for integration", "error", err)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-params.Clock.After(params.SyncPollInterval):
+		}
+	}
+}
+
+func fetchProxyPublicAddr(cache SyncerCache) (string, error) {
+	proxies, err := cache.GetProxies()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if len(proxies) == 0 {
+		return "", trace.NotFound("no proxies found")
+	}
+
+	proxy := proxies[0]
+	if proxy.GetPublicAddr() == "" {
+		return "", trace.NotFound("proxy %q does not have a public address", proxy.GetName())
+	}
+	return proxy.GetPublicAddr(), nil
+}
+
+func integrationsWithProfileSyncEnabled(ctx context.Context, cache SyncerCache) ([]types.Integration, error) {
+	var integrations []types.Integration
+	var nextKey string
+
+	for {
+		resp, respNextKey, err := cache.ListIntegrations(ctx, 0, nextKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, integration := range resp {
+			if integration.GetSubKind() != types.IntegrationSubKindAWSRolesAnywhere ||
+				integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig == nil ||
+				!integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.Enabled {
+
+				continue
+			}
+
+			integrations = append(integrations, integration)
+		}
+
+		if respNextKey == "" {
+			break
+		}
+		nextKey = respNextKey
+	}
+
+	return integrations, nil
+}
+
+func buildAWSRolesAnywhereClientForIntegration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams, integration types.Integration) (RolesAnywhereClient, error) {
+	trustAnchorARN := integration.GetAWSRolesAnywhereIntegrationSpec().TrustAnchorARN
+	profileSyncProfileARN := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
+	profileSyncRoleARN := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.RoleARN
+	profileAcceptsRoleSessionName := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileAcceptsRoleSessionName
+
+	parsedProfileSyncProfile, err := arn.Parse(profileSyncProfileARN)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	region := parsedProfileSyncProfile.Region
+
+	resp, err := GenerateCredentials(ctx, GenerateCredentialsRequest{
+		Clock:                 params.Clock,
+		TrustAnchorARN:        trustAnchorARN,
+		ProfileARN:            profileSyncProfileARN,
+		RoleARN:               profileSyncRoleARN,
+		SubjectCommonName:     params.subjectName,
+		AcceptRoleSessionName: profileAcceptsRoleSessionName,
+		KeyStoreManager:       params.KeyStoreManager,
+		Cache:                 params.Cache,
+		CreateSession:         params.createSession,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(region),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(resp.AccessKeyID, resp.SecretAccessKey, resp.SessionToken)),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// If a custom client is provided, use it instead.
+	// This must only be used for testing purposes.
+	if params.rolesAnywhereClient != nil {
+		return params.rolesAnywhereClient, nil
+	}
+
+	return rolesanywhere.NewFromConfig(awsConfig), nil
+}
+
+func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams, integration types.Integration, proxyPublicAddr string) error {
+	logger := params.Logger.With("integration", integration.GetName())
+
+	raClient, err := buildAWSRolesAnywhereClientForIntegration(ctx, params, integration)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var nextPage *string
+	for {
+		profilesListResp, err := raClient.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
+			NextToken: nextPage,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		for _, profile := range profilesListResp.Profiles {
+			err := processProfile(ctx, processProfileRequest{
+				Params:          params,
+				Profile:         profile,
+				RAClient:        raClient,
+				Integration:     integration,
+				ProxyPublicAddr: proxyPublicAddr,
+			})
+			if err != nil {
+				if errors.Is(err, errDisabledProfile) || errors.Is(err, errProfileIsUsedForSync) {
+					logger.DebugContext(ctx, "Skipping profile", "profile_name", aws.ToString(profile.Name), "error", err.Error())
+					continue
+				}
+
+				logger.WarnContext(ctx, "Failed to process profile", "profile_name", aws.ToString(profile.Name), "error", err)
+			}
+		}
+
+		if aws.ToString(profilesListResp.NextToken) == "" {
+			break
+		}
+		nextPage = profilesListResp.NextToken
+	}
+
+	return nil
+}
+
+var (
+	errDisabledProfile      = errors.New("profile is disabled")
+	errProfileIsUsedForSync = errors.New("profile is used to sync profiles and will not be added as an aws app")
+)
+
+type processProfileRequest struct {
+	Params          AWSRolesAnywherProfileSyncerParams
+	Profile         ratypes.ProfileDetail
+	RAClient        RolesAnywhereClient
+	Integration     types.Integration
+	ProxyPublicAddr string
+}
+
+func processProfile(ctx context.Context, req processProfileRequest) error {
+	profileSyncProfileARN := req.Integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
+
+	if aws.ToString(req.Profile.ProfileArn) == profileSyncProfileARN {
+		return errProfileIsUsedForSync
+	}
+
+	if !aws.ToBool(req.Profile.Enabled) {
+		return errDisabledProfile
+	}
+
+	profileTags, err := req.RAClient.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
+		ResourceArn: req.Profile.ProfileArn,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), profileTags.Tags, req.ProxyPublicAddr)
+	if err != nil {
+		return trace.BadParameter("failed to convert Profile to AppServer: %v", err)
+	}
+
+	if _, err := req.Params.AppServerUpserter.UpsertApplicationServer(ctx, appServer); err != nil {
+		return trace.BadParameter("failed to upsert application server from Profile: %v", err)
+	}
+
+	return nil
+}
+
+func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.ProfileDetail, integrationName string, profileTags []ratypes.Tag, proxyPublicAddr string) (types.AppServer, error) {
+	profileName := aws.ToString(profile.Name)
+	profileARN := aws.ToString(profile.ProfileArn)
+	parsedProfileARN, err := arn.Parse(profileARN)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	applicationName := profileName + "-" + integrationName
+
+	labels := make(map[string]string, len(profileTags))
+	for _, tag := range profileTags {
+		labels["aws/"+aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+
+		if aws.ToString(tag.Key) == types.AWSRolesAnywhereProfileNameOverrideLabel {
+			applicationName = aws.ToString(tag.Value)
+		}
+	}
+
+	appURL := utils.DefaultAppPublicAddr(strings.ToLower(applicationName), proxyPublicAddr)
+
+	labels[types.AWSAccountIDLabel] = parsedProfileARN.AccountID
+	labels[constants.AWSAccountIDLabel] = parsedProfileARN.AccountID
+	labels[types.IntegrationLabel] = integrationName
+	labels[types.AWSRolesAnywhereProfileARNLabel] = profileARN
+
+	// TODO(marco): add origin label in v19: teleport.dev/origin: integration_awsrolesanywhere
+	// types.Metadata.CheckAndSetDefaults in v17 returns an error if the origin label is set to AWS Roles Anywhere.
+	// Only V18 application services support the origin label, so we can only add it in V19.
+
+	expiration := params.Clock.Now().Add(params.SyncPollInterval * 2)
+
+	appServer, err := types.NewAppServerV3(types.Metadata{
+		Name:    applicationName,
+		Labels:  labels,
+		Expires: &expiration,
+	}, types.AppServerSpecV3{
+		HostID: params.HostUUID,
+		App: &types.AppV3{
+			Metadata: types.Metadata{
+				Name:   applicationName,
+				Labels: labels,
+			},
+			Spec: types.AppSpecV3{
+				URI:         constants.AWSConsoleURL,
+				Integration: integrationName,
+				PublicAddr:  appURL,
+				AWS: &types.AppAWS{
+					RolesAnywhereProfile: &types.AppAWSRolesAnywhereProfile{
+						ProfileARN:            aws.ToString(profile.ProfileArn),
+						AcceptRoleSessionName: aws.ToBool(profile.AcceptRoleSessionName),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return appServer, nil
+}

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -1,0 +1,329 @@
+//go:build go1.24 && enablesynctest
+
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+/*
+This file uses the experimental testing/synctest package introduced with Go 1.24:
+
+    https://go.dev/blog/synctest
+
+When editing this file, you should set GOEXPERIMENT=synctest for your editor/LSP
+to ensure that the language server doesn't fail to recognize the package.
+
+This file is also protected by a build tag to ensure that `go test` doesn't fail
+for users who haven't set the environment variable.
+*/
+
+func TestProfileSyncerTestAndSetDefaults(t *testing.T) {
+	baseParams := func() *AWSRolesAnywherProfileSyncerParams {
+		return &AWSRolesAnywherProfileSyncerParams{
+			KeyStoreManager:   keystore.NewSoftwareKeystoreForTests(t),
+			Cache:             &mockCache{},
+			AppServerUpserter: &mockCache{},
+		}
+	}
+
+	for _, tt := range []struct {
+		name       string
+		params     *AWSRolesAnywherProfileSyncerParams
+		errCheck   require.ErrorAssertionFunc
+		valueCheck func(*testing.T, *AWSRolesAnywherProfileSyncerParams)
+	}{
+		{
+			name:     "default values",
+			params:   baseParams(),
+			errCheck: require.NoError,
+			valueCheck: func(t *testing.T, p *AWSRolesAnywherProfileSyncerParams) {
+				require.Equal(t, 5*time.Minute, p.SyncPollInterval)
+				require.NotNil(t, p.Logger)
+				require.NotNil(t, p.Clock)
+				require.NotEmpty(t, p.HostUUID)
+			},
+		},
+		{
+			name: "missing key store manager",
+			params: func() *AWSRolesAnywherProfileSyncerParams {
+				p := baseParams()
+				p.KeyStoreManager = nil
+				return p
+			}(),
+			errCheck: require.Error,
+		},
+		{
+			name: "missing cache client",
+			params: func() *AWSRolesAnywherProfileSyncerParams {
+				p := baseParams()
+				p.Cache = nil
+				return p
+			}(),
+			errCheck: require.Error,
+		},
+		{
+			name: "missing AppServerUpserter",
+			params: func() *AWSRolesAnywherProfileSyncerParams {
+				p := baseParams()
+				p.AppServerUpserter = nil
+				return p
+			}(),
+			errCheck: require.Error,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.checkAndSetDefaults()
+			if tt.errCheck != nil {
+				tt.errCheck(t, err)
+			}
+			if tt.valueCheck != nil {
+				tt.valueCheck(t, tt.params)
+			}
+		})
+	}
+}
+
+func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
+	awsRolesAnywhereIntegration := func(t *testing.T, name string, syncEnabled bool) types.Integration {
+		t.Helper()
+
+		ig, err := types.NewIntegrationAWSRA(types.Metadata{Name: name}, &types.AWSRAIntegrationSpecV1{
+			TrustAnchorARN: "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/ExampleTrustAnchor",
+			ProfileSyncConfig: &types.AWSRolesAnywhereProfileSyncConfig{
+				Enabled:                       syncEnabled,
+				ProfileARN:                    "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2",
+				ProfileAcceptsRoleSessionName: true,
+				RoleARN:                       "arn:aws:iam::123456789012:role/SyncRole",
+			},
+		})
+		require.NoError(t, err)
+		return ig
+	}
+
+	mockCreateSession := func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
+		return &createsession.CreateSessionResponse{
+			Version:         1,
+			AccessKeyID:     "access-key-id",
+			SecretAccessKey: "secret-access-key",
+			SessionToken:    "session-token",
+			Expiration:      time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339),
+		}, nil
+	}
+
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	syncProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	disabledProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3"),
+		Enabled:               aws.Bool(false),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	exampleProfileTags := map[string][]ratypes.Tag{
+		aws.ToString(exampleProfile.ProfileArn): {
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}
+
+	syncEnabled := true
+	integrationWithProfileSync := awsRolesAnywhereIntegration(t, "test-integration", syncEnabled)
+
+	syncDisabled := false
+	integrationWithoutProfileSync := awsRolesAnywhereIntegration(t, "test-integration-no-profile-sync", syncDisabled)
+
+	baseServerClient := func(t *testing.T) *mockCache {
+		t.Helper()
+		return &mockCache{
+			integrations: []types.Integration{
+				integrationWithProfileSync,
+				integrationWithoutProfileSync,
+			},
+			ca: newCertAuthority(t, types.AWSRACA, "cluster-name"),
+		}
+	}
+
+	baseParams := func(serverClient *mockCache) AWSRolesAnywherProfileSyncerParams {
+		return AWSRolesAnywherProfileSyncerParams{
+			KeyStoreManager:   keystore.NewSoftwareKeystoreForTests(t),
+			Cache:             serverClient,
+			AppServerUpserter: serverClient,
+			Logger:            utils.NewSlogLoggerForTests(),
+			createSession:     mockCreateSession,
+		}
+	}
+
+	t.Run("sync profile and disabled profiles are skipped", func(t *testing.T) {
+		serverClient := baseServerClient(t)
+
+		params := baseParams(serverClient)
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			profiles: []ratypes.ProfileDetail{
+				syncProfile,
+				disabledProfile,
+			},
+			tags: exampleProfileTags,
+		}
+
+		synctest.Run(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				err := RunAWSRolesAnywherProfileSyncer(ctx, params)
+				assert.NoError(t, err)
+			}()
+
+			// Wait for the 1st profile sync iteration.
+			synctest.Wait()
+			cancel()
+
+			require.Len(t, serverClient.appServers, 0)
+		})
+	})
+
+	t.Run("app server is created", func(t *testing.T) {
+		serverClient := baseServerClient(t)
+
+		params := baseParams(serverClient)
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			profiles: []ratypes.ProfileDetail{
+				syncProfile,
+				disabledProfile,
+				exampleProfile,
+			},
+			tags: exampleProfileTags,
+		}
+
+		synctest.Run(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				err := RunAWSRolesAnywherProfileSyncer(ctx, params)
+				assert.NoError(t, err)
+			}()
+
+			// Wait for the 1st profile sync iteration.
+			synctest.Wait()
+			cancel()
+
+			require.Len(t, serverClient.appServers, 1)
+			appServer := serverClient.appServers[0]
+			require.Equal(t, "ExampleProfile-test-integration", appServer.GetName())
+			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
+			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
+			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
+			require.Equal(t, map[string]string{
+				"aws/MyTagKey":            "my-tag-value",
+				"aws_account_id":          "123456789012",
+				"teleport.dev/account-id": "123456789012",
+				"teleport.dev/aws-roles-anywhere-profile-arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
+				"teleport.dev/integration":                    "test-integration",
+			}, appServer.GetAllLabels())
+		})
+	})
+
+	t.Run("app server name is sourced from TeleportApplicationName Profile Tag, if set", func(t *testing.T) {
+		serverClient := baseServerClient(t)
+
+		params := baseParams(serverClient)
+		tags := map[string][]ratypes.Tag{
+			aws.ToString(exampleProfile.ProfileArn): {
+				{Key: aws.String("TeleportApplicationName"), Value: aws.String("ProfileCustomName")},
+			},
+		}
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+			},
+			tags: tags,
+		}
+
+		synctest.Run(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				err := RunAWSRolesAnywherProfileSyncer(ctx, params)
+				assert.NoError(t, err)
+			}()
+
+			// Wait for the 1st profile sync iteration.
+			synctest.Wait()
+			cancel()
+
+			require.Len(t, serverClient.appServers, 1)
+			appServer := serverClient.appServers[0]
+			require.Equal(t, "ProfileCustomName", appServer.GetName())
+			require.Equal(t, "123456789012", appServer.GetApp().GetAWSAccountID())
+			require.True(t, appServer.GetApp().GetAWSRolesAnywhereAcceptRoleSessionName())
+			require.Equal(t, "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1", appServer.GetApp().GetAWSRolesAnywhereProfileARN())
+			require.Equal(t, map[string]string{
+				"aws/TeleportApplicationName":                 "ProfileCustomName",
+				"aws_account_id":                              "123456789012",
+				"teleport.dev/account-id":                     "123456789012",
+				"teleport.dev/aws-roles-anywhere-profile-arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
+				"teleport.dev/integration":                    "test-integration",
+			}, appServer.GetAllLabels())
+		})
+	})
+}
+
+type mockRolesAnywhereClient struct {
+	profiles []ratypes.ProfileDetail
+	tags     map[string][]ratypes.Tag
+}
+
+// Lists all profiles in the authenticated account and Amazon Web Services Region.
+func (m *mockRolesAnywhereClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles: m.profiles,
+	}, nil
+}
+
+// Lists the tags attached to the resource.
+func (m *mockRolesAnywhereClient) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	tags := m.tags[aws.ToString(params.ResourceArn)]
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: tags,
+	}, nil
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -133,6 +133,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/s3sessions"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
+	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/joinserver"
@@ -2690,6 +2691,58 @@ func (process *TeleportProcess) initAuthService() error {
 
 	process.RegisterFunc("auth.recording_encryption_resolver", func() error {
 		return trace.Wrap(recordingEncryptionManager.Watch(process.GracefulExitContext(), authServer.Services))
+	})
+
+	awsRolesAnywhereProfileSyncProcessName := "aws-roles-anywhere.profile-sync"
+	process.RegisterFunc("auth."+awsRolesAnywhereProfileSyncProcessName+".service", func() error {
+		ctx := process.GracefulExitContext()
+		logger := process.logger.With("process", awsRolesAnywhereProfileSyncProcessName)
+
+		if _, err := process.WaitForEvent(ctx, TeleportReadyEvent); err != nil {
+			logger.DebugContext(ctx, "process exiting: failed to start AWS Roles Anywhere profile sync service")
+			return nil
+		}
+
+		params := awsra.AWSRolesAnywherProfileSyncerParams{
+			Clock:             process.Clock,
+			Logger:            logger,
+			KeyStoreManager:   authServer.GetKeyStore(),
+			Cache:             authServer.Cache,
+			AppServerUpserter: authServer.Services,
+			HostUUID:          process.Config.HostUUID,
+		}
+
+		runWhileLockedConfig := backend.RunWhileLockedConfig{
+			LockConfiguration: backend.LockConfiguration{
+				Backend:            process.backend,
+				LockNameComponents: []string{awsRolesAnywhereProfileSyncProcessName},
+				TTL:                1 * time.Minute,
+			},
+			RefreshLockInterval: 20 * time.Second,
+		}
+
+		runFunction := func(ctx context.Context) error {
+			return trace.Wrap(awsra.RunAWSRolesAnywherProfileSyncer(ctx, params))
+		}
+
+		waitWithJitter := retryutils.SeventhJitter(time.Second * 10)
+		for {
+			err := backend.RunWhileLocked(ctx, runWhileLockedConfig, runFunction)
+			if err != nil && ctx.Err() == nil {
+				logger.ErrorContext(
+					ctx,
+					"AWS Roles Anywhere profile syncer encountered a fatal error, it will restart after backoff",
+					"error", err,
+					"restart_after", waitWithJitter,
+				)
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(waitWithJitter):
+			}
+		}
 	})
 
 	// execute this when process is asked to exit:


### PR DESCRIPTION
This PR adds a new process that will sync AWS IAM Roles Anywhere Profiles as AWS Apps.

It runs on the Auth Server with a semaphore:1.
Every 5 minutes, for each Roles Anywhere Integration with profile sync enabled, it will:
- generate an aws client to list Roles Anywhere Profiles
- filter out Profiles (disabled, no Roles associated and profile used for the Profile Sync)
- convert the profile into an App Server and upsert it into the cluster.

Demo:
<img width="926" alt="image" src="https://github.com/user-attachments/assets/67c2f6b1-b2ec-484f-a640-7a80d8c50d37" />

See https://github.com/gravitational/teleport/issues/53192
