### PR TITLE
[vnet] feat: add "Connect with VNet" button to SSH servers

### DIFF
--- a/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
+++ b/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
@@ -54,7 +54,7 @@ export const MenuLoginWithActionMenu = ({
   inputType,
 }: {
   /** Button text for main menu button. */
-  buttonText: string;
+  buttonText?: string;
   /**
    * Handles select or click in main menu items.
    * If isExternalUrl item returned by getLoginItems is true, a button with <a> tag is rendered

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -71,14 +71,7 @@ export function ConnectServerActionButton(props: {
     const hostname = props.server.hostname;
     const cluster = ctx.clustersService.findClusterByResource(props.server.uri);
     const clusterName = cluster?.name || '<cluster>';
-    let addr = `${hostname}.${clusterName}`;
-    if (cluster.leaf) {
-      const rootCluster = ctx.clustersService.findRootClusterByResource(
-        props.server.uri
-      );
-      const rootClusterName = rootCluster?.name || '<root-cluster>';
-      addr = `${hostname}.${clusterName}.${rootClusterName}`;
-    }
+    const addr = `${hostname}.${clusterName}`;
     launchVnet({
       addrToCopy: addr,
       resourceUri: props.server.uri,

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
@@ -52,7 +52,9 @@ import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvi
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 import * as uri from 'teleterm/ui/uri';
+import { VnetContextProvider } from 'teleterm/ui/Vnet';
 
 const mio = mockIntersectionObserver();
 
@@ -318,12 +320,16 @@ test.each([
       <MockWorkspaceContextProvider>
         <ResourcesContextProvider>
           <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
-            <Refresher ref={ref} rootClusterUri={rootCluster.uri} />
-            <UnifiedResources
-              clusterUri={doc.clusterUri}
-              docUri={doc.uri}
-              queryParams={doc.queryParams}
-            />
+            <ConnectionsContextProvider>
+              <VnetContextProvider>
+                <Refresher ref={ref} rootClusterUri={rootCluster.uri} />
+                <UnifiedResources
+                  clusterUri={doc.clusterUri}
+                  docUri={doc.uri}
+                  queryParams={doc.queryParams}
+                />
+              </VnetContextProvider>
+            </ConnectionsContextProvider>
           </ConnectMyComputerContextProvider>
         </ResourcesContextProvider>
       </MockWorkspaceContextProvider>
@@ -398,7 +404,9 @@ it('passes props with stable identity to <Resources>', async () => {
         <MockWorkspaceContextProvider>
           <ResourcesContextProvider>
             <ConnectMyComputerContextProvider rootClusterUri={doc.clusterUri}>
-              {children}
+              <ConnectionsContextProvider>
+                <VnetContextProvider>{children}</VnetContextProvider>
+              </ConnectionsContextProvider>
             </ConnectMyComputerContextProvider>
           </ResourcesContextProvider>
         </MockWorkspaceContextProvider>

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -31,7 +31,7 @@ import { ResourceRequest } from 'teleterm/ui/services/workspacesService/accessRe
 import { IAppContext } from 'teleterm/ui/types';
 import { routing } from 'teleterm/ui/uri';
 import { assertUnreachable, retryWithRelogin } from 'teleterm/ui/utils';
-import { VnetAppLauncher } from 'teleterm/ui/Vnet';
+import { VnetLauncher } from 'teleterm/ui/Vnet';
 
 export interface SimpleAction {
   type: 'simple-action';
@@ -73,7 +73,7 @@ export type SearchAction = SimpleAction | ParametrizedAction;
 
 export function mapToAction(
   ctx: IAppContext,
-  launchVnet: VnetAppLauncher,
+  launchVnet: VnetLauncher,
   searchContext: SearchContext,
   result: SearchResult
 ): SearchAction {

--- a/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
@@ -38,7 +38,7 @@ import {
 } from 'teleterm/ui/Search/useSearch';
 import { routing } from 'teleterm/ui/uri';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
-import { useVnetAppLauncher, useVnetContext } from 'teleterm/ui/Vnet';
+import { useVnetContext, useVnetLauncher } from 'teleterm/ui/Vnet';
 
 import { useDisplayResults } from './useDisplayResults';
 
@@ -48,7 +48,7 @@ export function useActionAttempts() {
   const searchContext = useSearchContext();
   const { inputValue, filters, pauseUserInteraction } = searchContext;
   const { isSupported: isVnetSupported } = useVnetContext();
-  const vnetLauncher = useVnetAppLauncher();
+  const vnetLauncher = useVnetLauncher();
   const launchVnet = isVnetSupported ? vnetLauncher.launchVnet : undefined;
 
   const [resourceSearchAttempt, runResourceSearch, setResourceSearchAttempt] =

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
@@ -31,7 +31,7 @@ import type * as docTypes from 'teleterm/ui/services/workspacesService';
 import { routing } from 'teleterm/ui/uri';
 
 import appAccessPng from './app-access.png';
-import { useVnetAppLauncher } from './useVnetAppLauncher';
+import { useVnetLauncher } from './useVnetLauncher';
 import { useVnetContext } from './vnetContext';
 
 export function DocumentVnetInfo(props: {
@@ -46,7 +46,7 @@ export function DocumentVnetInfo(props: {
     stopAttempt,
     status,
   } = useVnetContext();
-  const { launchVnetWithoutFirstTimeCheck } = useVnetAppLauncher();
+  const { launchVnetWithoutFirstTimeCheck } = useVnetLauncher();
   const userAtHost = useMemo(() => {
     const { hostname, username } = mainProcessClient.getRuntimeSettings();
     return `${username}@${hostname}`;
@@ -55,13 +55,10 @@ export function DocumentVnetInfo(props: {
   const proxyHostname = routing.parseClusterName(rootClusterUri);
 
   const startVnet = async () => {
-    await launchVnetWithoutFirstTimeCheck({
-      addrToCopy: doc.app?.targetAddress,
-      isMultiPort: doc.app?.isMultiPort,
-    });
-    // Remove targetAddress so that subsequent launches of VNet from this specific doc won't copy
-    // the stale app address to the clipboard.
-    documentsService.update(doc.uri, { app: undefined });
+    await launchVnetWithoutFirstTimeCheck(doc.launcherArgs);
+    // Remove launcherArgs so that subsequent launches of VNet from this
+    // specific doc won't copy the stale address to the clipboard.
+    documentsService.update(doc.uri, { launcherArgs: undefined });
   };
 
   return (

--- a/web/packages/teleterm/src/ui/Vnet/index.ts
+++ b/web/packages/teleterm/src/ui/Vnet/index.ts
@@ -19,4 +19,4 @@
 export * from './VnetSliderStep';
 export * from './vnetContext';
 export { VnetConnectionItem } from './VnetConnectionItem';
-export * from './useVnetAppLauncher';
+export * from './useVnetLauncher';

--- a/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
@@ -19,31 +19,15 @@
 import { useCallback, useMemo } from 'react';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { VnetLauncherArgs } from 'teleterm/ui/services/workspacesService/documentsService/types';
 import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connectionsContext';
-import { ResourceUri, routing } from 'teleterm/ui/uri';
+import { routing } from 'teleterm/ui/uri';
 
 import { useVnetContext } from './vnetContext';
 
-export type VnetAppLauncher = (args: VnetAppLauncherArgs) => Promise<void>;
+export type VnetLauncher = (args: VnetLauncherArgs) => Promise<void>;
 
-// NOTE: Almost every field added to VnetAppLauncherArgs will need to be added to DocumentVnetInfo.
-//
-// This is because during the first launch of VNet through useVnetAppLauncher, the act of launching
-// VNet is split into two parts. When a user clicks the "Connect" button next to a TCP app or opens
-// one from the search bar, a DocumentVnetInfo is opened first. Then the user can start VNet from
-// there, which should carry out the launch of that particular app. Hence the need to copy some
-// arguments from the app to the doc.
-type VnetAppLauncherArgs = {
-  addrToCopy: string | undefined;
-  /**
-   * resourceUri lets the VNet launcher establish which workspace to open the info doc in if
-   * there's a need to do it.
-   */
-  resourceUri: ResourceUri;
-  isMultiPort: boolean;
-};
-
-export const useVnetAppLauncher = (): {
+export const useVnetLauncher = (): {
   /**
    * launchVnet is a function that manages VNet start when:
    *
@@ -53,14 +37,12 @@ export const useVnetAppLauncher = (): {
    * If the user is yet to start VNet, it opens the info doc. If they already started it in the past,
    * it starts VNet and then copies the address of the app to the clipboard.
    */
-  launchVnet: VnetAppLauncher;
+  launchVnet: VnetLauncher;
   /**
    * launchVnetWithoutFirstTimeCheck never opens the info doc, it starts VNet and then copies the
    * address of the app to the clipboard.
    */
-  launchVnetWithoutFirstTimeCheck: (
-    args: Pick<VnetAppLauncherArgs, 'addrToCopy' | 'isMultiPort'>
-  ) => Promise<void>;
+  launchVnetWithoutFirstTimeCheck: (args?: VnetLauncherArgs) => Promise<void>;
 } => {
   const { notificationsService, workspacesService } = useAppContext();
   const { start, status, startAttempt, hasEverStarted } = useVnetContext();
@@ -82,8 +64,8 @@ export const useVnetAppLauncher = (): {
   }, [status.value, startAttempt.status, open, start]);
 
   const openInfoDoc = useCallback(
-    async ({ addrToCopy, resourceUri, isMultiPort }: VnetAppLauncherArgs) => {
-      const rootClusterUri = routing.ensureRootClusterUri(resourceUri);
+    async (args: VnetLauncherArgs) => {
+      const rootClusterUri = routing.ensureRootClusterUri(args.resourceUri);
       // Since VNet app launcher might be called from the search bar, we have to account for the
       // user being in a different workspace than the selected app.
       const { isAtDesiredWorkspace } =
@@ -105,35 +87,39 @@ export const useVnetAppLauncher = (): {
       // Update targetAddress so that clicking "Start VNet" from the info doc is going to copy that
       // address to clipboard.
       docsService.update(docUri, {
-        app: { targetAddress: addrToCopy, isMultiPort },
+        launcherArgs: args,
       });
     },
     [workspacesService]
   );
 
   const launchVnetAndCopyAddr = useCallback(
-    async ({
-      addrToCopy,
-      isMultiPort,
-    }: Pick<VnetAppLauncherArgs, 'addrToCopy' | 'isMultiPort'>) => {
+    async (args?: VnetLauncherArgs) => {
       if (!(await launchVnet())) {
         return;
       }
-
-      if (!addrToCopy) {
+      if (!args) {
+        // args are optional, if unset don't copy anything to the clipboard.
         return;
       }
-
-      const copiedToClipboard = copyAddrToClipboard(addrToCopy);
-      notificationsService.notifyInfo(
-        [
-          `Connect via VNet by using ${addrToCopy}`,
-          copiedToClipboard && '(copied to clipboard)',
-          !isMultiPort && 'and any port',
-        ]
-          .filter(Boolean)
-          .join(' ') + '.'
-      );
+      const { addrToCopy, isMultiPortApp, resourceUri } = args;
+      const isApp = !!routing.parseAppUri(resourceUri)?.params?.appId;
+      const isServer = !!routing.parseServerUri(resourceUri)?.params?.serverId;
+      let msgParts = [];
+      if (isApp) {
+        msgParts.push(`Connect via VNet by using ${addrToCopy}`);
+      } else if (isServer) {
+        msgParts.push(`Connect with any SSH client to ${addrToCopy}`);
+      } else {
+        msgParts.push(`Connect via VNet to ${addrToCopy}`);
+      }
+      if (copyAddrToClipboard(addrToCopy)) {
+        msgParts.push('(copied to clipboard)');
+      }
+      if (isApp && !isMultiPortApp) {
+        msgParts.push('and any port');
+      }
+      notificationsService.notifyInfo(msgParts.join(' ') + '.');
     },
     [launchVnet, notificationsService]
   );

--- a/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
@@ -33,14 +33,15 @@ export const useVnetLauncher = (): {
    *
    * - The user clicks "Connect" next to a TCP app or selects one of the ports from the menu.
    * - The user selects a TCP app through the search bar.
+   * - The user clicks "Connect with VNet" on an SSH server.
    *
    * If the user is yet to start VNet, it opens the info doc. If they already started it in the past,
-   * it starts VNet and then copies the address of the app to the clipboard.
+   * it starts VNet and then copies the address of the resource to the clipboard.
    */
   launchVnet: VnetLauncher;
   /**
    * launchVnetWithoutFirstTimeCheck never opens the info doc, it starts VNet and then copies the
-   * address of the app to the clipboard.
+   * address of the resource to the clipboard.
    */
   launchVnetWithoutFirstTimeCheck: (args?: VnetLauncherArgs) => Promise<void>;
 } => {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -27,7 +27,7 @@ import {
 import { appToAddrToCopy } from 'teleterm/services/vnet/app';
 import { IAppContext } from 'teleterm/ui/types';
 import { AppUri, routing } from 'teleterm/ui/uri';
-import { VnetAppLauncher } from 'teleterm/ui/Vnet';
+import { VnetLauncher } from 'teleterm/ui/Vnet';
 
 import { DocumentOrigin } from './types';
 
@@ -46,7 +46,7 @@ export async function connectToApp(
    * launchVnet is supposed to be provided if VNet is supported. If so, connectToApp is going to use
    * this function when targeting a TCP app. Otherwise it'll create an app gateway.
    */
-  launchVnet: null | VnetAppLauncher,
+  launchVnet: null | VnetLauncher,
   target: App,
   telemetry: { origin: DocumentOrigin },
   options?: {
@@ -111,7 +111,7 @@ export async function connectToApp(
     await launchVnet({
       addrToCopy: appToAddrToCopy(target),
       resourceUri: target.uri,
-      isMultiPort: !!target.tcpPorts.length,
+      isMultiPortApp: !!target.tcpPorts.length,
     });
     return;
   }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -51,6 +51,7 @@ import {
   DocumentTshNode,
   DocumentVnetDiagReport,
   DocumentVnetInfo,
+  VnetLauncherArgs,
   WebSessionRequest,
 } from './types';
 
@@ -243,10 +244,7 @@ export class DocumentsService {
 
   createVnetInfoDocument(opts: {
     rootClusterUri: RootClusterUri;
-    app?: {
-      targetAddress: string;
-      isMultiPort: boolean;
-    };
+    launcherArgs?: VnetLauncherArgs;
   }): DocumentVnetInfo {
     const uri = routing.getDocUri({ docId: unique() });
 
@@ -255,7 +253,7 @@ export class DocumentsService {
       kind: 'doc.vnet_info',
       title: 'VNet',
       rootClusterUri: opts.rootClusterUri,
-      app: opts.app,
+      launcherArgs: opts.launcherArgs,
     };
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -222,7 +222,7 @@ export function makeDocumentVnetInfo(
     uri: '/docs/vnet-info',
     title: 'VNet',
     rootClusterUri,
-    app: undefined,
+    launcherArgs: undefined,
     ...props,
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -231,29 +231,25 @@ export interface DocumentVnetInfo extends DocumentBase {
   // the document fields, hence why rootClusterUri is defined here.
   rootClusterUri: uri.RootClusterUri;
   /**
-   * Details of the app if the doc was opened by selecting a specific TCP app.
+   * Details of the resource if the doc was opened by selecting a specific resource.
    *
    * This field is needed to facilitate a scenario where a first-time user clicks "Connect" next to
-   * a TCP app, which opens this doc. Once the user clicks "Start VNet" in the doc, Connect should
-   * continue the regular flow of connecting to a TCP app through VNet, which means it should copy
-   * the address of the app to the clipboard, hence this field.
+   * a TCP app or SSH server, which opens this doc. Once the user clicks "Start VNet" in the doc,
+   * Connect should continue the regular flow of connecting to a TCP app through VNet, which means
+   * it should copy the address of the resource to the clipboard, hence this field.
    *
    * app is removed when restoring persisted state. Let's say the user opens the doc through the
    * "Connect" button of a specific app. If they close the app and then reopen the docs, we don't
    * want the "Start VNet" button to copy the address of the app from the prev session.
    */
-  app:
-    | {
-        /**
-         * The address that's going to be copied to the clipboard after user starts VNet for the
-         * first time through this document.
-         *
-         */
-        targetAddress: string | undefined;
-        isMultiPort: boolean;
-      }
-    | undefined;
+  launcherArgs: VnetLauncherArgs | undefined;
 }
+
+export type VnetLauncherArgs = {
+  addrToCopy: string;
+  resourceUri: uri.ResourceUri;
+  isMultiPortApp?: boolean;
+};
 
 /**
  * Document to authorize a web session with device trust.

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -238,16 +238,25 @@ export interface DocumentVnetInfo extends DocumentBase {
    * Connect should continue the regular flow of connecting to a TCP app through VNet, which means
    * it should copy the address of the resource to the clipboard, hence this field.
    *
-   * app is removed when restoring persisted state. Let's say the user opens the doc through the
-   * "Connect" button of a specific app. If they close the app and then reopen the docs, we don't
+   * launcherArgs is removed when restoring persisted state. Let's say the user opens the doc through
+   * the "Connect" button of a specific app. If they close the app and then reopen the doc, we don't
    * want the "Start VNet" button to copy the address of the app from the prev session.
    */
   launcherArgs: VnetLauncherArgs | undefined;
 }
 
+/**
+ * Details about a user-selected resource that prompted the VNet launch, so
+ * that addrToCopy can be copied to the clipboard after VNet launches with a
+ * helpful message displayed in a notification.
+ */
 export type VnetLauncherArgs = {
+  // The address that's going to be copied to the clipboard.
   addrToCopy: string;
+  // The URI of the resource the user clicked.
   resourceUri: uri.ResourceUri;
+  // True if the user clicked a multi-port TCP app, used to render a slightly
+  // different message in the (copied to clipboard) notification.
   isMultiPortApp?: boolean;
 };
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -593,7 +593,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         if (d.kind === 'doc.vnet_info') {
           const documentVnetInfo: DocumentVnetInfo = {
             ...d,
-            app: undefined,
+            launcherArgs: undefined,
           };
           return documentVnetInfo;
         }


### PR DESCRIPTION
This commit adds a "Connect with VNet" option to all SSH servers in the unified resource view. It works similar to the existing Connect button on TCP apps, it will start VNet if it is not started, and if it's the first ever start of VNet it will open the VNet info page. The normal/existing Connect username dropdown still works, this just adds a menu next to it with a single option.

<img width="615" alt="Screenshot 2025-06-10 at 6 40 02 PM" src="https://github.com/user-attachments/assets/43e931a4-29a7-41e3-ad84-327e37a10076" />
<img width="369" alt="Screenshot 2025-06-10 at 6 40 08 PM" src="https://github.com/user-attachments/assets/f6666760-6cb0-450b-9b02-9092ba180c42" />
<img width="620" alt="Screenshot 2025-06-10 at 6 40 24 PM" src="https://github.com/user-attachments/assets/60c59006-572b-44b4-a324-12757098cda5" />


TODO in following PRs:
- mention SSH in the VNet info page
- update the VNet panel to mention SSH

Part of [RFD 207](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md)