### PR TITLE
Add scoped token storage service

### DIFF
--- a/lib/scopes/roles/roles_test.go
+++ b/lib/scopes/roles/roles_test.go
@@ -26,6 +26,7 @@ import (
 	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // TestValidateRole verifies basic functionality of strong and weak role validation functions.
@@ -267,7 +268,7 @@ func TestValidateRole(t *testing.T) {
 				require.Error(t, err, "strong validation should fail")
 			}
 
-			err = WeakValidateRole(tt.role)
+			err = scopes.WeakValidateResource(tt.role, KindScopedRole, types.V1)
 			if tt.weakOk {
 				require.NoError(t, err, "weak validation should not fail")
 			} else {

--- a/lib/scopes/tokens/tokens.go
+++ b/lib/scopes/tokens/tokens.go
@@ -1,0 +1,62 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tokens
+
+import (
+	"github.com/gravitational/trace"
+
+	scopedtokenv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedtoken/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+const (
+
+	// KindScopedToken is the kind of a scoped token resource.
+	KindScopedToken = "scoped_token"
+)
+
+// StrongValidateToken performs robust validation of a token to ensure it complies with all expected constraints. Prefer
+// using this function for validating tokens loaded from "external" sources (e.g. user input), and [scopes.WeakValidateResource] for
+// validating tokens loaded from "internal" sources (e.g. backend/control-plane).
+func StrongValidateToken(token *scopedtokenv1.ScopedToken) error {
+	if err := scopes.ValidateScopedResource(token, KindScopedToken, types.V1); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := scopes.StrongValidateSegment(token.GetMetadata().GetName()); err != nil {
+		return trace.BadParameter("scoped token name %q does not conform to segment naming rules: %v", token.GetMetadata().GetName(), err)
+	}
+
+	if err := scopes.StrongValidate(token.GetScope()); err != nil {
+		return trace.BadParameter("scoped token %q has invalid scope: %v", token.GetMetadata().GetName(), err)
+	}
+
+	if len(token.GetSpec().GetAssignedScope()) == 0 {
+		return trace.BadParameter("scoped token %q does not have any assignable scopes", token.GetMetadata().GetName())
+	}
+
+	if err := scopes.StrongValidateGlob(token.GetSpec().GetAssignedScope()); err != nil {
+		return trace.BadParameter("scoped token %q has invalid assignable scope %q: %v", token.GetMetadata().GetName(), token.GetSpec().GetAssignedScope(), err)
+	}
+
+	if !scopes.Glob(token.GetSpec().GetAssignedScope()).IsSubjectToPolicyResourceScope(token.GetScope()) {
+		return trace.BadParameter("scoped token %q has assignable scope %q that is not a sub-scope of the token's scope %q", token.GetMetadata().GetName(), token.GetSpec().GetAssignedScope(), token.GetScope())
+	}
+
+	return nil
+}

--- a/lib/scopes/validation.go
+++ b/lib/scopes/validation.go
@@ -1,0 +1,83 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scopes
+
+import (
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+)
+
+type scopedResource interface {
+	GetMetadata() *headerv1.Metadata
+	GetKind() string
+	GetSubKind() string
+	GetVersion() string
+	GetScope() string
+}
+
+// ValidateScopedResource performs the subset of resource validation common to both weak and strong validation.
+func ValidateScopedResource(r scopedResource, kind, version string) error {
+	if r.GetMetadata().GetName() == "" {
+		return trace.BadParameter("scoped resource %q is missing metadata.name", kind)
+	}
+
+	if r.GetKind() == "" {
+		return trace.BadParameter("scoped resource %q %q is missing kind", kind, r.GetMetadata().GetName())
+	}
+
+	if r.GetKind() != kind {
+		return trace.BadParameter("scoped resource %q %q has invalid kind %q, expected %q", kind, r.GetMetadata().GetName(), r.GetKind(), kind)
+	}
+
+	if r.GetSubKind() != "" {
+		return trace.BadParameter("scoped resource %q %q has unknown sub_kind %q", kind, r.GetMetadata().GetName(), r.GetSubKind())
+	}
+
+	if r.GetVersion() == "" {
+		return trace.BadParameter("scoped resource %q %q is missing version", kind, r.GetMetadata().GetName())
+	}
+
+	if r.GetVersion() != version {
+		return trace.BadParameter("scoped resource %q %q has unsupported version %q (expected %q)", kind, r.GetMetadata().GetName(), r.GetVersion(), version)
+	}
+
+	if r.GetScope() == "" {
+		return trace.BadParameter("scoped resource %q %q is missing scope", kind, r.GetMetadata().GetName())
+	}
+
+	return nil
+}
+
+// WeakValidateResource valides a resource to ensure it is free of obvious issues that would render it unusable and/or
+// induce serious unintended behavior. Prefer using this function for validating resources loaded from "internal" sources
+// (e.g. backend/control-plane), and stronger means for validating resources loaded from "external" sources (e.g. user input).
+func WeakValidateResource(r scopedResource, kind, version string) error {
+	if err := ValidateScopedResource(r, kind, version); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := WeakValidate(r.GetScope()); err != nil {
+		return trace.BadParameter("scoped resource %q %q has invalid scope: %v", kind, r.GetMetadata().GetName(), err)
+	}
+
+	// NOTE: in strong validation, this is where we'd check that the assignable scopes are valid. In weak validation
+	// we don't do that and instead rely on invalid assignable scopes being filtered out
+	// and excluded during runtime assignment validation checks. This helps us ensure that outdated agents continue
+	// to be able to understand and process the subset of assignments that they are able to reason about.
+	return nil
+}

--- a/lib/services/local/scoped_roles.go
+++ b/lib/services/local/scoped_roles.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	srpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedrole/v1"
+	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -94,7 +95,7 @@ func (s *ScopedRoleService) GetScopedRole(ctx context.Context, req *srpb.GetScop
 		return nil, trace.Wrap(err)
 	}
 
-	if err := sr.WeakValidateRole(role); err != nil {
+	if err := scopes.WeakValidateResource(role, sr.KindScopedRole, types.V1); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -127,7 +128,7 @@ func (s *ScopedRoleService) StreamScopedRoles(ctx context.Context) stream.Stream
 				continue
 			}
 
-			if err := sr.WeakValidateRole(role); err != nil {
+			if err := scopes.WeakValidateResource(role, sr.KindScopedRole, types.V1); err != nil {
 				// per-role errors are logged and skipped
 				s.logger.WarnContext(ctx, "skipping scoped role due to validation error", "error", err, "key", logutils.StringerAttr(item.Key))
 				continue

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -1,0 +1,125 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	scopedtokenv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopedtoken/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/tokens"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+// ScopedTokenService manages backend state for the ScopedTokens.
+type ScopedTokenService struct {
+	scopedTokens *generic.ServiceWrapper[*scopedtokenv1.ScopedToken]
+}
+
+const (
+	scopedTokenPrefix = "scoped_token"
+)
+
+// NewScopeTokenService creates a new ScopedTokenService for the specified backend.
+func NewScopeTokenService(bk backend.Backend) (*ScopedTokenService, error) {
+	s, err := generic.NewServiceWrapper(generic.ServiceConfig[*scopedtokenv1.ScopedToken]{
+		Backend:       bk,
+		ResourceKind:  tokens.KindScopedToken,
+		BackendPrefix: backend.NewKey(scopedTokenPrefix),
+		MarshalFunc:   services.MarshalProtoResource[*scopedtokenv1.ScopedToken],
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ScopedTokenService{scopedTokens: s}, nil
+}
+
+func (s *ScopedTokenService) CreateScopedToken(ctx context.Context, token *scopedtokenv1.ScopedToken) (*scopedtokenv1.ScopedToken, error) {
+	if token == nil {
+		return nil, trace.BadParameter("missing scoped token in create request")
+	}
+
+	if err := tokens.StrongValidateToken(token); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out, err := s.scopedTokens.CreateResource(ctx, token)
+	return out, trace.Wrap(err)
+}
+
+func (s *ScopedTokenService) UpdateScopedToken(ctx context.Context, token *scopedtokenv1.ScopedToken) (*scopedtokenv1.ScopedToken, error) {
+	if token == nil {
+		return nil, trace.BadParameter("missing scoped token in update request")
+	}
+
+	if err := tokens.StrongValidateToken(token); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	out, err := s.scopedTokens.ConditionalUpdateResource(ctx, token)
+	return out, trace.Wrap(err)
+}
+
+func (s *ScopedTokenService) DeleteScopedToken(ctx context.Context, name string) error {
+	return trace.Wrap(s.scopedTokens.DeleteResource(ctx, name))
+}
+
+func (s *ScopedTokenService) GetScopedToken(ctx context.Context, name string) (*scopedtokenv1.ScopedToken, error) {
+	if name == "" {
+		return nil, trace.BadParameter("missing scoped token name in get request")
+	}
+
+	token, err := s.scopedTokens.GetResource(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := scopes.WeakValidateResource(token, tokens.KindScopedToken, types.V1); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return token, nil
+}
+
+// StreamScopedRoles returns a stream of all scoped tokens in the backend. Malformed tokens are skipped. Returned tokens
+// have had weak validation applied.
+func (s *ScopedTokenService) ScopedTokens(ctx context.Context, pageSize int, pageToken string) stream.Stream[*scopedtokenv1.ScopedToken] {
+	return func(yield func(*scopedtokenv1.ScopedToken, error) bool) {
+		for token, err := range s.scopedTokens.Resources(ctx, pageToken, pageSize) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if err := scopes.WeakValidateResource(token, tokens.KindScopedToken, types.V1); err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			if !yield(token, nil) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Implements a new  service in services/local dedicated to scoped tokens.
- Adds `Resources(ctx context.Context, startKey string, limit int) stream.Stream[T]` to the generic backend services
- Moves some common scoped resource validation to lib/scopes/validation.go