### PR TITLE
Avoid unnecessary unified resources re-renders

### DIFF
--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -28,7 +28,7 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ReactNode } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import { MemoryRouter as Router } from 'react-router-dom';
 
 import { darkTheme } from 'design/theme';
@@ -47,7 +47,7 @@ export const testQueryClient = new QueryClient({
   },
 });
 
-function Providers({ children }: { children: ReactNode }) {
+export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={testQueryClient}>
       <ConfiguredThemeProvider theme={darkTheme}>
@@ -79,7 +79,7 @@ screen.debug = () => {
 };
 
 type RenderOptions = {
-  wrapper?: React.FC;
+  wrapper?: React.FC<PropsWithChildren>;
   container?: HTMLElement;
 };
 

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
@@ -18,9 +18,11 @@
 
 import {
   createContext,
+  FC,
   PropsWithChildren,
   useContext,
   useEffect,
+  useMemo,
   useState,
   type JSX,
 } from 'react';
@@ -80,20 +82,23 @@ export type InfoGuideConfig = {
 
 const InfoGuidePanelContext = createContext<InfoGuidePanelContextState>(null);
 
-export const InfoGuidePanelProvider: React.FC<
+export const InfoGuidePanelProvider: FC<
   PropsWithChildren<{ defaultPanelWidth?: number }>
 > = ({ children, defaultPanelWidth = generalInfoPanelWidth }) => {
   const [infoGuideConfig, setInfoGuideConfig] =
     useState<InfoGuideConfig | null>(null);
 
+  const providerValue = useMemo(
+    () => ({
+      infoGuideConfig,
+      setInfoGuideConfig,
+      panelWidth: infoGuideConfig?.panelWidth || defaultPanelWidth,
+    }),
+    [defaultPanelWidth, infoGuideConfig]
+  );
+
   return (
-    <InfoGuidePanelContext.Provider
-      value={{
-        infoGuideConfig,
-        setInfoGuideConfig,
-        panelWidth: infoGuideConfig?.panelWidth || defaultPanelWidth,
-      }}
-    >
+    <InfoGuidePanelContext.Provider value={providerValue}>
       {children}
     </InfoGuidePanelContext.Provider>
   );

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
@@ -417,25 +417,23 @@ it('passes props with stable identity to <Resources>', async () => {
   );
 
   const { rerender } = render(<Component />, { wrapper: Wrapper });
-
   act(mio.enterAll);
-
   // Wait for resources to render.
   await expect(
     screen.findByText(serverResource.hostname)
   ).resolves.toBeInTheDocument();
+  // Disabled because of a false positive.
+  // eslint-disable-next-line testing-library/render-result-naming-convention
+  const renderCountBeforeRerender = renderCount;
 
-  // When <Resources> is properly memoized and all params passed to it have stable identity, there
-  // are 8 renders within the Profiler tree before the resources are rendered to screen.
-  expect(renderCount).toEqual(8);
-
-  // Rerender the tree. Verify that it causes only one extra render within the tree, which is the
-  // render caused by the call to `rerender`.
-  //
-  // If <Resources> is properly memoized, this should not cause any extra renders.
   rerender(<Component />);
   await expect(
     screen.findByText(serverResource.hostname)
   ).resolves.toBeInTheDocument();
-  expect(renderCount).toEqual(9);
+  const renderCountDelta = renderCount - renderCountBeforeRerender;
+
+  // When <Resources> is properly memoized and all params passed to it have stable identity,
+  // rerendering the outer <UnifiedResources> with no prop changes should cause only one render
+  // within the tree.
+  expect(renderCountDelta).toEqual(1);
 });


### PR DESCRIPTION
If the provider value isn't memoized, it gets recreated on every render, triggering re-renders in all consumers.
It resulted in poor performance when quickly switching between tabs in Connect (by holding Ctrl+Tab).