### PR TITLE
[docs] Add `hcl` language marker in the code blocks

### DIFF
--- a/docs/pages/identity-security/access-graph/identity-activity-center.mdx
+++ b/docs/pages/identity-security/access-graph/identity-activity-center.mdx
@@ -93,7 +93,7 @@ Execute the following Terraform script to create the required infrastructure.
 
 `variables.tf` file includes the description of the required Terraform variables.
 
-```terraform
+```hcl
 (!examples/identity-activity-center/variables.tf!)
 ```
 
@@ -103,7 +103,7 @@ Execute the following Terraform script to create the required infrastructure.
 that Terraform will create and manage. This includes AWS KMS keys, AWS S3 Buckets
 for transient and long-term storage, and AWS Glue table and database.
 
-```
+```hcl
 (!examples/identity-activity-center/identity_activity_center.tf!)
 ```
 
@@ -113,7 +113,7 @@ for transient and long-term storage, and AWS Glue table and database.
 be attached to the AWS identity that the Identity Security service runs as,
 enabling it to access the resources and execute queries.
 
-```
+```hcl
 (!examples/identity-activity-center/policy.tf!)
 ```
 


### PR DESCRIPTION
Add `hcl` language marker in the code blocks so that the terraform code in the newly added identity activity center docs is properly rendered.

FWIW, if code blocks like the following were rendered correctly with file contents inlined in preview mode this would have probably been picked up earlier, no idea what it would take to make this happen though:

    ```
    (!examples/identity-activity-center/policy.tf!)
    ```

Related-pull-request: https://github.com/gravitational/teleport/pull/55519