### PR TITLE
Clarify Enhanced Session Recording test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -114,8 +114,7 @@ as well as an upgrade of the previous version of Teleport.
       - [ ] Host key checking disabled allows connection
 
 - [ ] Enhanced Session Recording
-  - [ ] `disk`, `command` and `network` events are being logged.
-  - [ ] Recorded events can be enforced by the `enhanced_recording` role option.
+  - [ ] Setting the `enhanced_recording` role option determine which types of events (`disk`, `command`, `network`) are logged on nodes with `enhanced_recording.enabled: true`
   - [ ] Enhanced session recording can be enabled on CentOS 7 with kernel 5.8+.
 
 - [ ] Auditd


### PR DESCRIPTION
Enhanced Session Recording is not "enforced" based on the role option - the role option is just used to determine _which_ events to record _if_ enhanced recording happens to be enabled for the Node the user is connecting to.

To back this up, there is no mention of enforcement in the [docs](https://goteleport.com/docs/enroll-resources/server-access/guides/bpf-session-recording/) or in the code dating back to v14.

Related to: https://github.com/gravitational/teleport/issues/55231