### PR TITLE
docs: remove note about kube joining not working in the web UI

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/joining-sessions.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/joining-sessions.mdx
@@ -20,8 +20,7 @@ When joining a session, users can be in one of three participant modes:
 - **Peer**: Can view the session and interact with it as if they were the session owner.
 - **Moderator**: (Enterprise only) Can view the session and terminate it.
 
-Users can join SSH sessions from the command line or from the Teleport web UI,
-but Kubernetes sessions can only be joined from the command line.
+Users can join sessions from the command line or from the Teleport web UI.
 
 The web UI forces users to select a join mode prior to joining. If you join a
 session with `tsh join` or `tsh kube join`, you can specify a participant mode


### PR DESCRIPTION
We added support for joining kube sessions in the web UI with #52993 and just missed this docs update.