### PR TITLE
audit: optimize JSON marshaling operations when reading unstructured events

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5901,7 +5901,10 @@ func (a *ServerWithRoles) SearchUnstructuredEvents(ctx context.Context, req even
 	}
 
 	outEvents, lastKey, err = a.alog.SearchUnstructuredEvents(ctx, req)
-	return outEvents, lastKey, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return outEvents, lastKey, nil
 }
 
 // ExportUnstructuredEvents exports events from a given event chunk returned by GetEventExportChunks. This API prioritizes

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5894,6 +5894,16 @@ func (a *ServerWithRoles) SearchEvents(ctx context.Context, req events.SearchEve
 	return outEvents, lastKey, nil
 }
 
+// SearchUnstructuredEvents allows searching for unstructured audit events with pagination support.
+func (a *ServerWithRoles) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) (outEvents []*auditlogpb.EventUnstructured, lastKey string, err error) {
+	if err := a.action(types.KindEvent, types.VerbList); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	outEvents, lastKey, err = a.alog.SearchUnstructuredEvents(ctx, req)
+	return outEvents, lastKey, trace.Wrap(err)
+}
+
 // ExportUnstructuredEvents exports events from a given event chunk returned by GetEventExportChunks. This API prioritizes
 // performance over ordering and filtering, and is intended for bulk export of events.
 func (a *ServerWithRoles) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -370,7 +370,10 @@ func (c *Client) SearchUnstructuredEvents(ctx context.Context, req events.Search
 		req.Order,
 		req.StartKey,
 	)
-	return events, lastKey, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return events, lastKey, nil
 }
 
 // UpsertClusterName not implemented: can only be called locally.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/client/usertask"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
+	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -355,6 +356,21 @@ func (c *Client) SearchSessionEvents(ctx context.Context, req events.SearchSessi
 	}
 
 	return events, lastKey, nil
+}
+
+// SearchUnstructuredEvents allows searching for audit events with pagination support and returns unstructured events.
+func (c *Client) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	events, lastKey, err := c.APIClient.SearchUnstructuredEvents(
+		ctx,
+		req.From,
+		req.To,
+		apidefaults.Namespace,
+		req.EventTypes,
+		req.Limit,
+		req.Order,
+		req.StartKey,
+	)
+	return events, lastKey, trace.Wrap(err)
 }
 
 // UpsertClusterName not implemented: can only be called locally.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5767,30 +5767,23 @@ func (g *GRPCServer) GetUnstructuredEvents(ctx context.Context, req *auditlogpb.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	rawEvents, lastkey, err := auth.ServerWithRoles.SearchEvents(ctx, events.SearchEventsRequest{
-		From:       req.StartDate.AsTime(),
-		To:         req.EndDate.AsTime(),
-		EventTypes: req.EventTypes,
-		Limit:      int(req.Limit),
-		Order:      types.EventOrder(req.Order),
-		StartKey:   req.StartKey,
-	})
+	rawEvents, lastkey, err := auth.ServerWithRoles.SearchUnstructuredEvents(
+		ctx,
+		events.SearchEventsRequest{
+			From:       req.StartDate.AsTime(),
+			To:         req.EndDate.AsTime(),
+			EventTypes: req.EventTypes,
+			Limit:      int(req.Limit),
+			Order:      types.EventOrder(req.Order),
+			StartKey:   req.StartKey,
+		},
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	unstructuredEvents := make([]*auditlogpb.EventUnstructured, 0, len(rawEvents))
-	for _, event := range rawEvents {
-		unstructuredEvent, err := apievents.ToUnstructured(event)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		unstructuredEvents = append(unstructuredEvents, unstructuredEvent)
-	}
-
 	return &auditlogpb.EventsUnstructured{
-		Items:   unstructuredEvents,
+		Items:   rawEvents,
 		LastKey: lastkey,
 	}, nil
 }

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -1192,6 +1192,16 @@ type AuditLogger interface {
 	// GetEventExportChunks returns a stream of event chunks that can be exported via ExportUnstructuredEvents. The returned
 	// list isn't ordered and polling for new chunks requires re-consuming the entire stream from the beginning.
 	GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEventExportChunksRequest) stream.Stream[*auditlogpb.EventExportChunk]
