### PR TITLE
Add scopes RPC services

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -69,6 +69,8 @@ import (
 	notificationsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	secreportsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	trustv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
@@ -105,6 +107,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
 	"github.com/gravitational/teleport/lib/auth/notifications/notificationsv1"
 	"github.com/gravitational/teleport/lib/auth/presence/presencev1"
+	scopedaccess "github.com/gravitational/teleport/lib/auth/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/auth/scopes/joining"
 	"github.com/gravitational/teleport/lib/auth/secreports/secreportsv1"
 	"github.com/gravitational/teleport/lib/auth/stableunixusers"
 	"github.com/gravitational/teleport/lib/auth/trust/trustv1"
@@ -5439,6 +5443,22 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		server,
 		stableUNIXUsersServiceServer,
 	)
+
+	scopedAccessControl, err := scopedaccess.New(scopedaccess.Config{
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating scoped access control service")
+	}
+	scopedaccessv1.RegisterScopedAccessServiceServer(server, scopedAccessControl)
+
+	scopedJoining, err := scopedjoining.New(scopedjoining.Config{
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating scoped provisioning service")
+	}
+	scopedjoiningv1.RegisterScopedJoiningServiceServer(server, scopedJoining)
 
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -1,0 +1,194 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesscontrol
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+// Config contains the parameters for [New].
+type Config struct {
+	Authorizer authz.Authorizer
+	Logger     *slog.Logger
+}
+
+// Server is the [scopedaccessv1.UnimplementedScopedAccessServiceServer] returned by [New].
+type Server struct {
+	scopedaccessv1.UnimplementedScopedAccessServiceServer
+
+	authorizer authz.Authorizer
+	logger     *slog.Logger
+}
+
+// New returns the auth server implementation for the scoped access control
+// service, including the gRPC interface, authz enforcement, and business logic.
+func New(c Config) (*Server, error) {
+	if c.Authorizer == nil {
+		return nil, trace.BadParameter("missing Authorizer")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+	}
+
+	return &Server{
+		authorizer: c.Authorizer,
+		logger:     c.Logger,
+	}, nil
+}
+
+// CreateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRole(ctx, req)
+}
+
+// CreateScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRoleAssignment(ctx, req)
+}
+
+// DeleteScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRole(ctx, req)
+}
+
+// DeleteScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped role assignment", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped role assignment", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRoleAssignment(ctx, req)
+}
+
+// GetScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRole(ctx, req)
+}
+
+// GetScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRoleAssignment(ctx, req)
+}
+
+// ListScopedRoleAssignments implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoleAssignments(ctx, req)
+}
+
+// ListScopedRoles implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoles(ctx, req)
+}
+
+// UpdateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission update scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission update scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).UpdateScopedRole(ctx, req)
+}

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -1,0 +1,134 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provisioning
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+// Config contains the parameters for [New].
+type Config struct {
+	Authorizer authz.Authorizer
+	Logger     *slog.Logger
+}
+
+// Server is the [scopedjoiningv1.ScopedJoiningServiceServer] returned by [New].
+type Server struct {
+	scopedjoiningv1.UnsafeScopedJoiningServiceServer
+
+	authorizer authz.Authorizer
+	logger     *slog.Logger
+}
+
+// New returns the auth server implementation for the scoped provisioning
+// service, including the gRPC interface, authz enforcement, and business logic.
+func New(c Config) (*Server, error) {
+	if c.Authorizer == nil {
+		return nil, trace.BadParameter("missing Authorizer")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+	}
+
+	return &Server{
+		authorizer: c.Authorizer,
+		logger:     c.Logger,
+	}, nil
+}
+
+// CreateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.CreateScopedTokenRequest) (*scopedjoiningv1.CreateScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).CreateScopedToken(ctx, req)
+}
+
+// DeleteScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.DeleteScopedTokenRequest) (*scopedjoiningv1.DeleteScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).DeleteScopedToken(ctx, req)
+}
+
+// GetScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) GetScopedToken(ctx context.Context, req *scopedjoiningv1.GetScopedTokenRequest) (*scopedjoiningv1.GetScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).GetScopedToken(ctx, req)
+}
+
+// ListScopedTokens implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.ListScopedTokensRequest) (*scopedjoiningv1.ListScopedTokensResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).ListScopedTokens(ctx, req)
+}
+
+// UpdateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.UpdateScopedTokenRequest) (*scopedjoiningv1.UpdateScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to update scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to update scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).UpdateScopedToken(ctx, req)
+}


### PR DESCRIPTION
Registers scopedaccessv1.ScopedRoleServiceServer and scopedjoiningv1.ScopedJoiningServiceServer RPC service stubs. The current implementation requires local admin and defers to the not implemented server.