### PR TITLE
Release 17.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,19 @@
 ## 17.5.0 (06/03/25)
 
 ### Azure Console via SAML IdP
-Teleport SAML IdP will support Azure web console as a service provider.
+Teleport SAML IdP now supports Azure web console as a service provider.
 
 ### Desktop Access in Teleport Connect
-Teleport Connect will allow users to connect to Windows desktops directly from the Teleport Connect application without needing to use a browser.
+Teleport Connect now allows users to connect to Windows desktops directly from the Teleport Connect application without needing to use a browser.
 
 ### Desktop Access latency detector
-Teleport's web UI will show latency measurements during remote desktop sessions which indicate both the latency between the user and the Teleport proxy as well as the latency between the Teleport proxy and the target host.
+Teleport's web UI now shows latency measurements during remote desktop sessions which indicate both the latency between the user and the Teleport proxy as well as the latency between the Teleport proxy and the target host.
 
 ### Machine & Workload Identity - Sigstore attestation
-Machine & Workload Identity will support attesting Sigstore signatures of workloads running on Docker, Podman and Kubernetes. This will allow the issuance of credentials to be restricted to workloads with container images produced by legitimate CI/CD systems.
+Machine & Workload Identity now supports attesting Sigstore signatures of workloads running on Docker, Podman and Kubernetes. This allows the issuance of credentials to be restricted to workloads with container images produced by legitimate CI/CD systems.
 
 ### Azure DevOps joining
-Teleport will support secretless authentication for Bots running within Azure DevOps pipelines.
+Teleport now supports secretless authentication for Bots running within Azure DevOps pipelines.
 
 ### Other fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 17.5.0 (06/03/25)
