### PR TITLE
[v17] MWI: Fix missing O_CLOEXEC in `botfs.openSecure()` and other issues

### DIFF
--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -135,8 +135,8 @@ func (s *ACLSelector) CheckAndSetDefaults() error {
 	return nil
 }
 
-// openStandard attempts to open the given path for reading and writing with
-// O_CREATE set.
+// openStandard attempts to open the given path. The file may be writable
+// depending on the provided `OpenFlags` value.
 func openStandard(path string, flags OpenFlags) (*os.File, error) {
 	file, err := os.OpenFile(path, flags.Flags(), DefaultMode)
 	if err != nil {

--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -66,12 +66,7 @@ const (
 
 	// ACLRequired enables ACL support and fails if ACLs are unavailable.
 	ACLRequired ACLMode = "required"
-)
 
-// OpenMode is a mode for opening files.
-type OpenMode int
-
-const (
 	// DefaultMode is the preferred permissions mode for bot files.
 	DefaultMode fs.FileMode = 0600
 
@@ -79,15 +74,31 @@ const (
 	// Directories need the execute bit set for most operations on their
 	// contents to succeed.
 	DefaultDirMode fs.FileMode = 0700
-
-	// ReadMode is the mode with which files should be opened for reading and
-	// writing.
-	ReadMode OpenMode = OpenMode(os.O_CREATE | os.O_RDONLY)
-
-	// WriteMode is the mode with which files should be opened specifically
-	// for writing.
-	WriteMode OpenMode = OpenMode(os.O_CREATE | os.O_WRONLY | os.O_TRUNC)
 )
+
+// OpenFlags is a bitmask containing flags passed to `open()`
+type OpenFlags int
+
+const (
+	// ReadFlags contains `open()` flags to be used when opening files for
+	// reading. The file will be created if it does not exist, and reads should
+	// return an empty byte array.
+	ReadFlags = iota
+
+	// WriteFlags is the mode with which files should be opened specifically
+	// for writing.
+	WriteFlags
+)
+
+// Flags returns opening flags for this OpenFlags variant.
+func (f OpenFlags) Flags() int {
+	switch f {
+	case WriteFlags:
+		return os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	default:
+		return os.O_RDONLY
+	}
+}
 
 // ACLOptions contains parameters needed to configure ACLs
 type ACLOptions struct {
@@ -126,8 +137,8 @@ func (s *ACLSelector) CheckAndSetDefaults() error {
 
 // openStandard attempts to open the given path for reading and writing with
 // O_CREATE set.
-func openStandard(path string, mode OpenMode) (*os.File, error) {
-	file, err := os.OpenFile(path, int(mode), DefaultMode)
+func openStandard(path string, flags OpenFlags) (*os.File, error) {
+	file, err := os.OpenFile(path, flags.Flags(), DefaultMode)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -146,7 +157,7 @@ func createStandard(path string, isDir bool) error {
 		return nil
 	}
 
-	f, err := openStandard(path, WriteMode)
+	f, err := openStandard(path, WriteFlags)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -29,7 +29,6 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -90,9 +89,15 @@ func openSecure(path string, flags OpenFlags) (*os.File, error) {
 			return nil, err
 		}
 
-		// os.File.Close() appears to close wrapped files sanely, so rely on that
-		// rather than relying on callers to use unix.Close(fd)
-		return os.NewFile(uintptr(fd), filepath.Base(path)), nil
+		file := os.NewFile(uintptr(fd), path)
+		if file == nil {
+			// Probably useless since this implies the fd itself is invalid, but
+			// attempt to close the fd anyway.
+			_ = unix.Close(fd)
+			return nil, os.ErrInvalid
+		}
+
+		return file, nil
 	}
 }
 

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -83,7 +83,7 @@ func openSecure(path string, flags OpenFlags) (*os.File, error) {
 
 	for {
 		fd, err := unix.Openat2(unix.AT_FDCWD, path, &how)
-		if err == syscall.EINTR {
+		if errors.Is(err, syscall.EINTR) {
 			// Per the stdlib's implementation, EINTR errors should be ignored
 			// and retried.
 			continue

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -67,11 +67,9 @@ var missingSyscallWarning sync.Once
 // RESOLVE_NO_SYMLINKS flag set.
 func openSecure(path string, flags OpenFlags) (*os.File, error) {
 	var mode uint64
-	if flags == ReadFlags {
-		// openat2() with nonzero mode will raise EINVAL unless O_CREATE or
-		// O_TMPFILE is set, so zero it out.
-		mode = 0
-	} else {
+	if flags != ReadFlags {
+		// openat2() with a nonzero mode will raise EINVAL unless O_CREATE or
+		// O_TMPFILE is set, so only set this in non-read mode.
 		mode = uint64(DefaultMode.Perm())
 	}
 

--- a/lib/tbot/botfs/fs_unix.go
+++ b/lib/tbot/botfs/fs_unix.go
@@ -61,7 +61,7 @@ func Read(path string, symlinksMode SymlinksMode) ([]byte, error) {
 		})
 	}
 
-	file, err := openStandard(path, ReadMode)
+	file, err := openStandard(path, ReadFlags)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -91,7 +91,7 @@ func Write(path string, data []byte, symlinksMode SymlinksMode) error {
 		})
 	}
 
-	file, err := openStandard(path, WriteMode)
+	file, err := openStandard(path, WriteFlags)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/botfs/fs_windows.go
+++ b/lib/tbot/botfs/fs_windows.go
@@ -62,7 +62,7 @@ func Read(path string, symlinksMode SymlinksMode) ([]byte, error) {
 		})
 	}
 
-	file, err := openStandard(path, ReadMode)
+	file, err := openStandard(path, ReadFlags)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -92,7 +92,7 @@ func Write(path string, data []byte, symlinksMode SymlinksMode) error {
 		})
 	}
 
-	file, err := openStandard(path, WriteMode)
+	file, err := openStandard(path, WriteFlags)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #55411 to branch/v17

changelog: The `tbot` client now ensures the `O_CLOEXEC` flag is used when opening files on Linux hosts
