### PR TITLE
Added support for querying the latest Teleport version via images published to public ECR

### DIFF
--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -30,17 +30,33 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/tomnomnom/linkheader"
 	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )
+
+const (
+	publicECRRegistryEndpoint = "https://public.ecr.aws/"
+	publicECRImageName        = "gravitational/teleport-ent-distroless"
+)
+
+type lookupConfig struct {
+	source      string
+	versionSpec string
+}
 
 func main() {
 	versionSpec, err := parseFlags()
@@ -48,9 +64,9 @@ func main() {
 		log.Fatalf("Failed to parse flags: %v.", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	tag, err := getLatest(ctx, versionSpec, github.NewGitHub())
+	tag, err := getLatest(ctx, versionSpec)
 	if err != nil {
 		log.Fatalf("Query failed: %v.", err)
 	}
@@ -58,20 +74,41 @@ func main() {
 	fmt.Println(tag)
 }
 
-func parseFlags() (string, error) {
+func parseFlags() (*lookupConfig, error) {
+	source := flag.String("source", "github", "source to use for querying the latest release")
+
 	flag.Parse()
 	if flag.NArg() == 0 {
-		return "", trace.BadParameter("missing argument: vX.X")
+		return nil, trace.BadParameter("missing argument: vX.X")
 	} else if flag.NArg() > 1 {
-		return "", trace.BadParameter("unexpected positional arguments: %q", flag.Args()[1:])
+		return nil, trace.BadParameter("unexpected positional arguments: %q", flag.Args()[1:])
 	}
 
-	versionSpec := flag.Args()[0]
+	versionSpec := flag.Arg(0)
+	if !semver.IsValid(versionSpec) {
+		return nil, trace.Errorf("version spec %q is not a valid semver", versionSpec)
+	}
 
-	return versionSpec, nil
+	return &lookupConfig{
+		versionSpec: versionSpec,
+		source:      strings.ToLower(*source),
+	}, nil
 }
 
-func getLatest(ctx context.Context, versionSpec string, gh github.GitHub) (string, error) {
+func getLatest(ctx context.Context, config *lookupConfig) (string, error) {
+	switch config.source {
+	case "github":
+		return getLatestViaGithubReleases(ctx, config.versionSpec)
+	case "ecr-public":
+		return getLatestViaECRPublic(ctx, config.versionSpec)
+	default:
+		return "", trace.Errorf("unsupported source %q", config.source)
+	}
+}
+
+func getLatestViaGithubReleases(ctx context.Context, versionSpec string) (string, error) {
+	gh := github.NewGitHub()
+
 	releases, err := gh.ListReleases(ctx, "gravitational", "teleport")
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -107,4 +144,218 @@ func getLatest(ctx context.Context, versionSpec string, gh github.GitHub) (strin
 	}
 
 	return "", trace.NotFound("no releases matched %q", versionSpec)
+}
+
+// Gets the latest matching version by querying the images published to the public.ecr.aws/gravitational/teleport-ent-distroless
+// PublicECR implements the Docker Registry HTTP API. Use it to get the latest matching image.
+// See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-discovery
+func getLatestViaECRPublic(ctx context.Context, versionSpec string) (string, error) {
+	ocidc, err := NewOCIDistributionClient(ctx, publicECRRegistryEndpoint)
+	if err != nil {
+		return "", trace.Wrap(err, "failed to build ECR public client for %q", publicECRRegistryEndpoint)
+	}
+
+	tags, err := ocidc.GetTags(ctx, publicECRImageName)
+	if err != nil {
+		return "", trace.Wrap(err, "failed to get tags for %q from %q", publicECRImageName, publicECRRegistryEndpoint)
+	}
+
+	// Filter the tags and return the latest matching the version spec
+	latestMatching := "v0"
+	foundMatch := false
+	for _, tag := range tags {
+		// The semver package doesn't actually support the semver spec, and requires a preceding `v`
+		tag = "v" + tag
+		if !semver.IsValid(tag) {
+			continue
+		}
+
+		if !strings.HasPrefix(tag, versionSpec) {
+			continue
+		}
+
+		// If the tag is newer than the previously recorded newest
+		if semver.Compare(tag, latestMatching) > 0 {
+			foundMatch = true
+			latestMatching = tag
+		}
+	}
+
+	if !foundMatch {
+		return "", trace.NotFound("no releases matched %q", versionSpec)
+	}
+
+	return latestMatching, nil
+}
+
+// Simple client for the OCI distribution API: https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+// This does not currently handle token expiration
+type ociDistributionClient struct {
+	endpoint string
+	token    string
+}
+
+// Creates a new OCI distribution API client.
+func NewOCIDistributionClient(ctx context.Context, endpoint string) (*ociDistributionClient, error) {
+	client := &ociDistributionClient{
+		endpoint: endpoint,
+	}
+
+	token, err := client.getOCIDistributionToken(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to get OCI distribution API token for %q", endpoint)
+	}
+	client.token = token
+
+	return client, nil
+}
+
+// Gets a new anonymous authentication token for the OCI distribution API.
+func (ocidc *ociDistributionClient) getOCIDistributionToken(ctx context.Context) (string, error) {
+	requestURL, err := url.JoinPath(ocidc.endpoint, "token")
+	if err != nil {
+		return "", trace.Wrap(err, "failed to build token URL")
+	}
+
+	tokenResponse := &struct {
+		Token string
+	}{}
+
+	if _, err := ocidc.doRequest(ctx, requestURL, http.MethodGet, tokenResponse); err != nil {
+		return "", trace.Wrap(err, "request to %q failed", requestURL)
+	}
+
+	if tokenResponse.Token == "" {
+		return "", trace.Errorf("token API endpoint did not include a token in the API response")
+	}
+
+	return tokenResponse.Token, nil
+}
+
+// Gets a list of all tags for the provided image.
+func (ocidc *ociDistributionClient) GetTags(ctx context.Context, image string) ([]string, error) {
+	baseRequestURL, err := url.JoinPath(ocidc.endpoint, "v2", image, "tags", "list")
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to build tags URL")
+	}
+
+	// AWS ECR public does not conform to the OCI distribution spec. Responses are limited to 1000
+	// tags despite the spec explicitly requiring that `n` results must always be returned if `n`
+	// tags are available. Tags are also not in lexical order as explicitly defined by the spec,
+	// so all tags must be retrieved by pagination every time.
+	tags := []string{}
+	requestCountLimit := 100
+	tagsPerRequest := 1000
+	baseRequestURL = fmt.Sprintf("%s?n=%d", baseRequestURL, tagsPerRequest)
+	requestURL := baseRequestURL
+
+	for requestCount := 0; requestCount < requestCountLimit; requestCount++ {
+		tagsResponse := &struct {
+			Tags []string
+		}{}
+
+		response, err := ocidc.doRequest(ctx, requestURL, http.MethodGet, tagsResponse)
+		if err != nil {
+			return nil, trace.Wrap(err, "request to %q failed", requestURL)
+		}
+
+		tags = append(tags, tagsResponse.Tags...)
+
+		if len(tagsResponse.Tags) < tagsPerRequest {
+			break
+		}
+
+		// Note: If there are _exactly_ multiples of tagsPerRequest in the registry,
+		// this may fail on public ECR because public ECR does not properly implement
+		// the spec. I don't have an easy easy way to test this. In this case, the
+		// response may not include a Link header of type `next` (because there are
+		// no more images in the last batch), and the public ECR implementation does
+		// not support the `last` query parameter with the tag as the value.
+
+		if linkHeaders, ok := response.Header["Link"]; ok {
+			links := linkheader.ParseMultiple(linkHeaders)
+			nextLinks := links.FilterByRel("next")
+			if len(nextLinks) > 0 {
+				requestURL = ocidc.endpoint + nextLinks[0].URL
+				continue
+			}
+		}
+
+		requestURL = fmt.Sprintf(baseRequestURL, "&last=%s", url.QueryEscape(tags[len(tags)-1]))
+	}
+
+	return tags, nil
+}
+
+// Sends and HTTP request to the given URL and parses the JSON response into the outVal, which is expected to be a pointer.
+// The returned response body read will be closed by this function.
+func (ocidc *ociDistributionClient) doRequest(ctx context.Context, requestURL string, method string, outVal any) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to build request")
+	}
+
+	if ocidc.token != "" {
+		request.Header.Add("Authorization", "Bearer "+ocidc.token)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return response, trace.Wrap(err, "request failed")
+	}
+
+	// Read the body. This is needed even when a non-2xx response code is returned.
+	// Errors will be aggregated below.
+	responseBody, readBodyErr := readLimitedSizeResponse(response.Body)
+	closeErr := response.Body.Close()
+
+	// Check the response status code, and error if the request was unsuccessful
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		statusCodeErr := trace.Errorf("received response code %d", response.StatusCode)
+		if readBodyErr == nil {
+			statusCodeErr = trace.Errorf("received response code %d with body %q ", response.StatusCode, string(responseBody))
+		}
+
+		return response, trace.NewAggregate(
+			statusCodeErr,
+			trace.Wrap(readBodyErr, "failed to read response body for error response"),
+			trace.Wrap(closeErr, "failed to close response body reader"),
+		)
+	}
+
+	if err = json.Unmarshal(responseBody, outVal); err != nil {
+		return response, trace.Wrap(err, "failed to unmarshal response body")
+	}
+
+	return response, nil
+}
+
+// Read up to a megabyte of response body
+func readLimitedSizeResponse(response io.Reader) ([]byte, error) {
+	sizeLimit := int64(1024 * 1024)
+	responseBody := make([]byte, sizeLimit)
+
+	readBytes, err := io.ReadFull(io.LimitReader(response, sizeLimit), responseBody)
+
+	// Truncate the body for return values
+	responseBody = responseBody[0:readBytes]
+
+	// EOF errors will _always_ occur when 0 < readBytes < sizeLimit
+	if readBytes > 0 && int64(readBytes) < sizeLimit && errors.Is(err, io.EOF) {
+		return responseBody, nil
+	}
+
+	// Check if at least one more byte can be read. If so, the response was too large and and error
+	// should be returned.
+	extraBytes := make([]byte, 1)
+	extraByteCount, extraReadErr := response.Read(extraBytes)
+	if extraByteCount == 0 {
+		return responseBody, nil
+	}
+	if extraReadErr != nil {
+		return nil, trace.Wrap(err, "failed to check if there were more than %d bytes in the response", sizeLimit)
+	}
+
+	// Normal error case when there are <= sizeLimit bytes in the body, but an error occurred while reading it
+	return nil, trace.Wrap(err, "failed to read response body")
 }

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -59,4 +59,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+require github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
+
 replace github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -88,6 +88,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d h1:xQcF7b7cZLWZG/+7A4G7un1qmEDYHIvId9qxRS1mZMs=
 github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d/go.mod h1:BzSc3WEF8R+lCaP5iGFRxd5kIXy4JKOZAwNe1w0cdc0=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
This uses the [OCI content discovery API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-discovery) to query the list of tags published to public.ecr.aws/gravitational/teleport-ent-distroless. Because we normally publish ECR images for private releases, this will cause the tool to consider private releases, instead of only public releases.
