### PR TITLE
[v17] Okta: Don't allow creating user_group Access Request in RO

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5450,10 +5450,7 @@ func (a *Server) checkResourcesRequestable(ctx context.Context, resourceIDs []ty
 		return nil
 	}
 
-	err := okta.CheckResourcesRequestable(ctx, resourceIDs, okta.AccessPoint{
-		Plugins:              a.Plugins,
-		UnifiedResourceCache: a.UnifiedResourceCache,
-	})
+	err := okta.CheckResourcesRequestable(ctx, resourceIDs, a)
 	if errors.Is(err, okta.OktaResourceNotRequestableError) {
 		return trace.Wrap(err)
 	} else if err != nil {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4685,12 +4685,12 @@ func TestListResources_KindUserGroup(t *testing.T) {
 	}
 
 	// Add user groups.
-	testUg1 := createUserGroup(t, s, "c", map[string]string{"label": "value"})
-	testUg2 := createUserGroup(t, s, "a", map[string]string{"label": "value"})
-	testUg3 := createUserGroup(t, s, "b", map[string]string{"label": "value"})
+	testUg1 := createUserGroup(t, s.authServer, "c", map[string]string{"label": "value"})
+	testUg2 := createUserGroup(t, s.authServer, "a", map[string]string{"label": "value"})
+	testUg3 := createUserGroup(t, s.authServer, "b", map[string]string{"label": "value"})
 
 	// This user group should never should up because the user doesn't have group label access to it.
-	_ = createUserGroup(t, s, "d", map[string]string{"inaccessible": "value"})
+	_ = createUserGroup(t, s.authServer, "d", map[string]string{"inaccessible": "value"})
 
 	authContext, err = srv.Authorizer.Authorize(authz.ContextWithUser(ctx, TestUser(user.GetName()).I))
 	require.NoError(t, err)
@@ -4775,13 +4775,15 @@ func TestListResources_KindUserGroup(t *testing.T) {
 	})
 }
 
-func createUserGroup(t *testing.T, s *ServerWithRoles, name string, labels map[string]string) types.UserGroup {
+func createUserGroup(t *testing.T, s *Server, name string, labels map[string]string) types.UserGroup {
+	t.Helper()
+	ctx := context.Background()
 	userGroup, err := types.NewUserGroup(types.Metadata{
 		Name:   name,
 		Labels: labels,
 	}, types.UserGroupSpecV1{})
 	require.NoError(t, err)
-	err = s.CreateUserGroup(context.Background(), userGroup)
+	err = s.CreateUserGroup(ctx, userGroup)
 	require.NoError(t, err)
 	return userGroup
 }
@@ -5508,12 +5510,23 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	// 1. Create Okta-originated app server in the backend.
+	// 1. Create Okta-originated app_server and user_group in the backend.
 
-	searchableOktaApp := newTestAppServerV3(t, srv.Auth(), "serachable-okta-app", map[string]string{
-		"name":            "serachable-okta-app",
-		types.OriginLabel: types.OriginOkta,
-	})
+	searchableOktaApp := createTestAppServerV3(t, srv.Auth(),
+		"serachable-okta-app",
+		map[string]string{
+			"name":            "serachable-okta-app",
+			types.OriginLabel: types.OriginOkta,
+		},
+	)
+
+	searchableUserGroup := createUserGroup(t, srv.Auth(),
+		"serachable-okta-group",
+		map[string]string{
+			"name":            "serachable-okta-group",
+			types.OriginLabel: types.OriginOkta,
+		},
+	)
 
 	// 2. Create a role allowing the Okta app (used for search_as_roles)
 
@@ -5521,6 +5534,9 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 		Allow: types.RoleConditions{
 			AppLabels: types.Labels{
 				"name": {searchableOktaApp.GetName()},
+			},
+			GroupLabels: types.Labels{
+				"name": {searchableUserGroup.GetName()},
 			},
 		},
 	})
@@ -5566,6 +5582,13 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 				mustResourceID(srv.ClusterName(), types.KindAppServer, searchableOktaApp.GetName()),
 			},
 		),
+		// requesting user_group
+		mustAccessRequest(t, alice.GetName(), types.RequestState_PENDING, srv.Clock().Now(), srv.Clock().Now().Add(time.Hour),
+			[]string{}, // roles
+			[]types.ResourceID{
+				mustResourceID(srv.ClusterName(), types.KindUserGroup, searchableUserGroup.GetName()),
+			},
+		),
 	}
 
 	// 7. Run tests