+
+	// SearchUnstructuredEvents is a flexible way to find events and returns them in an unstructured format (JSON like)
+	//
+	// Event types to filter can be specified and pagination is handled by an iterator key that allows
+	// a query to be resumed.
+	//
+	// The only mandatory requirement is a date range (UTC).
+	//
+	// This function may never return more than 1 MiB of event data.
+	SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error)
 }
 
 // EventFields instance is attached to every logged event

--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -528,7 +528,10 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 	}
 	// Convert the values to apievents.AuditEvent.
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
@@ -545,7 +548,10 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
@@ -554,7 +560,10 @@ func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEve
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSliceToUnstructured(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) Close() error {

--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -522,7 +522,13 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 }
 
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.querier.SearchEvents(ctx, req)
+	values, next, err := l.querier.SearchEvents(ctx, req)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// Convert the values to apievents.AuditEvent.
+	evts, err := events.FromEventFieldsSlice(values)
+	return evts, next, trace.Wrap(err)
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
@@ -534,7 +540,21 @@ func (l *Log) GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEvent
 }
 
 func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.querier.SearchSessionEvents(ctx, req)
+	values, next, err := l.querier.SearchSessionEvents(ctx, req)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSlice(values)
+	return evts, next, trace.Wrap(err)
+}
+
+func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	values, next, err := l.querier.SearchEvents(ctx, req)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSliceToUnstructured(values)
+	return evts, next, trace.Wrap(err)
 }
 
 func (l *Log) Close() error {

--- a/lib/events/athena/test.go
+++ b/lib/events/athena/test.go
@@ -185,6 +185,17 @@ func (e *EventuallyConsistentAuditLogger) SearchSessionEvents(ctx context.Contex
 	return e.Inner.SearchSessionEvents(ctx, req)
 }
 
+func (e *EventuallyConsistentAuditLogger) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.emitWasAfterLastDelay {
+		time.Sleep(e.QueryDelay)
+		// clear emit delay
+		e.emitWasAfterLastDelay = false
+	}
+	return e.Inner.SearchUnstructuredEvents(ctx, req)
+}
+
 func (e *EventuallyConsistentAuditLogger) Close() error {
 	return e.Inner.Close()
 }

--- a/lib/events/athena/types.go
+++ b/lib/events/athena/types.go
@@ -52,15 +52,3 @@ func auditEventToParquet(event apievents.AuditEvent) (*eventParquet, error) {
 		EventData: string(jsonBlob),
 	}, nil
 }
-
-func auditEventFromParquet(event eventParquet) (apievents.AuditEvent, error) {
-	var fields events.EventFields
-	if err := utils.FastUnmarshal([]byte(event.EventData), &fields); err != nil {
-		return nil, trace.Wrap(err, "failed to unmarshal event, %s", event.EventData)
-	}
-	e, err := events.FromEventFields(fields)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return e, nil
-}

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -104,6 +104,14 @@ func TestLogRotation(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, found, 1)
+
+		foundUnstructured, _, err := alog.SearchUnstructuredEvents(ctx, events.SearchEventsRequest{
+			From:  now.Add(-time.Hour),
+			To:    now.Add(time.Hour),
+			Order: types.EventOrderAscending,
+		})
+		require.NoError(t, err)
+		require.Len(t, foundUnstructured, 1)
 	}
 }
 

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -53,6 +53,10 @@ func (d *DiscardAuditLog) SearchSessionEvents(ctx context.Context, req SearchSes
 	return make([]apievents.AuditEvent, 0), "", nil
 }
 
+func (d *DiscardAuditLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	return make([]*auditlogpb.EventUnstructured, 0), "", nil
+}
+
 func (d *DiscardAuditLog) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
 	return stream.Empty[*auditlogpb.ExportEventUnstructured]()
 }

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -745,7 +745,10 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
@@ -754,7 +757,10 @@ func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEve
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSliceToUnstructured(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) searchEventsWithFilter(ctx context.Context, fromUTC, toUTC time.Time, namespace string, limit int, order types.EventOrder, startKey string, filter searchEventsFilter, sessionID string) ([]events.EventFields, string, error) {
@@ -1066,7 +1072,10 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 type searchEventsFilter struct {

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -740,30 +740,40 @@ type legacyCheckpointKey struct {
 //
 // This function may never return more than 1 MiB of event data.
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes}, "")
+	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes}, "")
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSlice(values)
+	return evts, next, trace.Wrap(err)
 }
 
