### PR TITLE
[v18] Add `scutil --dns` to VNet diag report

### DIFF
--- a/lib/vnet/diag/routeconflict_darwin.go
+++ b/lib/vnet/diag/routeconflict_darwin.go
@@ -129,5 +129,6 @@ func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (str
 func (c *RouteConflictDiag) commands(ctx context.Context) []*exec.Cmd {
 	return []*exec.Cmd{
 		exec.CommandContext(ctx, "netstat", "-rn", "-f", "inet"),
+		exec.CommandContext(ctx, "scutil", "--dns"),
 	}
 }


### PR DESCRIPTION
Backport #55168.

This didn't make the cut for v18 because of flaky tests. Not absolutely necessary for v18, but it's also a very small change that has already been backported to v17.