### PR TITLE
Add `teleport status --is-up-to-date`

### DIFF
--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -496,11 +496,16 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) (int, error) {
 		return 0, trace.Wrap(err)
 	}
 
+	return statusExitCode(ccfg, status), nil
+}
+
+// statusExitCode returns the desired exit code for the status command.
+func statusExitCode(ccfg *cliConfig, status autoupdate.Status) int {
 	// Implement --is-up-to-date
-	if ccfg.StatusWithExitCode && status.InWindow && status.Active.Version != status.Target.Version {
-		return notUpToDateExitCode, nil
+	if ccfg.StatusWithExitCode && status.InWindow && status.Active.String() != status.Target.String() {
+		return notUpToDateExitCode
 	}
-	return 0, nil
+	return 0
 }
 
 // cmdUninstall removes the updater-managed install of Teleport and gracefully reverts back to the Teleport package.

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -58,12 +58,7 @@ const (
 	updateLockTimeout = 10 * time.Minute
 
 	// notUpToDateExitCode is returned by `teleport-update status --is-up-to-date` if Teleport is not up-to-date.
-	// We don't want to use the exit code 1 as this makes "failure" and "out-of-date" results undifferentiable.
-	// Bash reserves codes between 126 and 165: https://tldp.org/LDP/abs/html/exitcodes.html
-	// Systemd reserved code >= 200: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Process%20Exit%20Codes
-	// Linux recommends codes 150-199 for application use.
-	// Hence, the first available recommended exit code is 166.
-	notUpToDateExitCode = 166
+	notUpToDateExitCode = 3
 )
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
@@ -182,8 +177,8 @@ func Run(args []string) int {
 		Required().StringVar(&ccfg.Path)
 
 	statusCmd := app.Command("status", "Show Teleport agent auto-update status.")
-	statusCmd.Flag("is-up-to-date",
-		fmt.Sprintf("Exits with code 0 if Teleport is up-to-date, and with code %d if 'teleport-update update' would attempt an update now.", notUpToDateExitCode),
+	statusCmd.Flag("err-if-should-update-now",
+		fmt.Sprintf("Exits with code %d if the agent should update now. Exit code 0 means that the agent should not update now, even if it might not run the target version.", notUpToDateExitCode),
 	).BoolVar(&ccfg.StatusWithExitCode)
 
 	uninstallCmd := app.Command("uninstall", "Uninstall the updater-managed installation of Teleport. If the Teleport package is installed, it is restored as the primary installation.")


### PR DESCRIPTION
This PR adds a flag `--is-up-to-date` to the `teleport-update status` command. In some specific setups, users don't have systemd but still want to write their own logic to update and restart Teleport. See this [Slack thread](https://goteleport.slack.com/archives/C066G3P0V3K/p1749667303827549?thread_ts=1749650187.925789&cid=C066G3P0V3K) for more context.

While we cannot cover every use-case, we can make it easy for users to detect if an update is required. They will then be responsible for triggering the update and reloading/restarting the teleport processes.

Changelog: Adds the the `teleport-update status --is-up-to-date` flag to change the return code based on the update status.