### PR TITLE
github: fix default start date on plugin creation

### DIFF
--- a/tool/tctl/common/plugin/github.go
+++ b/tool/tctl/common/plugin/github.go
@@ -40,7 +40,7 @@ type githubArgs struct {
 func (p *PluginsCommand) initInstallGithub(parent *kingpin.CmdClause) {
 	p.install.github.cmd = parent.Command("github", "Install an Access Graph Github integration.")
 	p.install.github.cmd.Flag("start-date", "Start date for the audit log ingest in the YYYY-MM-DD format.").
-		Default(time.Now().Add(10 * 24 * time.Hour).UTC().Format(time.DateOnly)).
+		Default(time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.DateOnly)).
 		StringVar(&p.install.github.startDate)
 }
 


### PR DESCRIPTION
The start when creating the plugin using `tctl` defaults to 10 days into the future instead of 10 days in the past.