### PR TITLE
Fix 9 Vale warnings

### DIFF
--- a/docs/pages/admin-guides/access-controls/getting-started.mdx
+++ b/docs/pages/admin-guides/access-controls/getting-started.mdx
@@ -10,6 +10,25 @@ desktops, and web apps.
 We will start with local users and preset roles, assign roles to SSO users, and
 wrap up with creating your own role.
 
+## How it works
+
+Teleport roles specify the permissions of a user for interacting with a Teleport
+cluster, with rules including the Teleport-protected infrastructure resources a
+user can access and the Teleport API resources a user can manage.  When a user
+authenticates to Teleport, the TLS and SSH certificates they receive encode
+their roles. 
+
+Teleport components can then inspect the user's roles for the required
+permissions before completing an action. For example, the Teleport Auth Service
+authorizes a user before reading or writing API resources, and Teleport Agents
+authorize a user before routing traffic to an infrastructure resource.
+
+When a user authenticates to Teleport with a single sign-on authentication
+connector, the user still receives TLS and SSH certificates that encode their
+roles. In this case, the Teleport Auth Service maps the user on the SSO identity
+provider to one or more Teleport roles using the configuration in the
+authentication connector.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/admin-guides/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/hardware-key-support.mdx
@@ -3,6 +3,11 @@ title: Hardware Key Support
 description: Hardware Key Support
 ---
 
+This guide explains how to configure Teleport authentication using
+hardware-based private keys.
+
+## How it works
+
 <Admonition type="warning" title="Enterprise">
   Hardware Key Support requires Teleport Enterprise.
 </Admonition>

--- a/docs/pages/admin-guides/access-controls/sso/adfs.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/adfs.mdx
@@ -13,6 +13,10 @@ allows Teleport administrators to define policies like:
 - Only members of "DBA" group can SSH into machines running PostgreSQL.
 - Developers must never SSH into production servers.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="ADFS"!)
+
 ## Prerequisites
 
 - ADFS installation with Admin access and users assigned to at least two groups.

--- a/docs/pages/admin-guides/access-controls/sso/azuread.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/azuread.mdx
@@ -16,6 +16,10 @@ The following steps configure an example SAML authentication connector matching
 Microsoft Entra ID groups with security roles. You can choose to configure other
 options.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="Microsoft Entra ID"!)
+
 ## Prerequisites
 
 Before you get started, you’ll need:

--- a/docs/pages/admin-guides/access-controls/sso/gitlab.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/gitlab.mdx
@@ -13,6 +13,10 @@ like:
 - Only members of "ProductionKubernetes" can access production Kubernetes clusters
 - Developers must never SSH into production servers.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="GitLab"!)
+
 ## Prerequisites
 
 - At least two groups in GitLab with users assigned. In our examples below,

--- a/docs/pages/admin-guides/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/google-workspace.mdx
@@ -12,6 +12,10 @@ access control (RBAC), you can define policies like the following:
 - Only members of the "DBA" Google group can connect to PostgreSQL databases.
 - Developers must never use SSH to access production servers.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="Google Workspace"!)
+
 ## Prerequisites
 
 Before you get started, verify the following:

--- a/docs/pages/admin-guides/access-controls/sso/keycloak.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/keycloak.mdx
@@ -14,6 +14,10 @@ administrators to define policies like:
 The following steps configure an example SAML authentication connector matching
 Keycloak groups. You can choose to configure other options.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="Keycloak"!)
+
 ## Prerequisites
 
 Before you get started, you’ll need:

--- a/docs/pages/admin-guides/access-controls/sso/oidc.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/oidc.mdx
@@ -12,6 +12,10 @@ policies like:
 - Only members of the "DBA" group can connect to PostgreSQL databases.
 - Developers must never SSH into production servers.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx!)
+
 ## Prerequisites
 
 - Admin access to the SSO/IdP being integrated with users assigned to groups/roles.

--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -31,6 +31,10 @@ guide you through configuring the Okta integration.
 
 </details>
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="Okta"!)
+
 ## Prerequisites
 
 - An Okta account with admin access. Your account must include users and at

--- a/docs/pages/admin-guides/access-controls/sso/one-login.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/one-login.mdx
@@ -16,6 +16,10 @@ to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
+## How it works
+
+(!docs/pages/includes/sso/how-it-works.mdx idp="OneLogin"!)
+
 ## Prerequisites
 
 - A OneLogin account with admin access, and users assigned to at least two groups.

--- a/docs/pages/includes/sso/how-it-works.mdx
+++ b/docs/pages/includes/sso/how-it-works.mdx
@@ -1,0 +1,18 @@
+{{ idp="your SSO provider" }}
+
+You can register your Teleport cluster as an application with {{ idp }}, then
+create an **authentication connector** resource that provides Teleport with
+information about your application. When a user signs in to Teleport, {{ idp }}
+executes its own authentication flow, then sends an HTTP request to your
+Teleport cluster to indicate that authentication has completed.
+
+Teleport authenticates users to your infrastructure by issuing short-lived
+certificates. After a user completes an SSO authentication flow, Teleport issues
+short-lived TLS and SSH certificates to the user. Teleport also creates a
+temporary user on the Auth Service backend. 
+
+Teleport roles are encoded in the user's certificates. To assign Teleport roles
+to the user, the Auth Service inspects the **role mapping** within the
+authentication connector, which associates user data on {{ idp }} with the names
+of one or more Teleport roles.
+


### PR DESCRIPTION
Add some missing "How it works" sections. This includes adding a partial for how-to guides in the SSO section.