### PR TITLE
[v18] docs: Add some instructions on HTTPS proxy or base-url changes for managed updates v2

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -595,4 +595,4 @@ $ sudo teleport-update enable --base-url https://teleport.artifactory.company.lo
 It is safe to re-run `sudo teleport-update enable` to modify the base URL.
 Existing updater settings will be preserved if not explicitly overridden by flags.
 
-More information about flags that can be used with `teleport-update enable` can be found [here](https://goteleport.com/docs/reference/cli/teleport-update/#teleport-update-enable).
+More information about flags that can be used with `teleport-update enable` can be found [here](../reference/cli/teleport-update.mdx/#teleport-update-enable).

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -569,13 +569,17 @@ Here are a couple of potential solutions to this issue:
 
 If you configure the `HTTPS_PROXY` variable in the `teleport-update` process's environment, it will use this proxy to pull updates.
 
-The easiest way to configure a proxy with a default install is to add this line to `/etc/systemd/system/teleport.service.d/teleport-update.conf`:
+The easiest way to configure a proxy with a default install is to add this variable to `/etc/systemd/system/teleport-update.service.d/override.conf`:
 
-```
-HTTPS_PROXY=http://proxy-url:3128
+```bash
+$ sudo mkdir -p /etc/systemd/system/teleport-update.service.d
+$ sudo tee -a /etc/systemd/system/teleport-update.service.d/override.conf > /dev/null <<'EOF'
+[Service]
+Environment=HTTPS_PROXY=http://proxy-url:3128
+EOF
 ```
 
-You can view the `teleport-update` process logs with `sudo journalctl -u teleport-update.service`
+You can view the `teleport-update` process logs with `sudo journalctl -u teleport-update.service`.
 
 #### Mirror the Teleport tarball packages and change the base-url
 

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -592,4 +592,7 @@ To change the `base-url`, you should add the `-b` or `--base-url` flag to the `t
 $ sudo teleport-update enable --base-url https://teleport.artifactory.company.local
 ```
 
+It is safe to re-run `sudo teleport-update enable` to modify the base URL.
+Existing updater settings will be preserved if not explicitly overridden by flags.
+
 More information about flags that can be used with `teleport-update enable` can be found [here](https://goteleport.com/docs/reference/cli/teleport-update/#teleport-update-enable).

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -559,3 +559,33 @@ $ journalctl -u teleport-update
    $ sudo teleport-update update --now
    ```
 
+### Using a different CDN URL
+
+If your agents cannot reach the default Teleport CDN URL (`cdn.teleport.dev`), they will be unable to download updates.
+
+Here are a couple of potential solutions to this issue:
+
+#### Use an HTTP CONNECT proxy
+
+If you configure the `HTTPS_PROXY` variable in the `teleport-update` process's environment, it will use this proxy to pull updates.
+
+The easiest way to configure a proxy with a default install is to add this line to `/etc/systemd/system/teleport.service.d/teleport-update.conf`:
+
+```
+HTTPS_PROXY=http://proxy-url:3128
+```
+
+You can view the `teleport-update` process logs with `sudo journalctl -u teleport-update.service`
+
+#### Mirror the Teleport tarball packages and change the base-url
+
+If you can mirror the Teleport tarball installers somewhere that your agents are able to access, you can change the `base-url`
+used by Teleport updaters so they can pull them directly.
+
+To change the `base-url`, you should add the `-b` or `--base-url` flag to the `teleport-update enable` command:
+
+```bash
+$ sudo teleport-update enable --base-url https://teleport.artifactory.company.local
+```
+
+More information about flags that can be used with `teleport-update enable` can be found [here](https://goteleport.com/docs/reference/cli/teleport-update/#teleport-update-enable).

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -595,4 +595,4 @@ $ sudo teleport-update enable --base-url https://teleport.artifactory.company.lo
 It is safe to re-run `sudo teleport-update enable` to modify the base URL.
 Existing updater settings will be preserved if not explicitly overridden by flags.
 
-More information about flags that can be used with `teleport-update enable` can be found [here](../reference/cli/teleport-update.mdx/#teleport-update-enable).
+More information about flags that can be used with `teleport-update enable` can be found [here](../reference/cli/teleport-update.mdx#teleport-update-enable)


### PR DESCRIPTION
Backport #54250 to branch/v18

Does not need to be merged until v18 release.