### PR TITLE
[v15] chore: Bump Go to 1.23.10

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.3
+FROM docker.io/golang:1.24.4
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.9
+go 1.23.10
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.9
+GOLANG_VERSION ?= go1.23.10
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.9
+go 1.23.10
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.9
+go 1.23.10
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.9
+go 1.23.10
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
The update addresses CVE-2025-4673, CVE-2025-0913 and CVE-2025-22874.

Changelog: Updated Go to 1.23.10