### PR TITLE
fixes a broken link in the SELinux docs

### DIFF
--- a/docs/pages/admin-guides/management/security/selinux.mdx
+++ b/docs/pages/admin-guides/management/security/selinux.mdx
@@ -123,7 +123,7 @@ The module source consists of two files, the type enforcement file and the file 
 
 The type enforcement file is the heart of the module and contains statements that define what Teleport SSH Service processes are allowed to do.
 
-The file contexts file maps files and directories Teleport SSH Service uses to the appropriate SELinux labels. For more information on SELinux labels refer to the Red Hat article [SELinux Contexts - Labeling Files](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files).
+The file contexts file maps files and directories Teleport SSH Service uses to the appropriate SELinux labels. For more information on SELinux labels refer to the Red Hat article [SELinux Contexts - Labeling Files](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files).
 
 The customized module source can be printed using Teleport:
 


### PR DESCRIPTION
Looks like Red Hat dumbed down their SELinux content for newer Red Hat versions for some reason, this useful page is only available for RHEL 7 docs