### PR TITLE
[vnet] fix: support <hostname>.<leaf-cluster> for VNet SSH

### DIFF
--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -226,11 +226,12 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	}, nil
 }
 
-// VNet SSH handles SSH hostnames matching "<hostname>.<cluster_name>." or
-// "<hostname>.<leaf_cluster_name>.<cluster_name>.". tryResolveSSH checks if
-// fqdn matches that pattern for any logged-in cluster and if so returns a
-// match. We never actually query for whether or not a matching SSH node exists,
-// we just attempt to dial it when the client connects to the assigned IP.
+// VNet SSH handles SSH hostnames matching "<hostname>.<cluster_name>.", where
+// the <cluster-name> may be the name of a root or leaf cluster.
+// tryResolveSSH checks if fqdn matches that pattern for any known cluster
+// and if so returns a match. We never actually query for whether or not a
+// matching SSH node exists, we just attempt to dial it when the client
+// connects to the assigned IP.
 func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
 	for _, profileName := range profileNames {
 		log := log.With("profile", profileName)
@@ -240,23 +241,21 @@ func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string,
 			continue
 		}
 		rootClusterName := rootClient.ClusterName()
-		if !isDescendantSubdomain(fqdn, rootClusterName) {
-			continue
-		}
+		log = log.With("root_cluster", rootClusterName)
 		leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
 		if err != nil {
 			// Good chance we're here because the user is not logged in to the profile.
 			log.ErrorContext(ctx, "Failed to list leaf clusters, SSH nodes in this cluster will not be resolved", "error", err)
-			return nil, errNoMatch
+			continue
 		}
 		rootDialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, profileName)
 		if err != nil {
 			log.ErrorContext(ctx, "Failed to get cluster dial options, SSH nodes in this cluster will not be resolved", "error", err)
-			return nil, errNoMatch
+			continue
 		}
 		for _, leafClusterName := range leafClusters {
 			log := log.With("leaf_cluster", leafClusterName)
-			if !isDescendantSubdomain(fqdn, leafClusterName+"."+rootClusterName) {
+			if !isDescendantSubdomain(fqdn, leafClusterName) {
 				continue
 			}
 			leafClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
@@ -282,8 +281,10 @@ func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string,
 				},
 			}, nil
 		}
-		// If it didn't match any leaf cluster assume it matches the root
-		// cluster.
+		// Didn't match any leaf, check if it's in the root cluster.
+		if !isDescendantSubdomain(fqdn, rootClusterName) {
+			continue
+		}
 		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, rootClient)
 		if err != nil {
 			log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)

--- a/lib/vnet/ssh_handler.go
+++ b/lib/vnet/ssh_handler.go
@@ -59,14 +59,13 @@ func (h *sshHandler) handleTCPConnector(ctx context.Context, localPort uint16, c
 		return trace.Wrap(err)
 	}
 	defer targetConn.Close()
