### PR TITLE
Add assume-role for EC2 discovery

### DIFF
--- a/lib/cloud/awsconfig/awsconfig.go
+++ b/lib/cloud/awsconfig/awsconfig.go
@@ -136,6 +136,10 @@ type options struct {
 	stsClientProvider STSClientProviderFunc
 	// baseCredentials is the base config used to assume the roles.
 	baseCredentials aws.CredentialsProvider
+	// withFallbackRegionResolver is a fallback region resolver func that is
+	// called if a config does not resolve a region. If the resolver returns an
+	// error, then the default region (us-east-1) will be used.
+	withFallbackRegionResolver func(ctx context.Context) (string, error)
 }
 
 func buildOptions(optFns ...OptionsFn) (*options, error) {
@@ -324,6 +328,15 @@ func WithBaseCredentialsProvider(baseCredentialsProvider aws.CredentialsProvider
 	}
 }
 
+// WithFallbackRegionResolver sets a fallback region resolver func that is
+// called if a config does not resolve a region. If the resolver returns an
+// error, then the default region (us-east-1) will be used.
+func WithFallbackRegionResolver(fn func(ctx context.Context) (string, error)) OptionsFn {
+	return func(o *options) {
+		o.withFallbackRegionResolver = fn
+	}
+}
+
 // GetConfig returns an AWS config for the specified region, optionally
 // assuming AWS IAM Roles.
 func GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error) {
@@ -343,12 +356,26 @@ func GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Con
 func loadDefaultConfig(ctx context.Context, region string, cred aws.CredentialsProvider, opts *options) (aws.Config, error) {
 	configOpts := buildConfigOptions(region, cred, opts)
 	cfg, err := config.LoadDefaultConfig(ctx, configOpts...)
-	return cfg, trace.Wrap(err)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+	if len(cfg.Region) == 0 && opts.withFallbackRegionResolver != nil {
+		region, err := opts.withFallbackRegionResolver(ctx)
+		if err == nil {
+			cfg.Region = region
+		} else {
+			slog.DebugContext(ctx, "fallback region resolver failed, using the default region",
+				"default_region", defaultRegion,
+				"error", err,
+			)
+			cfg.Region = defaultRegion
+		}
+	}
+	return cfg, nil
 }
 
 func buildConfigOptions(region string, cred aws.CredentialsProvider, opts *options) []func(*config.LoadOptions) error {
 	configOpts := []func(*config.LoadOptions) error{
-		config.WithDefaultRegion(defaultRegion),
 		config.WithRegion(region),
 		config.WithCredentialsProvider(cred),
 		config.WithCredentialsCacheOptions(awsCredentialsCacheOptions),
@@ -362,6 +389,12 @@ func buildConfigOptions(region string, cred aws.CredentialsProvider, opts *optio
 	if opts.maxRetries != nil {
 		configOpts = append(configOpts, config.WithRetryMaxAttempts(*opts.maxRetries))
 	}
+	if opts.withFallbackRegionResolver == nil {
+		// if we pass WithDefaultRegion, then we will never get back an empty
+		// region, so we have to skip passing it here if we want to make use of
+		// a custom fallback resolver.
+		configOpts = append(configOpts, config.WithDefaultRegion(defaultRegion))
+	}
 	return configOpts
 }
 
@@ -371,13 +404,14 @@ func getBaseConfig(ctx context.Context, region string, opts *options) (aws.Confi
 		return loadDefaultConfig(ctx, region, opts.baseCredentials, opts)
 	}
 
-	slog.DebugContext(ctx, "Initializing AWS config from default credential chain",
-		"region", region,
-	)
+	slog.DebugContext(ctx, "Initializing AWS config from default credential chain")
 	cfg, err := loadDefaultConfig(ctx, region, nil, opts)
 	if err != nil {
 		return aws.Config{}, trace.Wrap(err)
 	}
+	slog.DebugContext(ctx, "Loaded AWS config from default credential chain",
+		"region", cfg.Region,
+	)
 
 	if opts.credentialsSource == credentialsSourceIntegration {
 		slog.DebugContext(ctx, "Initializing AWS config with integration credentials",

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -107,6 +107,10 @@ type BootstrapFlags struct {
 	Proxy string
 	// ForceAssumesRoles forces the presence of additional external AWS IAM roles to assume.
 	ForceAssumesRoles string
+	// AssumeRoleARN is the ARN of the role to assume while bootstrapping.
+	AssumeRoleARN string
+	// ExternalID is the external ID to use when assuming a role.
+	ExternalID string
 }
 
 // ConfiguratorActionContext context passed across configurator actions. It is

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1115,10 +1115,10 @@ func (s *Server) heartbeatEICEInstance(instances *server.EC2Instances) {
 }
 
 func (s *Server) handleEC2RemoteInstallation(instances *server.EC2Instances) error {
-	// TODO(gavin): support assume_role_arn for ec2.
 	ssmClient, err := s.GetSSMClient(s.ctx,
 		instances.Region,
 		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: instances.Integration}),
+		awsconfig.WithAssumeRole(instances.AssumeRoleARN, instances.ExternalID),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -67,6 +67,10 @@ type EC2Instances struct {
 	// Integration is the integration used to fetch the Instance and should be used to access it.
 	// Might be empty for instances that didn't use an Integration.
 	Integration string
+	// AssumeRoleARN is the ARN of the role to assume while installing.
+	AssumeRoleARN string
+	// ExternalID is the external ID to use when assuming a role.
+	ExternalID string
 
 	// DiscoveryConfigName is the DiscoveryConfig name which originated this Run Request.
 	// Empty if using static matchers (coming from the `teleport.yaml`).
@@ -195,13 +199,25 @@ type EC2ClientGetter func(ctx context.Context, region string, opts ...awsconfig.
 
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
 func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client EC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
+	return matchersToEC2InstanceFetchers(ctx, matchers, func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+		if assumeRole != nil {
+			opts = append(opts, awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID))
+		}
+		return getEC2Client(ctx, region, opts...)
+	}, discoveryConfigName)
+}
+
+// innerEC2ClientGetter is an EC2 client getter that exposes assumeRole for tests.
+type innerEC2ClientGetter func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
+
+func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client innerEC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
 	ret := []Fetcher{}
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
-			// TODO(gavin): support assume_role_arn for ec2.
-			ec2Client, err := getEC2Client(ctx, region,
+			opts := []awsconfig.OptionsFn{
 				awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: matcher.Integration}),
-			)
+			}
+			ec2Client, err := getEC2Client(ctx, region, matcher.AssumeRole, opts...)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -242,6 +258,8 @@ type ec2InstanceFetcher struct {
 	Integration         string
 	DiscoveryConfigName string
 	EnrollMode          types.InstallParamEnrollMode
+	AssumeRoleARN       string
+	ExternalID          string
 
 	// cachedInstances keeps all of the ec2 instances that were matched
 	// in the last run of GetInstances for use as a cache with
@@ -326,7 +344,7 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		}
 	}
 
-	fetcherConfig := ec2InstanceFetcher{
+	fetcher := ec2InstanceFetcher{
 		EC2:                 cfg.EC2Client,
 		Filters:             tagFilters,
 		Region:              cfg.Region,
@@ -339,7 +357,11 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 			instances: map[cachedInstanceKey]struct{}{},
 		},
 	}
-	return &fetcherConfig
+	if ar := cfg.Matcher.AssumeRole; ar != nil {
+		fetcher.AssumeRoleARN = ar.RoleARN
+		fetcher.ExternalID = ar.ExternalID
+	}
+	return &fetcher
 }
 
 // GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes
