### PR TITLE
Automatically allow access to self-subject-reviews for kube access.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1440,6 +1440,15 @@ var KubernetesResourcesKinds = []string{
 	KindKubeIngress,
 }
 
+// KubernetesResourceSelfSubjectAccessReview is a Kubernetes resource that
+// represents a self-subject access review. This gets injected in the allow section in the roles.
+var KubernetesResourceSelfSubjectAccessReview = KubernetesResource{
+	Kind:     "selfsubjectaccessreviews",
+	Name:     Wildcard,
+	Verbs:    []string{"create"},
+	APIGroup: "authorization.k8s.io",
+}
+
 // KubernetesResourcesV7KindGroups maps the legacy Teleport kube kinds
 // to their kubernetes group.
 // Used for validation in role >=v8 to check whether an older value has

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -470,7 +470,12 @@ func (r *RoleV6) SetKubeGroups(rct RoleConditionType, groups []string) {
 // access to.
 func (r *RoleV6) GetKubeResources(rct RoleConditionType) []KubernetesResource {
 	if rct == Allow {
-		return r.convertAllowKubernetesResourcesBetweenRoleVersions(r.Spec.Allow.KubernetesResources)
+		out := r.convertAllowKubernetesResourcesBetweenRoleVersions(r.Spec.Allow.KubernetesResources)
+		// We need to support `kubectl auth can-i` as we prompt the user to use this when they get an access denied error.
+		// Inject a selfsubjectaccessreviews resource to allow for it. It can still be explicitly denied by the role if
+		// set in the `deny` section.
+		out = append(out, KubernetesResourceSelfSubjectAccessReview)
+		return out
 	}
 	return r.convertKubernetesResourcesBetweenRoleVersions(r.Spec.Deny.KubernetesResources)
 }

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -188,6 +188,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 			assertErrorCreation: require.NoError,
 		},
@@ -211,6 +212,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  "",
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 			assertErrorCreation: require.NoError,
 		},
@@ -316,6 +318,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -355,6 +358,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -413,6 +417,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:    []string{Wildcard},
 					APIGroup: Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -500,6 +505,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{Wildcard},
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 
@@ -580,6 +586,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:     []string{Wildcard},
 					APIGroup:  Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -623,6 +630,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:     []string{Wildcard},
 					APIGroup:  Wildcard,
 				},
+				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -632,7 +640,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 				resources: nil,
 			},
 			assertErrorCreation: require.NoError,
-			wantAllow:           nil,
+			wantAllow:           []KubernetesResource{KubernetesResourceSelfSubjectAccessReview},
 		},
 	}
 	for _, tt := range tests {
@@ -892,6 +900,7 @@ func appendV7KubeResources() []KubernetesResource {
 		},
 		)
 	}
+	resources = append(resources, KubernetesResourceSelfSubjectAccessReview)
 	return resources
 }
 

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -188,7 +188,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 			assertErrorCreation: require.NoError,
 		},
@@ -212,7 +211,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  "",
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 			assertErrorCreation: require.NoError,
 		},
@@ -318,7 +316,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -358,7 +355,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:      "test",
 					APIGroup:  Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -417,7 +413,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:    []string{Wildcard},
 					APIGroup: Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -505,7 +500,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{Wildcard},
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 
@@ -586,7 +580,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:     []string{Wildcard},
 					APIGroup:  Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -630,7 +623,6 @@ func TestRole_GetKubeResources(t *testing.T) {
 					Verbs:     []string{Wildcard},
 					APIGroup:  Wildcard,
 				},
-				KubernetesResourceSelfSubjectAccessReview,
 			},
 		},
 		{
@@ -640,7 +632,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 				resources: nil,
 			},
 			assertErrorCreation: require.NoError,
-			wantAllow:           []KubernetesResource{KubernetesResourceSelfSubjectAccessReview},
+			wantAllow:           nil,
 		},
 	}
 	for _, tt := range tests {
@@ -669,6 +661,7 @@ func TestRole_GetKubeResources(t *testing.T) {
 			}
 			if tt.wantDeny == nil {
 				got := r.GetKubeResources(Allow)
+				tt.wantAllow = append(tt.wantAllow, KubernetesResourceSelfSubjectAccessReview)
 				require.Equal(t, tt.wantAllow, got)
 			}
 			got := r.GetKubeResources(Deny)
@@ -900,7 +893,6 @@ func appendV7KubeResources() []KubernetesResource {
 		},
 		)
 	}
-	resources = append(resources, KubernetesResourceSelfSubjectAccessReview)
 	return resources
 }
 

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -431,3 +431,171 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 		})
 	}
 }
