### PR TITLE
fix: Text alignment in bot instances alert

### DIFF
--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -151,7 +151,7 @@ export function BotInstancesList({
       ]}
       emptyText="No active instances found"
       emptyButton={
-        <Info alignItems="flex-start" mt={5}>
+        <Info mt={5}>
           Bot instances are ephemeral, and disappear once all issued credentials
           have expired.
         </Info>


### PR DESCRIPTION
## Summary

The alert which shows on the Bot Instance page when there are zero records had vertically misaligned text. Fix is simply removing `alignItems="flex-start"`, which is required when an alert's text height is greater than the icon's height (designs [here](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=9245-35048&t=8DPFVpskIVhtSMeT-4)).

Updates: #55731

## Changes

- Remove `alignItems="flex-start"` from `<Info />` element

## Demo

**Before**
![Screenshot 2025-06-17 at 09 34 48](https://github.com/user-attachments/assets/d8f54967-0682-43ec-b5d0-12c74739762f)

**After**
![Screenshot 2025-06-17 at 09 35 19](https://github.com/user-attachments/assets/7d4c36e5-19fa-4e4b-99a2-3eed29aeea0d)
