### PR TITLE
Edit the standard prerequisites partial

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -4,7 +4,10 @@
   get started with Teleport, [sign up](https://goteleport.com/signup) for a free
   trial or [set up a demo environment](../linux-demo.mdx).
 
-- The {{ clients }}:
+- The {{ clients }}.
+
+  <details>
+  <summary>Installing {{ clients }}</summary>
 
   <Tabs>
     <TabItem label="Mac">
@@ -60,4 +63,5 @@
   $ curl https://example.teleport.sh/v1/webapi/ping | jq -r '.server_version'
   (=teleport.version=)
   ```
-  
+
+  </details>


### PR DESCRIPTION
Move the client tool installation instructions into a Details box. Otherwise, they are rather noisy, taking up most of the viewport and including a "danger" Admonition that is distracting if a user is not trying to install client tools.