### PR TITLE
Fix import order in `web_e2e_test.go`

### DIFF
--- a/e2e/web_e2e_test.go
+++ b/e2e/web_e2e_test.go
@@ -28,6 +28,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -35,8 +38,6 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSignup sets up a test instance of Teleport and runs a playwright test against it to test the signup flow.


### PR DESCRIPTION
## Purpose

Fixes the import order in `web_e2e_test`, this likely wasn't caught because the linter didn't run on the file due to the build tag, ~~so I also updated linter to prevent it from happening again in the future~~.