### PR TITLE
Minor operator and Helm doc fixes

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/teleport-operator/teleport-operator.mdx
@@ -25,22 +25,7 @@ Only one operator deployment should run against a Teleport cluster. Else, differ
 could cause instability and non-deterministic behaviour.
 </Admonition>
 
-Currently supported Teleport resources are:
-- Users (`TeleportUser`)
-- Roles
-  - `TeleportRole` creates role v5
-  - `TeleportRoleV6` creates role v6
-  - `TeleportRoleV7` creates role v7
-- OIDC Connectors (`TeleportOIDCConnector`)
-- SAML Connectors (`TeleportSAMLConnector`)
-- GitHub Connectors (`TeleportGithubConnector`)
-- Provision Tokens (`TeleportProvisionToken`)
-- Login Rules (`TeleportLoginRule`)
-- Access Lists (`TeleportAccessList`)
-- Okta Import Rules (`TeleportOktaImportRule`)
-- OpenSSHEICE Servers (`TeleportOpenSSHEICEServerV2`)
-- OpenSSH Servers (`TeleportOpenSSHServerV2`)
-- Trusted Clusters (`TeleportTrustedClusterV2`)
+Supported Teleport resources are listed in [the Operator Reference Page](../../../reference/operator-resources/operator-resources.mdx).
 
 ### Setting up the operator
 

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -1,5 +1,6 @@
 ---
 title: tbot Chart Reference
+sidebar_label: tbot
 description: Values that can be set using the tbot Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-access-graph.mdx
+++ b/docs/pages/reference/helm-reference/teleport-access-graph.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-access-graph Chart Reference
+sidebar_label: teleport-access-graph
 description: Values that can be set using the teleport-access-graph Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-cluster Chart Reference
+sidebar_label: teleport-cluster
 description: Values that can be set using the teleport-cluster Helm chart
 ---
 
@@ -668,27 +669,6 @@ By using this value you will update the Kubernetes volume specification to mount
   licenseSecretName: enterprise-license
   ```
 
-## `installCRDs`
-
-| Type   | Default value |
-|--------|---------------|
-| `bool` | `false`       |
-
-CRDs are not namespace-scoped resources - they can be installed only once in a cluster.
-
-CRDs are required by the Teleport Kubernetes Operator and are installed by default when `operator.enabled` is true.
-`installCRDs` overrides this behavior and allows users to indicate whether to deploy Teleport CRDs.
-
-If several releases of the `teleport-cluster` chart are deployed in the same Kubernetes cluster, only one
-release should have `installCRDs` enabled. Unless you are deploying multiple `teleport-cluster` Helm releases in
-the same Kubernetes cluster or installing the CRDs on your own you should not have to set this value.
-
-`values.yaml` example:
-
-  ```yaml
-  installCRDs: true
-  ```
-
 ## `operator`
 
 ### `operator.annotations.deployment`
@@ -766,6 +746,22 @@ If you are deploying multiple releases of the Helm chart in the same cluster you
   operator:
     enabled: true
   ```
+### `operator.installCRDs`
+
+| Type | Default |
+|------|---------|
+| `string` | `"dynamic"` |
+
+`operator.installCRDs` controls if the chart should install the CRDs.
+There are 3 possible values: dynamic, always, never.
+
+- "dynamic" means the CRDs are installed if the operator is enabled or if
+the CRDs are already present in the cluster. The presence check is here to
+avoid all CRDs to be removed if you temporarily disable the operator.
+Removing CRDs triggers a cascading deletion, which removes CRs, and all the
+related resources in Teleport.
+- "always" means the CRDs are always installed
+- "never" means the CRDs are never installed
 
 ### `operator.image`
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -738,7 +738,7 @@ Kubernetes annotations which should be applied to the `ServiceAccount` created b
 
 Enabling the operator will also deploy the Teleport CRDs in the Kubernetes cluster.
 If you are deploying multiple releases of the Helm chart in the same cluster you can override this behavior with
