### PR TITLE
MWI: Allow Roles Anywhere output to operate with cached credentials

### DIFF
--- a/lib/tbot/config/output.go
+++ b/lib/tbot/config/output.go
@@ -34,8 +34,12 @@ import (
 // If there's no destination in the provided yaml node, then this will return
 // nil, nil.
 func extractOutputDestination(node *yaml.Node) (bot.Destination, error) {
+	return extractDestinationField(node, "destination")
+}
+
+func extractDestinationField(node *yaml.Node, name string) (bot.Destination, error) {
 	for i, subNode := range node.Content {
-		if subNode.Value == "destination" {
+		if subNode.Value == name {
 			// Next node will be the contents
 			dest, err := unmarshalDestination(node.Content[i+1])
 			if err != nil {

--- a/lib/tbot/config/service_workload_identity_aws_ra_test.go
+++ b/lib/tbot/config/service_workload_identity_aws_ra_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorkloadIdentityAWSRAService_YAML(t *testing.T) {
@@ -68,6 +69,9 @@ func TestWorkloadIdentityAWSRAService_YAML(t *testing.T) {
 func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
+	cacheDest := &DestinationMemory{}
+	require.NoError(t, cacheDest.CheckAndSetDefaults())
+
 	tests := []testCheckAndSetDefaultsCase[*WorkloadIdentityAWSRAService]{
 		{
 			name: "valid",
@@ -96,6 +100,8 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					ACLs:     botfs.ACLOff,
 					Symlinks: botfs.SymlinksInsecure,
 				},
+				Cache:                  cacheDest,
+				X509SVIDTTL:            defaultAWSRAX509SVIDTTL,
 				SessionDuration:        defaultAWSSessionDuration,
 				SessionRenewalInterval: defaultAWSSessionRenewalInterval,
 				RoleARN:                "arn:aws:iam::123456789012:role/example-role",
@@ -125,6 +131,26 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					ProfileARN:             "arn:aws:rolesanywhere:us-east-1:123456789012:profile/0000000-0000-0000-0000-00000000000",
 					Region:                 "us-east-1",
 				}
+			},
+			want: &WorkloadIdentityAWSRAService{
+				Selector: WorkloadIdentitySelector{
+					Labels: map[string][]string{
+						"key": {"value"},
+					},
+				},
+				Destination: &DestinationDirectory{
+					Path:     "/opt/machine-id",
+					ACLs:     botfs.ACLOff,
+					Symlinks: botfs.SymlinksInsecure,
+				},
+				Cache:                  cacheDest,
+				X509SVIDTTL:            defaultAWSRAX509SVIDTTL,
+				SessionDuration:        1 * time.Hour,
+				SessionRenewalInterval: 30 * time.Minute,
+				RoleARN:                "arn:aws:iam::123456789012:role/example-role",
+				TrustAnchorARN:         "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/0000000-0000-0000-0000-000000000000",
+				ProfileARN:             "arn:aws:rolesanywhere:us-east-1:123456789012:profile/0000000-0000-0000-0000-00000000000",
+				Region:                 "us-east-1",
 			},
 		},
 		{
@@ -183,6 +209,27 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 				}
 			},
 			wantErr: "no destination configured for output",
+		},
+		{
+			name: "invalid cache destionation",
+			in: func() *WorkloadIdentityAWSRAService {
+				return &WorkloadIdentityAWSRAService{
+					Destination: &DestinationDirectory{
+						Path:     "/opt/machine-id",
+						ACLs:     botfs.ACLOff,
+						Symlinks: botfs.SymlinksInsecure,
+					},
+					Cache: &DestinationDirectory{},
+					Selector: WorkloadIdentitySelector{
+						Name: "my-workload-identity",
+					},
+					RoleARN:        "arn:aws:iam::123456789012:role/example-role",
+					TrustAnchorARN: "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/0000000-0000-0000-0000-000000000000",
+					ProfileARN:     "arn:aws:rolesanywhere:us-east-1:123456789012:profile/0000000-0000-0000-0000-00000000000",
+					Region:         "us-east-1",
+				}
+			},
+			wantErr: "destination path must not be empty",
 		},
 		{
 			name: "missing role_arn",


### PR DESCRIPTION
This PR closes #53711.

It builds on the work of #55170, #55202, and #55220 to allow `tbot`'s AWS Roles Anywhere output to continue running using a cached x509 certificate if the auth server is unavailable.

To use it, add the `cache` block and raise your `x509_svid_ttl` in your workload-identity-aws-roles-anywhere service configuration.

```yaml
services:
  - type: workload-identity-aws-roles-anywhere
    cache:
      type: directory
      path: /path/to/cache/directory
    x509_svid_ttl: 12h
    role_arn: ...
    profile_arn: ...
    trust_anchor_arn: ...
    region: ...
    selector: ...
    destination: ...
```

changelog: MWI: The `workload-identity-aws-roles-anywhere` service now supports operating with cached credentials when the Teleport auth server is unavailable 
