### PR TITLE
Add Plugin OAuth Token gRPC API

### DIFF
--- a/api/gen/proto/go/teleport/plugins/v1/plugin_service.pb.go
+++ b/api/gen/proto/go/teleport/plugins/v1/plugin_service.pb.go
@@ -909,6 +909,143 @@ func (x *CleanupRequest) GetType() string {
 	return ""
 }
 
+// CreatePluginOauthTokenRequest is the request type for creating an OAuth token for a plugin.
+type CreatePluginOauthTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// plugin_name is the name of the plugin for which the OAuth token is requested.
+	PluginName string `protobuf:"bytes,1,opt,name=plugin_name,json=pluginName,proto3" json:"plugin_name,omitempty"`
+	// client_id is the OAuth client identifier issued to the plugin.
+	ClientId string `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	// client_secret is the secret associated with the client_id.
+	ClientSecret string `protobuf:"bytes,3,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
+	// grant_type is the OAuth 2.0 grant type being used. Currently, only "client_credentials" is supported.
+	GrantType     string `protobuf:"bytes,4,opt,name=grant_type,json=grantType,proto3" json:"grant_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreatePluginOauthTokenRequest) Reset() {
+	*x = CreatePluginOauthTokenRequest{}
+	mi := &file_teleport_plugins_v1_plugin_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreatePluginOauthTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreatePluginOauthTokenRequest) ProtoMessage() {}
+
+func (x *CreatePluginOauthTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_plugins_v1_plugin_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreatePluginOauthTokenRequest.ProtoReflect.Descriptor instead.
+func (*CreatePluginOauthTokenRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_plugins_v1_plugin_service_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CreatePluginOauthTokenRequest) GetPluginName() string {
+	if x != nil {
+		return x.PluginName
+	}
+	return ""
+}
+
+func (x *CreatePluginOauthTokenRequest) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *CreatePluginOauthTokenRequest) GetClientSecret() string {
+	if x != nil {
+		return x.ClientSecret
+	}
+	return ""
+}
+
+func (x *CreatePluginOauthTokenRequest) GetGrantType() string {
+	if x != nil {
+		return x.GrantType
+	}
+	return ""
+}
+
+// CreatePluginOauthTokenResponse is the response type for a successful OAuth token creation.
+type CreatePluginOauthTokenResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// access_token is the generated token issued to the plugin.
+	AccessToken string `protobuf:"bytes,1,opt,name=access_token,json=accessToken,proto3" json:"access_token,omitempty"`
+	// token_type describes the type of the token issued
+	TokenType string `protobuf:"bytes,2,opt,name=token_type,json=tokenType,proto3" json:"token_type,omitempty"`
+	// expires_in is the number of seconds until the token expires.
+	ExpiresIn     int64 `protobuf:"varint,3,opt,name=expires_in,json=expiresIn,proto3" json:"expires_in,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreatePluginOauthTokenResponse) Reset() {
+	*x = CreatePluginOauthTokenResponse{}
+	mi := &file_teleport_plugins_v1_plugin_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreatePluginOauthTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreatePluginOauthTokenResponse) ProtoMessage() {}
+
+func (x *CreatePluginOauthTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_plugins_v1_plugin_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreatePluginOauthTokenResponse.ProtoReflect.Descriptor instead.
+func (*CreatePluginOauthTokenResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_plugins_v1_plugin_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *CreatePluginOauthTokenResponse) GetAccessToken() string {
+	if x != nil {
+		return x.AccessToken
+	}
+	return ""
+}
+
+func (x *CreatePluginOauthTokenResponse) GetTokenType() string {
+	if x != nil {
+		return x.TokenType
+	}
+	return ""
+}
+
+func (x *CreatePluginOauthTokenResponse) GetExpiresIn() int64 {
+	if x != nil {
+		return x.ExpiresIn
+	}
+	return 0
+}
+
 var File_teleport_plugins_v1_plugin_service_proto protoreflect.FileDescriptor
 
 const file_teleport_plugins_v1_plugin_service_proto_rawDesc = "" +
@@ -964,7 +1101,20 @@ const file_teleport_plugins_v1_plugin_service_proto_rawDesc = "" +
 	"\x14resources_to_cleanup\x18\x02 \x03(\v2\x11.types.ResourceIDR\x12resourcesToCleanup\x12#\n" +
 	"\rplugin_active\x18\x03 \x01(\bR\fpluginActive\"$\n" +
 	"\x0eCleanupRequest\x12\x12\n" +
-	"\x04type\x18\x01 \x01(\tR\x04type2\xac\b\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\"\xa1\x01\n" +
+	"\x1dCreatePluginOauthTokenRequest\x12\x1f\n" +
+	"\vplugin_name\x18\x01 \x01(\tR\n" +
+	"pluginName\x12\x1b\n" +
+	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12#\n" +
+	"\rclient_secret\x18\x03 \x01(\tR\fclientSecret\x12\x1d\n" +
+	"\n" +
+	"grant_type\x18\x04 \x01(\tR\tgrantType\"\x81\x01\n" +
+	"\x1eCreatePluginOauthTokenResponse\x12!\n" +
+	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12\x1d\n" +
+	"\n" +
+	"token_type\x18\x02 \x01(\tR\ttokenType\x12\x1d\n" +
+	"\n" +
+	"expires_in\x18\x03 \x01(\x03R\texpiresIn2\xb0\t\n" +
 	"\rPluginService\x12P\n" +
 	"\fCreatePlugin\x12(.teleport.plugins.v1.CreatePluginRequest\x1a\x16.google.protobuf.Empty\x12C\n" +
 	"\tGetPlugin\x12%.teleport.plugins.v1.GetPluginRequest\x1a\x0f.types.PluginV1\x12I\n" +
@@ -976,7 +1126,8 @@ const file_teleport_plugins_v1_plugin_service_proto_rawDesc = "" +
 	"\x17GetAvailablePluginTypes\x123.teleport.plugins.v1.GetAvailablePluginTypesRequest\x1a4.teleport.plugins.v1.GetAvailablePluginTypesResponse\x12\x96\x01\n" +
 	"\x1dSearchPluginStaticCredentials\x129.teleport.plugins.v1.SearchPluginStaticCredentialsRequest\x1a:.teleport.plugins.v1.SearchPluginStaticCredentialsResponse\x12c\n" +
 	"\fNeedsCleanup\x12(.teleport.plugins.v1.NeedsCleanupRequest\x1a).teleport.plugins.v1.NeedsCleanupResponse\x12F\n" +
-	"\aCleanup\x12#.teleport.plugins.v1.CleanupRequest\x1a\x16.google.protobuf.EmptyBRZPgithub.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1;pluginsv1b\x06proto3"
+	"\aCleanup\x12#.teleport.plugins.v1.CleanupRequest\x1a\x16.google.protobuf.Empty\x12\x81\x01\n" +
+	"\x16CreatePluginOauthToken\x122.teleport.plugins.v1.CreatePluginOauthTokenRequest\x1a3.teleport.plugins.v1.CreatePluginOauthTokenResponseBRZPgithub.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1;pluginsv1b\x06proto3"
 
 var (
 	file_teleport_plugins_v1_plugin_service_proto_rawDescOnce sync.Once
@@ -990,7 +1141,7 @@ func file_teleport_plugins_v1_plugin_service_proto_rawDescGZIP() []byte {
 	return file_teleport_plugins_v1_plugin_service_proto_rawDescData
 }
 
-var file_teleport_plugins_v1_plugin_service_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_teleport_plugins_v1_plugin_service_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_teleport_plugins_v1_plugin_service_proto_goTypes = []any{
 	(*PluginType)(nil),                            // 0: teleport.plugins.v1.PluginType
 	(*CreatePluginRequest)(nil),                   // 1: teleport.plugins.v1.CreatePluginRequest
@@ -1008,30 +1159,32 @@ var file_teleport_plugins_v1_plugin_service_proto_goTypes = []any{
 	(*NeedsCleanupRequest)(nil),                   // 13: teleport.plugins.v1.NeedsCleanupRequest
 	(*NeedsCleanupResponse)(nil),                  // 14: teleport.plugins.v1.NeedsCleanupResponse
 	(*CleanupRequest)(nil),                        // 15: teleport.plugins.v1.CleanupRequest
-	nil,                                           // 16: teleport.plugins.v1.CreatePluginRequest.CredentialLabelsEntry
-	nil,                                           // 17: teleport.plugins.v1.SearchPluginStaticCredentialsRequest.LabelsEntry
-	(*types.PluginV1)(nil),                        // 18: types.PluginV1
-	(*types.PluginBootstrapCredentialsV1)(nil),    // 19: types.PluginBootstrapCredentialsV1
-	(*types.PluginStaticCredentialsV1)(nil),       // 20: types.PluginStaticCredentialsV1
-	(*types.PluginCredentialsV1)(nil),             // 21: types.PluginCredentialsV1
-	(*types.PluginStatusV1)(nil),                  // 22: types.PluginStatusV1
-	(*types.ResourceID)(nil),                      // 23: types.ResourceID
-	(*emptypb.Empty)(nil),                         // 24: google.protobuf.Empty
+	(*CreatePluginOauthTokenRequest)(nil),         // 16: teleport.plugins.v1.CreatePluginOauthTokenRequest
+	(*CreatePluginOauthTokenResponse)(nil),        // 17: teleport.plugins.v1.CreatePluginOauthTokenResponse
+	nil,                                           // 18: teleport.plugins.v1.CreatePluginRequest.CredentialLabelsEntry
+	nil,                                           // 19: teleport.plugins.v1.SearchPluginStaticCredentialsRequest.LabelsEntry
+	(*types.PluginV1)(nil),                        // 20: types.PluginV1
+	(*types.PluginBootstrapCredentialsV1)(nil),    // 21: types.PluginBootstrapCredentialsV1
+	(*types.PluginStaticCredentialsV1)(nil),       // 22: types.PluginStaticCredentialsV1
+	(*types.PluginCredentialsV1)(nil),             // 23: types.PluginCredentialsV1
+	(*types.PluginStatusV1)(nil),                  // 24: types.PluginStatusV1
+	(*types.ResourceID)(nil),                      // 25: types.ResourceID
+	(*emptypb.Empty)(nil),                         // 26: google.protobuf.Empty
 }
 var file_teleport_plugins_v1_plugin_service_proto_depIdxs = []int32{
-	18, // 0: teleport.plugins.v1.CreatePluginRequest.plugin:type_name -> types.PluginV1
-	19, // 1: teleport.plugins.v1.CreatePluginRequest.bootstrap_credentials:type_name -> types.PluginBootstrapCredentialsV1
-	20, // 2: teleport.plugins.v1.CreatePluginRequest.static_credentials:type_name -> types.PluginStaticCredentialsV1
-	20, // 3: teleport.plugins.v1.CreatePluginRequest.static_credentials_list:type_name -> types.PluginStaticCredentialsV1
-	16, // 4: teleport.plugins.v1.CreatePluginRequest.credential_labels:type_name -> teleport.plugins.v1.CreatePluginRequest.CredentialLabelsEntry
-	18, // 5: teleport.plugins.v1.UpdatePluginRequest.plugin:type_name -> types.PluginV1
-	18, // 6: teleport.plugins.v1.ListPluginsResponse.plugins:type_name -> types.PluginV1
-	21, // 7: teleport.plugins.v1.SetPluginCredentialsRequest.credentials:type_name -> types.PluginCredentialsV1
-	22, // 8: teleport.plugins.v1.SetPluginStatusRequest.status:type_name -> types.PluginStatusV1
+	20, // 0: teleport.plugins.v1.CreatePluginRequest.plugin:type_name -> types.PluginV1
+	21, // 1: teleport.plugins.v1.CreatePluginRequest.bootstrap_credentials:type_name -> types.PluginBootstrapCredentialsV1
+	22, // 2: teleport.plugins.v1.CreatePluginRequest.static_credentials:type_name -> types.PluginStaticCredentialsV1
+	22, // 3: teleport.plugins.v1.CreatePluginRequest.static_credentials_list:type_name -> types.PluginStaticCredentialsV1
+	18, // 4: teleport.plugins.v1.CreatePluginRequest.credential_labels:type_name -> teleport.plugins.v1.CreatePluginRequest.CredentialLabelsEntry
+	20, // 5: teleport.plugins.v1.UpdatePluginRequest.plugin:type_name -> types.PluginV1
+	20, // 6: teleport.plugins.v1.ListPluginsResponse.plugins:type_name -> types.PluginV1
+	23, // 7: teleport.plugins.v1.SetPluginCredentialsRequest.credentials:type_name -> types.PluginCredentialsV1
+	24, // 8: teleport.plugins.v1.SetPluginStatusRequest.status:type_name -> types.PluginStatusV1
 	0,  // 9: teleport.plugins.v1.GetAvailablePluginTypesResponse.plugin_types:type_name -> teleport.plugins.v1.PluginType
-	17, // 10: teleport.plugins.v1.SearchPluginStaticCredentialsRequest.labels:type_name -> teleport.plugins.v1.SearchPluginStaticCredentialsRequest.LabelsEntry
-	20, // 11: teleport.plugins.v1.SearchPluginStaticCredentialsResponse.credentials:type_name -> types.PluginStaticCredentialsV1
-	23, // 12: teleport.plugins.v1.NeedsCleanupResponse.resources_to_cleanup:type_name -> types.ResourceID
+	19, // 10: teleport.plugins.v1.SearchPluginStaticCredentialsRequest.labels:type_name -> teleport.plugins.v1.SearchPluginStaticCredentialsRequest.LabelsEntry
+	22, // 11: teleport.plugins.v1.SearchPluginStaticCredentialsResponse.credentials:type_name -> types.PluginStaticCredentialsV1
+	25, // 12: teleport.plugins.v1.NeedsCleanupResponse.resources_to_cleanup:type_name -> types.ResourceID
 	1,  // 13: teleport.plugins.v1.PluginService.CreatePlugin:input_type -> teleport.plugins.v1.CreatePluginRequest
 	2,  // 14: teleport.plugins.v1.PluginService.GetPlugin:input_type -> teleport.plugins.v1.GetPluginRequest
 	3,  // 15: teleport.plugins.v1.PluginService.UpdatePlugin:input_type -> teleport.plugins.v1.UpdatePluginRequest
@@ -1043,19 +1196,21 @@ var file_teleport_plugins_v1_plugin_service_proto_depIdxs = []int32{
 	11, // 21: teleport.plugins.v1.PluginService.SearchPluginStaticCredentials:input_type -> teleport.plugins.v1.SearchPluginStaticCredentialsRequest
 	13, // 22: teleport.plugins.v1.PluginService.NeedsCleanup:input_type -> teleport.plugins.v1.NeedsCleanupRequest
 	15, // 23: teleport.plugins.v1.PluginService.Cleanup:input_type -> teleport.plugins.v1.CleanupRequest
-	24, // 24: teleport.plugins.v1.PluginService.CreatePlugin:output_type -> google.protobuf.Empty
-	18, // 25: teleport.plugins.v1.PluginService.GetPlugin:output_type -> types.PluginV1
-	18, // 26: teleport.plugins.v1.PluginService.UpdatePlugin:output_type -> types.PluginV1
-	24, // 27: teleport.plugins.v1.PluginService.DeletePlugin:output_type -> google.protobuf.Empty
-	5,  // 28: teleport.plugins.v1.PluginService.ListPlugins:output_type -> teleport.plugins.v1.ListPluginsResponse
-	24, // 29: teleport.plugins.v1.PluginService.SetPluginCredentials:output_type -> google.protobuf.Empty
-	24, // 30: teleport.plugins.v1.PluginService.SetPluginStatus:output_type -> google.protobuf.Empty
-	10, // 31: teleport.plugins.v1.PluginService.GetAvailablePluginTypes:output_type -> teleport.plugins.v1.GetAvailablePluginTypesResponse
-	12, // 32: teleport.plugins.v1.PluginService.SearchPluginStaticCredentials:output_type -> teleport.plugins.v1.SearchPluginStaticCredentialsResponse
-	14, // 33: teleport.plugins.v1.PluginService.NeedsCleanup:output_type -> teleport.plugins.v1.NeedsCleanupResponse
-	24, // 34: teleport.plugins.v1.PluginService.Cleanup:output_type -> google.protobuf.Empty
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
+	16, // 24: teleport.plugins.v1.PluginService.CreatePluginOauthToken:input_type -> teleport.plugins.v1.CreatePluginOauthTokenRequest
+	26, // 25: teleport.plugins.v1.PluginService.CreatePlugin:output_type -> google.protobuf.Empty
+	20, // 26: teleport.plugins.v1.PluginService.GetPlugin:output_type -> types.PluginV1
+	20, // 27: teleport.plugins.v1.PluginService.UpdatePlugin:output_type -> types.PluginV1
+	26, // 28: teleport.plugins.v1.PluginService.DeletePlugin:output_type -> google.protobuf.Empty
+	5,  // 29: teleport.plugins.v1.PluginService.ListPlugins:output_type -> teleport.plugins.v1.ListPluginsResponse
+	26, // 30: teleport.plugins.v1.PluginService.SetPluginCredentials:output_type -> google.protobuf.Empty
+	26, // 31: teleport.plugins.v1.PluginService.SetPluginStatus:output_type -> google.protobuf.Empty
+	10, // 32: teleport.plugins.v1.PluginService.GetAvailablePluginTypes:output_type -> teleport.plugins.v1.GetAvailablePluginTypesResponse
+	12, // 33: teleport.plugins.v1.PluginService.SearchPluginStaticCredentials:output_type -> teleport.plugins.v1.SearchPluginStaticCredentialsResponse
+	14, // 34: teleport.plugins.v1.PluginService.NeedsCleanup:output_type -> teleport.plugins.v1.NeedsCleanupResponse
+	26, // 35: teleport.plugins.v1.PluginService.Cleanup:output_type -> google.protobuf.Empty
+	17, // 36: teleport.plugins.v1.PluginService.CreatePluginOauthToken:output_type -> teleport.plugins.v1.CreatePluginOauthTokenResponse
+	25, // [25:37] is the sub-list for method output_type
+	13, // [13:25] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
 	13, // [13:13] is the sub-list for extension extendee
 	0,  // [0:13] is the sub-list for field type_name
@@ -1072,7 +1227,7 @@ func file_teleport_plugins_v1_plugin_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_plugins_v1_plugin_service_proto_rawDesc), len(file_teleport_plugins_v1_plugin_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/plugins/v1/plugin_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/plugins/v1/plugin_service_grpc.pb.go
@@ -46,6 +46,7 @@ const (
 	PluginService_SearchPluginStaticCredentials_FullMethodName = "/teleport.plugins.v1.PluginService/SearchPluginStaticCredentials"
 	PluginService_NeedsCleanup_FullMethodName                  = "/teleport.plugins.v1.PluginService/NeedsCleanup"
 	PluginService_Cleanup_FullMethodName                       = "/teleport.plugins.v1.PluginService/Cleanup"
+	PluginService_CreatePluginOauthToken_FullMethodName        = "/teleport.plugins.v1.PluginService/CreatePluginOauthToken"
 )
 
 // PluginServiceClient is the client API for PluginService service.
@@ -80,6 +81,11 @@ type PluginServiceClient interface {
 	NeedsCleanup(ctx context.Context, in *NeedsCleanupRequest, opts ...grpc.CallOption) (*NeedsCleanupResponse, error)
 	// Cleanup will clean up the resources for the given plugin type.
 	Cleanup(ctx context.Context, in *CleanupRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// CreatePluginOauthToken issues a short-lived OAuth access token for the specified plugin.
+	//
+	// This endpoint supports the OAuth 2.0 "client_credentials" grant type, where the plugin
+	// authenticates using its client ID and client secret
+	CreatePluginOauthToken(ctx context.Context, in *CreatePluginOauthTokenRequest, opts ...grpc.CallOption) (*CreatePluginOauthTokenResponse, error)
 }
 
 type pluginServiceClient struct {
@@ -200,6 +206,16 @@ func (c *pluginServiceClient) Cleanup(ctx context.Context, in *CleanupRequest, o
 	return out, nil
 }
 
+func (c *pluginServiceClient) CreatePluginOauthToken(ctx context.Context, in *CreatePluginOauthTokenRequest, opts ...grpc.CallOption) (*CreatePluginOauthTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreatePluginOauthTokenResponse)
+	err := c.cc.Invoke(ctx, PluginService_CreatePluginOauthToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginServiceServer is the server API for PluginService service.
 // All implementations must embed UnimplementedPluginServiceServer
 // for forward compatibility.
@@ -232,6 +248,11 @@ type PluginServiceServer interface {
 	NeedsCleanup(context.Context, *NeedsCleanupRequest) (*NeedsCleanupResponse, error)
 	// Cleanup will clean up the resources for the given plugin type.
 	Cleanup(context.Context, *CleanupRequest) (*emptypb.Empty, error)
+	// CreatePluginOauthToken issues a short-lived OAuth access token for the specified plugin.
+	//
+	// This endpoint supports the OAuth 2.0 "client_credentials" grant type, where the plugin
+	// authenticates using its client ID and client secret
+	CreatePluginOauthToken(context.Context, *CreatePluginOauthTokenRequest) (*CreatePluginOauthTokenResponse, error)
 	mustEmbedUnimplementedPluginServiceServer()
 }
 
@@ -274,6 +295,9 @@ func (UnimplementedPluginServiceServer) NeedsCleanup(context.Context, *NeedsClea
 }
 func (UnimplementedPluginServiceServer) Cleanup(context.Context, *CleanupRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Cleanup not implemented")
+}
+func (UnimplementedPluginServiceServer) CreatePluginOauthToken(context.Context, *CreatePluginOauthTokenRequest) (*CreatePluginOauthTokenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreatePluginOauthToken not implemented")
 }
 func (UnimplementedPluginServiceServer) mustEmbedUnimplementedPluginServiceServer() {}
 func (UnimplementedPluginServiceServer) testEmbeddedByValue()                       {}
@@ -494,6 +518,24 @@ func _PluginService_Cleanup_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginService_CreatePluginOauthToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreatePluginOauthTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginServiceServer).CreatePluginOauthToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginService_CreatePluginOauthToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginServiceServer).CreatePluginOauthToken(ctx, req.(*CreatePluginOauthTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginService_ServiceDesc is the grpc.ServiceDesc for PluginService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -544,6 +586,10 @@ var PluginService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Cleanup",
 			Handler:    _PluginService_Cleanup_Handler,
+		},
+		{
+			MethodName: "CreatePluginOauthToken",
+			Handler:    _PluginService_CreatePluginOauthToken_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/plugins/v1/plugin_service.proto
+++ b/api/proto/teleport/plugins/v1/plugin_service.proto
@@ -216,4 +216,32 @@ service PluginService {
 
   // Cleanup will clean up the resources for the given plugin type.
   rpc Cleanup(CleanupRequest) returns (google.protobuf.Empty);
+
+  // CreatePluginOauthToken issues a short-lived OAuth access token for the specified plugin.
+  //
+  // This endpoint supports the OAuth 2.0 "client_credentials" grant type, where the plugin
+  // authenticates using its client ID and client secret
+  rpc CreatePluginOauthToken(CreatePluginOauthTokenRequest) returns (CreatePluginOauthTokenResponse);
+}
+
+// CreatePluginOauthTokenRequest is the request type for creating an OAuth token for a plugin.
+message CreatePluginOauthTokenRequest {
+  // plugin_name is the name of the plugin for which the OAuth token is requested.
+  string plugin_name = 1;
+  // client_id is the OAuth client identifier issued to the plugin.
+  string client_id = 2;
+  // client_secret is the secret associated with the client_id.
+  string client_secret = 3;
+  // grant_type is the OAuth 2.0 grant type being used. Currently, only "client_credentials" is supported.
+  string grant_type = 4;
+}
+
+// CreatePluginOauthTokenResponse is the response type for a successful OAuth token creation.
+message CreatePluginOauthTokenResponse {
+  // access_token is the generated token issued to the plugin.
+  string access_token = 1;
+  // token_type describes the type of the token issued
+  string token_type = 2;
+  // expires_in is the number of seconds until the token expires.
+  int64 expires_in = 3;
 }


### PR DESCRIPTION
  ### What
  
This PR introduces a gRPC API endpoint that issues short-lived OAuth tokens for plugins.
  
  
In the current design (e.g., Okta integration), Teleport generates a static token that is hardcoded into the client and never rotated, which presents a security  concern when the token is exposed. 


RFD Design: 
https://github.com/gravitational/teleport.e/blob/867c66489130080e847170e0440e884a728bfe92/rfd/0025e-plugin-oauth-flow.md
