### PR TITLE
Organize the sidebar to aid practitioner focus

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -25,11 +25,6 @@
           "id": "installation"
         },
         {
-          "type": "doc",
-          "label": "Teleport Feature Matrix",
-          "id": "feature-matrix"
-        },
-        {
           "type": "category",
           "label": "Upgrading",
           "collapsible": true,
@@ -64,6 +59,18 @@
             "type": "doc",
             "id": "upgrading/upgrading"
           }
+        }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Quick Links",
+      "collapsible": true,
+      "items": [
+        {
+          "type": "doc",
+          "label": "Teleport Feature Matrix",
+          "id": "feature-matrix"
         },
         {
           "type": "doc",


### PR DESCRIPTION
Closes #55403

The Introduction section of the docs navigation sidebar includes two kinds of content:
- Foundational information that is critical to get starting with Teleport, including a Get Started guide, outline of core concepts, and installation and upgrading information.
- Information that is good to keep handy and prominent but not critical to getting started with Teleport.

Since the latter kind of content can distract first-time users and make it difficult to use the sidebar, this change proposes that we move it to its own sidebar section, "Quick Links". This change does not edit the structure of the `docs/pages` content directory.