### PR TITLE
MWI: Allow custom service names in tbot

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -64,6 +65,38 @@ var SupportedJoinMethods = []string{
 	string(types.JoinMethodTPM),
 	string(types.JoinMethodTerraformCloud),
 	string(types.JoinMethodBoundKeypair),
+}
+
+// ReservedServiceNames are the service names reserved for internal use.
+var ReservedServiceNames = []string{
+	"ca-rotation",
+	"crl-cache",
+	"heartbeat",
+	"identity",
+	"spiffe-trust-bundle-cache",
+}
+
+var reservedServiceNamesMap = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(ReservedServiceNames))
+	for _, k := range ReservedServiceNames {
+		m[k] = struct{}{}
+	}
+	return m
+}()
+
+var serviceNameRegex = regexp.MustCompile(`\A[a-z\d_\-+]+\z`)
+
+func validateServiceName(name string) error {
+	if name == "" {
+		return nil
+	}
+	if _, ok := reservedServiceNamesMap[name]; ok {
+		return trace.BadParameter("service name %q is reserved for internal use", name)
+	}
+	if !serviceNameRegex.MatchString(name) {
+		return trace.BadParameter("invalid service name: %q, may only contain lowercase letters, numbers, hyphens, underscores, or plus symbols", name)
+	}
+	return nil
 }
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
@@ -301,12 +334,22 @@ func (conf *BotConfig) CheckAndSetDefaults() error {
 
 	// We've migrated Outputs to Services, so copy all Outputs to Services.
 	conf.Services = append(conf.Services, conf.Outputs...)
+	uniqueNames := make(map[string]struct{}, len(conf.Services))
 	for i, service := range conf.Services {
 		if err := service.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err, "validating service[%d]", i)
 		}
 		if err := service.GetCredentialLifetime().Validate(conf.Oneshot); err != nil {
 			return trace.Wrap(err, "validating service[%d]", i)
+		}
+		if name := service.GetName(); name != "" {
+			if err := validateServiceName(name); err != nil {
+				return trace.Wrap(err, "validating service[%d]", i)
+			}
+			if _, seen := uniqueNames[name]; seen {
+				return trace.BadParameter("validating service[%d]: duplicate name: %q", i, name)
+			}
+			uniqueNames[name] = struct{}{}
 		}
 	}
 
@@ -399,6 +442,10 @@ type ServiceConfig interface {
 	// RenewalInterval. It's used for validation purposes; services that do not
 	// support these options should return the zero value.
 	GetCredentialLifetime() CredentialLifetime
+
+	// GetName returns the user-given name of the service, used for validation
+	// purposes.
+	GetName() string
 }
 
 // ServiceConfigs assists polymorphic unmarshaling of a slice of ServiceConfigs.

