### PR TITLE
Add AWS Roles Anywhere as valid origin label

### DIFF
--- a/api/types/common/constants.go
+++ b/api/types/common/constants.go
@@ -92,4 +92,5 @@ var OriginValues = []string{
 	OriginDiscoveryKubernetes,
 	OriginEntraID,
 	OriginAWSIdentityCenter,
+	OriginIntegrationAWSRolesAnywhere,
 }


### PR DESCRIPTION
For the AWS App Access using Roles Anywhere, we'll be creating AppServers based on the Roles Anywhere Profiles.

In order to properly identify them, we should add the integration identifier as a valid Origin.

This PR is meant to be merged into v18 before an actual release to ensure we can start adding the label in v19.

See https://github.com/gravitational/teleport/issues/53192