### PR TITLE
feat: add SQS, S3, and KMS support for AWS Access Graph integration

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -437,6 +437,58 @@ func StatementAccessGraphAWSSync() *Statement {
 	}
 }
 
+// StatementAccessGraphAWSSyncSQS returns the statement that allows
+// receiving, deleting, and sending messages to the specified SQS queue.
+// This is used for receiving and processing AWS cloud trail logs notifications
+// from SQS.
+func StatementAccessGraphAWSSyncSQS(sqsQueueARN string) *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"sqs:ReceiveMessage",
+			"sqs:DeleteMessage",
+		},
+		Resources: []string{sqsQueueARN},
+	}
+}
+
+// StatementAccessGraphAWSSyncS3BucketDownload returns the statement that allows downloading
+// objects from the specified S3 bucket. This is used for downloading AWS cloud trail logs.
+func StatementAccessGraphAWSSyncS3BucketDownload(s3BucketARN string) *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"s3:GetObject",
+			"s3:GetObjectVersion",
+			"s3:ListBucket",
+			"s3:ListBucketVersions",
+			"s3:GetBucketLocation",
+		},
+		Resources: []string{s3BucketARN},
+	}
+}
+
+// StatementAccessGraphAWSSyncKMSDecrypt returns the statement that allows decrypting
+// KMS encrypted data. This is used for decrypting AWS cloud trail logs from S3
+// and decrypting SQS messages that are encrypted with KMS.
+// It allows the following actions:
+// - `kms:Decrypt` to decrypt data.
+// - `kms:DescribeKey` to get information about the KMS key.
+// - `kms:GenerateDataKey` to generate a data key for encryption.
+// - `kms:GenerateDataKeyWithoutPlaintext` to generate a data key without plaintext.
+func StatementKMSDecrypt(kmsKeysARNs []string) *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"kms:Decrypt",
+			"kms:DescribeKey",
+			"kms:GenerateDataKey",
+			"kms:GenerateDataKeyWithoutPlaintext",
+		},
+		Resources: kmsKeysARNs,
+	}
+}
+
 // StatementForAWSIdentityCenterAccess returns AWS IAM policy statement that grants
 // permissions required for Teleport identity center client.
 // TODO(sshah): make the roles more granular by restricting resources scoped to

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -281,6 +281,12 @@ type IntegrationConfAccessGraphAWSSync struct {
 	AccountID string
 	// AutoConfirm skips user confirmation of the operation plan if true.
 	AutoConfirm bool
+	// SQSQueueURL is the URL of the SQS queue to use for the Identity Security Activity Center.
+	SQSQueueURL string
+	// CloudTrailBucketARN is the name of the S3 bucket to use for the Identity Security Activity Center.
+	CloudTrailBucketARN string
+	// KMSKeyARNs is the ARN of the KMS key to use for decrypting the Identity Security Activity Center data.
+	KMSKeyARNs []string
 }
 
 // IntegrationConfAccessGraphAzureSync contains the arguments of

