### PR TITLE
MWI: Handle failed bot identity renewal on-startup

### DIFF
--- a/lib/tbot/service_heartbeat.go
+++ b/lib/tbot/service_heartbeat.go
@@ -87,7 +87,7 @@ func (s *heartbeatService) OneShot(ctx context.Context) error {
 	// TODO(noah): Remove NotImplemented check at V18 assuming V17 first major
 	// with heartbeating.
 	if err != nil && !trace.IsNotImplemented(err) {
-		return trace.Wrap(err)
+		s.log.ErrorContext(ctx, "Submitting heartbeat failed", "error", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Part 3 of #53711.

Now, if renewing the bot's identity fails on startup (e.g. because the auth server is unavailable), `tbot` will keep running and retry in the background.

changelog: MWI: If `tbot` fails to renew its internal identity on-startup, it will now retry in the background rather than exiting immediately