### PR TITLE
[docs] Update database guides

### DIFF
--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Redshift Automatic User Provisioning
+sidebar_label: Amazon Redshift
 description: Configure automatic user provisioning for Amazon Redshift.
 ---
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -1,5 +1,6 @@
 ---
 title: MariaDB Automatic User Provisioning 
+sidebar_label: MariaDB
 description: Configure automatic user provisioning for MariaDB.
 ---
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -1,5 +1,6 @@
 ---
 title: MongoDB Automatic User Provisioning 
+sidebar_label: MongoDB
 description: Configure automatic user provisioning for MongoDB.
 ---
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -1,5 +1,6 @@
 ---
 title: MySQL Automatic User Provisioning
+sidebar_label: MySQL
 description: Configure automatic user provisioning for MySQL.
 ---
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -1,5 +1,6 @@
 ---
 title: PostgreSQL Automatic User Provisioning
+sidebar_label: PostgreSQL
 description: Configure automatic user provisioning for PostgreSQL.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon Keyspaces (Apache Cassandra)
+sidebar_label: Amazon Keyspaces (Apache Cassandra)
 description: How to configure Teleport database access with Amazon Keyspaces (Apache Cassandra)
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
@@ -60,7 +60,7 @@ Modify your Teleport Database Service configuration file to assume an external
 AWS IAM role when it is discovering AWS databases.
 
 ```yaml
-# This example configuration will discover AWS RDS databases in us-west-1
+# This example configuration will discover Amazon RDS databases in us-west-1
 # within AWS account `222222222222` by assuming the external AWS IAM role
 # "example-role".
 db_service:

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon DocumentDB
+sidebar_label: Amazon DocumentDB
 description: How to access Amazon DocumentDB with Teleport database access
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon DynamoDB
+sidebar_label: Amazon DynamoDB
 description: How to access Amazon DynamoDB with Teleport database access
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon OpenSearch
+sidebar_label: Amazon OpenSearch
 description: How to access Amazon OpenSearch with Teleport database access
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Redshift on AWS
+sidebar_label: Amazon Redshift
 description: How to configure Teleport database access with Amazon Redshift PostgreSQL.
 videoBanner: UFhT52d5bYg
 ---

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with AWS RDS Oracle with Kerberos Authentication
-description: How to configure Teleport Database Access with AWS RDS Oracle with Kerberos authentication.
+title: Database Access with Amazon RDS Oracle with Kerberos Authentication
+sidebar_label: Amazon RDS Oracle
+description: How to configure Teleport Database Access with Amazon RDS Oracle with Kerberos authentication.
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS for Oracle" dbConfigure="with Kerberos authentication"!)
@@ -29,8 +30,8 @@ Database Service forwards user traffic to the database.
 
 Before configuring Teleport, ensure your Oracle RDS instance has Kerberos authentication and TLS properly configured:
 
-1. Follow the [AWS RDS Oracle Kerberos Setup guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-kerberos-setting-up.html) to enable Kerberos authentication on your instance.
-2. Enable TLS on your Oracle RDS instance by following the [AWS RDS Oracle SSL Setup documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html). Ensure `SQLNET.SSL_VERSION` is set to `1.2` for optimal security. Make note of the SSL port choice; in the rest of the guide we will assume it is 2484. Also ensure `SQLNET.CIPHER_SUITE` parameter includes a supported value, for example `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`.
+1. Follow the [Amazon RDS Oracle Kerberos Setup guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-kerberos-setting-up.html) to enable Kerberos authentication on your instance.
+2. Enable TLS on your Oracle RDS instance by following the [Amazon RDS Oracle SSL Setup documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html). Ensure `SQLNET.SSL_VERSION` is set to `1.2` for optimal security. Make note of the SSL port choice; in the rest of the guide we will assume it is 2484. Also ensure `SQLNET.CIPHER_SUITE` parameter includes a supported value, for example `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`.
 
 <Admonition type="note">
   Verify connectivity between your Teleport Database Service host and the Oracle RDS instance before proceeding.
@@ -403,7 +404,7 @@ $ sql -L test/test@oracle-instance.aabbccddeegg.eu-central-1.rds.amazonaws.com:2
 
 ### Teleport can reach RDS Oracle instance, but TLS negotiation fails (handshake failure)
 
-Ensure that `SQLNET.SSL_VERSION` parameter enables `TLS 1.2` version. TLS 1.0 is rejected by Teleport due to known weaknesses. See [AWS RDS Oracle SSL Setup documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html) for more information.
+Ensure that `SQLNET.SSL_VERSION` parameter enables `TLS 1.2` version. TLS 1.0 is rejected by Teleport due to known weaknesses. See [Amazon RDS Oracle SSL Setup documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html) for more information.
 
 Teleport also rejects the following weak cipher suites:
 - `SSL_RSA_WITH_AES_256_CBC_SHA`
@@ -423,8 +424,8 @@ Installation-specific configuration variations may lead to different values, how
 
 ## Further reading
 
-- [AWS RDS Oracle Kerberos Setup](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-kerberos-setting-up.html).
-- [AWS RDS Oracle SSL Setup](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html).
-- [AWS RDS Oracle auditing](https://aws.amazon.com/blogs/database/part-1-security-auditing-in-amazon-rds-for-oracle/).
+- [Amazon RDS Oracle Kerberos Setup](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-kerberos-setting-up.html).
+- [Amazon RDS Oracle SSL Setup](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.SSL.html).
+- [Amazon RDS Oracle auditing](https://aws.amazon.com/blogs/database/part-1-security-auditing-in-amazon-rds-for-oracle/).
 - [Manually join a Linux instance](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/join_linux_instance.html) in the AWS documentation.
 - [Introduction to `adutil`](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-ad-auth-adutil-introduction) in the Microsoft documentation.

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with AWS RDS Proxy for MariaDB/MySQL
-description: How to configure Teleport database access with AWS RDS Proxy for MariaDB/MySQL.
+title: Database Access with Amazon RDS Proxy for MariaDB/MySQL
+sidebar_label: Amazon RDS Proxy for MariaDB/MySQL
+description: How to configure Teleport database access with Amazon RDS Proxy for MariaDB/MySQL.
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for MariaDB or MySQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with AWS RDS Proxy for PostgreSQL
-description: How to configure Teleport database access with AWS RDS Proxy for PostgreSQL
+title: Database Access with Amazon RDS Proxy for PostgreSQL
+sidebar_label: Amazon RDS Proxy for PostgreSQL
+description: How to configure Teleport database access with Amazon RDS Proxy for PostgreSQL
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for PostgreSQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with AWS RDS Proxy for Microsoft SQL Server
-description: How to configure Teleport database access with AWS RDS Proxy for Microsoft SQL Server
+title: Database Access with Amazon RDS Proxy for SQL Server
+sidebar_label: Amazon RDS Proxy for SQL Server
+description: How to configure Teleport database access with Amazon RDS Proxy for SQL Server
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for Microsoft SQL Server" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -1,7 +1,7 @@
 ---
-title: Database Access with AWS RDS and Aurora
-h1: Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB
-description: How to configure Teleport database access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
+title: Database Access with Amazon RDS and Aurora for PostgreSQL/MySQL/MariaDB
+sidebar_label: Amazon RDS and Aurora for PostgreSQL/MySQL/MariaDB
+description: How to configure Teleport database access with Amazon RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS or Aurora" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon ElastiCache and Amazon MemoryDB for Redis
+sidebar_label: Amazon ElastiCache/MemoryDB
 description: How to configure Teleport database access with Amazon ElastiCache and Amazon MemoryDB for Redis.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Amazon Redshift Serverless
+sidebar_label: Amazon Redshift Serverless
 description: How to configure Teleport database access with Amazon Redshift Serverless.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -1,6 +1,7 @@
 ---
-title: Database Access with Microsoft SQL Server with Active Directory authentication
-description: How to configure Teleport database access with Microsoft SQL Server with Active Directory authentication.
+title: Database Access with Amazon RDS for Microsoft SQL Server with Active Directory authentication
+sidebar_label: Amazon RDS for SQL Server
+description: How to configure Teleport database access with RDS for SQL Server with Active Directory authentication.
 videoBanner: k2wz79XCexY
 ---
 
@@ -287,7 +288,7 @@ Provide Active Directory parameters:
 You can use `ldapsearch` command to see the SPNs registered for your SQL
 Server. Typically, they take a form of `MSSQLSvc/<name>.<ad-domain>:<port>`.
 
-For example, an AWS RDS SQL Server named `sqlserver` and joined to an AWS managed
+For example, an Amazon RDS SQL Server named `sqlserver` and joined to an AWS managed
 Active Directory domain `EXAMPLE.COM` will have the following SPNs registered:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Azure PostgreSQL and MySQL
+sidebar_label: Azure PostgreSQL/MySQL
 description: How to configure Teleport database access with Azure Database for PostgreSQL and MySQL.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Azure Cache for Redis
+sidebar_label: Azure Cache for Redis
 description: How to configure Teleport database access with Azure Cache for Redis
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
@@ -1,5 +1,6 @@
 ---
-title: Database Access with SQL Server on Azure
+title: Database Access with Azure SQL Server
+sidebar_label: Azure SQL Server
 description: How to configure Teleport database access with Azure SQL Server using Microsoft Entra authentication.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Cloud SQL for MySQL
+sidebar_label: Cloud SQL for MySQL
 description: How to configure Teleport database access with Cloud SQL for MySQL.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Cloud SQL for PostgreSQL 
+sidebar_label: Cloud SQL for PostgreSQL
 description: How to configure Teleport database access with Cloud SQL for PostgreSQL.
 videoBanner: br9LZ3ZXqCk
 ---

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Cloud Spanner
+sidebar_label: Cloud Spanner
 description: How to configure Teleport database access with GCP's Cloud Spanner.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with MongoDB Atlas
+sidebar_label: MongoDB Atlas
 description: How to configure Teleport database access with MongoDB Atlas.
 videoBanner: mu_ZKTjnFJ8
 ---

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Oracle Exadata
+sidebar_label: Oracle Exadata
 description: How to configure Teleport database access with Oracle Exadata.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Snowflake
+sidebar_label: Snowflake
 description: How to configure Teleport database access with Snowflake.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Cassandra and ScyllaDB
+sidebar_label: Cassandra/ScyllaDB
 description: How to configure Teleport database access with Cassandra and ScyllaDB.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with ClickHouse
+sidebar_label: ClickHouse
 description: How to configure Teleport database access with ClickHouse.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Self-Hosted CockroachDB
+sidebar_label: CockroachDB
 description: How to configure Teleport database access with self-hosted CockroachDB.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Elasticsearch
+sidebar_label: Elasticsearch
 description: How to configure Teleport database access with Elasticsearch.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Self-Hosted MongoDB
+sidebar_label: MongoDB
 description: How to configure Teleport database access with self-hosted MongoDB.
 videoBanner: 6lgVObxoLkc
 ---

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
-title: Database Access with Self-Hosted MySQL/MariaDB
+title: Database Access with Self-Hosted MySQL or MariaDB
+sidebar_label: MySQL/MariaDB
 description: How to configure Teleport database access with self-hosted MySQL/MariaDB.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Oracle
+sidebar_label: Oracle
 description: How to configure Teleport database access with Oracle.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Self-Hosted PostgreSQL
+sidebar_label: PostgreSQL
 description: How to configure Teleport database access with self-hosted PostgreSQL.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Redis Cluster
+sidebar_label: Redis Cluster
 description: How to configure Teleport database access with Redis Cluster.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Redis
+sidebar_label: Redis
 description: How to configure Teleport database access with Redis.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -1,5 +1,6 @@
 ---
 title: Microsoft SQL Server access with PKINIT authentication
+sidebar_label: SQL Server
 description: How to configure Microsoft SQL Server access with Active Directory PKINIT authentication.
 ---
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access with Vitess (MySQL protocol)
+sidebar_label: Vitess (MySQL protocol)
 description: How to configure Teleport database access for Vitess (MySQL protocol)
 ---
 


### PR DESCRIPTION
- Remove redundant terms from the sidebar labels in database access enrollment guides
- Update all uses of "AWS RDS" to "Amazon RDS"

### Sidebar before

Redundant phrasing clutters the sidebar:

![image](https://github.com/user-attachments/assets/d7ecb42f-a218-4303-9702-aa30553a3b7f)

### Sidebar after

Redundant phrasing (mostly) removed:

![image](https://github.com/user-attachments/assets/d90e6655-d71e-4d52-aa97-232717d5d701)

I was tempted to also remove the product name prefix, for example how amazon likes to put "Amazon" at the start of every product name, so we could shorten "Amazon Redshift -> Redshift", but I figured others would disagree, since that's actually a part of the database product names 😉.

The point is just to shorten these sidebar names to make it nicer navigate.
I updated just the database access dropdown menus for azure, aws, google, "cloud-hosted", auto-user provisioning, and self-hosted databases. 