-[`installCRDs`](#installCRDs).
+[`installCRDs`](#operatorinstallcrds).
 
 `values.yaml` example:
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-kube-agent Chart Reference
+sidebar_label: teleport-kube-agent
 description: Values that can be set using the teleport-kube-agent Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/teleport-operator.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-operator Chart Reference
+sidebar_label: teleport-operator
 description: Values that can be set using the teleport-operator Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-datadog Chart Reference
+sidebar_label: teleport-plugin-datadog
 description: Values that can be set using the teleport-plugin-datadog Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-discord Chart Reference
+sidebar_label: teleport-plugin-discord
 description: Values that can be set using the teleport-plugin-discord Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-email Chart Reference
+sidebar_label: teleport-plugin-email
 description: Values that can be set using the teleport-plugin-email Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-event-handler Chart Reference
+sidebar_label: teleport-plugin-event-handler
 description: Values that can be set using the teleport-plugin-event-handler Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-jira Chart Reference
+sidebar_label: teleport-plugin-jira
 description: Values that can be set using the teleport-plugin-jira Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-mattermost Chart Reference
+sidebar_label: teleport-plugin-mattermost
 description: Values that can be set using the teleport-plugin-mattermost Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-msteams Chart Reference
+sidebar_label: teleport-plugin-msteams
 description: Values that can be set using the teleport-plugin-msteams Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-pagerduty Chart Reference
+sidebar_label: teleport-plugin-pagerduty
 description: Values that can be set using the teleport-plugin-pagerduty Helm chart
 ---
 

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -1,5 +1,6 @@
 ---
 title: teleport-plugin-slack Chart Reference
+sidebar_label: teleport-plugin-slack
 description: Values that can be set using the teleport-plugin-slack Helm chart
 ---
 

--- a/docs/pages/reference/operator-resources/operator-resources.mdx
+++ b/docs/pages/reference/operator-resources/operator-resources.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Teleport Kubernetes Operator Resource Reference Guides"
+sidebar_label: Teleport Kubernetes Operator
 description: "Comprehensive guides to fields available in Kubernetes resources you can apply to manage Teleport resources with the Teleport Kubernetes operator"
 ---
 

--- a/integrations/operator/README.md
+++ b/integrations/operator/README.md
@@ -12,25 +12,7 @@ For more details, read the corresponding [RFD](https://github.com/gravitational/
 
 ## Supported Resources
 
-The operator supports reconciling the following Kubernetes CRs:
-
-- TeleportUser
-- TeleportRole (creates role v5)
-- TeleportRoleV6 (creates role v6)
-- TeleportRoleV7 (creates role v7)
-- TeleportProvisionToken
-- TeleportGithubConnector
-- TeleportAccessList
-- TeleportOpenSSHEICEServerV2
-- TeleportOpenSSHServerV2
-- TeleportTrustedClusterV2
-- TeleportBotV1
-- TeleportSAMLConnector [1]
-- TeleportOIDCConnector [1]
-- TeleportLoginRule [1]
-- TeleportOktaImportRule [1]
-
-[1] Enterprise license required
+See the list of supported resources in the documentation: https://goteleport.com/docs/reference/operator-resources/
 
 ## Architecture
 Teleport Operator is a Kubernetes (K8s) operator based on the `operator-sdk`.


### PR DESCRIPTION
This PR addresses various minor documentation issues for the Helm chart and the operator:

- teleport-cluster reference:
  - `installCRDs` value was removed in v16, it is now `operator.installCRDs`
  - typo: `extraVolumesMounts` -> `extraVolumeMounts`
- teleport-operator docs contained a stale list of supported resources, I replaced it by a link to the auto-generated reference instead. It should no longer get out of date.
- cosmetic sidebar issues:
  - teleport-operator reference guide had a very long name that took 3 lines in the sidebar, replace with `Teleport Kubernetes Operator`, which is shorter and consistent with `Teleport Terraform Provider`
  - teleport helm chart references had all very long names in the sidebar, I added sidebar labels to make the sidebar more readable