### PR TITLE
Fix missing env var in Azure DevOps guide

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -5,6 +5,7 @@
     "AADUSER",
     "ABAC",
     "ABCDEFGHIJKL",
+    "ACCESSTOKEN",
     "ADFS",
     "AICPA",
     "AICPA’s",

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -165,7 +165,8 @@ steps:
   displayName: 'Download and extract Teleport'
 - env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  script: TELEPORT_ANONYMOUS_TELEMETRY=1 ./teleport/tbot start -c tbot.yaml
+    TELEPORT_ANONYMOUS_TELEMETRY: 1
+  script: ./teleport/tbot start -c tbot.yaml
 ```
 
 Note the inclusion of the `SYSTEM_ACCESSTOKEN` environment variable. This

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -163,8 +163,13 @@ steps:
     wget https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
   displayName: 'Download and extract Teleport'
-- script: TELEPORT_ANONYMOUS_TELEMETRY=1 ./teleport/tbot start -c tbot.yaml
+- env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  script: TELEPORT_ANONYMOUS_TELEMETRY=1 ./teleport/tbot start -c tbot.yaml
 ```
+
+Note the inclusion of the `SYSTEM_ACCESSTOKEN` environment variable. This
+variable must be populated in any step where `tbot` is run.
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
 telemetry. This helps us shape the future development of `tbot`. You can disable


### PR DESCRIPTION
The documentation was missing a key environment variable.