### PR TITLE
Pinning shared-workflow references

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
 
       - name: Setup base cache
         uses: actions/cache/restore@v3
@@ -93,7 +93,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
 
       - name: Setup base cache
         uses: actions/cache/restore@v3
@@ -93,7 +93,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   dependency-review:
-    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   dependency-review:
-    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@main
+    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -23,7 +23,7 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Create Amplify preview environment
-      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.1
+      uses: gravitational/shared-workflows/tools/amplify-preview@c46b731e6f7e2c50024454965c6097a72f866734 # tools/amplify-preview/v0.0.1
       continue-on-error: true
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
 
       - name: Find excluded tests
         id: find_excluded

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
 
       - name: Find excluded tests
         id: find_excluded

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   terraform-lint:
-    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
     with:
       # TODO: Fix Terraform linting issues and stop using force to pass the job.
       tflint_force: true

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   terraform-lint:
-    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@main
+    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
     with:
       # TODO: Fix Terraform linting issues and stop using force to pass the job.
       tflint_force: true

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trivy:
-    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
+    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trivy:
-    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@main
+    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # main
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
# Overview

This PR introduces pinning to `shared-workflows` references in our workflow files. The intention is to depend on an immutable reference to reduce the risk of an attack where malicious code is injected into our workflows by updating one of our mutable references (tag, branch) to a malicious reference.

Opening this PR in draft to gather some opinions on potential impacts of this change.

# Impact

* Versioning of reusable config in `shared-workflows` repository needs to be documented. To start off, I just created a `workflows/v0.0.1` tag. This should be picked up by an automated version management system.
* Potential issues with automated version management. Dependabot may not be able to handle parsing/updating the versioning format of our tags (`<prefix>/<version>`). Need to investigate if this is the case.
* Necessitates backports of version bumps. This doesn't seem to be done right now for other actions but changes to our internal reusable workflow config is likely to happen more frequently and missing features likely to cause issues with CI/CD in release branches.
