### PR TITLE
[vnet] feat: support proxy recording mode with VNet SSH

### DIFF
--- a/lib/vnet/ssh_agent.go
+++ b/lib/vnet/ssh_agent.go
@@ -47,8 +47,15 @@ func newSSHAgent() *sshAgent {
 }
 
 // setSessionKey must be called at most once, before the agent will be used.
-func (a *sshAgent) setSessionKey(signer ssh.Signer) {
+// It's not possible to initialize sshAgent with the SSH signer because the
+// agent must be passed to [proxy.Client.DialHost] before the session SSH
+// signer has been created.
+func (a *sshAgent) setSessionKey(signer ssh.Signer) error {
+	if a.signer != nil {
+		return trace.Errorf("sshAgent.setSessionKey must be called at most once (this is a bug)")
+	}
 	a.signer = signer
+	return nil
 }
 
 func (a *sshAgent) List() ([]*agent.Key, error) {

--- a/lib/vnet/ssh_agent.go
+++ b/lib/vnet/ssh_agent.go
@@ -1,0 +1,129 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"crypto/rand"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/gravitational/teleport/api/utils/sshutils"
+)
+
+var _ agent.ExtendedAgent = (*sshAgent)(nil)
+
+// sshAgent implements [agent.ExtendedAgent]. The sole purpose it to forward
+// the user's Teleport SSH key to the proxy in case the cluster is in proxy
+// recording mode. In this case there will be an SSH connection between VNet
+// and the root cluster proxy terminated with the SSH key in the
+// [ssh.ClientConfig], and then the key forwarded via this agent will be used
+// to terminate the final SSH connection to the target node.
+//
+// It is not safe for concurrent use, addSessionKey must only be called before
+// the agent will actually be used.
+type sshAgent struct {
+	signer ssh.Signer
+}
+
+func newSSHAgent() *sshAgent {
+	return &sshAgent{}
+}
+
+// setSessionKey must be called at most once, before the agent will be used.
+func (a *sshAgent) setSessionKey(signer ssh.Signer) {
+	a.signer = signer
+}
+
+func (a *sshAgent) List() ([]*agent.Key, error) {
+	if a.signer == nil {
+		return nil, nil
+	}
+	pub := a.signer.PublicKey()
+	return []*agent.Key{{
+		Format: pub.Type(),
+		Blob:   pub.Marshal(),
+	}}, nil
+}
+
+func (a *sshAgent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	return a.SignWithFlags(key, data, 0)
+}
+
+func (a *sshAgent) SignWithFlags(key ssh.PublicKey, data []byte, flags agent.SignatureFlags) (*ssh.Signature, error) {
+	if a.signer == nil {
+		return nil, trace.Errorf("VNet SSH agent has no signer")
+	}
+	if !sshutils.KeysEqual(a.signer.PublicKey(), key) {
+		return nil, trace.BadParameter("requested key does not equal VNet SSH agent key")
+	}
+	var algo string
+	switch flags {
+	case 0:
+	case agent.SignatureFlagRsaSha256:
+		algo = ssh.KeyAlgoRSASHA256
+	case agent.SignatureFlagRsaSha512:
+		algo = ssh.KeyAlgoRSASHA512
+	default:
+		return nil, trace.Errorf("unsupported signature flag %v", flags)
+	}
+	log.DebugContext(context.Background(), "VNet SSH agent signature requested",
+		"key_type", a.signer.PublicKey().Type(), "algo", algo)
+	if algo == "" {
+		sig, err := a.signer.Sign(rand.Reader, data)
+		return sig, trace.Wrap(err)
+	}
+	algorithmSigner, ok := a.signer.(ssh.AlgorithmSigner)
+	if !ok {
+		return nil, trace.Errorf("VNet SSH agent signer does not implement ssh.AlgorithmSigner")
+	}
+	sig, err := algorithmSigner.SignWithAlgorithm(rand.Reader, data, algo)
+	return sig, trace.Wrap(err, "signing with VNet SSH agent signer")
+}
+
+func (a *sshAgent) Signers() ([]ssh.Signer, error) {
+	if a.signer == nil {
+		return nil, nil
+	}
+	return []ssh.Signer{a.signer}, nil
+}
+
+func (a *sshAgent) Add(key agent.AddedKey) error {
+	return trace.NotImplemented("sshAgent.Add is not implemented")
+}
+
+func (a *sshAgent) Remove(key ssh.PublicKey) error {
+	return trace.NotImplemented("sshAgent.Remove is not implemented")
+}
+
+func (a *sshAgent) RemoveAll() error {
+	return trace.NotImplemented("sshAgent.RemoveAll is not implemented")
+}
+
+func (a *sshAgent) Lock(passphrase []byte) error {
+	return trace.NotImplemented("sshAgent.Lock is not implemented")
+}
+
+func (a *sshAgent) Unlock(passphrase []byte) error {
+	return trace.NotImplemented("sshAgent.Unlock is not implemented")
+}
+
+func (a *sshAgent) Extension(extensionType string, contents []byte) ([]byte, error) {
+	return nil, trace.NotImplemented("sshAgent.Extension is not implemented")
+}

--- a/lib/vnet/ssh_agent.go
+++ b/lib/vnet/ssh_agent.go
@@ -27,9 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 )
 
