### PR TITLE
Add ZIP target for macOS to support Connect in-app updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -774,13 +774,16 @@ release-connect: | $(RELEASE_DIR)
 	pnpm build-term
 	pnpm package-term -c.extraMetadata.version=$(VERSION) --$(ELECTRON_BUILDER_ARCH)
 	# Only copy proper builds with tsh.app to $(RELEASE_DIR)
-	# Drop -universal "arch" from dmg name when copying to $(RELEASE_DIR)
+	# Drop -universal "arch" from dmg and zip name when copying to $(RELEASE_DIR)
 	if [ -n "$$CONNECT_TSH_APP_PATH" ]; then \
-		TARGET_NAME="Teleport Connect-$(VERSION)-$(ARCH).dmg"; \
+		DMG_TARGET_NAME="Teleport Connect-$(VERSION)-$(ARCH).dmg"; \
+		ZIP_TARGET_NAME="Teleport Connect-$(VERSION)-$(ARCH)-mac.zip"; \
 		if [ "$(ARCH)" = 'universal' ]; then \
-			TARGET_NAME="$${TARGET_NAME/-universal/}"; \
+			DMG_TARGET_NAME="$${DMG_TARGET_NAME/-universal/}"; \
+			ZIP_TARGET_NAME="$${ZIP_TARGET_NAME/-universal/}"; \
 		fi; \
-		cp web/packages/teleterm/build/release/"Teleport Connect-$(VERSION)-$(ELECTRON_BUILDER_ARCH).dmg" "$(RELEASE_DIR)/$${TARGET_NAME}"; \
+		cp web/packages/teleterm/build/release/"Teleport Connect-$(VERSION)-$(ELECTRON_BUILDER_ARCH).dmg" "$(RELEASE_DIR)/$${DMG_TARGET_NAME}"; \
+		cp web/packages/teleterm/build/release/"Teleport Connect-$(VERSION)-$(ELECTRON_BUILDER_ARCH)-mac.zip" "$(RELEASE_DIR)/$${ZIP_TARGET_NAME}"; \
 	fi
 
 #

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -108,7 +108,8 @@ module.exports = {
     },
   ],
   mac: {
-    target: 'dmg',
+    // ZIP target is used only for app updates.
+    target: ['zip', 'dmg'],
     category: 'public.app-category.developer-tools',
     type: 'distribution',
     notarize: true,


### PR DESCRIPTION
Electron in-app updates for Mac [require zip packages](https://www.electron.build/auto-update):

>zip target for macOS is required for Squirrel.Mac, otherwise latest-mac.yml cannot be created, which causes autoUpdater error. Default [target](https://www.electron.build/mac#MacOptions-target) for macOS is dmg+zip, so there is no need to explicitly specify target.

This package won't be visible on the downloads page, it will only be accessible via a link.
The artifact name has the following format: `Teleport Connect-{version}-universal-mac.zip`.

A note about blackmap files: we've disabled blockmap generation for the DMG, but it's [not configurable for the ZIP target](https://github.com/electron-userland/electron-builder/issues/7242#issuecomment-1875696036). I haven't yet confirmed whether this reduces the download size, but maybe I will investigate it in the future.

[Dev build](https://github.com/gravitational/teleport.e/actions/runs/15537251770/job/43740767610)