-func (l *Log) searchEventsWithFilter(ctx context.Context, fromUTC, toUTC time.Time, namespace string, limit int, order types.EventOrder, startKey string, filter searchEventsFilter, sessionID string) ([]apievents.AuditEvent, string, error) {
+func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes}, "")
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSliceToUnstructured(values)
+	return evts, next, trace.Wrap(err)
+}
+
+func (l *Log) searchEventsWithFilter(ctx context.Context, fromUTC, toUTC time.Time, namespace string, limit int, order types.EventOrder, startKey string, filter searchEventsFilter, sessionID string) ([]events.EventFields, string, error) {
 	rawEvents, lastKey, err := l.searchEventsRaw(ctx, fromUTC, toUTC, namespace, limit, order, startKey, filter, sessionID)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	eventArr := make([]apievents.AuditEvent, 0, len(rawEvents))
+	eventArr := make([]events.EventFields, 0, len(rawEvents))
 	for _, rawEvent := range rawEvents {
-		event, err := events.FromEventFields(rawEvent.FieldsMap)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		eventArr = append(eventArr, event)
+		eventArr = append(eventArr, rawEvent.FieldsMap)
 	}
 
 	var toSort sort.Interface
 	switch order {
 	case types.EventOrderAscending:
-		toSort = byTimeAndIndex(eventArr)
+		toSort = events.ByTimeAndIndex(eventArr)
 	case types.EventOrderDescending:
-		toSort = sort.Reverse(byTimeAndIndex(eventArr))
+		toSort = sort.Reverse(events.ByTimeAndIndex(eventArr))
 	default:
 		return nil, "", trace.BadParameter("invalid event order: %v", order)
 	}
@@ -778,27 +788,6 @@ func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.Expo
 
 func (l *Log) GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEventExportChunksRequest) stream.Stream[*auditlogpb.EventExportChunk] {
 	return stream.Fail[*auditlogpb.EventExportChunk](trace.NotImplemented("dynamoevents backend does not support streaming export"))
-}
-
-// ByTimeAndIndex sorts events by time
-// and if there are several session events with the same session by event index.
-type byTimeAndIndex []apievents.AuditEvent
-
-func (f byTimeAndIndex) Len() int {
-	return len(f)
-}
-
-func (f byTimeAndIndex) Less(i, j int) bool {
-	itime := f[i].GetTime()
-	jtime := f[j].GetTime()
-	if itime.Equal(jtime) && events.GetSessionID(f[i]) == events.GetSessionID(f[j]) {
-		return f[i].GetIndex() < f[j].GetIndex()
-	}
-	return itime.Before(jtime)
-}
-
-func (f byTimeAndIndex) Swap(i, j int) {
-	f[i], f[j] = f[j], f[i]
 }
 
 // eventFilterList constructs a string of the form
@@ -1072,7 +1061,12 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 		filter.condExpr = expr
 		filter.condParams = params
 	}
