### PR TITLE
[v18] Teleport Connect: Support requiring reason and custom reason prompts

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/access_request.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/access_request.pb.go
@@ -71,7 +71,13 @@ type AccessRequest struct {
 	// approval).
 	RequestTtl *timestamppb.Timestamp `protobuf:"bytes,17,opt,name=request_ttl,json=requestTtl,proto3" json:"request_ttl,omitempty"`
 	// session_ttl indicates how long a certificate for a session should be valid for.
-	SessionTtl    *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=session_ttl,json=sessionTtl,proto3" json:"session_ttl,omitempty"`
+	SessionTtl *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=session_ttl,json=sessionTtl,proto3" json:"session_ttl,omitempty"`
+	// reason_mode specifies the reason mode for this Access Request. It can be either "optional" or
+	// "required". It's only added in response to a dry run request.
+	ReasonMode string `protobuf:"bytes,19,opt,name=reason_mode,json=reasonMode,proto3" json:"reason_mode,omitempty"`
+	// reason_prompts is a sorted and deduplicated list of reason prompts for this Access Request.
+	// It's only added in response to a dry run request.
+	ReasonPrompts []string `protobuf:"bytes,20,rep,name=reason_prompts,json=reasonPrompts,proto3" json:"reason_prompts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -228,6 +234,20 @@ func (x *AccessRequest) GetRequestTtl() *timestamppb.Timestamp {
 func (x *AccessRequest) GetSessionTtl() *timestamppb.Timestamp {
 	if x != nil {
 		return x.SessionTtl
+	}
+	return nil
+}
+
+func (x *AccessRequest) GetReasonMode() string {
+	if x != nil {
+		return x.ReasonMode
+	}
+	return ""
+}
+
+func (x *AccessRequest) GetReasonPrompts() []string {
+	if x != nil {
+		return x.ReasonPrompts
 	}
 	return nil
 }
@@ -508,7 +528,7 @@ var File_teleport_lib_teleterm_v1_access_request_proto protoreflect.FileDescript
 
 const file_teleport_lib_teleterm_v1_access_request_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/lib/teleterm/v1/access_request.proto\x12\x18teleport.lib.teleterm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x85\a\n" +
+	"-teleport/lib/teleterm/v1/access_request.proto\x12\x18teleport.lib.teleterm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xcd\a\n" +
 	"\rAccessRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12%\n" +
@@ -530,7 +550,10 @@ const file_teleport_lib_teleterm_v1_access_request_proto_rawDesc = "" +
 	"\vrequest_ttl\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"requestTtl\x12;\n" +
 	"\vsession_ttl\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"sessionTtl\"\xac\x02\n" +
+	"sessionTtl\x12\x1f\n" +
+	"\vreason_mode\x18\x13 \x01(\tR\n" +
+	"reasonMode\x12%\n" +
+	"\x0ereason_prompts\x18\x14 \x03(\tR\rreasonPrompts\"\xac\x02\n" +
 	"\x13AccessRequestReview\x12\x16\n" +
 	"\x06author\x18\x01 \x01(\tR\x06author\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x14\n" +

--- a/gen/proto/ts/teleport/lib/teleterm/v1/access_request_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/access_request_pb.ts
@@ -130,6 +130,20 @@ export interface AccessRequest {
      * @generated from protobuf field: google.protobuf.Timestamp session_ttl = 18;
      */
     sessionTtl?: Timestamp;
+    /**
+     * reason_mode specifies the reason mode for this Access Request. It can be either "optional" or
+     * "required". It's only added in response to a dry run request.
+     *
+     * @generated from protobuf field: string reason_mode = 19;
+     */
+    reasonMode: string;
+    /**
+     * reason_prompts is a sorted and deduplicated list of reason prompts for this Access Request.
+     * It's only added in response to a dry run request.
+     *
+     * @generated from protobuf field: repeated string reason_prompts = 20;
+     */
+    reasonPrompts: string[];
 }
 /**
  * @generated from protobuf message teleport.lib.teleterm.v1.AccessRequestReview
@@ -246,7 +260,9 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
             { no: 15, name: "assume_start_time", kind: "message", T: () => Timestamp },
             { no: 16, name: "max_duration", kind: "message", T: () => Timestamp },
             { no: 17, name: "request_ttl", kind: "message", T: () => Timestamp },
-            { no: 18, name: "session_ttl", kind: "message", T: () => Timestamp }
+            { no: 18, name: "session_ttl", kind: "message", T: () => Timestamp },
+            { no: 19, name: "reason_mode", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 20, name: "reason_prompts", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessRequest>): AccessRequest {
@@ -263,6 +279,8 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
         message.resourceIds = [];
         message.resources = [];
         message.promotedAccessListTitle = "";
+        message.reasonMode = "";
+        message.reasonPrompts = [];
         if (value !== undefined)
             reflectionMergePartial<AccessRequest>(this, message, value);
         return message;
@@ -325,6 +343,12 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
                     break;
                 case /* google.protobuf.Timestamp session_ttl */ 18:
                     message.sessionTtl = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.sessionTtl);
+                    break;
+                case /* string reason_mode */ 19:
+                    message.reasonMode = reader.string();
+                    break;
+                case /* repeated string reason_prompts */ 20:
+                    message.reasonPrompts.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -392,6 +416,12 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
         /* google.protobuf.Timestamp session_ttl = 18; */
         if (message.sessionTtl)
             Timestamp.internalBinaryWrite(message.sessionTtl, writer.tag(18, WireType.LengthDelimited).fork(), options).join();
+        /* string reason_mode = 19; */
+        if (message.reasonMode !== "")
+            writer.tag(19, WireType.LengthDelimited).string(message.reasonMode);
+        /* repeated string reason_prompts = 20; */
+        for (let i = 0; i < message.reasonPrompts.length; i++)
+            writer.tag(20, WireType.LengthDelimited).string(message.reasonPrompts[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/apiserver/handler/handler_access_requests.go
+++ b/lib/teleterm/apiserver/handler/handler_access_requests.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
 	accesslistv1conv "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -200,6 +201,11 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 		}
 	}
 
+	dryRunEnrichment := req.GetDryRunEnrichment()
+	if dryRunEnrichment == nil {
+		dryRunEnrichment = &types.AccessRequestDryRunEnrichment{}
+	}
+
 	return &api.AccessRequest{
 		Id:                      req.GetName(),
 		State:                   req.GetState().String(),
@@ -219,6 +225,8 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 		MaxDuration:             timestamppb.New(req.GetMaxDuration()),
 		RequestTtl:              timestamppb.New(req.Expiry()),
 		SessionTtl:              timestamppb.New(req.GetSessionTLL()),
+		ReasonMode:              string(dryRunEnrichment.ReasonMode),
+		ReasonPrompts:           dryRunEnrichment.ReasonPrompts,
 	}
 }
 

--- a/proto/teleport/lib/teleterm/v1/access_request.proto
+++ b/proto/teleport/lib/teleterm/v1/access_request.proto
@@ -56,6 +56,12 @@ message AccessRequest {
   google.protobuf.Timestamp request_ttl = 17;
   // session_ttl indicates how long a certificate for a session should be valid for.
   google.protobuf.Timestamp session_ttl = 18;
+  // reason_mode specifies the reason mode for this Access Request. It can be either "optional" or
+  // "required". It's only added in response to a dry run request.
+  string reason_mode = 19;
+  // reason_prompts is a sorted and deduplicated list of reason prompts for this Access Request.
+  // It's only added in response to a dry run request.
+  repeated string reason_prompts = 20;
 }
 
 message AccessRequestReview {

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -366,6 +366,8 @@ export const makeAccessRequest = (
   maxDuration: { seconds: 1729026573n, nanos: 0 },
   requestTtl: { seconds: 1729026573n, nanos: 0 },
   sessionTtl: { seconds: 1729026573n, nanos: 0 },
+  reasonMode: 'optional',
+  reasonPrompts: [],
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -102,6 +102,7 @@ export function AccessRequestCheckout() {
     onStartTimeChange,
     fetchKubeNamespaces,
     updateNamespacesForKubeCluster,
+    reasonMode,
     reasonPrompts,
   } = useAccessRequestCheckout();
 
@@ -269,7 +270,6 @@ export function AccessRequestCheckout() {
             clearAttempt={clearCreateAttempt}
             selectedReviewers={selectedReviewers}
             setSelectedReviewers={setSelectedReviewers}
-            requireReason={false}
             numRequestedResources={requestedCount}
             isResourceRequest={!isRoleRequest}
             fetchStatus={'loaded'}
@@ -284,6 +284,7 @@ export function AccessRequestCheckout() {
             onStartTimeChange={onStartTimeChange}
             fetchKubeNamespaces={fetchKubeNamespaces}
             updateNamespacesForKubeCluster={updateNamespacesForKubeCluster}
+            requireReason={reasonMode === 'required'}
             reasonPrompts={reasonPrompts}
           />
         )}

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
@@ -79,6 +79,8 @@ const mockedAccessRequest: AccessRequest = {
   maxDuration: { seconds: 1729026573n, nanos: 0 },
   requestTtl: { seconds: 1729026573n, nanos: 0 },
   sessionTtl: { seconds: 1729026573n, nanos: 0 },
+  reasonMode: 'optional',
+  reasonPrompts: [],
 };
 
 export function Browsing() {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
@@ -89,6 +89,8 @@ test('makeUiAccessRequest', async () => {
       seconds: 1709853650n,
       nanos: 520000000,
     },
+    reasonMode: 'optional',
+    reasonPrompts: [],
   };
 
   const processedRequest: AccessRequest = {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -104,6 +104,8 @@ export function makeUiAccessRequest(request: TshdAccessRequest) {
     suggestedReviewers: request.suggestedReviewers,
     thresholdNames: request.thresholdNames,
     resources: request.resources,
+    reasonMode: request.reasonMode || 'optional',
+    reasonPrompts: request.reasonPrompts,
   });
 }
 


### PR DESCRIPTION
Backport #55092 to branch/v18

changelog: Teleport Connect: Add support for custom reason prompts.