### PR TITLE
Fix 24 Vale warnings

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
@@ -77,9 +77,9 @@ to plan your backup procedure.
 <details>
 <summary>AWS Key Management Service users</summary>
 
-If the Teleport Auth Service in your cluster uses Amazon Key Management Service
-for certificate authority private keys, you must replicate your keys to the new
-AWS region before reinstalling the `teleport-cluster` Helm chart. See the [AWS
+If the Teleport Auth Service in your cluster uses AWS Key Management Service for
+certificate authority private keys, you must replicate your keys to the new AWS
+region before reinstalling the `teleport-cluster` Helm chart. See the [AWS
 documentation](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html")
 for information about using KMS keys in multiple regions. 
 

--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,17 +3,20 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 ---
 
+The guides in this section explain how to protect applications with
+Teleport.
+
 ## Getting started
 - [Introduction to Enrolling Applications](./introduction.mdx): How to set up Teleport to protect applications and cloud provider APIs
 - [Protect a Web Application with Teleport](./getting-started.mdx): Provides instructions to set up the Teleport Application Service and enable secure access to a web application.
 
 ## Guides
-- [Application Access Guides (section)](./guides/): Guides for configuring Teleport application access.
+- [Guides (section)](./guides/): Guides for configuring Teleport application access.
 - [Securing Access to Cloud APIs (section)](./cloud-apis/): How to use Teleport to achieve secure access while managing your cloud-based infrastructure.
-- [Application Access JWT Authentication (section)](./jwt/): Guides for using Teleport application access JWT authentication.
+- [JWT Authentication (section)](./jwt/): Guides for using Teleport application access JWT authentication.
 
 ## Configuration & management
-- [Application Access Role-Based Access Control](./controls.mdx): Role-Based Access Control (RBAC) for Teleport application access.
+- [Role-Based Access Control](./controls.mdx): Role-Based Access Control (RBAC) for Teleport application access.
 
 ## Troubleshooting & support
-- [Troubleshooting Application Access](./troubleshooting-apps.mdx): Describes common issues and solutions for access to applications protected by Teleport.
+- [Troubleshooting](./troubleshooting-apps.mdx): Describes common issues and solutions for access to applications protected by Teleport.

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -73,10 +73,10 @@ resources:
 - The Discovery Service can run on an Azure VM with attached managed identity. This
   is the recommended way of deploying the Discovery Service in production since
   it eliminates the need to manage Azure credentials.
-- The Discovery Service can be registered as an Azure AD application (via AD's "App
-  registrations") and configured with its credentials. This is only recommended
-  for development and testing purposes since it requires Azure credentials to
-  be present in the Discovery Service's environment.
+- The Discovery Service can be registered as a Microsoft Entra ID application
+  and configured with its credentials. This is only recommended for development
+  and testing purposes since it requires Azure credentials to be present in the
+  Discovery Service's environment.
 
 <Tabs>
 <TabItem label="Using managed identity">
@@ -104,14 +104,14 @@ resources:
 </TabItem>
 <TabItem label="Using app registrations">
   <Admonition type="note">
-    Registering the Discovery Service as Azure AD application is suitable for
-    test and development scenarios, or if your Discovery Service does not run on
-    an Azure VM. For production scenarios prefer to use the managed identity
-    approach.
+    Registering the Discovery Service as a Microsoft Entra ID application is
+    suitable for test and development scenarios, or if your Discovery Service
+    does not run on an Azure VM. For production scenarios prefer to use the
+    managed identity approach.
   </Admonition>
 
   Go to the [App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
-  page of your Azure Active Directory and click on *New registration*:
+  page in Microsoft Entra ID and click on *New registration*:
 
   ![App registrations](../../../../img/azure/app-registrations@2x.png)
 

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -24,7 +24,7 @@ agent services.
 
 ## Getting started
 
-- [Database Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport database access and AWS Aurora PostgreSQL.
+- [Getting Started Guide](./getting-started.mdx): Getting started with Teleport database access and AWS Aurora PostgreSQL.
 
 ## Guides
 
@@ -37,10 +37,10 @@ agent services.
 
 ## Configuration & management
 
-- [Database Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
+- [Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
 - [Using the Teleport Database Service (section)](./guides/): Guides to possibilities for running the Teleport Database Service.
 
 ## Troubleshooting & support
 
-- [Database Access FAQ](./faq.mdx): Frequently asked questions about Teleport database access.
-- [Troubleshooting Database Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's Database Access
+- [FAQ](./faq.mdx): Frequently asked questions about Teleport database access.
+- [Troubleshooting](./troubleshooting.mdx): Common issues and resolutions for Teleport's Database Access

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,6 +3,9 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
+The guides in this section explain how to protect Windows desktops with
+Teleport.
+
 ## Getting started
 
 - [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
@@ -20,4 +23,5 @@ description: Guides to protecting Windows desktops with Teleport
 
 ## Troubleshooting & support
 
-- [Troubleshooting Desktop Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's desktop access
+- [Troubleshooting](./troubleshooting.mdx): Common issues and resolutions for
+  protecting Windows desktops with Teleport.

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,6 +3,9 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 ---
 
+The guides in this section explain how to protect Kubernetes clusters with
+Teleport.
+
 ## Getting started
 
 - [Introduction to Enrolling Kubernetes Clusters](./introduction.mdx): Learn how Teleport can protect your Kubernetes clusters with RBAC, audit logging, and more.
@@ -15,9 +18,11 @@ description: Guides to protecting Kubernetes clusters with Teleport
 
 ## Configuration & management
 
-- [Teleport Kubernetes Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
+- [Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
 
 ## Troubleshooting & support
 
-- [Kubernetes Access FAQ](./faq.mdx): Frequently asked questions about Teleport Kubernetes Access
-- [Kubernetes Access Troubleshooting](./troubleshooting.mdx): Troubleshooting common issues with Kubernetes access
+- [FAQ](./faq.mdx): Frequently asked questions about
+  protecting Kubernetes clusters with Teleport.
+- [Troubleshooting](./troubleshooting.mdx): Troubleshooting
+  common issues with protecting Kubernetes clusters with Teleport.

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,14 +3,17 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 ---
 
+The guides in this section explain how to protect Linux servers with
+Teleport.
+
 ## Getting started
 
 - [Introduction to Enrolling Servers](./introduction.mdx): Teleport server access features and introduction.
-- [Server Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport server access.
+- [Getting Started Guide](./getting-started.mdx): Getting started with Teleport server access.
 
 ## Guides
 
-- [Server Access Guides (section)](./guides/): Teleport server access guides.
+- [Guides (section)](./guides/): Teleport server access guides.
 - [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
 
 ## Configuration & management
@@ -19,4 +22,4 @@ description: Guides to protecting Linux servers with Teleport, including OpenSSH
 
 ## Troubleshooting & support
 
-- [Troubleshooting Server Access](./troubleshooting-server.mdx): Describes common issues and solutions for access to servers.
+- [Troubleshooting](./troubleshooting-server.mdx): Describes common issues and solutions for access to servers.

--- a/docs/pages/includes/self-hosted-helm-dns.mdx
+++ b/docs/pages/includes/self-hosted-helm-dns.mdx
@@ -49,7 +49,8 @@ Obtain the address of your load balancer by following the instructions below.
    </Tabs>
 
 1. Once you create the records, use the following command to confirm that your
-   Teleport cluster is running:
+   Teleport cluster is running, assigning <Var name="clusterName" />  to the
+   name of your cluster:
 
    ```code
    $ curl https://<Var name="clusterName" />/webapi/ping


### PR DESCRIPTION
- Ensure all pages have introductory text before the first H2.
- Remove outdated "[Protocol] Access" language.
- Ensure all Vars have at least two instances of the same name within a page.
- Use official AWS and Azure product names.