### PR TITLE
[v18] Elevate the Linux Demo guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -728,6 +728,11 @@
       "source": "/admin-guides/access-controls/okta/user-sync/",
       "destination": "/identity-governance/okta/user-sync/",
       "permanent": true
+    },
+    {
+      "source": "/admin-guides/deploy-a-cluster/linux-demo/",
+      "destination": "/linux-demo/",
+      "permanent": true
     }
   ]
 }

--- a/docs/pages/admin-guides/infrastructure-as-code/managing-resources/trusted-cluster.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/managing-resources/trusted-cluster.mdx
@@ -23,7 +23,7 @@ Teleport supports three ways to dynamically create resources from code:
 
 ## Prerequisites
 
-- Access to **two** Teleport cluster instances. Follow the [Run a Self-Hosted Demo Cluster](../../deploy-a-cluster/linux-demo.mdx)
+- Access to **two** Teleport cluster instances. Follow the [Run a Self-Hosted Demo Cluster](../../../linux-demo.mdx)
   guide to learn how to deploy a self-hosted Teleport cluster on a Linux server.
 
   The two clusters should be at the same version or, at most, the leaf cluster can be one major version

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -45,7 +45,7 @@ We recommend following this guide on a fresh Teleport demo cluster so you can
 see how an Agent pool works. After you are familiar with the setup, apply the
 lessons from this guide to protect your infrastructure. You can get started with
 a demo cluster using:
-- A demo deployment on a [Linux server](../../../admin-guides/deploy-a-cluster/linux-demo.mdx)
+- A demo deployment on a [Linux server](../../../linux-demo.mdx)
 - A [Teleport Enterprise (Cloud) trial](https://goteleport.com/signup)
 
 </Admonition>

--- a/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
+++ b/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
@@ -34,7 +34,7 @@ to the Proxy Service.
 <TabItem scope={["oss"]} label="Open Source">
 
 - A running Teleport cluster. For details on how to set this up, see our
-  [Getting Started](../../deploy-a-cluster/linux-demo.mdx) guide (skip TLS certificate setup).
+  [Getting Started](../../../linux-demo.mdx) guide (skip TLS certificate setup).
 
 - A Teleport Proxy Service which does not have certificates or ACME automatic certificates configured.
 For example, this Teleport Proxy Service configuration would use self-signed certs:
@@ -254,7 +254,7 @@ flag](../../../connect-your-client/teleport-connect.mdx).
 
 ## Further reading
 
-- [Configuring Teleport TLS Certs](../../deploy-a-cluster/linux-demo.mdx#configure-teleport)
+- [Configuring Teleport TLS Certs](../../../linux-demo.mdx)
 - [Run Teleport as a systemd Daemon](./daemon.mdx)
 - [Teleport Proxy Service](../../../reference/architecture/proxy.mdx)
 - [Teleport Authentication](../../../reference/architecture/authentication.mdx)

--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -43,7 +43,7 @@ PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
 - A self-hosted Teleport Enterprise account. If you want to get started with
   self-hosted Teleport Enterprise, [contact
   Sales](https://goteleport.com/contact-us/). You can also [set up a demo
-  environment](../../deploy-a-cluster/linux-demo.mdx) with Teleport Community Edition.
+  environment](../../../linux-demo.mdx) with Teleport Community Edition.
 
   We recommend reading and understanding this guide completely before
   configuring your Teleport cluster to use the PROXY protocol.

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -8,7 +8,7 @@ Enterprise (Self-Hosted) and Teleport Enterprise (Cloud) to another Teleport
 plan. 
 
 We recommend that you try out a Teleport [demo
-cluster](deploy-a-cluster/linux-demo.mdx) with Teleport Community Edition,
+cluster](../linux-demo.mdx) with Teleport Community Edition,
 migrate to [Teleport Enterprise (Cloud)](../get-started.mdx) to roll out
 Teleport across your organization, and deploy a
 [self-hosted](deploy-a-cluster/deploy-a-cluster.mdx) Teleport Enterprise cluster

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -12,7 +12,7 @@ work with Teleport.
 
 - A running Teleport cluster. If you want to get started with Teleport, [sign
   up](https://goteleport.com/signup) for a free trial or [set up a demo
-  environment](../admin-guides/deploy-a-cluster/linux-demo.mdx).
+  environment](../linux-demo.mdx).
 
 - The `tsh` client tool. Visit [Installation](../installation.mdx) for instructions on downloading
   `tsh`. See the [Using Teleport Connect](./teleport-connect.mdx) guide for a graphical desktop client

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -17,7 +17,7 @@ within your infrastructure, such as Kubernetes clusters and Windows desktops.
 A minimal Teleport cluster consists of the **Teleport Auth Service** and
 **Teleport Proxy Service**. In a demo environment, you can run these two
 services from a single `teleport` process on a [Linux
-host](admin-guides/deploy-a-cluster/linux-demo.mdx).
+host](linux-demo.mdx).
 
 ### Teleport Auth Service
 

