### PR TITLE
[v17] Fix database web UI connect dialog not allowing users to type/select database username

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1018,12 +1018,56 @@ func (result *EnumerationResult) WildcardDenied() bool {
 	return result.wildcardDenied
 }
 
+// ToEntities converts result back to allowed and denied entity slices.
+//
+// If wildcard is denied, only "*" is returned for the denied slice.
+// If wildcard is allowed, allowed entities will be appended to the allowed
+// slice after the "*" as a hint for users to select.
+// Denied entities is only included if the wildcard is allowed.
+func (result *EnumerationResult) ToEntities() (allowed, denied []string) {
+	if result.wildcardDenied {
+		return nil, []string{types.Wildcard}
+	}
+	if result.wildcardAllowed {
+		return append([]string{types.Wildcard}, result.Allowed()...), result.Denied()
+	}
+	return result.Allowed(), nil
+}
+
 // NewEnumerationResult returns new EnumerationResult.
 func NewEnumerationResult() EnumerationResult {
 	return EnumerationResult{
 		allowedDeniedMap: map[string]bool{},
 		wildcardAllowed:  false,
 		wildcardDenied:   false,
+	}
+}
+
+// NewEnumerationResultFromEntities creates a new EnumerationResult and
+// populates the result with provided allowed and denied entries.
+func NewEnumerationResultFromEntities(allowed, denied []string) EnumerationResult {
+	var wildcardAllowed bool
+	var wildcardDenied bool
+	allowedDeniedMap := make(map[string]bool)
+	for _, allow := range allowed {
+		if allow == types.Wildcard {
+			wildcardAllowed = true
+		} else {
+			allowedDeniedMap[allow] = true
+		}
+	}
+	for _, deny := range denied {
+		if deny == types.Wildcard {
+			wildcardDenied = true
+			wildcardAllowed = false
+			break
+		}
+		allowedDeniedMap[deny] = false
+	}
+	return EnumerationResult{
+		allowedDeniedMap: allowedDeniedMap,
+		wildcardAllowed:  wildcardAllowed,
+		wildcardDenied:   wildcardDenied,
 	}
 }
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -9739,3 +9739,46 @@ func TestCheckAccessToGitServer(t *testing.T) {
 		})
 	}
 }
+
+func TestNewEnumerationResultFromEntities(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputAllowed []string
+		inputDenied  []string
+		wantAllowed  []string
+		wantDenied   []string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:         "wildcard denied",
+			inputAllowed: []string{"allow_entry"},
+			inputDenied:  []string{"deny_entry", "*"},
+			wantDenied:   []string{"*"},
+		},
+		{
+			name:         "wildcard allowed",
+			inputAllowed: []string{"allow_entry", "*", "deny_overwrite"},
+			inputDenied:  []string{"deny_overwrite"},
+			wantAllowed:  []string{"*", "allow_entry"},
+			wantDenied:   []string{"deny_overwrite"},
+		},
+		{
+			name:         "no wildcard",
+			inputAllowed: []string{"allow_entry_1", "deny_overwrite", "allow_entry_2"},
+			inputDenied:  []string{"deny_overwrite", "deny_entry"},
+			wantAllowed:  []string{"allow_entry_1", "allow_entry_2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := NewEnumerationResultFromEntities(test.inputAllowed, test.inputDenied)
+
+			actualAllowed, actualDenied := result.ToEntities()
+			require.Equal(t, test.wantAllowed, actualAllowed)
+			require.Equal(t, test.wantDenied, actualDenied)
+		})
+	}
+}

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -339,25 +339,23 @@ type DatabaseInteractiveChecker interface {
 // MakeDatabase creates database objects.
 func MakeDatabase(database types.Database, accessChecker services.AccessChecker, interactiveChecker DatabaseInteractiveChecker, requiresRequest bool) Database {
 	var (
-		dbUsers []string
-		dbRoles []string
+		autoUserEnabled bool
+		dbUsers         []string
+		dbRoles         []string
 	)
 	dbNamesResult := accessChecker.EnumerateDatabaseNames(database)
-	dbNames := dbNamesResult.Allowed()
-	if dbNamesResult.WildcardAllowed() {
-		dbNames = append(dbNames, types.Wildcard)
-	}
+	dbNames, _ := dbNamesResult.ToEntities()
 	if res, err := accessChecker.EnumerateDatabaseUsers(database); err == nil {
-		dbUsers = res.Allowed()
-		if res.WildcardAllowed() {
-			dbUsers = append(dbUsers, types.Wildcard)
-		}
+		dbUsers, _ = res.ToEntities()
 	}
 	if roles, err := accessChecker.CheckDatabaseRoles(database, nil); err == nil {
 		// Avoid assigning empty slice to keep the resulting roles nil.
 		if len(roles) > 0 {
 			dbRoles = roles
 		}
+	}
+	if autoUser, err := accessChecker.DatabaseAutoUserMode(database); err == nil {
+		autoUserEnabled = database.IsAutoUsersEnabled() && autoUser.IsEnabled()
 	}
 
 	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(database.GetAllLabels())
@@ -376,7 +374,7 @@ func MakeDatabase(database types.Database, accessChecker services.AccessChecker,
 		URI:                 database.GetURI(),
 		RequiresRequest:     requiresRequest,
 		SupportsInteractive: interactiveChecker.IsSupported(database.GetProtocol()),
-		AutoUsersEnabled:    database.IsAutoUsersEnabled(),
+		AutoUsersEnabled:    autoUserEnabled,
 	}
 
 	if database.IsAWSHosted() {


### PR DESCRIPTION
Backport #55532 (and some helper functions from #55292) to branch/v17

changelog: Fixed database connect options dialog displaying wrong database username options.
