### PR TITLE
Add inline-flex to HoverTooltip to fix layout issue

### DIFF
--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -173,6 +173,9 @@ export const HoverTooltip = ({
         onMouseLeave: () => setOpen(false),
       })}
       className={className}
+      css={`
+        display: inline-flex;
+      `}
     >
       {children}
       {isMounted && (


### PR DESCRIPTION
Whilst testing for v18 release, I noticed the following Options element was out of line. This is due to the HoverTooltip that wraps it.
![broke](https://github.com/user-attachments/assets/cd7271a0-ceea-4496-aa2d-401970fc0873)

This PR adds `inline-flex` to fix the issue:
![fixed](https://github.com/user-attachments/assets/002d6e53-9098-45c8-92b2-50a250adaceb)