### PR TITLE
[vnet] feat: add SSH configuration diagnostic

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -317,19 +317,26 @@ func FullProfilePath(dir string) string {
 
 // defaultProfilePath retrieves the default path of the TSH profile.
 func defaultProfilePath() string {
-	// start with UserHomeDir, which is the fastest option as it
-	// relies only on environment variables and does not perform
-	// a user lookup (which can be very slow on large AD environments)
-	home, err := os.UserHomeDir()
-	if err == nil && home != "" {
-		return filepath.Join(home, profileDir)
-	}
-
-	home = os.TempDir()
-	if u, err := user.Current(); err == nil && u.HomeDir != "" {
-		home = u.HomeDir
+	home, ok := UserHomeDir()
+	if !ok {
+		home = os.TempDir()
 	}
 	return filepath.Join(home, profileDir)
+}
+
+// UserHomeDir returns the current user's home directory if it can be found.
+func UserHomeDir() (string, bool) {
+	// Start with os.UserHomeDir, which is the fastest option as it relies only
+	// on environment variables and does not perform a user lookup (which can be
+	// very slow on large AD environments).
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home, true
+	}
+	// Fall back to the user lookup.
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
+		return u.HomeDir, true
+	}
+	return "", false
 }
 
 // FromDir reads the user profile from a given directory. If dir is empty,

--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -82,9 +82,9 @@ const (
 	// vnetKnownHosts is the file name of the known_hosts file trusted by
 	// third-party SSH clients connecting to VNet SSH.
 	vnetKnownHosts = "vnet_known_hosts"
-	// vnetSSHConfig is the file name of the generated OpenSSH-compatible config
+	// VNetSSHConfig is the file name of the generated OpenSSH-compatible config
 	// file to be used by third-party SSH clients connecting to VNet SSH.
-	vnetSSHConfig = "vnet_ssh_config"
+	VNetSSHConfig = "vnet_ssh_config"
 )
 
 // Here's the file layout of all these keypaths.
