### PR TITLE
feat: add TeleportCluster and Organization fields to AuditLogConfig and OktaConfigV1 respectively

### DIFF
--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
@@ -875,10 +875,12 @@ func (*AuditLogStreamRequest_BulkSync) isAuditLogStreamRequest_Action() {}
 
 // AuditLogConfig is the configuration for exporting audit logs.
 type AuditLogConfig struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	StartDate     *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"` // Start date for exporting audit logs.
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	StartDate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"` // Start date for exporting audit logs.
+	// teleport_cluster is the teleport cluster name this audit log config refers to.
+	TeleportCluster string `protobuf:"bytes,2,opt,name=teleport_cluster,json=teleportCluster,proto3" json:"teleport_cluster,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AuditLogConfig) Reset() {
@@ -916,6 +918,13 @@ func (x *AuditLogConfig) GetStartDate() *timestamppb.Timestamp {
 		return x.StartDate
 	}
 	return nil
+}
+
+func (x *AuditLogConfig) GetTeleportCluster() string {
+	if x != nil {
+		return x.TeleportCluster
+	}
+	return ""
 }
 
 // AuditLogEvents bundles a batch of unstructured audit log events with the
@@ -3471,10 +3480,11 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\x06config\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogConfigH\x00R\x06config\x12=\n" +
 	"\x06events\x18\x02 \x01(\v2#.accessgraph.v1alpha.AuditLogEventsH\x00R\x06events\x12G\n" +
 	"\tbulk_sync\x18\x03 \x01(\v2(.accessgraph.v1alpha.BulkResumeStateSyncH\x00R\bbulkSyncB\b\n" +
-	"\x06action\"K\n" +
+	"\x06action\"v\n" +
 	"\x0eAuditLogConfig\x129\n" +
 	"\n" +
-	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\"\xa2\x02\n" +
+	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\x12)\n" +
+	"\x10teleport_cluster\x18\x02 \x01(\tR\x0fteleportCluster\"\xa2\x02\n" +
 	"\x0eAuditLogEvents\x12?\n" +
 	"\x06events\x18\x01 \x03(\v2'.teleport.auditlog.v1.EventUnstructuredR\x06events\x12X\n" +
 	"\x13search_resume_state\x18\x02 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12e\n" +

--- a/gen/proto/go/accessgraph/v1alpha/okta.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/okta.pb.go
@@ -467,7 +467,9 @@ func (x *OktaAuditLogV1) GetCursor() *OktaAuditLogV1Cursor {
 type OktaConfigV1 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The desired start date from which to begin exporting Okta audit logs.
-	StartDate     *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
+	StartDate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
+	// organization is the Okta organization name.
+	Organization  string `protobuf:"bytes,2,opt,name=organization,proto3" json:"organization,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -507,6 +509,13 @@ func (x *OktaConfigV1) GetStartDate() *timestamppb.Timestamp {
 		return x.StartDate
 	}
 	return nil
+}
+
+func (x *OktaConfigV1) GetOrganization() string {
+	if x != nil {
+		return x.Organization
+	}
+	return ""
 }
 
 // OktaTokenV1 holds information about an Okta token (ex.: an API token),
@@ -961,10 +970,11 @@ const file_accessgraph_v1alpha_okta_proto_rawDesc = "" +
 	"\x0flast_event_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\rlastEventTime\"\x8d\x01\n" +
 	"\x0eOktaAuditLogV1\x128\n" +
 	"\x06events\x18\x01 \x03(\v2 .accessgraph.v1alpha.OktaEventV1R\x06events\x12A\n" +
-	"\x06cursor\x18\x02 \x01(\v2).accessgraph.v1alpha.OktaAuditLogV1CursorR\x06cursor\"I\n" +
+	"\x06cursor\x18\x02 \x01(\v2).accessgraph.v1alpha.OktaAuditLogV1CursorR\x06cursor\"m\n" +
 	"\fOktaConfigV1\x129\n" +
 	"\n" +
-	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\"\x8d\x02\n" +
+	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\x12\"\n" +
+	"\forganization\x18\x02 \x01(\tR\forganization\"\x8d\x02\n" +
 	"\vOktaTokenV1\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +

--- a/proto/accessgraph/v1alpha/access_graph_service.proto
+++ b/proto/accessgraph/v1alpha/access_graph_service.proto
@@ -338,6 +338,8 @@ message AuditLogStreamRequest {
 // AuditLogConfig is the configuration for exporting audit logs.
 message AuditLogConfig {
   google.protobuf.Timestamp start_date = 1; // Start date for exporting audit logs.
+  // teleport_cluster is the teleport cluster name this audit log config refers to.
+  string teleport_cluster = 2;
 }
 
 // AuditLogEvents bundles a batch of unstructured audit log events with the

--- a/proto/accessgraph/v1alpha/okta.proto
+++ b/proto/accessgraph/v1alpha/okta.proto
@@ -100,6 +100,8 @@ message OktaAuditLogV1 {
 message OktaConfigV1 {
   // The desired start date from which to begin exporting Okta audit logs.
   google.protobuf.Timestamp start_date = 1;
+  // organization is the Okta organization name.
+  string organization = 2;
 }
 
 // OktaTokenV1 holds information about an Okta token (ex.: an API token),


### PR DESCRIPTION
This PR adds the Teleport cluster name and okta organuzation name into respective configs.