### PR TITLE
docs: Fix multi-region blueprint

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -80,7 +80,7 @@ This section describes this setup in more detail.
   - on GCP, GCS has a multi-region location
   - on-prem, MinIO supports [multi-site bucket replication](https://min.io/docs/minio/linux/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.html)
   - on AWS, you can [set up two-way-replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mrap-create-two-way-replication-rules.html)
-    between S3 buckets.
+    between S3 buckets. See [the dedicated S3 replication section](#setting-up-multi-region-aws-s3-replication) for more details.
 - Setup [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
 
 ### Teleport backend configuration
@@ -311,3 +311,21 @@ Terraform. With 3 buckets `bucketA`, `bucketB`, `bucketC` you need 6 rules:
     If you want Teleport to automatically clean up session recordings, you must
     enable "Delete marker replication" in the replication rules.
 </Admonition>
+
+Finally, you must configure Teleport to only complete file uploads
+initiated by itself (so Teleport does not attempt to complete uploads caused
+by the bucket replication rules).
+
+You can do so by setting `complete_initiators=<Var name= "teleport-iam-role"/>` in the `audit_sessions_uri` value.
+<Var name= "teleport-iam-role"/> is the name of the IAM role used by the Teleport Auth service to upload recording to
+the S3 bucket:
+
+```yaml
+auth:
+  teleportConfig:
+    teleport:
+      storage:
+        # [other storage options here...]
+        audit_sessions_uri: "uri://to-your-regional-bucket?complete_initiators=<Var name= "teleport-iam-role"/>"
+        # ...
+```

--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -81,8 +81,7 @@ This section describes this setup in more detail.
   - on-prem, MinIO supports [multi-site bucket replication](https://min.io/docs/minio/linux/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.html)
   - on AWS, you can [set up two-way-replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mrap-create-two-way-replication-rules.html)
     between S3 buckets.
-- Set up IAM to allow access to the object storage. See [S3 docs](../../reference/backends.mdx#s3-iam-policy) for the reference.
-- Set up [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
+- Setup [a CockroachDB multi-region cluster](https://www.cockroachlabs.com/docs/v24.1/multiregion-overview)
 
 ### Teleport backend configuration
 
@@ -175,9 +174,8 @@ auth:
         conn_string: postgres://teleport@cockroachdb-public.<region>.svc.cluster.local:26257/teleport_backend?sslmode=verify-full&pool_max_conns=20
         audit_events_uri:
           - "postgres://teleport@cockroachdb-public.<region>.svc.cluster.local:26257/teleport_audit?sslmode=verify-full"
-        # replace this with the URI of your regional object storage (S3, GCS, MinIO) and IAM role configured for the object storage access
-        # set complete_initiators param to ensure Teleport will only complete uploads initiated by itself
-        audit_sessions_uri: "uri://to-your-regional-bucket?complete_initiators=<teleport-iam-role>"
+        # replace this with the URI of your regional object storage (S3, GCS, MinIO)
+        audit_sessions_uri: "uri://to-your-regional-bucket"
         ttl_job_cron: '*/20 * * * *'
     
     # Configure proxy peering

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -659,7 +659,7 @@ Service reads these parameters to configure its interactions with S3:
 initiated by the specified set of initiators. This is helpful in scenarios where
 software other than Teleport is initiating multipart uploads in the recordings
 bucket. This should be set to the display name of the initiator(s) you want to
-ignore.
+allow.
 
 ### S3 IAM policy
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -659,7 +659,7 @@ Service reads these parameters to configure its interactions with S3:
 initiated by the specified set of initiators. This is helpful in scenarios where
 software other than Teleport is initiating multipart uploads in the recordings
 bucket. This should be set to the display name of the initiator(s) you want to
-allow.
+ignore.
 
 ### S3 IAM policy
 


### PR DESCRIPTION
Followup on https://github.com/gravitational/teleport/pull/54869

The PR was merged prematurely and introduced AWS-specific parts in a cloud-agnostic guide. This PR moves the changes in the dedicated S3 section to avoid confusion for customers setting up non-AWS multi-region setups.