### PR TITLE
[v17] Fix improper redirect URL validation for `/web/sso_confirm`

### DIFF
--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/loginrule"
@@ -781,6 +782,35 @@ func TestValidateClientRedirect(t *testing.T) {
 				},
 			}
 			require.Error(t, ValidateClientRedirect(badURL+"?secret_key=", ssoTestFlowTrue, settings))
+		}
+	})
+
+	t.Run("SSOMFAWeb", func(t *testing.T) {
+		const ssoTestFlowFalse = false
+		settings := &types.SSOClientRedirectSettings{
+			AllowedHttpsHostnames: []string{
+				"allowed.domain.invalid",
+			},
+		}
+
+		// Only allow web mfa redirect as a relative path.
+		require.NoError(t, ValidateClientRedirect(sso.WebMFARedirect+"?channel_id=", ssoTestFlowFalse, settings))
+
+		for _, badURL := range []string{
+			"localhost:12345" + sso.WebMFARedirect,
+			"http://localhost:12345" + sso.WebMFARedirect,
+			"https://localhost:12345" + sso.WebMFARedirect,
+			"127.0.0.1:12345" + sso.WebMFARedirect,
+			"http://127.0.0.1:12345" + sso.WebMFARedirect,
+			"https://127.0.0.1:12345" + sso.WebMFARedirect,
+			"allowed.domain.invalid" + sso.WebMFARedirect,
+			"http://allowed.domain.invalid" + sso.WebMFARedirect,
+			"https://allowed.domain.invalid" + sso.WebMFARedirect,
+			"not.allowed.domain.invalid" + sso.WebMFARedirect,
+			"http://not.allowed.domain.invalid" + sso.WebMFARedirect,
+			"https://not.allowed.domain.invalid" + sso.WebMFARedirect,
+		} {
+			require.Error(t, ValidateClientRedirect(badURL+"?channel_id=", ssoTestFlowFalse, settings))
 		}
 	})
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2351,18 +2351,19 @@ func ConstructSSHResponse(response AuthParams) (*url.URL, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Extract secret out of the request.
-	secretKey := u.Query().Get("secret_key")
-
-	// We don't use a secret key for WebUI SSO MFA redirects. The request ID itself is
-	// kept a secret on the front end to minimize the risk of a phishing attack.
-	if secretKey == "" && u.Path == sso.WebMFARedirect && response.MFAToken != "" {
+	if u.Path == sso.WebMFARedirect {
+		// Transform the web sso mfa redirectURL into a relative redirect, preserving
+		// query parameters while ignoring scheme, hostname, and other url parts.
 		q := u.Query()
 		q.Add("response", string(out))
-		u.RawQuery = q.Encode()
-		return u, nil
+		return &url.URL{
+			Path:     sso.WebMFARedirect,
+			RawQuery: q.Encode(),
+		}, nil
 	}
 
+	// Extract secret out of the request.
+	secretKey := u.Query().Get("secret_key")
 	if secretKey == "" {
 		return nil, trace.BadParameter("missing secret_key")
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -111,6 +111,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/conntest"
 	dbrepl "github.com/gravitational/teleport/lib/client/db/repl"
+	"github.com/gravitational/teleport/lib/client/sso"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -3210,6 +3211,35 @@ func (f byTimeAndIndex) Less(i, j int) bool {
 
 func (f byTimeAndIndex) Swap(i, j int) {
 	f[i], f[j] = f[j], f[i]
+}
+
+// ConstructSSHResponse_WebMFA tests that [sso.WebMFARedirect] is always
+// transformed into a relative URL so that the sso callback will redirect
+// back to the proxy.
+func TestConstructSSHResponse_WebMFA(t *testing.T) {
+	baseURL := sso.WebMFARedirect + "?channel_id=" + uuid.NewString()
+	for _, clientRedirectURL := range []string{
+		baseURL,
+		"http://127.0.0.1:1234" + baseURL,
+		"http://localhost:1234" + baseURL,
+		"https://proxy.example.com" + baseURL,
+		"tcp://tcp.app.com" + baseURL,
+	} {
+		t.Run("clientRedirectURL: "+clientRedirectURL, func(t *testing.T) {
+			redirectURL, err := ConstructSSHResponse(AuthParams{
+				Username:          "foo",
+				Cert:              []byte{0x00},
+				TLSCert:           []byte{0x01},
+				MFAToken:          "token",
+				ClientRedirectURL: clientRedirectURL,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, redirectURL.Query().Get("channel_id"))
+			require.NotEmpty(t, redirectURL.Query().Get("response"))
+			withoutQueryParams, _, _ := strings.Cut(redirectURL.String(), "?")
+			require.Equal(t, sso.WebMFARedirect, withoutQueryParams)
+		})
+	}
 }
 
 // TestSearchClusterEvents makes sure web API allows querying events by type.


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/55398 to branch/v17

Changelog: Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack.