### PR TITLE
Unified resources: Make "Show requestable resources" clickable

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -291,16 +291,15 @@ const IncludedResourcesSelector = ({
         onClose={handleClose}
       >
         <AccessRequestsToggleItem>
-          <Text mr={2} mb={1}>
-            Show requestable resources
-          </Text>
           <Toggle
             isToggled={
               availabilityFilter.mode === 'requestable' ||
               availabilityFilter.mode === 'all'
             }
             onToggle={handleToggle}
-          />
+          >
+            <Text ml={2}>Show requestable resources</Text>
+          </Toggle>
         </AccessRequestsToggleItem>
       </Menu>
     </Flex>


### PR DESCRIPTION
Before this change, the text next to the toggle wasn't clickable.

By default, when you pass children to `<Toggle>`, they end up being used as a label for the toggle and the label is shown to the right of the toggle. Grepping through the project, it seems to be the most common use case for `<Toggle>`. This particular callsite was an outlier.

The flicker in the recordings is due to how the story is written, I didn't want to spend time on improving it. The preferences in [the story](https://localhost:9002/?path=/story/teleporte-unifiedresources--saml-app-edit-and-delete) are not even interactive without https://github.com/gravitational/teleport.e/pull/6599.

https://github.com/user-attachments/assets/1faab4e0-329d-4da7-b5b4-789b229fcb6b

https://github.com/user-attachments/assets/182c7d0c-b973-46e8-b7ab-ffd7ef453aa2

