### PR TITLE
Allow downgrade role v8-v7 with full wildcard.

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -2029,7 +2029,11 @@ func maybeDowngradeRoleK8sAPIGroupToV7(role *types.RoleV6) *types.RoleV6 {
 			if elem.APIGroup == types.Wildcard {
 				elem.APIGroup = ""
 			}
-
+			// If we have a wildcard kind, only keep it if the namespace is also a wildcard.
+			if elem.Kind == types.Wildcard && elem.Namespace == types.Wildcard && elem.APIGroup == "" {
+				out = append(out, elem)
+				continue
+			}
 			// If Kind is known in v7 and group is known, remove it the api group and keep the resource.
 			if v, ok := defaultRBACResources[allowedResourcesKey{elem.APIGroup, elem.Kind}]; ok {
 				elem.APIGroup = ""

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5366,6 +5366,14 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 		Allow: types.RoleConditions{
 			KubernetesResources: []types.KubernetesResource{
 				{
+					// Full wildcard has the same behavior in v7 and v8, so we can keep it.
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+				{
 					Kind:      "pods",
 					Name:      types.Wildcard,
 					Namespace: types.Wildcard,
@@ -5460,6 +5468,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 		Allow: types.RoleConditions{
 			KubernetesResources: []types.KubernetesResource{
 				{
+					// In v17, this would also grant access to cluster-wide resources, so we need to reject.
 					Kind:      types.Wildcard,
 					Name:      "foo",
 					Namespace: "bar",
@@ -5473,6 +5482,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 		Allow: types.RoleConditions{
 			KubernetesResources: []types.KubernetesResource{
 				{
+					// In v17, this wasn't supported.
 					Kind:      types.Wildcard,
 					Name:      "bar",
 					Namespace: "", // Cluster wide.
@@ -5572,6 +5582,12 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 			expectedRole: newRole(downgradev7comptibleK8sResourcesRole.GetName(), types.V7, types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					KubernetesResources: []types.KubernetesResource{
+						{
+							Kind:      types.Wildcard,
+							Name:      types.Wildcard,
+							Namespace: types.Wildcard,
+							Verbs:     []string{types.Wildcard},
+						},
 						{
 							Kind:      types.KindKubePod,
 							Name:      types.Wildcard,


### PR DESCRIPTION
This allows the default v8 role to use v17 kubernetes_services. While we can't downgrade wildcard with namespace or without namespace, when we have a wildcard in both, we can.

This allow for better UX and wouldn't prevent users from being able to create access requests on v17 cluster if they are allocated a v8 role.