### PR TITLE
Add `Resources` stream to generic storage services

### DIFF
--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -202,6 +202,46 @@ func TestGenericCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+	// Retrieve all resources from the stream
+	var streamedResources []*testResource
+	for r, err := range service.Resources(ctx, "", "") {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff(paginatedOut, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve all resources from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, r1.GetName(), r2.GetName()) {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff(paginatedOut, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve a single resource from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, r2.GetName(), "") {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff([]*testResource{r2}, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve a single resource from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, "", r1.GetName()) {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff([]*testResource{r1}, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
 	// Fetch a specific service provider.
 	r, err := service.GetResource(ctx, r2.GetName())
 	require.NoError(t, err)

--- a/lib/services/local/plugin_static_credentials.go
+++ b/lib/services/local/plugin_static_credentials.go
@@ -76,13 +76,11 @@ func (p *PluginStaticCredentialsService) UpdatePluginStaticCredentials(ctx conte
 
 // GetPluginStaticCredentialsByLabels will get a list of plugin static credentials resource by matching labels.
 func (p *PluginStaticCredentialsService) GetPluginStaticCredentialsByLabels(ctx context.Context, labels map[string]string) ([]types.PluginStaticCredentials, error) {
-	creds, err := p.svc.GetResources(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	var foundCredentials []types.PluginStaticCredentials
-	for _, cred := range creds {
+	for cred, err := range p.svc.Resources(ctx, "", "") {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		if types.MatchLabels(cred, labels) {
 			foundCredentials = append(foundCredentials, cred)
 		}


### PR DESCRIPTION
Both the generic.Service and generic.ServiceWrapper have a new `Resources(ctx context.Context, startKey, endKey string) iter.Seq2[Resource, error]` received method to allow iterating through a range of items stored. Their respective ListResources methods have been updated to use the backend.Items iteration instead of GetRange as well.

This can be utilized by higher layers which want a way to effectively paginate and filter items. For the moment, it is only consumed outside of tests by `(PluginStaticCredentialsService) GetPluginStaticCredentialsByLabels` but was specifically added to be consumed by some of the scoped resource APIs in the near future.