### PR TITLE
Correctly scope member counts per Access List

### DIFF
--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -224,11 +224,15 @@ func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName strin
 		return count, listCount, trace.Wrap(err)
 	}
 
-	startKey := accessListName + "/" + accesslist.MembershipKindList + "/"
-	endKey := sortcache.NextKey(startKey)
-	listCount := uint32(rg.store.count(accessListMemberKindIndex, startKey, endKey))
+	startUserKey := accessListName + "/" + accesslist.MembershipKindUser + "/"
+	endUserKey := sortcache.NextKey(startUserKey)
+	userCount := uint32(rg.store.count(accessListMemberKindIndex, startUserKey, endUserKey))
 
-	return uint32(rg.store.len()) - listCount, listCount, trace.Wrap(err)
+	startListKey := accessListName + "/" + accesslist.MembershipKindList + "/"
+	endListKey := sortcache.NextKey(startListKey)
+	listCount := uint32(rg.store.count(accessListMemberKindIndex, startListKey, endListKey))
+
+	return userCount, listCount, nil
 }
 
 // ListAccessListMembers returns a paginated list of all access list members.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -191,8 +191,8 @@ func newPackForAuth(t *testing.T) *testPack {
 	return newTestPack(t, ForAuth)
 }
 
-func newTestPack(t *testing.T, setupConfig SetupConfigFn) *testPack {
-	pack, err := newPack(t.TempDir(), setupConfig)
+func newTestPack(t *testing.T, setupConfig SetupConfigFn, opts ...packOption) *testPack {
+	pack, err := newPack(t.TempDir(), setupConfig, opts...)
 	require.NoError(t, err)
 	return pack
 }


### PR DESCRIPTION
Previously included global count of Access List members; now only counts members scoped to the given Access List.

Resolves [e#6597](https://github.com/gravitational/teleport.e/issues/6597).
