### PR TITLE
Fix List Deployed Database Services API when there's no services

### DIFF
--- a/lib/integrations/awsoidc/listdeployeddatabaseservice.go
+++ b/lib/integrations/awsoidc/listdeployeddatabaseservice.go
@@ -147,6 +147,10 @@ func ListDeployedDatabaseServices(ctx context.Context, clt ListDeployedDatabaseS
 		return nil, trace.Wrap(convertedError)
 	}
 
+	if len(listServicesOutput.ServiceArns) == 0 {
+		return &ListDeployedDatabaseServicesResponse{}, nil
+	}
+
 	describeServicesOutput, err := clt.DescribeServices(ctx, &ecs.DescribeServicesInput{
 		Services: listServicesOutput.ServiceArns,
 		Include:  []ecstypes.ServiceField{ecstypes.ServiceFieldTags},


### PR DESCRIPTION
Calling `ECS:DescribeServices` AWS API with an empty list returns an error.
Instead of doing so, if `ECS:ListServices` returns an empty list of Services, then return an empty list of deployed database services right away.

Reported by @kimlisa 

Eg error
<img width="2150" alt="image" src="https://github.com/user-attachments/assets/193ab439-35d9-407e-947c-a3cc5a50e130" />
