### PR TITLE
Fix `kubernetes_label` example in docs

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -648,7 +648,7 @@ version: v7
 spec:
   allow:
     kubernetes_labels:
-      - "region": "us-east-2"
+      "region": "us-east-2"
     kubernetes_resources:
       - kind: pod
         namespace: "development"


### PR DESCRIPTION
I stumbled across this incorrect example - the `kubernetes_label` field takes a map directly, not a slice of maps.