### PR TITLE
Fix 18 Vale warnings and 1 error

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-requests/automatic-reviews.mdx
+++ b/docs/pages/admin-guides/access-controls/access-requests/automatic-reviews.mdx
@@ -138,7 +138,7 @@ Automatic review rules can automatically approve or deny Access Requests based
 on the selected review decision. If an Access Request meets the conditions for
 both an approval rule and a denial rule, the denial rule takes precedence.
 
-### Resource access requests
+### Resource Access Requests
 
 Automatic review rules are not currently supported for resource Access Requests.
 These rules will not be applied to any Access Requests that include a resource

--- a/docs/pages/admin-guides/deploy-a-cluster/access-graph/identity-activity-center.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/access-graph/identity-activity-center.mdx
@@ -21,11 +21,11 @@ that's responsible for consuming messages from the queue, converting and enhanci
 them with metadata such as location, and writing them as Parquet files in the
 long-term S3 bucket.
 
-AWS Athena powers a query engine in the Identity Activity Center.
-To specify the schema and retrieve data from Parquet files kept in the
-long-term S3 bucket, AWS Athena makes use of an AWS Glue Table. With this
-configuration, audit logs can be efficiently queried and analyzed, leading
-to improved insights and simplified data management for identity security.
+Amazon Athena powers a query engine in the Identity Activity Center. To specify
+the schema and retrieve data from Parquet files kept in the long-term S3 bucket,
+Amazon Athena makes use of an AWS Glue Table. With this configuration, audit
+logs can be efficiently queried and analyzed, leading to improved insights and
+simplified data management for identity security.
 
 ## Prerequisites
 - A running Teleport Enterprise cluster v18.0.0 or later.
@@ -67,7 +67,7 @@ which are necessary for the Terraform script to execute.
 - <Var name="example-transient-bucket"/> is the transient S3 bucket used to store temporary files such as query results and large files.
 - <Var name="example-db"/> is the name of the AWS Glue database.
 - <Var name="example-table"/> is the name of the AWS Glue table.
-- <Var name="example-workgroup"/> is the name of the AWS Athena Workgroup.
+- <Var name="example-workgroup"/> is the name of the Amazon Athena Workgroup.
 - <Var name="aws-account-id"/> is the AWS account id.
 
 Define the variables using the script below or configure them in your
@@ -124,7 +124,7 @@ The Terraform script will output two variables:
 
 </details>
 
-##  Step 2/4. Configure MaxMind GeoIP City database (optional)
+## Step 2/4. Configure MaxMind GeoIP City database (optional)
 
 <Admonition type="note">
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -5,6 +5,8 @@ description: How to install and configure Teleport on IBM cloud
 
 This guide describes how to set up Teleport on IBM Cloud.
 
