### PR TITLE
[v16] Add Stack component

### DIFF
--- a/web/packages/design/src/Flex/Flex.story.js
+++ b/web/packages/design/src/Flex/Flex.story.js
@@ -57,3 +57,14 @@ export const Justified = () => (
     </Box>
   </Flex>
 );
+
+export const Inline = () => (
+  <Flex inline gap={5}>
+    <Box width={1 / 2} bg="pink" p={5}>
+      Box one
+    </Box>
+    <Box width={1 / 2} bg="orange" p={5}>
+      Box two
+    </Box>
+  </Flex>
+);

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -57,3 +57,45 @@ const Flex = styled(Box)<FlexProps>`
 Flex.displayName = 'Flex';
 
 export default Flex;
+
+/**
+ * Stack is a variant of Flex designed to distribute elements in a vertical space with consistent
+ * spacing using the gap property. If no gap is specified, it defaults to 1.
+ *
+ * It's possible to "split the stack" by setting `margin-top: auto;` on a specific child. That child
+ * and all children below it will be aligned to the bottom of the stack.
+ *
+ * Inspired by https://every-layout.dev/layouts/stack/. It follows the approach of styling the
+ * context, not the individual elements, to achieve desired spacing.
+ *
+ * @example
+ *
+ * <Stack gap={3}>
+ *   <Stack>
+ *     <Breadcrumbs />
+ *     <ComponentHeader/>
+ *   </Stack>
+ *
+ *   <Stack gap={2}>
+ *     <ComponentMainBody/>
+ *     <ComponentSidenote />
+ *   </Stack>
+ * </Stack>
+ */
+export const Stack = styled(Flex).attrs({
+  flexDirection: 'column',
+})`
+  // Prevents children from shrinking, within a stack we pretty much never want that to happen.
+  // Individual children can override this.
+  & > * {
+    flex-shrink: 0;
+  }
+`;
+Stack.defaultProps = {
+  gap: 1,
+  // align-items: flex-start lets children keep their original size. Otherwise elements like buttons
+  // would occupy all available horizontal space instead of the minimal amount of space they need.
+  //
+  // This is set as a default prop, as in some cases it might be necessary to override align-items.
+  alignItems: 'flex-start',
+};

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -98,20 +98,19 @@ export default Flex;
  *   </Stack>
  * </Stack>
  */
-export const Stack = styled(Flex).attrs({
+export const Stack = styled(Flex).attrs(props => ({
   flexDirection: 'column',
-})`
-  & > * {
-    // Prevents children from shrinking, within a stack we pretty much never want that to happen.
-    // Individual children can override this.
-    flex-shrink: 0;
-  }
-`;
-Stack.defaultProps = {
   gap: 1,
   // align-items: flex-start lets children keep their original size. Otherwise elements like buttons
   // would occupy all available horizontal space instead of the minimal amount of space they need.
   //
   // This is set as a default prop, as in some cases it might be necessary to override align-items.
   alignItems: 'flex-start',
-};
+  ...props,
+}))`
+  & > * {
+    // Prevents children from shrinking, within a stack we pretty much never want that to happen.
+    // Individual children can override this.
+    flex-shrink: 0;
+  }
+`;

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -42,10 +42,15 @@ interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
-    GapProps {}
+    GapProps {
+  /**
+   * Uses inline-flex instead of just flex as the display property.
+   */
+  inline?: boolean;
+}
 
 const Flex = styled(Box)<FlexProps>`
-  display: flex;
+  display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   ${alignItems}
   ${justifyContent}
   ${flexWrap}

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -47,6 +47,8 @@ interface FlexProps
    * Uses inline-flex instead of just flex as the display property.
    */
   inline?: boolean;
+  /** Makes the element and its immediate children have 100% width. */
+  fullWidth?: boolean;
 }
 
 const Flex = styled(Box)<FlexProps>`
@@ -57,6 +59,15 @@ const Flex = styled(Box)<FlexProps>`
   ${flexBasis}
   ${flexDirection}
   ${gap};
+
+  ${props =>
+    props.fullWidth &&
+    `
+    width: 100%;
+    & > * {
+      width: 100%;
+    }
+  `}
 `;
 
 Flex.displayName = 'Flex';
@@ -90,9 +101,9 @@ export default Flex;
 export const Stack = styled(Flex).attrs({
   flexDirection: 'column',
 })`
