### PR TITLE
[v16] Allow unknown ListUnifiedResourceRequest.Kinds

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1400,7 +1400,8 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 
 	for _, kind := range requested {
 		if _, ok := supportedUnifiedResourceKinds[kind]; !ok {
-			return nil, trace.BadParameter("Unsupported kind %q requested", kind)
+			resourceAccess.kindAccessMap[kind] = trace.AccessDenied("Unsupported kind %q requested", kind)
+			continue
 		}
 
 		actionVerbs := []string{types.VerbList, types.VerbRead}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/55171 to branch/v16

changelog: Prevent unknown resource kinds from rendering errors in the web UI