### PR TITLE
Move Teleport as IdP from Zero Trust Access to Identity Governance

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -35,8 +35,6 @@ Get started with Teleport Zero Trust Access:
   credentials like Touch ID and YubiKey Bio.
 - [Integrate your Single Sign-On provider](admin-guides/access-controls/sso/sso.mdx): Allow users
   to access infrastructure resources with IdPs like Okta.
-- [Use Teleport as an identity provider](admin-guides/access-controls/idps/saml-guide.mdx) to
-  authenticate to external services.
 
 ### Teleport Machine & Workload Identity
 
@@ -71,6 +69,8 @@ Get started with Teleport Identity Governance:
 - [Access Monitoring](admin-guides/access-controls/access-monitoring.mdx): Detect overly
   broad privileges and inspect sessions that are not using strong protection,
   such as multi-factor authentication and Device Trust.
+- [Use Teleport as an identity provider](admin-guides/access-controls/idps/saml-guide.mdx) to
+  authenticate to external services.
 
 ### Teleport Identity Security
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -69,8 +69,7 @@ Get started with Teleport Identity Governance:
 - [Access Monitoring](admin-guides/access-controls/access-monitoring.mdx): Detect overly
   broad privileges and inspect sessions that are not using strong protection,
   such as multi-factor authentication and Device Trust.
-- [Use Teleport as an identity provider](admin-guides/access-controls/idps/saml-guide.mdx) to
-  authenticate to external services.
+- [Teleport as an Identity Provider](admin-guides/access-controls/idps/saml-guide.mdx): Authenticate to external services using Teleport as your identity provider.
 
 ### Teleport Identity Security
 


### PR DESCRIPTION
Teleport as an IdP is an Identity Governance capability and should be listed under that product section.