### PR TITLE
[docs] Restructuring agent homepage links

### DIFF
--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,4 +3,17 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 ---
 
-<DocCardList />
+### Getting Started
+- [Introduction to Enrolling Applications](./introduction.mdx): How to set up Teleport to protect applications and cloud provider APIs
+- [Protect a Web Application with Teleport](./getting-started.mdx): Provides instructions to set up the Teleport Application Service and enable secure access to a web application.
+
+### Guides
+- [Application Access Guides (section)](./guides/): Guides for configuring Teleport application access.
+- [Securing Access to Cloud APIs (section)](./cloud-apis/): How to use Teleport to achieve secure access while managing your cloud-based infrastructure.
+- [Application Access JWT Authentication (section)](./jwt/): Guides for using Teleport application access JWT authentication.
+
+### Configuration & Management
+- [Application Access Role-Based Access Control](./controls.mdx): Role-Based Access Control (RBAC) for Teleport application access.
+
+### Troubleshooting & Support
+- [Troubleshooting Application Access](./troubleshooting-apps.mdx): Describes common issues and solutions for access to applications protected by Teleport.

--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,17 +3,17 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 ---
 
-### Getting Started
+## Getting started
 - [Introduction to Enrolling Applications](./introduction.mdx): How to set up Teleport to protect applications and cloud provider APIs
 - [Protect a Web Application with Teleport](./getting-started.mdx): Provides instructions to set up the Teleport Application Service and enable secure access to a web application.
 
-### Guides
+## Guides
 - [Application Access Guides (section)](./guides/): Guides for configuring Teleport application access.
 - [Securing Access to Cloud APIs (section)](./cloud-apis/): How to use Teleport to achieve secure access while managing your cloud-based infrastructure.
 - [Application Access JWT Authentication (section)](./jwt/): Guides for using Teleport application access JWT authentication.
 
-### Configuration & Management
+## Configuration & management
 - [Application Access Role-Based Access Control](./controls.mdx): Role-Based Access Control (RBAC) for Teleport application access.
 
-### Troubleshooting & Support
+## Troubleshooting & support
 - [Troubleshooting Application Access](./troubleshooting-apps.mdx): Describes common issues and solutions for access to applications protected by Teleport.

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -17,7 +17,7 @@ registered on the Auth Service backend.
 
 Set up Teleport auto-discovery for resources in your infrastructure:
 
-### Guides
+## Guides
 
 - [Database Discovery (section)](./databases/): Detailed guides for configuring database discovery.
 - [Enroll Kubernetes Services as Teleport Applications (section)](./kubernetes-applications/): Teleport can automatically detect applications running in your Kubernetes clusters and register them with Teleport for secure access.

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -17,4 +17,9 @@ registered on the Auth Service backend.
 
 Set up Teleport auto-discovery for resources in your infrastructure:
 
-<DocCardList />
+### Guides
+
+- [Database Discovery (section)](./databases/): Detailed guides for configuring database discovery.
+- [Enroll Kubernetes Services as Teleport Applications (section)](./kubernetes-applications/): Teleport can automatically detect applications running in your Kubernetes clusters and register them with Teleport for secure access.
+- [Kubernetes Clusters Discovery (section)](./kubernetes/): Detailed guides for configuring Kubernetes Clusters Discovery.
+- [Server Auto-Discovery (section)](./servers/): You can set up the Teleport Discovery Service to automatically enroll servers in your infrastructure.

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -33,11 +33,11 @@ agent services.
 - [Enroll Google Cloud Databases (section)](./enroll-google-cloud-databases/): Provides instructions on protecting databases in your Google Cloud-managed infrastructure with Teleport.
 - [Enroll Cloud-Hosted Database Platforms (section)](./enroll-managed-databases/): Provides instructions on protecting managed databases in your infrastructure with Teleport.
 - [Enroll Self-Hosted Databases (section)](./enroll-self-hosted-databases/): Provides instructions on protecting self-hosted databases in your infrastructure with Teleport.
