### PR TITLE
ci: Update master to use :teleport19 buildboxes, part 2

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -36,7 +36,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport18
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -39,7 +39,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport18
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
       env:
         # TODO(hugoShaka) remove the '-new' prefix when updating to teleport13 buildbox
         HELM_PLUGINS: /home/ci/.local/share/helm/plugins-new

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -48,7 +48,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport18
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -41,7 +41,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport18
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Test UI
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport18
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
       # See https://github.com/gravitational/teleport/blob/2aaa3ec9a129213db8a18083d5b4681f86328d34/web/packages/teleterm/src/agentCleanupDaemon/agentCleanupDaemon.test.ts#L82-L89
       # for the original impetus for adding --init.
       options: --init


### PR DESCRIPTION
Update the rest of the CI jobs that use buildboxes to use the `:teleport19`
versions now that we have bumped the master version to v19.0.0-dev.

Others were done in a previous PR due to GitHub issues with "too many
files on the PR"?!?! (only 17).

---

This is part 2 of https://github.com/gravitational/teleport/pull/55432
