### PR TITLE
[v17] build: Install correct version (0.2.95) of wasm-bindgen

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -177,7 +177,7 @@ function Install-WasmPack {
     begin {
         Write-Host "::group::Installing wasm-pack $WasmPackVersion"
         # TODO(camscale): Don't hard-code wasm-binden-cli version
-        cargo install wasm-bindgen-cli --locked --version 0.2.99
+        cargo install wasm-bindgen-cli --locked --version 0.2.95
         cargo install wasm-pack --locked --version "$WasmPackVersion"
         Write-Host "::endgroup::"
     }


### PR DESCRIPTION
Install version 0.2.95 of wasm-bindgen in the Windows build script
instead of 0.2.99. This should have been adjusted when backported from
master.

Related: https://github.com/gravitational/teleport/pull/54885