+
+// TestSelfSubjectAccessReviewsAllowed tests that the SelfSubjectAccessReview
+// endpoint can be accessed even if not explicitely allowed by the role.
+func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
+	t.Parallel()
+
+	_, testCtx := newTestKubeCRDMock(t, testingkubemock.WithTeleportRoleCRD)
+
+	newTestUserV7 := newTestUserFactory(t, testCtx, "", types.V7)
+	newTestUserV8 := newTestUserFactory(t, testCtx, "", types.V8)
+
+	tests := []struct {
+		name    string
+		user    types.User
+		wantErr bool
+	}{
+		{
+			name:    "full default access v7",
+			user:    newTestUserV7(nil, nil),
+			wantErr: false,
+		},
+		{
+			name:    "full default access v8",
+			user:    newTestUserV8(nil, nil),
+			wantErr: false,
+		},
+		{
+			name: "namespace access v7",
+			user: newTestUserV7([]types.KubernetesResource{
+				{
+					Kind:  types.KindKubeNamespace,
+					Name:  "default",
+					Verbs: []string{types.Wildcard},
+				},
+			}, nil),
+			wantErr: false,
+		},
+		{
+			name: "wildcard namespace access v8",
+			user: newTestUserV8([]types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: "default",
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}, nil),
+			wantErr: false,
+		},
+		{
+			name: "single pod access v7",
+			user: newTestUserV7([]types.KubernetesResource{
+				{
+					Kind:      types.KindKubePod,
+					Name:      "pod-1",
+					Namespace: "default",
+					Verbs:     []string{"get"},
+				},
+			}, nil),
+			wantErr: false,
+		},
+		{
+			name: "single pod access v8",
+			user: newTestUserV8([]types.KubernetesResource{
+				{
+					Kind:      "pods",
+					Name:      "pod-1",
+					Namespace: "default",
+					Verbs:     []string{"get"},
+					APIGroup:  "",
+				},
+			}, nil),
+			wantErr: false,
+		},
+		// NOTE: SelfSubjectAccessReview can't be explicitly denied in role v7.
+		{
+			name: "explicit deny v8",
+			user: newTestUserV8([]types.KubernetesResource{
+				{
+					Kind:      "pods",
+					Name:      "pod-1",
+					Namespace: "default",
+					Verbs:     []string{"get"},
+					APIGroup:  "",
+				},
+			}, []types.KubernetesResource{
+				{
+					Kind:     "selfsubjectaccessreviews",
+					Name:     types.Wildcard,
+					Verbs:    []string{"create"},
+					APIGroup: "authorization.k8s.io",
+				},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "wildcard deny v7",
+			user: newTestUserV7([]types.KubernetesResource{
+				{
+					Kind:      types.KindKubePod,
+					Name:      "pod-1",
+					Namespace: "default",
+					Verbs:     []string{"get"},
+				},
+			}, []types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+				},
+			}),
+			wantErr: true,
+		},
+		{
+			name: "wildcard deny v8",
+			user: newTestUserV8([]types.KubernetesResource{
+				{
+					Kind:      "pods",
+					Name:      "pod-1",
+					Namespace: "default",
+					Verbs:     []string{"get"},
+					APIGroup:  "",
+				},
+			}, []types.KubernetesResource{
+				{
+					Kind:      types.Wildcard,
+					Name:      types.Wildcard,
+					Namespace: types.Wildcard,
+					Verbs:     []string{types.Wildcard},
+					APIGroup:  types.Wildcard,
+				},
+			}),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a kube dynClient with user certs for auth.
+			client, _, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+
+			// Create a SelfSubjectAccessReview object.
+			obj := &authv1.SelfSubjectAccessReview{
+				Spec: authv1.SelfSubjectAccessReviewSpec{
+					ResourceAttributes: &authv1.ResourceAttributes{
+						Resource: "nodes",
+						Verb:     "list",
+					},
+				},
+			}
+
+			// Call the SelfSubjectAccessReview endpoint.
+			_, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
+				context.TODO(),
+				obj,
+				metav1.CreateOptions{},
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -433,7 +433,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 }
 
 // TestSelfSubjectAccessReviewsAllowed tests that the SelfSubjectAccessReview
-// endpoint can be accessed even if not explicitely allowed by the role.
+// endpoint can be accessed even if not explicitly allowed by the role.
 func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/lib/kube/proxy/testing/kube_server/data/api_authorization.k8s.io_v1.json
