### PR TITLE
Adding cache for `recording_encryption` resource

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -30,6 +30,7 @@ import (
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -156,6 +157,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	case types.Resource153UnwrapperT[*workloadidentityv1pb.WorkloadIdentityX509Revocation]:
 		out.Resource = &proto.Event_WorkloadIdentityX509Revocation{
 			WorkloadIdentityX509Revocation: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*recordingencryptionv1.RecordingEncryption]:
+		out.Resource = &proto.Event_RecordingEncryption{
+			RecordingEncryption: r.UnwrapT(),
 		}
 	case types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig]:
 		out.Resource = &proto.Event_HealthCheckConfig{
@@ -658,6 +663,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else if r := in.GetRelayServer(); r != nil {
+		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetRecordingEncryption(); r != nil {
 		out.Resource = types.ProtoResource153ToLegacy(r)
 		return &out, nil
 	} else {

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -35,6 +35,7 @@ import (
 	v16 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	v118 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	v113 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	v119 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	v117 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	v13 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
@@ -196,6 +197,7 @@ type Event struct {
 	//	*Event_ScopedRole
 	//	*Event_ScopedRoleAssignment
 	//	*Event_RelayServer
+	//	*Event_RecordingEncryption
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -938,6 +940,15 @@ func (x *Event) GetRelayServer() *v118.RelayServer {
 	return nil
 }
 
+func (x *Event) GetRecordingEncryption() *v119.RecordingEncryption {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_RecordingEncryption); ok {
+			return x.RecordingEncryption
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1332,6 +1343,11 @@ type Event_RelayServer struct {
 	RelayServer *v118.RelayServer `protobuf:"bytes,82,opt,name=relay_server,json=relayServer,proto3,oneof"`
 }
 
+type Event_RecordingEncryption struct {
+	// RecordingEncryption is a resource for controlling session recording encryption.
+	RecordingEncryption *v119.RecordingEncryption `protobuf:"bytes,83,opt,name=RecordingEncryption,proto3,oneof"`
+}
+
 func (*Event_ResourceHeader) isEvent_Resource() {}
 
 func (*Event_CertAuthority) isEvent_Resource() {}
@@ -1486,11 +1502,13 @@ func (*Event_ScopedRoleAssignment) isEvent_Resource() {}
 
 func (*Event_RelayServer) isEvent_Resource() {}
 
+func (*Event_RecordingEncryption) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xd5.\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xbf/\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1582,7 +1600,8 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"ScopedRole\x18P \x01(\v2%.teleport.scopes.access.v1.ScopedRoleH\x00R\n" +
 	"ScopedRole\x12e\n" +
 	"\x14ScopedRoleAssignment\x18Q \x01(\v2/.teleport.scopes.access.v1.ScopedRoleAssignmentH\x00R\x14ScopedRoleAssignment\x12F\n" +
-	"\frelay_server\x18R \x01(\v2!.teleport.presence.v1.RelayServerH\x00R\vrelayServerB\n" +
+	"\frelay_server\x18R \x01(\v2!.teleport.presence.v1.RelayServerH\x00R\vrelayServer\x12h\n" +
+	"\x13RecordingEncryption\x18S \x01(\v24.teleport.recordingencryption.v1.RecordingEncryptionH\x00R\x13RecordingEncryptionB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1682,6 +1701,7 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v117.ScopedRole)(nil),                     // 73: teleport.scopes.access.v1.ScopedRole
 	(*v117.ScopedRoleAssignment)(nil),           // 74: teleport.scopes.access.v1.ScopedRoleAssignment
 	(*v118.RelayServer)(nil),                    // 75: teleport.presence.v1.RelayServer
+	(*v119.RecordingEncryption)(nil),            // 76: teleport.recordingencryption.v1.RecordingEncryption
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1762,11 +1782,12 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	73, // 75: proto.Event.ScopedRole:type_name -> teleport.scopes.access.v1.ScopedRole
 	74, // 76: proto.Event.ScopedRoleAssignment:type_name -> teleport.scopes.access.v1.ScopedRoleAssignment
 	75, // 77: proto.Event.relay_server:type_name -> teleport.presence.v1.RelayServer
-	78, // [78:78] is the sub-list for method output_type
-	78, // [78:78] is the sub-list for method input_type
-	78, // [78:78] is the sub-list for extension type_name
-	78, // [78:78] is the sub-list for extension extendee
-	0,  // [0:78] is the sub-list for field type_name
+	76, // 78: proto.Event.RecordingEncryption:type_name -> teleport.recordingencryption.v1.RecordingEncryption
+	79, // [79:79] is the sub-list for method output_type
+	79, // [79:79] is the sub-list for method input_type
+	79, // [79:79] is the sub-list for extension type_name
+	79, // [79:79] is the sub-list for extension extendee
+	0,  // [0:79] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -1852,6 +1873,7 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_ScopedRole)(nil),
 		(*Event_ScopedRoleAssignment)(nil),
 		(*Event_RelayServer)(nil),
+		(*Event_RecordingEncryption)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -32,6 +32,7 @@ import "teleport/machineid/v1/federation.proto";
 import "teleport/notifications/v1/notifications.proto";
 import "teleport/presence/v1/relay_server.proto";
 import "teleport/provisioning/v1/provisioning.proto";
+import "teleport/recordingencryption/v1/recording_encryption.proto";
 import "teleport/scopes/access/v1/assignment.proto";
 import "teleport/scopes/access/v1/role.proto";
 import "teleport/secreports/v1/secreports.proto";
@@ -227,5 +228,7 @@ message Event {
     // ScopedRoleAssignment is an assignment of one or more scoped roles to a user.
     teleport.scopes.access.v1.ScopedRoleAssignment ScopedRoleAssignment = 81;
     teleport.presence.v1.RelayServer relay_server = 82;
+    // RecordingEncryption is a resource for controlling session recording encryption.
+    teleport.recordingencryption.v1.RecordingEncryption RecordingEncryption = 83;
   }
 }

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -112,6 +112,7 @@ type Config struct {
 	PluginStaticCredentials services.PluginStaticCredentials
 	GitServers              services.GitServers
 	HealthCheckConfig       services.HealthCheckConfigReader
+	RecordingEncryption     services.RecordingEncryption
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -213,6 +214,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		GitServers:              cfg.GitServers,
 		HealthCheckConfig:       cfg.HealthCheckConfig,
 		BotInstanceService:      cfg.BotInstance,
+		RecordingEncryption:     cfg.RecordingEncryption,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -256,6 +256,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 
 		recordingEncryptionManager, err := recordingencryption.NewManager(recordingencryption.ManagerConfig{
 			Backend:       localRecordingEncryption,
+			Cache:         localRecordingEncryption,
 			ClusterConfig: cfg.ClusterConfiguration,
 			KeyStore:      cfg.KeyStore,
 			Logger:        cfg.Logger,

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -553,6 +553,7 @@ func InitTestAuthCache(p TestAuthCacheParams) error {
 		GitServers:              p.AuthServer.Services.GitServers,
 		HealthCheckConfig:       p.AuthServer.Services.HealthCheckConfig,
 		BotInstance:             p.AuthServer.Services.BotInstance,
+		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -91,6 +91,7 @@ type VersionStorage interface {
 type RecordingEncryptionManager interface {
 	services.RecordingEncryption
 	recordingencryption.DecryptionKeyFinder
+	SetCache(cache recordingencryption.Cache)
 }
 
 // InitConfig is auth server init config

--- a/lib/auth/recordingencryption/manager_test.go
+++ b/lib/auth/recordingencryption/manager_test.go
@@ -134,6 +134,7 @@ func newManagerConfig(t *testing.T, bk backend.Backend, keyType types.PrivateKey
 
 	return recordingencryption.ManagerConfig{
 		Backend:       recordingEncryptionService,
+		Cache:         recordingEncryptionService,
 		ClusterConfig: clusterConfigService,
 		KeyStore:      &fakeKeyStore{keyType: keyType},
 		Logger:        utils.NewSlogLoggerForTests(),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -211,6 +211,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindHealthCheckConfig},
 		{Kind: types.KindRelayServer},
 		{Kind: types.KindBotInstance},
+		{Kind: types.KindRecordingEncryption},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	// We don't want to enable partial health for auth cache because auth uses an event stream
@@ -747,6 +748,8 @@ type Config struct {
 	HealthCheckConfig services.HealthCheckConfigReader
 	// BotInstanceService is the upstream service that we're caching
 	BotInstanceService services.BotInstance
+	// RecordingEncryption manages state surrounding session recording encryption
+	RecordingEncryption services.RecordingEncryption
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -34,6 +34,7 @@ import (
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -140,6 +141,7 @@ type collections struct {
 	secReportsStates                   *collection[*secreports.ReportState, securityReportStateIndex]
 	relayServers                       *collection[*presencev1.RelayServer, relayServerIndex]
 	botInstances                       *collection[*machineidv1.BotInstance, botInstanceIndex]
+	recordingEncryption                *collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in
@@ -740,10 +742,19 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.botInstances = collect
 			out.byKind[resourceKind] = out.botInstances
+		case types.KindRecordingEncryption:
+			collect, err := newRecordingEncryptionCollection(c.RecordingEncryption, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.recordingEncryption = collect
+			out.byKind[resourceKind] = out.recordingEncryption
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)
 			}
+
 		}
 	}
 

--- a/lib/cache/recording_encryption.go
+++ b/lib/cache/recording_encryption.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type recordingEncryptionIndex string
+
+const recordingEncryptionNameIndex recordingEncryptionIndex = "name"
+
+func newRecordingEncryptionCollection(upstream services.RecordingEncryption, w types.WatchKind) (*collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter RecordingEncryption")
+	}
+
+	return &collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]{
+		store: newStore(proto.CloneOf[*recordingencryptionv1.RecordingEncryption], map[recordingEncryptionIndex]func(*recordingencryptionv1.RecordingEncryption) string{
+			recordingEncryptionNameIndex: func(r *recordingencryptionv1.RecordingEncryption) string {
+				return r.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*recordingencryptionv1.RecordingEncryption, error) {
+			recordingEncryption, err := upstream.GetRecordingEncryption(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return []*recordingencryptionv1.RecordingEncryption{recordingEncryption}, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *recordingencryptionv1.RecordingEncryption {
+			return &recordingencryptionv1.RecordingEncryption{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetRecordingEncryption returns the cached RecordingEncryption for the cluster
+func (c *Cache) GetRecordingEncryption(ctx context.Context) (*recordingencryptionv1.RecordingEncryption, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRecordingEncryption")
+	defer span.End()
+
+	getter := genericGetter[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]{
+		cache:      c,
+		collection: c.collections.recordingEncryption,
+		index:      recordingEncryptionNameIndex,
+		upstreamGet: func(ctx context.Context, ident string) (*recordingencryptionv1.RecordingEncryption, error) {
+			encryption, err := c.Config.RecordingEncryption.GetRecordingEncryption(ctx)
+			return encryption, trace.Wrap(err)
+		},
+	}
+
+	out, err := getter.get(ctx, types.MetaNameRecordingEncryption)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/recording_encryption_test.go
+++ b/lib/cache/recording_encryption_test.go
@@ -1,0 +1,81 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func newRecordingEncryption() *recordingencryptionv1.RecordingEncryption {
+	return &recordingencryptionv1.RecordingEncryption{
+		Kind:    types.KindRecordingEncryption,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameRecordingEncryption,
+		},
+		Spec: &recordingencryptionv1.RecordingEncryptionSpec{
+			ActiveKeys: nil,
+		},
+	}
+}
+
+// TestRecordingEncryption tests that CRUD operations on the RecordingEncryption resource are
+// replicated from the backend to the cache.
+func TestRecordingEncryption(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*recordingencryptionv1.RecordingEncryption]{
+		newResource: func(name string) (*recordingencryptionv1.RecordingEncryption, error) {
+			return newRecordingEncryption(), nil
+		},
+		create: func(ctx context.Context, item *recordingencryptionv1.RecordingEncryption) error {
+			_, err := p.recordingEncryption.CreateRecordingEncryption(ctx, item)
+			return trace.Wrap(err)
+		},
+		update: func(ctx context.Context, item *recordingencryptionv1.RecordingEncryption) error {
+			_, err := p.recordingEncryption.UpdateRecordingEncryption(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*recordingencryptionv1.RecordingEncryption, error) {
+			item, err := p.recordingEncryption.GetRecordingEncryption(ctx)
+			if trace.IsNotFound(err) {
+				return []*recordingencryptionv1.RecordingEncryption{}, nil
+			}
+			return []*recordingencryptionv1.RecordingEncryption{item}, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*recordingencryptionv1.RecordingEncryption, error) {
+			item, err := p.cache.GetRecordingEncryption(ctx)
+			if trace.IsNotFound(err) {
+				return []*recordingencryptionv1.RecordingEncryption{}, nil
+			}
+			return []*recordingencryptionv1.RecordingEncryption{item}, trace.Wrap(err)
+		},
+		deleteAll: func(ctx context.Context) error {
+			return trace.Wrap(p.recordingEncryption.DeleteRecordingEncryption(ctx))
+		},
+	})
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2130,6 +2130,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 	recordingEncryptionManager, err := recordingencryption.NewManager(recordingencryption.ManagerConfig{
 		Backend:       localRecordingEncryption,
+		Cache:         localRecordingEncryption,
 		KeyStore:      keyStore,
 		Logger:        logger,
 		ClusterConfig: clusterConfig,
@@ -2327,6 +2328,7 @@ func (process *TeleportProcess) initAuthService() error {
 				return trace.Wrap(err)
 			}
 			as.Cache = cache
+			recordingEncryptionManager.SetCache(cache)
 
 			return nil
 		})
@@ -2796,6 +2798,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.GitServers = services.GitServers
 	cfg.HealthCheckConfig = services.HealthCheckConfig
 	cfg.BotInstance = services.BotInstance
+	cfg.RecordingEncryption = services.RecordingEncryptionManager
 
 	return accesspoint.NewCache(cfg)
 }


### PR DESCRIPTION
This adds cache support for the recording encryption resource. The only operation that makes use of the cache is decryption during replay which is powered by [FindDecryptionKey](https://github.com/gravitational/teleport/pull/55857/files#diff-adbb12b70a90913acc1b524f9925c6f100ed640a59c2ff07c8966cb7031d5316L369-L370)