### PR TITLE
Add focus-visible style to Toggle

### DIFF
--- a/web/packages/design/src/Toggle/Toggle.story.tsx
+++ b/web/packages/design/src/Toggle/Toggle.story.tsx
@@ -18,7 +18,7 @@
 
 import { useState } from 'react';
 
-import Flex from '../Flex';
+import Flex, { Stack } from '../Flex';
 import Text from '../Text';
 import { Toggle } from './Toggle';
 
@@ -28,10 +28,10 @@ export default {
 
 export const Default = () => {
   return (
-    <Flex flexDirection="column" gap={4}>
+    <Stack gap={4} bg="levels.surface" p={3}>
       <ToggleRow initialToggled={false} />
       <ToggleRow initialToggled={true} />
-    </Flex>
+    </Stack>
   );
 };
 

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -162,4 +162,14 @@ const StyledInput = styled.input.attrs({ type: 'checkbox' })<SizeProps>`
   &:disabled:checked + ${StyledSlider} {
     background: ${props => props.theme.colors.interactive.tonal.success[2]};
   }
+
+  &:focus-visible + ${StyledSlider} {
+    // box-shadow instead of border because border affects the overall size of the element.
+    box-shadow: 0 0 0 1px
+      ${props => props.theme.colors.interactive.solid.primary.default};
+    &:before {
+      box-shadow: 0 0 0 1px
+        ${props => props.theme.colors.interactive.solid.primary.default};
+    }
+  }
 `;

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -164,12 +164,6 @@ const StyledInput = styled.input.attrs({ type: 'checkbox' })<SizeProps>`
   }
 
   &:focus-visible + ${StyledSlider} {
-    // box-shadow instead of border because border affects the overall size of the element.
-    box-shadow: 0 0 0 1px
-      ${props => props.theme.colors.interactive.solid.primary.default};
-    &:before {
-      box-shadow: 0 0 0 1px
-        ${props => props.theme.colors.interactive.solid.primary.default};
-    }
-  }
+    outline: 1px solid ${props => props.theme.colors.interactive.solid.primary.default};
+    outline-offset: 1px;
 `;


### PR DESCRIPTION
`<Toggle>` had no focus styles which means its focus was not visible when using keyboard navigation. This PR makes it so that Toggle receives the same border color as text inputs when focus is visible.

The focus state is not particularly visible when the Toggle is enabled, but I couldn't come up with anything better and it's better than nothing.

[The Application Design System](https://www.figma.com/file/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?type=design&node-id=8543-43076&mode=design&t=lfboeNMENiqaZygH-4) does not seem to include focus style for toggles. [I asked the design team about this](https://gravitational.slack.com/archives/C07KG2RFA/p1748949224463569).

The "Enable (large)" column has focus-visible styles.

<img width="521" alt="image" src="https://github.com/user-attachments/assets/b7d04fc6-3ede-4486-893e-c8ef2cf5133a" />

---

* [`<Toggle>` story](https://localhost:9002/?path=/story/design-toggle--default)
* [Story that uses `<Toggle>` in a form](https://localhost:9002/?path=/story/teleterm-modalshost-hardwarekeys--change-pin)