### PR TITLE
Fix missing permissions in operator role

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -48,6 +48,10 @@ rules:
       - teleportappsv3/status
       - teleportdatabasesv3
       - teleportdatabasesv3/status
+      - teleportautoupdateconfigsv1
+      - teleportautoupdateconfigsv1/status
+      - teleportautoupdateversionsv1
+      - teleportautoupdateversionsv1/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/55309

Changelog: fix incomplete Teleport operator role that caused the operator to not reconciler CRs.

I tried to modify the operator unit tests to use the RBAC for the chart but this was not trivial because of Helm's templating.
I will look into this the next time I add a resource.