-	return trace.Wrap(h.handleTCPConnectorWithTargetConn(ctx, localPort, connector, targetConn))
+	return trace.Wrap(h.handleTCPConnectorWithTargetConn(ctx, connector, targetConn))
 }
 
 // handleTCPConnectorWithTargetTCPConn handles an incoming TCP connection from
 // VNet when a TCP connection to the target host has already been established.
 func (h *sshHandler) handleTCPConnectorWithTargetConn(
 	ctx context.Context,
-	localPort uint16,
 	connector func() (net.Conn, error),
 	targetConn net.Conn,
 ) error {

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -209,7 +209,7 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		h.setDecidedHandler(sshHandler)
 		// Handle the incoming connection with the TCP connection to the target
 		// SSH node that has already been established.
-		return sshHandler.handleTCPConnectorWithTargetConn(ctx, localPort, connector, targetConn)
+		return sshHandler.handleTCPConnectorWithTargetConn(ctx, connector, targetConn)
 	}
 	return trace.Errorf("rejecting connection to %s:%d", h.cfg.fqdn, localPort)
 }

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -116,6 +116,7 @@ func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*
 	processManager, processCtx := newProcessManager()
 	sshConfigurator := newSSHConfigurator(sshConfiguratorConfig{
 		clientApplication: clientApplication,
+		leafClusterCache:  leafClusterCache,
 	})
 	processManager.AddCriticalBackgroundTask("SSH configuration loop", func() error {
 		return trace.Wrap(sshConfigurator.runConfigurationLoop(processCtx))

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -750,20 +750,16 @@ func TestDialFakeApp(t *testing.T) {
 		clusters: map[string]testClusterSpec{
 			"root1.example.com": {
 				apps: []appSpec{
-					appSpec{publicAddr: "echo1.root1.example.com"},
-					appSpec{publicAddr: "echo2.root1.example.com"},
-					appSpec{publicAddr: "echo.myzone.example.com"},
-					appSpec{publicAddr: "echo.nested.myzone.example.com"},
-					appSpec{publicAddr: "not.in.a.custom.zone"},
-					appSpec{
+					{publicAddr: "echo1.root1.example.com"},
+					{publicAddr: "echo2.root1.example.com"},
+					{publicAddr: "echo.myzone.example.com"},
+					{publicAddr: "echo.nested.myzone.example.com"},
+					{publicAddr: "not.in.a.custom.zone"},
+					{
 						publicAddr: "multi-port.root1.example.com",
 						tcpPorts: []*types.PortRange{
-							&types.PortRange{
-								Port: 1337,
-							},
-							&types.PortRange{
-								Port: 4242,
-							},
+							{Port: 1337},
+							{Port: 4242},
 						},
 					},
 				},
@@ -774,36 +770,32 @@ func TestDialFakeApp(t *testing.T) {
 				leafClusters: map[string]testClusterSpec{
 					"leaf1.example.com": {
 						apps: []appSpec{
-							appSpec{publicAddr: "echo1.leaf1.example.com"},
-							appSpec{
+							{publicAddr: "echo1.leaf1.example.com"},
+							{
 								publicAddr: "multi-port.leaf1.example.com",
 								tcpPorts: []*types.PortRange{
-									&types.PortRange{
-										Port: 1337,
-									},
-									&types.PortRange{
-										Port: 4242,
-									},
+									{Port: 1337},
+									{Port: 4242},
 								},
 							},
 						},
 					},
 					"leaf2.example.com": {
 						apps: []appSpec{
-							appSpec{publicAddr: "echo1.leaf2.example.com"},
+							{publicAddr: "echo1.leaf2.example.com"},
 						},
 					},
 				},
 			},
 			"root2.example.com": {
 				apps: []appSpec{
-					appSpec{publicAddr: "echo1.root2.example.com"},
-					appSpec{publicAddr: "echo2.root2.example.com"},
+					{publicAddr: "echo1.root2.example.com"},
+					{publicAddr: "echo2.root2.example.com"},
 				},
 				leafClusters: map[string]testClusterSpec{
 					"leaf3.example.com": {
 						apps: []appSpec{
-							appSpec{publicAddr: "echo1.leaf3.example.com"},
+							{publicAddr: "echo1.leaf3.example.com"},
 						},
 					},
 				},
@@ -1045,7 +1037,7 @@ func TestOnNewConnection(t *testing.T) {
 		clusters: map[string]testClusterSpec{
 			"root1.example.com": {
 				apps: []appSpec{
-					appSpec{publicAddr: "echo1"},
+					{publicAddr: "echo1"},
 				},
 				cidrRange:    "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{},
@@ -1106,15 +1098,15 @@ func testWithAlgorithmSuite(t *testing.T, suite types.SignatureAlgorithmSuite) {
 		clusters: map[string]testClusterSpec{
 			"root.example.com": {
 				apps: []appSpec{
-					appSpec{publicAddr: "echo1"},
-					appSpec{publicAddr: "echo2"},
+					{publicAddr: "echo1"},
+					{publicAddr: "echo2"},
 				},
 				cidrRange: "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{
 					"leaf.example.com": {
 						apps: []appSpec{
-							appSpec{publicAddr: "echo1"},
-							appSpec{publicAddr: "echo2"},
+							{publicAddr: "echo1"},
+							{publicAddr: "echo2"},
 						},
 						cidrRange: "192.168.2.0/24",
 					},
@@ -1297,7 +1289,7 @@ func TestSSH(t *testing.T) {
 		},
 		{
 			// Connection to node in leaf cluster should work.
-			dialAddr:      "node.leaf1.example.com.root1.example.com",
+			dialAddr:      "node.leaf1.example.com",
 			dialPort:      22,
 			expectCIDR:    leaf1CIDR,
 			sshUser:       "testuser",
@@ -1315,7 +1307,7 @@ func TestSSH(t *testing.T) {
 		{
 			// Connection to node in leaf cluster in alternate profile should
 			// work.
-			dialAddr:      "node.leaf2.example.com.root2.example.com",
+			dialAddr:      "node.leaf2.example.com",
 			dialPort:      22,
 			expectCIDR:    leaf2CIDR,
 			sshUser:       "testuser",

--- a/rfd/0207-vnet-ssh.md
+++ b/rfd/0207-vnet-ssh.md
@@ -7,9 +7,9 @@ state: draft
 
 ## Required Approvers
 
-* Engineering: @espadolini && @rosstimothy
-* Security: doyensec
-* Product: @klizhentas
+- Engineering: @espadolini && @rosstimothy
+- Security: doyensec
+- Product: @klizhentas
 
 ## What
 
@@ -24,7 +24,7 @@ Advanced Teleport features like per-session MFA and hardware keys will be fully
 supported.
 
 Here's a demo with a proof-of-concept of the feature in action:
-https://goteleport.zoom.us/clips/share/3xSvI4taSD6YgM1C0l12nQ
+<https://goteleport.zoom.us/clips/share/3xSvI4taSD6YgM1C0l12nQ>
 
 ## Why
 
@@ -197,13 +197,11 @@ we already have an SSH forwarding server implemented in `lib/srv/forward/sshserv
 VNet SSH will support SSH connections to DNS names matching any of the following:
 
 - `<hostname>.<cluster name>`
-- `<hostname>.<leaf cluster name>.<root cluster name>`
 - `<host ID>.<cluster name>`
-- `<host ID>.<leaf cluster name>.<root cluster name>`
 
 These are the same patterns supported by our existing OpenSSH client
 integration, which will offer a seamless transition for users switching to VNet SSH
-https://goteleport.com/docs/enroll-resources/server-access/openssh/openssh-agentless/#step-23-generate-an-ssh-client-configuration
+<https://goteleport.com/docs/enroll-resources/server-access/openssh/openssh-agentless/#step-23-generate-an-ssh-client-configuration>
 
 If users prefer to use a shorter name to connect to SSH hosts, they can add
 a `CanonicalDomains` option to their `~/.ssh/config` file, e.g.
@@ -236,7 +234,7 @@ If the user runs `tsh vnet` instead of Connect, we won't add anything to
 `vnet_ssh_config` will include the following:
 
 ```
-Host *.teleport.example.com *.leaf.teleport.example.com
+Host *.root.example.com *.leaf.example.com
     IdentityFile "/Users/nic/Library/Application Support/tsh/id_vnet"
     GlobalKnownHostsFile "/Users/nic/Library/Application Support/tsh/vnet_known_hosts"
     UserKnownHostsFile /dev/null
@@ -299,9 +297,8 @@ When the VNet process receives a DNS query this is how it will be resolved:
    1. If it matches a web app the DNS request will be forwarded to upstream DNS
       servers (this is also as it implicitly works today, now we'll do it
       explicitly to skip assigning a VNet IP for web apps).
-1. If the name does not match `*.<cluster name>` or
-   `*.<leaf cluster name>.<root cluster name>` for any profile, the request will
-   be forwarded to upstream DNS servers.
+1. If the name does not match `*.<cluster name>` or for any cluster, the
+   request will be forwarded to upstream DNS servers.
 1. VNet will assign a free IP address to the FQDN, but at this point it will not
    know if this IP will later resolve to an SSH host or an app or neither.
 1. VNet will return the IP address in an authoritative DNS answer.
@@ -310,6 +307,7 @@ When the VNet process receives a DNS query this is how it will be resolved:
 
 When the VNet process receives a TCP connection at an address that has been
 assigned to an FQDN but does not yet know if there is a matching app or SSH host:
+
 1. An app lookup will run first in case an app has been added since the DNS
    query that assigned this IP.
    If the queried FQDN matches a TCP app then the IP will be permanently


### PR DESCRIPTION
In the initial VNet SSH design I wrote that nodes in leaf clusters would be accessible at `<hostname/hostid>.<leaf-cluster>.<root-cluster>`. This was based on a misunderstanding of our existing OpenSSH client support, I thought it did the same, but it turns out I was wrong. Supporting leaf hosts at `<hostname/hostid>.<leaf-cluster>` matches the existing OpenSSH client support and seems much more convenient for users. This PR makes that change.

For example, before this change, to access a host called `node` in leaf cluster `leaf.example.com` of root cluster `root.example.com`, you would have to hit `ssh node.leaf.example.com.root.example.com`. Now you can just use `ssh node.leaf.example.com`.