+++ b/lib/kube/proxy/testing/kube_server/data/api_authorization.k8s.io_v1.json
@@ -1,0 +1,43 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "authorization.k8s.io/v1",
+  "resources": [
+    {
+      "name": "localsubjectaccessreviews",
+      "singularName": "localsubjectaccessreview",
+      "namespaced": true,
+      "kind": "LocalSubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "selfsubjectaccessreviews",
+      "singularName": "selfsubjectaccessreview",
+      "namespaced": false,
+      "kind": "SelfSubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "selfsubjectrulesreviews",
+      "singularName": "selfsubjectrulesreview",
+      "namespaced": false,
+      "kind": "SelfSubjectRulesReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "subjectaccessreviews",
+      "singularName": "subjectaccessreview",
+      "namespaced": false,
+      "kind": "SubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/lib/kube/proxy/testing/kube_server/discovery.go
+++ b/lib/kube/proxy/testing/kube_server/discovery.go
@@ -40,13 +40,16 @@ var (
 	apiV1Response string
 	//go:embed data/apis_rbac.authorization.k8s.io_v1.json
 	apiRBACV1Response string
+	//go:embed data/api_authorization.k8s.io_v1.json
+	apiAuthzV1Response string
 )
 
 const (
-	apiEndpoint     = "/api"
-	apiV1Endpoint   = "/api/v1"
-	apisEndpoint    = "/apis"
-	apiRBACEndpoint = "/apis/rbac.authorization.k8s.io/v1"
+	apiEndpoint      = "/api"
+	apiV1Endpoint    = "/api/v1"
+	apisEndpoint     = "/apis"
+	apiRBACEndpoint  = "/apis/rbac.authorization.k8s.io/v1"
+	apiAuthzEndpoint = "/apis/authorization.k8s.io/v1"
 )
 
 func (s *KubeMockServer) discoveryEndpoint(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
@@ -59,6 +62,9 @@ func (s *KubeMockServer) discoveryEndpoint(w http.ResponseWriter, req *http.Requ
 		return nil, nil
 	case apiRBACEndpoint:
 		w.Write([]byte(apiRBACV1Response))
+		return nil, nil
+	case apiAuthzEndpoint:
+		w.Write([]byte(apiAuthzV1Response))
 		return nil, nil
 	case apisEndpoint:
 		w.Write(apisDiscovery(s.crds))
@@ -107,6 +113,19 @@ func apisDiscovery(crds map[GVP]*CRD) []byte {
 				Versions: []version{
 					{
 						GroupVersion: "rbac.authorization.k8s.io/v1",
+						Version:      "v1",
+					},
+				},
+			},
+			{
+				Name: "authorization.k8s.io",
+				PreferredVersion: version{
+					GroupVersion: "authorization.k8s.io/v1",
+					Version:      "v1",
+				},
+				Versions: []version{
+					{
+						GroupVersion: "authorization.k8s.io/v1",
 						Version:      "v1",
 					},
 				},

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -258,6 +258,7 @@ func (s *KubeMockServer) setup() {
 	router.Handle("DELETE /api/{ver}/namespaces/{namespace}/secrets/{name}", s.withWriter(s.deleteSecret))
 
 	router.Handle("POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews", s.withWriter(s.selfSubjectAccessReviews))
+	router.Handle("GET /apis/authorization.k8s.io/{ver}", s.withWriter(s.discoveryEndpoint))
 
 	for k, crd := range s.crds {
 		router.Handle("GET /apis/"+k.group+"/"+k.version+"/namespaces/{namespace}/"+k.plural, s.withWriter(s.listCRDs(crd)))

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -592,7 +592,7 @@ func (a *accessChecker) GetKubeResources(cluster types.KubeCluster) (allowed, de
 			return rolesAllowed, rolesDenied
 		}
 	}
-	return allowed, denied
+	return append(allowed, types.KubernetesResourceSelfSubjectAccessReview), denied
 }
 
 // matchKubernetesResource checks if the Kubernetes Resource does not match any

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -537,6 +537,10 @@ func TestAccessCheckerKubeResources(t *testing.T) {
 			tt.assertAccess(t, err)
 			sortKubeResourceSlice(gotAllowed)
 			sortKubeResourceSlice(gotDenied)
+			// The selfsubjectaccessrewview gets injected everywhere.
+			tt.wantAllowed = append(tt.wantAllowed, types.KubernetesResourceSelfSubjectAccessReview)
+			sortKubeResourceSlice(tt.wantAllowed)
+
 			require.EqualValues(t, tt.wantAllowed, gotAllowed)
 			require.EqualValues(t, tt.wantDenied, gotDenied)
 		})

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -8075,6 +8075,7 @@ func TestGetKubeResources(t *testing.T) {
 			set := NewRoleSet(tc.roles...)
 			accessChecker := makeAccessCheckerWithRoleSet(set)
 			allowed, denied := accessChecker.GetKubeResources(cluster)
+			tc.expectAllowed = append(tc.expectAllowed, types.KubernetesResourceSelfSubjectAccessReview)
 			require.ElementsMatch(t, tc.expectAllowed, allowed, "allow list mismatch")
 			require.ElementsMatch(t, tc.expectDenied, denied, "deny list mismatch")
 		})


### PR DESCRIPTION
Automatically allow access to self-subject-reviews for kube access to let the user call `kubectl auth can-i`.

Context: In v17, the selfsubjectreview resource was not explicitly handled and we deferred to the underly k8s rbac whether or not to allow the request. In v18, we now register that resource so it gets denied if not explicitly granted. As we already want to allow the user to call `auth can-i` (unless explicitly set in the deny section), inject that resource in the role when fetched.