### PR TITLE
Support TELEPORT_BASE_CDN_URL override in legacy install script

### DIFF
--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds/azure"
 	"github.com/gravitational/teleport/lib/cloud/imds/gcp"
 	"github.com/gravitational/teleport/lib/utils/packagemanager"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 func buildMockBins(t *testing.T) (map[string]*bintest.Mock, packagemanager.BinariesLocation, []func() error) {
@@ -223,7 +224,7 @@ func TestAutoDiscoverNode(t *testing.T) {
 							c.Exit(0)
 						})
 					case "sles":
-						mockBins["rpm"].Expect("--import", packagemanager.ZypperPublicKeyEndpoint)
+						mockBins["rpm"].Expect("--import", teleportassets.ZypperRepoGPGURL())
 						mockBins["rpm"].Expect("--eval", bintest.MatchAny())
 						mockBins["zypper"].Expect("--non-interactive", "addrepo", bintest.MatchAny())
 						mockBins["zypper"].Expect("--gpg-auto-import-keys", "refresh")

--- a/lib/utils/packagemanager/apt.go
+++ b/lib/utils/packagemanager/apt.go
@@ -33,12 +33,10 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/linux"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 const (
-	productionAPTPublicKeyEndpoint = "https://apt.releases.teleport.dev/gpg"
-	aptRepoEndpoint                = "https://apt.releases.teleport.dev/"
-
 	aptTeleportSourceListFileRelative = "/etc/apt/sources.list.d/teleport.list"
 
 	aptKeyringsLocation      = "/etc/apt/keyrings"
@@ -75,7 +73,7 @@ func (p *APTConfig) CheckAndSetDefaults() error {
 	}
 
 	if p.aptPublicKeyEndpoint == "" {
-		p.aptPublicKeyEndpoint = productionAPTPublicKeyEndpoint
+		p.aptPublicKeyEndpoint = teleportassets.AptRepoGPGURL()
 	}
 
 	p.bins.CheckAndSetDefaults()
@@ -135,7 +133,7 @@ func (pm *APT) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 	if err := os.MkdirAll(filepath.Join(pm.fsRootPrefix, aptKeyringsLocation), aptKeyringsLocationPerms); err != nil {
 		return trace.Wrap(err)
 	}
