### PR TITLE
Fix database web UI connect dialog not allowing users to type/select database username

### DIFF
--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -349,25 +349,23 @@ type DatabaseInteractiveChecker interface {
 // MakeDatabase creates database objects.
 func MakeDatabase(database types.Database, accessChecker services.AccessChecker, interactiveChecker DatabaseInteractiveChecker, requiresRequest bool) Database {
 	var (
-		dbUsers []string
-		dbRoles []string
+		autoUserEnabled bool
+		dbUsers         []string
+		dbRoles         []string
 	)
 	dbNamesResult := accessChecker.EnumerateDatabaseNames(database)
-	dbNames := dbNamesResult.Allowed()
-	if dbNamesResult.WildcardAllowed() {
-		dbNames = append(dbNames, types.Wildcard)
-	}
+	dbNames, _ := dbNamesResult.ToEntities()
 	if res, err := accessChecker.EnumerateDatabaseUsers(database); err == nil {
-		dbUsers = res.Allowed()
-		if res.WildcardAllowed() {
-			dbUsers = append(dbUsers, types.Wildcard)
-		}
+		dbUsers, _ = res.ToEntities()
 	}
 	if roles, err := accessChecker.CheckDatabaseRoles(database, nil); err == nil {
 		// Avoid assigning empty slice to keep the resulting roles nil.
 		if len(roles) > 0 {
 			dbRoles = roles
 		}
+	}
+	if autoUser, err := accessChecker.DatabaseAutoUserMode(database); err == nil {
+		autoUserEnabled = database.IsAutoUsersEnabled() && autoUser.IsEnabled()
 	}
 
 	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(database.GetAllLabels())
@@ -386,7 +384,7 @@ func MakeDatabase(database types.Database, accessChecker services.AccessChecker,
 		URI:                 database.GetURI(),
 		RequiresRequest:     requiresRequest,
 		SupportsInteractive: interactiveChecker.IsSupported(database.GetProtocol()),
-		AutoUsersEnabled:    database.IsAutoUsersEnabled(),
+		AutoUsersEnabled:    autoUserEnabled,
 	}
 
 	if database.IsAWSHosted() {


### PR DESCRIPTION
When connecting to the PostgreSQL database using WebUI, the database users select on connect dialog was mistakenly disabled due to the auto-provisioning user flag being set:

<details>
<summary>Example of wrong UI being shown</summary>

![Screenshot 2025-06-06 at 12 05 01](https://github.com/user-attachments/assets/7c539625-33b4-4ff7-8af2-27316eae111f)
</details>

The issue was that the auto-provisioning flag didn't consider the user role, only the database config. This PR updates this logic, mimicking the `tsh` behavior.

<details>
<summary>UI after the fix</summary>

![Screenshot 2025-06-06 at 12 11 01](https://github.com/user-attachments/assets/549c4142-ee8a-46ff-9057-20081efcd69c)
</details>


changelog: Fixed database connect options dialog displaying wrong database username options.