### PR TITLE
[vnet] feat: write VNet SSH keys to TELEPORT_HOME

### DIFF
--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -73,6 +73,15 @@ const (
 	profileFileExt = ".yaml"
 	// oracleWalletDirSuffix is the suffix of the oracle wallet database directory.
 	oracleWalletDirSuffix = "-wallet"
+	// VNetClientSSHKey is the file name of the SSH key used by third-party SSH
+	// clients to connect to VNet SSH.
+	VNetClientSSHKey = "id_vnet"
+	// VNetClientSSHKeyPub is the file name of the SSH public key matching
+	// VNetClientSSHKey.
+	VNetClientSSHKeyPub = VNetClientSSHKey + fileExtPub
+	// vnetKnownHosts is the file name of the known_hosts file trusted by
+	// third-party SSH clients connecting to VNet SSH.
+	vnetKnownHosts = "vnet_known_hosts"
 )
 
 // Here's the file layout of all these keypaths.
@@ -81,6 +90,9 @@ const (
 // ├── one.example.com.yaml            --> file containing profile details for proxy "one.example.com"
 // ├── two.example.com.yaml            --> file containing profile details for proxy "two.example.com"
 // ├── known_hosts                     --> trusted certificate authorities (their keys) in a format similar to known_hosts
+// ├── id_vnet                         --> SSH Private Key for third-party clients of VNet SSH
+// ├── id_vnet.pub                     --> SSH Public Key for third-party clients of VNet SSH
+// ├── vnet_known_hosts                --> trusted certificate authorities (their keys) for third-party clients of VNet SSH
 // └── keys							   --> session keys directory
 //    ├── one.example.com              --> Proxy hostname
 //    │   ├── certs.pem                --> TLS CA certs for the Teleport CA
@@ -427,6 +439,21 @@ func IsProfileKubeConfigPath(path string) (bool, error) {
 // <identity-file-dir>/<path>-cert.pub
 func IdentitySSHCertPath(path string) string {
 	return path + fileExtSSHCert
+}
+
+// VNetClientSSHKeyPath returns the path to the VNet client SSH private key.
+func VNetClientSSHKeyPath(baseDir string) string {
+	return filepath.Join(baseDir, VNetClientSSHKey)
+}
+
+// VNetClientSSHKeyPubPath returns the path to the VNet client SSH public key.
+func VNetClientSSHKeyPubPath(baseDir string) string {
+	return filepath.Join(baseDir, VNetClientSSHKeyPub)
+}
+
+// VNetKnownHostsPath returns the path to the VNet known_hosts file.
+func VNetKnownHostsPath(baseDir string) string {
+	return filepath.Join(baseDir, vnetKnownHosts)
 }
 
 // TrimKeyPathSuffix returns the given path with any key suffix/extension trimmed off.

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service.pb.go
@@ -2025,6 +2025,100 @@ func (x *SignForSSHSessionResponse) GetSignature() []byte {
 	return nil
 }
 
+// ExchangeSSHKeysRequest is a request to exchange SSH keys for VNet SSH.
+type ExchangeSSHKeysRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// HostPublicKey is the host key that should be trusted by clients connecting
+	// to VNet SSH addresses. It is encoded in OpenSSH wire format.
+	HostPublicKey []byte `protobuf:"bytes,1,opt,name=host_public_key,json=hostPublicKey,proto3" json:"host_public_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExchangeSSHKeysRequest) Reset() {
+	*x = ExchangeSSHKeysRequest{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeSSHKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeSSHKeysRequest) ProtoMessage() {}
+
+func (x *ExchangeSSHKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeSSHKeysRequest.ProtoReflect.Descriptor instead.
+func (*ExchangeSSHKeysRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ExchangeSSHKeysRequest) GetHostPublicKey() []byte {
+	if x != nil {
+		return x.HostPublicKey
+	}
+	return nil
+}
+
+// ExchangeSSHKeysResponse is a response for ExchangeSSHKeys.
+type ExchangeSSHKeysResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// UserPublicKey is the user key that should be trusted by VNet for incoming
+	// connections from SSH clients. It is encoded in OpenSSH wire format.
+	UserPublicKey []byte `protobuf:"bytes,1,opt,name=user_public_key,json=userPublicKey,proto3" json:"user_public_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExchangeSSHKeysResponse) Reset() {
+	*x = ExchangeSSHKeysResponse{}
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeSSHKeysResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeSSHKeysResponse) ProtoMessage() {}
+
+func (x *ExchangeSSHKeysResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeSSHKeysResponse.ProtoReflect.Descriptor instead.
+func (*ExchangeSSHKeysResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ExchangeSSHKeysResponse) GetUserPublicKey() []byte {
+	if x != nil {
+		return x.UserPublicKey
+	}
+	return nil
+}
+
 var File_teleport_lib_vnet_v1_client_application_service_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
@@ -2135,11 +2229,15 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x125\n" +
 	"\x04sign\x18\x02 \x01(\v2!.teleport.lib.vnet.v1.SignRequestR\x04sign\"9\n" +
 	"\x19SignForSSHSessionResponse\x12\x1c\n" +
-	"\tsignature\x18\x01 \x01(\fR\tsignature*<\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"@\n" +
+	"\x16ExchangeSSHKeysRequest\x12&\n" +
+	"\x0fhost_public_key\x18\x01 \x01(\fR\rhostPublicKey\"A\n" +
+	"\x17ExchangeSSHKeysResponse\x12&\n" +
+	"\x0fuser_public_key\x18\x01 \x01(\fR\ruserPublicKey*<\n" +
 	"\x04Hash\x12\x14\n" +
 	"\x10HASH_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tHASH_NONE\x10\x01\x12\x0f\n" +
-	"\vHASH_SHA256\x10\x022\xcc\v\n" +
+	"\vHASH_SHA256\x10\x022\xbc\f\n" +
 	"\x18ClientApplicationService\x12z\n" +
 	"\x13AuthenticateProcess\x120.teleport.lib.vnet.v1.AuthenticateProcessRequest\x1a1.teleport.lib.vnet.v1.AuthenticateProcessResponse\x12\x83\x01\n" +
 	"\x16ReportNetworkStackInfo\x123.teleport.lib.vnet.v1.ReportNetworkStackInfoRequest\x1a4.teleport.lib.vnet.v1.ReportNetworkStackInfoResponse\x12M\n" +
@@ -2154,7 +2252,8 @@ const file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc = "" +
 	"\vUserTLSCert\x12(.teleport.lib.vnet.v1.UserTLSCertRequest\x1a).teleport.lib.vnet.v1.UserTLSCertResponse\x12k\n" +
 	"\x0eSignForUserTLS\x12+.teleport.lib.vnet.v1.SignForUserTLSRequest\x1a,.teleport.lib.vnet.v1.SignForUserTLSResponse\x12q\n" +
 	"\x10SessionSSHConfig\x12-.teleport.lib.vnet.v1.SessionSSHConfigRequest\x1a..teleport.lib.vnet.v1.SessionSSHConfigResponse\x12t\n" +
-	"\x11SignForSSHSession\x12..teleport.lib.vnet.v1.SignForSSHSessionRequest\x1a/.teleport.lib.vnet.v1.SignForSSHSessionResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
+	"\x11SignForSSHSession\x12..teleport.lib.vnet.v1.SignForSSHSessionRequest\x1a/.teleport.lib.vnet.v1.SignForSSHSessionResponse\x12n\n" +
+	"\x0fExchangeSSHKeys\x12,.teleport.lib.vnet.v1.ExchangeSSHKeysRequest\x1a-.teleport.lib.vnet.v1.ExchangeSSHKeysResponseBLZJgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1;vnetv1b\x06proto3"
 
 var (
 	file_teleport_lib_vnet_v1_client_application_service_proto_rawDescOnce sync.Once
@@ -2169,7 +2268,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_rawDescGZIP() []
 }
 
 var file_teleport_lib_vnet_v1_client_application_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_teleport_lib_vnet_v1_client_application_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(Hash)(0),                                // 0: teleport.lib.vnet.v1.Hash
 	(*AuthenticateProcessRequest)(nil),       // 1: teleport.lib.vnet.v1.AuthenticateProcessRequest
@@ -2207,7 +2306,9 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_goTypes = []any{
 	(*SessionSSHConfigResponse)(nil),         // 33: teleport.lib.vnet.v1.SessionSSHConfigResponse
 	(*SignForSSHSessionRequest)(nil),         // 34: teleport.lib.vnet.v1.SignForSSHSessionRequest
 	(*SignForSSHSessionResponse)(nil),        // 35: teleport.lib.vnet.v1.SignForSSHSessionResponse
-	(*types.AppV3)(nil),                      // 36: types.AppV3
+	(*ExchangeSSHKeysRequest)(nil),           // 36: teleport.lib.vnet.v1.ExchangeSSHKeysRequest
+	(*ExchangeSSHKeysResponse)(nil),          // 37: teleport.lib.vnet.v1.ExchangeSSHKeysResponse
+	(*types.AppV3)(nil),                      // 38: types.AppV3
 }
 var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32{
 	4,  // 0: teleport.lib.vnet.v1.ReportNetworkStackInfoRequest.network_stack_info:type_name -> teleport.lib.vnet.v1.NetworkStackInfo
@@ -2216,7 +2317,7 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32
 	12, // 3: teleport.lib.vnet.v1.ResolveFQDNResponse.matched_cluster:type_name -> teleport.lib.vnet.v1.MatchedCluster
 	13, // 4: teleport.lib.vnet.v1.MatchedTCPApp.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 5: teleport.lib.vnet.v1.AppInfo.app_key:type_name -> teleport.lib.vnet.v1.AppKey
-	36, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
+	38, // 6: teleport.lib.vnet.v1.AppInfo.app:type_name -> types.AppV3
 	15, // 7: teleport.lib.vnet.v1.AppInfo.dial_options:type_name -> teleport.lib.vnet.v1.DialOptions
 	13, // 8: teleport.lib.vnet.v1.ReissueAppCertRequest.app_info:type_name -> teleport.lib.vnet.v1.AppInfo
 	14, // 9: teleport.lib.vnet.v1.SignForAppRequest.app_key:type_name -> teleport.lib.vnet.v1.AppKey
@@ -2241,21 +2342,23 @@ var file_teleport_lib_vnet_v1_client_application_service_proto_depIdxs = []int32
 	30, // 28: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:input_type -> teleport.lib.vnet.v1.SignForUserTLSRequest
 	32, // 29: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:input_type -> teleport.lib.vnet.v1.SessionSSHConfigRequest
 	34, // 30: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:input_type -> teleport.lib.vnet.v1.SignForSSHSessionRequest
-	2,  // 31: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
-	5,  // 32: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
-	7,  // 33: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
-	9,  // 34: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
-	17, // 35: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
-	20, // 36: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
-	22, // 37: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
-	24, // 38: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
-	26, // 39: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
-	29, // 40: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
-	31, // 41: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
-	33, // 42: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:output_type -> teleport.lib.vnet.v1.SessionSSHConfigResponse
-	35, // 43: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:output_type -> teleport.lib.vnet.v1.SignForSSHSessionResponse
-	31, // [31:44] is the sub-list for method output_type
-	18, // [18:31] is the sub-list for method input_type
+	36, // 31: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:input_type -> teleport.lib.vnet.v1.ExchangeSSHKeysRequest
+	2,  // 32: teleport.lib.vnet.v1.ClientApplicationService.AuthenticateProcess:output_type -> teleport.lib.vnet.v1.AuthenticateProcessResponse
+	5,  // 33: teleport.lib.vnet.v1.ClientApplicationService.ReportNetworkStackInfo:output_type -> teleport.lib.vnet.v1.ReportNetworkStackInfoResponse
+	7,  // 34: teleport.lib.vnet.v1.ClientApplicationService.Ping:output_type -> teleport.lib.vnet.v1.PingResponse
+	9,  // 35: teleport.lib.vnet.v1.ClientApplicationService.ResolveFQDN:output_type -> teleport.lib.vnet.v1.ResolveFQDNResponse
+	17, // 36: teleport.lib.vnet.v1.ClientApplicationService.ReissueAppCert:output_type -> teleport.lib.vnet.v1.ReissueAppCertResponse
+	20, // 37: teleport.lib.vnet.v1.ClientApplicationService.SignForApp:output_type -> teleport.lib.vnet.v1.SignForAppResponse
+	22, // 38: teleport.lib.vnet.v1.ClientApplicationService.OnNewConnection:output_type -> teleport.lib.vnet.v1.OnNewConnectionResponse
+	24, // 39: teleport.lib.vnet.v1.ClientApplicationService.OnInvalidLocalPort:output_type -> teleport.lib.vnet.v1.OnInvalidLocalPortResponse
+	26, // 40: teleport.lib.vnet.v1.ClientApplicationService.GetTargetOSConfiguration:output_type -> teleport.lib.vnet.v1.GetTargetOSConfigurationResponse
+	29, // 41: teleport.lib.vnet.v1.ClientApplicationService.UserTLSCert:output_type -> teleport.lib.vnet.v1.UserTLSCertResponse
+	31, // 42: teleport.lib.vnet.v1.ClientApplicationService.SignForUserTLS:output_type -> teleport.lib.vnet.v1.SignForUserTLSResponse
+	33, // 43: teleport.lib.vnet.v1.ClientApplicationService.SessionSSHConfig:output_type -> teleport.lib.vnet.v1.SessionSSHConfigResponse
+	35, // 44: teleport.lib.vnet.v1.ClientApplicationService.SignForSSHSession:output_type -> teleport.lib.vnet.v1.SignForSSHSessionResponse
+	37, // 45: teleport.lib.vnet.v1.ClientApplicationService.ExchangeSSHKeys:output_type -> teleport.lib.vnet.v1.ExchangeSSHKeysResponse
+	32, // [32:46] is the sub-list for method output_type
+	18, // [18:32] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
 	18, // [18:18] is the sub-list for extension extendee
 	0,  // [0:18] is the sub-list for field type_name
@@ -2278,7 +2381,7 @@ func file_teleport_lib_vnet_v1_client_application_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc), len(file_teleport_lib_vnet_v1_client_application_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/v1/client_application_service_grpc.pb.go
@@ -48,6 +48,7 @@ const (
 	ClientApplicationService_SignForUserTLS_FullMethodName           = "/teleport.lib.vnet.v1.ClientApplicationService/SignForUserTLS"
 	ClientApplicationService_SessionSSHConfig_FullMethodName         = "/teleport.lib.vnet.v1.ClientApplicationService/SessionSSHConfig"
 	ClientApplicationService_SignForSSHSession_FullMethodName        = "/teleport.lib.vnet.v1.ClientApplicationService/SignForSSHSession"
+	ClientApplicationService_ExchangeSSHKeys_FullMethodName          = "/teleport.lib.vnet.v1.ClientApplicationService/ExchangeSSHKeys"
 )
 
 // ClientApplicationServiceClient is the client API for ClientApplicationService service.
@@ -94,6 +95,9 @@ type ClientApplicationServiceClient interface {
 	// SignForSSHSession signs a digest with the SSH private key associated with the
 	// session from a previous call to SessionSSHConfig.
 	SignForSSHSession(ctx context.Context, in *SignForSSHSessionRequest, opts ...grpc.CallOption) (*SignForSSHSessionResponse, error)
+	// ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
+	// returns the user public key.
+	ExchangeSSHKeys(ctx context.Context, in *ExchangeSSHKeysRequest, opts ...grpc.CallOption) (*ExchangeSSHKeysResponse, error)
 }
 
 type clientApplicationServiceClient struct {
@@ -234,6 +238,16 @@ func (c *clientApplicationServiceClient) SignForSSHSession(ctx context.Context, 
 	return out, nil
 }
 
+func (c *clientApplicationServiceClient) ExchangeSSHKeys(ctx context.Context, in *ExchangeSSHKeysRequest, opts ...grpc.CallOption) (*ExchangeSSHKeysResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExchangeSSHKeysResponse)
+	err := c.cc.Invoke(ctx, ClientApplicationService_ExchangeSSHKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ClientApplicationServiceServer is the server API for ClientApplicationService service.
 // All implementations must embed UnimplementedClientApplicationServiceServer
 // for forward compatibility.
@@ -278,6 +292,9 @@ type ClientApplicationServiceServer interface {
 	// SignForSSHSession signs a digest with the SSH private key associated with the
 	// session from a previous call to SessionSSHConfig.
 	SignForSSHSession(context.Context, *SignForSSHSessionRequest) (*SignForSSHSessionResponse, error)
+	// ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
+	// returns the user public key.
+	ExchangeSSHKeys(context.Context, *ExchangeSSHKeysRequest) (*ExchangeSSHKeysResponse, error)
 	mustEmbedUnimplementedClientApplicationServiceServer()
 }
 
@@ -326,6 +343,9 @@ func (UnimplementedClientApplicationServiceServer) SessionSSHConfig(context.Cont
 }
 func (UnimplementedClientApplicationServiceServer) SignForSSHSession(context.Context, *SignForSSHSessionRequest) (*SignForSSHSessionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SignForSSHSession not implemented")
+}
+func (UnimplementedClientApplicationServiceServer) ExchangeSSHKeys(context.Context, *ExchangeSSHKeysRequest) (*ExchangeSSHKeysResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ExchangeSSHKeys not implemented")
 }
 func (UnimplementedClientApplicationServiceServer) mustEmbedUnimplementedClientApplicationServiceServer() {
 }
@@ -583,6 +603,24 @@ func _ClientApplicationService_SignForSSHSession_Handler(srv interface{}, ctx co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ClientApplicationService_ExchangeSSHKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExchangeSSHKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ClientApplicationServiceServer).ExchangeSSHKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ClientApplicationService_ExchangeSSHKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ClientApplicationServiceServer).ExchangeSSHKeys(ctx, req.(*ExchangeSSHKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ClientApplicationService_ServiceDesc is the grpc.ServiceDesc for ClientApplicationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -641,6 +679,10 @@ var ClientApplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SignForSSHSession",
 			Handler:    _ClientApplicationService_SignForSSHSession_Handler,
+		},
+		{
+			MethodName: "ExchangeSSHKeys",
+			Handler:    _ClientApplicationService_ExchangeSSHKeys_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lib/vnet/admin_process_common.go
+++ b/lib/vnet/admin_process_common.go
@@ -17,13 +17,15 @@
 package vnet
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 )
 
-func newNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
+func newNetworkStackConfig(ctx context.Context, tun tunDevice, clt *clientApplicationServiceClient) (*networkStackConfig, error) {
 	clock := clockwork.NewRealClock()
-	sshProvider, err := newSSHProvider(sshProviderConfig{
+	sshProvider, err := newSSHProvider(ctx, sshProviderConfig{
 		clt:   clt,
 		clock: clock,
 	})

--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -59,7 +59,7 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 	}
 	defer tun.Close()
 
-	networkStackConfig, err := newNetworkStackConfig(tun, clt)
+	networkStackConfig, err := newNetworkStackConfig(ctx, tun, clt)
 	if err != nil {
 		return trace.Wrap(err, "creating network stack config")
 	}

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -100,7 +100,7 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 	}
 	log.InfoContext(ctx, "Created TUN interface", "tun", tunName)
 
-	networkStackConfig, err := newNetworkStackConfig(device, clt)
+	networkStackConfig, err := newNetworkStackConfig(ctx, device, clt)
 	if err != nil {
 		return trace.Wrap(err, "creating network stack config")
 	}

--- a/lib/vnet/opensshconfig.go
+++ b/lib/vnet/opensshconfig.go
@@ -1,0 +1,123 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+
+	renameio "github.com/google/renameio/v2/maybe" // Writes aren't guaranteed to be atomic on Windows.
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keypaths"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
+
+const (
+	filePerms os.FileMode = 0o600
+)
+
+// writeSSHKeys writes hostCAKey to ${TELEPORT_HOME}/vnet_known_hosts so that
+// third-party SSH clients can trust it. It then reads or generates
+// ${TELEPORT_HOME}/id_vnet(.pub) which SSH clients should be configured to use
+// for connections to VNet SSH. It returns id_vnet.pub so that VNet SSH can
+// trust it for incoming connections.
+func writeSSHKeys(homePath string, hostCAKey ssh.PublicKey) (ssh.PublicKey, error) {
+	profilePath := fullProfilePath(homePath)
+	if err := writeKnownHosts(profilePath, hostCAKey); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	userPubKey, err := readUserPubKey(profilePath)
+	if trace.IsNotFound(err) {
+		userPubKey, err = generateAndWriteUserKey(profilePath)
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return userPubKey, nil
+}
+
+func fullProfilePath(homePath string) string {
+	if homePath == "" {
+		if homeDir := os.Getenv(types.HomeEnvVar); homeDir != "" {
+			homePath = filepath.Clean(homeDir)
+		}
+	}
+	return profile.FullProfilePath(homePath)
+}
+
+func writeKnownHosts(profilePath string, hostCAKey ssh.PublicKey) error {
+	// MarshalAuthorizedKey serializes the key for inclusion in an
+	// authorized_keys file, we need to add the @cert-authority prefix and the
+	// wildcard so this CA is trusted for all hosts. The SSH configuration file
+	// should only load this vnet_known_hosts file for hosts matching
+	// appropriate subdomains, there is no need to keep that list of domains
+	// updated in both the SSH config file and the vnet_known_hosts file.
+	authorizedKey := ssh.MarshalAuthorizedKey(hostCAKey)
+	authorizedCA := "@cert-authority * " + string(authorizedKey)
+	p := keypaths.VNetKnownHostsPath(profilePath)
+	err := renameio.WriteFile(p, []byte(authorizedCA), filePerms)
+	return trace.Wrap(trace.ConvertSystemError(err), "writing host CA to %s", p)
+}
+
+func readUserPubKey(profilePath string) (ssh.PublicKey, error) {
+	p := keypaths.VNetClientSSHKeyPubPath(profilePath)
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, trace.Wrap(trace.ConvertSystemError(err), "opening %s for reading", p)
+	}
+	defer f.Close()
+	const maxPubKeyFileSize = 10000 // RSA 4096 pub key files are ~750 bytes, ~10x to be safe.
+	pubKeyBytes, err := io.ReadAll(io.LimitReader(f, maxPubKeyFileSize))
+	if err != nil {
+		return nil, trace.Wrap(trace.ConvertSystemError(err), "reading user public key from %s", p)
+	}
+	userPubKey, _, _, _, err := ssh.ParseAuthorizedKey(pubKeyBytes)
+	return userPubKey, trace.Wrap(err, "parsing user public key from %s", p)
+}
+
+func generateAndWriteUserKey(profilePath string) (ssh.PublicKey, error) {
+	userKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
+	if err != nil {
+		return nil, trace.Wrap(err, "generating SSH user key")
+	}
+
+	privPemBlock, err := ssh.MarshalPrivateKey(userKey, "")
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling SSH user key")
+	}
+	privKeyBytes := pem.EncodeToMemory(privPemBlock)
+	privKeyPath := keypaths.VNetClientSSHKeyPath(profilePath)
+	if err := renameio.WriteFile(privKeyPath, privKeyBytes, filePerms); err != nil {
+		return nil, trace.Wrap(trace.ConvertSystemError(err), "writing user private key to %s", privKeyPath)
+	}
+
+	userPubKey, err := ssh.NewPublicKey(userKey.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pubKeyPath := keypaths.VNetClientSSHKeyPubPath(profilePath)
+	if err := renameio.WriteFile(pubKeyPath, ssh.MarshalAuthorizedKey(userPubKey), filePerms); err != nil {
+		return nil, trace.Wrap(trace.ConvertSystemError(err), "writing user public key to %s", pubKeyPath)
+	}
+	return userPubKey, nil
+}

--- a/proto/teleport/lib/vnet/v1/client_application_service.proto
+++ b/proto/teleport/lib/vnet/v1/client_application_service.proto
@@ -62,6 +62,9 @@ service ClientApplicationService {
   // SignForSSHSession signs a digest with the SSH private key associated with the
   // session from a previous call to SessionSSHConfig.
   rpc SignForSSHSession(SignForSSHSessionRequest) returns (SignForSSHSessionResponse);
+  // ExchangeSSHKeys sends VNet's SSH host CA key to the client application and
+  // returns the user public key.
+  rpc ExchangeSSHKeys(ExchangeSSHKeysRequest) returns (ExchangeSSHKeysResponse);
 }
 
 // AuthenticateProcessRequest is a request for AuthenticateProcess.
@@ -376,4 +379,18 @@ message SignForSSHSessionRequest {
 message SignForSSHSessionResponse {
   // Signature is the signature.
   bytes signature = 1;
+}
+
+// ExchangeSSHKeysRequest is a request to exchange SSH keys for VNet SSH.
+message ExchangeSSHKeysRequest {
+  // HostPublicKey is the host key that should be trusted by clients connecting
+  // to VNet SSH addresses. It is encoded in OpenSSH wire format.
+  bytes host_public_key = 1;
+}
+
+// ExchangeSSHKeysResponse is a response for ExchangeSSHKeys.
+message ExchangeSSHKeysResponse {
+  // UserPublicKey is the user key that should be trusted by VNet for incoming
+  // connections from SSH clients. It is encoded in OpenSSH wire format.
+  bytes user_public_key = 1;
 }


### PR DESCRIPTION
This PR is the next step in the implementation of VNet SSH ([RFD](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md)).

In this PR the VNet service sends its host CA public key to the client application which writes it to `${TELEPORT_HOME}/vnet_known_hosts` so that third-party SSH clients can trust it. It then reads or generates `${TELEPORT_HOME}/id_vnet(.pub)` which SSH clients should be configured to use for connections to VNet SSH. `id_vnet.pub` is sent back to the VNet service and trusted for incoming connections from third-party SSH clients. This is as described at https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md#ssh-client-configuration

With this PR in place connections through VNet SSH fully work. The only thing that's needed is manual configuration of the SSH client so that the correct keys are used, an example is included below. In the following PR this configuration will be automatically generated.

```sh
$ cat ./connect_dev_vnet_ssh_config
Host *.one.private
  IdentityFile "/Users/nic/Library/Application Support/Electron/tsh/id_vnet"
  GlobalKnownHostsFile "/Users/nic/Library/Application Support/Electron/tsh/vnet_known_hosts"
  UserKnownHostsFile /dev/null
  StrictHostKeyChecking yes
  IdentitiesOnly yes
$ ssh -F ./connect_dev_vnet_ssh_config node-iot.one.private
Nics-MacBook-Pro:~ nic$ date
Wed May 28 12:15:40 PDT 2025
Nics-MacBook-Pro:~ nic$ exit
logout
Connection to node-iot.one.private closed.
$ ssh -F ./connect_dev_vnet_ssh_config two-auth.two-prod.one.private
Nics-MacBook-Pro:~ nic$ logout
Connection to two-auth.two-prod.one.private closed.
```

Parent PR: https://github.com/gravitational/teleport/pull/55156
Child PR: https://github.com/gravitational/teleport/pull/55239