### PR TITLE
Add TeleportRoleV8 support to the operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -16,6 +16,8 @@ rules:
       - teleportrolesv6/status
       - teleportrolesv7
       - teleportrolesv7/status
+      - teleportrolesv8
+      - teleportrolesv8/status
       - teleportusers
       - teleportusers/status
       - teleportgithubconnectors

--- a/integrations/operator/controllers/resources/rolev7_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev7_controller_test.go
@@ -63,7 +63,7 @@ func (g *roleV7TestingPrimitives) SetupTeleportFixtures(ctx context.Context) err
 }
 
 func (g *roleV7TestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
-	role, err := types.NewRoleWithVersion(name, types.V6, roleV6Spec)
+	role, err := types.NewRoleWithVersion(name, types.V7, roleV7Spec)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integrations/operator/controllers/resources/rolev8_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev8_controller_test.go
@@ -65,7 +65,7 @@ func (g *roleV8TestingPrimitives) SetupTeleportFixtures(ctx context.Context) err
 }
 
 func (g *roleV8TestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
-	role, err := types.NewRoleWithVersion(name, types.V6, roleV6Spec)
+	role, err := types.NewRoleWithVersion(name, types.V8, roleV8Spec)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integrations/operator/controllers/resources/rolev8_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev8_controller_test.go
@@ -1,0 +1,147 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gravitational/teleport/api/types"
+	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
+	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
+)
+
+var roleV8Spec = types.RoleSpecV6{
+	Allow: types.RoleConditions{
+		Logins:           []string{"foo"},
+		KubernetesLabels: types.Labels{"env": {"dev", "prod"}},
+		KubernetesResources: []types.KubernetesResource{
+			{
+				Kind:      "*",
+				Namespace: "monitoring",
+				Name:      "^prometheus-.*",
+				// APIGroup is required for rolev8
+				APIGroup: "monitoring.coreos.com",
+			},
+		},
+	},
+	Deny: types.RoleConditions{},
+}
+
+type roleV8TestingPrimitives struct {
+	setup *testSetup
+	reconcilers.ResourceWithLabelsAdapter[types.Role]
+}
+
+func (g *roleV8TestingPrimitives) Init(setup *testSetup) {
+	g.setup = setup
+}
+
+func (g *roleV8TestingPrimitives) SetupTeleportFixtures(ctx context.Context) error {
+	return nil
+}
+
+func (g *roleV8TestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
+	role, err := types.NewRoleWithVersion(name, types.V6, roleV6Spec)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	role.SetOrigin(types.OriginKubernetes)
+	_, err = g.setup.TeleportClient.CreateRole(ctx, role)
+	return trace.Wrap(err)
+}
+
+func (g *roleV8TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Role, error) {
+	return g.setup.TeleportClient.GetRole(ctx, name)
+}
+
+func (g *roleV8TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
+	return trace.Wrap(g.setup.TeleportClient.DeleteRole(ctx, name))
+}
+
+func (g *roleV8TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	role := &resourcesv1.TeleportRoleV8{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
+		},
+		Spec: resourcesv1.TeleportRoleV8Spec(roleV8Spec),
+	}
+	return trace.Wrap(g.setup.K8sClient.Create(ctx, role))
+}
+
+func (g *roleV8TestingPrimitives) DeleteKubernetesResource(ctx context.Context, name string) error {
+	role := &resourcesv1.TeleportRoleV8{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
+		},
+	}
+	return trace.Wrap(g.setup.K8sClient.Delete(ctx, role))
+}
+
+func (g *roleV8TestingPrimitives) GetKubernetesResource(ctx context.Context, name string) (*resourcesv1.TeleportRoleV8, error) {
+	role := &resourcesv1.TeleportRoleV8{}
+	obj := kclient.ObjectKey{
+		Name:      name,
+		Namespace: g.setup.Namespace.Name,
+	}
+	err := g.setup.K8sClient.Get(ctx, obj, role)
+	return role, trace.Wrap(err)
+}
+
+func (g *roleV8TestingPrimitives) ModifyKubernetesResource(ctx context.Context, name string) error {
+	role, err := g.GetKubernetesResource(ctx, name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	role.Spec.Allow.Logins = []string{"foo", "bar"}
+	return g.setup.K8sClient.Update(ctx, role)
+}
+
+func (g *roleV8TestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.Role, kubeResource *resourcesv1.TeleportRoleV8) (bool, string) {
+	ignoreServerSideDefaults := []cmp.Option{
+		cmpopts.IgnoreFields(types.RoleSpecV6{}, "Options"),
+		cmpopts.IgnoreFields(types.RoleConditions{}, "Namespaces"),
+	}
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions(ignoreServerSideDefaults...)...)
+	return diff == "", diff
+}
+
+func TestTeleportRoleV8Creation(t *testing.T) {
+	test := &roleV8TestingPrimitives{}
+	testlib.ResourceCreationTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+}
+
+func TestTeleportRoleV8DeletionDrift(t *testing.T) {
+	test := &roleV8TestingPrimitives{}
+	testlib.ResourceDeletionDriftTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+}
+
+func TestTeleportRoleV8Update(t *testing.T) {
+	test := &roleV8TestingPrimitives{}
+	testlib.ResourceUpdateTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+}

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -104,3 +104,17 @@ func NewRoleV7Reconciler(client kclient.Client, tClient *client.Client) (control
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }
+
+// NewRoleV8Reconciler instantiates a new Kubernetes controller reconciling role v8 resources
+func NewRoleV8Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+	roleClient := &roleClient{
+		teleportClient: tClient,
+	}
+
+	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[types.Role, *resourcesv1.TeleportRoleV8](
+		client,
+		roleClient,
+	)
+
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
+}

--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -42,6 +42,7 @@ func SetupAllControllers(log logr.Logger, mgr manager.Manager, teleportClient *c
 		{"TeleportRole", NewRoleReconciler},
 		{"TeleportRoleV6", NewRoleV6Reconciler},
 		{"TeleportRoleV7", NewRoleV7Reconciler},
+		{"TeleportRoleV8", NewRoleV8Reconciler},
 		{"TeleportUser", NewUserReconciler},
 		{"TeleportGithubConnector", NewGithubConnectorReconciler},
 		{"TeleportProvisionToken", NewProvisionTokenReconciler},


### PR DESCRIPTION
This PR adds a controller watching for TeleportRoleV8 resources and creating Role v8.

@creack did all the heavy lifting and already created the CR api types and generated the CRD manifests. I only added the controller and the standard resource tests.

Changelog: Add `TeleportRoleV8` support to the Teleport Kubernetes Operator.