### PR TITLE
Fix typo in Join Methods documentation page

### DIFF
--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -7,7 +7,7 @@ tocDepth: 3
 ---
 
 This guide explains the core concepts behind the Teleport joining process,
-references all support join methods and classifies them based on their
+references all supported join methods and classifies them based on their
 security properties. This guide does not explain step-by-step how to
 join an instance with each join method, but links to the relevant How-To
 guides when possible.


### PR DESCRIPTION
Small typo in this page: https://goteleport.com/docs/reference/join-methods/

support -> _supported_