-	teleportRepoMetadata := fmt.Sprintf("deb [signed-by=%s] %s%s %s %s", aptTeleportPublicKeyFile, aptRepoEndpoint, linuxInfo.ID, linuxInfo.VersionCodename, repoChannel)
+	teleportRepoMetadata := fmt.Sprintf("deb [signed-by=%s] %s%s %s %s", aptTeleportPublicKeyFile, teleportassets.AptRepoURL(), linuxInfo.ID, linuxInfo.VersionCodename, repoChannel)
 
 	switch {
 	case pm.legacy:
@@ -146,7 +144,7 @@ func (pm *APT) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 		if err != nil {
 			return trace.Wrap(err, string(aptKeyAddCMDOutput))
 		}
-		teleportRepoMetadata = fmt.Sprintf("deb %s %s %s", aptRepoEndpoint, linuxInfo.VersionCodename, repoChannel)
+		teleportRepoMetadata = fmt.Sprintf("deb %s %s %s", teleportassets.AptRepoURL(), linuxInfo.VersionCodename, repoChannel)
 
 	default:
 		pm.logger.InfoContext(ctx, "Writing Teleport repository key", "destination", aptTeleportPublicKeyFile)

--- a/lib/utils/packagemanager/yum.go
+++ b/lib/utils/packagemanager/yum.go
@@ -27,9 +27,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/linux"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
-
-const yumRepoEndpoint = "https://yum.releases.teleport.dev/"
 
 var (
 	// yumDistroMap maps distro IDs that teleport doesn't officially support but are known to work.
@@ -96,7 +95,7 @@ func (pm *YUM) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 
 	// Repo location looks like this:
 	// https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo
-	repoLocation := fmt.Sprintf("%s%s/%s/Teleport/%%{_arch}/%s/teleport.repo", yumRepoEndpoint, distroID, versionID, repoChannel)
+	repoLocation := fmt.Sprintf("%s%s/%s/Teleport/%%{_arch}/%s/teleport.repo", teleportassets.YumRepoURL(), distroID, versionID, repoChannel)
 	pm.logger.InfoContext(ctx, "Building rpm metadata for Teleport repo", "command", "rpm --eval "+repoLocation)
 	rpmEvalTeleportRepoCMD := exec.CommandContext(ctx, pm.bins.Rpm, "--eval", repoLocation)
 	rpmEvalTeleportRepoCMDOutput, err := rpmEvalTeleportRepoCMD.CombinedOutput()

--- a/lib/utils/packagemanager/zypper.go
+++ b/lib/utils/packagemanager/zypper.go
@@ -26,13 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/linux"
-)
-
-const (
-	// ZypperPublicKeyEndpoint is the endpoint that contains the Teleport's GPG production Key.
-	ZypperPublicKeyEndpoint = "https://zypper.releases.teleport.dev/gpg"
-	// zypperRepoEndpoint is the repo endpoint for Zypper based distros.
-	zypperRepoEndpoint = "https://zypper.releases.teleport.dev/"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 // Zypper is a wrapper for apt package manager.
@@ -84,8 +78,8 @@ func (pm *Zypper) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OS
 		versionID = "15" // tumbleweed uses dated VERSION_IDs like 20230702
 	}
 
-	pm.logger.InfoContext(ctx, "Trusting Teleport repository key", "command", "rpm --import "+ZypperPublicKeyEndpoint)
-	importPublicKeyCMD := exec.CommandContext(ctx, pm.bins.Rpm, "--import", ZypperPublicKeyEndpoint)
+	pm.logger.InfoContext(ctx, "Trusting Teleport repository key", "command", "rpm --import "+teleportassets.ZypperRepoGPGURL())
+	importPublicKeyCMD := exec.CommandContext(ctx, pm.bins.Rpm, "--import", teleportassets.ZypperRepoGPGURL())
 	importPublicKeyCMDOutput, err := importPublicKeyCMD.CombinedOutput()
 	if err != nil {
 		return trace.Wrap(err, string(importPublicKeyCMDOutput))
@@ -93,7 +87,7 @@ func (pm *Zypper) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OS
 
 	// Repo location looks like this:
 	// https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo
-	repoLocation := fmt.Sprintf("%s%s/%s/Teleport/%%{_arch}/%s/teleport.repo", zypperRepoEndpoint, linuxInfo.ID, versionID, repoChannel)
+	repoLocation := fmt.Sprintf("%s%s/%s/Teleport/%%{_arch}/%s/teleport.repo", teleportassets.ZypperRepoURL(), linuxInfo.ID, versionID, repoChannel)
 	pm.logger.InfoContext(ctx, "Building rpm metadata for Teleport repo", "command", "rpm --eval "+repoLocation)
 	rpmEvalTeleportRepoCMD := exec.CommandContext(ctx, pm.bins.Rpm, "--eval", repoLocation)
 	rpmEvalTeleportRepoCMDOutput, err := rpmEvalTeleportRepoCMD.CombinedOutput()

--- a/lib/utils/teleportassets/teleportassets.go
+++ b/lib/utils/teleportassets/teleportassets.go
@@ -20,6 +20,7 @@ package teleportassets
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/coreos/go-semver/semver"
 
@@ -34,7 +35,44 @@ const (
 	// teleportPreReleaseCDN is the Teleport CDN URL for pre-release builds.
 	// This can be used to download the Teleport binary for pre-release builds.
 	teleportPreReleaseCDN = "https://cdn.cloud.gravitational.io"
+	// TeleportRepoBaseDomain is the base domain hosting the apt and yum package repos.
+	teleportRepoBaseDomain = "releases.teleport.dev"
+
+	teleportRepoBaseDomainEnvVar = "TELEPORT_REPO_BASE_DOMAIN"
 )
+
+var repoBaseDomain string
+
+func init() {
+	if base := os.Getenv(teleportRepoBaseDomainEnvVar); base != "" {
+		repoBaseDomain = base
+	}
+	repoBaseDomain = teleportRepoBaseDomain
+}
+
+func AptRepoURL() string {
+	return "https://apt." + repoBaseDomain + "/"
+}
+
+func AptRepoGPGURL() string {
+	return AptRepoURL() + "gpg"
+}
+
+func YumRepoURL() string {
+	return "https://yum." + repoBaseDomain + "/"
+}
+
+func ZypperRepoURL() string {
+	return "https://zypper." + repoBaseDomain + "/"
+}
+
+func ZypperRepoGPGURL() string {
+	return ZypperRepoURL() + "gpg"
+}
+
+func RepoBaseDomain() string {
+	return repoBaseDomain
+}
 
 // CDNBaseURL returns the URL of the CDN that can be used to download Teleport
 // binary assets.

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -38,6 +38,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 // appURIPattern is a regexp excluding invalid characters from application URIs.
@@ -193,6 +194,7 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 		"discoveryInstallMode":       strconv.FormatBool(opts.DiscoveryServiceEnabled),
 		"discoveryGroup":             shsprintf.EscapeDefaultContext(opts.DiscoveryGroup),
 		"cdnBaseURL":                 cdnBaseURL,
+		"repoBaseDomain":             teleportassets.RepoBaseDomain(),
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -152,6 +152,11 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 		}
 	}
 