-var _ agent.ExtendedAgent = (*sshAgent)(nil)
-
-// sshAgent implements [agent.ExtendedAgent]. The sole purpose it to forward
+// sshAgent implements [agent.ExtendedAgent]. The sole purpose is to forward
 // the user's Teleport SSH key to the proxy in case the cluster is in proxy
 // recording mode. In this case there will be an SSH connection between VNet
 // and the root cluster proxy terminated with the SSH key in the

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -53,6 +53,7 @@ type sshProviderConfig struct {
 		target dialTarget,
 		tlsConfig *tls.Config,
 		dialOpts *vnetv1.DialOptions,
+		agent *sshAgent,
 	) (net.Conn, error)
 }
 
@@ -77,7 +78,7 @@ func newSSHProvider(ctx context.Context, cfg sshProviderConfig) (*sshProvider, e
 }
 
 // dial dials the target SSH host.
-func (p *sshProvider) dial(ctx context.Context, target dialTarget) (net.Conn, error) {
+func (p *sshProvider) dial(ctx context.Context, target dialTarget, agent *sshAgent) (net.Conn, error) {
 	userTLSCertResp, err := p.cfg.clt.UserTLSCert(ctx, target.profile)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -89,9 +90,10 @@ func (p *sshProvider) dial(ctx context.Context, target dialTarget) (net.Conn, er
 		return nil, trace.Wrap(err)
 	}
 	if p.cfg.overrideNodeDialer != nil {
-		return p.cfg.overrideNodeDialer(ctx, target, tlsConfig, dialOpts)
+		conn, err := p.cfg.overrideNodeDialer(ctx, target, tlsConfig, dialOpts, agent)
+		return conn, trace.Wrap(err)
 	}
-	return p.dialViaProxy(ctx, target, tlsConfig, dialOpts)
+	return p.dialViaProxy(ctx, target, tlsConfig, dialOpts, agent)
 }
 
 // dialViaProxy dials the target SSH host via the proxy transport service.
@@ -100,6 +102,7 @@ func (p *sshProvider) dialViaProxy(
 	target dialTarget,
 	tlsConfig *tls.Config,
 	dialOpts *vnetv1.DialOptions,
+	agent *sshAgent,
 ) (net.Conn, error) {
 	// TODO(nklaassen): consider reusing proxy clients, need to figure out when
 	// it's necessary to make a new client e.g. if the user's TLS credentials
@@ -117,8 +120,14 @@ func (p *sshProvider) dialViaProxy(
 	if err != nil {
 		return nil, trace.Wrap(err, "building proxy client")
 	}
-	// TODO(nklaassen): pass an SSH keyring to support proxy recording mode.
-	conn, _, err := pclt.DialHost(ctx, target.addr, target.cluster, nil /*keyRing*/)
+	// Forward an SSH agent in case proxy recording mode is enabled in the cluster.
+	// At this point there is no SSH key for the user yet and the agent is
+	// empty, the SSH key will be added to the agent in [sshProvider.sessionSSHConfig].
+	// This forwarded agent will be used only to make the next SSH connection
+	// to the target SSH node, it is not actually forwarded to the target node
+	// and does not prevent the client from forwarding its own agent if
+	// requested.
+	conn, _, err := pclt.DialHost(ctx, target.addr, target.cluster, agent)
 	if err != nil {
 		pclt.Close()
 		return nil, trace.Wrap(err, "dialing target via proxy")
@@ -168,6 +177,7 @@ func (p *sshProvider) sessionSSHConfig(
 	ctx context.Context,
 	target dialTarget,
 	user string,
+	agent *sshAgent,
 ) (*ssh.ClientConfig, error) {
 	// TODO(nklaassen): cache session SSH configs so we don't have to regenerate
 	// every time.
@@ -202,6 +212,11 @@ func (p *sshProvider) sessionSSHConfig(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// Add the session SSH key to the SSH agent in case proxy recording mode is
+	// enabled. Adding it to the agent here before returning an
+	// ssh.ClientConfig guarantees the key is added to the agent before the
+	// agent could be used.
+	agent.setSessionKey(certSigner)
 	hostKeyCallback, err := buildHostKeyCallback(resp.GetTrustedCas(), p.cfg.clock)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/vnet/ssh_provider.go
+++ b/lib/vnet/ssh_provider.go
@@ -216,7 +216,9 @@ func (p *sshProvider) sessionSSHConfig(
 	// enabled. Adding it to the agent here before returning an
 	// ssh.ClientConfig guarantees the key is added to the agent before the
 	// agent could be used.
-	agent.setSessionKey(certSigner)
+	if err := agent.setSessionKey(certSigner); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	hostKeyCallback, err := buildHostKeyCallback(resp.GetTrustedCas(), p.cfg.clock)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -189,7 +189,8 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		log.DebugContext(ctx, "Resolved FQDN to a matched cluster")
 		// Attempt a dial to the target SSH node to see if it exists.
 		target := computeDialTarget(matchedCluster, h.cfg.fqdn)
-		targetConn, err := h.cfg.sshProvider.dial(ctx, target)
+		agent := newSSHAgent()
+		targetConn, err := h.cfg.sshProvider.dial(ctx, target, agent)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {
 				log.DebugContext(ctx, "Failed TCP dial to target, node might be offline")
@@ -209,7 +210,7 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		h.setDecidedHandler(sshHandler)
 		// Handle the incoming connection with the TCP connection to the target
 		// SSH node that has already been established.
-		return sshHandler.handleTCPConnectorWithTargetConn(ctx, connector, targetConn)
+		return sshHandler.handleTCPConnectorWithTargetConn(ctx, connector, targetConn, agent)
 	}
 	return trace.Errorf("rejecting connection to %s:%d", h.cfg.fqdn, localPort)
 }

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -370,6 +370,8 @@ type fakeClientApp struct {
 	// requestedRouteToApps indexed by public address.
 	requestedRouteToApps   map[string][]*proto.RouteToApp
 	requestedRouteToAppsMu sync.RWMutex
+
+	forwardedAgents *forwardedAgents
 }
 
 type fakeClientAppConfig struct {
@@ -393,13 +395,16 @@ func newFakeClientApp(ctx context.Context, t *testing.T, cfg *fakeClientAppConfi
 	teleportUserCA, err := ssh.NewSignerFromSigner(teleportUserCAKey)
 	require.NoError(t, err)
 
+	forwardedAgents := &forwardedAgents{}
+
 	tlsCA := newSelfSignedCA(t)
 	dialOpts := mustStartFakeWebProxy(ctx, t, fakeWebProxyConfig{
-		tlsCA:  tlsCA,
-		hostCA: teleportHostCA,
-		userCA: teleportUserCA,
-		clock:  cfg.clock,
-		suite:  cfg.signatureAlgorithmSuite,
+		tlsCA:           tlsCA,
+		hostCA:          teleportHostCA,
+		userCA:          teleportUserCA,
+		clock:           cfg.clock,
+		suite:           cfg.signatureAlgorithmSuite,
+		forwardedAgents: forwardedAgents,
 	})
 
 	return &fakeClientApp{
@@ -409,6 +414,7 @@ func newFakeClientApp(ctx context.Context, t *testing.T, cfg *fakeClientAppConfi
 		teleportHostCA:       teleportHostCA,
 		teleportUserCA:       teleportUserCA,
 		requestedRouteToApps: make(map[string][]*proto.RouteToApp),
+		forwardedAgents:      forwardedAgents,
 	}
 }
 
@@ -573,6 +579,7 @@ func (p *fakeClientApp) dialSSHNode(
 	target dialTarget,
 	tlsConfig *tls.Config,
 	dialOpts *vnetv1.DialOptions,
+	agent *sshAgent,
 ) (net.Conn, error) {
 	targetCluster, ok := p.cfg.clusters[target.profile]
 	if !ok {
@@ -587,6 +594,12 @@ func (p *fakeClientApp) dialSSHNode(
 	if _, ok := targetCluster.nodes[target.hostname]; !ok {
 		return nil, trace.NotFound("no such host")
 	}
+	// In this test suite all SSH dials go to a single faked web proxy expecting
+	// the ALPN protocol alpncomm.ProtocolProxySSH for SSH dials. It doesn't
+	// run the real transport service that handles SSH agent forwarding over
+	// gRPC, but the test shares the forwarded agent with the fake proxy via
+	// the forwardedAgents collection.
+	p.forwardedAgents.add(agent)
 	tlsConfig.NextProtos = []string{string(alpncommon.ProtocolProxySSH)}
 	return tls.Dial("tcp", dialOpts.GetWebProxyAddr(), tlsConfig)
 }
@@ -1598,11 +1611,12 @@ func newLeafCert(
 }
 
 type fakeWebProxyConfig struct {
-	tlsCA  tls.Certificate
-	hostCA ssh.Signer
-	userCA ssh.Signer
-	clock  clockwork.Clock
-	suite  types.SignatureAlgorithmSuite
+	tlsCA           tls.Certificate
+	hostCA          ssh.Signer
+	userCA          ssh.Signer
+	clock           clockwork.Clock
+	suite           types.SignatureAlgorithmSuite
+	forwardedAgents *forwardedAgents
 }
 
 func mustStartFakeWebProxy(
@@ -1665,6 +1679,13 @@ func mustStartFakeWebProxy(
 			PublicKeyCallback: func(conn ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
 				if conn.User() == "denyuser" {
 					return nil, trace.AccessDenied("access denied for denyuser")
+				}
+				// The test suite doesn't implement real "proxy recording mode"
+				// or SSH agent forwarding, but at least test here that the
+				// user key used to make this connection was forwarded so that
+				// the real SSH forwarding proxy would have access to it.
+				if !cfg.forwardedAgents.forwarded(pubKey) {
+					return nil, trace.Errorf("user SSH key was not forwarded")
 				}
 				return certChecker.Authenticate(conn, pubKey)
 			},
@@ -1750,4 +1771,36 @@ func mustStartFakeWebProxy(
 		Sni:                   proxyCN,
 	}
 	return dialOpts
+}
+
+// forwardedAgents is a crude way of tracking all the forwarded SSH agents and
+// checking if any of them forward a specific SSH key.
+type forwardedAgents struct {
+	mu     sync.Mutex
+	agents []*sshAgent
+}
+
+func (a *forwardedAgents) add(agent *sshAgent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.agents = append(a.agents, agent)
+}
+
+func (a *forwardedAgents) forwarded(key ssh.PublicKey) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	blob := key.Marshal()
+	for _, agent := range a.agents {
+		agentKeys, err := agent.List()
+		if err != nil {
+			// sshAgent.List never returns an error.
+			continue
+		}
+		for _, agentKey := range agentKeys {
+			if slices.Equal(agentKey.Blob, blob) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR forwards an SSH agent when dialing the target node in order to support proxy recording mode, where the root cluster proxy terminates the SSH connection to record the session, and makes a subsequent connection to the target node using the user SSH key from the forwarded agent.