### PR TITLE
MWI: Add a useful `/readyz` endpoint to tbot

### DIFF
--- a/lib/tbot/loop.go
+++ b/lib/tbot/loop.go
@@ -118,7 +118,7 @@ func runOnInterval(ctx context.Context, cfg runOnIntervalConfig) error {
 	}
 
 	log := cfg.log.With("task", cfg.name)
-	
+
 	if cfg.identityReadyCh != nil {
 		select {
 		case <-cfg.identityReadyCh:

--- a/lib/tbot/readyz/http.go
+++ b/lib/tbot/readyz/http.go
@@ -1,0 +1,77 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package readyz
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// HTTPHandler returns an HTTP handler that implements tbot's
+// /readyz(/{service}) endpoints.
+func HTTPHandler(reg *Registry) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.Handle("/readyz/{service}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		status, ok := reg.ServiceStatus(r.PathValue("service"))
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_ = writeJSON(w, struct {
+				Error string `json:"error"`
+			}{
+				fmt.Sprintf("Service named %q not found.", r.PathValue("service")),
+			})
+			return
+		}
+
+		w.WriteHeader(status.Status.HTTPStatusCode())
+		if err := writeJSON(w, status); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to write response", "error", err)
+		}
+	}))
+
+	mux.Handle("/readyz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status := reg.OverallStatus()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status.Status.HTTPStatusCode())
+
+		if err := writeJSON(w, status); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to write response", "error", err)
+		}
+	}))
+
+	return mux
+}
+
+func writeJSON(w io.Writer, v any) error {
+	output, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(output); err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/tbot/readyz/http.go
+++ b/lib/tbot/readyz/http.go
@@ -37,11 +37,13 @@ func HTTPHandler(reg *Registry) http.Handler {
 		status, ok := reg.ServiceStatus(r.PathValue("service"))
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
-			_ = writeJSON(w, struct {
+			if err := writeJSON(w, struct {
 				Error string `json:"error"`
 			}{
 				fmt.Sprintf("Service named %q not found.", r.PathValue("service")),
-			})
+			}); err != nil {
+				slog.ErrorContext(r.Context(), "Failed to write response", "error", err)
+			}
 			return
 		}
 

--- a/lib/tbot/readyz/readyz.go
+++ b/lib/tbot/readyz/readyz.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package readyz
+
+import "sync"
+
+// NewRegistry returns a Registry to track the health of tbot's services.
+func NewRegistry() *Registry {
+	return &Registry{
+		services: make(map[string]*ServiceStatus),
+	}
+}
+
+// Registry tracks the status/health of tbot's services.
+type Registry struct {
+	mu       sync.Mutex
+	services map[string]*ServiceStatus
+}
+
+// AddService adds a service to the registry so that its health will be reported
+// from our readyz endpoints. It returns a Reporter the service can use to report
+// status changes.
+func (r *Registry) AddService(name string) Reporter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	status, ok := r.services[name]
+	if !ok {
+		status = &ServiceStatus{}
+		r.services[name] = status
+	}
+	return &reporter{
+		mu:     &r.mu,
+		status: status,
+	}
+}
+
+// ServiceStatus reads the named service's status. The bool value will be false
+// if the service has not been registered.
+func (r *Registry) ServiceStatus(name string) (*ServiceStatus, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if status, ok := r.services[name]; ok {
+		return status.Clone(), true
+	}
+
+	return nil, false
+}
+
+// OverallStatus returns tbot's overall status when taking service statuses into
+// account.
+func (r *Registry) OverallStatus() *OverallStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	status := Healthy
+	services := make(map[string]*ServiceStatus, len(r.services))
+
+	for name, svc := range r.services {
+		services[name] = svc.Clone()
+
+		if svc.Status != Healthy {
+			status = Unhealthy
+		}
+	}
+
+	return &OverallStatus{
+		Status:   status,
+		Services: services,
+	}
+}
+
+// ServiceStatus is a snapshot of the service's status.
+type ServiceStatus struct {
+	// Status of the service.
+	Status Status `json:"status"`
+
+	// Reason string describing why the service has its current status.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Clone the status to avoid data races.
+func (s *ServiceStatus) Clone() *ServiceStatus {
+	clone := *s
+	return &clone
+}
+
+// OverallStatus is tbot's overall aggregate status.
+type OverallStatus struct {
+	// Status of tbot overall. If any service isn't Healthy, the overall status
+	// will be Unhealthy.
+	Status Status `json:"status"`
+
+	// Services contains the service-specific statuses.
+	Services map[string]*ServiceStatus `json:"services"`
+}

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -1,0 +1,148 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package readyz_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+)
+
+func TestReadyz(t *testing.T) {
+	t.Parallel()
+
+	reg := readyz.NewRegistry()
+
+	a := reg.AddService("a")
+	b := reg.AddService("b")
+
+	srv := httptest.NewServer(readyz.HTTPHandler(reg))
+	srv.URL = srv.URL + "/readyz"
+	t.Cleanup(srv.Close)
+
+	t.Run("initial state - overall", func(t *testing.T) {
+		rsp, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusServiceUnavailable, rsp.StatusCode)
+
+		var response readyz.OverallStatus
+		err = json.NewDecoder(rsp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			readyz.OverallStatus{
+				Status: readyz.Unhealthy,
+				Services: map[string]*readyz.ServiceStatus{
+					"a": {Status: readyz.Unknown},
+					"b": {Status: readyz.Unknown},
+				},
+			},
+			response,
+		)
+	})
+
+	t.Run("individual service", func(t *testing.T) {
+		a.ReportReason(readyz.Unhealthy, "database is down")
+
+		rsp, err := http.Get(srv.URL + "/a")
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusServiceUnavailable, rsp.StatusCode)
+
+		var response readyz.ServiceStatus
+		err = json.NewDecoder(rsp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			readyz.ServiceStatus{
+				Status: readyz.Unhealthy,
+				Reason: "database is down",
+			},
+			response,
+		)
+	})
+
+	t.Run("mixed state", func(t *testing.T) {
+		a.Report(readyz.Healthy)
+		b.ReportReason(readyz.Unhealthy, "database is down")
+
+		rsp, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusServiceUnavailable, rsp.StatusCode)
+
+		var response readyz.OverallStatus
+		err = json.NewDecoder(rsp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			readyz.OverallStatus{
+				Status: readyz.Unhealthy,
+				Services: map[string]*readyz.ServiceStatus{
+					"a": {Status: readyz.Healthy},
+					"b": {Status: readyz.Unhealthy, Reason: "database is down"},
+				},
+			},
+			response,
+		)
+	})
+
+	t.Run("all healthy", func(t *testing.T) {
+		a.Report(readyz.Healthy)
+		b.Report(readyz.Healthy)
+
+		rsp, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusOK, rsp.StatusCode)
+
+		var response readyz.OverallStatus
+		err = json.NewDecoder(rsp.Body).Decode(&response)
+		require.NoError(t, err)
+
+		require.Equal(t,
+			readyz.OverallStatus{
+				Status: readyz.Healthy,
+				Services: map[string]*readyz.ServiceStatus{
+					"a": {Status: readyz.Healthy},
+					"b": {Status: readyz.Healthy},
+				},
+			},
+			response,
+		)
+	})
+
+	t.Run("unknown service", func(t *testing.T) {
+		rsp, err := http.Get(srv.URL + "/foo")
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, rsp.StatusCode)
+	})
+}

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -56,8 +56,8 @@ func TestReadyz(t *testing.T) {
 			readyz.OverallStatus{
 				Status: readyz.Unhealthy,
 				Services: map[string]*readyz.ServiceStatus{
-					"a": {Status: readyz.Unknown},
-					"b": {Status: readyz.Unknown},
+					"a": {Status: readyz.Initializing},
+					"b": {Status: readyz.Initializing},
 				},
 			},
 			response,

--- a/lib/tbot/readyz/reporter.go
+++ b/lib/tbot/readyz/reporter.go
@@ -1,0 +1,58 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package readyz
+
+import "sync"
+
+// Reporter can be used by a service to report its status.
+type Reporter interface {
+	// Report the service's status.
+	Report(status Status)
+
+	// ReportReason reports the service's status including reason/description text.
+	ReportReason(status Status, reason string)
+}
+
+type reporter struct {
+	mu     *sync.Mutex
+	status *ServiceStatus
+}
+
+func (r *reporter) Report(status Status) {
+	r.ReportReason(status, "")
+}
+
+func (r *reporter) ReportReason(status Status, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.status.Status = status
+	r.status.Reason = reason
+}
+
+// NoopReporter returns a no-op Reporter that can be used when no real reporter
+// is available (e.g. in tests).
+func NoopReporter() Reporter {
+	return noopReporter{}
+}
+
+type noopReporter struct{}
+
+func (noopReporter) Report(Status)               {}
+func (noopReporter) ReportReason(Status, string) {}

--- a/lib/tbot/readyz/status.go
+++ b/lib/tbot/readyz/status.go
@@ -27,8 +27,8 @@ import (
 type Status uint
 
 const (
-	// Unknown means no status has been reported for the service.
-	Unknown Status = iota
+	// Initializing means no status has been reported for the service.
+	Initializing Status = iota
 
 	// Healthy means the service is healthy and ready to serve traffic or it has
 	// recently succeeded generating an output.
@@ -41,12 +41,14 @@ const (
 // String implements fmt.Stringer.
 func (s Status) String() string {
 	switch s {
+	case Initializing:
+		return "initializing"
 	case Healthy:
 		return "healthy"
 	case Unhealthy:
 		return "unhealthy"
 	default:
-		return "unknown"
+		return "<unknown status>"
 	}
 }
 
@@ -67,7 +69,7 @@ func (s *Status) UnmarshalJSON(j []byte) error {
 	case "unhealthy":
 		*s = Unhealthy
 	default:
-		*s = Unknown
+		*s = Initializing
 	}
 	return nil
 }

--- a/lib/tbot/readyz/status.go
+++ b/lib/tbot/readyz/status.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package readyz
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Status describes the healthiness of a service or tbot overall.
+type Status uint
+
+const (
+	// Unknown means no status has been reported for the service.
+	Unknown Status = iota
+
+	// Healthy means the service is healthy and ready to serve traffic or it has
+	// recently succeeded generating an output.
+	Healthy
+
+	// Unhealthy means the service is failing to serve traffic or generate output.
+	Unhealthy
+)
+
+// String implements fmt.Stringer.
+func (s Status) String() string {
+	switch s {
+	case Healthy:
+		return "healthy"
+	case Unhealthy:
+		return "unhealthy"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s Status) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// MarshalJSON implements json.Unmarshaler.
+func (s *Status) UnmarshalJSON(j []byte) error {
+	var str string
+	if err := json.Unmarshal(j, &str); err != nil {
+		return err
+	}
+	switch str {
+	case "healthy":
+		*s = Healthy
+	case "unhealthy":
+		*s = Unhealthy
+	default:
+		*s = Unknown
+	}
+	return nil
+}
+
+// HTTPStatusCode returns the HTTP response code that represents this status.
+func (s Status) HTTPStatusCode() int {
+	switch s {
+	case Healthy:
+		return http.StatusOK
+	default:
+		return http.StatusServiceUnavailable
+	}
+}

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 // ApplicationOutputService generates the artifacts necessary to connect to a
@@ -46,6 +47,7 @@ type ApplicationOutputService struct {
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 }
 
 func (s *ApplicationOutputService) String() string {
@@ -69,6 +71,7 @@ func (s *ApplicationOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -51,6 +52,7 @@ type ApplicationTunnelService struct {
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
 	botIdentityReadyCh <-chan struct{}
+	statusReporter     readyz.Reporter
 }
 
 func (s *ApplicationTunnelService) Run(ctx context.Context) error {
@@ -98,10 +100,16 @@ func (s *ApplicationTunnelService) Run(ctx context.Context) error {
 	}()
 	s.log.InfoContext(ctx, "Listening for connections.", "address", l.Addr().String())
 
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+	s.statusReporter.Report(readyz.Healthy)
+
 	select {
 	case <-ctx.Done():
 		return nil
 	case err := <-errCh:
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
 		return trace.Wrap(err, "local proxy failed")
 	}
 }

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -26,6 +26,7 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 // ClientCredentialOutputService produces credentials which can be used to
@@ -41,6 +42,7 @@ type ClientCredentialOutputService struct {
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
+	statusReporter     readyz.Reporter
 }
 
 func (s *ClientCredentialOutputService) String() string {
@@ -64,6 +66,7 @@ func (s *ClientCredentialOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 // DatabaseOutputService generates the artifacts necessary to connect to a
@@ -47,6 +48,7 @@ type DatabaseOutputService struct {
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 }
 
 func (s *DatabaseOutputService) String() string {
@@ -70,6 +72,7 @@ func (s *DatabaseOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -71,6 +72,7 @@ type DatabaseTunnelService struct {
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
 	botIdentityReadyCh <-chan struct{}
+	statusReporter     readyz.Reporter
 }
 
 // buildLocalProxyConfig initializes the service, fetching any initial information and setting
@@ -234,10 +236,16 @@ func (s *DatabaseTunnelService) Run(ctx context.Context) error {
 	}()
 	s.log.InfoContext(ctx, "Listening for connections.", "address", l.Addr().String())
 
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+	s.statusReporter.Report(readyz.Healthy)
+
 	select {
 	case <-ctx.Done():
 		return nil
 	case err := <-errCh:
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
 		return trace.Wrap(err, "local proxy failed")
 	}
 }

--- a/lib/tbot/service_heartbeat.go
+++ b/lib/tbot/service_heartbeat.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 type heartbeatSubmitter interface {
@@ -50,6 +51,7 @@ type heartbeatService struct {
 	botIdentityReadyCh <-chan struct{}
 	interval           time.Duration
 	retryLimit         int
+	statusReporter     readyz.Reporter
 }
 
 func (s *heartbeatService) heartbeat(ctx context.Context, isStartup bool) error {
@@ -119,6 +121,7 @@ func (s *heartbeatService) Run(ctx context.Context) error {
 			return nil
 		},
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/ssh"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -57,6 +58,7 @@ type IdentityOutputService struct {
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath   func() (string, error)
@@ -84,6 +86,7 @@ func (s *IdentityOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -62,6 +63,7 @@ type KubernetesOutputService struct {
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath func() (string, error)
@@ -88,6 +90,7 @@ func (s *KubernetesOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -61,6 +62,7 @@ type KubernetesV2OutputService struct {
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath func() (string, error)
@@ -87,6 +89,7 @@ func (s *KubernetesV2OutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	}))
 }
 

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 )
 
@@ -59,6 +60,7 @@ type SPIFFESVIDOutputService struct {
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
+	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
 	trustBundleCache *workloadidentity.TrustBundleCache
@@ -94,6 +96,10 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 		return trace.Wrap(err, "getting trust bundle set")
 	}
 
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+
 	jitter := retryutils.DefaultJitter
 	var res *machineidv1pb.SignX509SVIDsResponse
 	var privateKey crypto.Signer
@@ -104,6 +110,7 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 	for {
 		var retryAfter <-chan time.Time
 		if failures > 0 {
+			s.statusReporter.Report(readyz.Unhealthy)
 			backoffTime := min(time.Second*time.Duration(math.Pow(2, float64(failures-1))), time.Minute)
 			backoffTime = jitter(backoffTime)
 			s.log.WarnContext(
@@ -153,6 +160,7 @@ func (s *SPIFFESVIDOutputService) Run(ctx context.Context) error {
 			failures++
 			continue
 		}
+		s.statusReporter.Report(readyz.Healthy)
 		failures = 0
 	}
 }

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/attrs"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
@@ -81,6 +82,7 @@ type SPIFFEWorkloadAPIService struct {
 	log              *slog.Logger
 	resolver         reversetunnelclient.Resolver
 	trustBundleCache *workloadidentity.TrustBundleCache
+	statusReporter   readyz.Reporter
 
 	// client holds the impersonated client for the service
 	client           *apiclient.Client
@@ -131,6 +133,10 @@ func (s *SPIFFEWorkloadAPIService) setup(ctx context.Context) (err error) {
 	s.attestor, err = workloadattest.NewAttestor(s.log, s.cfg.Attestors)
 	if err != nil {
 		return trace.Wrap(err, "setting up workload attestation")
+	}
+
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
 	}
 
 	return nil
@@ -283,7 +289,12 @@ func (s *SPIFFEWorkloadAPIService) Run(ctx context.Context) error {
 		return nil
 	})
 
-	return trace.Wrap(eg.Wait())
+	s.statusReporter.Report(readyz.Healthy)
+	if err := eg.Wait(); err != nil {
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		return trace.Wrap(eg.Wait())
+	}
+	return nil
 }
 
 // serialString returns a human-readable colon-separated string of the serial

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 type SSHHostOutputService struct {
@@ -50,6 +51,7 @@ type SSHHostOutputService struct {
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 }
 
 func (s *SSHHostOutputService) String() string {
@@ -73,6 +75,7 @@ func (s *SSHHostOutputService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/ssh"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/uds"
@@ -105,6 +106,7 @@ type SSHMultiplexerService struct {
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
 	resolver           reversetunnelclient.Resolver
+	statusReporter     readyz.Reporter
 
 	// Fields below here are initialized by the service itself on startup.
 	identity *identity.Facade
@@ -564,7 +566,16 @@ func (s *SSHMultiplexerService) Run(ctx context.Context) (err error) {
 		return s.identityRenewalLoop(egCtx, proxyHost, authClient)
 	})
 
-	return eg.Wait()
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+	s.statusReporter.Report(readyz.Healthy)
+
+	if err := eg.Wait(); err != nil {
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		return err
+	}
+	return nil
 }
 
 func (s *SSHMultiplexerService) handleConn(

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/attrs"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
@@ -73,6 +74,7 @@ type WorkloadIdentityAPIService struct {
 	resolver         reversetunnelclient.Resolver
 	trustBundleCache *workloadidentity.TrustBundleCache
 	crlCache         *workloadidentity.CRLCache
+	statusReporter   readyz.Reporter
 
 	// client holds the impersonated client for the service
 	client           *apiclient.Client
@@ -123,6 +125,10 @@ func (s *WorkloadIdentityAPIService) setup(ctx context.Context) (err error) {
 	s.attestor, err = workloadattest.NewAttestor(s.log, s.cfg.Attestors)
 	if err != nil {
 		return trace.Wrap(err, "setting up workload attestation")
+	}
+
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
 	}
 
 	return nil
@@ -220,7 +226,12 @@ func (s *WorkloadIdentityAPIService) Run(ctx context.Context) error {
 		return nil
 	})
 
-	return trace.Wrap(eg.Wait())
+	s.statusReporter.Report(readyz.Healthy)
+	if err := eg.Wait(); err != nil {
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func (s *WorkloadIdentityAPIService) authenticateClient(

--- a/lib/tbot/service_workload_identity_aws_ra.go
+++ b/lib/tbot/service_workload_identity_aws_ra.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 )
 
@@ -52,6 +53,7 @@ type WorkloadIdentityAWSRAService struct {
 	log                *slog.Logger
 	resolver           reversetunnelclient.Resolver
 	reloadBroadcaster  *channelBroadcaster
+	statusReporter     readyz.Reporter
 }
 
 // String returns a human-readable description of the service.
@@ -80,6 +82,7 @@ func (s *WorkloadIdentityAWSRAService) Run(ctx context.Context) error {
 		log:             s.log,
 		reloadCh:        reloadCh,
 		identityReadyCh: s.botIdentityReadyCh,
+		statusReporter:  s.statusReporter,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 )
 
@@ -44,6 +45,7 @@ type WorkloadIdentityJWTService struct {
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
+	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
 	trustBundleCache *workloadidentity.TrustBundleCache
@@ -72,6 +74,10 @@ func (s *WorkloadIdentityJWTService) Run(ctx context.Context) error {
 		return trace.Wrap(err, "getting trust bundle set")
 	}
 
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+
 	jitter := retryutils.DefaultJitter
 	var cred *workloadidentityv1pb.Credential
 	var failures int
@@ -80,6 +86,7 @@ func (s *WorkloadIdentityJWTService) Run(ctx context.Context) error {
 	for {
 		var retryAfter <-chan time.Time
 		if failures > 0 {
+			s.statusReporter.Report(readyz.Unhealthy)
 			backoffTime := min(time.Second*time.Duration(math.Pow(2, float64(failures-1))), time.Minute)
 			backoffTime = jitter(backoffTime)
 			s.log.WarnContext(
@@ -129,6 +136,7 @@ func (s *WorkloadIdentityJWTService) Run(ctx context.Context) error {
 			failures++
 			continue
 		}
+		s.statusReporter.Report(readyz.Healthy)
 		failures = 0
 	}
 }

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 )
 
@@ -48,6 +49,7 @@ type WorkloadIdentityX509Service struct {
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
 	resolver       reversetunnelclient.Resolver
+	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
 	trustBundleCache *workloadidentity.TrustBundleCache
@@ -100,6 +102,10 @@ func (s *WorkloadIdentityX509Service) Run(ctx context.Context) error {
 		return trace.Wrap(err, "getting CRL set from cache")
 	}
 
+	if s.statusReporter == nil {
+		s.statusReporter = readyz.NoopReporter()
+	}
+
 	jitter := retryutils.DefaultJitter
 	var x509Cred *workloadidentityv1pb.Credential
 	var privateKey crypto.Signer
@@ -109,6 +115,7 @@ func (s *WorkloadIdentityX509Service) Run(ctx context.Context) error {
 	for {
 		var retryAfter <-chan time.Time
 		if failures > 0 {
+			s.statusReporter.Report(readyz.Unhealthy)
 			backoffTime := min(time.Second*time.Duration(math.Pow(2, float64(failures-1))), time.Minute)
 			backoffTime = jitter(backoffTime)
 			s.log.WarnContext(
@@ -167,6 +174,7 @@ func (s *WorkloadIdentityX509Service) Run(ctx context.Context) error {
 			failures++
 			continue
 		}
+		s.statusReporter.Report(readyz.Healthy)
 		failures = 0
 	}
 }

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -73,7 +73,7 @@ type CRLCache struct {
 	revocationsClient  workloadidentityv1pb.WorkloadIdentityRevocationServiceClient
 	logger             *slog.Logger
 	botIdentityReadyCh <-chan struct{}
-	statusReporter    readyz.Reporter
+	statusReporter     readyz.Reporter
 
 	mu     sync.Mutex
 	crlSet *CRLSet
@@ -86,7 +86,7 @@ type CRLCacheConfig struct {
 	RevocationsClient  workloadidentityv1pb.WorkloadIdentityRevocationServiceClient
 	Logger             *slog.Logger
 	BotIdentityReadyCh <-chan struct{}
-	StatusReporter    readyz.Reporter
+	StatusReporter     readyz.Reporter
 }
 
 // NewCRLCache creates a new CRLCache.
@@ -104,7 +104,7 @@ func NewCRLCache(cfg CRLCacheConfig) (*CRLCache, error) {
 		revocationsClient:  cfg.RevocationsClient,
 		logger:             cfg.Logger,
 		botIdentityReadyCh: cfg.BotIdentityReadyCh,
-		statusReporter:    cfg.StatusReporter,
+		statusReporter:     cfg.StatusReporter,
 		initialized:        make(chan struct{}),
 	}, nil
 }

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 // CRLSet is a collection of CRLs.
@@ -72,6 +73,7 @@ type CRLCache struct {
 	revocationsClient  workloadidentityv1pb.WorkloadIdentityRevocationServiceClient
 	logger             *slog.Logger
 	botIdentityReadyCh <-chan struct{}
+	statusReporter    readyz.Reporter
 
 	mu     sync.Mutex
 	crlSet *CRLSet
@@ -84,6 +86,7 @@ type CRLCacheConfig struct {
 	RevocationsClient  workloadidentityv1pb.WorkloadIdentityRevocationServiceClient
 	Logger             *slog.Logger
 	BotIdentityReadyCh <-chan struct{}
+	StatusReporter    readyz.Reporter
 }
 
 // NewCRLCache creates a new CRLCache.
@@ -94,10 +97,14 @@ func NewCRLCache(cfg CRLCacheConfig) (*CRLCache, error) {
 	case cfg.Logger == nil:
 		return nil, trace.BadParameter("missing Logger")
 	}
+	if cfg.StatusReporter == nil {
+		cfg.StatusReporter = readyz.NoopReporter()
+	}
 	return &CRLCache{
 		revocationsClient:  cfg.RevocationsClient,
 		logger:             cfg.Logger,
 		botIdentityReadyCh: cfg.BotIdentityReadyCh,
+		statusReporter:    cfg.StatusReporter,
 		initialized:        make(chan struct{}),
 	}, nil
 }
@@ -147,6 +154,7 @@ func (m *CRLCache) Run(ctx context.Context) error {
 				"error", err,
 				"backoff", trustBundleInitFailureBackoff,
 			)
+			m.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
 		}
 		select {
 		case <-ctx.Done():
@@ -168,6 +176,7 @@ func (m *CRLCache) watch(ctx context.Context) error {
 		return trace.Wrap(err, "opening CRL stream")
 	}
 
+	m.statusReporter.Report(readyz.Healthy)
 	for {
 		res, err := stream.Recv()
 		if err != nil {

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
 var tracer = otel.Tracer("github.com/gravitational/teleport/lib/spiffe")
@@ -176,7 +177,8 @@ type TrustBundleCache struct {
 	clusterName        string
 	botIdentityReadyCh <-chan struct{}
 
-	logger *slog.Logger
+	logger         *slog.Logger
+	statusReporter readyz.Reporter
 
 	mu        sync.RWMutex
 	bundleSet *BundleSet
@@ -198,6 +200,7 @@ type TrustBundleCacheConfig struct {
 	ClusterName        string
 	Logger             *slog.Logger
 	BotIdentityReadyCh <-chan struct{}
+	StatusReporter     readyz.Reporter
 }
 
 // NewTrustBundleCache creates a new TrustBundleCache.
@@ -214,6 +217,9 @@ func NewTrustBundleCache(cfg TrustBundleCacheConfig) (*TrustBundleCache, error) 
 	case cfg.Logger == nil:
 		return nil, trace.BadParameter("missing Logger")
 	}
+	if cfg.StatusReporter == nil {
+		cfg.StatusReporter = readyz.NoopReporter()
+	}
 	return &TrustBundleCache{
 		federationClient:   cfg.FederationClient,
 		trustClient:        cfg.TrustClient,
@@ -221,6 +227,7 @@ func NewTrustBundleCache(cfg TrustBundleCacheConfig) (*TrustBundleCache, error) 
 		clusterName:        cfg.ClusterName,
 		logger:             cfg.Logger,
 		botIdentityReadyCh: cfg.BotIdentityReadyCh,
+		statusReporter:     cfg.StatusReporter,
 		initialized:        make(chan struct{}),
 	}, nil
 }
@@ -259,6 +266,7 @@ func (m *TrustBundleCache) Run(ctx context.Context) error {
 				"error", err,
 				"backoff", trustBundleInitFailureBackoff,
 			)
+			m.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
 		}
 		select {
 		case <-ctx.Done():
@@ -310,6 +318,8 @@ func (m *TrustBundleCache) watch(ctx context.Context) error {
 	case <-watcher.Done():
 		return trace.Wrap(watcher.Error(), "watcher closed before initialization")
 	}
+
+	m.statusReporter.Report(readyz.Healthy)
 
 	// Now that we know our watcher is streaming events, we can fetch the
 	// current point-in-time list of resources.


### PR DESCRIPTION
This PR makes tbot's `/readyz` endpoint representative of the actual health of the bot. It also introduces a `/readyz/{service}` endpoint (following the K8s API Server's example) to discover the health of an individual service.

If any service is not `healthy`, the overall status of the bot will be `unhealthy` and the `/readyz` endpoint will return **503 Service Unavailable**.

In a future PR, we'll make it possible to configure the service name yourself - as the auto-generated names often aren't URL-safe.

### Examples

```shell
$ curl -v http://localhost:1234/readyz

< HTTP/1.1 503 Service Unavailable
< Content-Type: application/json
< Date: Mon, 16 Jun 2025 11:29:38 GMT
< Content-Length: 679
<
{
  "status": "unhealthy",
  "services": {
    "ca-rotation": {
      "status": "healthy"
    },
    "crl-cache": {
      "status": "healthy"
    },
    "heartbeat": {
      "status": "healthy"
    },
    "identity": {
      "status": "healthy"
    },
    "spiffe-trust-bundle-cache": {
      "status": "healthy"
    },
    "workload-identity-api:unix:///Users/dan/Desktop/tbot.sock": {
      "status": "healthy"
    },
    "workload-identity-aws-roles-anywhere (directory: /Users/dan/Desktop/tbot/aws-ra)": {
      "status": "unhealthy",
      "reason": "requesting SVID\n\tgenerating X509 SVID\n\t\taccess denied to perform action \"read\" on \"workload_identity\""
    }
  }
}
```

```shell
$ curl -v http://localhost:1234/readyz/identity

< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Mon, 16 Jun 2025 11:32:18 GMT
< Content-Length: 25
<
{
  "status": "healthy"
}
```

Closes https://github.com/gravitational/teleport/issues/19412

changelog: MWI: tbot's `/readyz` endpoint is now representative of the bot's health