+	cdnBaseURL := teleportUpdateDefaultCDN
+	if opts.InstallOptions.CDNBaseURL != "" {
+		cdnBaseURL = opts.InstallOptions.CDNBaseURL
+	}
+
 	var buf bytes.Buffer
 
 	// TODO(hugoShaka): burn this map and replace it by something saner in a future PR.
@@ -187,6 +192,7 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 		"db_service_resource_labels": dbServiceResourceLabels,
 		"discoveryInstallMode":       strconv.FormatBool(opts.DiscoveryServiceEnabled),
 		"discoveryGroup":             shsprintf.EscapeDefaultContext(opts.DiscoveryGroup),
+		"cdnBaseURL":                 cdnBaseURL,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -22,6 +22,7 @@ TELEPORT_BINARY_LIST_darwin="teleport" # only install server binaries for macOS
 TELEPORT_CONFIG_PATH="/etc/teleport.yaml"
 TELEPORT_DATA_DIR="/var/lib/teleport"
 TELEPORT_DOCS_URL="https://goteleport.com/docs/"
+TELEPORT_CDN_BASE_URL="{{.cdnBaseURL}}"
 # TELEPORT_FORMAT contains the Teleport installation formats.
 # The value is dynamically computed unless OVERRIDE_FORMAT it set.
 # Possible values are:
