### PR TITLE
Skeleton for `relay_service` and heartbeat

### DIFF
--- a/api/client/proto/inventory.pb.go
+++ b/api/client/proto/inventory.pb.go
@@ -24,6 +24,7 @@
 package proto
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -855,8 +856,10 @@ type InventoryHeartbeat struct {
 	DatabaseServer *types.DatabaseServerV3 `protobuf:"bytes,3,opt,name=DatabaseServer,proto3" json:"DatabaseServer,omitempty"`
 	// KubeServer is a complete kube server spec to be heartbeated.
 	KubernetesServer *types.KubernetesServerV3 `protobuf:"bytes,4,opt,name=KubernetesServer,proto3" json:"KubernetesServer,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// A relay_server to be heartbeated.
+	RelayServer   *v1.RelayServer `protobuf:"bytes,5,opt,name=relay_server,json=relayServer,proto3" json:"relay_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InventoryHeartbeat) Reset() {
@@ -913,6 +916,13 @@ func (x *InventoryHeartbeat) GetDatabaseServer() *types.DatabaseServerV3 {
 func (x *InventoryHeartbeat) GetKubernetesServer() *types.KubernetesServerV3 {
 	if x != nil {
 		return x.KubernetesServer
+	}
+	return nil
+}
+
+func (x *InventoryHeartbeat) GetRelayServer() *v1.RelayServer {
+	if x != nil {
+		return x.RelayServer
 	}
 	return nil
 }
@@ -1146,8 +1156,10 @@ type DownstreamInventoryHello_SupportedCapabilities struct {
 	KubernetesHeartbeats bool `protobuf:"varint,17,opt,name=KubernetesHeartbeats,proto3" json:"KubernetesHeartbeats,omitempty"`
 	// KubernetesCleanup indicates the ICS supports deleting kubernetes clusters when UpstreamInventoryGoodbye.DeleteResources is set.
 	KubernetesCleanup bool `protobuf:"varint,18,opt,name=KubernetesCleanup,proto3" json:"KubernetesCleanup,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Indicates that the ICS supports heartbeating relay_server entries as well as deleting them on disconnect if UpstreamInventoryGoodbye.DeleteResources is set.
+	RelayServerHeartbeatsCleanup bool `protobuf:"varint,19,opt,name=relay_server_heartbeats_cleanup,json=relayServerHeartbeatsCleanup,proto3" json:"relay_server_heartbeats_cleanup,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *DownstreamInventoryHello_SupportedCapabilities) Reset() {
@@ -1306,11 +1318,18 @@ func (x *DownstreamInventoryHello_SupportedCapabilities) GetKubernetesCleanup() 
 	return false
 }
 
+func (x *DownstreamInventoryHello_SupportedCapabilities) GetRelayServerHeartbeatsCleanup() bool {
+	if x != nil {
+		return x.RelayServerHeartbeatsCleanup
+	}
+	return false
+}
+
 var File_teleport_legacy_client_proto_inventory_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\n" +
-	",teleport/legacy/client/proto/inventory.proto\x12\x05proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/legacy/types/types.proto\"\xd1\x02\n" +
+	",teleport/legacy/client/proto/inventory.proto\x12\x05proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/legacy/types/types.proto\x1a'teleport/presence/v1/relay_server.proto\"\xd1\x02\n" +
 	"\x16UpstreamInventoryOneOf\x125\n" +
 	"\x05Hello\x18\x01 \x01(\v2\x1d.proto.UpstreamInventoryHelloH\x00R\x05Hello\x129\n" +
 	"\tHeartbeat\x18\x02 \x01(\v2\x19.proto.InventoryHeartbeatH\x00R\tHeartbeat\x122\n" +
@@ -1344,11 +1363,11 @@ const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\x0eInstallMethods\x18\x05 \x03(\tR\x0eInstallMethods\x12*\n" +
 	"\x10ContainerRuntime\x18\x06 \x01(\tR\x10ContainerRuntime\x124\n" +
 	"\x15ContainerOrchestrator\x18\a \x01(\tR\x15ContainerOrchestrator\x12*\n" +
-	"\x10CloudEnvironment\x18\b \x01(\tR\x10CloudEnvironment\"\x9f\b\n" +
+	"\x10CloudEnvironment\x18\b \x01(\tR\x10CloudEnvironment\"\xe6\b\n" +
 	"\x18DownstreamInventoryHello\x12\x18\n" +
 	"\aVersion\x18\x01 \x01(\tR\aVersion\x12\x1a\n" +
 	"\bServerID\x18\x02 \x01(\tR\bServerID\x12Y\n" +
-	"\fCapabilities\x18\x03 \x01(\v25.proto.DownstreamInventoryHello.SupportedCapabilitiesR\fCapabilities\x1a\xf1\x06\n" +
+	"\fCapabilities\x18\x03 \x01(\v25.proto.DownstreamInventoryHello.SupportedCapabilitiesR\fCapabilities\x1a\xb8\a\n" +
 	"\x15SupportedCapabilities\x12(\n" +
 	"\x0fProxyHeartbeats\x18\x01 \x01(\bR\x0fProxyHeartbeats\x12\"\n" +
 	"\fProxyCleanup\x18\x02 \x01(\bR\fProxyCleanup\x12&\n" +
@@ -1370,7 +1389,8 @@ const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\x1fWindowsDesktopServiceHeartbeats\x18\x0f \x01(\bR\x1fWindowsDesktopServiceHeartbeats\x12B\n" +
 	"\x1cWindowsDesktopServiceCleanup\x18\x10 \x01(\bR\x1cWindowsDesktopServiceCleanup\x122\n" +
 	"\x14KubernetesHeartbeats\x18\x11 \x01(\bR\x14KubernetesHeartbeats\x12,\n" +
-	"\x11KubernetesCleanup\x18\x12 \x01(\bR\x11KubernetesCleanup\"\xea\x01\n" +
+	"\x11KubernetesCleanup\x18\x12 \x01(\bR\x11KubernetesCleanup\x12E\n" +
+	"\x1frelay_server_heartbeats_cleanup\x18\x13 \x01(\bR\x1crelayServerHeartbeatsCleanup\"\xea\x01\n" +
 	"\x1cInventoryUpdateLabelsRequest\x12\x1a\n" +
 	"\bServerID\x18\x01 \x01(\tR\bServerID\x12*\n" +
 	"\x04Kind\x18\x02 \x01(\x0e2\x16.proto.LabelUpdateKindR\x04Kind\x12G\n" +
@@ -1383,12 +1403,13 @@ const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\x06Labels\x18\x02 \x03(\v22.proto.DownstreamInventoryUpdateLabels.LabelsEntryR\x06Labels\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfd\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc3\x02\n" +
 	"\x12InventoryHeartbeat\x12-\n" +
 	"\tSSHServer\x18\x01 \x01(\v2\x0f.types.ServerV2R\tSSHServer\x120\n" +
 	"\tAppServer\x18\x02 \x01(\v2\x12.types.AppServerV3R\tAppServer\x12?\n" +
 	"\x0eDatabaseServer\x18\x03 \x01(\v2\x17.types.DatabaseServerV3R\x0eDatabaseServer\x12E\n" +
-	"\x10KubernetesServer\x18\x04 \x01(\v2\x19.types.KubernetesServerV3R\x10KubernetesServer\"d\n" +
+	"\x10KubernetesServer\x18\x04 \x01(\v2\x19.types.KubernetesServerV3R\x10KubernetesServer\x12D\n" +
+	"\frelay_server\x18\x05 \x01(\v2!.teleport.presence.v1.RelayServerR\vrelayServer\"d\n" +
 	"\x18UpstreamInventoryGoodbye\x12(\n" +
 	"\x0fDeleteResources\x18\x01 \x01(\bR\x0fDeleteResources\x12\x1e\n" +
 	"\n" +
@@ -1456,6 +1477,7 @@ var file_teleport_legacy_client_proto_inventory_proto_goTypes = []any{
 	(*types.AppServerV3)(nil),        // 23: types.AppServerV3
 	(*types.DatabaseServerV3)(nil),   // 24: types.DatabaseServerV3
 	(*types.KubernetesServerV3)(nil), // 25: types.KubernetesServerV3
+	(*v1.RelayServer)(nil),           // 26: teleport.presence.v1.RelayServer
 }
 var file_teleport_legacy_client_proto_inventory_proto_depIdxs = []int32{
 	5,  // 0: proto.UpstreamInventoryOneOf.Hello:type_name -> proto.UpstreamInventoryHello
@@ -1477,15 +1499,16 @@ var file_teleport_legacy_client_proto_inventory_proto_depIdxs = []int32{
 	23, // 16: proto.InventoryHeartbeat.AppServer:type_name -> types.AppServerV3
 	24, // 17: proto.InventoryHeartbeat.DatabaseServer:type_name -> types.DatabaseServerV3
 	25, // 18: proto.InventoryHeartbeat.KubernetesServer:type_name -> types.KubernetesServerV3
-	5,  // 19: proto.InventoryStatusSummary.Connected:type_name -> proto.UpstreamInventoryHello
-	17, // 20: proto.InventoryStatusSummary.VersionCounts:type_name -> proto.InventoryStatusSummary.VersionCountsEntry
-	18, // 21: proto.InventoryStatusSummary.UpgraderCounts:type_name -> proto.InventoryStatusSummary.UpgraderCountsEntry
-	19, // 22: proto.InventoryStatusSummary.ServiceCounts:type_name -> proto.InventoryStatusSummary.ServiceCountsEntry
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	26, // 19: proto.InventoryHeartbeat.relay_server:type_name -> teleport.presence.v1.RelayServer
+	5,  // 20: proto.InventoryStatusSummary.Connected:type_name -> proto.UpstreamInventoryHello
+	17, // 21: proto.InventoryStatusSummary.VersionCounts:type_name -> proto.InventoryStatusSummary.VersionCountsEntry
+	18, // 22: proto.InventoryStatusSummary.UpgraderCounts:type_name -> proto.InventoryStatusSummary.UpgraderCountsEntry
+	19, // 23: proto.InventoryStatusSummary.ServiceCounts:type_name -> proto.InventoryStatusSummary.ServiceCountsEntry
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_inventory_proto_init() }

--- a/api/proto/teleport/legacy/client/proto/inventory.proto
+++ b/api/proto/teleport/legacy/client/proto/inventory.proto
@@ -20,6 +20,7 @@ package proto;
 
 import "google/protobuf/timestamp.proto";
 import "teleport/legacy/types/types.proto";
+import "teleport/presence/v1/relay_server.proto";
 
 option go_package = "github.com/gravitational/teleport/api/client/proto";
 
@@ -166,6 +167,8 @@ message DownstreamInventoryHello {
     bool KubernetesHeartbeats = 17;
     // KubernetesCleanup indicates the ICS supports deleting kubernetes clusters when UpstreamInventoryGoodbye.DeleteResources is set.
     bool KubernetesCleanup = 18;
+    // Indicates that the ICS supports heartbeating relay_server entries as well as deleting them on disconnect if UpstreamInventoryGoodbye.DeleteResources is set.
+    bool relay_server_heartbeats_cleanup = 19;
   }
 
   // SupportedCapabilities advertises the supported features of the auth server.
@@ -217,6 +220,8 @@ message InventoryHeartbeat {
   types.DatabaseServerV3 DatabaseServer = 3;
   // KubeServer is a complete kube server spec to be heartbeated.
   types.KubernetesServerV3 KubernetesServer = 4;
+  // A relay_server to be heartbeated.
+  teleport.presence.v1.RelayServer relay_server = 5;
 }
 
 // UpstreamInventoryGoodbye informs the upstream service that instance

--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -39,6 +39,8 @@ const (
 	RoleProxy SystemRole = "Proxy"
 	// RoleAdmin is admin role
 	RoleAdmin SystemRole = "Admin"
+	// RoleRelay is the system role for a relay in the cluster.
+	RoleRelay SystemRole = "Relay"
 	// RoleProvisionToken is a role for nodes authenticated using provisioning tokens
 	RoleProvisionToken SystemRole = "ProvisionToken"
 	// RoleTrustedCluster is a role needed for tokens used to add trusted clusters.
@@ -90,6 +92,7 @@ var roleMappings = map[string]SystemRole{
 	"node":              RoleNode,
 	"proxy":             RoleProxy,
 	"admin":             RoleAdmin,
+	"relay":             RoleRelay,
 	"provisiontoken":    RoleProvisionToken,
 	"trusted_cluster":   RoleTrustedCluster,
 	"trustedcluster":    RoleTrustedCluster,
@@ -132,6 +135,7 @@ var localServiceMappings = map[SystemRole]struct{}{
 	RoleAuth:              {},
 	RoleNode:              {},
 	RoleProxy:             {},
+	RoleRelay:             {},
 	RoleKube:              {},
 	RoleApp:               {},
 	RoleDatabase:          {},

--- a/constants.go
+++ b/constants.go
@@ -120,6 +120,9 @@ const (
 	// ComponentProxy is SSH proxy (SSH server forwarding connections)
 	ComponentProxy = "proxy"
 
+	// ComponentRelay is the component name for the relay service.
+	ComponentRelay = "relay"
+
 	// ComponentProxyPeer is the proxy peering component of the proxy service
 	ComponentProxyPeer = "proxy:peer"
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4916,7 +4916,14 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 	certRequest.DNSNames = append(certRequest.DNSNames, DefaultDNSNamesForRole(req.Role)...)
 	// Unlike additional principals, DNS Names is x509 specific and is limited
 	// to services with TLS endpoints (e.g. auth, proxies, kubernetes)
-	if (types.SystemRoles{req.Role}).IncludeAny(types.RoleAuth, types.RoleAdmin, types.RoleProxy, types.RoleKube, types.RoleWindowsDesktop) {
+	if (types.SystemRoles{req.Role}).IncludeAny(
+		types.RoleAuth,
+		types.RoleAdmin,
+		types.RoleProxy,
+		types.RoleRelay,
+		types.RoleKube,
+		types.RoleWindowsDesktop,
+	) {
 		certRequest.DNSNames = append(certRequest.DNSNames, req.DNSNames...)
 	}
 	hostTLSCert, err := tlsAuthority.GenerateCertificate(certRequest)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4963,13 +4963,14 @@ func (a *Server) RegisterInventoryControlStream(ics client.UpstreamInventoryCont
 		Version:  teleport.Version,
 		ServerID: a.ServerID,
 		Capabilities: &proto.DownstreamInventoryHello_SupportedCapabilities{
-			NodeHeartbeats:       true,
-			AppHeartbeats:        true,
-			AppCleanup:           true,
-			DatabaseHeartbeats:   true,
-			DatabaseCleanup:      true,
-			KubernetesHeartbeats: true,
-			KubernetesCleanup:    true,
+			NodeHeartbeats:               true,
+			AppHeartbeats:                true,
+			AppCleanup:                   true,
+			DatabaseHeartbeats:           true,
+			DatabaseCleanup:              true,
+			KubernetesHeartbeats:         true,
+			KubernetesCleanup:            true,
+			RelayServerHeartbeatsCleanup: true,
 		},
 	}
 	if err := ics.Send(a.CloseContext(), downstreamHello); err != nil {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6987,6 +6987,11 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 		if role == types.RoleAuth || role == types.RoleMDM || role == types.RoleAccessGraphPlugin {
 			continue
 		}
+		// TODO(espadolini): figure out if the relay service needs to emit
+		// events or not (and if it needs blanket event write access or not).
+		if role == types.RoleRelay {
+			continue
+		}
 
 		t.Run(role.String(), func(t *testing.T) {
 			ctx := context.Background()

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -252,6 +252,7 @@ var connectedResourceGauges = map[string]prometheus.Gauge{
 	constants.KeepAliveDatabase:              connectedResources.WithLabelValues(constants.KeepAliveDatabase),
 	constants.KeepAliveDatabaseService:       connectedResources.WithLabelValues(constants.KeepAliveDatabaseService),
 	constants.KeepAliveWindowsDesktopService: connectedResources.WithLabelValues(constants.KeepAliveWindowsDesktopService),
+	teleport.ComponentRelay:                  connectedResources.WithLabelValues(teleport.ComponentRelay),
 }
 
 // SendKeepAlives allows node to send a stream of keep alive requests

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1094,6 +1094,20 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 			role.String(),
 			roleSpecForProxyWithRecordAtProxy(clusterName),
 		)
+	case types.RoleRelay:
+		return services.RoleFromSpec(
+			role.String(),
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Namespaces: []string{
+						types.Wildcard,
+					},
+					Rules: []types.Rule{
+						// TODO(espadolini): define permissions for relay role
+					},
+				},
+			},
+		)
 	case types.RoleSignup:
 		return services.RoleFromSpec(
 			role.String(),

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -723,6 +723,12 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 	}
 
+	if fc.Relay.Enabled {
+		if err := applyRelayConfig(fc, cfg); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	return nil
 }
 
@@ -3009,5 +3015,28 @@ func applyJamfConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		ExitOnSync:  fc.Jamf.ExitOnSync,
 		Credentials: creds,
 	}
+	return nil
+}
+
+func applyRelayConfig(fc *FileConfig, cfg *servicecfg.Config) error {
+	// TODO(espadolini): potential compatibility checks here like requiring
+	// config v3+ and proxy_server
+
+	// we're here because fc.Relay.Enabled is true
+	cfg.Relay.Enabled = true
+
+	if fc.Relay.RelayGroup == "" {
+		return trace.BadParameter("missing relay_service.relay_group")
+	}
+	cfg.Relay.RelayGroup = fc.Relay.RelayGroup
+
+	if len(fc.Relay.APIPublicHostnames) < 1 {
+		return trace.BadParameter("missing relay_service.api_public_hostnames")
+	}
+	if slices.Contains(fc.Relay.APIPublicHostnames, "") {
+		return trace.BadParameter("empty string in relay_service.api_public_hostnames")
+	}
+	cfg.Relay.APIPublicHostnames = slices.Clone(fc.Relay.APIPublicHostnames)
+
 	return nil
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -66,6 +66,7 @@ type FileConfig struct {
 	Auth    Auth  `yaml:"auth_service,omitempty"`
 	SSH     SSH   `yaml:"ssh_service,omitempty"`
 	Proxy   Proxy `yaml:"proxy_service,omitempty"`
+	Relay   Relay `yaml:"relay_service,omitempty"`
 	Kube    Kube  `yaml:"kubernetes_service,omitempty"`
 
 	// Apps is the "app_service" section in Teleport file configuration which
@@ -2869,4 +2870,17 @@ func readJamfPasswordFile(path, key string) (string, error) {
 	}
 
 	return pwd, nil
+}
+
+type Relay struct {
+	// Enabled is set if the relay service is enabled, defaults to false.
+	Enabled bool `yaml:"enabled"`
+
+	// RelayGroup is the Relay group name, required if the relay service is
+	// enabled.
+	RelayGroup string `yaml:"relay_group"`
+
+	// APIPublicHostnames is the list of DNS names and IP addresses that the
+	// Relay service credentials should be authoritative for.
+	APIPublicHostnames []string `yaml:"api_public_hostnames"`
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2872,6 +2872,7 @@ func readJamfPasswordFile(path, key string) (string, error) {
 	return pwd, nil
 }
 
+// Relay is the relay_service section of the Teleport config file.
 type Relay struct {
 	// Enabled is set if the relay service is enabled, defaults to false.
 	Enabled bool `yaml:"enabled"`

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -29,11 +29,15 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/time/rate"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/inventory/internal/delay"
@@ -57,6 +61,9 @@ type Auth interface {
 
 	UpsertKubernetesServer(context.Context, types.KubeServer) (*types.KeepAlive, error)
 	DeleteKubernetesServer(ctx context.Context, hostID, name string) error
+
+	UpsertRelayServer(ctx context.Context, relayServer *presencev1.RelayServer) (*presencev1.RelayServer, error)
+	DeleteRelayServer(ctx context.Context, name string) error
 
 	KeepAliveServer(context.Context, types.KeepAlive) error
 	UpsertInstance(ctx context.Context, instance types.Instance) error
@@ -253,6 +260,7 @@ type Controller struct {
 	appHBVariableDuration      *interval.VariableDuration
 	dbHBVariableDuration       *interval.VariableDuration
 	kubeHBVariableDuration     *interval.VariableDuration
+	relayHBVariableDuration    *interval.VariableDuration
 	maxKeepAliveErrs           int
 	usageReporter              usagereporter.UsageReporter
 	testEvents                 chan testEvent
@@ -284,6 +292,8 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 		appHBVariableDuration  *interval.VariableDuration
 		dbHBVariableDuration   *interval.VariableDuration
 		kubeHBVariableDuration *interval.VariableDuration
+
+		relayHBVariableDuration *interval.VariableDuration
 	)
 	serverTTL := apidefaults.ServerAnnounceTTL
 	if !variableRateHeartbeatsDisabledEnv() {
@@ -310,6 +320,11 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 			MaxDuration: options.serverKeepAlive * 4,
 			Step:        heartbeatStepSize,
 		})
+		relayHBVariableDuration = interval.NewVariableDuration(interval.VariableDurationConfig{
+			MinDuration: options.serverKeepAlive,
+			MaxDuration: options.serverKeepAlive * 4,
+			Step:        heartbeatStepSize,
+		})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -325,6 +340,7 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 		appHBVariableDuration:      appHBVariableDuration,
 		dbHBVariableDuration:       dbHBVariableDuration,
 		kubeHBVariableDuration:     kubeHBVariableDuration,
+		relayHBVariableDuration:    relayHBVariableDuration,
 		maxKeepAliveErrs:           options.maxKeepAliveErrs,
 		auth:                       auth,
 		authID:                     options.authID,
@@ -424,11 +440,13 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 	// these delays are lazily initialized upon receipt of the first heartbeat
 	// since not all servers send all heartbeats
 	var sshKeepAliveDelay *delay.Delay
+	var relayKeepAliveDelay *delay.Delay
 
 	defer func() {
 		// this is a function expression because the variables are initialized
 		// later and we want to call Stop on the initialized value (if any)
 		sshKeepAliveDelay.Stop()
+		relayKeepAliveDelay.Stop()
 		handle.appKeepAliveDelay.Stop()
 		handle.dbKeepAliveDelay.Stop()
 		handle.kubeKeepAliveDelay.Stop()
@@ -456,6 +474,14 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 				c.sshHBVariableDuration.Dec()
 			}
 			handle.sshServer = nil
+		}
+
+		if handle.relayServer != nil {
+			c.onDisconnectFunc(teleport.ComponentRelay, 1)
+			if c.relayHBVariableDuration != nil {
+				c.relayHBVariableDuration.Dec()
+			}
+			handle.relayServer = nil
 		}
 
 		if len(handle.appServers) > 0 {
@@ -512,6 +538,17 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 					}
 
 					if err := c.handleSSHServerHB(handle, m.SSHServer, sshKeepAliveDelay); err != nil {
+						handle.CloseWithError(trace.Wrap(err))
+						return
+					}
+				}
+
+				if m.RelayServer != nil {
+					if relayKeepAliveDelay == nil {
+						relayKeepAliveDelay = c.createKeepAliveDelay(c.relayHBVariableDuration)
+					}
+
+					if err := c.handleRelayServerHB(handle, m.RelayServer, relayKeepAliveDelay); err != nil {
 						handle.CloseWithError(trace.Wrap(err))
 						return
 					}
@@ -578,6 +615,14 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 				return
 			}
 			c.testEvent(keepAliveSSHTick)
+
+		case now := <-relayKeepAliveDelay.Elapsed():
+			relayKeepAliveDelay.Advance(now)
+
+			if err := c.keepAliveRelayServer(handle, now); err != nil {
+				handle.CloseWithError(err)
+				return
+			}
 
 		case now := <-handle.appKeepAliveDelay.Elapsed():
 			key := handle.appKeepAliveDelay.Tick(now)
@@ -654,8 +699,19 @@ func (c *Controller) doResourceCleanup(handle *upstreamHandle) {
 		"apps", len(handle.appServers),
 		"dbs", len(handle.databaseServers),
 		"kube", len(handle.kubernetesServers),
+		"relay", handle.relayServer != nil,
 		"server_id", handle.Hello().ServerID,
 	)
+
+	if handle.relayServer != nil {
+		if err := c.auth.DeleteRelayServer(c.closeContext, handle.Hello().GetServerID()); err != nil {
+			slog.WarnContext(c.closeContext, "Failed to delete relay_server on termination",
+				"relay_server", handle.Hello().GetServerID(),
+				"error", err,
+			)
+		}
+	}
+
 	for _, app := range handle.appServers {
 		if err := c.cleanupLimiter.Wait(cleanupCtx); err != nil {
 			slog.WarnContext(c.closeContext, "halting remaining resource cleanup", "instance_id", handle.Hello().ServerID, "error", err)
@@ -881,6 +937,57 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 		handle.sshServer.retryUpsert = true
 	}
 	handle.sshServer.resource = sshServer
+	return nil
+}
+
+func (c *Controller) handleRelayServerHB(handle *upstreamHandle, relayServer *presencev1.RelayServer, relayDelay *delay.Delay) error {
+	// the auth layer verifies that a stream's hello message matches the identity and capabilities of the
+	// client cert. after that point it is our responsibility to ensure that heartbeated information is
+	// consistent with the identity and capabilities claimed in the initial hello.
+	if !handle.HasService(types.RoleRelay) {
+		return trace.AccessDenied("control stream not configured to support relay service heartbeats")
+	}
+	if expected, actual := handle.Hello().GetServerID(), relayServer.GetMetadata().GetName(); expected != actual {
+		return trace.AccessDenied("incorrect relay server ID (expected %q, got %q)", expected, actual)
+	}
+
+	// TODO(espadolini): check the relay_server for consistency if there's any
+	// checks that will not be performed by ValidateRelayServer (which happens
+	// on Upsert).
+
+	if handle.relayServer == nil {
+		c.onConnectFunc(teleport.ComponentRelay)
+		if c.relayHBVariableDuration != nil {
+			c.relayHBVariableDuration.Inc()
+		}
+	} else if handle.relayServerErrorCount == 0 && gproto.Equal(handle.relayServer, relayServer) {
+		// if we have successfully upserted this exact server the last time we
+		// don't need to upsert it again right now, we can let the keepalive
+		// ticker deal with it
+		return nil
+	}
+	handle.relayServer = relayServer
+
+	relayServer = gproto.CloneOf(handle.relayServer)
+	relayServer.GetMetadata().Expires = timestamppb.New(time.Now().Add(c.serverTTL))
+	if _, err := c.auth.UpsertRelayServer(c.closeContext, relayServer); err == nil {
+		// reset the error status
+		handle.relayServerErrorCount = 0
+		relayDelay.Reset()
+	} else {
+		closing := handle.relayServerErrorCount < 0 || handle.relayServerErrorCount >= c.maxKeepAliveErrs
+		slog.WarnContext(c.closeContext, "Failed to announce relay server",
+			"server_id", handle.Hello().GetServerID(),
+			"error", err,
+			"error_count", handle.relayServerErrorCount,
+			"closing", closing,
+		)
+
+		if closing {
+			return trace.Wrap(err, "failed to announce relay server")
+		}
+		handle.relayServerErrorCount = -1
+	}
 	return nil
 }
 
@@ -1289,6 +1396,45 @@ func (c *Controller) keepAliveSSHServer(handle *upstreamHandle, now time.Time) e
 		if closing {
 			return trace.Wrap(err, "failed to keep alive SSH server")
 		}
+	}
+
+	return nil
+}
+
+func (c *Controller) keepAliveRelayServer(handle *upstreamHandle, now time.Time) error {
+	if handle.relayServer == nil {
+		return nil
+	}
+
+	relayServer := gproto.CloneOf(handle.relayServer)
+	relayServer.GetMetadata().Expires = timestamppb.New(now.Add(c.serverTTL))
+	_, err := c.auth.UpsertRelayServer(c.closeContext, relayServer)
+	if err == nil {
+		handle.relayServerErrorCount = 0
+		return nil
+	}
+	if handle.relayServerErrorCount < 0 {
+		slog.WarnContext(c.closeContext, "Failed to upsert relay server on retry",
+			"server_id", handle.Hello().GetServerID(),
+			"error", err,
+		)
+		// if we're here it means that we have failed to upsert it _again_,
+		// so we have fallen quite far behind
+		return trace.Wrap(err, "failed to upsert relay server on retry")
+	}
+
+	handle.relayServerErrorCount++
+
+	closing := handle.relayServerErrorCount > c.maxKeepAliveErrs
+	slog.WarnContext(c.closeContext, "Failed to keep alive relay server",
+		"server_id", handle.Hello().ServerID,
+		"error", err,
+		"error_count", handle.relayServerErrorCount,
+		"closing", closing,
+	)
+
+	if closing {
+		return trace.Wrap(err, "failed to keep alive relay server")
 	}
 
 	return nil

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/inventory/metadata"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
@@ -155,6 +156,16 @@ func (a *fakeAuth) KeepAliveServer(_ context.Context, ka types.KeepAlive) error 
 	}
 	a.lastServerExpiry = ka.Expires
 	return a.err
+}
+
+// UpsertRelayServer implements [Auth].
+func (a *fakeAuth) UpsertRelayServer(ctx context.Context, relayServer *presencev1.RelayServer) (*presencev1.RelayServer, error) {
+	panic("unimplemented")
+}
+
+// DeleteRelayServer implements [Auth].
+func (a *fakeAuth) DeleteRelayServer(ctx context.Context, name string) error {
+	panic("unimplemented")
 }
 
 func (a *fakeAuth) UpsertInstance(ctx context.Context, instance types.Instance) error {

--- a/lib/inventory/inventory.go
+++ b/lib/inventory/inventory.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/inventory/internal/delay"
 	"github.com/gravitational/teleport/lib/inventory/metadata"
@@ -708,6 +709,14 @@ type upstreamHandle struct {
 
 	// kubernetesServers track kubernetesServers server details.
 	kubernetesServers map[resourceKey]*heartBeatInfo[*types.KubernetesServerV3]
+
+	// relayServer, if set, is the current relay heartbeat.
+	relayServer *presencev1.RelayServer
+
+	// relayServerErrorCount counts how many times in a row we have failed to
+	// keepalive the relay server heartbeat, or, if negative, signals that we
+	// have failed to upsert a new resource.
+	relayServerErrorCount int
 
 	// appKeepAliveDelay is a multi-delay that controls the cadence of app server keepalive
 	// operations. Note that this is not created automatically by newUpstreamHandle.

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -1,0 +1,69 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	apitypes "github.com/gravitational/teleport/api/types"
+)
+
+func (process *TeleportProcess) initRelay() {
+	process.RegisterWithAuthServer(apitypes.RoleRelay, RelayIdentityEvent)
+	process.RegisterCriticalFunc("relay.run", process.runRelayService)
+}
+
+func (process *TeleportProcess) runRelayService() error {
+	log := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentRelay, process.id))
+
+	defer func() {
+		if err := process.closeImportedDescriptors(teleport.ComponentRelay); err != nil {
+			log.WarnContext(process.ExitContext(), "Failed closing imported file descriptors.", "error", err)
+		}
+	}()
+
+	conn, err := process.WaitForConnector(RelayIdentityEvent, log)
+	if conn == nil {
+		return trace.Wrap(err)
+	}
+	defer conn.Close()
+
+	process.BroadcastEvent(Event{Name: RelayReady})
+	log.InfoContext(process.ExitContext(), "The relay service has successfully started.")
+
+	exitEvent, _ := process.WaitForEvent(process.ExitContext(), TeleportExitEvent)
+	ctx, _ := exitEvent.Payload.(context.Context)
+	if ctx == nil {
+		// if we're here it's because we got an ungraceful exit event or
+		// WaitForEvent errored out because of the ungraceful shutdown; either
+		// way, process.ExitContext() is a done context and all operations
+		// should get canceled immediately
+		log.InfoContext(ctx, "Stopping the relay service ungracefully.")
+		ctx = process.ExitContext()
+	} else {
+		log.InfoContext(ctx, "Stopping the relay service.")
+	}
+
+	warnOnErr(ctx, conn.Close(), log)
+
+	log.InfoContext(ctx, "The relay service has stopped.")
+
+	return nil
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -192,6 +192,11 @@ const (
 	// identity has been registered with the Auth Server.
 	ProxyIdentityEvent = "ProxyIdentity"
 
+	// RelayIdentityEvent is generated after the Teleport agent has successfully
+	// joined a cluster or reused credentials to connect to the control plane as
+	// a relay service.
+	RelayIdentityEvent = "RelayIdentityEvent"
+
 	// SSHIdentityEvent is generated when node's identity has been registered
 	// with the Auth Server.
 	SSHIdentityEvent = "SSHIdentity"
@@ -240,6 +245,10 @@ const (
 	// ProxySSHReady is generated when the proxy has initialized a SSH server
 	// and is ready to start accepting connections.
 	ProxySSHReady = "ProxySSHReady"
+
+	// RelayReady is generated when a relay service is ready to accept
+	// connections.
+	RelayReady = "RelayReady"
 
 	// NodeSSHReady is generated when the Teleport node has initialized a SSH server
 	// and is ready to start accepting SSH connections.
@@ -1424,6 +1433,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 	if cfg.Proxy.Enabled {
 		eventMapping.In = append(eventMapping.In, ProxySSHReady)
 	}
+	if cfg.Relay.Enabled {
+		eventMapping.In = append(eventMapping.In, RelayReady)
+	}
 	if cfg.Kube.Enabled {
 		eventMapping.In = append(eventMapping.In, KubernetesReady)
 	}
@@ -1480,6 +1492,13 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		serviceStarted = true
 	} else {
 		warnOnErr(process.ExitContext(), process.closeImportedDescriptors(teleport.ComponentProxy), process.logger)
+	}
+
+	if cfg.Relay.Enabled {
+		process.initRelay()
+		serviceStarted = true
+	} else {
+		warnOnErr(process.ExitContext(), process.closeImportedDescriptors(teleport.ComponentRelay), process.logger)
 	}
 
 	if cfg.Kube.Enabled {
@@ -3903,6 +3922,8 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 				}
 			}
 		}
+	case types.RoleRelay:
+		dnsNames = append(dnsNames, process.Config.Relay.APIPublicHostnames...)
 	case types.RoleAuth, types.RoleAdmin:
 		addrs = process.Config.Auth.PublicAddrs
 	case types.RoleNode:
@@ -6008,6 +6029,10 @@ func (process *TeleportProcess) registerExpectedServices(cfg *servicecfg.Config)
 
 	if cfg.Proxy.Enabled {
 		process.SetExpectedInstanceRole(types.RoleProxy, ProxyIdentityEvent)
+	}
+
+	if cfg.Relay.Enabled {
+		process.SetExpectedInstanceRole(types.RoleRelay, RelayIdentityEvent)
 	}
 
 	if cfg.Kube.Enabled {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -91,6 +91,9 @@ type Config struct {
 	// connections to the cluster.
 	Proxy ProxyConfig
 
+	// Relay contains the configuration for the Relay service.
+	Relay RelayConfig
+
 	// SSH service configuration. Manages SSH servers running within the cluster.
 	SSH SSHConfig
 
@@ -352,6 +355,7 @@ type RoleAndIdentityEvent struct {
 func DisableLongRunningServices(cfg *Config) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
+	cfg.Relay.Enabled = false
 	cfg.SSH.Enabled = false
 	cfg.Kube.Enabled = false
 	cfg.Apps.Enabled = false
@@ -793,6 +797,7 @@ func verifyEnabledService(cfg *Config) error {
 		cfg.Auth.Enabled,
 		cfg.SSH.Enabled,
 		cfg.Proxy.Enabled,
+		cfg.Relay.Enabled,
 		cfg.Kube.Enabled,
 		cfg.Apps.Enabled,
 		cfg.Databases.Enabled,
@@ -810,7 +815,8 @@ func verifyEnabledService(cfg *Config) error {
 	}
 
 	return trace.BadParameter(
-		"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service or jamf_service")
+		"config: enable at least one of auth_service, ssh_service, proxy_service, relay_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service or jamf_service",
+	)
 }
 
 // SetLogLevel changes the loggers log level.

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -456,7 +456,7 @@ func TestValidateConfig(t *testing.T) {
 			config: &Config{
 				Version: defaults.TeleportConfigVersionV2,
 			},
-			wantErr: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service ",
+			wantErr: "config: enable at least one of ",
 		},
 		{
 			desc: "no auth_servers or proxy_server specified",
@@ -546,6 +546,11 @@ func TestVerifyEnabledService(t *testing.T) {
 		{
 			desc:             "proxy enabled",
 			config:           &Config{Proxy: ProxyConfig{Enabled: true}},
+			errAssertionFunc: require.NoError,
+		},
+		{
+			desc:             "relay enabled",
+			config:           &Config{Relay: RelayConfig{Enabled: true}},
 			errAssertionFunc: require.NoError,
 		},
 		{

--- a/lib/service/servicecfg/relay.go
+++ b/lib/service/servicecfg/relay.go
@@ -1,0 +1,29 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package servicecfg
+
+type RelayConfig struct {
+	Enabled bool
+
+	// RelayGroup is the Relay group name, required if the relay service is
+	// enabled.
+	RelayGroup string
+
+	// APIPublicHostnames is the list of DNS names and IP addresses that the
+	// Relay service credentials should be authoritative for.
+	APIPublicHostnames []string
+}

--- a/lib/service/servicecfg/relay.go
+++ b/lib/service/servicecfg/relay.go
@@ -16,6 +16,7 @@
 
 package servicecfg
 
+// RelayConfig contains the configuration for the Relay service.
 type RelayConfig struct {
 	Enabled bool
 

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -283,6 +283,7 @@ var metricsServicesRunningMap = map[string]string{
 	"ssh.node":             "ssh_service",
 	"auth.tls":             "auth_service",
 	"proxy.web":            "proxy_service",
+	"relay.run":            "relay_service",
 	"kube.init":            "kubernetes_service",
 	"apps.start":           "application_service",
 	"db.init":              "database_service",


### PR DESCRIPTION
This PR adds a `relay_service` skeleton service that does nothing except heartbeat for itself and wait for shutdown, as well as a `teleport.yaml` section to enable the service.