### PR TITLE
tools: Query teleport-private in addition for latest releases

### DIFF
--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -102,7 +102,7 @@ func getLatest(ctx context.Context, versionSpec string, gh github.GitHub) (strin
 func getLatestForRepo(ctx context.Context, versionSpec string, gh github.GitHub, repo string) (string, error) {
 	releases, err := gh.ListReleases(ctx, "gravitational", repo)
 	if err != nil {
-		return "", trace.Wrap(err, "couldn't list releases")
+		return "", trace.Wrap(err, "couldn't list releases for repo %q", repo)
 	}
 	if len(releases) == 0 {
 		return "", trace.NotFound("failed to find any releases on GitHub")

--- a/build.assets/tooling/cmd/query-latest/main_test.go
+++ b/build.assets/tooling/cmd/query-latest/main_test.go
@@ -38,7 +38,8 @@ func TestGetLatest(t *testing.T) {
 			desc: "pass",
 			spec: "v8",
 			releases: map[string][]string{
-				"teleport": {"v8.1.9", "v8.1.10", "v8.0.11"},
+				"teleport":         {"v8.1.9", "v8.1.10", "v8.0.11"},
+				"teleport-private": {"v1.0.1"},
 			},
 			wantErr: require.NoError,
 			latest:  "v8.1.10",
@@ -47,7 +48,8 @@ func TestGetLatest(t *testing.T) {
 			desc: "fail-bad-spec",
 			spec: "v9",
 			releases: map[string][]string{
-				"teleport": {"v8.1.9", "v8.1.10", "v8.0.11"},
+				"teleport":         {"v8.1.9", "v8.1.10", "v8.0.11"},
+				"teleport-private": {"v1.0.1"},
 			},
 			wantErr: require.Error,
 			latest:  "",
@@ -56,7 +58,8 @@ func TestGetLatest(t *testing.T) {
 			desc: "pass-prerelease",
 			spec: "v8",
 			releases: map[string][]string{
-				"teleport": {"v8.1.10-rc.1", "v8.1.10", "v8.1.10-alpha.1"},
+				"teleport":         {"v8.1.10-rc.1", "v8.1.10", "v8.1.10-alpha.1"},
+				"teleport-private": {"v1.0.1"},
 			},
 			wantErr: require.NoError,
 			latest:  "v8.1.10",
@@ -65,7 +68,8 @@ func TestGetLatest(t *testing.T) {
 			desc: "pass-major-minor",
 			spec: "v8.1",
 			releases: map[string][]string{
-				"teleport": {"v8.1.9", "v8.2.1", "v8.1.10", "v8.0.11"},
+				"teleport":         {"v8.1.9", "v8.2.1", "v8.1.10", "v8.0.11"},
+				"teleport-private": {"v1.0.1"},
 			},
 			wantErr: require.NoError,
 			latest:  "v8.1.10",
@@ -86,6 +90,26 @@ func TestGetLatest(t *testing.T) {
 			releases: map[string][]string{
 				"teleport":         {"v8.1.9", "v8.2.3", "v8.1.10", "v8.0.11"},
 				"teleport-private": {"v8.2.2"},
+			},
+			wantErr: require.NoError,
+			latest:  "v8.2.3",
+		},
+		{
+			desc: "no-private-releases",
+			spec: "v8",
+			releases: map[string][]string{
+				"teleport":         {"v8.1.9", "v8.2.3", "v8.1.10", "v8.0.11"},
+				"teleport-private": {},
+			},
+			wantErr: require.Error,
+			latest:  "",
+		},
+		{
+			desc: "no-matching-private",
+			spec: "v8",
+			releases: map[string][]string{
+				"teleport":         {"v8.1.9", "v8.2.3", "v8.1.10", "v8.0.11"},
+				"teleport-private": {"v7.5.2"},
 			},
 			wantErr: require.NoError,
 			latest:  "v8.2.3",


### PR DESCRIPTION
Extend `query-latest` to query releases in `teleport-private` in
addition to the current `teleport` repository so that we can rebuild OCI
images released from `teleport-private`.

If the latest release for a version is in the `teleport-private`
repository, the version number printed will be prefixed with `private-`.

As `teleport-private` is a private repository, the environment variable
`GITHUB_TOKEN` must be set to a token with permissions to read the
releases of the `teleport-private` repository.

When testing locally, this can be done with:

    # may require `gh auth refresh` first
    export GITHUB_TOKEN=$(gh auth token)

assuming you have `gh` set up properly with credentials.

Test-run: https://github.com/gravitational/teleport.e/actions/runs/15601530288
Test-run: https://github.com/gravitational/teleport.e/actions/runs/15601976879

---

Currently the nightly rebuild is disabled (deleted) so changing the
output of this `query-latest` command will not break anything. When I
add back the workflow, I'll adjust it to handle the `private-*` output
properly.

I have created private releases for 15.5.3 and 17.5.2 in teleport-private.
You can see in the first test run of the output of the "Trigger Builds" step
where it would trigger private release builds of 15.5.3 and 17.5.2, but not
16.5.11 for which I have not yet created the private GitHub release.

The second test run shows the rebuild of 15.5.3 from teleport-private, which
was successful. I verified the AWS registry has 15, 15.5 and 15.5.3 on the
same image.