### PR TITLE
Make `<b>` and `<strong>` bolder in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
@@ -18,7 +18,7 @@
 
 import { createGlobalStyle, css } from 'styled-components';
 
-import { getPlatformType } from 'design/platform';
+import { getPlatform, Platform } from 'design/platform';
 
 const GlobalStyle = createGlobalStyle`
 
@@ -61,7 +61,7 @@ const GlobalStyle = createGlobalStyle`
     font-weight: ${props => props.theme.fontWeights.bold};
   }
 
-  ${() => !getPlatformType().isMac && customScrollbar}
+  ${() => getPlatform() !== Platform.macOS && customScrollbar}
 `;
 
 const customScrollbar = css`

--- a/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/globals.ts
@@ -51,6 +51,16 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  b, strong {
+    // Overrides the default font-weight: bolder which results in the bold font not being bold
+    // enough. That's because if the regular font-weight is set to 300, "bolder" means it'll go to
+    // just 400.
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#meaning_of_relative_weights
+    //
+    // The Web UI uses <Text bold> to render bold text, whereas Connect mostly uses <strong>.
+    font-weight: ${props => props.theme.fontWeights.bold};
+  }
+
   ${() => !getPlatformType().isMac && customScrollbar}
 `;
 


### PR DESCRIPTION
Closes #55280.

| Before | After |
| --- | --- |
| <img width="504" alt="before" src="https://github.com/user-attachments/assets/539b4c96-cb77-4f0e-a2c1-16aebe46b977" /> | <img width="504" alt="after" src="https://github.com/user-attachments/assets/c215f2b3-e13d-4a00-85b9-11d645ea8458" /> |
| <img width="1287" alt="before-search" src="https://github.com/user-attachments/assets/919e75f9-d1ce-4a33-99d9-3c37eb22ee67" /> | <img width="1287" alt="after-search" src="https://github.com/user-attachments/assets/32c24c56-d74d-48fc-a4a6-b852c29d14ab" /> |

#44502 has changed the typography. One of the changes was the reduction of the default font weight from 400 to 300. In the PR, there's a discussion about how it affects Connect since, unlike the Web UI, it doesn't use the Ubuntu font on every platform. Changing that could be a good direction, but I don't think we have enough time to test such a sweeping change. I'll create a separate issue so that we can tackle that before v19.

Under #44502, Grzegorz suggested changing the default weight in Connect. There's always some tension between making the product look uniform across different platforms and making the product align with how apps look like on a given platform. I think with something as foundational as the font we should try to keep it uniform, otherwise we risk introducing inconsistencies in the shared code (unified resources, access requests, possibly more in the future).

Instead of addressing either the default font weight or changing the default font, I decided to fix the font-weight for `<b>` and `<strong>`.

## Font weight for `<b>` and `<strong>`

The reason that bold fonts were not bold enough in Connect after #44502 is that the useragent style for those tags in Chromium is `font-weight: bolder`. It's different from `bold`:

> One relative font weight heavier than the parent element. Note that only four font weights are considered for relative weight calculation; see the [Meaning of relative weights](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#meaning_of_relative_weights) section below.

If you look at the linked table, you can see that it means that if parent has font weight set to 300, the child becomes 400.

This probably wasn't a big problem in Web UI as I assume most callsites use `<Text bold>` to render bold text which sets the weight to `theme.fontWeight.bold` which is currently 600. Connect mostly uses `<strong>` or `<b>`.

Using an absolute font-weight for `<strong>` rather than a relative one is not great in some cases. As you can see in the login modal, "postgres" and "alice" can be easily distinguished from other text. However, "localhost" in the title is now closer to the rest of the title. This would warrant adding manual overrides for h1s and other stuff and I just didn't want to deal with that since 1) it doesn't look that bad 2) we might migrate to Ubuntu at some point.

The text in Connect hasn't been bold enough since v17.0.0 at least. I'm not sure why I haven't caught it earlier, probably because I maybe just wasn't using parts of the app where we use bold text.