### PR TITLE
Fix pagination bug with overlapping prefixes in StreamRange

### DIFF
--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -69,7 +69,7 @@ func KeyFromString(s string) Key {
 		components: components,
 		s:          s,
 		exactKey:   s == SeparatorString || (s != "" && s[len(s)-1] == Separator),
-		noEnd:      s == string(noEnd),
+		noEnd:      s == noEnd,
 	}
 }
 
@@ -100,7 +100,7 @@ func (k Key) ExactKey() Key {
 // each component concatenated together via the [Separator].
 func (k Key) String() string {
 	if k.noEnd {
-		return string(noEnd)
+		return noEnd
 	}
 
 	return k.s

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -58,7 +58,7 @@ func IsKeySafe(key Key) bool {
 	components := key.Components()
 	for i, k := range components {
 		switch k {
-		case string(noEnd):
+		case noEnd:
 			continue
 		case ".", "..":
 			return false


### PR DESCRIPTION
This PR fixes a pagination bug in `backend.StreamRange` which thankfully is only triggered by items with overlapping keys, which is never the case in normal conditions for the current of the function (users, serverinfo and instance).