### PR TITLE
MWI: Use gRPC clients directly in `tbot`

### DIFF
--- a/api/client/streamwatcher.go
+++ b/api/client/streamwatcher.go
@@ -28,12 +28,19 @@ import (
 
 // NewWatcher returns a new streamWatcher
 func (c *Client) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	return StreamWatcherWithClient(ctx, c.grpc, watch)
+}
+
+// StreamWatcherWithClient creates a streamWatcher using the given auth service
+// client. In most cases you should prefer Client.NewWatcher, but this method is
+// useful when managing your own gRPC clients.
+func StreamWatcherWithClient(ctx context.Context, client proto.AuthServiceClient, watch types.Watch) (types.Watcher, error) {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	protoWatch := proto.Watch{
 		Kinds:               watch.Kinds,
 		AllowPartialSuccess: watch.AllowPartialSuccess,
 	}
-	stream, err := c.grpc.WatchEvents(cancelCtx, &protoWatch)
+	stream, err := client.WatchEvents(cancelCtx, &protoWatch)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -27,8 +27,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -39,13 +40,15 @@ import (
 // DatabaseOutputService generates the artifacts necessary to connect to a
 // database using Teleport.
 type DatabaseOutputService struct {
-	botAuthClient     *authclient.Client
-	botCfg            *config.BotConfig
-	cfg               *config.DatabaseOutput
-	getBotIdentity    getBotIdentityFn
-	log               *slog.Logger
-	reloadBroadcaster *channelBroadcaster
-	resolver          reversetunnelclient.Resolver
+	authClient          proto.AuthServiceClient
+	clusterConfigClient clusterconfigpb.ClusterConfigServiceClient
+	trustClient         trustpb.TrustServiceClient
+	botCfg              *config.BotConfig
+	cfg                 *config.DatabaseOutput
+	getBotIdentity      getBotIdentityFn
+	log                 *slog.Logger
+	reloadBroadcaster   *channelBroadcaster
+	resolver            reversetunnelclient.Resolver
 }
 
 func (s *DatabaseOutputService) String() string {
@@ -95,7 +98,7 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 	var err error
 	roles := s.cfg.Roles
 	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
+		roles, err = fetchDefaultRoles(ctx, s.authClient, s.getBotIdentity())
 		if err != nil {
 			return trace.Wrap(err, "fetching default roles")
 		}
@@ -103,7 +106,8 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 
 	id, err := generateIdentity(
 		ctx,
-		s.botAuthClient,
+		s.authClient,
+		s.clusterConfigClient,
 		s.getBotIdentity(),
 		roles,
 		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
@@ -136,7 +140,8 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	routedIdentity, err := generateIdentity(
 		ctx,
-		s.botAuthClient,
+		s.authClient,
+		s.clusterConfigClient,
 		id,
 		roles,
 		effectiveLifetime.TTL,
@@ -156,18 +161,18 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 		"db_service", route.ServiceName,
 	)
 
-	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
+	hostCAs, err := getCertAuthorities(ctx, s.trustClient, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	// TODO(noah): It's likely the Database output does not really need to
 	// output all these CAs - but - for backwards compat reasons, we output them.
 	// Revisit this at a later date and make a call.
-	userCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.UserCA, false)
+	userCAs, err := getCertAuthorities(ctx, s.trustClient, types.UserCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	databaseCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.DatabaseCA, false)
+	databaseCAs, err := getCertAuthorities(ctx, s.trustClient, types.DatabaseCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -279,7 +279,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 
 	services = append(services, &caRotationService{
 		getBotIdentity: b.botIdentitySvc.GetIdentity,
-		botClient:      b.botIdentitySvc.GetClient(),
+		authClient:     clients.AuthService,
 		log: b.log.With(
 			teleport.ComponentKey, teleport.Component(componentTBot, "ca-rotation"),
 		),
@@ -298,7 +298,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		trustBundleCache, err = workloadidentity.NewTrustBundleCache(workloadidentity.TrustBundleCacheConfig{
 			FederationClient: clients.SPIFFEFederationService,
 			TrustClient:      clients.TrustService,
-			EventsClient:     b.botIdentitySvc.GetClient(),
+			EventsClient:     workloadidentity.NewEventsClient(clients.AuthService),
 			ClusterName:      b.botIdentitySvc.GetIdentity().ClusterName,
 			Logger: b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "spiffe-trust-bundle-cache"),

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -358,7 +358,7 @@ func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr util
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "retrieving cluster name")
 	}
-	knownHosts, _, err := ssh.GenerateKnownHosts(ctx, clt, []string{clusterName.GetClusterName()}, addr.Host())
+	knownHosts, _, err := ssh.GenerateKnownHosts(ctx, clt.TrustClient(), []string{clusterName.GetClusterName()}, addr.Host())
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "retrieving SSH Host CA")
 	}


### PR DESCRIPTION
Part 2 of #53711.

Replaces dependencies on `*apiclient.Client` with the gRPC client stubs, which sacrifices some conveniences (introduces some duplication) but means we can use the new "uninitialized" connection introduced in #55170.

The next PR will gracefully handle failing to renew the bot identity on-startup and retrying it in the background.
