### PR TITLE
ci: Use :teleport19 buildbox in lint RFD job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -248,7 +248,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport19
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Update the buildbox used for the lint (RFD) job from :teleport17 to
:teleport19. This was missed in the previous PRs as it only changed
:teleport18 to :teleport19. Presumably this job was missed when updating
to :teleport18 earlier.
