### PR TITLE
Add no-restricted-imports to curb cyclic imports between JS packages

### DIFF
--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -28,6 +28,20 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
+    // Citing from the ESLint docs:
+    // https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores
+    //
+    // "By default, ESLint lints files that match the patterns **/*.js, **/*.cjs, and **/*.mjs.
+    // Those files are always matched unless you explicitly exclude them using global ignores."
+    //
+    // "Configuration objects without files or ignores are automatically applied to any file that is
+    // matched by any other configuration object."
+    //
+    // Since no configs apply rules to jsx files specifically, we need to specify them manually.
+    // And just to be future-proof we specify other non-default extensions used in the project.
+    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.jsx'],
+  },
+  {
     ignores: [
       '**/dist/**',
       '**/*_pb.*',

--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -168,5 +168,73 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-require-imports': 'warn',
     },
+  },
+
+  /*
+   * Restricted imports
+   *
+   * If an import is caught by these rules, it means that the imported package needs to be moved
+   * elsewhere in the dependency tree.
+   * https://github.com/gravitational/teleport/issues/54872
+   */
+  {
+    files: ['web/packages/shared/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleport/*', 'e-teleport/*', 'teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['web/packages/teleport/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['e-teleport/*', 'teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['e/web/teleport/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['web/packages/teleterm/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleport/*', 'e-teleport/*'],
+            },
+          ],
+        },
+      ],
+    },
   }
 );

--- a/web/packages/design/src/Menu/MenuItemIcon.jsx
+++ b/web/packages/design/src/Menu/MenuItemIcon.jsx
@@ -26,8 +26,8 @@ const MenuItemIcon = styled.span`
     color: ${props => props.theme.colors.text.main};
   }
   svg {
-    height: ${props => `${props.size}px` || '18px'};
-    height: ${props => `${props.size}px` || '18px'};
+    height: ${props => (props.size && `${props.size}px`) || '18px'};
+    height: ${props => (props.size && `${props.size}px`) || '18px'};
   }
 `;
 

--- a/web/packages/design/src/theme/palette.story.jsx
+++ b/web/packages/design/src/theme/palette.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*eslint import/namespace: ['error', { allowComputed: true }]*/
-
 import { Box, Flex } from '..';
 import * as colors from './palette';
 import { getContrastText } from './themes/sharedStyles';