@@ -5587,8 +5610,9 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 
 		// v17 only - we need to support okta_service where no plugin exists:
 		for _, accessRequest := range testAccessRequests {
+			msg := fmt.Sprintf("requested resources = %v", accessRequest.GetRequestedResourceIDs())
 			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
-			require.NoError(t, err)
+			require.NoError(t, err, msg)
 		}
 	})
 
@@ -5607,8 +5631,9 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 		)
 
 		for _, accessRequest := range testAccessRequests {
+			msg := fmt.Sprintf("requested resources = %v", accessRequest.GetRequestedResourceIDs())
 			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
-			require.NoError(t, err)
+			require.NoError(t, err, msg)
 		}
 	})
 
@@ -5669,10 +5694,11 @@ func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
 		)
 
 		for _, accessRequest := range testAccessRequests {
+			msg := fmt.Sprintf("requested resources = %v", accessRequest.GetRequestedResourceIDs())
 			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
-			require.Error(t, err)
-			require.True(t, trace.IsBadParameter(err))
-			require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error())
+			require.Error(t, err, msg)
+			require.True(t, trace.IsBadParameter(err), msg)
+			require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error(), msg)
 		}
 	})
 }
@@ -5684,14 +5710,14 @@ func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
 
 	// 1. Create app resources
 
