### PR TITLE
[vnet] feat: serve DNS on IPv4

### DIFF
--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -75,12 +75,13 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 		return trace.Wrap(err, "reporting network stack info to client application")
 	}
 
-	osConfigProvider, err := newOSConfigProvider(
-		clt,
-		tunName,
-		networkStackConfig.ipv6Prefix.String(),
-		networkStackConfig.dnsIPv6.String(),
-	)
+	osConfigProvider, err := newOSConfigProvider(osConfigProviderConfig{
+		clt:           clt,
+		tunName:       tunName,
+		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
+		addDNSAddress: networkStack.addDNSAddress,
+	})
 	if err != nil {
 		return trace.Wrap(err, "creating OS config provider")
 	}

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -116,12 +116,13 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		return trace.Wrap(err, "reporting network stack info to client application")
 	}
 
-	osConfigProvider, err := newOSConfigProvider(
-		clt,
-		tunName,
-		networkStackConfig.ipv6Prefix.String(),
-		networkStackConfig.dnsIPv6.String(),
-	)
+	osConfigProvider, err := newOSConfigProvider(osConfigProviderConfig{
+		clt:           clt,
+		tunName:       tunName,
+		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
+		addDNSAddress: networkStack.addDNSAddress,
+	})
 	if err != nil {
 		return trace.Wrap(err, "creating OS config provider")
 	}

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -548,7 +548,7 @@ func (ns *networkStack) assignUDPHandler(addr tcpip.Address, handler udpHandler)
 	return nil
 }
 
-// addDNSAddress adds a DNS handler at the given ip.
+// addDNSAddress adds a DNS handler at the given IP.
 func (ns *networkStack) addDNSAddress(ip net.IP) error {
 	slog.DebugContext(context.Background(), "Serving DNS on IPv4.", "dns_addr", ip.String())
 	return trace.Wrap(ns.assignUDPHandler(tcpip.AddrFromSlice(ip), ns.dnsServer),

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"os/exec"
 	"strings"
@@ -32,7 +31,7 @@ type osConfig struct {
 	tunIPv4    string
 	tunIPv6    string
 	cidrRanges []string
-	dnsAddr    string
+	dnsAddrs   []string
 	dnsZones   []string
 }
 
@@ -123,20 +122,6 @@ func tunIPv6ForPrefix(ipv6Prefix string) (string, error) {
 		return "", trace.BadParameter("IPv6 prefix %s is not an IPv6 address", ipv6Prefix)
 	}
 	return addr.Next().String(), nil
-}
-
-// tunIPv4ForCIDR returns the IPv4 address to use for the TUN interface in
-// cidrRange. It always returns the second address in the range.
-func tunIPv4ForCIDR(cidrRange string) (string, error) {
-	_, ipnet, err := net.ParseCIDR(cidrRange)
-	if err != nil {
-		return "", trace.Wrap(err, "parsing CIDR %q", cidrRange)
-	}
-	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
-	// Add 1 to assign the TUN address, like 100.64.0.1
-	tunAddress := ipnet.IP
-	tunAddress[len(tunAddress)-1]++
-	return tunAddress.String(), nil
 }
 
 func runCommand(ctx context.Context, path string, args ...string) error {

--- a/lib/vnet/osconfig_provider.go
+++ b/lib/vnet/osconfig_provider.go
@@ -19,6 +19,7 @@ package vnet
 import (
 	"context"
 	"net"
+	"slices"
 
 	"github.com/gravitational/trace"
 
@@ -102,19 +103,19 @@ func (p *osConfigProvider) setV4IPsFromFirstCIDR(cidrRange string) error {
 
 // ipsForCIDR returns the V4 IPs to assign to the interface and use for DNS in
 // cidrRange.
-func ipsForCIDR(cidrRange string) (net.IP, net.IP, error) {
+func ipsForCIDR(cidrRange string) (tunIP net.IP, dnsIP net.IP, err error) {
 	_, ipnet, err := net.ParseCIDR(cidrRange)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "parsing CIDR %q", cidrRange)
 	}
 	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
 	// Add 1 to assign the TUN address, like 100.64.0.1
-	tunAddress := ipnet.IP
-	tunAddress[len(tunAddress)-1]++
+	tunIP = ipnet.IP
+	tunIP[len(tunIP)-1]++
 
 	// Add 1 again to assign the DNS address, like 100.64.0.2
-	dnsAddress := append(net.IP{}, tunAddress...)
-	dnsAddress[len(dnsAddress)-1]++
+	dnsIP = slices.Clone(tunIP)
+	dnsIP[len(dnsIP)-1]++
 
-	return tunAddress, dnsAddress, nil
+	return tunIP, dnsIP, nil
 }

--- a/lib/vnet/osconfig_provider_test.go
+++ b/lib/vnet/osconfig_provider_test.go
@@ -50,7 +50,7 @@ func TestOSConfigProvider(t *testing.T) {
 				tunName: "testtun1",
 				// Should be the first non-broadcast address under the IPv6 prefix.
 				tunIPv6:  "fd01:2345:6789::1",
-				dnsAddr:  "fd01:2345:6789::2",
+				dnsAddrs: []string{"fd01:2345:6789::2"},
 				dnsZones: []string{"test.example.com"},
 			},
 		},
@@ -64,9 +64,10 @@ func TestOSConfigProvider(t *testing.T) {
 			expectTargetOSConfig: &osConfig{
 				tunName: "testtun1",
 				// Should be the first non-broadcast address in the CIDR range.
-				tunIPv4:    "192.168.1.1",
-				tunIPv6:    "fd01:2345:6789::1",
-				dnsAddr:    "fd01:2345:6789::2",
+				tunIPv4: "192.168.1.1",
+				tunIPv6: "fd01:2345:6789::1",
+				// Should include the second non-broadcast address in the CIDR range.
+				dnsAddrs:   []string{"fd01:2345:6789::2", "192.168.1.2"},
 				dnsZones:   []string{"test.example.com"},
 				cidrRanges: []string{"192.168.1.0/24"},
 			},
@@ -83,7 +84,7 @@ func TestOSConfigProvider(t *testing.T) {
 				// Should be chosen from the first CIDR range.
 				tunIPv4:    "10.64.0.1",
 				tunIPv6:    "fd01:2345:6789::1",
-				dnsAddr:    "fd01:2345:6789::2",
+				dnsAddrs:   []string{"fd01:2345:6789::2", "10.64.0.2"},
 				dnsZones:   []string{"test.example.com"},
 				cidrRanges: []string{"10.64.0.0/16", "192.168.1.0/24"},
 			},

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -44,4 +44,5 @@ var (
 	_ = (*osConfigurator).runOSConfigurationLoop
 	_ = runCommand
 	_ = newNetworkStackConfig
+	_ = (*networkStack).addDNSAddress
 )


### PR DESCRIPTION
This PR makes VNet configure a DNS server on an IPv4 address to support clients where IPv6 is blocked. It does this by configuring an additional nameserver in the OS when VNet first assigns itself an IPv4 address once the user logs in to a cluster and we find the IPv4 CIDR range for the cluster.

Because the V4 DNS address is assigned dynamically, I updated the virtual network stack to handle DNS on UDP port 53 no matter which address it receives the request from.

changelog: Made VNet DNS available over IPv4