### PR TITLE
Fix example Access Request plugin values files

### DIFF
--- a/examples/resources/plugins/teleport-discord-helm.yaml
+++ b/examples/resources/plugins/teleport-discord-helm.yaml
@@ -10,7 +10,7 @@ discord:
   token: "XXXXXXXX"  # Discord Bot OAuth token
 
 # Mapping from role to recipients
-roleToRecipients: []
+roleToRecipients: {}
 #  "*":
 #    - "1234567890"  # security-team
 #  "dev":

--- a/examples/resources/plugins/teleport-msteams-helm.yaml
+++ b/examples/resources/plugins/teleport-msteams-helm.yaml
@@ -15,9 +15,11 @@ msTeams:
   tenantID: "TENANT_ID"
   teamsAppID: "TEAMS_APP_ID"
 
-roleToRecipients:
-  "*": "TELEPORT_USERNAME"
-  "editor": "TELEPORT_USERNAME"
+roleToRecipients: {}
+  # "*": "admin@example.com"
+  # dev:
+  #  - "https://teams.microsoft.com/l/channel/19%3ae06a7383ed98468f90217a35fa1980d7%40thread.tacv2/Approval%2520Channel%25202?groupId=f2b3c8ed-5502-4449-b76f-dc3acea81f1c&tenantId=ff882432-09b0-437b-bd22-ca13c0037ded"
+  #  - "devops@example.com"
 
 log:
   output: stdout

--- a/examples/resources/plugins/teleport-slack-helm.yaml
+++ b/examples/resources/plugins/teleport-slack-helm.yaml
@@ -10,6 +10,6 @@ slack:
   token: "xoxb-11xx"  # Slack Bot OAuth token
 
 # Mapping from role to recipients
-roleToRecipients: []
+roleToRecipients: {}
   # "dev": "devs-slack-channel"
   # "*": ["admin@email.com", "admin-slack-channel"]


### PR DESCRIPTION
Closes #55257

- Change some `roleToRecipients` field values from an empty `[]` to an empty `{}`, since the value is a mapping instead of a list.

- In the example values file for the MS Teams plugin chart, use less ambiguous example values for `roleToRecipients`.