### PR TITLE
Support custom envvars in the loadtest node-agent chart

### DIFF
--- a/assets/loadtest/helm/node-agent/templates/deployment.yaml
+++ b/assets/loadtest/helm/node-agent/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
             - name: SSL_CERT_FILE
               value: /etc/teleport-tls-ca/ca.pem
             {{- end }}
+            {{- if $.Values.env }}{{ toYaml $.Values.env | nindent 12 }}{{ end }}
           volumeMounts:
             - mountPath: /etc/teleport-config
               name: config

--- a/assets/loadtest/helm/node-agent/templates/deployment.yaml
+++ b/assets/loadtest/helm/node-agent/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: SSL_CERT_FILE
               value: /etc/teleport-tls-ca/ca.pem
             {{- end }}
-            {{- if $.Values.env }}{{ toYaml $.Values.env | nindent 12 }}{{ end }}
+            {{- if $.Values.extraEnv }}{{ toYaml $.Values.extraEnv | nindent 12 }}{{ end }}
           volumeMounts:
             - mountPath: /etc/teleport-config
               name: config

--- a/assets/loadtest/helm/node-agent/values.yaml
+++ b/assets/loadtest/helm/node-agent/values.yaml
@@ -32,7 +32,7 @@ tls:
 
 # envvars set in each container
 # array of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core
-env: []
+extraEnv: []
 
 # resource requirements for each container
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core

--- a/assets/loadtest/helm/node-agent/values.yaml
+++ b/assets/loadtest/helm/node-agent/values.yaml
@@ -19,11 +19,24 @@ joinParams:
   # DO NOT USE THIS IN PRODUCTION
   token_name: ""
 
+# pod tolerations
+# array of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#toleration-v1-core
 tolerations: []
 
+# pod affinity rules
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#affinity-v1-core
 affinity: {}
 
 tls:
   existingCASecretName: ""
 
+# envvars set in each container
+# array of https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#envvar-v1-core
+env: []
+
+# resource requirements for each container
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#resourcerequirements-v1-core
+resources: {}
+
+# Teleport labels
 labels: {}


### PR DESCRIPTION
This PR adds custom envvars to the node-agent loadtest helm chart, so it's possible to add values such as GOMAXPROCS and GOMEMLIMIT (to match requests and limits) without having to modify the chart templates. Backporting just in case even though we're likely going to copy the chart from master to apply it anyway.