+
+### Azure Console via SAML IdP
+Teleport SAML IdP will support Azure web console as a service provider.
+
+### Desktop Access in Teleport Connect
+Teleport Connect will allow users to connect to Windows desktops directly from the Teleport Connect application without needing to use a browser.
+
+### Desktop Access latency detector
+Teleport's web UI will show latency measurements during remote desktop sessions which indicate both the latency between the user and the Teleport proxy as well as the latency between the Teleport proxy and the target host.
+
+### Machine & Workload Identity - Sigstore attestation
+Machine & Workload Identity will support attesting Sigstore signatures of workloads running on Docker, Podman and Kubernetes. This will allow the issuance of credentials to be restricted to workloads with container images produced by legitimate CI/CD systems.
+
+### Azure DevOps joining
+Teleport will support secretless authentication for Bots running within Azure DevOps pipelines.
+
+### Other fixes and improvements
+
+* Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)
+* Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack. [#55399](https://github.com/gravitational/teleport/pull/55399)
+* View details for a bot instance. [#55347](https://github.com/gravitational/teleport/pull/55347)
+* Prevent unknown resource kinds from rendering errors in the web UI. [#55208](https://github.com/gravitational/teleport/pull/55208)
+* View and explore "active" bot instances. [#55201](https://github.com/gravitational/teleport/pull/55201)
+* UI: Access Request reason prompts configured in Role.spec.options.request_prompt are now displayed in the reason text box, if such a role is assigned to the user. [#55173](https://github.com/gravitational/teleport/pull/55173)
+* Okta: Fixed RBAC sync and Access Requests when only App and Group sync is enabled (no Access Lists sync). [#55169](https://github.com/gravitational/teleport/pull/55169)
+* Fixed `tctl` rendering of timestamps in BotInstance resource YAML. [#55163](https://github.com/gravitational/teleport/pull/55163)
+* Fix the impact of malicious `--db-user` values on PKINIT flow. [#55142](https://github.com/gravitational/teleport/pull/55142)
+* Fix an issue with Hardware Key Support on Windows where a command would fail if the PIN prompt was not answered within 5 seconds. [#55110](https://github.com/gravitational/teleport/pull/55110)
+* Fix an issue "Allowed Users" from "tsh db ls" may include irrelevant entities. [#55068](https://github.com/gravitational/teleport/pull/55068)
+* Updated Web UI, tsh and Connect SSO login to support SAML `http-post` binding authentication method. The feature can be enabled from the SSO connector configuration by adding a new field as `preferred_request_binding: http-post`. [#55065](https://github.com/gravitational/teleport/pull/55065)
+* Fix an issue database discovery fails when there are more than 5 OpenSearch domains. [#55058](https://github.com/gravitational/teleport/pull/55058)
+* Fixed an issue with Device Trust web authentication redirection that lost the original encoding of SAML authentication data during service provider initiated SAML login. [#55048](https://github.com/gravitational/teleport/pull/55048)
+* Fix configured X509 CA override chain not being used by AWS Roles Anywhere exchange. [#54947](https://github.com/gravitational/teleport/pull/54947)
+* Disabled the "another session is active" prompt when per-session MFA is enabled, since MFA already enforces user confirmation when starting a desktop session. [#54928](https://github.com/gravitational/teleport/pull/54928)
+* Added support for desktop access in Teleport Connect. [#54926](https://github.com/gravitational/teleport/pull/54926)
+* Added workload_identity_x509_issuer_override kind to editor preset role. [#54913](https://github.com/gravitational/teleport/pull/54913)
+* Hardware Key Agent validates known keys by checking active or expired login session. [#54907](https://github.com/gravitational/teleport/pull/54907)
+* Expose the Teleport service cache health via prometheus metrics. [#54902](https://github.com/gravitational/teleport/pull/54902)
+* Updated Go to 1.23.9. [#54896](https://github.com/gravitational/teleport/pull/54896)
+* Okta: Fix creating Access Requests for Okta-originated resources in the legacy okta_service setup. [#54876](https://github.com/gravitational/teleport/pull/54876)
+* Introduced the azure_devops join method to support Bot joining from the Azure Devops CI/CD platform. [#54875](https://github.com/gravitational/teleport/pull/54875)
+* Add support for exclude filter for AWS IC account and groups filters. [#54835](https://github.com/gravitational/teleport/pull/54835)
+* Terraform: Fixed Access List resource import. [#54802](https://github.com/gravitational/teleport/pull/54802)
+* Fixed Proxy cache initialization errors in clusters with large amounts of open web sessions. [#54781](https://github.com/gravitational/teleport/pull/54781)
+* Prevent restrictive validation of cluster auth preferences from causing non-auth instances to become healthy. [#54761](https://github.com/gravitational/teleport/pull/54761)
+* Improved performance of joining & improved audit log entries for failed joins. [#54747](https://github.com/gravitational/teleport/pull/54747)
+* Resolved an issue that could cause Teleport Connect to crash after downgrading from a newer version. [#54740](https://github.com/gravitational/teleport/pull/54740)
+* Reverted the default behavior of the `teleport-cluster` Helm chart to use `authentication.secondFactor` rather than `authentication.secondFactors` to avoid incompatibility during upgrades. [#54735](https://github.com/gravitational/teleport/pull/54735)
+* Workload ID: Added binary_path and binary_hash to the Unix workload attestor's attributes. [#54716](https://github.com/gravitational/teleport/pull/54716)
+* Includes the attributes used in templating and rule evaluation within the audit log event for a workload identity credential issuance. [#54714](https://github.com/gravitational/teleport/pull/54714)
+* Fix an issue with PIV PIN caching where a PIN that is incorrect would be cached. [#54697](https://github.com/gravitational/teleport/pull/54697)
+* Fix a bug causing a malformed user to break Teleport web UI's "Users" page. [#54681](https://github.com/gravitational/teleport/pull/54681)
+* Machine ID: Allow `--no-oneshot` and similar flags to override config file values. [#54651](https://github.com/gravitational/teleport/pull/54651)
+* Fixed major version check for stateless environment. [#54639](https://github.com/gravitational/teleport/pull/54639)
+* Teleport-update: full support for FIPS agent installations. [#54609](https://github.com/gravitational/teleport/pull/54609)
+* Added support for SSO MFA as a headless MFA method. [#54599](https://github.com/gravitational/teleport/pull/54599)
+* Fixed an issue preventing connections due to missing client IPs when using class E address space with GKE or CloudFlare pseudo IPv4 forward headers. [#54597](https://github.com/gravitational/teleport/pull/54597)
+* Create and edit GitHub join tokens from the Join Tokens page. [#54477](https://github.com/gravitational/teleport/pull/54477)
+
+Enterprise:
+* Verify required Okta OAuth scopes during plugin creation/update.
+* Added ability to re-run group import in Identity Center integration.
+
 ## 17.4.8 (05/06/25)
 
 * Fixed a possible moderator/observer terminal freeze when joining a Kubernetes moderated session. [#54523](https://github.com/gravitational/teleport/pull/54523)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,22 +24,28 @@ These issues are present in previous v17 releases.
 Impacted users are recommended to upgrade their auth and proxy servers to the latest version.
 
 #### [High] Unauthorized deletion in AWS IAM Identity Center integration
-Teleport did not implement sufficient authorization checks for AWS Identity Center integration deletion APIs. This could allow a malicious actor to delete Teleport resources related to the integration leading to denial of service.
+
+* Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)
+
 This vulnerability affects all AWS IAM Identity Center integration users. You can check whether you have AWS Identity Center integration installed either in the Teleport web UI under Zero Trust Access / Integrations or by running “tctl get plugins/aws-identity-center” CLI command.
 
 #### [High] Short to long term access escalation in Okta integration
+
+* Enterprise fix: Verify required Okta OAuth scopes during plugin creation/update.
+
 In Okta integration configurations with enabled access lists sync, a user with an approved  just-in-time access request to an Okta application could be unintentionally promoted to an access list granting access to the same application. This would result in the access to the Okta app/group persisting after the access request expiration.
+
 This vulnerability affects Okta integration users who have access lists sync enabled. You can check whether you have an Okta integration installed with access lists sync enabled either in the Teleport web UI under Zero Trust Access / Integrations page or by running “tctl get plugins/okta” CLI command and looking at the “spec.settings.okta.sync_settings.sync_access_lists” flag.
 
 #### [High] Credential theft via GitHub SSO authentication flow
-In some cases Teleport did not sufficiently validate the GitHub SSO client redirect URL. This could allow an attacker who is able to induce an authenticated user to follow a malicious link to obtain a cert/key pair on behalf of that user.
+
+* Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack. [#55399](https://github.com/gravitational/teleport/pull/55399)
+
 This vulnerability affects GitHub SSO users. You can check whether you’re using GitHub SSO either on the Zero Trust Access / Auth Connectors page in Teleport web UI or by running “tctl get connectors” CLI command against your cluster.
 
 ### Other fixes and improvements
 
 * Allow the `ssh_service.listen_addr` to forcibly be enabled when operating in reverse tunnel mode to provide an optional direct access path to hosts. [#54215](https://github.com/gravitational/teleport/pull/54215)
-* Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)
-* Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack. [#55399](https://github.com/gravitational/teleport/pull/55399)
 * View details for a bot instance. [#55347](https://github.com/gravitational/teleport/pull/55347)
 * Prevent unknown resource kinds from rendering errors in the web UI. [#55208](https://github.com/gravitational/teleport/pull/55208)
 * View and explore "active" bot instances. [#55201](https://github.com/gravitational/teleport/pull/55201)
@@ -80,7 +86,6 @@ This vulnerability affects GitHub SSO users. You can check whether you’re usin
 * Create and edit GitHub join tokens from the Join Tokens page. [#54477](https://github.com/gravitational/teleport/pull/54477)
 
 Enterprise:
-* Verify required Okta OAuth scopes during plugin creation/update.
 * Added ability to re-run group import in Identity Center integration.
 
 ## 17.4.8 (05/06/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This vulnerability affects GitHub SSO users. You can check whether you’re usin
 
 ### Other fixes and improvements
 
+* Allow the `ssh_service.listen_addr` to forcibly be enabled when operating in reverse tunnel mode to provide an optional direct access path to hosts. [#54215](https://github.com/gravitational/teleport/pull/54215)
 * Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)
 * Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack. [#55399](https://github.com/gravitational/teleport/pull/55399)
 * View details for a bot instance. [#55347](https://github.com/gravitational/teleport/pull/55347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Machine & Workload Identity now supports attesting Sigstore signatures of worklo
 ### Azure DevOps joining
 Teleport now supports secretless authentication for Bots running within Azure DevOps pipelines.
 
+### Security fixes
+
+This release also includes fixes for the following security issues. 
+These issues are present in previous v17 releases. 
+Impacted users are recommended to upgrade their auth and proxy servers to the latest version.
+
+#### [High] Unauthorized deletion in AWS IAM Identity Center integration
+Teleport did not implement sufficient authorization checks for AWS Identity Center integration deletion APIs. This could allow a malicious actor to delete Teleport resources related to the integration leading to denial of service.
+This vulnerability affects all AWS IAM Identity Center integration users. You can check whether you have AWS Identity Center integration installed either in the Teleport web UI under Zero Trust Access / Integrations or by running “tctl get plugins/aws-identity-center” CLI command.
+
+#### [High] Short to long term access escalation in Okta integration
+In Okta integration configurations with enabled access lists sync, a user with an approved  just-in-time access request to an Okta application could be unintentionally promoted to an access list granting access to the same application. This would result in the access to the Okta app/group persisting after the access request expiration.
+This vulnerability affects Okta integration users who have access lists sync enabled. You can check whether you have an Okta integration installed with access lists sync enabled either in the Teleport web UI under Zero Trust Access / Integrations page or by running “tctl get plugins/okta” CLI command and looking at the “spec.settings.okta.sync_settings.sync_access_lists” flag.
+
+#### [High] Credential theft via GitHub SSO authentication flow
+In some cases Teleport did not sufficiently validate the GitHub SSO client redirect URL. This could allow an attacker who is able to induce an authenticated user to follow a malicious link to obtain a cert/key pair on behalf of that user.
+This vulnerability affects GitHub SSO users. You can check whether you’re using GitHub SSO either on the Zero Trust Access / Auth Connectors page in Teleport web UI or by running “tctl get connectors” CLI command against your cluster.
+
 ### Other fixes and improvements
 
 * Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=17.4.8
+VERSION=17.5.0
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "17.4.8"
+const Version = "17.5.0"
 
 const VersionMajor = 17
-const VersionMinor = 4
-const VersionPatch = 8
+const VersionMinor = 5
+const VersionPatch = 0
 const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.4.8</string>
+		<string>17.5.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.4.8</string>
+		<string>17.5.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.4.8</string>
+		<string>17.5.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.4.8</string>
+		<string>17.5.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-datadog-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-datadog-17.5.0
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-datadog-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-datadog-17.5.0
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-datadog-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-datadog-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-discord-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-discord-17.5.0
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-discord-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-discord-17.5.0
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-discord-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-discord-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-email-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-email-17.5.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-email-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-email-17.5.0
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-jira-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-jira-17.5.0
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-jira-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-jira-17.5.0
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-jira-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-jira-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-mattermost-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-mattermost-17.5.0
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-mattermost-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-mattermost-17.5.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-mattermost-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-mattermost-17.5.0
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-mattermost-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-mattermost-17.5.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-mattermost-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-mattermost-17.5.0
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-mattermost-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-mattermost-17.5.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-mattermost-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-mattermost-17.5.0
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.4.8
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.5.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-msteams-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-msteams-17.5.0
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-msteams-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-msteams-17.5.0
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-msteams-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-msteams-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-pagerduty-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-pagerduty-17.5.0
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-pagerduty-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-pagerduty-17.5.0
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-pagerduty-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-pagerduty-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-slack-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-slack-17.5.0
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-slack-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-slack-17.5.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-plugin-slack-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-plugin-slack-17.5.0
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-event-handler-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-event-handler-17.5.0
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-plugin-event-handler-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-plugin-event-handler-17.5.0
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.4.8
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.5.0
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.4.8
+            helm.sh/chart: tbot-17.5.0
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:17.4.8
+            image: public.ecr.aws/gravitational/tbot-distroless:17.5.0
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -164,7 +164,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.4.8
+            helm.sh/chart: tbot-17.5.0
         spec:
           containers:
           - args:
@@ -186,7 +186,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:17.4.8
+            image: public.ecr.aws/gravitational/tbot-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-cluster-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-cluster-17.5.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1955,8 +1955,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-cluster-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-cluster-17.5.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -274,7 +274,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -378,7 +378,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-cluster-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-cluster-17.5.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.4.8
-        helm.sh/chart: teleport-cluster-17.4.8
+        app.kubernetes.io/version: 17.5.0
+        helm.sh/chart: teleport-cluster-17.5.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 21ffed6e057797c197381b69db7331d34f1ca9667778de64e90c338c7c53cd48
+            checksum/config: 62e942ba594a80ccd9842241b75799688b2623ed7324643f3b5dc6a5aae3ec63
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 17.4.8
-            helm.sh/chart: teleport-cluster-17.4.8
+            app.kubernetes.io/version: 17.5.0
+            helm.sh/chart: teleport-cluster-17.5.0
             teleport.dev/majorVersion: "17"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v16.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -349,7 +349,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -418,7 +418,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
       resources:
         limits:
@@ -475,7 +475,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -544,7 +544,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
       resources:
         limits:
@@ -601,7 +601,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -670,7 +670,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -727,7 +727,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -796,7 +796,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.4.8"
+.version: &version "17.5.0"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+          image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -91,7 +91,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -188,7 +188,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -293,7 +293,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -366,7 +366,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -459,7 +459,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -542,7 +542,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -615,7 +615,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -688,7 +688,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -775,7 +775,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -860,7 +860,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -933,7 +933,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1006,7 +1006,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1081,7 +1081,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1159,7 +1159,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1240,7 +1240,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1323,7 +1323,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1408,7 +1408,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1489,7 +1489,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1562,7 +1562,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1693,7 +1693,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1852,7 +1852,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2071,7 +2071,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2158,7 +2158,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2231,7 +2231,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2314,7 +2314,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2387,7 +2387,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2467,7 +2467,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2540,7 +2540,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2613,7 +2613,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2686,7 +2686,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.4.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.4.8
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.4.8
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.5.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
## 17.5.0 (06/03/25)

### Azure Console via SAML IdP
Teleport SAML IdP now supports Azure web console as a service provider.

### Desktop Access in Teleport Connect
Teleport Connect now allows users to connect to Windows desktops directly from the Teleport Connect application without needing to use a browser.

### Desktop Access latency detector
Teleport's web UI now shows latency measurements during remote desktop sessions which indicate both the latency between the user and the Teleport proxy as well as the latency between the Teleport proxy and the target host.

### Machine & Workload Identity - Sigstore attestation
Machine & Workload Identity now supports attesting Sigstore signatures of workloads running on Docker, Podman and Kubernetes. This allows the issuance of credentials to be restricted to workloads with container images produced by legitimate CI/CD systems.

### Azure DevOps joining
Teleport now supports secretless authentication for Bots running within Azure DevOps pipelines.

### Security fixes

This release also includes fixes for the following security issues. 
These issues are present in previous v17 releases. 
Impacted users are recommended to upgrade their auth and proxy servers to the latest version.

#### [High] Unauthorized deletion in AWS IAM Identity Center integration

* Fixed an issue that allowed unauthenticated access to delete resources created by Identity Center integration. [#55400](https://github.com/gravitational/teleport/pull/55400)

This vulnerability affects all AWS IAM Identity Center integration users. You can check whether you have AWS Identity Center integration installed either in the Teleport web UI under Zero Trust Access / Integrations or by running “tctl get plugins/aws-identity-center” CLI command.

#### [High] Short to long term access escalation in Okta integration

* Enterprise fix: Verify required Okta OAuth scopes during plugin creation/update.

In Okta integration configurations with enabled access lists sync, a user with an approved  just-in-time access request to an Okta application could be unintentionally promoted to an access list granting access to the same application. This would result in the access to the Okta app/group persisting after the access request expiration.

This vulnerability affects Okta integration users who have access lists sync enabled. You can check whether you have an Okta integration installed with access lists sync enabled either in the Teleport web UI under Zero Trust Access / Integrations page or by running “tctl get plugins/okta” CLI command and looking at the “spec.settings.okta.sync_settings.sync_access_lists” flag.

#### [High] Credential theft via GitHub SSO authentication flow

* Fix improper redirect URL validation for SSO login which could be taken advantage of in a phishing attack. [#55399](https://github.com/gravitational/teleport/pull/55399)

This vulnerability affects GitHub SSO users. You can check whether you’re using GitHub SSO either on the Zero Trust Access / Auth Connectors page in Teleport web UI or by running “tctl get connectors” CLI command against your cluster.

### Other fixes and improvements

* Allow the `ssh_service.listen_addr` to forcibly be enabled when operating in reverse tunnel mode to provide an optional direct access path to hosts. [#54215](https://github.com/gravitational/teleport/pull/54215)
* View details for a bot instance. [#55347](https://github.com/gravitational/teleport/pull/55347)
* Prevent unknown resource kinds from rendering errors in the web UI. [#55208](https://github.com/gravitational/teleport/pull/55208)
* View and explore "active" bot instances. [#55201](https://github.com/gravitational/teleport/pull/55201)
* UI: Access Request reason prompts configured in Role.spec.options.request_prompt are now displayed in the reason text box, if such a role is assigned to the user. [#55173](https://github.com/gravitational/teleport/pull/55173)
* Okta: Fixed RBAC sync and Access Requests when only App and Group sync is enabled (no Access Lists sync). [#55169](https://github.com/gravitational/teleport/pull/55169)
* Fixed `tctl` rendering of timestamps in BotInstance resource YAML. [#55163](https://github.com/gravitational/teleport/pull/55163)
* Fix the impact of malicious `--db-user` values on PKINIT flow. [#55142](https://github.com/gravitational/teleport/pull/55142)
* Fix an issue with Hardware Key Support on Windows where a command would fail if the PIN prompt was not answered within 5 seconds. [#55110](https://github.com/gravitational/teleport/pull/55110)
* Fix an issue "Allowed Users" from "tsh db ls" may include irrelevant entities. [#55068](https://github.com/gravitational/teleport/pull/55068)
* Updated Web UI, tsh and Connect SSO login to support SAML `http-post` binding authentication method. The feature can be enabled from the SSO connector configuration by adding a new field as `preferred_request_binding: http-post`. [#55065](https://github.com/gravitational/teleport/pull/55065)
* Fix an issue database discovery fails when there are more than 5 OpenSearch domains. [#55058](https://github.com/gravitational/teleport/pull/55058)
* Fixed an issue with Device Trust web authentication redirection that lost the original encoding of SAML authentication data during service provider initiated SAML login. [#55048](https://github.com/gravitational/teleport/pull/55048)
* Fix configured X509 CA override chain not being used by AWS Roles Anywhere exchange. [#54947](https://github.com/gravitational/teleport/pull/54947)
* Disabled the "another session is active" prompt when per-session MFA is enabled, since MFA already enforces user confirmation when starting a desktop session. [#54928](https://github.com/gravitational/teleport/pull/54928)
* Added support for desktop access in Teleport Connect. [#54926](https://github.com/gravitational/teleport/pull/54926)
* Added workload_identity_x509_issuer_override kind to editor preset role. [#54913](https://github.com/gravitational/teleport/pull/54913)
* Hardware Key Agent validates known keys by checking active or expired login session. [#54907](https://github.com/gravitational/teleport/pull/54907)
* Expose the Teleport service cache health via prometheus metrics. [#54902](https://github.com/gravitational/teleport/pull/54902)
* Updated Go to 1.23.9. [#54896](https://github.com/gravitational/teleport/pull/54896)
* Okta: Fix creating Access Requests for Okta-originated resources in the legacy okta_service setup. [#54876](https://github.com/gravitational/teleport/pull/54876)
* Introduced the azure_devops join method to support Bot joining from the Azure Devops CI/CD platform. [#54875](https://github.com/gravitational/teleport/pull/54875)
* Add support for exclude filter for AWS IC account and groups filters. [#54835](https://github.com/gravitational/teleport/pull/54835)
* Terraform: Fixed Access List resource import. [#54802](https://github.com/gravitational/teleport/pull/54802)
* Fixed Proxy cache initialization errors in clusters with large amounts of open web sessions. [#54781](https://github.com/gravitational/teleport/pull/54781)
* Prevent restrictive validation of cluster auth preferences from causing non-auth instances to become healthy. [#54761](https://github.com/gravitational/teleport/pull/54761)
* Improved performance of joining & improved audit log entries for failed joins. [#54747](https://github.com/gravitational/teleport/pull/54747)
* Resolved an issue that could cause Teleport Connect to crash after downgrading from a newer version. [#54740](https://github.com/gravitational/teleport/pull/54740)
* Reverted the default behavior of the `teleport-cluster` Helm chart to use `authentication.secondFactor` rather than `authentication.secondFactors` to avoid incompatibility during upgrades. [#54735](https://github.com/gravitational/teleport/pull/54735)
* Workload ID: Added binary_path and binary_hash to the Unix workload attestor's attributes. [#54716](https://github.com/gravitational/teleport/pull/54716)
* Includes the attributes used in templating and rule evaluation within the audit log event for a workload identity credential issuance. [#54714](https://github.com/gravitational/teleport/pull/54714)
* Fix an issue with PIV PIN caching where a PIN that is incorrect would be cached. [#54697](https://github.com/gravitational/teleport/pull/54697)
* Fix a bug causing a malformed user to break Teleport web UI's "Users" page. [#54681](https://github.com/gravitational/teleport/pull/54681)
* Machine ID: Allow `--no-oneshot` and similar flags to override config file values. [#54651](https://github.com/gravitational/teleport/pull/54651)
* Fixed major version check for stateless environment. [#54639](https://github.com/gravitational/teleport/pull/54639)
* Teleport-update: full support for FIPS agent installations. [#54609](https://github.com/gravitational/teleport/pull/54609)
* Added support for SSO MFA as a headless MFA method. [#54599](https://github.com/gravitational/teleport/pull/54599)
* Fixed an issue preventing connections due to missing client IPs when using class E address space with GKE or CloudFlare pseudo IPv4 forward headers. [#54597](https://github.com/gravitational/teleport/pull/54597)
* Create and edit GitHub join tokens from the Join Tokens page. [#54477](https://github.com/gravitational/teleport/pull/54477)

Enterprise:
* Added ability to re-run group import in Identity Center integration.
