### PR TITLE
Slack Plugin: Remove trailing dot

### DIFF
--- a/integrations/access/accessrequest/message.go
+++ b/integrations/access/accessrequest/message.go
@@ -46,7 +46,7 @@ const (
 var reviewReplyTemplate = template.Must(template.New("review reply").Parse(
 	`{{.Author}} reviewed the request at {{.Created.Format .TimeFormat}}.
 Resolution: {{.ProposedStateEmoji}} {{.ProposedState}}.
-{{if .Reason}}Reason: {{.Reason}}.{{end}}`,
+{{if .Reason}}Reason: {{.Reason}}{{end}}`,
 ))
 
 func MsgStatusText(tag pd.ResolutionTag, reason string) string {

--- a/integrations/access/accessrequest/message_test.go
+++ b/integrations/access/accessrequest/message_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
 )
 
@@ -88,4 +89,20 @@ func ExampleMsgFields_logins() {
 	// *Reason*: ```
 	// test```
 	// *Link*: https://example.teleport.sh/web/requests/00000000-0000-0000-0000-000000000000
+}
+
+func ExampleMsgReview() {
+	review := types.AccessReview{
+		Author:        "example@goteleport.com",
+		ProposedState: types.RequestState_APPROVED,
+		Reason:        "example reason",
+	}
+
+	msg, _ := MsgReview(review)
+	fmt.Println(msg)
+
+	// Output: example@goteleport.com reviewed the request at 01 Jan 01 00:00 UTC.
+	// Resolution: ✅ APPROVED.
+	// Reason: ```
+	// example reason```
 }


### PR DESCRIPTION
Changelog: Remove trailing dot from slack plugin review messages

This is a minor fix for the slack plugin review messages. This removes a trailing `.` at the end of the message.

### Before
<img width="546" alt="Screenshot 2025-05-30 at 3 56 20 PM" src="https://github.com/user-attachments/assets/af2083e9-789e-4c95-8060-23c4917b1e59" />

### After
<img width="547" alt="Screenshot 2025-05-30 at 4 30 21 PM" src="https://github.com/user-attachments/assets/401dbbca-65aa-4b58-bcee-2b9683e737dd" />
