### PR TITLE
scopes cache filtering and listing

### DIFF
--- a/lib/scopes/cache/assignments/assignment_cache.go
+++ b/lib/scopes/cache/assignments/assignment_cache.go
@@ -1,0 +1,166 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package assignments
+
+import (
+	"context"
+	"slices"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/cache"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+)
+
+const (
+	defaultPageSize = 256
+	maxPageSize     = 1024
+)
+
+// AssignmentCache is a cache for scoped role assignments.
+type AssignmentCache struct {
+	cache *cache.Cache[*accessv1.ScopedRoleAssignment, string]
+}
+
+// NewAssignmentCache creates a new assignment cache instance.
+func NewAssignmentCache() *AssignmentCache {
+	return &AssignmentCache{
+		cache: cache.Must(cache.Config[*accessv1.ScopedRoleAssignment, string]{
+			Scope: func(assignment *accessv1.ScopedRoleAssignment) string {
+				return assignment.GetScope()
+			},
+			Key: func(assignment *accessv1.ScopedRoleAssignment) string {
+				return assignment.GetMetadata().GetName()
+			},
+			Clone: proto.CloneOf[*accessv1.ScopedRoleAssignment],
+		}),
+	}
+}
+
+// ListScopedRoleAssignments returns a paginated list of scoped role assignments.
+func (c *AssignmentCache) ListScopedRoleAssignments(ctx context.Context, req *accessv1.ListScopedRoleAssignmentsRequest) (*accessv1.ListScopedRoleAssignmentsResponse, error) {
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	if req.GetResourceScope() != nil && req.GetAssignedScope() != nil {
+		return nil, trace.BadParameter("cannot filter by both resource scope and assigned scope simultaneously")
+	}
+
+	filter := func(assignment *accessv1.ScopedRoleAssignment) bool {
+		if req.GetUser() != "" && assignment.GetSpec().GetUser() != req.GetUser() {
+			return false
+		}
+
+		if req.GetRole() != "" {
+			if !slices.ContainsFunc(assignment.GetSpec().Assignments, func(a *accessv1.Assignment) bool { return a.GetRole() == req.GetRole() }) {
+				// if the assignment does not have the requested role, skip it
+				return false
+			}
+		}
+
+		return true
+	}
+
+	cursor, err := cache.DecodeStringCursor(req.GetPageToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// resources subject to policy scope root is basically the scoped resource equivalent
+	// of a "get all". this is a reasonable default for most queries.
+	getter := c.cache.ResourcesSubjectToPolicyScope
+	scope := scopes.Root
+
+	// if a resource scope filter has been provided, the user has specified a custom scope/mode to
+	// query by.
+	if req.GetResourceScope() != nil {
+		// a resource-scope based filter has been provided
+		switch req.GetResourceScope().GetMode() {
+		case scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE:
+			getter = c.cache.ResourcesSubjectToPolicyScope
+		case scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE:
+			getter = c.cache.PoliciesApplicableToResourceScope
+		default:
+			return nil, trace.BadParameter("unsupported or unspecified scoping mode %q in scoped role assignment resource scope filter", req.GetResourceScope().GetMode())
+		}
+		scope = req.GetResourceScope().GetScope()
+	}
+
+	if req.GetAssignedScope() != nil {
+		// NOTE: we eventually want to be able to query assignments by the scopes at which they assign roles,
+		// instead of just resource scope. this is important for introspection/auditing but not necessary for
+		// the core funcationality of teleport until we've fully migrated to PDP. For now, the implementation has
+		// been deferred. (will require implementation of a more complex caching structure where each resource
+		// will be associable with multiple scopes)
+		return nil, trace.NotImplemented("assigned scope filtering for scoped role assignments is not yet supported")
+	}
+
+	var out []*accessv1.ScopedRoleAssignment
+	var nextCursor cache.Cursor[string]
+Outer:
+	for scope := range getter(scope, c.cache.WithFilter(filter), c.cache.WithCursor(cursor)) {
+		for assignment := range scope.Items() {
+			if len(out) == pageSize {
+				nextCursor = cache.Cursor[string]{
+					Scope: scope.Scope(),
+					Key:   assignment.GetMetadata().GetName(),
+				}
+				break Outer
+			}
+			out = append(out, assignment)
+		}
+	}
+
+	var nextPageToken string
+	if !nextCursor.IsZero() {
+		nextPageToken, err = cache.EncodeStringCursor(nextCursor)
+		if err != nil {
+			return nil, trace.Errorf("failed to encode cursor %+v: %w (this is a bug)", nextCursor, err)
+		}
+	}
+
+	return &accessv1.ListScopedRoleAssignmentsResponse{
+		Assignments:   out,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+// Put adds a new assignment to the cache. It will overwrite any existing assignment with the same name.
+func (c *AssignmentCache) Put(assignment *accessv1.ScopedRoleAssignment) error {
+	if err := sr.WeakValidateAssignment(assignment); err != nil {
+		return trace.Wrap(err)
+	}
+
+	c.cache.Put(assignment)
+	return nil
+}
+
+// Del removes an assignment from the cache by name.
+func (c *AssignmentCache) Delete(name string) {
+	c.cache.Del(name)
+}

--- a/lib/scopes/cache/assignments/assignment_cache_test.go
+++ b/lib/scopes/cache/assignments/assignment_cache_test.go
@@ -1,0 +1,622 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package assignments
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+)
+
+// TestListScopedRoleAssignmentsScenarios tests particular more tricky ListScopedRoleAssignments scenarios, such
+// as attempts to use an out-of-band cursor to read values outside of the target scope.
+func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
+	t.Parallel()
+
+	assignments := []*accessv1.ScopedRoleAssignment{
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-01",
+			},
+			Scope: "/",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-01",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-02",
+						Scope: "/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-02",
+			},
+			Scope: "/aa",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-03",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-04",
+						Scope: "/aa/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "bob-01",
+			},
+			Scope: "/",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-01",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-02",
+						Scope: "/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "bob-02",
+			},
+			Scope: "/aa",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-03",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-04",
+						Scope: "/aa/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-03",
+			},
+			Scope: "/aa/bb",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-05",
+						Scope: "/aa/bb",
+					},
+					{
+						Role:  "role-06",
+						Scope: "/aa/bb/cc",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "bob-03",
+			},
+			Scope: "/aa/bb",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-05",
+						Scope: "/aa/bb",
+					},
+					{
+						Role:  "role-06",
+						Scope: "/aa/bb/cc",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "carol-01",
+			},
+			Scope: "/bb",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "carol",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-07",
+						Scope: "/bb",
+					},
+					{
+						Role:  "role-08",
+						Scope: "/bb/cc",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	cache := NewAssignmentCache()
+	for _, assignment := range assignments {
+		cache.Put(assignment)
+	}
+
+	// verify expected behavior for standard cursors in resources subject to scope mode
+	rsp, err := cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:bob-02@/aa",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
+
+	// try to inject a malicious root out-of-band cursor in resources subject to scope mode (no effect)
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:bob-01@/",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"alice-02", "bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
+
+	// try to inject a malicious orthogonal out-of-band cursor in resources subject to scope mode (no effect)
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:carol-01@/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"alice-02", "bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
+
+	// verify expected behavior for standard cursors in policies applicable to scope mode
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:bob-01@/",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"bob-01", "alice-02", "bob-02"}, collectAssignmentNames(rsp.Assignments))
+
+	// try to inject a malicious child out-of-band cursor in policies applicable to scope mode (effect is
+	// to ignore all items in valid query path).
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:bob-03@/aa/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Empty(t, collectAssignmentNames(rsp.Assignments))
+
+	// try to inject a malicious orthogonal out-of-band cursor in policies applicable to scope mode (effect is to
+	// ignore root, but process leaf normally).
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:carol-01@/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"alice-02", "bob-02"}, collectAssignmentNames(rsp.Assignments))
+
+	// verify rejection of unknown cursor version
+	_, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v2:bob-02@/aa",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+}
+
+// TestListScopedRoleAssignmentsBasics tests some basic functionality of the ListScopedRoleAssignments method.
+func TestListScopedRoleAssignmentsBasics(t *testing.T) {
+	t.Parallel()
+
+	assignments := []*accessv1.ScopedRoleAssignment{
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-01",
+			},
+			Scope: "/",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-01",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-02",
+						Scope: "/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "alice-02",
+			},
+			Scope: "/aa",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-03",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-04",
+						Scope: "/aa/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "bob-01",
+			},
+			Scope: "/",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-01",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-02",
+						Scope: "/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "bob-02",
+			},
+			Scope: "/aa",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-03",
+						Scope: "/aa",
+					},
+					{
+						Role:  "role-04",
+						Scope: "/aa/bb",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRoleAssignment,
+			Metadata: &headerpb.Metadata{
+				Name: "carol-01",
+			},
+			Scope: "/bb",
+			Spec: &accessv1.ScopedRoleAssignmentSpec{
+				User: "carol",
+				Assignments: []*accessv1.Assignment{
+					{
+						Role:  "role-05",
+						Scope: "/bb",
+					},
+					{
+						Role:  "role-06",
+						Scope: "/bb/cc",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	tts := []struct {
+		name   string
+		req    *accessv1.ListScopedRoleAssignmentsRequest
+		expect [][]string
+	}{
+		{
+			name: "all single page explicit excess",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				PageSize: int32(len(assignments) + 1),
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+					"alice-02",
+					"bob-02",
+					"carol-01",
+				},
+			},
+		},
+		{
+			name: "all single page implicit excess",
+			req:  &accessv1.ListScopedRoleAssignmentsRequest{},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+					"alice-02",
+					"bob-02",
+					"carol-01",
+				},
+			},
+		},
+		{
+			name: "all single page exact",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				PageSize: int32(len(assignments)),
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+					"alice-02",
+					"bob-02",
+					"carol-01",
+				},
+			},
+		},
+		{
+			name: "all multi page",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				PageSize: 2,
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+				},
+				{
+					"alice-02",
+					"bob-02",
+				},
+				{
+					"carol-01",
+				},
+			},
+		},
+		{
+			name: "user single page",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				User: "alice",
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"alice-02",
+				},
+			},
+		},
+		{
+			name: "user multi page",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				PageSize: 1,
+				User:     "alice",
+			},
+			expect: [][]string{
+				{"alice-01"},
+				{"alice-02"},
+			},
+		},
+		{
+			name: "user nonexistent",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				User: "dave",
+			},
+			expect: nil,
+		},
+		{
+			name: "role single page",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				Role: "role-01",
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+				},
+			},
+		},
+		{
+			name: "role multi page",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				PageSize: 1,
+				Role:     "role-01",
+			},
+			expect: [][]string{
+				{"alice-01"},
+				{"bob-01"},
+			},
+		},
+		{
+			name: "role nonexistent",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				Role: "role-99",
+			},
+			expect: nil,
+		},
+		{
+			name: "resource scope root",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/",
+				},
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+					"alice-02",
+					"bob-02",
+					"carol-01",
+				},
+			},
+		},
+		{
+			name: "resource scope non-root",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/aa",
+				},
+			},
+			expect: [][]string{
+				{
+					"alice-02",
+					"bob-02",
+				},
+			},
+		},
+		{
+			name: "policy scope root",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/",
+				},
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+				},
+			},
+		},
+		{
+			name: "policy scope non-root",
+			req: &accessv1.ListScopedRoleAssignmentsRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/aa",
+				},
+			},
+			expect: [][]string{
+				{
+					"alice-01",
+					"bob-01",
+					"alice-02",
+					"bob-02",
+				},
+			},
+		},
+	}
+
+	cache := NewAssignmentCache()
+	for _, assignment := range assignments {
+		cache.Put(assignment)
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			var out [][]string
+			for {
+				rsp, err := cache.ListScopedRoleAssignments(t.Context(), tt.req)
+				require.NoError(t, err)
+
+				if len(rsp.Assignments) == 0 {
+					break
+				}
+
+				out = append(out, collectAssignmentNames(rsp.Assignments))
+
+				if rsp.NextPageToken == "" {
+					break
+				}
+
+				tt.req.PageToken = rsp.NextPageToken
+			}
+
+			require.Equal(t, tt.expect, out)
+		})
+	}
+}
+
+func collectAssignmentNames(assignments []*accessv1.ScopedRoleAssignment) []string {
+	var names []string
+	for _, assignment := range assignments {
+		names = append(names, assignment.Metadata.Name)
+	}
+	return names
+}

