### PR TITLE
[v16] Remove github.com/elastic/go-elasticsearch dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/go-elasticsearch/v8 v8.13.1
 	github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/fatih/color v1.17.0
@@ -318,7 +317,6 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
-	github.com/elastic/elastic-transport-go/v8 v8.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.3 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1144,10 +1144,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/elastic/elastic-transport-go/v8 v8.5.0 h1:v5membAl7lvQgBTexPRDBO/RdnlQX+FM9fUVDyXxvH0=
-github.com/elastic/elastic-transport-go/v8 v8.5.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/go-elasticsearch/v8 v8.13.1 h1:du5F8IzUUyCkzxyHdrO9AtopcG95I/qwi2WK8Kf1xlg=
-github.com/elastic/go-elasticsearch/v8 v8.13.1/go.mod h1:DIn7HopJs4oZC/w0WoJR13uMUxtHeq92eI5bqv5CRfI=
 github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8 h1:0+BTyxIYgiVAry/P5s8R4dYuLkhB9Nhso8ogFWNr4IQ=
 github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8/go.mod h1:JkjcmqbLW+khwt2fmBPJFBhx2zGZ8XobRZ+O0VhlwWo=
 github.com/emicklei/go-restful/v3 v3.11.3 h1:yagOQz/38xJmcNeZJtrUcKjkHRltIaIFXKWeG1SkWGE=

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -404,10 +404,6 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/elastic/elastic-transport-go/v8 v8.5.0 h1:v5membAl7lvQgBTexPRDBO/RdnlQX+FM9fUVDyXxvH0=
-github.com/elastic/elastic-transport-go/v8 v8.5.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/go-elasticsearch/v8 v8.13.1 h1:du5F8IzUUyCkzxyHdrO9AtopcG95I/qwi2WK8Kf1xlg=
-github.com/elastic/go-elasticsearch/v8 v8.13.1/go.mod h1:DIn7HopJs4oZC/w0WoJR13uMUxtHeq92eI5bqv5CRfI=
 github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8 h1:0+BTyxIYgiVAry/P5s8R4dYuLkhB9Nhso8ogFWNr4IQ=
 github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8/go.mod h1:JkjcmqbLW+khwt2fmBPJFBhx2zGZ8XobRZ+O0VhlwWo=
 github.com/emicklei/go-restful/v3 v3.11.3 h1:yagOQz/38xJmcNeZJtrUcKjkHRltIaIFXKWeG1SkWGE=

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/ClickHouse/ch-go"
 	cqlclient "github.com/datastax/go-cassandra-native-protocol/client"
-	elastic "github.com/elastic/go-elasticsearch/v8"
 	mysqlclient "github.com/go-mysql-org/go-mysql/client"
 	mysqllib "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/google/uuid"
@@ -2050,7 +2049,7 @@ func (c *testContext) snowflakeClient(ctx context.Context, teleportUser, dbServi
 }
 
 // elasticsearchClient returns an Elasticsearch test DB client.
-func (c *testContext) elasticsearchClient(ctx context.Context, teleportUser, dbService, dbUser string) (*elastic.Client, *alpnproxy.LocalProxy, error) {
+func (c *testContext) elasticsearchClient(ctx context.Context, teleportUser, dbService, dbUser string) (*elasticsearch.TestClient, *alpnproxy.LocalProxy, error) {
 	route := tlsca.RouteToDatabase{
 		ServiceName: dbService,
 		Protocol:    defaults.ProtocolElasticsearch,

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"strconv"
 
-	elastic "github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -69,8 +68,18 @@ func (e *Engine) SendError(err error) {
 		return
 	}
 
+	// ErrorCause type.
+	//
+	// https://github.com/elastic/elasticsearch-specification/blob/f6a370d0fba975752c644fc730f7c45610e28f36/specification/_types/Errors.ts#L25-L50
+	type ErrorCause struct {
+		// Reason A human-readable explanation of the error, in English.
+		Reason *string `json:"reason,omitempty"`
+		// Type The type of error
+		Type string `json:"type"`
+	}
+
 	reason := err.Error()
-	cause := elastic.ErrorCause{
+	cause := ErrorCause{
 		Reason: &reason,
 		Type:   "internal_server_error_exception",
 	}

--- a/lib/srv/db/elasticsearch/test.go
+++ b/lib/srv/db/elasticsearch/test.go
@@ -24,9 +24,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
+	"strings"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -122,18 +123,44 @@ func (s *TestServer) Close() error {
 	return s.listener.Close()
 }
 
-// MakeTestClient returns Redis client connection according to the provided
-// parameters.
-func MakeTestClient(_ context.Context, config common.TestClientConfig) (*elasticsearch.Client, error) {
-	es, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{"http://" + config.Address},
-	})
+type TestClient struct {
+	addr string
+}
 
+func (t TestClient) Ping() (*http.Response, error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   t.addr,
+		Path:   "/",
+	}
+	req, err := http.NewRequest(http.MethodHead, u.String(), http.NoBody)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, err
 	}
 
-	return es, nil
+	return http.DefaultClient.Do(req)
+}
+
+func (t TestClient) Query(q string) (*http.Response, error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   t.addr,
+		Path:   "/_sql",
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), strings.NewReader(q))
+	if err != nil {
+		return nil, err
+	}
+
+	return http.DefaultClient.Do(req)
+}
+
+// MakeTestClient returns Redis client connection according to the provided
+// parameters.
+func MakeTestClient(_ context.Context, config common.TestClientConfig) (*TestClient, error) {
+	return &TestClient{
+		addr: config.Address,
+	}, nil
 }
 
 const (


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/55319 to branch/v16