-	return l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, filter, req.SessionID)
+	values, next, err := l.searchEventsWithFilter(ctx, req.From, req.To, apidefaults.Namespace, req.Limit, req.Order, req.StartKey, filter, req.SessionID)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSlice(values)
+	return evts, next, trace.Wrap(err)
 }
 
 type searchEventsFilter struct {

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -201,7 +201,10 @@ func (l *FileLog) SearchEvents(ctx context.Context, req SearchEventsRequest) ([]
 	}
 	// Convert the raw events to audit events.
 	evts, err := FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *FileLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
@@ -212,7 +215,10 @@ func (l *FileLog) SearchUnstructuredEvents(ctx context.Context, req SearchEvents
 	}
 	// Convert the raw events to unstructured.
 	evts, err := FromEventFieldsSliceToUnstructured(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *FileLog) searchEventsWithFilter(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startAfter string, filter searchEventsFilter) ([]EventFields, string, error) {
@@ -375,7 +381,10 @@ func (l *FileLog) SearchSessionEvents(ctx context.Context, req SearchSessionEven
 	}
 	// Convert the raw events to audit events.
 	evts, err := FromEventFieldsSlice(events)
-	return evts, lastKey, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, lastKey, nil
 }
 
 func (l *FileLog) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -195,10 +195,27 @@ func (l *FileLog) trimSizeAndMarshal(event apievents.AuditEvent) ([]byte, error)
 // This function may never return more than 1 MiB of event data.
 func (l *FileLog) SearchEvents(ctx context.Context, req SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
 	l.logger.DebugContext(ctx, "SearchEvents", "from", req.From, "to", req.To, "event_type", req.EventTypes, "limit", req.Limit)
-	return l.searchEventsWithFilter(req.From, req.To, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes})
+	values, next, err := l.searchEventsWithFilter(req.From, req.To, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// Convert the raw events to audit events.
+	evts, err := FromEventFieldsSlice(values)
+	return evts, next, trace.Wrap(err)
 }
 
-func (l *FileLog) searchEventsWithFilter(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startAfter string, filter searchEventsFilter) ([]apievents.AuditEvent, string, error) {
+func (l *FileLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	l.logger.DebugContext(ctx, "SearchUnstructuredEvents", "from", req.From, "to", req.To, "event_type", req.EventTypes, "limit", req.Limit)
+	values, next, err := l.searchEventsWithFilter(req.From, req.To, req.Limit, req.Order, req.StartKey, searchEventsFilter{eventTypes: req.EventTypes})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// Convert the raw events to unstructured.
+	evts, err := FromEventFieldsSliceToUnstructured(values)
+	return evts, next, trace.Wrap(err)
+}
+
+func (l *FileLog) searchEventsWithFilter(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startAfter string, filter searchEventsFilter) ([]EventFields, string, error) {
 	if limit <= 0 {
 		limit = defaults.EventsIterationLimit
 	}
@@ -243,7 +260,7 @@ func (l *FileLog) searchEventsWithFilter(fromUTC, toUTC time.Time, limit int, or
 	}
 	sort.Sort(toSort)
 
-	events := make([]apievents.AuditEvent, 0, len(dynamicEvents))
+	events := make([]EventFields, 0, len(dynamicEvents))
 
 	// This is used as a flag to check if we have found the startAfter checkpoint or not.
 	foundStart := startAfter == ""
@@ -252,12 +269,6 @@ func (l *FileLog) searchEventsWithFilter(fromUTC, toUTC time.Time, limit int, or
 
 outer:
 	for _, dynamicEvent := range dynamicEvents {
-		// Convert the event from a dynamic representation to a typed representation.
-		event, err := FromEventFields(dynamicEvent)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-
 		size, err := estimateEventSize(dynamicEvent)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
@@ -266,7 +277,7 @@ outer:
 		// Skip until we've found the start checkpoint and once more
 		// since it was the last key of the previous set.
 		if !foundStart {
-			checkpoint, err := getCheckpointFromEvent(event)
+			checkpoint, err := getCheckpointFromEvent(dynamicEvent)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
 			}
@@ -280,11 +291,11 @@ outer:
 		// Skip until we've found the first event within the desired timeframe.
 		switch order {
 		case types.EventOrderAscending:
-			if event.GetTime().Before(fromUTC) {
+			if dynamicEvent.GetTime(EventTime).Before(fromUTC) {
 				continue outer
 			}
 		case types.EventOrderDescending:
-			if event.GetTime().After(toUTC) {
+			if dynamicEvent.GetTime(EventTime).After(toUTC) {
 				continue outer
 			}
 		}
@@ -294,11 +305,11 @@ outer:
 		// to the sort so we just break out here and consider the query as finished.
 		switch order {
 		case types.EventOrderAscending:
-			if event.GetTime().After(toUTC) {
+			if dynamicEvent.GetTime(EventTime).After(toUTC) {
 				break outer
 			}
 		case types.EventOrderDescending:
-			if event.GetTime().Before(fromUTC) {
+			if dynamicEvent.GetTime(EventTime).Before(fromUTC) {
 				break outer
 			}
 		}
@@ -311,7 +322,7 @@ outer:
 			return events, checkpoint, nil
 		}
 
-		events = append(events, event)
+		events = append(events, dynamicEvent)
 		totalSize += size
 
 		// Check if there is a limit and if so, check if we've hit it.
@@ -330,7 +341,7 @@ outer:
 	return events, "", nil
 }
 
-func getCheckpointFromEvent(event apievents.AuditEvent) (string, error) {
+func getCheckpointFromEvent(event EventFields) (string, error) {
 	if event.GetID() == "" {
 		data, err := utils.FastMarshal(event)
 		if err != nil {
@@ -359,7 +370,12 @@ func (l *FileLog) SearchSessionEvents(ctx context.Context, req SearchSessionEven
 		filter.condition = condFn
 	}
 	events, lastKey, err := l.searchEventsWithFilter(req.From, req.To, req.Limit, req.Order, req.StartKey, filter)
-	return events, lastKey, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// Convert the raw events to audit events.
+	evts, err := FromEventFieldsSlice(events)
+	return evts, lastKey, trace.Wrap(err)
 }
 
 func (l *FileLog) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -376,7 +376,10 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 type searchEventsWithFilterParams struct {
@@ -569,7 +572,10 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
@@ -647,7 +653,10 @@ func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEve
 		return nil, "", trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSliceToUnstructured(values)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) purgeExpiredEvents() error {

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -80,6 +80,24 @@ func (m *MultiLog) SearchEvents(ctx context.Context, req SearchEventsRequest) (e
 	return events, lastKey, err
 }
 
+// SearchUnstructuredEvents is a flexible way to find events in an unstructured format.
+//
+// Event types to filter can be specified and pagination is handled by an iterator key that allows
+// a query to be resumed.
+//
+// The only mandatory requirement is a date range (UTC).
+//
+// This function may never return more than 1 MiB of event data.
+func (m *MultiLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) (events []*auditlogpb.EventUnstructured, lastKey string, err error) {
+	for _, log := range m.loggers {
+		events, lastKey, err := log.SearchUnstructuredEvents(ctx, req)
+		if !trace.IsNotImplemented(err) {
+			return events, lastKey, err
+		}
+	}
+	return events, lastKey, err
+}
+
 func (m *MultiLog) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
 	var foundImplemented bool
 	var pos int

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -412,7 +412,7 @@ func (l *Log) searchEvents(
 	fromTime, toTime time.Time,
 	eventTypes []string, cond *types.WhereExpr, sessionID string,
 	limit int, order types.EventOrder, startKey string,
-) ([]apievents.AuditEvent, string, error) {
+) ([]events.EventFields, string, error) {
 	if limit <= 0 {
 		limit = defaults.EventsIterationLimit
 	}
@@ -480,7 +480,7 @@ func (l *Log) searchEvents(
 	const fetchSize = defaults.EventsIterationLimit
 	fetchQuery := fmt.Sprintf("FETCH %d FROM cur", fetchSize)
 
-	var evs []apievents.AuditEvent
+	var evs []events.EventFields
 	var sizeLimit bool
 	var endTime time.Time
 	var endID uuid.UUID
@@ -528,12 +528,7 @@ func (l *Log) searchEvents(
 				}
 				totalSize += len(data)
 
-				ev, err := events.FromEventFields(evf)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-
-				evs = append(evs, ev)
+				evs = append(evs, evf)
 				endTime = t
 				endID = id
 
@@ -574,7 +569,27 @@ func (l *Log) searchEvents(
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
 	var emptyCond *types.WhereExpr
 	const emptySessionID = ""
-	return l.searchEvents(ctx, req.From, req.To, req.EventTypes, emptyCond, emptySessionID, req.Limit, req.Order, req.StartKey)
+
+	evtsRaw, next, err := l.searchEvents(ctx, req.From, req.To, req.EventTypes, emptyCond, emptySessionID, req.Limit, req.Order, req.StartKey)
+	if err != nil {
+		return nil, next, trace.Wrap(err)
+	}
+
+	evts, err := events.FromEventFieldsSlice(evtsRaw)
+	return evts, next, trace.Wrap(err)
+}
+
+// SearchUnstructuredEvents implements [events.AuditLogger].
+func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	var emptyCond *types.WhereExpr
+	const emptySessionID = ""
+
+	evtsRaw, next, err := l.searchEvents(ctx, req.From, req.To, req.EventTypes, emptyCond, emptySessionID, req.Limit, req.Order, req.StartKey)
+	if err != nil {
+		return nil, next, trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSliceToUnstructured(evtsRaw)
+	return evts, next, trace.Wrap(err)
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
@@ -587,7 +602,12 @@ func (l *Log) GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEvent
 
 // SearchSessionEvents implements [events.AuditLogger].
 func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.searchEvents(ctx, req.From, req.To, events.SessionRecordingEvents, req.Cond, req.SessionID, req.Limit, req.Order, req.StartKey)
+	evtsRaw, next, err := l.searchEvents(ctx, req.From, req.To, events.SessionRecordingEvents, req.Cond, req.SessionID, req.Limit, req.Order, req.StartKey)
+	if err != nil {
+		return nil, next, trace.Wrap(err)
+	}
+	evts, err := events.FromEventFieldsSlice(evtsRaw)
+	return evts, next, trace.Wrap(err)
 }
 
 // sessionIDBase is a randomly-generated UUID used as the basis for deriving

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -576,7 +576,10 @@ func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) 
 	}
 
 	evts, err := events.FromEventFieldsSlice(evtsRaw)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 // SearchUnstructuredEvents implements [events.AuditLogger].
@@ -589,7 +592,10 @@ func (l *Log) SearchUnstructuredEvents(ctx context.Context, req events.SearchEve
 		return nil, next, trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSliceToUnstructured(evtsRaw)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
@@ -607,7 +613,10 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 		return nil, next, trace.Wrap(err)
 	}
 	evts, err := events.FromEventFieldsSlice(evtsRaw)
-	return evts, next, trace.Wrap(err)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return evts, next, nil
 }
 
 // sessionIDBase is a randomly-generated UUID used as the basis for deriving

--- a/lib/events/writer.go
+++ b/lib/events/writer.go
@@ -65,6 +65,10 @@ func (w *WriterLog) SearchEvents(ctx context.Context, req SearchEventsRequest) (
 	return nil, "", trace.NotImplemented(writerCannotRead)
 }
 
+func (w *WriterLog) SearchUnstructuredEvents(ctx context.Context, req SearchEventsRequest) (events []*auditlogpb.EventUnstructured, lastKey string, err error) {
+	return nil, "", trace.NotImplemented(writerCannotRead)
+}
+
 func (w *WriterLog) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
 	return stream.Fail[*auditlogpb.ExportEventUnstructured](trace.NotImplemented(writerCannotRead))
 }

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -327,6 +327,12 @@ func (c *ErrorCountingLogger) SearchEvents(ctx context.Context, req events.Searc
 	return events, key, err
 }
 
+func (c *ErrorCountingLogger) SearchUnstructuredEvents(ctx context.Context, req events.SearchEventsRequest) ([]*auditlogpb.EventUnstructured, string, error) {
+	events, key, err := c.wrapped.SearchUnstructuredEvents(ctx, req)
+	c.searches.observe(err)
+	return events, key, err
+}
+
 func (c *ErrorCountingLogger) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
 	return stream.MapErr(c.wrapped.ExportUnstructuredEvents(ctx, req), func(err error) error {
 		c.searches.observe(err)


### PR DESCRIPTION
Reduce the number of JSON marshal/unmarshal operations in GetUnstructuredEvents to improve performance when reading audit logs from Teleport.

Previously, reading unstructured events involved 6 operations:
  1. Read data from backend
  2. JSON unmarshal to events.EventFields
  3. Marshal to JSON
  4. JSON unmarshal to events satisfying apievents.AuditEvent
  5. Marshal to JSON
  6. Protojson unmarshal to structpb.Struct

This optimization reduces the process to 3 operations:
  1. Read data from backend
  2. JSON unmarshal to events.EventFields
  3. Direct conversion using structpb.NewStruct(fields)

This change minimizes JSON marshal/unmarshal overhead while maintaining unchanged the non-unstructured endpoints (steps 1-4 remain unchanged).