--- a/lib/scopes/cache/roles/role_cache.go
+++ b/lib/scopes/cache/roles/role_cache.go
@@ -1,0 +1,149 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package roles
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/cache"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+)
+
+const (
+	defaultPageSize = 256
+	maxPageSize     = 1024
+)
+
+// RoleCache is a cache for scoped role roles.
+type RoleCache struct {
+	cache *cache.Cache[*accessv1.ScopedRole, string]
+}
+
+// NewRoleCache creates a new role cache instance.
+func NewRoleCache() *RoleCache {
+	return &RoleCache{
+		cache: cache.Must(cache.Config[*accessv1.ScopedRole, string]{
+			Scope: func(role *accessv1.ScopedRole) string {
+				return role.GetScope()
+			},
+			Key: func(role *accessv1.ScopedRole) string {
+				return role.GetMetadata().GetName()
+			},
+			Clone: proto.CloneOf[*accessv1.ScopedRole],
+		}),
+	}
+}
+
+// ListScopedRoles returns a paginated list of scoped roles.
+func (c *RoleCache) ListScopedRoles(ctx context.Context, req *accessv1.ListScopedRolesRequest) (*accessv1.ListScopedRolesResponse, error) {
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	if req.GetResourceScope() != nil && req.GetAssignableScope() != nil {
+		return nil, trace.BadParameter("cannot filter by both resource scope and assignable scope simultaneously")
+	}
+
+	cursor, err := cache.DecodeStringCursor(req.GetPageToken())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// resources subject to policy scope root is basically the scoped resource equivalent
+	// of a "get all". this is a reasonable default for most queries.
+	getter := c.cache.ResourcesSubjectToPolicyScope
+	scope := scopes.Root
+
+	// if a resource scope filter has been provided, the user has specified a custom scope/mode to
+	// query by.
+	if req.GetResourceScope() != nil {
+		// a resource-scope based filter has been provided
+		switch req.GetResourceScope().GetMode() {
+		case scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE:
+			getter = c.cache.ResourcesSubjectToPolicyScope
+		case scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE:
+			getter = c.cache.PoliciesApplicableToResourceScope
+		default:
+			return nil, trace.BadParameter("unsupported or unspecified scoping mode %q in scoped role role resource scope filter", req.GetResourceScope().GetMode())
+		}
+		scope = req.GetResourceScope().GetScope()
+	}
+
+	if req.GetAssignableScope() != nil {
+		// NOTE: we eventually want to be able to query roles by the scopes at which they are assignable,
+		// instead of just resource scope. this is important for introspection/auditing but not necessary for
+		// the core funcationality of teleport, so implementation has been deferred. (will require implementation
+		// of a more complex caching structure where each resource will be associable with multiple scopes)
+		return nil, trace.NotImplemented("assignable scope filtering for scoped role roles is not yet supported")
+	}
+
+	var out []*accessv1.ScopedRole
+	var nextCursor cache.Cursor[string]
+Outer:
+	for scope := range getter(scope, c.cache.WithCursor(cursor)) {
+		for role := range scope.Items() {
+			if len(out) == pageSize {
+				nextCursor = cache.Cursor[string]{
+					Scope: scope.Scope(),
+					Key:   role.GetMetadata().GetName(),
+				}
+				break Outer
+			}
+			out = append(out, role)
+		}
+	}
+
+	var nextPageToken string
+	if !nextCursor.IsZero() {
+		nextPageToken, err = cache.EncodeStringCursor(nextCursor)
+		if err != nil {
+			return nil, trace.Errorf("failed to encode cursor %+v: %w (this is a bug)", nextCursor, err)
+		}
+	}
+
+	return &accessv1.ListScopedRolesResponse{
+		Roles:         out,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+// Put adds a new role to the cache. It will overwrite any existing role with the same name.
+func (c *RoleCache) Put(role *accessv1.ScopedRole) error {
+	if err := sr.WeakValidateRole(role); err != nil {
+		return trace.Wrap(err)
+	}
+
+	c.cache.Put(role)
+	return nil
+}
+
+// Del removes an role from the cache by name.
+func (c *RoleCache) Delete(name string) {
+	c.cache.Del(name)
+}

--- a/lib/scopes/cache/roles/role_cache_test.go
+++ b/lib/scopes/cache/roles/role_cache_test.go
@@ -1,0 +1,418 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package roles
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	sr "github.com/gravitational/teleport/lib/scopes/roles"
+)
+
+// TestListScopedRolesScenarios tests particular more tricky ListScopedRoles scenarios, such
+// as attempts to use an out-of-band cursor to read values outside of the target scope.
+func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
+	t.Parallel()
+
+	roles := []*accessv1.ScopedRole{
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "admin-01",
+			},
+			Scope:   "/",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "admin-02",
+			},
+			Scope:   "/aa",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "user-01",
+			},
+			Scope:   "/",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "user-02",
+			},
+			Scope:   "/aa",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "admin-03",
+			},
+			Scope:   "/aa/bb",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "user-03",
+			},
+			Scope:   "/aa/bb",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "intern-01",
+			},
+			Scope:   "/bb",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+	}
+
+	cache := NewRoleCache()
+	for _, role := range roles {
+		cache.Put(role)
+	}
+
+	// verify expected behavior for standard cursors in resources subject to scope mode
+	rsp, err := cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:user-02@/aa",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"user-02", "admin-03", "user-03"}, collectRoleNames(rsp.Roles))
+
+	// try to inject a malicious root out-of-band cursor in resources subject to scope mode (no effect)
+	rsp, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:user-01@/",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"admin-02", "user-02", "admin-03", "user-03"}, collectRoleNames(rsp.Roles))
+
+	// try to inject a malicious orthogonal out-of-band cursor in resources subject to scope mode (no effect)
+	rsp, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:intern-01@/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"admin-02", "user-02", "admin-03", "user-03"}, collectRoleNames(rsp.Roles))
+
+	// verify expected behavior for standard cursors in policies applicable to scope mode
+	rsp, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:user-01@/",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"user-01", "admin-02", "user-02"}, collectRoleNames(rsp.Roles))
+
+	// try to inject a malicious child out-of-band cursor in policies applicable to scope mode (effect is
+	// to ignore all items in valid query path).
+	rsp, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:user-03@/aa/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Empty(t, collectRoleNames(rsp.Roles))
+
+	// try to inject a malicious orthogonal out-of-band cursor in policies applicable to scope mode (effect is to
+	// ignore root, but process leaf normally).
+	rsp, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v1:intern-01@/bb",
+	})
+	require.NoError(t, err)
+	require.Empty(t, rsp.NextPageToken)
+	require.Equal(t, []string{"admin-02", "user-02"}, collectRoleNames(rsp.Roles))
+
+	// verify rejection of unknown cursor version
+	_, err = cache.ListScopedRoles(t.Context(), &accessv1.ListScopedRolesRequest{
+		ResourceScope: &scopespb.Filter{
+			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+			Scope: "/aa",
+		},
+		PageToken: "v2:user-02@/aa",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
+}
+
+// TestListScopedRolesBasics tests some basic functionality of the ListScopedRoles method.
+func TestListScopedRolesBasics(t *testing.T) {
+	t.Parallel()
+
+	roles := []*accessv1.ScopedRole{
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "admin-01",
+			},
+			Scope:   "/",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "admin-02",
+			},
+			Scope:   "/aa",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "user-01",
+			},
+			Scope:   "/",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "user-02",
+			},
+			Scope:   "/aa",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+		{
+			Kind: sr.KindScopedRole,
+			Metadata: &headerpb.Metadata{
+				Name: "intern-01",
+			},
+			Scope:   "/bb",
+			Spec:    &accessv1.ScopedRoleSpec{},
+			Version: types.V1,
+		},
+	}
+
+	tts := []struct {
+		name   string
+		req    *accessv1.ListScopedRolesRequest
+		expect [][]string
+	}{
+		{
+			name: "all single page explicit excess",
+			req: &accessv1.ListScopedRolesRequest{
+				PageSize: int32(len(roles) + 1),
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+					"admin-02",
+					"user-02",
+					"intern-01",
+				},
+			},
+		},
+		{
+			name: "all single page implicit excess",
+			req:  &accessv1.ListScopedRolesRequest{},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+					"admin-02",
+					"user-02",
+					"intern-01",
+				},
+			},
+		},
+		{
+			name: "all single page exact",
+			req: &accessv1.ListScopedRolesRequest{
+				PageSize: int32(len(roles)),
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+					"admin-02",
+					"user-02",
+					"intern-01",
+				},
+			},
+		},
+		{
+			name: "all multi page",
+			req: &accessv1.ListScopedRolesRequest{
+				PageSize: 2,
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+				},
+				{
+					"admin-02",
+					"user-02",
+				},
+				{
+					"intern-01",
+				},
+			},
+		},
+		{
+			name: "resource scope root",
+			req: &accessv1.ListScopedRolesRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/",
+				},
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+					"admin-02",
+					"user-02",
+					"intern-01",
+				},
+			},
+		},
+		{
+			name: "resource scope non-root",
+			req: &accessv1.ListScopedRolesRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/aa",
+				},
+			},
+			expect: [][]string{
+				{
+					"admin-02",
+					"user-02",
+				},
+			},
+		},
+		{
+			name: "policy scope root",
+			req: &accessv1.ListScopedRolesRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/",
+				},
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+				},
+			},
+		},
+		{
+			name: "policy scope non-root",
+			req: &accessv1.ListScopedRolesRequest{
+				ResourceScope: &scopespb.Filter{
+					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/aa",
+				},
+			},
+			expect: [][]string{
+				{
+					"admin-01",
+					"user-01",
+					"admin-02",
+					"user-02",
+				},
+			},
+		},
+	}
+
+	cache := NewRoleCache()
+	for _, role := range roles {
+		cache.Put(role)
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			var out [][]string
+			for {
+				rsp, err := cache.ListScopedRoles(t.Context(), tt.req)
+				require.NoError(t, err)
+
+				if len(rsp.Roles) == 0 {
+					break
+				}
+
+				out = append(out, collectRoleNames(rsp.Roles))
+
+				if rsp.NextPageToken == "" {
+					break
+				}
+
+				tt.req.PageToken = rsp.NextPageToken
+			}
+
+			require.Equal(t, tt.expect, out)
+		})
+	}
+}
+
+func collectRoleNames(roles []*accessv1.ScopedRole) []string {
+	var names []string
+	for _, role := range roles {
+		names = append(names, role.Metadata.Name)
+	}
+	return names
+}

