### PR TITLE
docs: Link to jwt_claims information from JWT page

### DIFF
--- a/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
@@ -123,3 +123,9 @@ Many existing web applications and APIs support JWT authentication.
 The following guides are currently available showing how to configure it:
 
 - [ElasticSearch](./elasticsearch.mdx)
+
+## Troubleshooting
+
+If you do not require the `Teleport-Jwt-Assertion` header and its inclusion is causing header size issues for
+your proxied applications, you can disable the header by setting `rewrite.jwt_claims: none` under the application
+configuration. [Read more about the jwt_claims configuration here](https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#configuring-the-jwt-token).

--- a/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
@@ -126,6 +126,11 @@ The following guides are currently available showing how to configure it:
 
 ## Troubleshooting
 
-If you do not require the `Teleport-Jwt-Assertion` header and its inclusion is causing header size issues for
-your proxied applications, you can disable the header by setting `rewrite.jwt_claims: none` under the application
-configuration. [Read more about the jwt_claims configuration here](https://goteleport.com/docs/enroll-resources/application-access/guides/connecting-apps/#configuring-the-jwt-token).
+By default, the `Teleport-Jwt-Assertion` header is sent along with every request that Teleport makes to an
+upstream web application.
+
+In some circumstances, including this header can increase the total header size beyond the limits that the
+upstream web application can handle. If needed, you can disable this header on a per-app basis by setting
+`jwt_claims: none` under the `rewrite` configuration for the given application.
+
+You can [read more about the jwt_claims configuration here](../guides/connecting-apps.mdx#configuring-the-jwt-token).


### PR DESCRIPTION
A customer pointed out that they couldn't find an easy way to disable the `Teleport-Jwt-Assertion` header in our JWT docs. I figure adding an extra link to make the `jwt_claims` config easier to find would help.