### PR TITLE
exporter: Remove clockwork Clock

### DIFF
--- a/lib/events/export/date_exporter.go
+++ b/lib/events/export/date_exporter.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -69,8 +68,6 @@ type DateExporterConfig struct {
 	MaxBackoff time.Duration
 	// PollInterval optionally overrides the default poll interval used to fetch event chunks.
 	PollInterval time.Duration
-	// Clock is an optional parameter used to provide a clock for testing purposes.
-	Clock clockwork.Clock
 }
 
 // CheckAndSetDefaults validates configuration and sets default values for optional parameters.
@@ -97,7 +94,6 @@ func (cfg *DateExporterConfig) CheckAndSetDefaults() error {
 		cfg.BatchExport.MaxDelay = cmp.Or(cfg.BatchExport.MaxDelay, 5*time.Second)
 		cfg.BatchExport.MaxSize = cmp.Or(cfg.BatchExport.MaxSize, 2*1024*1024 /* 2MiB */)
 	}
-	cfg.Clock = cmp.Or(cfg.Clock, clockwork.NewRealClock())
 	return nil
 }
 
@@ -529,7 +525,7 @@ func (e *DateExporter) batchExportEvents(ctx context.Context, stream stream.Stre
 		chunk:   chunk,
 		entry:   entry,
 	}
-	timer := e.cfg.Clock.NewTimer(e.cfg.BatchExport.MaxDelay)
+	timer := time.NewTimer(e.cfg.BatchExport.MaxDelay)
 	defer timer.Stop()
 loop:
 	for {
@@ -544,7 +540,7 @@ loop:
 				continue
 			}
 			unprocessedEvent = exportEvent
-		case <-timer.Chan():
+		case <-timer.C:
 			if batch.isEmpty() {
 				timer.Reset(e.cfg.BatchExport.MaxDelay)
 				continue

--- a/lib/events/export/exporter.go
+++ b/lib/events/export/exporter.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/time/rate"
 
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
@@ -128,8 +127,6 @@ type ExporterConfig struct {
 	MaxBackoff time.Duration
 	// PollInterval optionally overrides the default poll interval used to fetch event chunks.
 	PollInterval time.Duration
-	// Clock is an optional parameter used to provide a clock for testing purposes.
-	Clock clockwork.Clock
 }
 
 // CheckAndSetDefaults validates configuration and sets default values for optional parameters.
@@ -156,7 +153,6 @@ func (cfg *ExporterConfig) CheckAndSetDefaults() error {
 		cfg.BatchExport.MaxDelay = cmp.Or(cfg.BatchExport.MaxDelay, 5*time.Second)
 		cfg.BatchExport.MaxSize = cmp.Or(cfg.BatchExport.MaxSize, 2*1024*1024 /* 2MiB */)
 	}
-	cfg.Clock = cmp.Or(cfg.Clock, clockwork.NewRealClock())
 	return nil
 }
 
@@ -335,7 +331,7 @@ func (e *Exporter) poll(ctx context.Context) (bool, error) {
 
 	var caughtUp bool
 	if e.current.IsIdle() {
-		if normalizeDate(e.cfg.Clock.Now()).After(e.currentDate) {
+		if normalizeDate(time.Now()).After(e.currentDate) {
 			nextDate := e.currentDate.AddDate(0, 0, 1)
 			// current date is idle and in the past, advance to the next date
 			if err := e.startExportLocked(ctx, nextDate); err != nil {
@@ -459,7 +455,6 @@ func (e *Exporter) resumeExportLocked(ctx context.Context, date time.Time, state
 		Concurrency:   e.cfg.Concurrency,
 		MaxBackoff:    e.cfg.MaxBackoff,
 		PollInterval:  e.cfg.PollInterval,
-		Clock:         e.cfg.Clock,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Remove clockwork Clock which was intended to be used in teleport-enterprise tests, but it turnsout Go's new testing/synctest package is sufficient for our needs here.

companion-pr: https://github.com/gravitational/teleport.e/pull/6585