### PR TITLE
SELinux improvements

### DIFF
--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -31,6 +31,7 @@ import (
 	ocselinux "github.com/opencontainers/selinux/go-selinux"
 
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/lib/versioncontrol"
 )
 
@@ -39,8 +40,13 @@ const (
 	selinuxRoot          = "/var/lib/selinux"
 	selinuxTypeTag       = "SELINUXTYPE"
 	moduleName           = "teleport_ssh"
+	execType             = "teleport_ssh_exec_t"
 	domain               = "teleport_ssh_t"
 	permissiveModuleName = "permissive_" + domain
+
+	// the SELinux user and role that Systemd services run as by default
+	selinuxSystemUser = "system_u"
+	selinuxSystemRole = "system_r"
 )
 
 //go:embed teleport_ssh.te
@@ -86,9 +92,39 @@ func FileContexts(dataDir, configPath string) (string, error) {
 	return buf.String(), nil
 }
 
+type selinuxContext struct {
+	user               string
+	role               string
+	domain             string
+	multiLevelSecurity string
+}
+
+// parseLabel parses an SELinux context string.
+func parseLabel(label string) (*selinuxContext, error) {
+	seCtx, err := ocselinux.NewContext(label)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse SELinux context")
+	}
+
+	return &selinuxContext{
+		user:               seCtx["user"],
+		role:               seCtx["role"],
+		domain:             seCtx["type"],
+		multiLevelSecurity: seCtx["level"],
+	}, nil
+}
+
+func (c *selinuxContext) String() string {
+	if c.multiLevelSecurity == "" {
+		return c.user + ":" + c.role + ":" + c.domain
+	}
+	return c.user + ":" + c.role + ":" + c.domain + ":" + c.multiLevelSecurity
+}
+
 // CheckConfiguration returns an error if SELinux is not configured to
 // enforce the SSH service correctly.
 func CheckConfiguration(ensureEnforced bool, logger *slog.Logger) error {
+	// ensure SELinux is enabled and running with the correct mode.
 	if !ocselinux.GetEnabled() {
 		return trace.Errorf("SELinux is disabled or not present")
 	}
@@ -103,6 +139,20 @@ func CheckConfiguration(ensureEnforced bool, logger *slog.Logger) error {
 		}
 	}
 
+	// ensure we are running under the correct domain.
+	label, err := ocselinux.CurrentLabel()
+	if err != nil {
+		return trace.Wrap(err, "failed to get SELinux context")
+	}
+	seCtx, err := parseLabel(label)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if seCtx.domain != domain {
+		return trace.Wrap(diagnoseWrongDomain(seCtx, logger))
+	}
+
+	// ensure the SELinux module is installed and enabled.
 	selinuxType, err := readConfig(selinuxTypeTag)
 	if err != nil {
 		return trace.Wrap(err, "failed to find SELinux type")
@@ -129,6 +179,42 @@ func CheckConfiguration(ensureEnforced bool, logger *slog.Logger) error {
 	}
 
 	return nil
+}
+
+// this function attempts to diagnose why Teleport is not running under the correct SELinux domain.
+func diagnoseWrongDomain(procCtx *selinuxContext, logger *slog.Logger) error {
+	if procCtx.user != selinuxSystemUser || procCtx.role != selinuxSystemRole {
+		logger.WarnContext(
+			context.Background(),
+			"Teleport is not running as the system_u:system_r SELinux user and role, running Teleport as a Systemd service is recommended when --enable-selinux is passed",
+			"selinux_context", logutils.StringerAttr(procCtx),
+		)
+	}
+	const fallbackErrMsg = "" +
+		"Teleport is running under the wrong SELinux domain %q instead of %q, SELinux will not enforce Teleport correctly. " +
+		"Refer to https://goteleport.com/docs/admin-guides/management/security/selinux/ for more information."
+	fallbackErr := trace.Errorf(fallbackErrMsg, procCtx.domain, domain)
+
+	execPath, err := os.Executable()
+	if err != nil {
+		return trace.NewAggregate(trace.Wrap(err, "failed to get executable path"), fallbackErr)
+	}
+	label, err := ocselinux.FileLabel(execPath)
+	if err != nil {
+		return trace.NewAggregate(trace.Wrap(err, "failed to get SELinux label of executable"), fallbackErr)
+	}
+	fileCtx, err := parseLabel(label)
+	if err != nil {
+		return trace.NewAggregate(trace.Wrap(err, "failed to parse SELinux context"), fallbackErr)
+	}
+	if fileCtx.domain != domain {
+		const binaryLabelErrMsg = "" +
+			"Teleport binary %q is labeled with SELinux type %q, it needs to be labeled with type %q to be enforced by SELinux correctly. " +
+			"Refer to https://goteleport.com/docs/admin-guides/management/security/selinux/ for how to label the binary correctly."
+		return trace.Errorf(binaryLabelErrMsg, execPath, fileCtx.domain, execType)
+	}
+
+	return fallbackErr
 }
 
 func moduleStatus(modulesDir string) (installed bool, disabled bool, permissive bool, err error) {

--- a/lib/selinux/teleport_ssh.te
+++ b/lib/selinux/teleport_ssh.te
@@ -183,9 +183,6 @@ allow teleport_ssh_t self:capability { chown dac_read_search dac_override fowner
 fs_search_cgroup_dirs(teleport_ssh_t);
 fs_rw_cgroup_files(teleport_ssh_t);
 
-# allow SSH shell process to start a Teleport process (needed to detirmine home dir)
-allow unconfined_t teleport_ssh_exec_t:file entrypoint;
-
 # host auth
 auth_use_nsswitch(teleport_ssh_t);
 allow teleport_ssh_t passwd_file_t:file read_file_perms;


### PR DESCRIPTION
Ensure that Teleport is running under the correct SELinux context when `--enable-selinux` is passed, set the SELinux exec label later so the `checkhomedir` child process will inherit the parent's SELinux domain.

The domain check is very helpful, as it's easy to assume Teleport SSH is getting enforced by SELinux when SELinux is configured correctly, the module is installed, and Teleport doesn't report any errors. But all it takes is something other than systemd starting Teleport for it not to get enforced correctly. This should catch some future SELinux problems I haven't anticipated as well.