--- a/web/packages/shared/components/AccessRequests/NewRequest/resource.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/resource.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceIdKind } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { KubeResourceKind } from 'teleport/services/kube';
 
 /** Available request kinds for resource-based and role-based access requests. */

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/types.ts
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/types.ts
@@ -18,6 +18,7 @@
 
 import { RequestState } from 'shared/services/accessRequests';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 export type RequestFlags = {

--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -24,6 +24,7 @@ import InputSearch from 'design/DataTable/InputSearch';
 import { PageIndicatorText } from 'design/DataTable/Pager/PageIndicatorText';
 import { AdvancedSearchToggle } from 'shared/components/AdvancedSearchToggle';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceFilter } from 'teleport/services/agents';
 
 export function SearchPanel({

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.test.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.test.tsx
@@ -19,6 +19,7 @@
 import { fireEvent, render, screen } from 'design/utils/testing';
 import Validation from 'shared/components/Validation';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 import {

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -25,6 +25,7 @@ import { FieldSelectCreatable } from 'shared/components/FieldSelect';
 import { Option } from 'shared/components/Select';
 import { requiredAll, requiredField } from 'shared/components/Validation/rules';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 /**

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -23,13 +23,21 @@ import styled from 'styled-components';
 import { ButtonBorder } from 'design';
 import { gap, GapProps } from 'design/system';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { SamlAppActionProvider } from 'teleport/SamlApplications/useSamlAppActions';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceActionButton } from 'teleport/UnifiedResources/ResourceActionButton';
 
 import {

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -24,6 +24,7 @@ import { CheckboxInput } from 'design/Checkbox';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../shared/CopyButton';

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -20,11 +20,17 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { ButtonBorder, Flex } from 'design';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
 
 import {

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -25,6 +25,7 @@ import { Tags, Warning } from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../shared/CopyButton';

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -28,13 +28,21 @@ import {
 } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
 import { makeErrorAttempt, makeProcessingAttempt } from 'shared/hooks/useAsync';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps, moreApps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { UrlResourcesParams } from 'teleport/config';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases, moreDatabases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops, moreDesktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { gitServers } from 'teleport/GitServers/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes, moreKubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { moreNodes, nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
 
 import { InfoGuidePanelProvider } from '../SlidingSidePanel/InfoGuide';

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -56,6 +56,7 @@ import {
 } from 'shared/hooks/useInfiniteScroll';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
 
 import { useInfoGuide } from '../SlidingSidePanel/InfoGuide';

--- a/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { App } from 'teleport/services/apps';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
 
 import { guessAppIcon } from './guessAppIcon';

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -23,7 +23,9 @@ import { ResourceIconName } from 'design/ResourceIcon';
 import { AppSubKind, NodeSubKind } from 'shared/services';
 import { DbProtocol } from 'shared/services/databases';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceLabel } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AppMCP, PermissionSet } from 'teleport/services/apps';
 
 // "mixed" indicates the resource has a mix of health

--- a/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
@@ -18,6 +18,7 @@
 
 import 'whatwg-fetch';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { Node } from 'teleport/services/nodes';
 
 /**

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
@@ -18,7 +18,9 @@
 
 import { act, renderHook } from '@testing-library/react';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ApiError } from 'teleport/services/api/parseError';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { Node } from 'teleport/services/nodes';
 
 import { newFetchFunc, resourceClusterIds, resourceNames } from './testUtils';

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -27,7 +27,9 @@ import {
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { isAbortError } from 'shared/utils/abortError';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ApiError } from 'teleport/services/api/parseError';
 
 /**

--- a/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
+++ b/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
@@ -251,9 +251,13 @@ const ReactSlider = createReactClass({
     this.tempArray = value.slice();
 
     for (var i = 0; i < value.length; i++) {
+      // Disabling since this is legacy code copied from some other library.
+      // eslint-disable-next-line react/no-direct-mutation-state
       this.state.value[i] = this._trimAlignValue(value[i], newProps);
     }
     if (this.state.value.length > value.length)
+      // Disabling since this is legacy code copied from some other library.
+      // eslint-disable-next-line react/no-direct-mutation-state
       this.state.value.length = value.length;
 
     // If an upperBound has not yet been determined (due to the component being hidden

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
@@ -36,6 +36,7 @@ import type { IconProps } from 'design/Icon/Icon';
 import Indicator from 'design/Indicator';
 import { MenuIcon } from 'shared/components/MenuAction';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 import type * as tsh from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';


### PR DESCRIPTION
This PR attempts to curb the amount of new cyclic imports between packages (#54872) by turning on an ESLint rule `no-restricted-imports` on specific directories. Existing issues are ignored through `eslint-disable-next-line`. This should to some extent prevent new imports from being added without having to deal with all existing issues first.

Mind you that this is a different problem than circular deps between files (#32940). That problem requires different stopgaps and solutions.

Here's how a violation of this rule looks like when running ESLint:

```
web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
  39:1  error  'teleport/components/formatters' import is restricted from being used by a pattern  no-restricted-imports
```

## What problem does this solve?

The dependency graph for JS packages should look somewhat like this:

<img alt="dependency graph" src="https://github.com/user-attachments/assets/abd05292-d8d9-4266-9173-d3af5433e548" width="256" />

However, we do have code in shared importing from teleport or code in teleterm importing from teleport.

### Why is it bad?

It's difficult to explain this succinctly. The most direct argument would be that it breaks several assumptions related to how JS packages work.

In the past, this prevented us from enabling TypeScript's strict mode in in the design package. When strict mode is enabled, every file in the package needs to adhere to it. The design package was a good first candidate for that as on paper it's a "leaf" dep imported by every other package.

But in practice the design package was importing some files from shared and teleport. If we wanted to keep it that way, those packages would need to adhere to strict mode too. So before strict mode was enabled in the design package (#47694, #47850), Grzegorz had to refactor the package to not import files from other packages (#47346, #47446).

An argument that's harder to illustrate is that it leads to bad software design and makes it harder to understand the responsibilities of individual packages, functions and files. Most of the practical problems typically introduced by those imports are currently salvaged by the fact that the Web UI and Connect get compiled to single JS files and do not extract any chunks.

#### Root cause of the issue

Looking at most of the existing violations of the new rule, the problem stems from the fact the Web UI doesn't have some sort of separate API layer. What follows is that a feature is created (e.g., unified resources or access requests) which depends on some values returned by the HTTP API from `lib/web`. So we create new TS types to reflect those API responses, typically in `web/packages/teleport/src/services`. The feature is then implemented in Connect by either moving the code to the shared package or copying some code to teleterm. But the feature implementation still operates on shapes returned by the web API and those are not moved to shared. So we end up with the shared package or teleterm imorting files from teleport.

If the API layer of the Web UI was organized differently, say by using protobufs, those TS types that need to be created could exist in `get/proto/ts` which is truly at the bottom of the dep graph and does not depend on any other packages.

## How does this PR address the problem?

Fixing all of the imports would take a lot of effort. This PR doesn't aim to fix any of them, but rather to curb the number of new imports being added. Without the new linter rule it's way to easy to add more of them without really noticing.

### Alternatives

Grzegorz had two good suggestions: TypeScript's project references or just disabling custom TS paths and importing packages in the form of `@gravitational/*` (see #54872). However, both of them require taking care of existing imports upfront.

## What if my code is caught by this rule?

If you end up importing some files from teleport in shared or teleterm, consider moving the imports to the shared package or the design package (depending on the use case). See [a recent example from unified resources](https://github.com/gravitational/teleport/pull/55306#discussion_r2126939706). If the values are imported by code in teleport.e, [a deprecated re-export can be left at the original location](https://github.com/gravitational/teleport/pull/55306/files#diff-07a57e99f8b8a80a642e632235bcf13012dad7d6177bd54d107ea3c968448a66R81-R86) to address teleport.e in [a separate PR](https://github.com/gravitational/teleport.e/pull/6658) without breaking the build.

If moving the imported values is not possible, consider duplicating them. As the last resort there's always the option of adding another `eslint-disable-next-line`, but I encourage you to consider other approaches first.