-  // Prevents children from shrinking, within a stack we pretty much never want that to happen.
-  // Individual children can override this.
   & > * {
+    // Prevents children from shrinking, within a stack we pretty much never want that to happen.
+    // Individual children can override this.
     flex-shrink: 0;
   }
 `;

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -21,6 +21,8 @@ import styled from 'styled-components';
 import {
   alignItems,
   AlignItemsProps,
+  columnGap,
+  ColumnGapProps,
   flexBasis,
   FlexBasisProps,
   flexDirection,
@@ -31,6 +33,8 @@ import {
   GapProps,
   justifyContent,
   JustifyContentProps,
+  rowGap,
+  RowGapProps,
 } from 'design/system';
 
 import Box, { BoxProps } from '../Box';
@@ -42,6 +46,8 @@ interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
+    RowGapProps,
+    ColumnGapProps,
     GapProps {
   /**
    * Uses inline-flex instead of just flex as the display property.
@@ -58,6 +64,8 @@ const Flex = styled(Box)<FlexProps>`
   ${flexWrap}
   ${flexBasis}
   ${flexDirection}
+  ${rowGap};
+  ${columnGap};
   ${gap};
 
   ${props =>

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -21,6 +21,8 @@ import styled from 'styled-components';
 import {
   alignItems,
   AlignItemsProps,
+  boxShadow,
+  BoxShadowProps,
   columnGap,
   ColumnGapProps,
   flexBasis,
@@ -46,6 +48,7 @@ interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
+    BoxShadowProps,
     RowGapProps,
     ColumnGapProps,
     GapProps {
@@ -64,9 +67,10 @@ const Flex = styled(Box)<FlexProps>`
   ${flexWrap}
   ${flexBasis}
   ${flexDirection}
-  ${rowGap};
-  ${columnGap};
-  ${gap};
+  ${boxShadow}
+  ${rowGap}
+  ${columnGap}
+  ${gap}
 
   ${props =>
     props.fullWidth &&

--- a/web/packages/design/src/Flex/Stack.story.tsx
+++ b/web/packages/design/src/Flex/Stack.story.tsx
@@ -1,0 +1,75 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import Box from 'design/Box';
+import { ButtonPrimary } from 'design/Button';
+import { P } from 'design/Text/Text';
+
+import { Stack } from './Flex';
+
+export default {
+  title: 'Design/Flex/Stack',
+};
+
+export const Basic = () => (
+  <Stack gap={6}>
+    <Square bg="pink" />
+
+    <Stack gap={3}>
+      {/* If no gap prop is given, a default gap of 1 is used. */}
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Foo</ButtonPrimary>
+      </Stack>
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Bar</ButtonPrimary>
+      </Stack>
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Baz</ButtonPrimary>
+      </Stack>
+    </Stack>
+
+    <Square bg="yellow" />
+  </Stack>
+);
+
+export const MarginAuto = () => (
+  <Stack gap={6} height="90vh">
+    <P>
+      <code>margin-top: auto</code> can be used to automatically align elements
+      after a certain child to the end of the stack.
+    </P>
+    <SmallSquare bg="pink" />
+    <SmallSquare bg="green" />
+    <SmallSquare bg="brown" />
+    <SmallSquare
+      bg="yellow"
+      css={`
+        margin-top: auto;
+      `}
+    />
+    <SmallSquare bg="orange" />
+  </Stack>
+);
+
+const Square = styled(Box).attrs({ width: '150px', height: '150px' })``;
+const SmallSquare = styled(Box).attrs({ width: '50px', height: '50px' })``;

--- a/web/packages/design/src/Flex/Stack.story.tsx
+++ b/web/packages/design/src/Flex/Stack.story.tsx
@@ -16,34 +16,61 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta } from '@storybook/react';
 import styled from 'styled-components';
 
 import Box from 'design/Box';
 import { ButtonPrimary } from 'design/Button';
-import { P } from 'design/Text/Text';
+import { P, P2 } from 'design/Text/Text';
 
 import { Stack } from './Flex';
 
-export default {
-  title: 'Design/Flex/Stack',
+type StoryProps = {
+  fullWidth: boolean;
 };
 
-export const Basic = () => (
-  <Stack gap={6}>
+const meta: Meta<StoryProps> = {
+  title: 'Design/Flex/Stack',
+  args: {
+    fullWidth: false,
+  },
+};
+export default meta;
+
+export const Basic = ({ fullWidth }: StoryProps) => (
+  <Stack gap={6} fullWidth={fullWidth}>
     <Square bg="pink" />
 
-    <Stack gap={3}>
+    <Stack gap={3} fullWidth={fullWidth}>
       {/* If no gap prop is given, a default gap of 1 is used. */}
       <Stack>
         <Square bg="green" />
         <ButtonPrimary>Foo</ButtonPrimary>
       </Stack>
-      <Stack>
-        <Square bg="green" />
+      <Stack fullWidth={fullWidth}>
+        <Square bg="green">
+          {fullWidth && (
+            <Para>
+              Only the middle one among these three sibling Stacks is given{' '}
+              <code>fullWidth</code>. This demonstrates that{' '}
+              <code>fullWidth</code> can be used for specific child Stacks
+              within multiple levels of nested Stacks.
+            </Para>
+          )}
+        </Square>
         <ButtonPrimary>Bar</ButtonPrimary>
       </Stack>
-      <Stack>
-        <Square bg="green" />
+      <Stack width="100%">
+        <Square bg="green" width="100%">
+          {fullWidth && (
+            <Para>
+              With <code>fullWidth</code>, all immediate children of a Stack
+              have the width set to 100%. If only specific children are supposed
+              to have 100% width, the width can be set manually, like in this
+              last stack. Notice how the button doesn't span full width.
+            </Para>
+          )}
+        </Square>
         <ButtonPrimary>Baz</ButtonPrimary>
       </Stack>
     </Stack>
@@ -52,8 +79,8 @@ export const Basic = () => (
   </Stack>
 );
 
-export const MarginAuto = () => (
-  <Stack gap={6} height="90vh">
+export const MarginAuto = ({ fullWidth }: StoryProps) => (
+  <Stack gap={6} height="90vh" fullWidth={fullWidth}>
     <P>
       <code>margin-top: auto</code> can be used to automatically align elements
       after a certain child to the end of the stack.
@@ -71,5 +98,9 @@ export const MarginAuto = () => (
   </Stack>
 );
 
-const Square = styled(Box).attrs({ width: '150px', height: '150px' })``;
+const Square = styled(Box)``;
+Square.defaultProps = { width: '150px', height: '150px', p: 2 };
 const SmallSquare = styled(Box).attrs({ width: '50px', height: '50px' })``;
+const Para = styled(P2)`
+  max-width: 60ch;
+`;

--- a/web/packages/design/src/Flex/Stack.story.tsx
+++ b/web/packages/design/src/Flex/Stack.story.tsx
@@ -98,8 +98,12 @@ export const MarginAuto = ({ fullWidth }: StoryProps) => (
   </Stack>
 );
 
-const Square = styled(Box)``;
-Square.defaultProps = { width: '150px', height: '150px', p: 2 };
+const Square = styled(Box).attrs(props => ({
+  width: '150px',
+  height: '150px',
+  p: 2,
+  ...props,
+}))``;
 const SmallSquare = styled(Box).attrs({ width: '50px', height: '50px' })``;
 const Para = styled(P2)`
   max-width: 60ch;

--- a/web/packages/design/src/Flex/index.ts
+++ b/web/packages/design/src/Flex/index.ts
@@ -18,4 +18,6 @@
 
 import Flex from './Flex';
 
+export { Stack } from './Flex';
+
 export default Flex;

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -114,4 +114,5 @@ export {
 };
 export type { TextAreaProps } from './TextArea';
 export * from './keyframes';
+export { Stack } from './Flex';
 export { breakpointsPx } from './theme';

--- a/web/packages/design/src/system/index.ts
+++ b/web/packages/design/src/system/index.ts
@@ -88,6 +88,26 @@ export interface GapProps<TLength = TLengthStyledSystem> {
   gap?: ResponsiveValue<Property.Gap<TLength>>;
 }
 
+const rowGap = style({
+  prop: 'rowGap',
+  cssProperty: 'row-gap',
+  key: 'space',
+});
+
+export interface RowGapProps<TLength = TLengthStyledSystem> {
+  rowGap?: ResponsiveValue<Property.RowGap<TLength>>;
+}
+
+const columnGap = style({
+  prop: 'columnGap',
+  cssProperty: 'column-gap',
+  key: 'space',
+});
+
+export interface ColumnGapProps<TLength = TLengthStyledSystem> {
+  columnGap?: ResponsiveValue<Property.ColumnGap<TLength>>;
+}
+
 export {
   alignItems,
   type AlignItemsProps,
@@ -116,6 +136,8 @@ export {
   fontWeight,
   type FontWeightProps,
   gap,
+  rowGap,
+  columnGap,
   height,
   type HeightProps,
   justifyContent,

--- a/web/packages/design/src/system/index.ts
+++ b/web/packages/design/src/system/index.ts
@@ -76,7 +76,7 @@ import {
 import borderRadius, { BorderRadiusProps } from './borderRadius';
 import typography, { TypographyProps } from './typography';
 
-const gap = style({
+export const gap = style({
   prop: 'gap',
   cssProperty: 'gap',
   // This makes gap use the space defined in the theme.
@@ -88,7 +88,7 @@ export interface GapProps<TLength = TLengthStyledSystem> {
   gap?: ResponsiveValue<Property.Gap<TLength>>;
 }
 
-const rowGap = style({
+export const rowGap = style({
   prop: 'rowGap',
   cssProperty: 'row-gap',
   key: 'space',
@@ -98,7 +98,7 @@ export interface RowGapProps<TLength = TLengthStyledSystem> {
   rowGap?: ResponsiveValue<Property.RowGap<TLength>>;
 }
 
-const columnGap = style({
+export const columnGap = style({
   prop: 'columnGap',
   cssProperty: 'column-gap',
   key: 'space',
@@ -106,6 +106,20 @@ const columnGap = style({
 
 export interface ColumnGapProps<TLength = TLengthStyledSystem> {
   columnGap?: ResponsiveValue<Property.ColumnGap<TLength>>;
+}
+
+// Defining a custom style for boxShadow, as the one from styled-system doesn't support reading
+// values from the theme.
+export const boxShadow = style({
+  prop: 'boxShadow',
+  cssProperty: 'box-shadow',
+  key: 'boxShadow',
+});
+
+export interface BoxShadowProps<TLength = TLengthStyledSystem> {
+  // Using Property.Gap on purpose, as Property.BoxShadow doesn't accept a generic value (so it
+  // seemingly doesn't accept passing an index for a value from the theme).
+  boxShadow?: ResponsiveValue<Property.Gap<TLength>>;
 }
 
 export {
@@ -135,9 +149,6 @@ export {
   type FontSizeProps,
   fontWeight,
   type FontWeightProps,
-  gap,
-  rowGap,
-  columnGap,
   height,
   type HeightProps,
   justifyContent,

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -55,6 +55,11 @@ export const sharedStyles: SharedStyles = {
     large: `${breakpointsPx.large}px`,
   },
   topBarHeight: [44, 56, 72],
+  /**
+   *
+   * idx:    0  1  2   3   4   5   6   7   8   9  10  11
+   * space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80]
+   */
   space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
   borders: [
     0,

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -322,6 +322,11 @@ export type SharedStyles = {
     large: string;
   };
   topBarHeight: number[];
+  /**
+   *
+   * idx:    0  1  2   3   4   5   6   7   8   9  10  11
+   * space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80]
+   */
   space: number[];
   borders: (string | number)[];
   typography: typeof typography;


### PR DESCRIPTION
Backport #52003, #53087, #53440

This backports the `<Stack>` component to v16 so that all release branches have it. I should've done this sooner, but at least this PR makes it so that there's virtually no difference between Stack on v16 and other release branches.

```diff
$ g diff r7s/v16/backport-52003-stack master -- web/packages/design/src/Flex/Flex.tsx
diff --git a/web/packages/design/src/Flex/Flex.tsx b/web/packages/design/src/Flex/Flex.tsx
index f3a8ecbe3f6..019ffc34dcb 100644
--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -41,7 +41,7 @@ import {
 
 import Box, { BoxProps } from '../Box';
 
-interface FlexProps
+export interface FlexProps
   extends BoxProps,
     AlignItemsProps,
     JustifyContentProps,

```

I had to move `Flex/index.js` to `Flex/index.ts`. `Box` on v16 doesn't have the `marginTop` prop, so I had to use `css` in the story.