### PR TITLE
Connect Win installer: Update system rather than user path

### DIFF
--- a/web/packages/teleterm/build_resources/installer.nsh
+++ b/web/packages/teleterm/build_resources/installer.nsh
@@ -10,8 +10,8 @@
 # https://nsis.sourceforge.io/EnVar_plug-in
 
 !macro customInstall
-    # Make EnVar define user env vars instead of system env vars.
-    EnVar::SetHKCU
+    # Make EnVar define system env vars since Connect is installed per-machine.
+    EnVar::SetHKLM
     EnVar::AddValue "Path" $INSTDIR\resources\bin
 
     nsExec::ExecToStack '"$INSTDIR\resources\bin\tsh.exe" vnet-install-service'
@@ -25,7 +25,7 @@
 !macroend
 
 !macro customUnInstall
-    EnVar::SetHKCU
+    EnVar::SetHKLM
     # Inside the uninstaller, $INSTDIR is the directory where the uninstaller lies.
     # Fortunately, electron-builder puts the uninstaller directly into the actual installation dir.
     # https://nsis.sourceforge.io/Docs/Chapter4.html#varother


### PR DESCRIPTION
Closes #55355.

v17.3 made it so that Connect is installed per-machine, but the installer continued to add tsh to the user path rather than the system path.

I have verified that we don't have to worry about any extra migration steps. When installing a new version, the installer first runs the uninstaller of the previous version. So first it's going to remove the tsh dir from the user path and then it's going to add the tsh dir to the system path.

Interestingly, on Windows [user env vars takes precedence over system env vars](https://superuser.com/a/878382/395400) with the exception of path, where the user path is appended to the system path.

changelog: The Windows installer of Teleport Connect now adds the folder with tsh to the system path rather than the user path