--- a/lib/scopes/cache/utils.go
+++ b/lib/scopes/cache/utils.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cache
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// cursorV1Prefix is used to ensure that future changes in cursor format don't need to worry
+// about causing unintended behaviors of inadvertently passed to older instances.
+const cursorV1Prefix = "v1:"
+
+// DecodeStringCursor decodes a cursor of the form `v1:<key>@<scope>` into a Cursor[string] struct. This is a reasonable
+// default encoding for page tokens for string-keyed scoped items, so long as the key does not contain the '@' character.
+func DecodeStringCursor(cursor string) (Cursor[string], error) {
+	if cursor == "" {
+		return Cursor[string]{}, nil
+	}
+
+	if !strings.HasPrefix(cursor, cursorV1Prefix) {
+		return Cursor[string]{}, trace.BadParameter("cursor %q is not a valid v1 cursor", cursor)
+	}
+
+	var out Cursor[string]
+	var n int
+	for part := range strings.SplitSeq(strings.TrimPrefix(cursor, cursorV1Prefix), "@") {
+		n++
+		switch n {
+		case 1:
+			out.Key = part
+		case 2:
+			out.Scope = part
+		default:
+			return Cursor[string]{}, trace.BadParameter("too many parts in cursor: %q", cursor)
+		}
+	}
+
+	if out.Key == "" || out.Scope == "" {
+		return Cursor[string]{}, trace.BadParameter("cursor %q is missing key or scope", cursor)
+	}
+
+	if err := scopes.WeakValidate(out.Scope); err != nil {
+		return Cursor[string]{}, trace.BadParameter("cursor %q has invalid scope %q: %v", cursor, out.Scope, err)
+	}
+
+	return out, nil
+}
+
+// EncodeStringCursor encodes a cursor struct into a string of the form `v1:<key>@<scope>`. This is a reasonable
+// default encoding for page tokens for string-keyed scoped items, so long as the key does not contain the '@' character.
+func EncodeStringCursor(cursor Cursor[string]) (string, error) {
+	if cursor.Scope == "" && cursor.Key == "" {
+		return "", nil
+	}
+
+	if cursor.Scope == "" || cursor.Key == "" {
+		return "", trace.BadParameter("cursor key and scope must be non-empty")
+	}
+
+	if strings.Contains(cursor.Key, "@") {
+		return "", trace.BadParameter("cursor key %q contains invalid character '@'", cursor.Key)
+	}
+
+	return cursorV1Prefix + cursor.Key + "@" + cursor.Scope, nil
+}

