### PR TITLE
Connect login form: Refocus password field on submission error

### DIFF
--- a/web/packages/shared/hooks/useRefAutoFocus/useRefAutoFocus.ts
+++ b/web/packages/shared/hooks/useRefAutoFocus/useRefAutoFocus.ts
@@ -24,6 +24,10 @@ import { DependencyList, MutableRefObject, useEffect, useRef } from 'react';
  */
 export function useRefAutoFocus<T extends { focus(): void }>(options: {
   shouldFocus: boolean;
+  /**
+   * @deprecated Include items from refocusDeps into the calculation of shouldFocus instead.
+   * The list of useEffect deps should be statically known.
+   */
   refocusDeps?: DependencyList;
 }): MutableRefObject<T> {
   const ref = useRef<T>(undefined);

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from 'design/utils/testing';
+
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+
+import { ClusterLogin } from './ClusterLogin';
+
+it('keeps the focus on the password field on submission error', async () => {
+  const user = userEvent.setup();
+  const cluster = makeRootCluster();
+  const appContext = new MockAppContext();
+  appContext.addRootCluster(cluster);
+
+  jest
+    .spyOn(appContext.tshd, 'login')
+    .mockResolvedValue(
+      new MockedUnaryCall(undefined, new Error('whoops something went wrong'))
+    );
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <ClusterLogin
+        clusterUri={cluster.uri}
+        onCancel={() => {}}
+        prefill={{ username: 'alice' }}
+        reason={undefined}
+      />
+    </MockAppContextProvider>
+  );
+
+  const passwordField = await screen.findByLabelText('Password');
+  expect(passwordField).toHaveFocus();
+
+  await user.type(passwordField, 'foo');
+  await user.click(screen.getByText('Sign In'));
+
+  await screen.findByText('whoops something went wrong');
+  expect(passwordField).toHaveFocus();
+});

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
@@ -38,11 +38,18 @@ export const FormLocal = ({
   const [pass, setPass] = useState('');
   const [user, setUser] = useState(loggedInUserName || '');
 
+  // loginAttempt.status needs to be checked here so that auto focus is automatically managed when
+  // the form reverts from a processing state to an error state.
+  const isAutoFocusAllowed =
+    autoFocus && hasTransitionEnded && loginAttempt.status !== 'processing';
+  // useRefAutoFocus is used instead of just plain autoFocus because of some weird focus issues
+  // stemming from, most probably, using <StepSlider> within a modal. autoFocus generally works
+  // within modals. We've never documented why we use this hook so that knowledge is lost in time.
   const usernameInputRef = useRefAutoFocus<HTMLInputElement>({
-    shouldFocus: hasTransitionEnded && autoFocus && !loggedInUserName,
+    shouldFocus: isAutoFocusAllowed && !loggedInUserName,
   });
   const passwordInputRef = useRefAutoFocus<HTMLInputElement>({
-    shouldFocus: hasTransitionEnded && autoFocus && !!loggedInUserName,
+    shouldFocus: isAutoFocusAllowed && !!loggedInUserName,
   });
 
   function onLoginClick(


### PR DESCRIPTION
Closes #54508.

To understand the fix, one first must understand how it worked before. I assumed that some normal browser behavior caused it to work, but that's not the case.

Prior to #47883, upon submission the form would immediately switch to the next "step", before a response from the login attempt even arrived. When the response arrived with an error, the form would go back to the previous step, thus re-firing all effects, including the one that would focus the password field.

https://github.com/gravitational/teleport/blob/33f2bbf360f7ee905ca9aee50082c0257244cc62/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx#L44-L46

<details>
https://github.com/user-attachments/assets/d834a228-65d3-4fbb-9cb8-fdf636e1b41e
</details>

After the cleanup from #47883, the form doesn't go into the next step immediately on submission. Instead it disables the fields and shows a progress bar. When an error response arrives, it enables the fields, but the focus is no longer on the form itself. The focus effects do not fire because their deps haven't changed.

<details>
https://github.com/user-attachments/assets/114d00f1-51b9-4a7a-babf-dfd3fc3993c4
</details>

The fix is to include the state of the form submission in the value that decides whether a particular field should be focused or not.

<details>
https://github.com/user-attachments/assets/df1c89fd-d793-4f34-81a9-4570f9f30dd3
</details>

I'm still not sure if regular forms lose focus on submission as well, or if the need to trigger those focus effects comes from the same place that the need to use `useRefAutoFocus` instead of `autoFocus`.
