### PR TITLE
Fix link in the Agentless OpenSSH guide

### DIFF
--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -16,7 +16,7 @@ and running, but in the long run, we would recommend replacing `sshd` with `tele
 
 - RBAC and resource filtering based on [dynamically updated labels](../../../admin-guides/management/admin/labels.mdx)
 - [Session recording without SSH connection termination](../guides/recording-proxy-mode.mdx)
-- [Session sharing](../../../connect-your-client/tsh.mdx)
+- [Session sharing](../../../admin-guides/access-controls/guides/joining-sessions.mdx)
 - [Advanced session recording](../guides/bpf-session-recording.mdx)
 
 ## How it works


### PR DESCRIPTION
Closes #55573

Link to content related to session joining instead of the general `tsh` user guide.