### PR TITLE
Add Identity Security IAC enabled to storage service

### DIFF
--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -261,6 +261,10 @@ export const storageService = {
     return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_ENABLED, false);
   },
 
+  getAccessGraphIacEnabled(): boolean {
+    return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_IAC_ENABLED, false);
+  },
+
   getAccessGraphSQLEnabled(): boolean {
     return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_SQL_ENABLED, false);
   },

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -29,6 +29,7 @@ export const KeysEnum = {
   ACCESS_GRAPH_SEARCH_MODE: 'grv_teleport_access_graph_search_mode',
   ACCESS_GRAPH_QUERY: 'grv_teleport_access_graph_query',
   ACCESS_GRAPH_ENABLED: 'grv_teleport_access_graph_enabled',
+  ACCESS_GRAPH_IAC_ENABLED: 'grv_teleport_access_graph_iac_enabled',
   ACCESS_GRAPH_SQL_ENABLED: 'grv_teleport_access_graph_sql_enabled',
   ACCESS_GRAPH_ROLE_TESTER_ENABLED:
     'grv_teleport_access_graph_role_tester_enabled',


### PR DESCRIPTION
We load the access graph features on load and set the values into local storage. This adds `grv_teleport_access_graph_iac_enabled` to the storage service for retrieval, which will be the state of Identity Security Identity Activity Center being setup.