+- [Database Automatic User Provisioning (section)](./auto-user-provisioning/): Configure automatic user provisioning for databases.
 
 ## Configuration & management
 
 - [Database Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
-- [Database Automatic User Provisioning (section)](./auto-user-provisioning/): Configure automatic user provisioning for databases.
 - [Using the Teleport Database Service (section)](./guides/): Guides to possibilities for running the Teleport Database Service.
 
 ## Troubleshooting & support

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -22,11 +22,11 @@ agent services.
 
 ![Architecture diagram for enrolling databases with Teleport](../../../img/database-access/architecture.svg)
 
-### Getting Started
+## Getting started
 
 - [Database Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport database access and AWS Aurora PostgreSQL.
 
-### Guides
+## Guides
 
 - [Enroll AWS Databases (section)](./enroll-aws-databases/): Provides instructions on protecting databases in your AWS-managed infrastructure with Teleport.
 - [Enroll Azure Databases (section)](./enroll-azure-databases/): Provides instructions on protecting databases in your Azure-managed infrastructure with Teleport.
@@ -34,13 +34,13 @@ agent services.
 - [Enroll Cloud-Hosted Database Platforms (section)](./enroll-managed-databases/): Provides instructions on protecting managed databases in your infrastructure with Teleport.
 - [Enroll Self-Hosted Databases (section)](./enroll-self-hosted-databases/): Provides instructions on protecting self-hosted databases in your infrastructure with Teleport.
 
-### Configuration & Management
+## Configuration & management
 
 - [Database Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
 - [Database Automatic User Provisioning (section)](./auto-user-provisioning/): Configure automatic user provisioning for databases.
 - [Using the Teleport Database Service (section)](./guides/): Guides to possibilities for running the Teleport Database Service.
 
-### Troubleshooting & Support
+## Troubleshooting & support
 
 - [Database Access FAQ](./faq.mdx): Frequently asked questions about Teleport database access.
 - [Troubleshooting Database Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's Database Access

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -22,4 +22,25 @@ agent services.
 
 ![Architecture diagram for enrolling databases with Teleport](../../../img/database-access/architecture.svg)
 
-<DocCardList />
+### Getting Started
+
+- [Database Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport database access and AWS Aurora PostgreSQL.
+
+### Guides
+
+- [Enroll AWS Databases (section)](./enroll-aws-databases/): Provides instructions on protecting databases in your AWS-managed infrastructure with Teleport.
+- [Enroll Azure Databases (section)](./enroll-azure-databases/): Provides instructions on protecting databases in your Azure-managed infrastructure with Teleport.
+- [Enroll Google Cloud Databases (section)](./enroll-google-cloud-databases/): Provides instructions on protecting databases in your Google Cloud-managed infrastructure with Teleport.
+- [Enroll Cloud-Hosted Database Platforms (section)](./enroll-managed-databases/): Provides instructions on protecting managed databases in your infrastructure with Teleport.
+- [Enroll Self-Hosted Databases (section)](./enroll-self-hosted-databases/): Provides instructions on protecting self-hosted databases in your infrastructure with Teleport.
+
+### Configuration & Management
+
+- [Database Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
+- [Database Automatic User Provisioning (section)](./auto-user-provisioning/): Configure automatic user provisioning for databases.
+- [Using the Teleport Database Service (section)](./guides/): Guides to possibilities for running the Teleport Database Service.
+
+### Troubleshooting & Support
+
+- [Database Access FAQ](./faq.mdx): Frequently asked questions about Teleport database access.
+- [Troubleshooting Database Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's Database Access

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,4 +3,18 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
-<DocCardList />
+### Guides
+
+- [Configure access for Active Directory manually](./active-directory.mdx): Explains how to manually connect Teleport to an Active Directory domain.
+- [Configure access for local Windows users](./getting-started.mdx): Use Teleport to configure passwordless access for local Windows users.
+- [Directory Sharing](./directory-sharing.mdx): Teleport desktop Directory Sharing lets you easily send files to a remote desktop.
+- [Dynamic Windows Desktop Registration](./dynamic-registration.mdx): Register/unregister Windows desktops without restarting Teleport.
+
+### Configuration & Management
+
+- [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
+- [Role-Based Access Control for Desktops](./rbac.mdx): Role-based access control (RBAC) for desktops protected by Teleport.
+
+### Troubleshooting & Support
+
+- [Troubleshooting Desktop Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's desktop access

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,18 +3,18 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
-### Guides
+## Guides
 
 - [Configure access for Active Directory manually](./active-directory.mdx): Explains how to manually connect Teleport to an Active Directory domain.
 - [Configure access for local Windows users](./getting-started.mdx): Use Teleport to configure passwordless access for local Windows users.
 - [Directory Sharing](./directory-sharing.mdx): Teleport desktop Directory Sharing lets you easily send files to a remote desktop.
 - [Dynamic Windows Desktop Registration](./dynamic-registration.mdx): Register/unregister Windows desktops without restarting Teleport.
 
-### Configuration & Management
+## Configuration & management
 
 - [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
 - [Role-Based Access Control for Desktops](./rbac.mdx): Role-based access control (RBAC) for desktops protected by Teleport.
 
-### Troubleshooting & Support
+## Troubleshooting & support
 
 - [Troubleshooting Desktop Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's desktop access

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,16 +3,19 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
+## Getting started
+
+- [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
+
 ## Guides
 
-- [Configure access for Active Directory manually](./active-directory.mdx): Explains how to manually connect Teleport to an Active Directory domain.
 - [Configure access for local Windows users](./getting-started.mdx): Use Teleport to configure passwordless access for local Windows users.
+- [Configure access for Active Directory manually](./active-directory.mdx): Explains how to manually connect Teleport to an Active Directory domain.
 - [Directory Sharing](./directory-sharing.mdx): Teleport desktop Directory Sharing lets you easily send files to a remote desktop.
 - [Dynamic Windows Desktop Registration](./dynamic-registration.mdx): Register/unregister Windows desktops without restarting Teleport.
 
 ## Configuration & management
 
-- [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
 - [Role-Based Access Control for Desktops](./rbac.mdx): Role-based access control (RBAC) for desktops protected by Teleport.
 
 ## Troubleshooting & support

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,4 +3,21 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 ---
 
-<DocCardList />
+### Getting Started
+
+- [Introduction to Enrolling Kubernetes Clusters](./introduction.mdx): Learn how Teleport can protect your Kubernetes clusters with RBAC, audit logging, and more.
+- [Enroll a Kubernetes Cluster](./getting-started.mdx): Demonstrates how to enroll a Kubernetes cluster as a resource protected by Teleport.
+
+### Guides
+
+- [Registering Kubernetes Clusters with Teleport (section)](./register-clusters/): How to manually add a Kubernetes cluster to Teleport after creating it.
+
+### Configuration & Management
+
+- [Setting Up Access Controls for Kubernetes](./manage-access.mdx): How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
+- [Teleport Kubernetes Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
+
+### Troubleshooting & Support
+
+- [Kubernetes Access FAQ](./faq.mdx): Frequently asked questions about Teleport Kubernetes Access
+- [Kubernetes Access Troubleshooting](./troubleshooting.mdx): Troubleshooting common issues with Kubernetes access

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,21 +3,21 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 ---
 
-### Getting Started
+## Getting started
 
 - [Introduction to Enrolling Kubernetes Clusters](./introduction.mdx): Learn how Teleport can protect your Kubernetes clusters with RBAC, audit logging, and more.
 - [Enroll a Kubernetes Cluster](./getting-started.mdx): Demonstrates how to enroll a Kubernetes cluster as a resource protected by Teleport.
 
-### Guides
+## Guides
 
 - [Registering Kubernetes Clusters with Teleport (section)](./register-clusters/): How to manually add a Kubernetes cluster to Teleport after creating it.
 
-### Configuration & Management
+## Configuration & management
 
 - [Setting Up Access Controls for Kubernetes](./manage-access.mdx): How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
 - [Teleport Kubernetes Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
 
-### Troubleshooting & Support
+## Troubleshooting & support
 
 - [Kubernetes Access FAQ](./faq.mdx): Frequently asked questions about Teleport Kubernetes Access
 - [Kubernetes Access Troubleshooting](./troubleshooting.mdx): Troubleshooting common issues with Kubernetes access

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -11,10 +11,10 @@ description: Guides to protecting Kubernetes clusters with Teleport
 ## Guides
 
 - [Registering Kubernetes Clusters with Teleport (section)](./register-clusters/): How to manually add a Kubernetes cluster to Teleport after creating it.
+- [Setting Up Access Controls for Kubernetes](./manage-access.mdx): How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
 
 ## Configuration & management
 
-- [Setting Up Access Controls for Kubernetes](./manage-access.mdx): How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
 - [Teleport Kubernetes Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
 
 ## Troubleshooting & support

--- a/docs/pages/enroll-resources/machine-id/machine-id.mdx
+++ b/docs/pages/enroll-resources/machine-id/machine-id.mdx
@@ -3,4 +3,21 @@ title: Machine ID
 description: Guides to using Machine ID, which allows you to provide secure access to your infrastructure from automated services.
 ---
 
-<DocCardList />
+### Getting Started
+
+- [Introduction to Machine ID](./introduction.mdx): Teleport Machine ID introduction, demo and resources.
+- [Machine ID Getting Started Guide](./getting-started.mdx): Getting started with Teleport Machine ID
+
+### Guides
+
+- [Access your Infrastructure with Machine ID](./access-guides/) (section): How to use Machine ID to enable secure access to Teleport resources.
+- [Deploy Machine ID](./deployment/) (section): Explains how to deploy Machine ID on your platform and join it to your Teleport cluster.
+
+### Configuration & Management
+
+- [Machine ID Manifesto](./manifesto.mdx): A manifesto for Machine Identity
+
+### Troubleshooting & Support
+
+- [Machine ID FAQ](./faq.mdx): Frequently asked questions about Teleport Machine ID
+- [Machine ID Troubleshooting Guide](./troubleshooting.mdx): Troubleshooting common issues with Machine ID

--- a/docs/pages/enroll-resources/machine-id/machine-id.mdx
+++ b/docs/pages/enroll-resources/machine-id/machine-id.mdx
@@ -3,21 +3,21 @@ title: Machine ID
 description: Guides to using Machine ID, which allows you to provide secure access to your infrastructure from automated services.
 ---
 
-### Getting Started
+## Getting started
 
 - [Introduction to Machine ID](./introduction.mdx): Teleport Machine ID introduction, demo and resources.
 - [Machine ID Getting Started Guide](./getting-started.mdx): Getting started with Teleport Machine ID
 
-### Guides
+## Guides
 
 - [Access your Infrastructure with Machine ID](./access-guides/) (section): How to use Machine ID to enable secure access to Teleport resources.
 - [Deploy Machine ID](./deployment/) (section): Explains how to deploy Machine ID on your platform and join it to your Teleport cluster.
 
-### Configuration & Management
+## Configuration & management
 
 - [Machine ID Manifesto](./manifesto.mdx): A manifesto for Machine Identity
 
-### Troubleshooting & Support
+## Troubleshooting & support
 
 - [Machine ID FAQ](./faq.mdx): Frequently asked questions about Teleport Machine ID
 - [Machine ID Troubleshooting Guide](./troubleshooting.mdx): Troubleshooting common issues with Machine ID

--- a/docs/pages/enroll-resources/machine-id/machine-id.mdx
+++ b/docs/pages/enroll-resources/machine-id/machine-id.mdx
@@ -7,15 +7,12 @@ description: Guides to using Machine ID, which allows you to provide secure acce
 
 - [Introduction to Machine ID](./introduction.mdx): Teleport Machine ID introduction, demo and resources.
 - [Machine ID Getting Started Guide](./getting-started.mdx): Getting started with Teleport Machine ID
+- [Machine ID Manifesto](./manifesto.mdx): A manifesto for Machine Identity
 
 ## Guides
 
 - [Access your Infrastructure with Machine ID](./access-guides/) (section): How to use Machine ID to enable secure access to Teleport resources.
 - [Deploy Machine ID](./deployment/) (section): Explains how to deploy Machine ID on your platform and join it to your Teleport cluster.
-
-## Configuration & management
-
-- [Machine ID Manifesto](./manifesto.mdx): A manifesto for Machine Identity
 
 ## Troubleshooting & support
 

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,4 +3,20 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 ---
 
-<DocCardList />
+### Getting Started
+
+- [Introduction to Enrolling Servers](./introduction.mdx): Teleport server access features and introduction.
+- [Server Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport server access.
+
+### Guides
+
+- [Server Access Guides (section)](./guides/): Teleport server access guides.
+
+### Configuration & Management
+
+- [Access Controls for Servers](./rbac.mdx): Role-based access control (RBAC) for Teleport server access.
+- [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
+
+### Troubleshooting & Support
+
+- [Troubleshooting Server Access](./troubleshooting-server.mdx): Describes common issues and solutions for access to servers.

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,20 +3,20 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 ---
 
-### Getting Started
+## Getting started
 
 - [Introduction to Enrolling Servers](./introduction.mdx): Teleport server access features and introduction.
 - [Server Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport server access.
 
-### Guides
+## Guides
 
 - [Server Access Guides (section)](./guides/): Teleport server access guides.
 
-### Configuration & Management
+## Configuration & management
 
 - [Access Controls for Servers](./rbac.mdx): Role-based access control (RBAC) for Teleport server access.
 - [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
 
-### Troubleshooting & Support
+## Troubleshooting & support
 
 - [Troubleshooting Server Access](./troubleshooting-server.mdx): Describes common issues and solutions for access to servers.

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -11,11 +11,11 @@ description: Guides to protecting Linux servers with Teleport, including OpenSSH
 ## Guides
 
 - [Server Access Guides (section)](./guides/): Teleport server access guides.
+- [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
 
 ## Configuration & management
 
 - [Access Controls for Servers](./rbac.mdx): Role-based access control (RBAC) for Teleport server access.
-- [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
 
 ## Troubleshooting & support
 

--- a/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
@@ -3,19 +3,19 @@ title: Workload Identity
 description: Securely issue flexible short-lived identities to your workloads
 ---
 
-### Getting Started
+## Getting started
 - [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
 - [Introduction to Workload Identity](./introduction.mdx): Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
 - [Getting Started with Workload Identity](./getting-started.mdx): Getting started with Teleport Workload Identity for SPIFFE and Machine ID
 
-### Guides
+## Guides
 - [Configuring Workload Identity and AWS OIDC Federation](./aws-oidc-federation.mdx): Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
 - [Configuring Workload Identity and AWS Roles Anywhere](./aws-roles-anywhere.mdx): Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
 - [Configuring Workload Identity and Azure Federated Credentials](./azure-federated-credentials.mdx): Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
 - [Configuring Workload Identity and GCP Workload Identity Federation with JWTs](./gcp-workload-identity-federation-jwt.mdx): Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
 - [Workload Identity and tsh](./tsh.mdx): Issuing SPIFFE SVIDs using Workload Identity and tsh
 
-### Configuration & Management
+## Configuration & management
 - [Best Practices for Teleport Workload Identity](./best-practices.mdx): Answers common questions and describes best practices for using Teleport Workload Identity in production.
 - [JWT SVIDs](./jwt-svids.mdx): An overview of the JWT SVIDs issued by Teleport Workload Identity
 - [SPIFFE Federation](./federation.mdx): An overview of the Teleport Workload Identity SPIFFE Federation feature.

--- a/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
@@ -3,4 +3,20 @@ title: Workload Identity
 description: Securely issue flexible short-lived identities to your workloads
 ---
 
-<DocCardList />
+### Getting Started
+- [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
+- [Introduction to Workload Identity](./introduction.mdx): Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
+- [Getting Started with Workload Identity](./getting-started.mdx): Getting started with Teleport Workload Identity for SPIFFE and Machine ID
+
+### Guides
+- [Configuring Workload Identity and AWS OIDC Federation](./aws-oidc-federation.mdx): Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
+- [Configuring Workload Identity and AWS Roles Anywhere](./aws-roles-anywhere.mdx): Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
+- [Configuring Workload Identity and Azure Federated Credentials](./azure-federated-credentials.mdx): Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
+- [Configuring Workload Identity and GCP Workload Identity Federation with JWTs](./gcp-workload-identity-federation-jwt.mdx): Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
+- [Workload Identity and tsh](./tsh.mdx): Issuing SPIFFE SVIDs using Workload Identity and tsh
+
+### Configuration & Management
+- [Best Practices for Teleport Workload Identity](./best-practices.mdx): Answers common questions and describes best practices for using Teleport Workload Identity in production.
+- [JWT SVIDs](./jwt-svids.mdx): An overview of the JWT SVIDs issued by Teleport Workload Identity
+- [SPIFFE Federation](./federation.mdx): An overview of the Teleport Workload Identity SPIFFE Federation feature.
+- [Workload Attestation](./workload-attestation.mdx): An overview of the Teleport Workload Identity Workload Attestation feature.

--- a/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
@@ -4,8 +4,8 @@ description: Securely issue flexible short-lived identities to your workloads
 ---
 
 ## Getting started
-- [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
 - [Introduction to Workload Identity](./introduction.mdx): Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
+- [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
 - [Getting Started with Workload Identity](./getting-started.mdx): Getting started with Teleport Workload Identity for SPIFFE and Machine ID
 
 ## Guides


### PR DESCRIPTION
The Enroll Agent homepages previously had just a plain list of links on each. Looking through these, and thinking about the structure, there are links that correspond to 
- getting started
- guides
- configuration
- troubleshooting

In this PR, I've taken the list of links and placed them under the appropriate headings to try to provide some separation and clarity