### PR TITLE
Fix ElastiCache/MemoryDB IAM auth

### DIFF
--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -1328,8 +1328,9 @@ func (r *awsRedisIAMTokenRequest) toSignedRequestURI(ctx context.Context) (strin
 // getSignableRequest creates a new request suitable for pre-signing with SigV4.
 func (r *awsRedisIAMTokenRequest) getSignableRequest() (*http.Request, error) {
 	query := url.Values{
-		"Action": {"connect"},
-		"User":   {r.userID},
+		"Action":        {"connect"},
+		"User":          {r.userID},
+		"X-Amz-Expires": {"900"},
 	}
 	reqURI := url.URL{
 		Scheme:   "http",


### PR DESCRIPTION
fixes #55258 
- #55258 

introduced by AWS SDK migration. no older backports necessary besides v18