--- a/lib/scopes/cache/utils_test.go
+++ b/lib/scopes/cache/utils_test.go
@@ -1,0 +1,89 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringCursorFormat(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name   string
+		cursor Cursor[string]
+		enc    string
+		ok     bool
+	}{
+		{
+			name:   "empty",
+			cursor: Cursor[string]{},
+			enc:    "",
+			ok:     true,
+		},
+		{
+			name:   "root",
+			cursor: Cursor[string]{Key: "foo", Scope: "/"},
+			enc:    "v1:foo@/",
+			ok:     true,
+		},
+		{
+			name:   "non-root",
+			cursor: Cursor[string]{Key: "foo", Scope: "/bar"},
+			enc:    "v1:foo@/bar",
+			ok:     true,
+		},
+		{
+			name:   "empty scope",
+			cursor: Cursor[string]{Key: "foo", Scope: ""},
+			enc:    "v1:foo@",
+			ok:     false,
+		},
+		{
+			name:   "empty key",
+			cursor: Cursor[string]{Key: "", Scope: "/bar"},
+			enc:    "v1:@/bar",
+			ok:     false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			enc, err := EncodeStringCursor(tt.cursor)
+			if tt.ok {
+				require.NoError(t, err)
+				require.Equal(t, tt.enc, enc)
+			} else {
+				require.Error(t, err)
+				require.Empty(t, enc)
+			}
+
+			cursor, err := DecodeStringCursor(tt.enc)
+			if tt.ok {
+				require.NoError(t, err)
+				require.Equal(t, tt.cursor, cursor)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, Cursor[string]{}, cursor)
+			}
+		})
+	}
+}

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -61,6 +61,12 @@ const (
 	breakingChars = "\\@(){}\"'%*?#$!+=|<>,;~`&[]/"
 )
 