-	searchableGenericApp := newTestAppServerV3(t, srv.Auth(),
+	searchableGenericApp := createTestAppServerV3(t, srv.Auth(),
 		"test_generic_app",
 		map[string]string{
 			"find_me": "please",
 		},
 	)
 
-	searchableOktaApp := newTestAppServerV3(t, srv.Auth(),
+	searchableOktaApp := createTestAppServerV3(t, srv.Auth(),
 		"test_searchable_okta_app",
 		map[string]string{
 			"find_me":         "please",
@@ -5699,7 +5725,7 @@ func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
 		},
 	)
 
-	assignedOktaApp := newTestAppServerV3(t, srv.Auth(),
+	assignedOktaApp := createTestAppServerV3(t, srv.Auth(),
 		"test_assigned_okta_app",
 		map[string]string{
 			"owner":           "alice",
@@ -10609,7 +10635,7 @@ func TestValidateOracleJoinToken(t *testing.T) {
 	})
 }
 
-func newTestAppServerV3(t *testing.T, auth *Server, name string, labels map[string]string) *types.AppServerV3 {
+func createTestAppServerV3(t *testing.T, auth *Server, name string, labels map[string]string) *types.AppServerV3 {
 	t.Helper()
 	ctx := context.Background()
 

--- a/lib/auth/okta/auth.go
+++ b/lib/auth/okta/auth.go
@@ -20,13 +20,14 @@ package okta
 
 import (
 	"context"
+	"slices"
 
 	"github.com/gravitational/trace"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	oktaplugin "github.com/gravitational/teleport/lib/okta/plugin"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // Okta-origin resources have some special access rules that are implemented in
@@ -99,7 +100,7 @@ func CheckAccess(authzCtx *authz.Context, existingResource types.ResourceWithLab
 
 // BidirectionalSyncEnabled checks if the bidirectional sync is enabled on the Okta plugin.  If the
 // Okta plugin does not exist the result is false.
-func BidirectionalSyncEnabled(ctx context.Context, plugins services.Plugins) (bool, error) {
+func BidirectionalSyncEnabled(ctx context.Context, plugins PluginGetter) (bool, error) {
 	plugin, err := oktaplugin.Get(ctx, plugins, false /* withSecrets */)
 	if trace.IsNotFound(err) {
 		// v17 only: since we still support the legacy okta_service configuration there is
@@ -114,12 +115,6 @@ func BidirectionalSyncEnabled(ctx context.Context, plugins services.Plugins) (bo
 		return false, trace.Wrap(err, "getting Okta plugin")
 	}
 	return plugin.Spec.GetOkta().GetSyncSettings().GetEnableBidirectionalSync(), nil
-}
-
-// AccessPoint provides services required by [CheckResourcesRequestable].
-type AccessPoint struct {
-	Plugins              services.Plugins
-	UnifiedResourceCache *services.UnifiedResourceCache
 }
 
 var (
@@ -137,8 +132,12 @@ var (
 //
 // If any resource is not requestable, [OktaResourceNotRequestableError] will be returned. Any
 // other error can be returned.
-func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, ap AccessPoint) error {
-	bidirectionalSyncEnabled, err := BidirectionalSyncEnabled(ctx, ap.Plugins)
+func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, auth AuthServer) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	bidirectionalSyncEnabled, err := BidirectionalSyncEnabled(ctx, auth)
 	if err != nil {
 		return trace.Wrap(err, "getting bidirectional sync")
 	}
@@ -146,20 +145,48 @@ func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, ap A
 		return nil
 	}
 
-	var denied []types.ResourceID
-	for app, err := range ap.UnifiedResourceCache.AppServers(ctx, services.UnifiedResourcesIterateParams{}) {
+	hasApps := slices.ContainsFunc(ids, func(id types.ResourceID) bool {
+		return id.Kind == types.KindAppServer || id.Kind == types.KindApp
+	})
+	var oktaAppServers []types.AppServer
+	if hasApps {
+		// Unfortunately we have to pull all app_server resources here as there is no
+		// dedicated method to fetch a single app_server by name.
+		//
+		// [services.UnifiedResourceCache].GetUnifiedResourcesByIDs can't be used neither
+		// because Okta resources are keyed with [types.FriendlyName] (see
+		// [services.makeResourceSortKey]) and [types.ResourceID] does not contain labels.
+		//
+		// TODO(kopiczko): Create GetApplicationServer(ctx, name) of fix GetUnifiedResourcesByIDs and use it instead. See comments above.
+		oktaAppServers, err = auth.GetApplicationServers(ctx, apidefaults.Namespace)
 		if err != nil {
-			return trace.Wrap(err, "iterating cached AppServers")
+			return trace.Wrap(err, "getting app servers")
 		}
-		for _, id := range ids {
-			switch id.Kind {
-			case types.KindApp, types.KindAppServer:
-				// ok
-			default:
+		oktaAppServers = slices.DeleteFunc(oktaAppServers, func(appServer types.AppServer) bool {
+			return appServer.Origin() != types.OriginOkta
+		})
+	}
+
+	var denied []types.ResourceID
+	for _, id := range ids {
+		switch id.Kind {
+		case types.KindAppServer, types.KindApp:
+			if slices.ContainsFunc(oktaAppServers, func(appServer types.AppServer) bool {
+				return appServer.GetName() == id.Name
+			}) {
+				denied = append(denied, id)
 				continue
 			}
-			if app.GetName() == id.Name && app.Origin() == types.OriginOkta {
+		case types.KindUserGroup:
+			userGroup, err := auth.GetUserGroup(ctx, id.Name)
+			switch {
+			case trace.IsNotFound(err):
+				// ok
+			case err != nil:
+				return trace.Wrap(err, "getting user group %q", id.Name)
+			case userGroup.Origin() == types.OriginOkta:
 				denied = append(denied, id)
+				continue
 			}
 		}
 	}

--- a/lib/auth/okta/auth.go
+++ b/lib/auth/okta/auth.go
@@ -20,11 +20,11 @@ package okta
 
 import (
 	"context"
-	"slices"
+	"fmt"
 
 	"github.com/gravitational/trace"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	oktaplugin "github.com/gravitational/teleport/lib/okta/plugin"
@@ -145,35 +145,18 @@ func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, auth
 		return nil
 	}
 
-	hasApps := slices.ContainsFunc(ids, func(id types.ResourceID) bool {
-		return id.Kind == types.KindAppServer || id.Kind == types.KindApp
-	})
-	var oktaAppServers []types.AppServer
-	if hasApps {
-		// Unfortunately we have to pull all app_server resources here as there is no
-		// dedicated method to fetch a single app_server by name.
-		//
-		// [services.UnifiedResourceCache].GetUnifiedResourcesByIDs can't be used neither
-		// because Okta resources are keyed with [types.FriendlyName] (see
-		// [services.makeResourceSortKey]) and [types.ResourceID] does not contain labels.
-		//
-		// TODO(kopiczko): Create GetApplicationServer(ctx, name) of fix GetUnifiedResourcesByIDs and use it instead. See comments above.
-		oktaAppServers, err = auth.GetApplicationServers(ctx, apidefaults.Namespace)
-		if err != nil {
-			return trace.Wrap(err, "getting app servers")
-		}
-		oktaAppServers = slices.DeleteFunc(oktaAppServers, func(appServer types.AppServer) bool {
-			return appServer.Origin() != types.OriginOkta
-		})
-	}
-
 	var denied []types.ResourceID
+
 	for _, id := range ids {
 		switch id.Kind {
 		case types.KindAppServer, types.KindApp:
-			if slices.ContainsFunc(oktaAppServers, func(appServer types.AppServer) bool {
-				return appServer.GetName() == id.Name
-			}) {
+			_, err := getOktaAppServer(ctx, auth, id.Name)
+			switch {
+			case trace.IsNotFound(err):
+				// ok
+			case err != nil:
+				return trace.Wrap(err, "getting app_server %q", id.Name)
+			default:
 				denied = append(denied, id)
 				continue
 			}
@@ -183,7 +166,7 @@ func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, auth
 			case trace.IsNotFound(err):
 				// ok
 			case err != nil:
-				return trace.Wrap(err, "getting user group %q", id.Name)
+				return trace.Wrap(err, "getting user_group %q", id.Name)
 			case userGroup.Origin() == types.OriginOkta:
 				denied = append(denied, id)
 				continue
@@ -201,4 +184,30 @@ func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, auth
 	}
 
 	return trace.Wrap(OktaResourceNotRequestableError, "requested Okta resources: %s", resourcesStr)
+}
+
+func getOktaAppServer(ctx context.Context, auth AuthServer, name string) (types.AppServer, error) {
+	req := proto.ListResourcesRequest{
+		ResourceType: types.KindAppServer,
+		Limit:        1,
+		Labels: map[string]string{
+			types.OriginLabel: types.OriginOkta,
+		},
+		PredicateExpression: fmt.Sprintf(`name == %q`, name),
+	}
+
+	resp, err := auth.ListResources(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(resp.Resources) != 1 {
+		return nil, trace.NotFound("found %d resources when getting Okta-originated app_server %q", len(resp.Resources), name)
+	}
+
+	appServer, ok := resp.Resources[0].(types.AppServer)
+	if !ok {
+		return nil, trace.BadParameter("expected %T, found %T", appServer, resp.Resources[0])
+	}
+	return appServer, nil
 }

--- a/lib/auth/okta/interfaces.go
+++ b/lib/auth/okta/interfaces.go
@@ -21,6 +21,7 @@ package okta
 import (
 	"context"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -30,8 +31,8 @@ type PluginGetter interface {
 
 type AuthServer interface {
 	PluginGetter
-	// GetApplicationServers returns all registered application servers.
-	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
+	// ListResources returns paginated resources depending on the resource type.
+	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 	// GetUserGroup returns the specified user group resources.
 	GetUserGroup(ctx context.Context, name string) (types.UserGroup, error)
 }

--- a/lib/okta/plugin/interfaces.go
+++ b/lib/okta/plugin/interfaces.go
@@ -21,29 +21,9 @@ package oktaplugin
 import (
 	"context"
 
-	"github.com/gravitational/trace"
-
 	"github.com/gravitational/teleport/api/types"
 )
 
-// Get fetches the Okta plugin if it exists and does proper type assertions.
-func Get(ctx context.Context, plugins PluginGetter, withSecrets bool) (*types.PluginV1, error) {
-	plugin, err := plugins.GetPlugin(ctx, types.PluginTypeOkta, withSecrets)
-	if err != nil {
-		return nil, trace.Wrap(err, "getting Okta plugin")
-	}
-	pluginV1, ok := plugin.(*types.PluginV1)
-	if !ok {
-		return nil, trace.BadParameter("plugin.(%T) is not of type PluginV1", plugin)
-	}
-
-	oktaSettings := pluginV1.Spec.GetOkta()
-	if oktaSettings == nil {
-		return nil, trace.BadParameter("plugin %q does not have Okta settings", plugin.GetName())
-	}
-	if oktaSettings.SyncSettings == nil {
-		oktaSettings.SyncSettings = &types.PluginOktaSyncSettings{}
-	}
-
-	return pluginV1, nil
+type PluginGetter interface {
+	GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error)
 }


### PR DESCRIPTION
Backport #55420 to branch/v17

https://github.com/gravitational/teleport.e/pull/6671 should be merged first

changelog: UX: Forbid creating Access Requests to user_group resources when Okta bidirectional sync is disabled.