### PR TITLE
api/client: support dialing and creating the client separately

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -117,6 +117,16 @@ func TestNew(t *testing.T) {
 			_, err = clt.Ping(ctx)
 			assert.NoError(t, err, "Ping failed")
 			assert.NoError(t, clt.Close(), "Close failed")
+
+			// Try dialing the connection and creating the client separately.
+			conn, err := Dial(ctx, cfg)
+			require.NoError(t, err)
+
+			clt = NewWithConnection(conn)
+
+			_, err = clt.Ping(ctx)
+			assert.NoError(t, err, "Ping failed")
+			assert.NoError(t, clt.Close(), "Close failed")
 		})
 	}
 }


### PR DESCRIPTION
In #55170, we added support for wrapping `tbot`'s gRPC connection so that we can handle the auth server being unavailable on-startup. This PR makes it possible to create a Client from an existing (i.e. wrapped) gRPC connection.

It's a little bit inefficient in that `lib/auth/authclient` still creates an HTTP client which we never use, and it feels like it'd be cleaner to separate them at a lower-level - but this seems like the least disruptive approach.

changelog: api/client: support for creating a client from an existing gRPC connection
