### PR TITLE
label calling binary's path for SELinux

### DIFF
--- a/lib/selinux/selinux.go
+++ b/lib/selinux/selinux.go
@@ -19,7 +19,7 @@
 package selinux
 
 type filePaths struct {
-	InstallDir     string
+	BinaryPath     string
 	DataDir        string
 	ConfigPath     string
 	UpgradeUnitDir string

--- a/lib/selinux/selinux_others.go
+++ b/lib/selinux/selinux_others.go
@@ -34,7 +34,7 @@ func ModuleSource() string {
 }
 
 // FileContexts returns file contexts for the SELinux SSH module.
-func FileContexts(installDir, dataDir, configPath string) (string, error) {
+func FileContexts(dataDir, configPath string) (string, error) {
 	return "", trace.Errorf(errPlatformNotSupportedMsg)
 }
 

--- a/lib/selinux/selinux_test.go
+++ b/lib/selinux/selinux_test.go
@@ -35,7 +35,7 @@ func TestFileContextTemplate(t *testing.T) {
 	fcTempl, err := template.New("selinux file contexts").Parse(string(fileConTmpl))
 	require.NoError(t, err)
 	err = fcTempl.Execute(io.Discard, &filePaths{
-		InstallDir:     "/dir",
+		BinaryPath:     "/dir",
 		DataDir:        "/dir",
 		ConfigPath:     "/dir",
 		UpgradeUnitDir: "/dir",

--- a/lib/selinux/teleport_ssh.fc.tmpl
+++ b/lib/selinux/teleport_ssh.fc.tmpl
@@ -1,9 +1,5 @@
-# teleport-update install dir
-{{ .InstallDir }}/versions/[0-9\.]+/bin/teleport  -- gen_context(system_u:object_r:teleport_ssh_exec_t,s0)
-# teleport binary installed by RPM package
-{{ .InstallDir }}/system/bin/teleport             -- gen_context(system_u:object_r:teleport_ssh_exec_t,s0)
-/usr/local/bin/teleport                           -- gen_context(system_u:object_r:teleport_ssh_exec_t,s0)
-/run/.teleport.pid                                -- gen_context(system_u:object_r:teleport_ssh_pid_t,s0)
-{{ .ConfigPath }}                                 -- gen_context(system_u:object_r:teleport_ssh_conf_t,s0)
-{{ .DataDir }}(/.*)?                                 gen_context(system_u:object_r:teleport_ssh_data_t,s0)
-{{ .UpgradeUnitDir }}(/.*)?                          gen_context(system_u:object_r:teleport_ssh_upgrade_data_t,s0)
+{{ .BinaryPath }}            -- gen_context(system_u:object_r:teleport_ssh_exec_t,s0)
+/run/teleport.pid            -- gen_context(system_u:object_r:teleport_ssh_pid_t,s0)
+{{ .ConfigPath }}            -- gen_context(system_u:object_r:teleport_ssh_conf_t,s0)
+{{ .DataDir }}(/.*)?            gen_context(system_u:object_r:teleport_ssh_data_t,s0)
+{{ .UpgradeUnitDir }}(/.*)?     gen_context(system_u:object_r:teleport_ssh_upgrade_data_t,s0)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1138,7 +1138,7 @@ func onSELinuxFileContexts(configPath string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fileContexts, err := selinux.FileContexts("/opt/teleport/default", cfg.DataDir, configPath)
+	fileContexts, err := selinux.FileContexts(cfg.DataDir, configPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Instead of hoping the binary used to run Teleport SSH is installed in standard locations, use the path of the binary when generating the file contexts file. This will simplify SELinux configuration as SELinux will now recognize Teleport and enforce it no matter where it is in the filesystem.