### PR TITLE
Connect: Make Chromium use GTK 3

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -48,6 +48,10 @@ if (!process.defaultApp) {
   app.setAsDefaultProtocolClient(CUSTOM_PROTOCOL);
 }
 
+// Fix a bug introduced in Electron 36.
+// https://github.com/electron/electron/issues/46538#issuecomment-2808806722
+app.commandLine.appendSwitch('gtk-version', '3');
+
 if (app.requestSingleInstanceLock()) {
   initializeApp();
 } else {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/55279.

This fixes a bug which prevents Connect from starting on Fedora.

Tested in a VM on Fedora, first by building the app from master, verifying that it doesn't work, then applying the fix and verifying that it launches. I also launched it on Ubuntu before and after the fix and everything appears to work fine. Same with macOS where the flag is simply unused as Chromium doesn't use GTK on macOS.