+// Root is the root scope. Non-policy resources being grandfathered into scoping should use this
+// as their default scope value, which will exclude the resource from administration by any policy
+// other than non-scoped policies and root-scoped policies. Note that there is no sane default scoping
+// for a policy. Policy resources should never use this or any other default scope value.
+const Root = separator
+
 // StrongValidate checks if the scope is valid according to all scope formatting rules. This function
 // *must* be called on all scope values received from user input and/or cluster-external sources (e.g.
 // an identity provider). Use of this function should be avoided when checking the validity of scopes


### PR DESCRIPTION
This PR adds filtering to the core `scopes/cache` cache, adds a standard cursor format for string-like cursors, and introduces implementations of the `ListScopedRoles` and `ListScopedRoleAssignments` methods based on `scopes/cache`.

This isn't the end of caching-related work for scoped roles/assignments since we also need to add said resources to the event stream and augment their respective cache impls to have proper event-based init/update/fallback semantics, but this does represent the last set of behavioral implementations for the CRUD RPC methods of these resources.

During the course of writing test coverage for the above changes, a bug in `scopes/cache.Cache` cursor handling was also discovered and fixed, and an additional test case was added to detect future regressions.

This PR is a direct follow-up to https://github.com/gravitational/teleport/pull/54736 and https://github.com/gravitational/teleport/pull/54969.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).