@@ -463,7 +463,7 @@ func VNetKnownHostsPath(baseDir string) string {
 // VNetSSHConfigPath returns the path to VNet's generated OpenSSH-compatible
 // config file.
 func VNetSSHConfigPath(baseDir string) string {
-	return filepath.Join(baseDir, vnetSSHConfig)
+	return filepath.Join(baseDir, VNetSSHConfig)
 }
 
 // TrimKeyPathSuffix returns the given path with any key suffix/extension trimmed off.

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
@@ -496,6 +496,7 @@ type CheckReport struct {
 	// Types that are valid to be assigned to Report:
 	//
 	//	*CheckReport_RouteConflictReport
+	//	*CheckReport_SshConfigurationReport
 	Report        isCheckReport_Report `protobuf_oneof:"report"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -554,6 +555,15 @@ func (x *CheckReport) GetRouteConflictReport() *RouteConflictReport {
 	return nil
 }
 
+func (x *CheckReport) GetSshConfigurationReport() *SSHConfigurationReport {
+	if x != nil {
+		if x, ok := x.Report.(*CheckReport_SshConfigurationReport); ok {
+			return x.SshConfigurationReport
+		}
+	}
+	return nil
+}
+
 type isCheckReport_Report interface {
 	isCheckReport_Report()
 }
@@ -564,7 +574,14 @@ type CheckReport_RouteConflictReport struct {
 	RouteConflictReport *RouteConflictReport `protobuf:"bytes,2,opt,name=route_conflict_report,json=routeConflictReport,proto3,oneof"`
 }
 
+type CheckReport_SshConfigurationReport struct {
+	// ssh_configuration_report reports the status of the system's SSH configuration.
+	SshConfigurationReport *SSHConfigurationReport `protobuf:"bytes,3,opt,name=ssh_configuration_report,json=sshConfigurationReport,proto3,oneof"`
+}
+
 func (*CheckReport_RouteConflictReport) isCheckReport_Report() {}
+
+func (*CheckReport_SshConfigurationReport) isCheckReport_Report() {}
 
 // CommandAttempt describes the attempt at running a particular command associated with a diagnostic
 // check.
@@ -761,6 +778,73 @@ func (x *RouteConflict) GetInterfaceApp() string {
 	return ""
 }
 
+// SSHConfigurationReport describes the state of the system's SSH configuration.
+type SSHConfigurationReport struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// UserOpensshConfigPath is the full path to the user's default OpenSSH config
+	// file (~/.ssh/config).
+	UserOpensshConfigPath string `protobuf:"bytes,1,opt,name=user_openssh_config_path,json=userOpensshConfigPath,proto3" json:"user_openssh_config_path,omitempty"`
+	// VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
+	// file.
+	VnetSshConfigPath string `protobuf:"bytes,2,opt,name=vnet_ssh_config_path,json=vnetSshConfigPath,proto3" json:"vnet_ssh_config_path,omitempty"`
+	// UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
+	// configuration file includes VNet's SSH config file.
+	UserOpensshConfigIncludesVnetSshConfig bool `protobuf:"varint,3,opt,name=user_openssh_config_includes_vnet_ssh_config,json=userOpensshConfigIncludesVnetSshConfig,proto3" json:"user_openssh_config_includes_vnet_ssh_config,omitempty"`
+	unknownFields                          protoimpl.UnknownFields
+	sizeCache                              protoimpl.SizeCache
+}
+
+func (x *SSHConfigurationReport) Reset() {
+	*x = SSHConfigurationReport{}
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHConfigurationReport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHConfigurationReport) ProtoMessage() {}
+
+func (x *SSHConfigurationReport) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHConfigurationReport.ProtoReflect.Descriptor instead.
+func (*SSHConfigurationReport) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_vnet_diag_v1_diag_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SSHConfigurationReport) GetUserOpensshConfigPath() string {
+	if x != nil {
+		return x.UserOpensshConfigPath
+	}
+	return ""
+}
+
+func (x *SSHConfigurationReport) GetVnetSshConfigPath() string {
+	if x != nil {
+		return x.VnetSshConfigPath
+	}
+	return ""
+}
+
+func (x *SSHConfigurationReport) GetUserOpensshConfigIncludesVnetSshConfig() bool {
+	if x != nil {
+		return x.UserOpensshConfigIncludesVnetSshConfig
+	}
+	return false
+}
+
 var File_teleport_lib_vnet_diag_v1_diag_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
@@ -785,10 +869,11 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2-.teleport.lib.vnet.diag.v1.CheckAttemptStatusR\x06status\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12I\n" +
 	"\fcheck_report\x18\x03 \x01(\v2&.teleport.lib.vnet.diag.v1.CheckReportR\vcheckReport\x12E\n" +
-	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xc3\x01\n" +
+	"\bcommands\x18\x04 \x03(\v2).teleport.lib.vnet.diag.v1.CommandAttemptR\bcommands\"\xb2\x02\n" +
 	"\vCheckReport\x12D\n" +
 	"\x06status\x18\x01 \x01(\x0e2,.teleport.lib.vnet.diag.v1.CheckReportStatusR\x06status\x12d\n" +
-	"\x15route_conflict_report\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.RouteConflictReportH\x00R\x13routeConflictReportB\b\n" +
+	"\x15route_conflict_report\x18\x02 \x01(\v2..teleport.lib.vnet.diag.v1.RouteConflictReportH\x00R\x13routeConflictReport\x12m\n" +
+	"\x18ssh_configuration_report\x18\x03 \x01(\v21.teleport.lib.vnet.diag.v1.SSHConfigurationReportH\x00R\x16sshConfigurationReportB\b\n" +
 	"\x06report\"\xa1\x01\n" +
 	"\x0eCommandAttempt\x12G\n" +
 	"\x06status\x18\x01 \x01(\x0e2/.teleport.lib.vnet.diag.v1.CommandAttemptStatusR\x06status\x12\x14\n" +
@@ -801,7 +886,11 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp*w\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xe0\x01\n" +
+	"\x16SSHConfigurationReport\x127\n" +
+	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
+	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
+	",user_openssh_config_includes_vnet_ssh_config\x18\x03 \x01(\bR&userOpensshConfigIncludesVnetSshConfig*w\n" +
 	"\x12CheckAttemptStatus\x12$\n" +
 	" CHECK_ATTEMPT_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17CHECK_ATTEMPT_STATUS_OK\x10\x01\x12\x1e\n" +
@@ -828,23 +917,24 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_lib_vnet_diag_v1_diag_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_lib_vnet_diag_v1_diag_proto_goTypes = []any{
-	(CheckAttemptStatus)(0),       // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
-	(CheckReportStatus)(0),        // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
-	(CommandAttemptStatus)(0),     // 2: teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	(*Report)(nil),                // 3: teleport.lib.vnet.diag.v1.Report
-	(*NetworkStackAttempt)(nil),   // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt
-	(*NetworkStack)(nil),          // 5: teleport.lib.vnet.diag.v1.NetworkStack
-	(*CheckAttempt)(nil),          // 6: teleport.lib.vnet.diag.v1.CheckAttempt
-	(*CheckReport)(nil),           // 7: teleport.lib.vnet.diag.v1.CheckReport
-	(*CommandAttempt)(nil),        // 8: teleport.lib.vnet.diag.v1.CommandAttempt
-	(*RouteConflictReport)(nil),   // 9: teleport.lib.vnet.diag.v1.RouteConflictReport
-	(*RouteConflict)(nil),         // 10: teleport.lib.vnet.diag.v1.RouteConflict
-	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
+	(CheckAttemptStatus)(0),        // 0: teleport.lib.vnet.diag.v1.CheckAttemptStatus
+	(CheckReportStatus)(0),         // 1: teleport.lib.vnet.diag.v1.CheckReportStatus
+	(CommandAttemptStatus)(0),      // 2: teleport.lib.vnet.diag.v1.CommandAttemptStatus
+	(*Report)(nil),                 // 3: teleport.lib.vnet.diag.v1.Report
+	(*NetworkStackAttempt)(nil),    // 4: teleport.lib.vnet.diag.v1.NetworkStackAttempt
+	(*NetworkStack)(nil),           // 5: teleport.lib.vnet.diag.v1.NetworkStack
+	(*CheckAttempt)(nil),           // 6: teleport.lib.vnet.diag.v1.CheckAttempt
+	(*CheckReport)(nil),            // 7: teleport.lib.vnet.diag.v1.CheckReport
+	(*CommandAttempt)(nil),         // 8: teleport.lib.vnet.diag.v1.CommandAttempt
+	(*RouteConflictReport)(nil),    // 9: teleport.lib.vnet.diag.v1.RouteConflictReport
+	(*RouteConflict)(nil),          // 10: teleport.lib.vnet.diag.v1.RouteConflict
+	(*SSHConfigurationReport)(nil), // 11: teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	(*timestamppb.Timestamp)(nil),  // 12: google.protobuf.Timestamp
 }
 var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
-	11, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
+	12, // 0: teleport.lib.vnet.diag.v1.Report.created_at:type_name -> google.protobuf.Timestamp
 	4,  // 1: teleport.lib.vnet.diag.v1.Report.network_stack_attempt:type_name -> teleport.lib.vnet.diag.v1.NetworkStackAttempt
 	6,  // 2: teleport.lib.vnet.diag.v1.Report.checks:type_name -> teleport.lib.vnet.diag.v1.CheckAttempt
 	0,  // 3: teleport.lib.vnet.diag.v1.NetworkStackAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CheckAttemptStatus
@@ -854,13 +944,14 @@ var file_teleport_lib_vnet_diag_v1_diag_proto_depIdxs = []int32{
 	8,  // 7: teleport.lib.vnet.diag.v1.CheckAttempt.commands:type_name -> teleport.lib.vnet.diag.v1.CommandAttempt
 	1,  // 8: teleport.lib.vnet.diag.v1.CheckReport.status:type_name -> teleport.lib.vnet.diag.v1.CheckReportStatus
 	9,  // 9: teleport.lib.vnet.diag.v1.CheckReport.route_conflict_report:type_name -> teleport.lib.vnet.diag.v1.RouteConflictReport
-	2,  // 10: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
-	10, // 11: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 10: teleport.lib.vnet.diag.v1.CheckReport.ssh_configuration_report:type_name -> teleport.lib.vnet.diag.v1.SSHConfigurationReport
+	2,  // 11: teleport.lib.vnet.diag.v1.CommandAttempt.status:type_name -> teleport.lib.vnet.diag.v1.CommandAttemptStatus
+	10, // 12: teleport.lib.vnet.diag.v1.RouteConflictReport.route_conflicts:type_name -> teleport.lib.vnet.diag.v1.RouteConflict
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_vnet_diag_v1_diag_proto_init() }
@@ -870,6 +961,7 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 	}
 	file_teleport_lib_vnet_diag_v1_diag_proto_msgTypes[4].OneofWrappers = []any{
 		(*CheckReport_RouteConflictReport)(nil),
+		(*CheckReport_SshConfigurationReport)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -877,7 +969,7 @@ func file_teleport_lib_vnet_diag_v1_diag_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc), len(file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
+++ b/gen/proto/go/teleport/lib/vnet/diag/v1/diag.pb.go
@@ -781,17 +781,23 @@ func (x *RouteConflict) GetInterfaceApp() string {
 // SSHConfigurationReport describes the state of the system's SSH configuration.
 type SSHConfigurationReport struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// UserOpensshConfigPath is the full path to the user's default OpenSSH config
-	// file (~/.ssh/config).
+	// user_openssh_config_path is the full path to the user's default OpenSSH
+	// config file (~/.ssh/config).
 	UserOpensshConfigPath string `protobuf:"bytes,1,opt,name=user_openssh_config_path,json=userOpensshConfigPath,proto3" json:"user_openssh_config_path,omitempty"`
-	// VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
-	// file.
+	// vnet_ssh_config_path is the path to VNet's generated OpenSSH-compatible
+	// config file.
 	VnetSshConfigPath string `protobuf:"bytes,2,opt,name=vnet_ssh_config_path,json=vnetSshConfigPath,proto3" json:"vnet_ssh_config_path,omitempty"`
-	// UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
-	// configuration file includes VNet's SSH config file.
+	// user_openssh_config_includes_vnet_ssh_config is true if the default
+	// OpenSSH user configuration file includes VNet's SSH config file.
 	UserOpensshConfigIncludesVnetSshConfig bool `protobuf:"varint,3,opt,name=user_openssh_config_includes_vnet_ssh_config,json=userOpensshConfigIncludesVnetSshConfig,proto3" json:"user_openssh_config_includes_vnet_ssh_config,omitempty"`
-	unknownFields                          protoimpl.UnknownFields
-	sizeCache                              protoimpl.SizeCache
+	// user_openssh_config_exists is true if a file exists at
+	// user_openssh_config_path (~/.ssh/config).
+	UserOpensshConfigExists bool `protobuf:"varint,4,opt,name=user_openssh_config_exists,json=userOpensshConfigExists,proto3" json:"user_openssh_config_exists,omitempty"`
+	// user_openssh_config_contents contains the contents of the file at
+	// user_openssh_config_path if it exists.
+	UserOpensshConfigContents string `protobuf:"bytes,5,opt,name=user_openssh_config_contents,json=userOpensshConfigContents,proto3" json:"user_openssh_config_contents,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *SSHConfigurationReport) Reset() {
@@ -845,6 +851,20 @@ func (x *SSHConfigurationReport) GetUserOpensshConfigIncludesVnetSshConfig() boo
 	return false
 }
 
+func (x *SSHConfigurationReport) GetUserOpensshConfigExists() bool {
+	if x != nil {
+		return x.UserOpensshConfigExists
+	}
+	return false
+}
+
+func (x *SSHConfigurationReport) GetUserOpensshConfigContents() string {
+	if x != nil {
+		return x.UserOpensshConfigContents
+	}
+	return ""
+}
+
 var File_teleport_lib_vnet_diag_v1_diag_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
@@ -886,11 +906,13 @@ const file_teleport_lib_vnet_diag_v1_diag_proto_rawDesc = "" +
 	"\x04dest\x18\x01 \x01(\tR\x04dest\x12\x1b\n" +
 	"\tvnet_dest\x18\x02 \x01(\tR\bvnetDest\x12%\n" +
 	"\x0einterface_name\x18\x03 \x01(\tR\rinterfaceName\x12#\n" +
-	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xe0\x01\n" +
+	"\rinterface_app\x18\x04 \x01(\tR\finterfaceApp\"\xde\x02\n" +
 	"\x16SSHConfigurationReport\x127\n" +
 	"\x18user_openssh_config_path\x18\x01 \x01(\tR\x15userOpensshConfigPath\x12/\n" +
 	"\x14vnet_ssh_config_path\x18\x02 \x01(\tR\x11vnetSshConfigPath\x12\\\n" +
-	",user_openssh_config_includes_vnet_ssh_config\x18\x03 \x01(\bR&userOpensshConfigIncludesVnetSshConfig*w\n" +
+	",user_openssh_config_includes_vnet_ssh_config\x18\x03 \x01(\bR&userOpensshConfigIncludesVnetSshConfig\x12;\n" +
+	"\x1auser_openssh_config_exists\x18\x04 \x01(\bR\x17userOpensshConfigExists\x12?\n" +
+	"\x1cuser_openssh_config_contents\x18\x05 \x01(\tR\x19userOpensshConfigContents*w\n" +
 	"\x12CheckAttemptStatus\x12$\n" +
 	" CHECK_ATTEMPT_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17CHECK_ATTEMPT_STATUS_OK\x10\x01\x12\x1e\n" +

--- a/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
+++ b/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
@@ -278,26 +278,40 @@ export interface RouteConflict {
  */
 export interface SSHConfigurationReport {
     /**
-     * UserOpensshConfigPath is the full path to the user's default OpenSSH config
-     * file (~/.ssh/config).
+     * user_openssh_config_path is the full path to the user's default OpenSSH
+     * config file (~/.ssh/config).
      *
      * @generated from protobuf field: string user_openssh_config_path = 1;
      */
     userOpensshConfigPath: string;
     /**
-     * VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
-     * file.
+     * vnet_ssh_config_path is the path to VNet's generated OpenSSH-compatible
+     * config file.
      *
      * @generated from protobuf field: string vnet_ssh_config_path = 2;
      */
     vnetSshConfigPath: string;
     /**
-     * UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
-     * configuration file includes VNet's SSH config file.
+     * user_openssh_config_includes_vnet_ssh_config is true if the default
+     * OpenSSH user configuration file includes VNet's SSH config file.
      *
      * @generated from protobuf field: bool user_openssh_config_includes_vnet_ssh_config = 3;
      */
     userOpensshConfigIncludesVnetSshConfig: boolean;
+    /**
+     * user_openssh_config_exists is true if a file exists at
+     * user_openssh_config_path (~/.ssh/config).
+     *
+     * @generated from protobuf field: bool user_openssh_config_exists = 4;
+     */
+    userOpensshConfigExists: boolean;
+    /**
+     * user_openssh_config_contents contains the contents of the file at
+     * user_openssh_config_path if it exists.
+     *
+     * @generated from protobuf field: string user_openssh_config_contents = 5;
+     */
+    userOpensshConfigContents: string;
 }
 /**
  * CheckAttemptStatus describes whether CheckAttempt finished successfully. This is different from
@@ -893,7 +907,9 @@ class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
         super("teleport.lib.vnet.diag.v1.SSHConfigurationReport", [
             { no: 1, name: "user_openssh_config_path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "vnet_ssh_config_path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "user_openssh_config_includes_vnet_ssh_config", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 3, name: "user_openssh_config_includes_vnet_ssh_config", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "user_openssh_config_exists", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 5, name: "user_openssh_config_contents", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<SSHConfigurationReport>): SSHConfigurationReport {
@@ -901,6 +917,8 @@ class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
         message.userOpensshConfigPath = "";
         message.vnetSshConfigPath = "";
         message.userOpensshConfigIncludesVnetSshConfig = false;
+        message.userOpensshConfigExists = false;
+        message.userOpensshConfigContents = "";
         if (value !== undefined)
             reflectionMergePartial<SSHConfigurationReport>(this, message, value);
         return message;
@@ -918,6 +936,12 @@ class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
                     break;
                 case /* bool user_openssh_config_includes_vnet_ssh_config */ 3:
                     message.userOpensshConfigIncludesVnetSshConfig = reader.bool();
+                    break;
+                case /* bool user_openssh_config_exists */ 4:
+                    message.userOpensshConfigExists = reader.bool();
+                    break;
+                case /* string user_openssh_config_contents */ 5:
+                    message.userOpensshConfigContents = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -940,6 +964,12 @@ class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
         /* bool user_openssh_config_includes_vnet_ssh_config = 3; */
         if (message.userOpensshConfigIncludesVnetSshConfig !== false)
             writer.tag(3, WireType.Varint).bool(message.userOpensshConfigIncludesVnetSshConfig);
+        /* bool user_openssh_config_exists = 4; */
+        if (message.userOpensshConfigExists !== false)
+            writer.tag(4, WireType.Varint).bool(message.userOpensshConfigExists);
+        /* string user_openssh_config_contents = 5; */
+        if (message.userOpensshConfigContents !== "")
+            writer.tag(5, WireType.LengthDelimited).string(message.userOpensshConfigContents);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
+++ b/gen/proto/ts/teleport/lib/vnet/diag/v1/diag_pb.ts
@@ -184,6 +184,14 @@ export interface CheckReport {
          */
         routeConflictReport: RouteConflictReport;
     } | {
+        oneofKind: "sshConfigurationReport";
+        /**
+         * ssh_configuration_report reports the status of the system's SSH configuration.
+         *
+         * @generated from protobuf field: teleport.lib.vnet.diag.v1.SSHConfigurationReport ssh_configuration_report = 3;
+         */
+        sshConfigurationReport: SSHConfigurationReport;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -262,6 +270,34 @@ export interface RouteConflict {
      * @generated from protobuf field: string interface_app = 4;
      */
     interfaceApp: string;
+}
+/**
+ * SSHConfigurationReport describes the state of the system's SSH configuration.
+ *
+ * @generated from protobuf message teleport.lib.vnet.diag.v1.SSHConfigurationReport
+ */
+export interface SSHConfigurationReport {
+    /**
+     * UserOpensshConfigPath is the full path to the user's default OpenSSH config
+     * file (~/.ssh/config).
+     *
+     * @generated from protobuf field: string user_openssh_config_path = 1;
+     */
+    userOpensshConfigPath: string;
+    /**
+     * VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
+     * file.
+     *
+     * @generated from protobuf field: string vnet_ssh_config_path = 2;
+     */
+    vnetSshConfigPath: string;
+    /**
+     * UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
+     * configuration file includes VNet's SSH config file.
+     *
+     * @generated from protobuf field: bool user_openssh_config_includes_vnet_ssh_config = 3;
+     */
+    userOpensshConfigIncludesVnetSshConfig: boolean;
 }
 /**
  * CheckAttemptStatus describes whether CheckAttempt finished successfully. This is different from
@@ -599,7 +635,8 @@ class CheckReport$Type extends MessageType<CheckReport> {
     constructor() {
         super("teleport.lib.vnet.diag.v1.CheckReport", [
             { no: 1, name: "status", kind: "enum", T: () => ["teleport.lib.vnet.diag.v1.CheckReportStatus", CheckReportStatus, "CHECK_REPORT_STATUS_"] },
-            { no: 2, name: "route_conflict_report", kind: "message", oneof: "report", T: () => RouteConflictReport }
+            { no: 2, name: "route_conflict_report", kind: "message", oneof: "report", T: () => RouteConflictReport },
+            { no: 3, name: "ssh_configuration_report", kind: "message", oneof: "report", T: () => SSHConfigurationReport }
         ]);
     }
     create(value?: PartialMessage<CheckReport>): CheckReport {
@@ -624,6 +661,12 @@ class CheckReport$Type extends MessageType<CheckReport> {
                         routeConflictReport: RouteConflictReport.internalBinaryRead(reader, reader.uint32(), options, (message.report as any).routeConflictReport)
                     };
                     break;
+                case /* teleport.lib.vnet.diag.v1.SSHConfigurationReport ssh_configuration_report */ 3:
+                    message.report = {
+                        oneofKind: "sshConfigurationReport",
+                        sshConfigurationReport: SSHConfigurationReport.internalBinaryRead(reader, reader.uint32(), options, (message.report as any).sshConfigurationReport)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -642,6 +685,9 @@ class CheckReport$Type extends MessageType<CheckReport> {
         /* teleport.lib.vnet.diag.v1.RouteConflictReport route_conflict_report = 2; */
         if (message.report.oneofKind === "routeConflictReport")
             RouteConflictReport.internalBinaryWrite(message.report.routeConflictReport, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.lib.vnet.diag.v1.SSHConfigurationReport ssh_configuration_report = 3; */
+        if (message.report.oneofKind === "sshConfigurationReport")
+            SSHConfigurationReport.internalBinaryWrite(message.report.sshConfigurationReport, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -841,3 +887,66 @@ class RouteConflict$Type extends MessageType<RouteConflict> {
  * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.RouteConflict
  */
 export const RouteConflict = new RouteConflict$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SSHConfigurationReport$Type extends MessageType<SSHConfigurationReport> {
+    constructor() {
+        super("teleport.lib.vnet.diag.v1.SSHConfigurationReport", [
+            { no: 1, name: "user_openssh_config_path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "vnet_ssh_config_path", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "user_openssh_config_includes_vnet_ssh_config", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+    create(value?: PartialMessage<SSHConfigurationReport>): SSHConfigurationReport {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.userOpensshConfigPath = "";
+        message.vnetSshConfigPath = "";
+        message.userOpensshConfigIncludesVnetSshConfig = false;
+        if (value !== undefined)
+            reflectionMergePartial<SSHConfigurationReport>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SSHConfigurationReport): SSHConfigurationReport {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string user_openssh_config_path */ 1:
+                    message.userOpensshConfigPath = reader.string();
+                    break;
+                case /* string vnet_ssh_config_path */ 2:
+                    message.vnetSshConfigPath = reader.string();
+                    break;
+                case /* bool user_openssh_config_includes_vnet_ssh_config */ 3:
+                    message.userOpensshConfigIncludesVnetSshConfig = reader.bool();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SSHConfigurationReport, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string user_openssh_config_path = 1; */
+        if (message.userOpensshConfigPath !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.userOpensshConfigPath);
+        /* string vnet_ssh_config_path = 2; */
+        if (message.vnetSshConfigPath !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.vnetSshConfigPath);
+        /* bool user_openssh_config_includes_vnet_ssh_config = 3; */
+        if (message.userOpensshConfigIncludesVnetSshConfig !== false)
+            writer.tag(3, WireType.Varint).bool(message.userOpensshConfigIncludesVnetSshConfig);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.vnet.diag.v1.SSHConfigurationReport
+ */
+export const SSHConfigurationReport = new SSHConfigurationReport$Type();

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,6 +30,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/types"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	apiteleterm "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
@@ -90,6 +93,7 @@ type Config struct {
 	// reporting.
 	InstallationID string
 	Clock          clockwork.Clock
+	profilePath    string
 }
 
 // CheckAndSetDefaults checks and sets the defaults
@@ -108,6 +112,10 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
+	}
+
+	if c.profilePath == "" {
+		c.profilePath = profile.FullProfilePath(os.Getenv(types.HomeEnvVar))
 	}
 
 	return nil

--- a/lib/teleterm/vnet/service_darwin.go
+++ b/lib/teleterm/vnet/service_darwin.go
@@ -62,10 +62,20 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 		return nil, trace.Wrap(err)
 	}
 
+	sshDiag, err := diag.NewSSHDiag(&diag.SSHConfig{
+		ProfilePath: s.cfg.profilePath,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	report, err := diag.GenerateReport(ctx, diag.ReportPrerequisites{
 		Clock:               s.cfg.Clock,
 		NetworkStackAttempt: nsa,
-		DiagChecks:          []diag.DiagCheck{routeConflictDiag},
+		DiagChecks: []diag.DiagCheck{
+			routeConflictDiag,
+			sshDiag,
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -107,7 +107,7 @@ func (d *SSHDiag) isVNetSSHConfigIncluded(ctx context.Context) (bool, error) {
 	err = trace.ConvertSystemError(err)
 	switch {
 	case trace.IsNotFound(err):
-		// If the user OpenSSH config file does not exist, it definetely
+		// If the user OpenSSH config file does not exist, it definitely
 		// doesn't include the VNet SSH config.
 		return false, nil
 	case err != nil:

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -1,0 +1,194 @@
+package diag
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils/keypaths"
+	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
+	"github.com/gravitational/trace"
+)
+
+// SSHConfig includes everything that [SSHDiag] needs to run.
+type SSHConfig struct {
+	// ProfilePath is the path to the user profile (TELEPORT_HOME) where VNet's
+	// SSH configuration file is stored.
+	ProfilePath string
+}
+
+// SSHDiag is a diagnostic check that inspects whether the default user OpenSSH
+// config file includes VNet's generated SSH config file.
+type SSHDiag struct {
+	cfg                   *SSHConfig
+	userHome              string
+	userOpenSSHConfigPath string
+	vnetSSHConfigPath     string
+	isWindows             bool
+}
+
+// NewSSHDiag returns a new [SSHDiag].
+func NewSSHDiag(cfg *SSHConfig) (*SSHDiag, error) {
+	userHome, ok := profile.UserHomeDir()
+	if !ok {
+		return nil, trace.Errorf("unable to find user's home directory")
+	}
+	userOpenSSHConfigPath := filepath.Join(userHome, ".ssh", "config")
+	vnetSSHConfigPath := filepath.Join(cfg.ProfilePath, keypaths.VNetSSHConfig)
+	return &SSHDiag{
+		cfg:                   cfg,
+		userHome:              userHome,
+		userOpenSSHConfigPath: userOpenSSHConfigPath,
+		vnetSSHConfigPath:     vnetSSHConfigPath,
+		isWindows:             runtime.GOOS == "windows",
+	}, nil
+}
+
+// Run runs the diagnostic.
+func (d *SSHDiag) Run(ctx context.Context) (*diagv1.CheckReport, error) {
+	included, err := d.isVNetSSHConfigIncluded(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "checking if the default user OpenSSH config includes VNet's SSH configuration")
+	}
+	return &diagv1.CheckReport{
+		// This intentionally always returns CHECK_REPORT_STATUS_OK even if
+		// ~/.ssh/config does not include the VNet generated SSH config. It is
+		// not mandatory to configure SSH and returning an error status would
+		// case an alert and notification in Connect.
+		Status: diagv1.CheckReportStatus_CHECK_REPORT_STATUS_OK,
+		Report: &diagv1.CheckReport_SshConfigurationReport{
+			SshConfigurationReport: &diagv1.SSHConfigurationReport{
+				UserOpensshConfigPath:                  d.userOpenSSHConfigPath,
+				VnetSshConfigPath:                      d.vnetSSHConfigPath,
+				UserOpensshConfigIncludesVnetSshConfig: included,
+			},
+		},
+	}, nil
+}
+
+// Commands returns a command that prints the default user OpenSSH config file
+// which may be helpful for debugging.
+func (d *SSHDiag) Commands(ctx context.Context) []*exec.Cmd {
+	return []*exec.Cmd{
+		exec.CommandContext(ctx, "cat", d.userOpenSSHConfigPath),
+	}
+}
+
+// EmptyCheckReport returns an empty SSH configuration report.
+func (d *SSHDiag) EmptyCheckReport() *diagv1.CheckReport {
+	return &diagv1.CheckReport{Report: &diagv1.CheckReport_SshConfigurationReport{}}
+}
+
+func (d *SSHDiag) isVNetSSHConfigIncluded(ctx context.Context) (bool, error) {
+	openSSHConfigFile, err := os.Open(d.userOpenSSHConfigPath)
+	if err != nil {
+		return false, trace.Wrap(trace.ConvertSystemError(err), "opening %s for reading", d.userOpenSSHConfigPath)
+	}
+	defer openSSHConfigFile.Close()
+	return d.openSSHConfigIncludesVNetSSHConfig(openSSHConfigFile)
+}
+
+func (d *SSHDiag) openSSHConfigIncludesVNetSSHConfig(r io.Reader) (bool, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if d.openSSHConfigLineIncludesPath(scanner.Text(), d.vnetSSHConfigPath) {
+			return true, nil
+		}
+	}
+	return false, trace.Wrap(scanner.Err())
+}
+
+// openSSHConfigLineIncludesPath returns true if the given line of an OpenSSH
+// configuration file is an include statement for the given path.
+func (d *SSHDiag) openSSHConfigLineIncludesPath(line, wantPath string) bool {
+	wantPath = d.normalizePath(wantPath)
+	line = strings.TrimSpace(line)
+
+	// Only consider lines that begin with "include" (case-insensitive).
+	i := strings.IndexFunc(line, isSpace)
+	if i == -1 {
+		return false
+	}
+	if strings.ToLower(line[:i]) != "include" {
+		return false
+	}
+	// Consider the rest of the line after "include".
+	line = line[i+1:]
+
+	// Include lines may specify multiple pathnames and each pathname may
+	// contain glob wildcards, tokens, environment variables, ~, escaped
+	// characters and may or may not be quoted. This function does not support
+	// glob wildcards, tokens, or environment variables. It splits each argument
+	// at unescaped and unqouted whitespace and if the argument matches wantPath
+	// returns true. It does support ~ as an alias for the user's home
+	// directory.
+	var (
+		// b is a running buffer holding the current argument as parsed up to
+		// the current point.
+		b        strings.Builder
+		escape   = false
+		inQuotes = false
+	)
+loop:
+	for _, c := range line {
+		switch {
+		case escape:
+			// Always write escaped characters literally.
+			b.WriteRune(c)
+			escape = false
+		case c == '\\':
+			// The next character is escaped.
+			escape = true
+		case c == '"':
+			// Entering or exiting a quoted section.
+			inQuotes = !inQuotes
+		case b.Len() == 0 && c == '~':
+			// Support ~ as an alias for the user's home directory.
+			b.WriteString(d.userHome)
+		case !inQuotes && isSpace(c):
+			// Reached the end of this argument, check if it matches wantPath.
+			if d.normalizePath(b.String()) == wantPath {
+				return true
+			}
+			b.Reset()
+		case !inQuotes && c == '#':
+			// Found a comment in the middle of the line, ignore the rest.
+			break loop
+		default:
+			// By default just append the current character to the current
+			// argument.
+			b.WriteRune(c)
+		}
+	}
+	// Handle an argument that ends at the end of the line.
+	return d.normalizePath(b.String()) == wantPath
+}
+
+func (d *SSHDiag) normalizePath(path string) string {
+	if d.isWindows {
+		// Normalize all paths to use unix-style separators since OpenSSH
+		// supports / or \\ on Windows.
+		path = strings.ReplaceAll(path, `\`, `/`)
+		// Windows paths are case-insensitive.
+		path = strings.ToLower(path)
+	}
+	return filepath.Clean(path)
+}
+
+func userSSHConfigPath(userHome string) string {
+	return filepath.Join(userHome, ".ssh", "config")
+}
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t':
+		return true
+	}
+	return false
+}

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package diag
 
 import (

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -10,10 +10,11 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
-	"github.com/gravitational/trace"
 )
 
 // SSHConfig includes everything that [SSHDiag] needs to run.
@@ -179,10 +180,6 @@ func (d *SSHDiag) normalizePath(path string) string {
 		path = strings.ToLower(path)
 	}
 	return filepath.Clean(path)
-}
-
-func userSSHConfigPath(userHome string) string {
-	return filepath.Join(userHome, ".ssh", "config")
 }
 
 func isSpace(r rune) bool {

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -1,0 +1,174 @@
+package diag
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSHDiag tests the SSH configuration diagnostic, specifically its ability
+// to check whether an OpenSSH config file includes the VNet SSH config file.
+func TestSSHDiag(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc        string
+		profilePath string
+		userHome    string
+		isWindows   bool
+		input       string
+		expect      bool
+	}{
+		{
+			desc:        "empty",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+		},
+		{
+			desc:        "macos tsh",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include /Users/user/.tsh/vnet_ssh_config`,
+			expect:      true,
+		},
+		{
+			desc:        "macos tsh ~",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include ~/.tsh/vnet_ssh_config`,
+			expect:      true,
+		},
+		{
+			desc:        "macos connect",
+			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "macos connect ~",
+			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include "~/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "macos tsh not match connect",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+		},
+		{
+			desc:        "macos connect not match tsh",
+			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include /Users/user/.tsh/vnet_ssh_config`,
+		},
+		{
+			desc:        "windows tsh",
+			profilePath: `C:\Users\User\.tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows tsh unix path",
+			profilePath: `C:\Users\User\.tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:/Users/User/.tsh/vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows tsh ~",
+			profilePath: `C:\Users\User\.tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "~\\.tsh\\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows connect",
+			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows connect unix path",
+			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:/Users/User/AppData/Roaming/Teleport\ Connect/tsh/vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows connect ~",
+			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "~\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows tsh not match connect",
+			profilePath: `C:\Users\User\.tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+		},
+		{
+			desc:        "windows connect not match tsh",
+			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
+		},
+		{
+			desc:        "some other file",
+			profilePath: `/Users/user/.tsh`,
+			input:       `Include /Users/user/.tsh/ssh_config`,
+		},
+		{
+			desc:        "multiple includes",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input: `
+Include ~/.ssh/include/*
+Include /Users/user/ssh_config
+Include /Users/user/.tsh/vnet_ssh_config
+`,
+			expect: true,
+		},
+		{
+			desc:        "commented",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include #/Users/user/.tsh/vnet_ssh_config`,
+		},
+		{
+			desc:        "mine",
+			profilePath: `/Users/nic/Library/Application Support/Electron/tsh`,
+			userHome:    `/Users/nic`,
+			input:       `Include "/Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config"`,
+			expect:      true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			diag, err := NewSSHDiag(&SSHConfig{
+				ProfilePath: tc.profilePath,
+			})
+			require.NoError(t, err)
+
+			// Override isWindows and userHome for the purpose of the test.
+			diag.isWindows = tc.isWindows
+			diag.userHome = tc.userHome
+
+			result, err := diag.openSSHConfigIncludesVNetSSHConfig(strings.NewReader(tc.input))
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, result)
+		})
+	}
+}

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package diag
 
 import (

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -93,6 +93,14 @@ func TestSSHDiag(t *testing.T) {
 			expect:      true,
 		},
 		{
+			desc:        "windows tsh unescaped",
+			profilePath: `C:\Users\User\.tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\Users\User\.tsh\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
 			desc:        "windows tsh unix path",
 			profilePath: `C:\Users\User\.tsh`,
 			userHome:    `C:\Users\User`,
@@ -114,6 +122,14 @@ func TestSSHDiag(t *testing.T) {
 			userHome:    `C:\Users\User`,
 			isWindows:   true,
 			input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+			expect:      true,
+		},
+		{
+			desc:        "windows connect unescaped",
+			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+			userHome:    `C:\Users\User`,
+			isWindows:   true,
+			input:       `Include "C:\Users\User\AppData\Roaming\Teleport Connect\tsh\vnet_ssh_config"`,
 			expect:      true,
 		},
 		{
@@ -169,10 +185,10 @@ Include /Users/user/.tsh/vnet_ssh_config
 			input:       `Include #/Users/user/.tsh/vnet_ssh_config`,
 		},
 		{
-			desc:        "mine",
-			profilePath: `/Users/nic/Library/Application Support/Electron/tsh`,
-			userHome:    `/Users/nic`,
-			input:       `Include "/Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config"`,
+			desc:        "single quotes",
+			profilePath: `/Users/user/.tsh`,
+			userHome:    `/Users/user`,
+			input:       `Include '/Users/user/.tsh/vnet_ssh_config'`,
 			expect:      true,
 		},
 	} {

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -215,6 +215,8 @@ Include /Users/user/.tsh/vnet_ssh_config
 						UserOpensshConfigPath:                  userOpenSSHConfigPath,
 						VnetSshConfigPath:                      keypaths.VNetSSHConfigPath(tc.profilePath),
 						UserOpensshConfigIncludesVnetSshConfig: tc.expect,
+						UserOpensshConfigExists:                len(tc.input) > 0,
+						UserOpensshConfigContents:              tc.input,
 					},
 				},
 			}

--- a/proto/teleport/lib/vnet/diag/v1/diag.proto
+++ b/proto/teleport/lib/vnet/diag/v1/diag.proto
@@ -107,6 +107,8 @@ message CheckReport {
     // route_conflict reports whether there are routes that might conflict with routes set up by
     // VNet.
     RouteConflictReport route_conflict_report = 2;
+    // ssh_configuration_report reports the status of the system's SSH configuration.
+    SSHConfigurationReport ssh_configuration_report = 3;
   }
 }
 
@@ -157,4 +159,17 @@ message RouteConflict {
   // the output of `ifconfig -v <interface name>`. Not all VPN applications use this framework, so
   // it's likely to be empty.
   string interface_app = 4;
+}
+
+// SSHConfigurationReport describes the state of the system's SSH configuration.
+message SSHConfigurationReport {
+  // UserOpensshConfigPath is the full path to the user's default OpenSSH config
+  // file (~/.ssh/config).
+  string user_openssh_config_path = 1;
+  // VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
+  // file.
+  string vnet_ssh_config_path = 2;
+  // UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
+  // configuration file includes VNet's SSH config file.
+  bool user_openssh_config_includes_vnet_ssh_config = 3;
 }

--- a/proto/teleport/lib/vnet/diag/v1/diag.proto
+++ b/proto/teleport/lib/vnet/diag/v1/diag.proto
@@ -163,13 +163,19 @@ message RouteConflict {
 
 // SSHConfigurationReport describes the state of the system's SSH configuration.
 message SSHConfigurationReport {
-  // UserOpensshConfigPath is the full path to the user's default OpenSSH config
-  // file (~/.ssh/config).
+  // user_openssh_config_path is the full path to the user's default OpenSSH
+  // config file (~/.ssh/config).
   string user_openssh_config_path = 1;
-  // VnetSshConfigPath is the path to VNet's generated OpenSSH-compatible config
-  // file.
+  // vnet_ssh_config_path is the path to VNet's generated OpenSSH-compatible
+  // config file.
   string vnet_ssh_config_path = 2;
-  // UserOpensshConfigIncludesVnetSshConfig is true if the default OpenSSH user
-  // configuration file includes VNet's SSH config file.
+  // user_openssh_config_includes_vnet_ssh_config is true if the default
+  // OpenSSH user configuration file includes VNet's SSH config file.
   bool user_openssh_config_includes_vnet_ssh_config = 3;
+  // user_openssh_config_exists is true if a file exists at
+  // user_openssh_config_path (~/.ssh/config).
+  bool user_openssh_config_exists = 4;
+  // user_openssh_config_contents contains the contents of the file at
+  // user_openssh_config_path if it exists.
+  string user_openssh_config_contents = 5;
 }

--- a/web/packages/teleterm/src/helpers.ts
+++ b/web/packages/teleterm/src/helpers.ts
@@ -26,6 +26,7 @@ import { WindowsDesktop } from 'gen-proto-ts/teleport/lib/teleterm/v1/windows_de
 import {
   CheckReport,
   RouteConflictReport,
+  SSHConfigurationReport,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import {
@@ -193,4 +194,13 @@ export function reportOneOfIsRouteConflictReport(
   routeConflictReport: RouteConflictReport;
 } {
   return report.oneofKind === 'routeConflictReport';
+}
+
+export function reportOneOfIsSSHConfigurationReport(
+  report: CheckReport['report']
+): report is {
+  oneofKind: 'sshConfigurationReport';
+  sshConfigurationReport: SSHConfigurationReport;
+} {
+  return report.oneofKind === 'sshConfigurationReport';
 }

--- a/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
+++ b/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
@@ -46,9 +46,8 @@ default            link#25            UCSIg               utun4
 | User OpenSSH config file | ~/.ssh/config  |
 | VNet SSH config file     | /Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config  |
 
-\`\`\`
-$ cat ~/.ssh/config
-Include ~/.ssh/includes/*
-\`\`\`
+~/.ssh/config does not exist
+
+
 "
 `;

--- a/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
+++ b/web/packages/teleterm/src/services/vnet/__snapshots__/diag.test.ts.snap
@@ -33,5 +33,22 @@ default            link#25            UCSIg               utun4
 100.100.100.100    link#25            UHWIi               utun4       
 
 \`\`\`
+
+---
+⚠️ VNet SSH is not configured.
+
+  The user's default SSH configuration file does not include VNet's
+  generated configuration file and connections to VNet SSH hosts will
+  not work by default.
+
+| File description         | Path |
+| ------------------------ | ---- |
+| User OpenSSH config file | ~/.ssh/config  |
+| VNet SSH config file     | /Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config  |
+
+\`\`\`
+$ cat ~/.ssh/config
+Include ~/.ssh/includes/*
+\`\`\`
 "
 `;

--- a/web/packages/teleterm/src/services/vnet/diag.test.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.test.ts
@@ -61,6 +61,8 @@ describe('reportToText', () => {
         vnetSshConfigPath:
           '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
         userOpensshConfigIncludesVnetSshConfig: false,
+        userOpensshConfigExists: false,
+        userOpensshConfigContents: "",
       },
     };
     const report = makeReport({
@@ -71,12 +73,6 @@ describe('reportToText', () => {
         }),
         makeCheckAttempt({
           checkReport: sshConfigReport,
-          commands: [
-            makeCommandAttempt({
-              command: 'cat ~/.ssh/config',
-              output: 'Include ~/.ssh/includes/*',
-            }),
-          ],
         }),
       ],
     });

--- a/web/packages/teleterm/src/services/vnet/diag.test.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.test.ts
@@ -74,8 +74,7 @@ describe('reportToText', () => {
           commands: [
             makeCommandAttempt({
               command: 'cat ~/.ssh/config',
-              output:
-                'Include ~/.ssh/includes/*',
+              output: 'Include ~/.ssh/includes/*',
             }),
           ],
         }),

--- a/web/packages/teleterm/src/services/vnet/diag.test.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.test.ts
@@ -62,7 +62,7 @@ describe('reportToText', () => {
           '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
         userOpensshConfigIncludesVnetSshConfig: false,
         userOpensshConfigExists: false,
-        userOpensshConfigContents: "",
+        userOpensshConfigContents: '',
       },
     };
     const report = makeReport({

--- a/web/packages/teleterm/src/services/vnet/diag.test.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.test.ts
@@ -29,10 +29,10 @@ import {
 
 describe('reportToText', () => {
   it('converts report correctly', () => {
-    const checkReport = makeCheckReport({
+    const routeConflictReport = makeCheckReport({
       status: diag.CheckReportStatus.ISSUES_FOUND,
     });
-    checkReport.report = {
+    routeConflictReport.report = {
       oneofKind: 'routeConflictReport',
       routeConflictReport: {
         routeConflicts: [
@@ -51,11 +51,33 @@ describe('reportToText', () => {
         ],
       },
     };
+    const sshConfigReport = makeCheckReport({
+      status: diag.CheckReportStatus.OK,
+    });
+    sshConfigReport.report = {
+      oneofKind: 'sshConfigurationReport',
+      sshConfigurationReport: {
+        userOpensshConfigPath: '~/.ssh/config',
+        vnetSshConfigPath:
+          '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
+        userOpensshConfigIncludesVnetSshConfig: false,
+      },
+    };
     const report = makeReport({
       checks: [
         makeCheckAttempt({
-          checkReport,
+          checkReport: routeConflictReport,
           commands: [makeCommandAttempt()],
+        }),
+        makeCheckAttempt({
+          checkReport: sshConfigReport,
+          commands: [
+            makeCommandAttempt({
+              command: 'cat ~/.ssh/config',
+              output:
+                'Include ~/.ssh/includes/*',
+            }),
+          ],
         }),
       ],
     });

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -161,20 +161,38 @@ function sshConfigurationReportToText({ report }: diag.CheckReport): string {
   if (!reportOneOfIsSSHConfigurationReport(report)) {
     return null;
   }
-  const pathsTable = `
-| File description         | Path |
-| ------------------------ | ---- |
-| User OpenSSH config file | ${report.sshConfigurationReport.userOpensshConfigPath}  |
-| VNet SSH config file     | ${report.sshConfigurationReport.vnetSshConfigPath}  |`;
+  const {
+    userOpensshConfigPath,
+    vnetSshConfigPath,
+    userOpensshConfigIncludesVnetSshConfig,
+    userOpensshConfigExists,
+    userOpensshConfigContents,
+  } = report.sshConfigurationReport;
 
-  if (report.sshConfigurationReport.userOpensshConfigIncludesVnetSshConfig) {
-    return '✅ VNet SSH is configured correctly.\n' + pathsTable;
-  }
-  return (
-    `⚠️ VNet SSH is not configured.
+  const status = userOpensshConfigIncludesVnetSshConfig
+    ? '✅ VNet SSH is configured correctly.'
+    : `⚠️ VNet SSH is not configured.
 
   The user's default SSH configuration file does not include VNet's
   generated configuration file and connections to VNet SSH hosts will
-  not work by default.\n` + pathsTable
-  );
+  not work by default.`;
+
+  const pathsTable = `
+| File description         | Path |
+| ------------------------ | ---- |
+| User OpenSSH config file | ${userOpensshConfigPath}  |
+| VNet SSH config file     | ${vnetSshConfigPath}  |`;
+
+  const currentContents = userOpensshConfigExists
+    ? `Current contents of ${userOpensshConfigPath}:
+
+\`\`\`
+${userOpensshConfigContents}
+\`\`\``
+    : `${userOpensshConfigPath} does not exist`;
+
+  return `${status}
+${pathsTable}
+
+${currentContents}`;
 }

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -157,10 +157,7 @@ function routeConflictReportToText({
 ${tableRows}`;
 }
 
-function sshConfigurationReportToText({
-  report,
-  status,
-}: diag.CheckReport): string {
+function sshConfigurationReportToText({ report }: diag.CheckReport): string {
   if (!reportOneOfIsSSHConfigurationReport(report)) {
     return null;
   }

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -49,6 +49,12 @@ import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/conne
 import { DocumentVnetDiagReport as Component } from './DocumentVnetDiagReport';
 import { useVnetContext, VnetContextProvider } from './vnetContext';
 
+const defaultUserSSHConfigContents = `Include "/Users/User/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config"
+
+Host github.com
+  IdentityFile ~/.ssh/id_ed25519
+`;
+
 type StoryProps = {
   asText: boolean;
   networkStackAttempt: 'ok' | 'error';
@@ -59,7 +65,8 @@ type StoryProps = {
   routeConflictCommandAttempt: 'ok' | 'error';
   sshConfigAttempt: 'ok' | 'error';
   sshConfigured: boolean;
-  sshConfigCommandAttempt: 'ok' | 'error';
+  userOpenSSHConfigExists: boolean;
+  userOpenSSHConfigContents: string;
   displayUnsupportedCheckAttempt: boolean;
   vnetRunning: boolean;
   reRunDiagnostics: 'success' | 'error' | 'processing';
@@ -99,12 +106,10 @@ const meta: Meta<StoryProps> = {
       control: { type: 'inline-radio' },
       options: ['ok', 'error'],
     },
+    userOpenSSHConfigExists: {},
+    userOpenSSHConfigContents: {},
     sshConfigured: {
       control: { type: 'boolean' },
-    },
-    sshConfigCommandAttempt: {
-      control: { type: 'inline-radio' },
-      options: ['ok', 'error'],
     },
     displayUnsupportedCheckAttempt: {
       description:
@@ -138,7 +143,8 @@ const meta: Meta<StoryProps> = {
     routeConflictCommandAttempt: 'ok',
     sshConfigAttempt: 'ok',
     sshConfigured: false,
-    sshConfigCommandAttempt: 'ok',
+    userOpenSSHConfigExists: true,
+    userOpenSSHConfigContents: defaultUserSSHConfigContents,
     displayUnsupportedCheckAttempt: false,
     vnetRunning: true,
     reRunDiagnostics: 'success',
@@ -231,6 +237,8 @@ export function DocumentVnetDiagReport(props: StoryProps) {
     userOpensshConfigPath: '/Users/User/.ssh/config',
     vnetSshConfigPath:
       '/Users/User/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
+    userOpensshConfigExists: props.userOpenSSHConfigExists,
+    userOpensshConfigContents: props.userOpenSSHConfigContents,
   };
   const sshConfigCheckAttempt = makeCheckAttempt({
     status:
@@ -247,21 +255,6 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       },
     }),
   });
-  if (props.sshConfigCommandAttempt === 'error') {
-    sshConfigCheckAttempt.commands.push({
-      status: CommandAttemptStatus.ERROR,
-      error: 'something went wrong',
-      command: 'cat /Users/User/.ssh/config',
-      output: '',
-    });
-  } else {
-    sshConfigCheckAttempt.commands.push({
-      status: CommandAttemptStatus.OK,
-      error: '',
-      command: 'cat /Users/User/.ssh/config',
-      output: userSSHConfigContents,
-    });
-  }
   report.checks.push(sshConfigCheckAttempt);
 
   if (props.displayUnsupportedCheckAttempt) {
@@ -356,10 +349,4 @@ default            link#25            UCSIg               utun4
 239.255.255.250    1:0:5e:7f:ff:fa    UHmLWI                en0       
 255.255.255.255/32 link#14            UCS                   en0      !
 255.255.255.255/32 link#25            UCSI                utun4       
-`;
-
-const userSSHConfigContents = `Include "/Users/User/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config"
-
-Host github.com
-  IdentityFile ~/.ssh/id_ed25519
 `;

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -234,9 +234,11 @@ export function DocumentVnetDiagReport(props: StoryProps) {
   };
   const sshConfigCheckAttempt = makeCheckAttempt({
     status:
-      props.sshConfigAttempt == 'ok'
+      props.sshConfigAttempt === 'ok'
         ? CheckAttemptStatus.OK
         : CheckAttemptStatus.ERROR,
+    error:
+      props.sshConfigAttempt === 'error' ? 'something went wrong' : undefined,
     checkReport: makeCheckReport({
       status: CheckReportStatus.OK,
       report: {
@@ -245,7 +247,7 @@ export function DocumentVnetDiagReport(props: StoryProps) {
       },
     }),
   });
-  if (props.sshConfigCommandAttempt == 'error') {
+  if (props.sshConfigCommandAttempt === 'error') {
     sshConfigCheckAttempt.commands.push({
       status: CommandAttemptStatus.ERROR,
       error: 'something went wrong',

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -21,7 +21,7 @@ import styled from 'styled-components';
 
 import { Button, Alert as DesignAlert, Flex, H1, Link, Stack } from 'design';
 import { AlertProps } from 'design/Alert/Alert';
-import Table, { TextCell } from 'design/DataTable';
+import Table, { Cell, TextCell } from 'design/DataTable';
 import { displayDateTime } from 'design/datetime';
 import {
   Copy,
@@ -35,6 +35,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+import { TextSelectCopy } from 'shared/components/TextSelectCopy';
 import { CanceledError, useAsync } from 'shared/hooks/useAsync';
 import { pluralize } from 'shared/utils/text';
 
@@ -402,38 +403,49 @@ function CheckReportSSHConfiguration({
       ]}
       columns={[
         { key: 'desc', headerText: 'File description' },
-        { key: 'path', headerText: 'Path' },
+        {
+          key: 'path',
+          headerText: 'Path',
+          render: row => (
+            <Cell>
+              <code>{row.path}</code>
+            </Cell>
+          ),
+        },
       ]}
     />
   );
   if (userOpensshConfigIncludesVnetSshConfig) {
     return (
       <>
-        <P1>
-          <Success /> VNet SSH is configured correctly.
-        </P1>
-        <P2>
-          The user's default SSH configuration file correctly includes VNet's
-          generated configuration file.
-        </P2>
+        <Stack>
+          <P1>
+            <Success /> VNet SSH is configured correctly.
+          </P1>
+          <P2>
+            The user's default SSH configuration file correctly includes VNet's
+            generated configuration file.
+          </P2>
+        </Stack>
         {pathsTable}
       </>
     );
   }
   return (
     <>
-      <P1>
-        <Warning /> VNet SSH is not configured.
-      </P1>
-      <P2>
-        The user's default SSH configuration file does not include VNet's
-        generated SSH configuration file. SSH clients will not be able to make
-        connections to VNet SSH addresses by default. Add the following line to{' '}
-        {userOpensshConfigPath} to configure OpenSSH-compatible clients for
-        VNet:
-      </P2>
-      <P2>Include "{vnetSshConfigPath}"</P2>
-      <br />
+      <Stack>
+        <P1>
+          <Warning /> VNet SSH is not configured.
+        </P1>
+        <P2 m={0}>
+          The user's default SSH configuration file does not include VNet's
+          generated SSH configuration file. SSH clients will not be able to make
+          connections to VNet SSH addresses by default. Add the following line
+          to {userOpensshConfigPath} to configure OpenSSH-compatible clients for
+          VNet:
+        </P2>
+        <TextSelectCopy text={`Include "${vnetSshConfigPath}"`} bash={false} />
+      </Stack>
       {pathsTable}
     </>
   );

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -441,7 +441,7 @@ function CheckReportSSHConfiguration({
           The user's default SSH configuration file does not include VNet's
           generated SSH configuration file. SSH clients will not be able to make
           connections to VNet SSH addresses by default. Add the following line
-          to {userOpensshConfigPath} to configure OpenSSH-compatible clients for
+          to <code>{userOpensshConfigPath}</code> to configure OpenSSH-compatible clients for
           VNet:
         </P2>
         <TextSelectCopy text={`Include "${vnetSshConfigPath}"`} bash={false} />

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -387,6 +387,8 @@ function CheckReportSSHConfiguration({
     userOpensshConfigPath,
     vnetSshConfigPath,
     userOpensshConfigIncludesVnetSshConfig,
+    userOpensshConfigExists,
+    userOpensshConfigContents,
   } = report.sshConfigurationReport;
   const pathsTable = (
     <Table
@@ -446,7 +448,14 @@ function CheckReportSSHConfiguration({
         </P2>
         <TextSelectCopy text={`Include "${vnetSshConfigPath}"`} bash={false} />
       </Stack>
-      {pathsTable}
+      {userOpensshConfigExists ? (
+        <details>
+          <Summary>
+            Current contents of <code>{userOpensshConfigPath}</code>
+          </Summary>
+          <Pre>{userOpensshConfigContents}</Pre>
+        </details>
+      ) : null}
     </>
   );
 }

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -441,8 +441,8 @@ function CheckReportSSHConfiguration({
           The user's default SSH configuration file does not include VNet's
           generated SSH configuration file. SSH clients will not be able to make
           connections to VNet SSH addresses by default. Add the following line
-          to <code>{userOpensshConfigPath}</code> to configure OpenSSH-compatible clients for
-          VNet:
+          to <code>{userOpensshConfigPath}</code> to configure
+          OpenSSH-compatible clients for VNet:
         </P2>
         <TextSelectCopy text={`Include "${vnetSshConfigPath}"`} bash={false} />
       </Stack>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -24,7 +24,6 @@ import { AlertProps } from 'design/Alert/Alert';
 import Table, { TextCell } from 'design/DataTable';
 import { displayDateTime } from 'design/datetime';
 import {
-  Check,
   Copy,
   Download,
   Refresh,
@@ -376,7 +375,7 @@ function CheckReportRouteConflict({
 }
 
 function CheckReportSSHConfiguration({
-  checkReport: { report, status },
+  checkReport: { report },
 }: {
   checkReport: diag.CheckReport;
 }) {


### PR DESCRIPTION
This commit adds a VNet diagnostic that reports whether the default user OpenSSH config file (`~/.ssh/config`) includes VNet's generated SSH config file.

Part of [RFD 207](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md)

Example diagnostics:
<details><summary>screenshots</summary>
<img width="746" alt="Screenshot 2025-06-10 at 8 50 13 AM" src="https://github.com/user-attachments/assets/e899ef9a-f0ce-4dfd-a0eb-6ad45ce42859" />
<img width="681" alt="Screenshot 2025-06-10 at 8 50 38 AM" src="https://github.com/user-attachments/assets/f996797f-2267-4fc5-a37a-1e6b5cb0e5c7" />
</details>

<details><summary>Copied text with VNet not configured</summary>
VNet Diagnostic Report

Created at: 2025-06-10 08:50:25 (Tue, 10 Jun 2025 15:50:25 GMT)
Network interface: utun5
IPv4 CIDR ranges: 100.64.0.0/10
IPv6 prefix: fdc3:29fa:bc6e::
DNS zones: one.private, nicklaassen.ca

---
✅ There are no network routes in conflict with VNet.

```
$ netstat -rn -f inet
Routing tables

Internet:
Destination        Gateway            Flags               Netif Expire
default            192.168.50.1       UGScg                 en0       
100.64/10          utun5              USc                 utun5       
100.64.0.1         100.64.0.1         UH                  utun5       
127                127.0.0.1          UCS                   lo0       
127.0.0.1          127.0.0.1          UH                    lo0       
169.254            link#14            UCS                   en0      !
169.254.169.254    link#14            UHRLSW                en0      !
192.168.50         link#14            UCS                   en0      !
192.168.50.1/32    link#14            UCS                   en0      !
192.168.50.1       10:7c:61:43:1:f8   UHLWIir               en0   1172
192.168.50.16      74:13:ea:a5:2e:27  UHLWI                 en0    769
192.168.50.25      3c:61:5:e:f:94     UHLWI                 en0   1183
192.168.50.44      f0:b3:ec:b:8d:9    UHLWI                 en0    629
192.168.50.84      34:3e:a4:23:90:1d  UHLWI                 en0   1178
192.168.50.94      40:91:51:af:5d:60  UHLWI                 en0   1171
192.168.50.126/32  link#14            UCS                   en0      !
192.168.50.148     d8:80:83:e5:69:9a  UHLWI                 en0    619
192.168.50.206     ec:64:c9:42:1:40   UHLWI                 en0      !
192.168.50.243     a6:c6:9e:4b:4e:fd  UHLWI                 en0    144
192.168.50.255     ff:ff:ff:ff:ff:ff  UHLWbI                en0      !
224.0.0/4          link#14            UmCS                  en0      !
224.0.0.251        1:0:5e:0:0:fb      UHmLWI                en0       
239.255.255.250    1:0:5e:7f:ff:fa    UHmLWI                en0       
255.255.255.255/32 link#14            UCS                   en0      !

```

```
$ scutil --dns
DNS configuration

resolver #1
  nameserver[0] : 192.168.50.1
  if_index : 14 (en0)
  flags    : Request A records
  reach    : 0x00020002 (Reachable,Directly Reachable Address)

resolver #2
  domain   : local
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300000

resolver #3
  domain   : 254.169.in-addr.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300200

resolver #4
  domain   : 8.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300400

resolver #5
  domain   : 9.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300600

resolver #6
  domain   : a.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300800

resolver #7
  domain   : b.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 301000

resolver #8
  domain   : nicklaassen.ca
  nameserver[0] : fdc3:29fa:bc6e::2
  flags    : Request A records
  reach    : 0x00000002 (Reachable)

resolver #9
  domain   : one.private
  nameserver[0] : fdc3:29fa:bc6e::2
  flags    : Request A records
  reach    : 0x00000002 (Reachable)

DNS configuration (for scoped queries)

resolver #1
  nameserver[0] : 192.168.50.1
  if_index : 14 (en0)
  flags    : Scoped, Request A records
  reach    : 0x00020002 (Reachable,Directly Reachable Address)

```

---
⚠️ VNet SSH is not configured.

  The user's default SSH configuration file does not include VNet's
  generated configuration file and connections to VNet SSH hosts will
  not work by default.

| File description         | Path |
| ------------------------ | ---- |
| User OpenSSH config file | /Users/nic/.ssh/config  |
| VNet SSH config file     | /Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config  |

```
$ cat /Users/nic/.ssh/config
# Include "/Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config"
Include "/Users/nic/.tsh/vnet_ssh_config"

Host github.com
  IdentityFile ~/.ssh/id_ed25519
```
</details>

<details><summary>Copied text with VNet configured</summary>
VNet Diagnostic Report

Created at: 2025-06-10 08:53:26 (Tue, 10 Jun 2025 15:53:26 GMT)
Network interface: utun5
IPv4 CIDR ranges: 100.64.0.0/10
IPv6 prefix: fdc3:29fa:bc6e::
DNS zones: one.private, nicklaassen.ca

---
✅ There are no network routes in conflict with VNet.

```
$ netstat -rn -f inet
Routing tables

Internet:
Destination        Gateway            Flags               Netif Expire
default            192.168.50.1       UGScg                 en0       
100.64/10          utun5              USc                 utun5       
100.64.0.1         100.64.0.1         UH                  utun5       
127                127.0.0.1          UCS                   lo0       
127.0.0.1          127.0.0.1          UH                    lo0       
169.254            link#14            UCS                   en0      !
169.254.169.254    link#14            UHRLSW                en0      !
192.168.50         link#14            UCS                   en0      !
192.168.50.1/32    link#14            UCS                   en0      !
192.168.50.1       10:7c:61:43:1:f8   UHLWIir               en0   1196
192.168.50.16      74:13:ea:a5:2e:27  UHLWI                 en0    588
192.168.50.25      3c:61:5:e:f:94     UHLWI                 en0   1122
192.168.50.44      f0:b3:ec:b:8d:9    UHLWI                 en0    448
192.168.50.84      34:3e:a4:23:90:1d  UHLWI                 en0   1177
192.168.50.94      40:91:51:af:5d:60  UHLWI                 en0   1170
192.168.50.126/32  link#14            UCS                   en0      !
192.168.50.148     d8:80:83:e5:69:9a  UHLWI                 en0    438
192.168.50.206     ec:64:c9:42:1:40   UHLWI                 en0      !
192.168.50.243     a6:c6:9e:4b:4e:fd  UHLWI                 en0      !
192.168.50.255     ff:ff:ff:ff:ff:ff  UHLWbI                en0      !
224.0.0/4          link#14            UmCS                  en0      !
224.0.0.251        1:0:5e:0:0:fb      UHmLWI                en0       
239.255.255.250    1:0:5e:7f:ff:fa    UHmLWI                en0       
255.255.255.255/32 link#14            UCS                   en0      !

```

```
$ scutil --dns
DNS configuration

resolver #1
  nameserver[0] : 192.168.50.1
  if_index : 14 (en0)
  flags    : Request A records
  reach    : 0x00020002 (Reachable,Directly Reachable Address)

resolver #2
  domain   : local
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300000

resolver #3
  domain   : 254.169.in-addr.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300200

resolver #4
  domain   : 8.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300400

resolver #5
  domain   : 9.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300600

resolver #6
  domain   : a.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300800

resolver #7
  domain   : b.e.f.ip6.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 301000

resolver #8
  domain   : nicklaassen.ca
  nameserver[0] : fdc3:29fa:bc6e::2
  flags    : Request A records
  reach    : 0x00000002 (Reachable)

resolver #9
  domain   : one.private
  nameserver[0] : fdc3:29fa:bc6e::2
  flags    : Request A records
  reach    : 0x00000002 (Reachable)

DNS configuration (for scoped queries)

resolver #1
  nameserver[0] : 192.168.50.1
  if_index : 14 (en0)
  flags    : Scoped, Request A records
  reach    : 0x00020002 (Reachable,Directly Reachable Address)

```

---
✅ VNet SSH is configured correctly.

| File description         | Path |
| ------------------------ | ---- |
| User OpenSSH config file | /Users/nic/.ssh/config  |
| VNet SSH config file     | /Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config  |

```
$ cat /Users/nic/.ssh/config
Include "/Users/nic/Library/Application Support/Electron/tsh/vnet_ssh_config"
Include "/Users/nic/.tsh/vnet_ssh_config"

Host github.com
  IdentityFile ~/.ssh/id_ed25519
```
</details>