@@ -435,6 +457,8 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 					Parameters:          f.Parameters,
 					Rotation:            rotation,
 					Integration:         f.Integration,
+					AssumeRoleARN:       f.AssumeRoleARN,
+					ExternalID:          f.ExternalID,
 					DiscoveryConfigName: f.DiscoveryConfigName,
 					EnrollMode:          f.EnrollMode,
 				}

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -54,6 +54,18 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 	return &output, nil
 }
 
+func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) innerEC2ClientGetter {
+	return func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+		var roleARN string
+		if assumeRole != nil {
+			roleARN = assumeRole.RoleARN
+		}
+		return &mockEC2Client{
+			output: m[roleARN],
+		}, nil
+	}
+}
+
 func instanceMatches(inst ec2types.Instance, filters []ec2types.Filter) bool {
 	allMatched := true
 	for _, filter := range filters {
@@ -123,7 +135,6 @@ func TestNewEC2InstanceFetcherTags(t *testing.T) {
 
 func TestEC2Watcher(t *testing.T) {
 	t.Parallel()
-	client := &mockEC2Client{}
 	matchers := []types.AWSMatcher{
 		{
 			Params: &types.InstallerParams{
@@ -151,8 +162,17 @@ func TestEC2Watcher(t *testing.T) {
 			Integration: "my-aws-integration",
 			SSM:         &types.AWSSSM{},
 		},
+		{
+			Params:  &types.InstallerParams{},
+			Types:   []string{"EC2"},
+			Regions: []string{"us-west-2"},
+			Tags:    map[string]utils.Strings{"env": {"dev"}},
+			SSM:     &types.AWSSSM{},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: "alternate-role-arn",
+			},
+		},
 	}
-	ctx := context.Background()
 
 	present := ec2types.Instance{
 		InstanceId: aws.String("instance-present"),
@@ -185,6 +205,16 @@ func TestEC2Watcher(t *testing.T) {
 		Tags: []ec2types.Tag{{
 			Key:   aws.String("with-eice"),
 			Value: aws.String("please"),
+		}},
+		State: &ec2types.InstanceState{
+			Name: ec2types.InstanceStateNameRunning,
+		},
+	}
+	altAccountPresent := ec2types.Instance{
+		InstanceId: aws.String("alternate-instance"),
+		Tags: []ec2types.Tag{{
+			Key:   aws.String("env"),
+			Value: aws.String("dev"),
 		}},
 		State: &ec2types.InstanceState{
 			Name: ec2types.InstanceStateNameRunning,
@@ -223,41 +253,80 @@ func TestEC2Watcher(t *testing.T) {
 			},
 		}},
 	}
-	client.output = &output
+	altAccountOutput := ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{
+			Instances: []ec2types.Instance{
+				altAccountPresent,
+				{
+					InstanceId: aws.String("alternate-absent"),
+					Tags: []ec2types.Tag{{
+						Key:   aws.String("env"),
+						Value: aws.String("prod"),
+					}},
+					State: &ec2types.InstanceState{
+						Name: ec2types.InstanceStateNameRunning,
+					},
+				},
+			},
+		}},
+	}
+	getClient := makeMockClients(map[string]*ec2.DescribeInstancesOutput{
+		"":                   &output,
+		"alternate-role-arn": &altAccountOutput,
+	})
 
 	const noDiscoveryConfig = ""
 	fetchersFn := func() []Fetcher {
-		fetchers, err := MatchersToEC2InstanceFetchers(ctx, matchers, func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
-			return client, nil
-		}, noDiscoveryConfig)
+		fetchers, err := matchersToEC2InstanceFetchers(t.Context(), matchers, getClient, noDiscoveryConfig)
 		require.NoError(t, err)
 
 		return fetchers
 	}
-	watcher, err := NewEC2Watcher(ctx, fetchersFn, make(<-chan []types.Server))
+	watcher, err := NewEC2Watcher(t.Context(), fetchersFn, make(<-chan []types.Server))
 	require.NoError(t, err)
 
 	go watcher.Run()
 
-	result := <-watcher.InstancesC
-	require.Equal(t, EC2Instances{
-		Region:     "us-west-2",
-		Instances:  []EC2Instance{toEC2Instance(present)},
-		Parameters: map[string]string{"token": "", "scriptName": ""},
-	}, *result.EC2)
-	result = <-watcher.InstancesC
-	require.Equal(t, EC2Instances{
-		Region:     "us-west-2",
-		Instances:  []EC2Instance{toEC2Instance(presentOther)},
-		Parameters: map[string]string{"token": "", "scriptName": ""},
-	}, *result.EC2)
-	result = <-watcher.InstancesC
-	require.Equal(t, EC2Instances{
-		Region:      "us-west-2",
-		Instances:   []EC2Instance{toEC2Instance(presentForEICE)},
-		Parameters:  map[string]string{"token": "", "scriptName": "", "sshdConfigPath": ""},
-		Integration: "my-aws-integration",
-	}, *result.EC2)
+	expectedInstances := []EC2Instances{
+		{
+			Region:     "us-west-2",
+			Instances:  []EC2Instance{toEC2Instance(present)},
+			Parameters: map[string]string{"token": "", "scriptName": ""},
+		},
+		{
+			Region:     "us-west-2",
+			Instances:  []EC2Instance{toEC2Instance(presentOther)},
+			Parameters: map[string]string{"token": "", "scriptName": ""},
+		},
+		{
+			Region:      "us-west-2",
+			Instances:   []EC2Instance{toEC2Instance(presentForEICE)},
+			Parameters:  map[string]string{"token": "", "scriptName": "", "sshdConfigPath": ""},
+			Integration: "my-aws-integration",
+		},
+		{
+			Region:        "us-west-2",
+			Instances:     []EC2Instance{toEC2Instance(altAccountPresent)},
+			Parameters:    map[string]string{"token": "", "scriptName": "", "sshdConfigPath": ""},
+			AssumeRoleARN: "alternate-role-arn",
+		},
+	}
+
+	for _, instances := range expectedInstances {
+		select {
+		case result := <-watcher.InstancesC:
+			require.NotNil(t, result.EC2)
+			require.Equal(t, instances, *result.EC2)
+		case <-t.Context().Done():
+			require.Fail(t, "context canceled")
+		}
+	}
+
+	select {
+	case inst := <-watcher.InstancesC:
+		require.Fail(t, "unexpected instance: %v", inst)
+	default:
+	}
 }
 
 func TestConvertEC2InstancesToServerInfos(t *testing.T) {

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -373,6 +373,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	discoveryBootstrapCmd.Flag("manual", "When executed in \"manual\" mode, it will print the instructions to complete the configuration instead of applying them directly.").BoolVar(&configureDiscoveryBootstrapFlags.config.Manual)
 	discoveryBootstrapCmd.Flag("database-service-role", "Role name to attach database access policies to. If specified, bootstrap for the database service that accesses the databases discovered by this discovery service.").StringVar(&configureDiscoveryBootstrapFlags.databaseServiceRole)
 	discoveryBootstrapCmd.Flag("database-service-policy-name", "Name of the policy for bootstrapping database service when database-service-role is provided. ").Default(awsconfigurators.DatabaseAccessPolicyName).StringVar(&configureDiscoveryBootstrapFlags.databaseServicePolicyName)
+	discoveryBootstrapCmd.Flag("assume-role-arn", "Optional AWS IAM role to assume while bootstrapping.").StringVar(&configureDiscoveryBootstrapFlags.config.AssumeRoleARN)
+	discoveryBootstrapCmd.Flag("external-id", "Optional AWS external ID used when assuming an AWS role.").StringVar(&configureDiscoveryBootstrapFlags.config.ExternalID)
 
 	// "teleport install" command and its subcommands
 	installCmd := app.Command("install", "Teleport install commands.")


### PR DESCRIPTION
This change allows Teleport to assume a role when performing EC2 auto-discovery, same as for database discovery. It also adds the option to specify a role to assume as part of `teleport discovery bootstrap` (support for assuming different roles per matcher while bootstrapping will be in a later PR).

Resolves #23452.

Changelog: Added cross-account support for EC2 discovery