--- a/lib/tbot/config/service_application.go
+++ b/lib/tbot/config/service_application.go
@@ -35,6 +35,8 @@ var (
 const ApplicationOutputType = "application"
 
 type ApplicationOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 	// Roles is the list of roles to request for the generated credentials.
@@ -66,6 +68,11 @@ func (o *ApplicationOutput) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *ApplicationOutput) GetName() string {
+	return o.Name
 }
 
 func (o *ApplicationOutput) GetDestination() bot.Destination {

--- a/lib/tbot/config/service_application_tunnel.go
+++ b/lib/tbot/config/service_application_tunnel.go
@@ -35,6 +35,8 @@ const ApplicationTunnelServiceType = "application-tunnel"
 // ApplicationTunnelService opens an authenticated tunnel for Application
 // Access.
 type ApplicationTunnelService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Listen is the address on which database tunnel should listen. Example:
 	// - "tcp://127.0.0.1:3306"
 	// - "tcp://0.0.0.0:3306
@@ -57,6 +59,11 @@ type ApplicationTunnelService struct {
 
 func (s *ApplicationTunnelService) Type() string {
 	return ApplicationTunnelServiceType
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *ApplicationTunnelService) GetName() string {
+	return o.Name
 }
 
 func (s *ApplicationTunnelService) MarshalYAML() (any, error) {

--- a/lib/tbot/config/service_client_credential.go
+++ b/lib/tbot/config/service_client_credential.go
@@ -47,9 +47,17 @@ var (
 // be modified. This output is currently part of an experiment and could be
 // removed in a future release.
 type UnstableClientCredentialOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
+
 	mu     sync.Mutex
 	facade *identity.Facade
 	ready  chan struct{}
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *UnstableClientCredentialOutput) GetName() string {
+	return o.Name
 }
 
 // Ready returns a channel which closes when the Output is ready to be used

--- a/lib/tbot/config/service_database.go
+++ b/lib/tbot/config/service_database.go
@@ -76,6 +76,8 @@ var (
 // DatabaseOutput produces credentials which can be used to connect to a
 // database through teleport.
 type DatabaseOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 	// Roles is the list of roles to request for the generated credentials.
@@ -99,6 +101,11 @@ type DatabaseOutput struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *DatabaseOutput) GetName() string {
+	return o.Name
 }
 
 func (o *DatabaseOutput) Init(ctx context.Context) error {

--- a/lib/tbot/config/service_database_tunnel.go
+++ b/lib/tbot/config/service_database_tunnel.go
@@ -30,6 +30,8 @@ const DatabaseTunnelServiceType = "database-tunnel"
 
 // DatabaseTunnelService opens an authenticated tunnel for Database Access.
 type DatabaseTunnelService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Listen is the address on which database tunnel should listen. Example:
 	// - "tcp://127.0.0.1:3306"
 	// - "tcp://0.0.0.0:3306
@@ -53,6 +55,11 @@ type DatabaseTunnelService struct {
 	// Listener overrides "listen" and directly provides an opened listener to
 	// use.
 	Listener net.Listener `yaml:"-"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *DatabaseTunnelService) GetName() string {
+	return o.Name
 }
 
 func (s *DatabaseTunnelService) Type() string {

--- a/lib/tbot/config/service_example.go
+++ b/lib/tbot/config/service_example.go
@@ -29,11 +29,19 @@ const ExampleServiceType = "example"
 // not intended to be used and exists to demonstrate how a user configurable
 // service integrates with the tbot service manager.
 type ExampleService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
+
 	Message string `yaml:"message"`
 }
 
 func (s *ExampleService) Type() string {
 	return ExampleServiceType
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (s *ExampleService) GetName() string {
+	return s.Name
 }
 
 func (s *ExampleService) MarshalYAML() (any, error) {

--- a/lib/tbot/config/service_identity.go
+++ b/lib/tbot/config/service_identity.go
@@ -75,6 +75,8 @@ var (
 // It cannot be used to connect to Applications, Databases or Kubernetes
 // Clusters.
 type IdentityOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 	// Roles is the list of roles to request for the generated credentials.
@@ -105,6 +107,11 @@ type IdentityOutput struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *IdentityOutput) GetName() string {
+	return o.Name
 }
 
 func (o *IdentityOutput) Init(ctx context.Context) error {

--- a/lib/tbot/config/service_kubernetes.go
+++ b/lib/tbot/config/service_kubernetes.go
@@ -37,6 +37,8 @@ const KubernetesOutputType = "kubernetes"
 // KubernetesOutput produces credentials which can be used to connect to a
 // Kubernetes Cluster through teleport.
 type KubernetesOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 	// Roles is the list of roles to request for the generated credentials.
@@ -58,6 +60,11 @@ type KubernetesOutput struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *KubernetesOutput) GetName() string {
+	return o.Name
 }
 
 func (o *KubernetesOutput) CheckAndSetDefaults() error {

--- a/lib/tbot/config/service_kubernetes_v2.go
+++ b/lib/tbot/config/service_kubernetes_v2.go
@@ -37,6 +37,8 @@ const KubernetesV2OutputType = "kubernetes/v2"
 // KubernetesOutput produces credentials which can be used to connect to a
 // Kubernetes Cluster through teleport.
 type KubernetesV2Output struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 
@@ -54,6 +56,11 @@ type KubernetesV2Output struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *KubernetesV2Output) GetName() string {
+	return o.Name
 }
 
 func (o *KubernetesV2Output) CheckAndSetDefaults() error {

--- a/lib/tbot/config/service_spiffe_svid.go
+++ b/lib/tbot/config/service_spiffe_svid.go
@@ -117,6 +117,8 @@ func (o JWTSVID) CheckAndSetDefaults() error {
 // SPIFFESVIDOutput is the configuration for the SPIFFE SVID output.
 // Emulates the output of https://github.com/spiffe/spiffe-helper
 type SPIFFESVIDOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination                  bot.Destination `yaml:"destination"`
 	SVID                         SVIDRequest     `yaml:"svid"`
@@ -128,6 +130,11 @@ type SPIFFESVIDOutput struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *SPIFFESVIDOutput) GetName() string {
+	return o.Name
 }
 
 // Init initializes the destination.

--- a/lib/tbot/config/service_spiffe_workload_api.go
+++ b/lib/tbot/config/service_spiffe_workload_api.go
@@ -114,6 +114,8 @@ func (o SVIDRequestRule) LogValue() slog.Value {
 // SPIFFEWorkloadAPIService is the configuration for the SPIFFE Workload API
 // service.
 type SPIFFEWorkloadAPIService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Listen is the address on which the SPIFFE Workload API server should
 	// listen. This should either be prefixed with "unix://" or "tcp://".
 	Listen string `yaml:"listen"`
@@ -130,6 +132,11 @@ type SPIFFEWorkloadAPIService struct {
 	// CredentialLifetime contains configuration for how long X.509 SVIDs will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *SPIFFEWorkloadAPIService) GetName() string {
+	return o.Name
 }
 
 func (s *SPIFFEWorkloadAPIService) Type() string {

--- a/lib/tbot/config/service_ssh_host.go
+++ b/lib/tbot/config/service_ssh_host.go
@@ -49,6 +49,8 @@ var (
 // SSHHostOutput generates a host certificate signed by the Teleport CA. This
 // can be used to allow OpenSSH server to be trusted by Teleport SSH clients.
 type SSHHostOutput struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the credentials should be written to.
 	Destination bot.Destination `yaml:"destination"`
 	// Roles is the list of roles to request for the generated credentials.
@@ -61,6 +63,11 @@ type SSHHostOutput struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *SSHHostOutput) GetName() string {
+	return o.Name
 }
 
 func (o *SSHHostOutput) Init(ctx context.Context) error {

--- a/lib/tbot/config/service_ssh_multiplexer.go
+++ b/lib/tbot/config/service_ssh_multiplexer.go
@@ -30,6 +30,8 @@ const SSHMultiplexerServiceType = "ssh-multiplexer"
 
 // SSHMultiplexerService is the configuration for the `ssh-proxy` service
 type SSHMultiplexerService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Destination is where the config and tunnel should be written to. It
 	// should be a DestinationDirectory.
 	Destination bot.Destination `yaml:"destination"`
@@ -52,6 +54,11 @@ type SSHMultiplexerService struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *SSHMultiplexerService) GetName() string {
+	return o.Name
 }
 
 func (s *SSHMultiplexerService) SessionResumptionEnabled() bool {

--- a/lib/tbot/config/service_workload_identity_api.go
+++ b/lib/tbot/config/service_workload_identity_api.go
@@ -32,6 +32,8 @@ var (
 // WorkloadIdentityAPIService is the configuration for the
 // WorkloadIdentityAPIService
 type WorkloadIdentityAPIService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Listen is the address on which the SPIFFE Workload API server should
 	// listen. This should either be prefixed with "unix://" or "tcp://".
 	Listen string `yaml:"listen"`
@@ -58,6 +60,11 @@ func (o *WorkloadIdentityAPIService) CheckAndSetDefaults() error {
 		return trace.Wrap(err, "validating selector")
 	}
 	return nil
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *WorkloadIdentityAPIService) GetName() string {
+	return o.Name
 }
 
 // Type returns the type of the service.

--- a/lib/tbot/config/service_workload_identity_aws_ra.go
+++ b/lib/tbot/config/service_workload_identity_aws_ra.go
@@ -43,6 +43,8 @@ var (
 // WorkloadIdentityAWSRAService is the configuration for the
 // WorkloadIdentityAWSRAService
 type WorkloadIdentityAWSRAService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Selector is the selector for the WorkloadIdentity resource that will be
 	// used to issue WICs.
 	Selector WorkloadIdentitySelector `yaml:"selector"`
@@ -94,6 +96,11 @@ type WorkloadIdentityAWSRAService struct {
 	// This is designed to be leveraged by tests and unset in production
 	// circumstances.
 	EndpointOverride string `yaml:"-"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *WorkloadIdentityAWSRAService) GetName() string {
+	return o.Name
 }
 
 // Init initializes the destination.

--- a/lib/tbot/config/service_workload_identity_jwt.go
+++ b/lib/tbot/config/service_workload_identity_jwt.go
@@ -34,6 +34,8 @@ var (
 
 // WorkloadIdentityJWTService is the configuration for the WorkloadIdentityJWTService
 type WorkloadIdentityJWTService struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Selector is the selector for the WorkloadIdentity resource that will be
 	// used to issue WICs.
 	Selector WorkloadIdentitySelector `yaml:"selector"`
@@ -45,6 +47,11 @@ type WorkloadIdentityJWTService struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o WorkloadIdentityJWTService) GetName() string {
+	return o.Name
 }
 
 // Init initializes the destination.

--- a/lib/tbot/config/service_workload_identity_x509.go
+++ b/lib/tbot/config/service_workload_identity_x509.go
@@ -63,6 +63,8 @@ func (s *WorkloadIdentitySelector) CheckAndSetDefaults() error {
 // WorkloadIdentityX509Service is the configuration for the WorkloadIdentityX509Service
 // Emulates the output of https://github.com/spiffe/spiffe-helper
 type WorkloadIdentityX509Service struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
 	// Selector is the selector for the WorkloadIdentity resource that will be
 	// used to issue WICs.
 	Selector WorkloadIdentitySelector `yaml:"selector"`
@@ -75,6 +77,11 @@ type WorkloadIdentityX509Service struct {
 	// CredentialLifetime contains configuration for how long credentials will
 	// last and the frequency at which they'll be renewed.
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o WorkloadIdentityX509Service) GetName() string {
+	return o.Name
 }
 
 // Init initializes the destination.

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -49,7 +49,10 @@ type ApplicationOutputService struct {
 }
 
 func (s *ApplicationOutputService) String() string {
-	return fmt.Sprintf("application-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("application-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *ApplicationOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -262,5 +262,8 @@ func (s *ApplicationTunnelService) issueCert(
 // String returns a human-readable string that can uniquely identify the
 // service.
 func (s *ApplicationTunnelService) String() string {
-	return fmt.Sprintf("%s:%s:%s", config.ApplicationTunnelServiceType, s.cfg.Listen, s.cfg.AppName)
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("%s:%s:%s", config.ApplicationTunnelServiceType, s.cfg.Listen, s.cfg.AppName),
+	)
 }

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -19,6 +19,7 @@
 package tbot
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 
@@ -44,7 +45,10 @@ type ClientCredentialOutputService struct {
 }
 
 func (s *ClientCredentialOutputService) String() string {
-	return "client-credential-output"
+	return cmp.Or(
+		s.cfg.Name,
+		"client-credential-output",
+	)
 }
 
 func (s *ClientCredentialOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -50,7 +50,10 @@ type DatabaseOutputService struct {
 }
 
 func (s *DatabaseOutputService) String() string {
-	return fmt.Sprintf("database-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("database-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *DatabaseOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -309,5 +309,8 @@ func (s *DatabaseTunnelService) issueCert(
 // String returns a human-readable string that can uniquely identify the
 // service.
 func (s *DatabaseTunnelService) String() string {
-	return fmt.Sprintf("%s:%s:%s", config.DatabaseTunnelServiceType, s.cfg.Listen, s.cfg.Service)
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("%s:%s:%s", config.DatabaseTunnelServiceType, s.cfg.Listen, s.cfg.Service),
+	)
 }

--- a/lib/tbot/service_example.go
+++ b/lib/tbot/service_example.go
@@ -19,6 +19,7 @@
 package tbot
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"time"
@@ -46,5 +47,8 @@ func (s *ExampleService) Run(ctx context.Context) error {
 }
 
 func (s *ExampleService) String() string {
-	return fmt.Sprintf("%s:%s", config.ExampleServiceType, s.Message)
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("%s:%s", config.ExampleServiceType, s.Message),
+	)
 }

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -64,7 +64,10 @@ type IdentityOutputService struct {
 }
 
 func (s *IdentityOutputService) String() string {
-	return fmt.Sprintf("identity-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("identity-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *IdentityOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -68,7 +68,10 @@ type KubernetesOutputService struct {
 }
 
 func (s *KubernetesOutputService) String() string {
-	return fmt.Sprintf("kubernetes-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("kubernetes-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *KubernetesOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -67,7 +67,10 @@ type KubernetesV2OutputService struct {
 }
 
 func (s *KubernetesV2OutputService) String() string {
-	return fmt.Sprintf("kubernetes-v2-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("kubernetes-v2-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *KubernetesV2OutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -65,7 +65,10 @@ type SPIFFESVIDOutputService struct {
 }
 
 func (s *SPIFFESVIDOutputService) String() string {
-	return fmt.Sprintf("spiffe-svid-output (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("spiffe-svid-output (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *SPIFFESVIDOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -893,5 +893,8 @@ func (s *SPIFFEWorkloadAPIService) ValidateJWTSVID(
 // String returns a human-readable string that can uniquely identify the
 // service.
 func (s *SPIFFEWorkloadAPIService) String() string {
-	return fmt.Sprintf("%s:%s", config.SPIFFEWorkloadAPIServiceType, s.cfg.Listen)
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("%s:%s", config.SPIFFEWorkloadAPIServiceType, s.cfg.Listen),
+	)
 }

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -53,7 +53,10 @@ type SSHHostOutputService struct {
 }
 
 func (s *SSHHostOutputService) String() string {
-	return fmt.Sprintf("ssh-host (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("ssh-host (%s)", s.cfg.Destination.String()),
+	)
 }
 
 func (s *SSHHostOutputService) OneShot(ctx context.Context) error {

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -797,7 +797,10 @@ func (s *SSHMultiplexerService) handleConn(
 }
 
 func (s *SSHMultiplexerService) String() string {
-	return config.SSHMultiplexerServiceType
+	return cmp.Or(
+		s.cfg.Name,
+		config.SSHMultiplexerServiceType,
+	)
 }
 
 type hostDialer interface {

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -698,5 +698,8 @@ func (s *WorkloadIdentityAPIService) ValidateJWTSVID(
 // String returns a human-readable string that can uniquely identify the
 // service.
 func (s *WorkloadIdentityAPIService) String() string {
-	return fmt.Sprintf("%s:%s", config.WorkloadIdentityAPIServiceType, s.cfg.Listen)
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("%s:%s", config.WorkloadIdentityAPIServiceType, s.cfg.Listen),
+	)
 }

--- a/lib/tbot/service_workload_identity_aws_ra.go
+++ b/lib/tbot/service_workload_identity_aws_ra.go
@@ -56,7 +56,10 @@ type WorkloadIdentityAWSRAService struct {
 
 // String returns a human-readable description of the service.
 func (s *WorkloadIdentityAWSRAService) String() string {
-	return fmt.Sprintf("workload-identity-aws-roles-anywhere (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("workload-identity-aws-roles-anywhere (%s)", s.cfg.Destination.String()),
+	)
 }
 
 // OneShot runs the service once, generating the output and writing it to the

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -51,7 +51,10 @@ type WorkloadIdentityJWTService struct {
 
 // String returns a human-readable description of the service.
 func (s *WorkloadIdentityJWTService) String() string {
-	return fmt.Sprintf("workload-identity-jwt (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("workload-identity-jwt (%s)", s.cfg.Destination.String()),
+	)
 }
 
 // OneShot runs the service once, generating the output and writing it to the

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -56,7 +56,10 @@ type WorkloadIdentityX509Service struct {
 
 // String returns a human-readable description of the service.
 func (s *WorkloadIdentityX509Service) String() string {
-	return fmt.Sprintf("workload-identity-x509 (%s)", s.cfg.Destination.String())
+	return cmp.Or(
+		s.cfg.Name,
+		fmt.Sprintf("workload-identity-x509 (%s)", s.cfg.Destination.String()),
+	)
 }
 
 // OneShot runs the service once, generating the output and writing it to the


### PR DESCRIPTION
Allows you to set custom service names in your tbot configuration, which will be used in logs and the readiness endpoint introduced by #55761.

changelog: MWI: You can now override the service names used in tbot's logs and `/readyz` endpoint
