### PR TITLE
Fix six Vale warnings

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -7,18 +7,20 @@ This guide explains how to set up the Teleport Access Request plugin for Jira.
 Teleport's Jira integration allows you to manage Access Requests as
 Jira issues.
 
-The Teleport Jira plugin synchronizes a Jira project board with the Access
-Requests processed by your Teleport cluster. When you change the status of an
-Access Request within Teleport, the plugin updates the board. And when you
-update the status of an Access Request on the board, the plugin notifies a Jira
-webhook run by the plugin, which modifies the Access Request in Teleport.
-
 <details>
 <summary>This integration is hosted on Teleport Cloud</summary>
 
 (!docs/pages/includes/plugins/enroll.mdx name="the Mattermost integration"!)
 
 </details>
+
+## How it works
+
+The Teleport Jira plugin synchronizes a Jira project board with the Access
+Requests processed by your Teleport cluster. When you change the status of an
+Access Request within Teleport, the plugin updates the board. And when you
+update the status of an Access Request on the board, the plugin notifies a Jira
+webhook run by the plugin, which modifies the Access Request in Teleport.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -6,12 +6,7 @@ description: How to set up Teleport's Mattermost plugin for privilege elevation 
 import BotLogo from "/static/avatar_logo.png";
 
 This guide explains how to integrate Access Requests with Mattermost, an open 
-source messaging platform. The Teleport Mattermost plugin notifies individuals of
-Access Requests. Users can then approve and deny Access Requests by following the
-message link, making it easier to implement security best practices without
-compromising productivity.
-
-![The Mattermost Access Request plugin](../../../../img/enterprise/plugins/mattermost/diagram.png)
+source messaging platform. 
 
 <details>
 <summary>This integration is hosted on Teleport Cloud</summary>
@@ -19,6 +14,15 @@ compromising productivity.
 (!docs/pages/includes/plugins/enroll.mdx name="the Mattermost integration"!)
 
 </details>
+
+## How it works
+
+The Teleport Mattermost plugin notifies individuals of Access Requests. Users
+can then approve and deny Access Requests by following the message link, making
+it easier to implement security best practices without compromising
+productivity.
+
+![The Mattermost Access Request plugin](../../../../img/enterprise/plugins/mattermost/diagram.png)
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -4,12 +4,7 @@ description: How to set up Teleport's Microsoft Teams plugin for privilege eleva
 ---
 
 This guide will explain how to set up Microsoft Teams to receive Access Request messages
-from Teleport. Teleport's Microsoft Teams integration notifies individuals of
-Access Requests. Users can then approve and deny Access Requests by following the
-message link, making it easier to implement security best practices without
-compromising productivity.
-
-![The Microsoft Teams Access Request plugin](../../../../img/enterprise/plugins/msteams.png)
+from Teleport. 
 
 <details>
 <summary>This integration is hosted on Teleport Enterprise (Cloud)</summary>
@@ -23,6 +18,15 @@ Once enrolled you can download the required `app.zip` file from the integrations
 ![Download app.zip](../../../../img/enterprise/plugins/msteams/app-zip.png)
 
 </details>
+
+## How it works
+
+Teleport's Microsoft Teams integration notifies individuals of Access Requests.
+Users can then approve and deny Access Requests by following the message link,
+making it easier to implement security best practices without compromising
+productivity.
+
+![The Microsoft Teams Access Request plugin](../../../../img/enterprise/plugins/msteams.png)
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -5,7 +5,10 @@ description: How to set up Teleport's PagerDuty plugin for privilege elevation a
 
 With Teleport's PagerDuty integration, engineers can access the infrastructure
 they need to resolve incidents quickly—without longstanding admin permissions
-that can become a vector for attacks.
+that can become a vector for attacks. This guide explains how to set up
+Teleport's Access Request plugin for PagerDuty.
+
+## How it works
 
 Teleport's PagerDuty integration allows you to treat Teleport Role Access
 Requests as PagerDuty incidents, notify the appropriate on-call team, and
@@ -19,9 +22,6 @@ the on-call team for a service affected by an incident.
 (!docs/pages/includes/plugins/enroll.mdx name="the PagerDuty integration"!)
 
 </details>
-
-This guide will explain how to set up Teleport's Access Request plugin for
-PagerDuty.
 
 ![PagerDuty plugin architecture](../../../../img/enterprise/plugins/pagerduty/diagram.png)
 

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -4,10 +4,7 @@ description: How to set up Teleport's Slack plugin for privilege elevation appro
 ---
 
 This guide will explain how to set up Slack to receive Access Request messages
-from Teleport. Teleport's Slack integration notifies individuals and channels of
-Access Requests. Users are then directed to log in to the Teleport cluster where
-they can approve and deny Access Requests, making it easier to implement security 
-best practices without compromising productivity.
+from Teleport. 
 
 <details>
 <summary>This integration is hosted on Teleport Cloud</summary>
@@ -15,6 +12,13 @@ best practices without compromising productivity.
 (!docs/pages/includes/plugins/enroll.mdx name="the Slack integration"!)
 
 </details>
+
+## How it works
+
+Teleport's Slack integration notifies individuals and channels of
+Access Requests. Users are then directed to log in to the Teleport cluster where
+they can approve and deny Access Requests, making it easier to implement security 
+best practices without compromising productivity.
 
 ![The Slack Access Request plugin](../../../../img/enterprise/plugins/slack/diagram.png)
 

--- a/docs/pages/enroll-resources/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/azure-devops.mdx
@@ -78,7 +78,8 @@ matches all the fields within a single rule is granted access.
 In this example, you will create a token with a rule that grants access to any
 Azure DevOps pipeline within a specific project.
 
-Create a file named `bot-token.yaml`:
+Create a file named `bot-token.yaml`, assigning <Var name="my-project" /> to the
+name of your Azure DevOps project:
 
 ```yaml
 kind: token


### PR DESCRIPTION
- Add five required "How it works" H2s to how-to guides in the Access Request plugins section that nevertheless included brief architectural overviews.
- Fix a Var with only one instance on a page.