### PR TITLE
Add parmeters to empty oidc tasks story

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -46,6 +46,21 @@ export function TasksEmpty() {
     </MockAwsOidcStatusProvider>
   );
 }
+TasksEmpty.parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        cfg.getIntegrationUserTasksListUrl(integrationName, TaskState.Open),
+        () => {
+          return HttpResponse.json({
+            items: [],
+            nextKey: '1',
+          });
+        }
+      ),
+    ],
+  },
+};
 
 // Populated tasks table
 export function TaskView() {
@@ -61,7 +76,6 @@ export function TaskView() {
     </MockAwsOidcStatusProvider>
   );
 }
-
 TaskView.parameters = {
   msw: {
     handlers: [


### PR DESCRIPTION
The `Empty Tasks` story was returning a 404 without a mocked response

before
<img width="1284" alt="Screenshot 2025-06-04 at 8 58 13 AM" src="https://github.com/user-attachments/assets/baab2daf-af3b-4fd5-90d2-54a43ea23ce8" />


after
<img width="1280" alt="Screenshot 2025-06-04 at 8 57 40 AM" src="https://github.com/user-attachments/assets/fcddf417-1c17-425e-8073-db8f5769311a" />