--- a/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
+++ b/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
@@ -1,0 +1,96 @@
+"access-graph-aws-iam" will perform the following action:
+
+Attach an inline IAM policy named "AccessGraphSyncAccess" to IAM role "integrationrole".
+PutRolePolicy: {
+    "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeImages",
+                    "ec2:DescribeTags",
+                    "ec2:DescribeSnapshots",
+                    "ec2:DescribeKeyPairs",
+                    "eks:ListClusters",
+                    "eks:DescribeCluster",
+                    "eks:ListAccessEntries",
+                    "eks:ListAccessPolicies",
+                    "eks:ListAssociatedAccessPolicies",
+                    "eks:DescribeAccessEntry",
+                    "rds:DescribeDBInstances",
+                    "rds:DescribeDBClusters",
+                    "rds:ListTagsForResource",
+                    "rds:DescribeDBProxies",
+                    "dynamodb:ListTables",
+                    "dynamodb:DescribeTable",
+                    "redshift:DescribeClusters",
+                    "redshift:Describe*",
+                    "s3:ListAllMyBuckets",
+                    "s3:GetBucketPolicy",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetBucketTagging",
+                    "s3:GetBucketPolicyStatus",
+                    "s3:GetBucketAcl",
+                    "iam:ListUsers",
+                    "iam:GetUser",
+                    "iam:ListRoles",
+                    "iam:ListGroups",
+                    "iam:ListPolicies",
+                    "iam:ListGroupsForUser",
+                    "iam:ListInstanceProfiles",
+                    "iam:ListUserPolicies",
+                    "iam:GetUserPolicy",
+                    "iam:ListAttachedUserPolicies",
+                    "iam:ListGroupPolicies",
+                    "iam:GetGroupPolicy",
+                    "iam:ListAttachedGroupPolicies",
+                    "iam:GetPolicy",
+                    "iam:GetPolicyVersion",
+                    "iam:ListRolePolicies",
+                    "iam:ListAttachedRolePolicies",
+                    "iam:GetRolePolicy",
+                    "iam:ListSAMLProviders",
+                    "iam:GetSAMLProvider",
+                    "iam:ListOpenIDConnectProviders",
+                    "iam:GetOpenIDConnectProvider"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage"
+                ],
+                "Resource": "arn:aws:sqs:us-west-2:123456789012:my-queue"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:GetObjectVersion",
+                    "s3:ListBucket",
+                    "s3:ListBucketVersions",
+                    "s3:GetBucketLocation"
+                ],
+                "Resource": "arn:aws:s3:::my-cloudtrail-bucket"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "kms:Decrypt",
+                    "kms:DescribeKey",
+                    "kms:GenerateDataKey",
+                    "kms:GenerateDataKeyWithoutPlaintext"
+                ],
+                "Resource": "arn:aws:kms:us-west-2:123456789012:key/my-kms-key"
+            }
+        ]
+    },
+    "PolicyName": "AccessGraphSyncAccess",
+    "RoleName": "integrationrole"
+}
+

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -216,9 +216,12 @@ func onIntegrationConfAccessGraphAWSSync(ctx context.Context, params config.Inte
 	}
 
 	confReq := awsoidc.AccessGraphAWSIAMConfigureRequest{
-		IntegrationRole: params.Role,
-		AccountID:       params.AccountID,
-		AutoConfirm:     params.AutoConfirm,
+		IntegrationRole:     params.Role,
+		AccountID:           params.AccountID,
+		AutoConfirm:         params.AutoConfirm,
+		SQSQueueURL:         params.SQSQueueURL,
+		CloudTrailBucketARN: params.CloudTrailBucketARN,
+		KMSKeyARNs:          params.KMSKeyARNs,
 	}
 	return trace.Wrap(awsoidc.ConfigureAccessGraphSyncIAM(ctx, clt, confReq))
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -522,6 +522,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfAccessGraphAWSSyncCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.Role)
 	integrationConfAccessGraphAWSSyncCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.AccountID)
 	integrationConfAccessGraphAWSSyncCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.AutoConfirm)
+	integrationConfAccessGraphAWSSyncCmd.Flag("sqs-queue-url", "SQS Queue URL used to receive notifications from CloudTrail.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.SQSQueueURL)
+	integrationConfAccessGraphAWSSyncCmd.Flag("cloud-trail-bucket", "ARN of the S3 bucket where CloudTrail writes events to.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.CloudTrailBucketARN)
+	integrationConfAccessGraphAWSSyncCmd.Flag("kms-key", "List of KMS Keys used to decrypt SQS and S3 bucket data.").StringsVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.KMSKeyARNs)
 
 	integrationConfAccessGraphAzureSyncCmd := integrationConfAccessGraphCmd.Command("azure", "Adds required Azure permissions for syncing Azure resources into Access Graph service.")
 	integrationConfAccessGraphAzureSyncCmd.Flag("managed-identity", "The ID of the managed identity to run the Discovery service.").Required().StringVar(&ccf.IntegrationConfAccessGraphAzureSyncArguments.ManagedIdentity)


### PR DESCRIPTION
- Updated configuration to acept SQSQueueURL, CloudTrailBucket, and KMSKeyARNs.
- Updated integration commands to accept new parameters for SQS and S3.