### PR TITLE
Update usage-billing.mdx to include IG MAUs

### DIFF
--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -72,6 +72,7 @@ calculate three types of billing metrics:
 - Monthly Active Users
 - Teleport Protected Resources
 - Machine & Workload Identities
+- Identity Governance Monthly Active Users
 
 ### Usage metrics in the Web UI
 
@@ -154,6 +155,21 @@ as one SPIFFE ID for billing.
 
 The sum of your calculated Bots, Bot Instances, and unique SPIFFE IDs is your
 total MWI for the billing period.
+
+### Identity Governance Monthly Active Users
+
+Identity Governance Monthly Active Users (IG MAU) is the aggregate number of unique users performing Identity Governance-related activities in Teleport.
+
+We aggregate IG MAU over each monthly period starting on the subscription start date and ending on each monthly anniversary thereafter.
+
+Identity Governance "active user" means a user having performed any of the following activities:
+- Submitting an access request
+- Reviewing an access request
+- Getting roles assigned during login through access list membership
+- Reviewing an access list
+- Logging in to a service provider application via Teleport SAML IdP
+
+IG MAU is calculated separately from standard MAU and represents users specifically engaging with Teleport's Identity Governance features. A user can contribute to both standard MAU and IG MAU billing metrics within the same period if they perform activities that qualify for both metrics.
 
 ## Usage measurement for billing
 


### PR DESCRIPTION
Identity Governance MAU billing has been live for months, but we're missing this from our customer-facing billing documentation. Customers need to understand what activities count toward their IG MAU charges.

We will need to backport this to v17 and v16 docs.

I've structured this to match our existing billing metric documentation style, but this is an initial draft and welcome suggestions to make sure customers have clear visibility into how we're calculating IG MAUs.

Closes #55372