+## How it works
+
 We will use the following services to deploy Teleport on IBM cloud:
 - [Compute: IBM Cloud Kubernetes Service](https://www.ibm.com/products/kubernetes-service)
   to deploy Teleport using the [`teleport-cluster` Helm chart](../../../reference/helm-reference/teleport-cluster.mdx)
@@ -14,7 +16,6 @@ We will use the following services to deploy Teleport on IBM cloud:
 - [Storage: IBM Cloud Object Storage](https://www.ibm.com/products/cloud-object-storage) to store the Teleport
   session recordings.
 - [Network: IBM Cloud DNS Services](https://www.ibm.com/products/dns) to route Teleport
-
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -6,6 +6,8 @@ description: This guide shows you how to deploy Teleport on a Kubernetes cluster
 Teleport can provide secure, unified access to your Kubernetes clusters. This
 guide will show you how to deploy Teleport on a Kubernetes cluster using Helm.
 
+## How it works
+
 While completing this guide, you will deploy one Teleport pod each for the Auth
 Service and Proxy Service in your Kubernetes cluster, and a load balancer that
 forwards outside traffic to your Teleport cluster. Users can then access your

--- a/docs/pages/admin-guides/management/admin/labels.mdx
+++ b/docs/pages/admin-guides/management/admin/labels.mdx
@@ -310,18 +310,19 @@ corresponding `server_info` resource.
 
 To add resource-based labels first get the SSH server details.
 
-1. Retrieve the SSH server that you wish to apply labels to.
+1. Retrieve the SSH server that you wish to apply labels to. Assign <Var
+   name="node_name" /> to the name of the SSH server:
 
-```code
-$ tctl get node/<Var name="foo" />
-kind: node
-metadata:
-  expires: "2024-01-12T00:41:17.355013266Z"
-  name: 116b08d2-7167-4eab-85a8-cf93f054b217
-spec:
-  addr: 127.0.0.1:3022
-  hostname: foo
-```
+   ```code
+   $ tctl get node/<Var name="node_name" />
+   kind: node
+   metadata:
+     expires: "2024-01-12T00:41:17.355013266Z"
+     name: 116b08d2-7167-4eab-85a8-cf93f054b217
+   spec:
+     addr: 127.0.0.1:3022
+     hostname: foo
+   ```
 
 1. Create the corresponding `server_info.yaml` for the node above.
 

--- a/docs/pages/admin-guides/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/admin-guides/management/export-audit-events/fluentd.mdx
@@ -11,8 +11,14 @@ guide, we will:
 - Forward events with Fluentd.
 
 This guide also serves as an explanation for the Teleport Event Handler plugin,
-using Fluentd as the target service. We'll create a local Docker container as a
-destination for the Event Handler:
+using Fluentd as the target service. 
+
+## How it works
+
+The Teleport event handler runs alongside the Fluentd forwarder, receives events
+from Teleport's events API, and forwards them to Fluentd.
+
+We'll create a local Docker container as a destination for the Event Handler:
 
 ![The Teleport Fluentd plugin](../../../../img/enterprise/plugins/fluentd-diagram.png)
 
@@ -40,9 +46,6 @@ to integrate with your infrastructure.
   ```
 
 ## Step 1/6. Install the event handler plugin
-
-The Teleport event handler runs alongside the Fluentd forwarder, receives events
-from Teleport's events API, and forwards them to Fluentd.
 
 (!docs/pages/includes/install-event-handler.mdx!)
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/github.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/github.mdx
@@ -58,7 +58,7 @@ file download. Save the file for later. Also copy the **Client ID** displayed in
 the App's **About** section.
 
 To restrict access to specific IPs, you can configure the **IP allow list** section
-to allow access only from the Teleport Auth server’s IP addresses.
+to allow access only from the Teleport Auth Service’s IP addresses.
 
 Finally, select **Install App** and install the application into the desired organization.
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/teleport.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/teleport.mdx
@@ -46,8 +46,9 @@ Please select the deployment mode used to deploy your cluster.
 <Tabs>
 <TabItem label="Self-hosted cluster">
 
-When running a self-hosted cluster, edit each one of your Teleport Auth Server's configuration file,
-by default `/etc/teleport.yaml`, and merge the following YAML snippet:
+When running a self-hosted cluster, edit each one of your Teleport Auth Service
+instances' configuration files, by default `/etc/teleport.yaml`, and merge the
+following YAML snippet:
 
 ```yaml
 access_graph:
@@ -64,7 +65,7 @@ access_graph:
 
 ```
 
-Once completed, please restart your Teleport Auth Server with:
+Once completed, restart your Teleport Auth Service with:
 
 ```bash
 $ sudo systemctl restart teleport

--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -14,6 +14,13 @@ behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
 For other methods of joining a Teleport process to a cluster, see [Joining
 Teleport Services to a Cluster](agents.mdx).
 
+## How it works
+
+Under the hood, Teleport processes prove that they are running in your Azure
+subscription by sending a signed attested data document and access token to the
+Teleport Auth Service. The VM's identity must match an allow rule configured in
+your Azure joining token.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -34,11 +41,6 @@ look up the virtual machine. No other permissions are required.
 (!docs/pages/includes/server-access/azure-join-managed-identity.mdx!)
 
 ## Step 2/5. Create the Azure joining token
-
-Under the hood, Teleport processes will prove that they are running in your
-Azure subscription by sending a signed attested data document and access token
-to the Teleport Auth Service. The VM's identity must match an allow rule
-configured in your Azure joining token.
 
 Create the following `token.yaml` with an `allow` rule specifying your Azure
 subscription and the resource group that your VM's identity must match.

--- a/docs/pages/enroll-resources/agents/gcp.mdx
+++ b/docs/pages/enroll-resources/agents/gcp.mdx
@@ -7,11 +7,17 @@ This guide will explain how to use the **GCP join method** to configure Teleport
 processes to join your Teleport cluster without sharing any secrets when they
 are running in a GCP VM.
 
+## How it works
+
 The GCP join method is available to any Teleport process running on a GCP VM.
 The VM must have a
 [service account](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
 assigned to it (the default service account is fine). No IAM roles are required
 on the Teleport process joining the cluster.
+
+Under the hood, services prove that they are running in your GCP project by
+sending a signed ID token which matches an allow rule configured in your GCP
+joining token.
 
 ## Prerequisites
 
@@ -25,10 +31,6 @@ on the Teleport process joining the cluster.
 
 Configure your Teleport Auth Service with a special dynamic token which will
 allow services from your GCP projects to join your Teleport cluster.
-
-Under the hood, services will prove that they are running in your GCP project
-by sending a signed ID token which matches an allow rule configured in your GCP
-joining token.
 
 Create the following `token.yaml` file with a `gcp.allow` rule specifying your GCP
 project ID(s), service account(s), and location(s) in which your GCP instances

--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -7,8 +7,14 @@ This guide will explain how to use the **Oracle join method** to configure
 Teleport processes to join your Teleport cluster without sharing any secrets
 when they are running in an Oracle Cloud Infrastructure (OCI) Compute instance.
 
+## How it works
+
 The Oracle join method is available to any Teleport process running on an
 OCI Compute instance.
+
+Under the hood, services prove that they are running in your OCI tenant by
+sending a presigned self-authentication request to the OCI API for the Auth
+Service to execute.
 
 ## Prerequisites
 
@@ -21,10 +27,6 @@ OCI Compute instance.
 
 Configure your Teleport Auth Service with a special dynamic token which will
 allow services from your OCI tenants to join your Teleport cluster.
-
-Under the hood, services will prove that they are running in your OCI
-tenant by sending a presigned self-authentication request to the OCI API
-for the Auth Service to execute.
 
 Create the following `token.yaml` file with an `oracle.allow` rule specifying
 the Oracle tenant(s), compartment(s), and region(s) in which your OCI

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -3,6 +3,11 @@ title: Automatically Discover Azure Virtual Machines
 description: How to configure Teleport to automatically enroll Azure virtual machines.
 ---
 
+This guide shows you how to set up automatic server discovery for Azure virtual
+machines.
+
+## How it works
+
 The Teleport Discovery Service can connect to Azure and automatically
 discover and enroll virtual machines matching configured labels. It will then
 execute a script on these discovered instances that will install Teleport,

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -3,6 +3,11 @@ title: Automatically Discover GCP Compute Instances
 description: How to configure Teleport to automatically enroll GCP compute instances.
 ---
 
+This guide shows you how to set up automatic server discovery for Google Compute
+Engine virtual machines.
+
+## How it works
+
 The Teleport Discovery Service can connect to GCP and automatically
 discover and enroll GCP Compute Engine instances matching configured labels. It will then
 execute a script on these discovered instances that will install Teleport,

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -15,6 +15,17 @@ In this guide, we will show you how to set up dynamic Kubernetes cluster
 registration, then create, list, update, and delete Kubernetes clusters via
 `tctl`.
 
+## How it works
+
+The Teleport Kubernetes Service proxies traffic from Teleport users to a
+Kubernetes API server so you can take advantage of passwordless authentication,
+role-based access controls, audit logging, and other Teleport features in order
+to manage access to Kubernetes. 
+
+In this step, you will install the Teleport Kubernetes Service on a Linux host
+and configure it to access any Kubernetes cluster you register with your
+Teleport cluster. 
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -36,14 +47,8 @@ registration, then create, list, update, and delete Kubernetes clusters via
 
 ## Step 1/3. Set up the Teleport Kubernetes Service
 
-The Teleport Kubernetes Service proxies traffic from Teleport users to a
-Kubernetes API server so you can take advantage of passwordless authentication,
-role-based access controls, audit logging, and other Teleport features in order
-to manage access to Kubernetes. 
-
-In this step, you will install the Teleport Kubernetes Service on a Linux host
-and configure it to access any Kubernetes cluster you register with your
-Teleport cluster. 
+This step shows you how to install the Teleport Kubernetes Service on a Linux
+server.
 
 ### Get a join token
 

--- a/docs/pages/enroll-resources/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/workload-identity/getting-started.mdx
@@ -8,6 +8,8 @@ for workloads. It is compatible with the industry-standard SPIFFE specification
 meaning that it can be used in place of other SPIFFE compatible identity
 providers.
 
+## How it works
+
 In this guide, you'll configure the RBAC necessary to allow a Bot to issue
 workload identity credentials and then configure `tbot` to expose a SPIFFE
 Workload API endpoint. You can then connect your workloads to this endpoint to


### PR DESCRIPTION
- Fix an error related to a malformed "Step" heading.
- Fix warnings related to messaging and capitalization.
- Fix a `Var` with a single instance.
- Add "How it works" H2s to how-to guides that already include architectural information, but not the expected heading.