### PR TITLE
Correct the Webauthn options struct version number

### DIFF
--- a/lib/auth/webauthnwin/api_test.go
+++ b/lib/auth/webauthnwin/api_test.go
@@ -191,7 +191,7 @@ func TestLogin(t *testing.T) {
 			origin:      origin,
 			assertionIn: func() *wantypes.CredentialAssertion { return okAssertion },
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(6), req.opts.dwVersion)
+				assert.Equal(t, uint32(5), req.opts.dwVersion)
 
 				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
 
@@ -208,7 +208,7 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(6), req.opts.dwVersion)
+				assert.Equal(t, uint32(5), req.opts.dwVersion)
 
 				assert.Equal(t, webauthnUserVerificationRequired, req.opts.dwUserVerificationRequirement)
 
@@ -225,7 +225,7 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(6), req.opts.dwVersion)
+				assert.Equal(t, uint32(5), req.opts.dwVersion)
 
 				assert.Equal(t, webauthnUserVerificationPreferred, req.opts.dwUserVerificationRequirement)
 
@@ -242,7 +242,7 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(6), req.opts.dwVersion)
+				assert.Equal(t, uint32(5), req.opts.dwVersion)
 
 				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
 			},

--- a/lib/auth/webauthnwin/conv.go
+++ b/lib/auth/webauthnwin/conv.go
@@ -50,7 +50,7 @@ func assertOptionsToCType(in wantypes.PublicKeyCredentialRequestOptions, loginOp
 		// https://github.com/microsoft/webauthn/blob/7ab979cc833bfab9a682ed51761309db57f56c8c/webauthn.h#L36-L97
 		// contains information about different versions.
 		// We can set newest version and it still works on older APIs.
-		dwVersion:                     6,
+		dwVersion:                     5,
 		dwTimeoutMilliseconds:         uint32(in.Timeout),
 		dwAuthenticatorAttachment:     dwAuthenticatorAttachment,
 		dwUserVerificationRequirement: userVerificationToCType(in.UserVerification),


### PR DESCRIPTION
This makes it consistent with the structure size and fixes an access violation exception. Version 6 of the structure includes some additional fields that WebAuthn API would then attempt to read from a potentially unallocated memory area. There are two potential fixes: this one (simply lowering the structure version, since we don't use the v6-specific fields anyway) or adding v6 fields and keeping them uninitialized. Simply lowering the version sounds much easier.

Fixes #55290.