### PR TITLE
Fix `(Cache) GetRole` not found error message

### DIFF
--- a/lib/cache/role.go
+++ b/lib/cache/role.go
@@ -156,6 +156,9 @@ func (c *Cache) GetRole(ctx context.Context, name string) (types.Role, error) {
 			if role, err := c.Config.Access.GetRole(ctx, name); err == nil {
 				return role, nil
 			}
+
+			// This error message format should be kept in sync with web/packages/teleport/src/services/api/api.isRoleNotFoundError
+			return nil, trace.NotFound("role %v is not found", name)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/role_test.go
+++ b/lib/cache/role_test.go
@@ -21,10 +21,23 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
+
+func TestRoleNotFound(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForNode)
+	t.Cleanup(p.Close)
+
+	_, err := p.cache.GetRole(t.Context(), "test-role")
+	assert.Error(t, err)
+	assert.True(t, trace.IsNotFound(err))
+	assert.Equal(t, "role test-role is not found", err.Error())
+}
 
 // TestRoles tests caching of roles
 func TestRoles(t *testing.T) {

--- a/lib/services/local/access_test.go
+++ b/lib/services/local/access_test.go
@@ -27,11 +27,29 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
+
+func TestRoleNotFound(t *testing.T) {
+	t.Parallel()
+
+	backend, err := memory.New(memory.Config{
+		Context: t.Context(),
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	access := NewAccessService(backend)
+
+	_, err = access.GetRole(t.Context(), "test-role")
+	assert.Error(t, err)
+	assert.True(t, trace.IsNotFound(err))
+	assert.Equal(t, "role test-role is not found", err.Error())
+}
 
 func TestLockCRUD(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
The web UI relies on error messages returned when roles do not exist to be in a specific format to know when a user should be reauthenticated. When switching the cache to use the new in memory machinery the error message was not kept in sync with the services/local implementation and resulted in weird errors in the UI instead of detecting that a logout is required.

A test was added to ensure that the Cache and the Backend implementations of GetRole return the same message when roles are not found.