### PR TITLE
Move Kubernetes specific http helpers to lib/kube

### DIFF
--- a/lib/kube/grpc/utils.go
+++ b/lib/kube/grpc/utils.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/kube/internal"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -94,7 +94,7 @@ func (s *Server) buildKubeClient() (kubernetes.Interface, error) {
 
 	cfg := &rest.Config{
 		Host:      s.proxyAddress,
-		Transport: auth.NewImpersonatorRoundTripper(transport),
+		Transport: internal.NewImpersonatorRoundTripper(transport),
 	}
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	return kubeClient, trace.Wrap(err)

--- a/lib/kube/internal/http.go
+++ b/lib/kube/internal/http.go
@@ -1,0 +1,111 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+const (
+	// teleportImpersonateUserHeader is a header that specifies teleport user identity
+	// that the proxy is impersonating.
+	teleportImpersonateUserHeader = "Teleport-Impersonate-User"
+	// teleportImpersonateIPHeader is a header that specifies the real user IP address.
+	teleportImpersonateIPHeader = "Teleport-Impersonate-IP"
+)
+
+// ImpersonatorRoundTripper is a round tripper that impersonates a user with
+// the identity provided.
+type ImpersonatorRoundTripper struct {
+	http.RoundTripper
+}
+
+// NewImpersonatorRoundTripper returns a new impersonator round tripper.
+func NewImpersonatorRoundTripper(rt http.RoundTripper) *ImpersonatorRoundTripper {
+	return &ImpersonatorRoundTripper{
+		RoundTripper: rt,
+	}
+}
+
+// RoundTrip implements [http.RoundTripper] to include the identity
+// in the request header.
+func (r *ImpersonatorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+
+	identity, err := authz.UserFromContext(req.Context())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	b, err := json.Marshal(identity.GetIdentity())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.Header.Set(teleportImpersonateUserHeader, string(b))
+
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(req.Context())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req.Header.Set(teleportImpersonateIPHeader, clientSrcAddr.String())
+
+	return r.RoundTripper.RoundTrip(req)
+}
+
+// CloseIdleConnections ensures that the returned [net.RoundTripper]
+// has a CloseIdleConnections method.
+func (r *ImpersonatorRoundTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if c, ok := r.RoundTripper.(closeIdler); ok {
+		c.CloseIdleConnections()
+	}
+}
+
+// IdentityForwardingHeaders returns a copy of the provided headers with
+// the TeleportImpersonateUserHeader and TeleportImpersonateIPHeader headers
+// set to the identity provided.
+// The returned headers shouldn't be used across requests as they contain
+// the client's IP address and the user's identity.
+func IdentityForwardingHeaders(ctx context.Context, originalHeaders http.Header) (http.Header, error) {
+	identity, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	b, err := json.Marshal(identity.GetIdentity())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	headers := originalHeaders.Clone()
+	headers.Set(teleportImpersonateUserHeader, string(b))
+
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	headers.Set(teleportImpersonateIPHeader, clientSrcAddr.String())
+	return headers, nil
+}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -68,7 +68,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/entitlements"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/authz"
@@ -76,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
+	"github.com/gravitational/teleport/lib/kube/internal"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	"github.com/gravitational/teleport/lib/modules"
@@ -1325,7 +1325,7 @@ func (f *Forwarder) remoteJoin(ctx *authContext, w http.ResponseWriter, req *htt
 
 	headers := http.Header{}
 	if impersonationHeaders {
-		if headers, err = auth.IdentityForwardingHeaders(req.Context(), headers); err != nil {
+		if headers, err = internal.IdentityForwardingHeaders(req.Context(), headers); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apimachinery/third_party/forked/golang/netutil"
 
 	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/kube/internal"
 )
 
 // SpdyRoundTripper knows how to upgrade an HTTP request to one that supports
@@ -222,7 +222,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	// If we're using identity forwarding, we need to add the impersonation
 	// headers to the request before we send the request.
 	if s.useIdentityForwarding {
-		if header, err = auth.IdentityForwardingHeaders(s.ctx, header); err != nil {
+		if header, err = internal.IdentityForwardingHeaders(s.ctx, header); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/kube/proxy/roundtrip_websocket.go
+++ b/lib/kube/proxy/roundtrip_websocket.go
@@ -28,7 +28,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	kwebsocket "k8s.io/client-go/transport/websocket"
 
-	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/kube/internal"
 )
 
 // WebsocketRoundTripper knows how to upgrade an HTTP request to one that supports
@@ -68,7 +68,7 @@ func (w *WebsocketRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	// If we're using identity forwarding, we need to add the impersonation
 	// headers to the request before we send the request.
 	if w.useIdentityForwarding {
-		if header, err = auth.IdentityForwardingHeaders(w.ctx, header); err != nil {
+		if header, err = internal.IdentityForwardingHeaders(w.ctx, header); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/kube/internal"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -178,7 +178,7 @@ func (f *Forwarder) newRemoteClusterTransport(clusterName string) (http.RoundTri
 
 	return instrumentedRoundtripper(
 		f.cfg.KubeServiceType,
-		auth.NewImpersonatorRoundTripper(h2Transport),
+		internal.NewImpersonatorRoundTripper(h2Transport),
 	), tlsConfig.Clone(), nil
 }
 
@@ -279,7 +279,7 @@ func (f *Forwarder) newLocalClusterTransport(kubeClusterName string) (http.Round
 
 	return instrumentedRoundtripper(
 		f.cfg.KubeServiceType,
-		auth.NewImpersonatorRoundTripper(h2Transport),
+		internal.NewImpersonatorRoundTripper(h2Transport),
 	), tlsConfig.Clone(), nil
 }
 


### PR DESCRIPTION
`auth.ImpersonatorRoundTripper` and `auth.IdentityForwardingHeaders` have been relocated to lib/kube/internal. Both types were only consumed within lib/kube and were the last remaining reason that lib/kube depended on lib/auth.