### PR TITLE
Connect: minor style improvements

### DIFF
--- a/web/packages/teleterm/src/ui/App.test.tsx
+++ b/web/packages/teleterm/src/ui/App.test.tsx
@@ -208,7 +208,7 @@ test.each<{
 
   expect(
     await screen.findByText(
-      'Do you want to reopen tabs from the previous session?'
+      /Do you want to reopen tabs from the previous session/
     )
   ).toBeInTheDocument();
 

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -82,7 +82,7 @@ export function ClusterLogout({
           </ButtonIcon>
         </DialogHeader>
         <DialogContent mb={4}>
-          <P color="text.slightlyMuted">Are you sure you want to log out?</P>
+          <P>Are you sure you want to log out?</P>
           {status === 'error' && (
             <Alerts.Danger mb={5} details={statusText}>
               Could not log out

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -65,13 +65,11 @@ export function ClusterLogout({
       <form
         onSubmit={e => {
           e.preventDefault();
-          removeClusterAndClose();
+          void removeClusterAndClose();
         }}
       >
-        <DialogHeader justifyContent="space-between" mb={4}>
-          <H2 style={{ whiteSpace: 'nowrap' }}>
-            Log out from cluster {clusterTitle}
-          </H2>
+        <DialogHeader justifyContent="space-between">
+          <H2 style={{ whiteSpace: 'nowrap' }}>Log out from {clusterTitle}</H2>
           <ButtonIcon
             type="button"
             disabled={status === 'processing'}
@@ -81,10 +79,10 @@ export function ClusterLogout({
             <Cross size="medium" />
           </ButtonIcon>
         </DialogHeader>
-        <DialogContent mb={4}>
+        <DialogContent mb={4} gap={2}>
           <P>Are you sure you want to log out?</P>
           {status === 'error' && (
-            <Alerts.Danger mb={5} details={statusText}>
+            <Alerts.Danger mb={0} details={statusText}>
               Could not log out
             </Alerts.Danger>
           )}

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -60,12 +60,8 @@ export function DocumentsReopen(props: {
           props.onConfirm();
         }}
       >
-        <DialogHeader
-          justifyContent="space-between"
-          mb={0}
-          alignItems="baseline"
-        >
-          <H2 mb={4}>Reopen previous session</H2>
+        <DialogHeader justifyContent="space-between" alignItems="baseline">
+          <H2>Reopen previous session</H2>
           <ButtonIcon
             type="button"
             onClick={props.onDiscard}
@@ -76,13 +72,14 @@ export function DocumentsReopen(props: {
           </ButtonIcon>
         </DialogHeader>
         <DialogContent mb={4}>
-          <P>Do you want to reopen tabs from the previous session?</P>
           <P
             // Split long continuous cluster names into separate lines.
             css={`
               word-wrap: break-word;
             `}
           >
+            Do you want to reopen tabs from the previous session?
+            <br />
             {/*
               We show this mostly because we needed to show the cluster name somewhere during UI
               initialization. When you open the app and have some tabs to restore, the UI will show

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -76,11 +76,8 @@ export function DocumentsReopen(props: {
           </ButtonIcon>
         </DialogHeader>
         <DialogContent mb={4}>
-          <P color="text.slightlyMuted">
-            Do you want to reopen tabs from the previous session?
-          </P>
+          <P>Do you want to reopen tabs from the previous session?</P>
           <P
-            color="text.slightlyMuted"
             // Split long continuous cluster names into separate lines.
             css={`
               word-wrap: break-word;

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -107,17 +107,17 @@ export function HeadlessPrompt({
         </Alerts.Danger>
       )}
       <DialogContent>
-        <P color="text.slightlyMuted">
+        <P>
           Someone initiated a headless command from <b>{clientIp}</b>.
         </P>
         <P>If it was not you, click Reject and contact your administrator.</P>
-        <P3 color="text.muted">Request ID: {headlessAuthenticationId}</P3>
+        <P3 color="text.slightlyMuted">
+          Request ID: {headlessAuthenticationId}
+        </P3>
       </DialogContent>
       {waitForMfa && (
         <DialogContent mb={2}>
-          <Text color="text.slightlyMuted">
-            Complete MFA verification to approve the Headless Login.
-          </Text>
+          <P>Complete MFA verification to approve the Headless Login.</P>
 
           <Image mt={4} mb={4} width="200px" src={svgHardwareKey} mx="auto" />
           <Box textAlign="center" style={{ position: 'relative' }}>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ChangeAccessRequestKind/ChangeAccessRequestKind.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ChangeAccessRequestKind/ChangeAccessRequestKind.tsx
@@ -50,7 +50,7 @@ export function ChangeAccessRequestKind({
           <Cross size="small" />
         </ButtonIcon>
       </DialogHeader>
-      <DialogContent mb={4} color="text.slightlyMuted">
+      <DialogContent mb={4}>
         <P>
           Resource Access Request cannot be combined with Role Access Request.
           The current items will be cleared.

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -83,7 +83,7 @@ export function ChangePin(props: {
 
             <DialogContent mb={4}>
               <Flex flexDirection="column" gap={4} alignItems="flex-start">
-                <P2 color="text.slightlyMuted">
+                <P2>
                   The default PIV PIN is not allowed.
                   <br />
                   Please set a new PIV PIN for your hardware key before
@@ -119,7 +119,7 @@ export function ChangePin(props: {
                   )}
                 />
 
-                <P2 color="text.slightlyMuted">
+                <P2>
                   To change the PIN, please provide your PUK code.
                   <br />
                   For security purposes, the default PUK ({DEFAULT_PUK}) cannot

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -53,7 +53,7 @@ export function OverwriteSlot(props: {
         />
 
         <DialogContent mb={4}>
-          <P2 color="text.slightlyMuted">{props.req.message}</P2>
+          <P2>{props.req.message}</P2>
         </DialogContent>
 
         <DialogFooter>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -170,7 +170,7 @@ export const ReAuthenticate: FC<{
 
             <DialogContent mb={4}>
               <Flex flexDirection="column" gap={4} alignItems="flex-start">
-                <Text color="text.slightlyMuted">
+                <Text>
                   {req.reason}
                   {isLeafCluster && ` from trusted cluster "${clusterName}"`}
                 </Text>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
@@ -62,11 +62,11 @@ export function UsageData(props: {
           </ButtonIcon>
         </DialogHeader>
         <DialogContent mb={4}>
-          <P color="text.slightlyMuted">
+          <P>
             Do you agree to Teleport Connect collecting anonymized usage data?
             This will help us improve the product.
           </P>
-          <P color="text.slightlyMuted">
+          <P>
             To learn more, see{' '}
             <Link
               href="https://goteleport.com/docs/faq/#teleport-connect"

--- a/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
@@ -42,7 +42,7 @@ export function ClustersFilterableList(props: ClustersFilterableListProps) {
           onFilterChange={value =>
             value.length ? setActiveIndex(0) : setActiveIndex(-1)
           }
-          placeholder="Search Leaf Cluster"
+          placeholder="Search leaf clusters"
           Node={({ item, index }) => (
             <ClusterItem
               item={item}

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionsFilterableList.tsx
@@ -64,7 +64,7 @@ export function ConnectionsFilterableList(props: {
     <FilterableList<ExtendedTrackedConnection | VnetConnection>
       items={items}
       filterBy="title"
-      placeholder="Search Connections"
+      placeholder="Search connections"
       onFilterChange={value =>
         value.length ? setActiveIndex(0) : setActiveIndex(-1)
       }

--- a/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.test.tsx
+++ b/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.test.tsx
@@ -84,7 +84,7 @@ test('render empty list when search does not match any item', () => {
 });
 
 test('render provided placeholder in the search box', () => {
-  const placeholder = 'Search Connections';
+  const placeholder = 'Search connections';
   render(
     <FilterableList<TestItem>
       items={[]}


### PR DESCRIPTION
Most of the texts in dialogs in Connect use `text.slightlyMuted` color, but I don't think there's any particular reason behind this decision. I believe we should avoid using `text.slightlyMuted` for primary information - such as the question in the "Reopen previous session" dialog.  In Web UI, dialogs use the default `text.main` color. 

I also changed slightly spacing in the following dialogs:

|  Before | After  |
|---|---|
| <img width="530" alt="image" src="https://github.com/user-attachments/assets/9c001474-46f6-477b-9a05-9942d4a6d65c" />  | <img width="530" alt="image" src="https://github.com/user-attachments/assets/216e22b0-47f7-4ac8-94c0-fb501a23bb29" /> |
| <img width="530" alt="image" src="https://github.com/user-attachments/assets/e06a7fed-83a6-4f97-a5ca-d5e3a8933ba0" /> | <img width="530" alt="image" src="https://github.com/user-attachments/assets/50457e15-8921-43c0-a020-c073f29ff953" /> |