### PR TITLE
Web: remove multi re-authn in a row when creating github bot

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
@@ -20,8 +20,10 @@ import React, { useContext, useState } from 'react';
 
 import { Option } from 'shared/components/Select';
 import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';
+import { getErrorMessage } from 'shared/utils/error';
 
 import { ResourceLabel } from 'teleport/services/agents';
+import auth from 'teleport/services/auth';
 import {
   createBotToken,
   GITHUB_ACTIONS_LABEL_KEY,
@@ -64,7 +66,7 @@ export function GitHubFlowProvider({
   bot = initialBotState,
 }: React.PropsWithChildren<{ bot?: CreateBotRequest }>) {
   const { resourceService } = useTeleport();
-  const { attempt, run, setAttempt } = useAttempt();
+  const { attempt, setAttempt } = useAttempt();
   const [createBotRequest, setCreateBotRequest] =
     useState<CreateBotRequest>(bot);
   const [repoRules, setRepoRules] = useState<Rule[]>([defaultRule]);
@@ -80,57 +82,74 @@ export function GitHubFlowProvider({
     }
   }
 
-  function createBot(): Promise<boolean> {
-    return run(() =>
-      resourceService
-        .createRole(
-          getRoleYaml(
-            createBotRequest.botName,
-            createBotRequest.labels,
-            createBotRequest.login
-          )
-        )
-        .then(() => {
-          let repoHost = '';
-          // Check if user sent a GitHub Enterprise host address.
-          // We can just check the first rule, as the UI will not allow
-          // using different hosts on multiple rules.
-          if (repoRules.length > 0) {
-            const { host } = parseRepoAddress(repoRules[0].repoAddress);
-            // the enterprise server host should be omited if using github.com
-            if (host !== GITHUB_HOST) {
-              repoHost = host;
-            }
-          }
+  async function createBot(): Promise<boolean> {
+    setAttempt({ status: 'processing' });
 
-          return createBotToken({
-            integrationName: createBotRequest.botName,
-            joinMethod: 'github',
-            webFlowLabel: GITHUB_ACTIONS_LABEL_VAL,
-            gitHub: {
-              enterpriseServerHost: repoHost,
-              allow: repoRules.map((r): GitHubRepoRule => {
-                const { owner, repository } = parseRepoAddress(r.repoAddress);
-                return {
-                  repository: `${owner}/${repository}`,
-                  repositoryOwner: owner,
-                  actor: r.actor,
-                  environment: r.environment,
-                  ref: r.ref,
-                  refType: r.refType.value || null,
-                  workflow: r.workflowName,
-                };
-              }),
-            },
-          }).then(token => {
-            setTokenName(token.id);
-            return serviceCreateBot({
-              ...createBotRequest,
-              roles: [createBotRequest.botName],
-            });
-          });
-        })
-    );
+    try {
+      // Re-authn once, so we can re-use it for other actions
+      // that require re-authn.
+      const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(
+        true /* allow re-use */
+      );
+
+      await resourceService.createRole(
+        getRoleYaml(
+          createBotRequest.botName,
+          createBotRequest.labels,
+          createBotRequest.login
+        ),
+        mfaResponse
+      );
+
+      let repoHost = '';
+      // Check if user sent a GitHub Enterprise host address.
+      // We can just check the first rule, as the UI will not allow
+      // using different hosts on multiple rules.
+      if (repoRules.length > 0) {
+        const { host } = parseRepoAddress(repoRules[0].repoAddress);
+        // the enterprise server host should be omited if using github.com
+        if (host !== GITHUB_HOST) {
+          repoHost = host;
+        }
+      }
+
+      const token = await createBotToken(
+        {
+          integrationName: createBotRequest.botName,
+          joinMethod: 'github',
+          webFlowLabel: GITHUB_ACTIONS_LABEL_VAL,
+          gitHub: {
+            enterpriseServerHost: repoHost,
+            allow: repoRules.map((r): GitHubRepoRule => {
+              const { owner, repository } = parseRepoAddress(r.repoAddress);
+              return {
+                repository: `${owner}/${repository}`,
+                repositoryOwner: owner,
+                actor: r.actor,
+                environment: r.environment,
+                ref: r.ref,
+                refType: r.refType.value || null,
+                workflow: r.workflowName,
+              };
+            }),
+          },
+        },
+        mfaResponse
+      );
+      setTokenName(token.id);
+
+      await serviceCreateBot(
+        {
+          ...createBotRequest,
+          roles: [createBotRequest.botName],
+        },
+        mfaResponse
+      );
+
+      return true; // success
+    } catch (err) {
+      setAttempt({ status: 'failed', statusText: getErrorMessage(err) });
+    }
   }
 
   const value: GitHubFlowContext = {

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
@@ -82,6 +82,10 @@ export function GitHubFlowProvider({
     }
   }
 
+  // setting attempt to "success" is skipped because
+  // it saves a re-render caused by it since
+  // after the fetch is successful, we render the
+  // finish step.
   async function createBot(): Promise<boolean> {
     setAttempt({ status: 'processing' });
 

--- a/web/packages/teleport/src/services/bot/bot.ts
+++ b/web/packages/teleport/src/services/bot/bot.ts
@@ -27,6 +27,7 @@ import {
 import ResourceService, { RoleResource } from 'teleport/services/resources';
 import { FeatureFlags } from 'teleport/types';
 
+import { MfaChallengeResponse } from '../mfa';
 import {
   BotList,
   BotResponse,
@@ -36,8 +37,16 @@ import {
   FlatBot,
 } from './types';
 
-export function createBot(config: CreateBotRequest): Promise<void> {
-  return api.post(cfg.getBotsUrl(), config);
+export function createBot(
+  config: CreateBotRequest,
+  mfaResponse: MfaChallengeResponse
+): Promise<void> {
+  return api.post(
+    cfg.getBotsUrl(),
+    config,
+    undefined /* abort signal */,
+    mfaResponse
+  );
 }
 
 export async function getBot(name: string): Promise<FlatBot | null> {
@@ -52,13 +61,21 @@ export async function getBot(name: string): Promise<FlatBot | null> {
   }
 }
 
-export function createBotToken(req: CreateBotJoinTokenRequest) {
-  return api.post(cfg.getBotTokenUrl(), {
-    integrationName: req.integrationName,
-    joinMethod: req.joinMethod,
-    webFlowLabel: req.webFlowLabel,
-    gitHub: toApiGitHubTokenSpec(req.gitHub),
-  });
+export function createBotToken(
+  req: CreateBotJoinTokenRequest,
+  mfaResponse?: MfaChallengeResponse
+) {
+  return api.post(
+    cfg.getBotTokenUrl(),
+    {
+      integrationName: req.integrationName,
+      joinMethod: req.joinMethod,
+      webFlowLabel: req.webFlowLabel,
+      gitHub: toApiGitHubTokenSpec(req.gitHub),
+    },
+    undefined /* abort signal */,
+    mfaResponse
+  );
 }
 
 export function fetchBots(

--- a/web/packages/teleport/src/services/bot/bot.ts
+++ b/web/packages/teleport/src/services/bot/bot.ts
@@ -39,7 +39,7 @@ import {
 
 export function createBot(
   config: CreateBotRequest,
-  mfaResponse: MfaChallengeResponse
+  mfaResponse?: MfaChallengeResponse
 ): Promise<void> {
   return api.post(
     cfg.getBotsUrl(),

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -21,6 +21,7 @@ import api from 'teleport/services/api';
 
 import { ResourcesResponse, UnifiedResource } from '../agents';
 import auth, { MfaChallengeScope } from '../auth/auth';
+import { MfaChallengeResponse } from '../mfa';
 import {
   CreateOrOverwriteGitServer,
   DefaultAuthConnector,
@@ -132,9 +133,14 @@ class ResourceService {
       .then(res => makeResource<'trusted_cluster'>(res));
   }
 
-  createRole(content: string) {
+  createRole(content: string, mfaResponse?: MfaChallengeResponse) {
     return api
-      .post(cfg.getRoleUrl(), { content })
+      .post(
+        cfg.getRoleUrl(),
+        { content },
+        undefined /* abort signal */,
+        mfaResponse
+      )
       .then(res => makeResource<'role'>(res));
   }
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/55232

With admin action enabled, creating a bot required user to re-authn 3 times in a row before succeeding. It was because there was 3 different api calls being made under the hood, each of them requiring re-authn.

There are no major changes other than requiring user to re-authn once, and then reusing that mfa response for other api calls. Changed promise chaining to try/catch block.

Tested changes that it only requires one re-authn.