### PR TITLE
[v18] Add no-restricted-imports to curb cyclic imports between JS packages

### DIFF
--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -28,6 +28,20 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
+    // Citing from the ESLint docs:
+    // https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores
+    //
+    // "By default, ESLint lints files that match the patterns **/*.js, **/*.cjs, and **/*.mjs.
+    // Those files are always matched unless you explicitly exclude them using global ignores."
+    //
+    // "Configuration objects without files or ignores are automatically applied to any file that is
+    // matched by any other configuration object."
+    //
+    // Since no configs apply rules to jsx files specifically, we need to specify them manually.
+    // And just to be future-proof we specify other non-default extensions used in the project.
+    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.jsx'],
+  },
+  {
     ignores: [
       '**/dist/**',
       '**/*_pb.*',
@@ -153,6 +167,74 @@ export default tseslint.config(
     files: ['**/*.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'warn',
+    },
+  },
+
+  /*
+   * Restricted imports
+   *
+   * If an import is caught by these rules, it means that the imported package needs to be moved
+   * elsewhere in the dependency tree.
+   * https://github.com/gravitational/teleport/issues/54872
+   */
+  {
+    files: ['web/packages/shared/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleport/*', 'e-teleport/*', 'teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['web/packages/teleport/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['e-teleport/*', 'teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['e/web/teleport/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleterm/*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['web/packages/teleterm/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['teleport/*', 'e-teleport/*'],
+            },
+          ],
+        },
+      ],
     },
   }
 );

--- a/web/packages/design/src/Menu/MenuItemIcon.jsx
+++ b/web/packages/design/src/Menu/MenuItemIcon.jsx
@@ -26,8 +26,8 @@ const MenuItemIcon = styled.span`
     color: ${props => props.theme.colors.text.main};
   }
   svg {
-    height: ${props => `${props.size}px` || '18px'};
-    height: ${props => `${props.size}px` || '18px'};
+    height: ${props => (props.size && `${props.size}px`) || '18px'};
+    height: ${props => (props.size && `${props.size}px`) || '18px'};
   }
 `;
 

--- a/web/packages/design/src/theme/palette.story.jsx
+++ b/web/packages/design/src/theme/palette.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*eslint import/namespace: ['error', { allowComputed: true }]*/
-
 import { Box, Flex } from '..';
 import * as colors from './palette';
 import { getContrastText } from './themes/sharedStyles';

--- a/web/packages/shared/components/AccessRequests/NewRequest/resource.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/resource.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceIdKind } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { KubeResourceKind } from 'teleport/services/kube';
 
 /** Available request kinds for resource-based and role-based access requests. */

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/types.ts
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/types.ts
@@ -18,6 +18,7 @@
 
 import { RequestState } from 'shared/services/accessRequests';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 export type RequestFlags = {

--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -24,6 +24,7 @@ import InputSearch from 'design/DataTable/InputSearch';
 import { PageIndicatorText } from 'design/DataTable/Pager/PageIndicatorText';
 import { AdvancedSearchToggle } from 'shared/components/AdvancedSearchToggle';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceFilter } from 'teleport/services/agents';
 
 export function SearchPanel({

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.test.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.test.tsx
@@ -19,6 +19,7 @@
 import { fireEvent, render, screen } from 'design/utils/testing';
 import Validation from 'shared/components/Validation';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 import {

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -25,6 +25,7 @@ import { FieldSelectCreatable } from 'shared/components/FieldSelect';
 import { Option } from 'shared/components/Select';
 import { requiredAll, requiredField } from 'shared/components/Validation/rules';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AllUserTraits } from 'teleport/services/user';
 
 /**

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -23,13 +23,21 @@ import styled from 'styled-components';
 import { ButtonBorder } from 'design';
 import { gap, GapProps } from 'design/system';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { SamlAppActionProvider } from 'teleport/SamlApplications/useSamlAppActions';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceActionButton } from 'teleport/UnifiedResources/ResourceActionButton';
 
 import {

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -24,6 +24,7 @@ import { CheckboxInput } from 'design/Checkbox';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../shared/CopyButton';

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -20,11 +20,17 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { ButtonBorder, Flex } from 'design';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
 
 import {

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -25,6 +25,7 @@ import { Tags, Warning } from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../shared/CopyButton';

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -28,13 +28,21 @@ import {
 } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
 import { makeErrorAttempt, makeProcessingAttempt } from 'shared/hooks/useAsync';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { apps, moreApps } from 'teleport/Apps/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { UrlResourcesParams } from 'teleport/config';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { databases, moreDatabases } from 'teleport/Databases/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { desktops, moreDesktops } from 'teleport/Desktops/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { gitServers } from 'teleport/GitServers/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { kubes, moreKubes } from 'teleport/Kubes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { moreNodes, nodes } from 'teleport/Nodes/fixtures';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
 
 import { InfoGuidePanelProvider } from '../SlidingSidePanel/InfoGuide';

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -56,6 +56,7 @@ import {
 } from 'shared/hooks/useInfiniteScroll';
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
 
 import { useInfoGuide } from '../SlidingSidePanel/InfoGuide';

--- a/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.test.ts
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { App } from 'teleport/services/apps';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import makeApp from 'teleport/services/apps/makeApps';
 
 import { guessAppIcon } from './guessAppIcon';

--- a/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/guessAppIcon.ts
@@ -22,6 +22,7 @@ import {
   resourceIconSpecs,
 } from 'design/ResourceIcon';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AppSubKind } from 'teleport/services/apps';
 
 import { UnifiedResourceApp } from '../types';

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -23,7 +23,9 @@ import { ResourceIconName } from 'design/ResourceIcon';
 import { NodeSubKind } from 'shared/services';
 import { DbProtocol } from 'shared/services/databases';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourceLabel } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { AppSubKind, PermissionSet } from 'teleport/services/apps';
 
 /**

--- a/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/testUtils.ts
@@ -18,6 +18,7 @@
 
 import 'whatwg-fetch';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { Node } from 'teleport/services/nodes';
 
 /**

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.test.ts
@@ -18,7 +18,9 @@
 
 import { act, renderHook } from '@testing-library/react';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ApiError } from 'teleport/services/api/parseError';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { Node } from 'teleport/services/nodes';
 
 import { newFetchFunc, resourceClusterIds, resourceNames } from './testUtils';

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -27,7 +27,9 @@ import {
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { isAbortError } from 'shared/utils/abortError';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ResourcesResponse } from 'teleport/services/agents';
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { ApiError } from 'teleport/services/api/parseError';
 
 /**

--- a/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
+++ b/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
@@ -251,9 +251,13 @@ const ReactSlider = createReactClass({
     this.tempArray = value.slice();
 
     for (var i = 0; i < value.length; i++) {
+      // Disabling since this is legacy code copied from some other library.
+      // eslint-disable-next-line react/no-direct-mutation-state
       this.state.value[i] = this._trimAlignValue(value[i], newProps);
     }
     if (this.state.value.length > value.length)
+      // Disabling since this is legacy code copied from some other library.
+      // eslint-disable-next-line react/no-direct-mutation-state
       this.state.value.length = value.length;
 
     // If an upperBound has not yet been determined (due to the component being hidden

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
@@ -36,6 +36,7 @@ import type { IconProps } from 'design/Icon/Icon';
 import Indicator from 'design/Indicator';
 import { MenuIcon } from 'shared/components/MenuAction';
 
+// eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 import type * as tsh from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';


### PR DESCRIPTION
Backport #55523.

This is a change related to dev tooling that does not affect the behavior of the app.

Compared to master, I had to add one extra ignore in `web/packages/shared/components/UnifiedResources/shared/guessAppIcon.ts`.