@@ -863,7 +864,7 @@ fi
 install_from_file() {
     # select correct URL/installation method based on distro
     if [[ ${TELEPORT_FORMAT} == "tarball" ]]; then
-        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
+        URL="${TELEPORT_CDN_BASE_URL}/${TELEPORT_PACKAGE_NAME}-v${TELEPORT_VERSION}-${TELEPORT_BINARY_TYPE}-${TELEPORT_ARCH}-bin.tar.gz"
 
         # check that needed tools are installed
         check_exists_fatal curl tar
@@ -890,7 +891,7 @@ install_from_file() {
         elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
             DEB_ARCH="arm64"
         fi
-        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
+        URL="${TELEPORT_CDN_BASE_URL}/${TELEPORT_PACKAGE_NAME}_${TELEPORT_VERSION}_${DEB_ARCH}.deb"
         check_deb_not_already_installed
         # check that needed tools are installed
         check_exists_fatal curl dpkg
@@ -912,7 +913,7 @@ install_from_file() {
         elif [[ ${TELEPORT_ARCH} == "arm64" ]]; then
             RPM_ARCH="arm64"
         fi
-        URL="https://cdn.teleport.dev/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
+        URL="${TELEPORT_CDN_BASE_URL}/${TELEPORT_PACKAGE_NAME}-${TELEPORT_VERSION}-1.${RPM_ARCH}.rpm"
         check_rpm_not_already_installed
         # check for package managers
         if check_exists dnf; then

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -23,6 +23,7 @@ TELEPORT_CONFIG_PATH="/etc/teleport.yaml"
 TELEPORT_DATA_DIR="/var/lib/teleport"
 TELEPORT_DOCS_URL="https://goteleport.com/docs/"
 TELEPORT_CDN_BASE_URL="{{.cdnBaseURL}}"
+TELEPORT_REPO_BASE_DOMAIN="{{.repoBaseDomain}}"
 # TELEPORT_FORMAT contains the Teleport installation formats.
 # The value is dynamically computed unless OVERRIDE_FORMAT it set.
 # Possible values are:
@@ -970,14 +971,14 @@ install_from_repo() {
             ($ID == "debian" && $VERSION_ID == "9" )
         ]]; then
             apt install apt-transport-https gnupg -y
-            curl -fsSL https://apt.releases.teleport.dev/gpg | apt-key add -
-            echo "deb https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
+            curl -fsSL "https://apt.${TELEPORT_REPO_BASE_DOMAIN}/gpg" | apt-key add -
+            echo "deb https://apt.${TELEPORT_REPO_BASE_DOMAIN}/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         else
             mkdir -p /etc/apt/keyrings
-            curl -fsSL https://apt.releases.teleport.dev/gpg \
+            curl -fsSL "https://apt.${TELEPORT_REPO_BASE_DOMAIN}/gpg" \
                 -o /etc/apt/keyrings/teleport-archive-keyring.asc
             echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \
-            https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
+            https://apt.${TELEPORT_REPO_BASE_DOMAIN}/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         fi
         apt-get update
         apt-get install -y ${PACKAGE_LIST}
@@ -990,7 +991,7 @@ install_from_repo() {
         fi
         yum install -y yum-utils
         yum-config-manager --add-repo \
-        "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/${REPO_CHANNEL}/teleport.repo")"
+        "$(rpm --eval "https://yum.${TELEPORT_REPO_BASE_DOMAIN}/$ID/$VERSION_ID/Teleport/%{_arch}/${REPO_CHANNEL}/teleport.repo")"
 
         # Remove metadata cache to prevent cache from other channel (eg, prior version)
         # See: https://github.com/gravitational/teleport/issues/22581
@@ -1003,8 +1004,8 @@ install_from_repo() {
         else
           VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
         fi
-        sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
-        sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/${REPO_CHANNEL}/teleport.repo")"
+        sudo rpm --import "https://zypper.${TELEPORT_REPO_BASE_DOMAIN}/gpg"
+        sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.${TELEPORT_REPO_BASE_DOMAIN}/sles/$VERSION_ID/Teleport/%{_arch}/${REPO_CHANNEL}/teleport.repo")"
         sudo zypper --gpg-auto-import-keys refresh
         sudo zypper --non-interactive install ${PACKAGE_LIST}
     else


### PR DESCRIPTION
During the test plan, we identified that it was hard to test  `node-install.sh` with binary. This was solved for managed updates with the TELEPORT_CDN_BASE_URL env var but this has not been ported to the existing scripts.

This PR makes the node-install.sh scrip honour the env var.

As I wrote this, I realized we have the same problem with `*.releases.teleport.dev` domains. This is a tentative fix for this issue. I also asked for feedback on slack.