### PR TITLE
[v18] Fix validation in PIV PIN and PUK form in Connect, increase new PIN timeout

### DIFF
--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -439,7 +439,11 @@ func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwareke
 	y.pinCache.mu.Lock()
 	defer y.pinCache.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
+	// Use a longer timeout than pinPromptTimeout since this specific prompt requires the user to
+	// re-type both PIN and PUK. The user might also want to save the values somewhere.
+	// pinPromptTimeout just doesn't give enough time for that.
+	const newPinPromptTimeout = 3 * time.Minute
+	ctx, cancel := context.WithTimeout(ctx, newPinPromptTimeout)
 	defer cancel()
 
 	pinAndPUK, err := prompt.ChangePIN(ctx, keyInfo)

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -87,7 +87,7 @@ export function ChangePin(props: {
                   The default PIV PIN is not allowed.
                   <br />
                   Please set a new PIV PIN for your hardware key before
-                  proceeding. Both the PIN and PUK must be 4-6 characters long.
+                  proceeding. Both the PIN and PUK must be 6–8 characters long.
                 </P2>
 
                 <FieldInput
@@ -100,7 +100,7 @@ export function ChangePin(props: {
                   rule={requiredAll(
                     requiredField('New PIV PIN is required'),
                     notDefaultPin(),
-                    correctLength('PIV PIN must be 4-6 characters long')
+                    correctLength('PIV PIN must be 6–8 characters long')
                   )}
                 />
                 <FieldInput
@@ -115,7 +115,7 @@ export function ChangePin(props: {
                       doesNotMatch: 'PIV PIN does not match',
                     }),
                     notDefaultPin(),
-                    correctLength('PIV PIN must be 4-6 characters long')
+                    correctLength('PIV PIN must be 6–8 characters long')
                   )}
                 />
 
@@ -145,7 +145,7 @@ export function ChangePin(props: {
                     rule={requiredAll(
                       requiredField('PUK is required'),
                       notDefaultPuk(),
-                      correctLength('PUK must be 4-6 characters long')
+                      correctLength('PUK must be 6–8 characters long')
                     )}
                   />
                 ) : (
@@ -159,7 +159,7 @@ export function ChangePin(props: {
                       rule={requiredAll(
                         requiredField('New PUK is required'),
                         notDefaultPuk(),
-                        correctLength('PUK must be 4-6 characters long')
+                        correctLength('PUK must be 6–8 characters long')
                       )}
                     />
                     <FieldInput
@@ -174,7 +174,7 @@ export function ChangePin(props: {
                           doesNotMatch: 'PUK does not match',
                         }),
                         notDefaultPuk(),
-                        correctLength('PUK must be 4-6 characters long')
+                        correctLength('PUK must be 6–8 characters long')
                       )}
                     />
                   </>
@@ -221,7 +221,7 @@ const correctLength =
   value =>
   () => {
     const valid =
-      typeof value === 'string' && value.length >= 4 && value.length <= 6;
+      typeof value === 'string' && value.length >= 6 && value.length <= 8;
     return {
       valid,
       message: !valid ? message : '',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -169,7 +169,7 @@ export function ChangePin(props: {
                       onChange={e => setConfirmNewPuk(e.target.value)}
                       mb={0}
                       rule={requiredAll(
-                        requiredConfirmed(pin, {
+                        requiredConfirmed(newPuk, {
                           confirm: 'Confirm New PUK is required',
                           doesNotMatch: 'PUK does not match',
                         }),


### PR DESCRIPTION
Backport #55401 to branch/v18

changelog: Fixed updating the default PIN and PUK for hardware key support in Teleport Connect
