### PR TITLE
[v17] Web: fix regression when upserting join token with admin actions

### DIFF
--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -152,10 +152,12 @@ const api = {
    * It returns the JSON data if it is a valid JSON and
    * there were no response errors.
    *
-   * The field "mfaResponse" may be required if the cluster auth setting is
-   * set to: `auth_service.authentication.second_factor: webauthn` which
-   * require users to re-authenticate before performing admin actions like
-   * creating join tokens or deleting users etc.
+   * The field "mfaResponse" accepts a pre-made response to an MFA challenge
+   * for an admin action with allowReuse set to true.
+   *
+   * The cluster requires the user to re-authenticate before performing certain
+   * admin actions (e.g., creating join tokens or deleting users) when
+   * second_factor is set to webauthn.
    *
    * Generally, mfaResponse is not needed because this func will first attempt
    * a fetch without it and if the response had an error and it contained a MFA
@@ -164,9 +166,8 @@ const api = {
    * with the original URL is attempted.
    *
    * There are a few cases where providing a mfaResponse is required and it
-   * starts by creating a MFA challenge with `allowReuse` set to true:
-   *
-   *     services > auth > auth.ts > getMfaChallengeResponseForAdminAction
+   * starts by creating a MFA challenge with `allowReuse` set to true
+   * (see services/auth/auth.ts > getMfaChallengeResponseForAdminAction).
    *
    * This allow users to require re-authenticating ONCE for the following:
    *   - In the web app, we can be calling multiple endpoints back to back,
@@ -180,7 +181,8 @@ const api = {
    *     require re-authenticating. Providing a reusable mfaResponse resolves
    *     this issue.
    *
-   * The mfaResponse with reuse is good for about 5 minutes.
+   * The mfaResponse lasts for WebauthnChallengeTimeout defined in:
+   * https://github.com/gravitational/teleport/blob/b8a65486844b4125ea1cf1f08ae17e2fc5a4db5a/lib/defaults/defaults.go#L598
    */
   async fetchJsonWithMfaAuthnRetry(
     url: string,

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -152,11 +152,35 @@ const api = {
    * It returns the JSON data if it is a valid JSON and
    * there were no response errors.
    *
-   * If a response had an error and it contained a MFA authn
-   * required message, then a retry is attempted after a user
-   * successfully re-authenticates with an MFA device.
+   * The field "mfaResponse" may be required if the cluster auth setting is
+   * set to: `auth_service.authentication.second_factor: webauthn` which
+   * require users to re-authenticate before performing admin actions like
+   * creating join tokens or deleting users etc.
    *
-   * All other errors will be thrown.
+   * Generally, mfaResponse is not needed because this func will first attempt
+   * a fetch without it and if the response had an error and it contained a MFA
+   * authn required message, then this func will fetch a challenge and prompt
+   * the user to re-authn. After successfully re-authenticating, a retry fetch
+   * with the original URL is attempted.
+   *
+   * There are a few cases where providing a mfaResponse is required and it
+   * starts by creating a MFA challenge with `allowReuse` set to true:
+   *
+   *     services > auth > auth.ts > getMfaChallengeResponseForAdminAction
+   *
+   * This allow users to require re-authenticating ONCE for the following:
+   *   - In the web app, we can be calling multiple endpoints back to back,
+   *     and some or all endpoints require re-authenticating. If a non reusable
+   *     mfaResponse was provided, or mfaResponse wasn't provided then each
+   *     fetch will ask the user to re-authenticate.
+   *   - We can make a single fetch without a mfaResponse, re-authenticate
+   *     successfully as required, but the retry attempt still fails with a
+   *     vague "access denied" error. This is because there are some endpoints
+   *     where it's in the backend that are calling multiple endpoints that
+   *     require re-authenticating. Providing a reusable mfaResponse resolves
+   *     this issue.
+   *
+   * The mfaResponse with reuse is good for about 5 minutes.
    */
   async fetchJsonWithMfaAuthnRetry(
     url: string,

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -20,6 +20,7 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
 import { makeLabelMapOfStrArrs } from '../agents/make';
+import { MfaChallengeResponse } from '../mfa';
 import { withUnsupportedLabelFeatureErrorConversion } from '../version/unsupported';
 import makeJoinToken from './makeJoinToken';
 import {
@@ -98,12 +99,20 @@ class JoinTokenService {
       .then(makeJoinToken);
   }
 
-  async createJoinToken(req: CreateJoinTokenRequest) {
-    return api.post(cfg.getJoinTokensUrl(), req).then(makeJoinToken);
+  async createJoinToken(
+    req: CreateJoinTokenRequest,
+    mfaResponse: MfaChallengeResponse
+  ) {
+    return api
+      .post(cfg.getJoinTokensUrl(), req, null /* abortSignal */, mfaResponse)
+      .then(makeJoinToken);
   }
 
-  async editJoinToken(req: CreateJoinTokenRequest) {
-    const json = await api.put(cfg.getJoinTokensUrl(), req);
+  async editJoinToken(
+    req: CreateJoinTokenRequest,
+    mfaResponse: MfaChallengeResponse
+  ) {
+    const json = await api.put(cfg.getJoinTokensUrl(), req, mfaResponse);
     return makeJoinToken(json);
   }
 


### PR DESCRIPTION
Backport #55703 to branch/v17

changelog: Fixed error when creating or updating join tokens in the web UI when admin action is enabled (second_factor set to webauthn).

✅  tested CRUD with and without admin actions