### PR TITLE
Fix firestore tests

### DIFF
--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -469,6 +469,11 @@ func TestFirestoreMigration(t *testing.T) {
 	uut, err := New(context.Background(), cfg, Options{Clock: clock})
 	require.NoError(t, err)
 
+	// Empty the collection to make sure previous tests don't interfere
+	snapshot, err := uut.svc.Collection(uut.CollectionName).Documents(context.Background()).GetAll()
+	require.NoError(t, err)
+	require.NoError(t, uut.deleteDocuments(snapshot))
+
 	type byteAlias []byte
 	type badRecord struct {
 		Key        byteAlias `firestore:"key,omitempty"`


### PR DESCRIPTION
Fixes a firestore test that is failing when running against a non-empty collection.

Related to: https://github.com/gravitational/teleport/issues/55231