--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -20,7 +20,7 @@ sessions, so you can review them later.
 
 You can also set up a Teleport cluster on a self-hosted virtual machine with
 Teleport Community Edition. For instructions, read [Run a Self-Hosted Demo
-Cluster](./admin-guides/deploy-a-cluster/linux-demo.mdx).
+Cluster](linux-demo.mdx).
 
 </Admonition>
 

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,7 +1,8 @@
 {{ version="(=teleport.version=)" edition="Teleport" clients="`tctl` and `tsh` clients" }}
 
-- A running {{ edition }} cluster version {{ version }} or above. If you do not
-  have one, read [Get Started with Teleport](../get-started.mdx).
+- A running Teleport cluster version {{ version }} or above. If you do not have
+  one, read [Get Started with Teleport](../get-started.mdx) or [set up a demo
+  environment](../linux-demo.mdx).
 
 - The {{ clients }}.
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -11,6 +11,11 @@ The Teleport Infrastructure Identity Platform implements trusted computing at
 scale, with unified cryptographic identities for humans, machines and workloads,
 endpoints, infrastructure assets, and AI agents. 
 
+## Get started
+
+You can quickly see how Teleport works by following our [Get
+Started](./get-started.mdx) guide to enroll your first resource with Teleport.
+
 ## Products
 
 The Teleport Infrastructure Identity Platform consists of four products.

--- a/docs/pages/linux-demo.mdx
+++ b/docs/pages/linux-demo.mdx
@@ -16,7 +16,7 @@ signing up for a [free trial of Teleport Enterprise
 Cloud](https://goteleport.com/signup/).
 
 ![Architecture of the setup you will complete in this
-guide](../../../img/linux-server-diagram.png)
+guide](../img/linux-server-diagram.png)
 
 We will run the following Teleport services:
 
@@ -111,7 +111,7 @@ Community Edition.
 You should see a welcome screen similar to
 the following:
 
-![Teleport Welcome Screen](../../../img/quickstart/welcome.png)
+![Teleport Welcome Screen](../img/quickstart/welcome.png)
 
 ## Step 3/4. Create a Teleport user and set up multi-factor authentication
 
@@ -147,7 +147,7 @@ Visit the provided URL in order to create your Teleport user.
   will get authentication errors later in this tutorial.
 
   If a user does not already exist, you can create it with `adduser <login>` or
-  use [host user creation](../../enroll-resources/server-access/guides/host-user-creation.mdx).
+  use [host user creation](enroll-resources/server-access/guides/host-user-creation.mdx).
 
   If you do not have the permission to create new users on the Linux host, run
   `tctl users add teleport $(whoami)` to explicitly allow Teleport to
@@ -193,7 +193,7 @@ $ tsh login --proxy=<Var name="teleport.example.com" /> --user=teleport-admin
 Once you finish setting up your user, you will see your SSH server in the
 Teleport Web UI:
 
-![Teleport Web UI showing an SSH server](../../../img/new-ssh-server.png)
+![Teleport Web UI showing an SSH server](../img/new-ssh-server.png)
 
 With Teleport, you can protect all of the resources in your infrastructure
 behind a single identity-aware access proxy, including servers, databases,
@@ -211,4 +211,4 @@ databases, Kubernetes clusters, cloud provider APIs, and Windows desktops.
 Step 4 showed you how to install agents manually, and you can also launch agents
 and enroll resources with them using infrastructure-as-code tools. For example,
 you can use Terraform to declare a pool of Teleport Agents and configure them to
-proxy your infrastructure. Read [Protect Infrastructure with Teleport](../../enroll-resources/agents/agents.mdx) to get started.
+proxy your infrastructure. Read [Protect Infrastructure with Teleport](enroll-resources/agents/agents.mdx) to get started.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -21,6 +21,11 @@
         },
         {
           "type": "doc",
+          "label": "Linux Demo",
+          "id": "linux-demo"
+        },
+        {
+          "type": "doc",
           "label": "Installation",
           "id": "installation"
         },


### PR DESCRIPTION
Backports #55534

The Linux Demo guide is currently our only guide to running a self-hosted demo cluster. Make this guide more prominent in order to invite practitioners to try out Teleport.

- Move the Linux Demo guide to the root docs directory and update the sidebar configuration.
- Link to the Linux Demo guide in Get Started.
- Add a link to the Get Started guide early in the docs index page. Avoid the temptation to include a two-item list that also includes the Linux Demo guide, since we want to lead the user down a narrow path instead of forcing them to make decisions with insufficient context.