### PR TITLE
Fix small docs typos found during test plan

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/oidc.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/oidc.mdx
@@ -50,9 +50,9 @@ authentication is complete. The redirect URL must be selected by a Teleport
 administrator in advance.
 
 The redirect URL for OIDC authentication in Teleport is <nobr>
-<Var name="mytenant.teleport.sh" description="Your Teleport Cloud tenant or Proxy
+<Var name="mytenant.teleport.sh:443" description="Your Teleport Cloud tenant or Proxy
 Service address"/>`/v1/webapi/oidc/callback`</nobr>. 
-Replace <Var name="mytenant.teleport.sh" /> with your Teleport Cloud tenant or
+Replace <Var name="mytenant.teleport.sh:443" /> with your Teleport Cloud tenant or
 Proxy Service address.
 
 ## OIDC connector configuration
@@ -138,7 +138,7 @@ Before applying the connector to your cluster, you can test that it's configured
 correctly:
 
 ```code
-$ cat oidc-connector | tctl sso test
+$ cat oidc-connector.yaml | tctl sso test
 ```
 
 This should open up your web browser and attempt to log you in to the Teleport

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -11,7 +11,7 @@ We will use the following services to deploy Teleport on IBM cloud:
 - [Compute: IBM Cloud Kubernetes Service](https://www.ibm.com/products/kubernetes-service)
   to deploy Teleport using the [`teleport-cluster` Helm chart](../../../reference/helm-reference/teleport-cluster.mdx)
 - [Storage: IBM Cloud Databases for PostgreSQL](https://www.ibm.com/products/databases-for-postgresql)
-  to store the Teleport cluster state, and the Teleport audit events (see []backends reference](../../../reference/backends.mdx)
+  to store the Teleport cluster state, and the Teleport audit events (see [backends reference](../../../reference/backends.mdx)
   for more details).
 - [Storage: IBM Cloud Object Storage](https://www.ibm.com/products/cloud-object-storage) to store the Teleport
   session recordings.


### PR DESCRIPTION
XS PR fixing a couple of types found when reading the docs during the v18 test plan:
- broken ling in IBM guide
- missing `.yaml` extension in a command
- missing port on the OIDC guide, causing a callback URL mismatch with the resource from `tctl sso configure`. Teleport never strips the port, even when it's 443.