### PR TITLE
MWI: Refactor identity impersonation

### DIFF
--- a/lib/tbot/client/builder.go
+++ b/lib/tbot/client/builder.go
@@ -1,0 +1,75 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package client
+
+import (
+	"context"
+	"log/slog"
+
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/config"
+)
+
+// NewBuilder creates a new Builder.
+func NewBuilder(cfg BuilderConfig) (*Builder, error) {
+	return &Builder{cfg: cfg}, nil
+}
+
+// BuilderConfig contains the configuration options for a Builder.
+type BuilderConfig struct {
+	// Address that will be dialed to create the client connection.
+	Address Address
+
+	// AuthServerAddressMode controls the behavior when a proxy address is
+	// given as an auth server address.
+	AuthServerAddressMode config.AuthServerAddressMode
+
+	// Resolver that will be used to find the address of a proxy server.
+	Resolver reversetunnelclient.Resolver
+
+	// Logger to which log messages will be written.
+	Logger *slog.Logger
+
+	// Insecure controls whether we will skip TLS host verification.
+	Insecure bool
+
+	// Metrics will record gRPC client metrics.
+	Metrics *grpcprom.ClientMetrics
+}
+
+// Builder provides a convenient way to create a client for a given identity
+// such as when services need to impersonate the a role to fetch a resource.
+type Builder struct{ cfg BuilderConfig }
+
+// Build a client for the given identity.
+func (b *Builder) Build(ctx context.Context, id Identity) (*client.Client, error) {
+	return New(ctx, Config{
+		Identity: id,
+
+		Address:               b.cfg.Address,
+		AuthServerAddressMode: b.cfg.AuthServerAddressMode,
+		Resolver:              b.cfg.Resolver,
+		Logger:                b.cfg.Logger,
+		Insecure:              b.cfg.Insecure,
+		Metrics:               b.cfg.Metrics,
+	})
+}

--- a/lib/tbot/client/builder.go
+++ b/lib/tbot/client/builder.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"log/slog"
 
-	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -53,7 +53,7 @@ type BuilderConfig struct {
 	Insecure bool
 
 	// Metrics will record gRPC client metrics.
-	Metrics *grpcprom.ClientMetrics
+	Metrics *prometheus.ClientMetrics
 }
 
 // Builder provides a convenient way to create a client for a given identity

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -1,0 +1,368 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package identity
+
+import (
+	"cmp"
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/crypto/ssh"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/identity")
+
+// GeneratorConfig contains the configuration options for a Generator.
+type GeneratorConfig struct {
+	// Client that will be used to request identity certificates.
+	Client *apiclient.Client
+
+	// Logger to which errors and messages will be written. Can be overridden
+	// on a per-call basis by setting GenerateParams.Logger.
+	Logger *slog.Logger
+
+	// BotIdentity is a Facade containing the bot's internal identity.
+	BotIdentity *Facade
+
+	// FIPS controls whether FIPS mode is enabled.
+	FIPS bool
+
+	// Insecure controls whether the generated identity TLS config verifies
+	// host certificate authenticity, etc.
+	Insecure bool
+}
+
+// CheckAndSetDefaults checks whether the configuration is valid and sets any
+// default values.
+func (cfg *GeneratorConfig) CheckAndSetDefaults() error {
+	switch {
+	case cfg.Client == nil:
+		return trace.BadParameter("Client is required")
+	case cfg.BotIdentity == nil:
+		return trace.BadParameter("BotIdentity is required")
+	}
+
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	return nil
+}
+
+// NewGenerator creates a new Generator with the given configuration.
+func NewGenerator(cfg GeneratorConfig) (*Generator, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, err
+	}
+	return &Generator{
+		client:      cfg.Client,
+		logger:      cfg.Logger,
+		botIdentity: cfg.BotIdentity,
+		fips:        cfg.FIPS,
+		insecure:    cfg.Insecure,
+	}, nil
+}
+
+// Generator can be used by tbot's services to generate non-renewable identities
+// scoped to the requested roles, TTL, etc.
+type Generator struct {
+	client         *apiclient.Client
+	logger         *slog.Logger
+	botIdentity    *Facade
+	fips, insecure bool
+}
+
+// GenerateOption allows you to set fields on the certificates request.
+type GenerateOption func(req *proto.UserCertsRequest)
+
+// WithKubernetesCluster sets the KubernetesCluster field on the certificates
+// request.
+func WithKubernetesCluster(name string) GenerateOption {
+	return func(req *proto.UserCertsRequest) {
+		req.KubernetesCluster = name
+	}
+}
+
+// WithRouteToApp sets the RouteToApp field on the certificates request.
+func WithRouteToApp(route proto.RouteToApp) GenerateOption {
+	return func(req *proto.UserCertsRequest) {
+		req.RouteToApp = route
+	}
+}
+
+// WithRouteToDatabase sets the RouteToDatabase field on the certificates
+// request.
+func WithRouteToDatabase(route proto.RouteToDatabase) GenerateOption {
+	return func(req *proto.UserCertsRequest) {
+		req.RouteToDatabase = route
+	}
+}
+
+// WithReissuableRoleImpersonation sets the WithReissuableRoleImpersonation
+// field on the certificates request.
+func WithReissuableRoleImpersonation(allow bool) GenerateOption {
+	return func(req *proto.UserCertsRequest) {
+		req.ReissuableRoleImpersonation = allow
+	}
+}
+
+// WithRouteToCluster sets the RouteToCluster field on the certificates request.
+func WithRouteToCluster(cluster string) GenerateOption {
+	return func(req *proto.UserCertsRequest) {
+		req.RouteToCluster = cluster
+	}
+}
+
+// GenerateParams are the parameters to Generator.Generate.
+type GenerateParams struct {
+	// Roles the generated identity should include.
+	//
+	// Generally, if the user did not specify any roles, it's best to leave
+	// this empty and rely on the default behavior (of fetching all the bot's
+	// available roles). If CurrentIdentity is set, we'll default to using the
+	// roles in its TLS certificate to avoid re-fetching them.
+	Roles []string
+
+	// TTL is the desired time to live of the certificate.
+	TTL time.Duration
+
+	// RenewalInterval is a hint of how frequently the certificate will be
+	// renewed. It's used for logging purposes only.
+	RenewalInterval time.Duration
+
+	// Options are used to set various fields on the certificates request
+	// see: WithRouteToCluster, etc.
+	Options []GenerateOption
+
+	// CurrentIdentity sets the identity on which the generated identity will be
+	// based. This largely just affects the default roles and cluster name.
+	//
+	// If you do not set CurrentIdentity, the bot's internal identity will be
+	// used. Note: you should *not* explicitly set CurrentIdentity to the bot's
+	// internal identity.
+	CurrentIdentity *Identity
+
+	// Logger to which errors and messages will be written.
+	Logger *slog.Logger
+}
+
+// GenerateFacade calls Generate and wraps the resulting Identity in a Facade
+// for easy use in API clients, etc.
+func (g *Generator) GenerateFacade(ctx context.Context, params GenerateParams) (*Facade, error) {
+	id, err := g.Generate(ctx, params)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return NewFacade(g.fips, g.insecure, id), nil
+}
+
+// Generate a non-renewable identity with the given roles, TTL, etc.
+func (g *Generator) Generate(ctx context.Context, params GenerateParams) (*Identity, error) {
+	ctx, span := tracer.Start(ctx, "Generator/Generate")
+	defer span.End()
+
+	log := cmp.Or(params.Logger, g.logger)
+
+	if len(params.Roles) == 0 {
+		if params.CurrentIdentity != nil {
+			// If the caller provided an impersonated identity, take its roles.
+			params.Roles = params.CurrentIdentity.TLSIdentity.Groups
+		} else {
+			// Otherwise, fetch the bot identity's default roles.
+			var err error
+			if params.Roles, err = g.botDefaultRoles(ctx); err != nil {
+				return nil, trace.Wrap(err, "fetching default roles")
+			}
+			log.DebugContext(ctx, "No roles configured, using all roles available.", "roles", params.Roles)
+		}
+	}
+
+	if params.CurrentIdentity == nil {
+		params.CurrentIdentity = g.botIdentity.Get()
+	}
+
+	req := proto.UserCertsRequest{
+		Username:       params.CurrentIdentity.X509Cert.Subject.CommonName,
+		Expires:        time.Now().Add(params.TTL),
+		RoleRequests:   params.Roles,
+		RouteToCluster: params.CurrentIdentity.ClusterName,
+
+		// Make sure to specify this is an impersonated cert request. If unset,
+		// auth cannot differentiate renewable vs impersonated requests when
+		// len(roleRequests) == 0.
+		UseRoleRequests: true,
+	}
+
+	for _, opt := range params.Options {
+		opt(&req)
+	}
+
+	keyPurpose := cryptosuites.BotImpersonatedIdentity
+	if req.RouteToDatabase.ServiceName != "" {
+		// We still used RSA for all database clients, all other bot
+		// impersonated identities can use ECDSA.
+		keyPurpose = cryptosuites.DatabaseClient
+	}
+
+	// Generate a fresh keypair for the impersonated identity. We don't care to
+	// reuse keys here, constantly rotate private keys to limit their effective
+	// lifetime.
+	key, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.GetCurrentSuiteFromAuthPreference(g.client),
+		keyPurpose)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.SSHPublicKey = ssh.MarshalAuthorizedKey(sshPub)
+
+	req.TLSPublicKey, err = keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// First, ask the auth server to generate a new set of certs with a new
+	// expiration date.
+	certs, err := g.client.GenerateUserCerts(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// The root CA included with the returned user certs will only contain the
+	// Teleport User CA. We'll also need the host CA for future API calls.
+	localCA, err := g.client.GetClusterCACert(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	caCerts, err := tlsca.ParseCertificatePEMs(localCA.TLSCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Append the host CAs from the auth server.
+	for _, cert := range caCerts {
+		pemBytes, err := tlsca.MarshalCertificatePEM(cert)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		certs.TLSCACerts = append(certs.TLSCACerts, pemBytes)
+	}
+
+	// Do not trust SSH CA certs as returned by GenerateUserCerts() with an
+	// impersonated identity. It only returns the SSH UserCA in this context,
+	// but we also need the HostCA and can't directly set `includeHostCA` as
+	// part of the UserCertsRequest.
+	// Instead, copy the SSHCACerts from the primary identity.
+	certs.SSHCACerts = params.CurrentIdentity.SSHCACertBytes
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	newIdentity, err := ReadIdentityFromStore(&LoadIdentityParams{
+		PrivateKeyBytes: privateKeyPEM,
+		PublicKeyBytes:  req.SSHPublicKey,
+	}, certs)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	warnOnEarlyExpiration(
+		ctx,
+		log,
+		newIdentity,
+		params.TTL,
+		params.RenewalInterval,
+	)
+
+	return newIdentity, nil
+}
+
+func (g *Generator) botDefaultRoles(ctx context.Context) ([]string, error) {
+	role, err := g.client.GetRole(ctx, g.botIdentity.Get().X509Cert.Subject.CommonName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	conditions := role.GetImpersonateConditions(types.Allow)
+	return conditions.Roles, nil
+}
+
+// warnOnEarlyExpiration logs a warning if the given identity is likely to
+// expire problematically early. This can happen if either the configured TTL is
+// less than the renewal interval, or if the server returns certs valid for a
+// shorter-than-expected period of time.
+// This assumes the identity was just renewed, for the purposes of calculating
+// TTLs, and may log false positive warnings if the time delta is large; the
+// time calculations include a 1m buffer to mitigate this.
+func warnOnEarlyExpiration(
+	ctx context.Context,
+	log *slog.Logger,
+	ident *Identity,
+	ttl, renewalInterval time.Duration,
+) {
+	// Calculate a rough TTL, assuming this was called shortly after the
+	// identity was returned. We'll add a minute buffer to compensate and avoid
+	// superfluous warning messages.
+	effectiveTTL := time.Until(ident.TLSIdentity.Expires) + time.Minute
+
+	if effectiveTTL < ttl {
+		l := log.With(
+			"requested_ttl", ttl,
+			"renewal_interval", renewalInterval,
+			"effective_ttl", effectiveTTL,
+			"expires", ident.TLSIdentity.Expires,
+			"roles", ident.TLSIdentity.Groups,
+		)
+
+		// TODO(timothyb89): we can technically fetch our individual roles
+		// without explicit permission, and could determine which role in
+		// particular limited the TTL.
+
+		if effectiveTTL < renewalInterval {
+			//nolint:sloglint // multiline string is actually constant
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"expected and below the configured renewal interval, probably "+
+				"due to a `max_session_ttl` configured on a server-side role. "+
+				"Unless corrected, the credentials will be invalid for some "+
+				"period until renewal.")
+		} else {
+			//nolint:sloglint // multiline string is actually constant
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"the requested TTL, probably due to a `max_session_ttl` "+
+				"configured on a server-side role. It may not remain valid as "+
+				"long as expected.")
+		}
+	}
+}

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -46,8 +46,9 @@ type ApplicationOutputService struct {
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 func (s *ApplicationOutputService) String() string {
@@ -99,30 +100,18 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	var err error
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-		if err != nil {
-			return trace.Wrap(err, "fetching default roles")
-		}
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
-	if err != nil {
-		return trace.Wrap(err, "generating identity")
-	}
-	// create a client that uses the impersonated identity, so that when we
-	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -138,22 +127,20 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	routedIdentity, err := generateIdentity(
+	routedIdentity, err := s.identityGenerator.Generate(
 		ctx,
-		s.botAuthClient,
-		id,
-		roles,
-		effectiveLifetime.TTL,
-		func(req *proto.UserCertsRequest) {
-			req.RouteToApp = routeToApp
+		identity.GenerateParams{
+			Roles:           s.cfg.Roles,
+			TTL:             effectiveLifetime.TTL,
+			RenewalInterval: effectiveLifetime.RenewalInterval,
+			Logger:          s.log,
+			CurrentIdentity: id.Get(),
+			Options:         []identity.GenerateOption{identity.WithRouteToApp(routeToApp)},
 		},
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	s.log.InfoContext(
 		ctx,

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -28,11 +28,10 @@ import (
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -48,11 +47,12 @@ type ApplicationTunnelService struct {
 	cfg                *config.ApplicationTunnelService
 	proxyPingCache     *proxyPingCache
 	log                *slog.Logger
-	resolver           reversetunnelclient.Resolver
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
 	botIdentityReadyCh <-chan struct{}
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 func (s *ApplicationTunnelService) Run(ctx context.Context) error {
@@ -140,17 +140,6 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 		}
 	}
 
-	// Determine the roles to use for the impersonated app access user. We fall
-	// back to all the roles the bot has if none are configured.
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botClient, s.getBotIdentity())
-		if err != nil {
-			return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "fetching default roles")
-		}
-		s.log.DebugContext(ctx, "No roles configured, using all roles available.", "roles", roles)
-	}
-
 	proxyPing, err := s.proxyPingCache.ping(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
@@ -161,7 +150,7 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 	}
 
 	s.log.DebugContext(ctx, "Issuing initial certificate for local proxy.")
-	appCert, app, err := s.issueCert(ctx, roles)
+	appCert, app, err := s.issueCert(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err)
 	}
@@ -174,7 +163,7 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 
 			if err := lp.CheckCertExpiry(ctx); err != nil {
 				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.", "reason", err.Error())
-				cert, _, err := s.issueCert(ctx, roles)
+				cert, _, err := s.issueCert(ctx)
 				if err != nil {
 					return trace.Wrap(err, "issuing cert")
 				}
@@ -209,7 +198,6 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 
 func (s *ApplicationTunnelService) issueCert(
 	ctx context.Context,
-	roles []string,
 ) (*tls.Certificate, types.Application, error) {
 	ctx, span := tracer.Start(ctx, "ApplicationTunnelService/issueCert")
 	defer span.End()
@@ -218,24 +206,17 @@ func (s *ApplicationTunnelService) issueCert(
 	// session ID may need to change. Once v17 hits, this will be automagically
 	// calculated by the auth server on cert generation, and we can fetch the
 	// routeToApp once.
-	impersonatedIdentity, err := generateIdentity(
-		ctx,
-		s.botClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	impersonatedClient, err := clientForFacade(
-		ctx,
-		s.log,
-		s.botCfg,
-		identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, impersonatedIdentity),
-		s.resolver,
-	)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, impersonatedIdentity)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -250,15 +231,13 @@ func (s *ApplicationTunnelService) issueCert(
 	}
 
 	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
-	routedIdent, err := generateIdentity(
-		ctx,
-		s.botClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		func(req *proto.UserCertsRequest) {
-			req.RouteToApp = route
-		})
+	routedIdent, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Options:         []identity.GenerateOption{identity.WithRouteToApp(route)},
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -207,12 +207,12 @@ func (s *ApplicationTunnelService) issueCert(
 	// calculated by the auth server on cert generation, and we can fetch the
 	// routeToApp once.
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		Roles:           s.cfg.Roles,
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	identityOpts := []identity.GenerateOption{
+		identity.WithRoles(s.cfg.Roles),
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	}
+	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -231,13 +231,7 @@ func (s *ApplicationTunnelService) issueCert(
 	}
 
 	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
-	routedIdent, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
-		Roles:           s.cfg.Roles,
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Options:         []identity.GenerateOption{identity.WithRouteToApp(route)},
-		Logger:          s.log,
-	})
+	routedIdent, err := s.identityGenerator.Generate(ctx, append(identityOpts, identity.WithRouteToApp(route))...)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -38,10 +39,10 @@ import (
 	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
-	"github.com/gravitational/teleport/lib/client"
+	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -59,8 +60,8 @@ type identityService struct {
 	log               *slog.Logger
 	reloadBroadcaster *channelBroadcaster
 	cfg               *config.BotConfig
-	resolver          reversetunnelclient.Resolver
 	statusReporter    readyz.Reporter
+	clientBuilder     *client.Builder
 
 	mu              sync.Mutex
 	client          *apiclient.Client
@@ -82,6 +83,22 @@ func (s *identityService) GetClient() *apiclient.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.client
+}
+
+func (s *identityService) GetGenerator() (*identity.Generator, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return identity.NewGenerator(identity.GeneratorConfig{
+		Client:      s.client,
+		BotIdentity: s.facade,
+		FIPS:        s.cfg.FIPS,
+		Insecure:    s.cfg.Insecure,
+		Logger: s.log.With(
+			teleport.ComponentKey,
+			teleport.Component(componentTBot, "identity-generator"),
+		),
+	})
 }
 
 // Ready returns a channel that will be closed when the initial identity renewal
@@ -246,7 +263,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 	} else {
 		if valid {
 			// If the identity is valid (not expired), try to renew it.
-			newIdentity, err = renewIdentity(ctx, s.log, s.cfg, s.resolver, loadedIdent)
+			newIdentity, err = renewIdentity(ctx, s.log, s.cfg, s.clientBuilder, loadedIdent)
 		} else {
 			// If the identity has expired, try to join again from scratch.
 			newIdentity, err = botIdentityFromToken(ctx, s.log, s.cfg, nil)
@@ -265,7 +282,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 		// connection and exit immediately if the connection is unavailable.
 		if err != nil {
 			facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Insecure, loadedIdent)
-			client, clientErr := clientForFacade(ctx, s.log, s.cfg, facade, s.resolver)
+			client, clientErr := s.clientBuilder.Build(ctx, facade)
 			if clientErr != nil {
 				return trace.Wrap(clientErr)
 			}
@@ -287,7 +304,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 	}
 
 	facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Insecure, newIdentity)
-	c, err := clientForFacade(ctx, s.log, s.cfg, facade, s.resolver)
+	c, err := s.clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -395,7 +412,7 @@ func (s *identityService) renew(
 		return trace.Wrap(err, "Cannot write to destination %s, aborting.", botDestination)
 	}
 
-	newIdentity, err := renewIdentity(ctx, s.log, s.cfg, s.resolver, currentIdentity)
+	newIdentity, err := renewIdentity(ctx, s.log, s.cfg, s.clientBuilder, currentIdentity)
 	if err != nil {
 		return trace.Wrap(err, "renewing identity")
 	}
@@ -426,7 +443,7 @@ func renewIdentity(
 	ctx context.Context,
 	log *slog.Logger,
 	botCfg *config.BotConfig,
-	resolver reversetunnelclient.Resolver,
+	clientBuilder *client.Builder,
 	oldIdentity *identity.Identity,
 ) (*identity.Identity, error) {
 	ctx, span := tracer.Start(ctx, "renewIdentity")
@@ -435,7 +452,7 @@ func renewIdentity(
 	// made with the most recent identity and that a connection associated with
 	// an old identity will not be used.
 	facade := identity.NewFacade(botCfg.FIPS, botCfg.Insecure, oldIdentity)
-	authClient, err := clientForFacade(ctx, log, botCfg, facade, resolver)
+	authClient, err := clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating auth client")
 	}
@@ -561,7 +578,7 @@ func botIdentityFromToken(
 		CAPins:             cfg.Onboarding.CAPins,
 		CAPath:             cfg.Onboarding.CAPath,
 		FIPS:               cfg.FIPS,
-		GetHostCredentials: client.HostCredentials,
+		GetHostCredentials: libclient.HostCredentials,
 		CipherSuites:       cfg.CipherSuites(),
 	}
 	if authClient != nil {

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -85,11 +85,10 @@ func (s *ClientCredentialOutputService) generate(ctx context.Context) error {
 	defer span.End()
 	s.log.InfoContext(ctx, "Generating output")
 
-	id, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
-		TTL:             s.botCfg.CredentialLifetime.TTL,
-		RenewalInterval: s.botCfg.CredentialLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.Generate(ctx,
+		identity.WithLifetime(s.botCfg.CredentialLifetime.TTL, s.botCfg.CredentialLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -27,6 +27,7 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
@@ -44,6 +45,7 @@ type ClientCredentialOutputService struct {
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
 }
 
 func (s *ClientCredentialOutputService) String() string {
@@ -83,19 +85,11 @@ func (s *ClientCredentialOutputService) generate(ctx context.Context) error {
 	defer span.End()
 	s.log.InfoContext(ctx, "Generating output")
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return trace.Wrap(err, "fetching default roles")
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		s.botCfg.CredentialLifetime.TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		TTL:             s.botCfg.CredentialLifetime.TTL,
+		RenewalInterval: s.botCfg.CredentialLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -27,11 +27,10 @@ import (
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client/identityfile"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -47,8 +46,9 @@ type DatabaseOutputService struct {
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 func (s *DatabaseOutputService) String() string {
@@ -100,30 +100,19 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	var err error
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-		if err != nil {
-			return trace.Wrap(err, "fetching default roles")
-		}
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -141,22 +130,17 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	routedIdentity, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		id,
-		roles,
-		effectiveLifetime.TTL,
-		func(req *proto.UserCertsRequest) {
-			req.RouteToDatabase = route
-		},
-	)
+	routedIdentity, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		CurrentIdentity: id.Get(),
+		Logger:          s.log,
+		Options:         []identity.GenerateOption{identity.WithRouteToDatabase(route)},
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	s.log.InfoContext(
 		ctx,

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -248,12 +248,11 @@ func (s *DatabaseTunnelService) getRouteToDatabaseWithImpersonation(ctx context.
 	defer span.End()
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		Roles:           s.cfg.Roles,
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithRoles(s.cfg.Roles),
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return proto.RouteToDatabase{}, trace.Wrap(err)
 	}
@@ -280,13 +279,12 @@ func (s *DatabaseTunnelService) issueCert(
 
 	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	ident, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
-		Roles:           s.cfg.Roles,
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Options:         []identity.GenerateOption{identity.WithRouteToDatabase(route)},
-		Logger:          s.log,
-	})
+	ident, err := s.identityGenerator.Generate(ctx,
+		identity.WithRoles(s.cfg.Roles),
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+		identity.WithRouteToDatabase(route),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -29,9 +29,9 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -68,11 +68,12 @@ type DatabaseTunnelService struct {
 	cfg                *config.DatabaseTunnelService
 	proxyPingCache     *proxyPingCache
 	log                *slog.Logger
-	resolver           reversetunnelclient.Resolver
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
 	botIdentityReadyCh <-chan struct{}
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 // buildLocalProxyConfig initializes the service, fetching any initial information and setting
@@ -94,17 +95,6 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 		}
 	}
 
-	// Determine the roles to use for the impersonated db access user. We fall
-	// back to all the roles the bot has if none are configured.
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botClient, s.getBotIdentity())
-		if err != nil {
-			return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "fetching default roles")
-		}
-		s.log.DebugContext(ctx, "No roles configured, using all roles available.", "roles", roles)
-	}
-
 	proxyPing, err := s.proxyPingCache.ping(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
@@ -120,7 +110,7 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	// of the service and this reduces the time needed to issue a new
 	// certificate.
 	s.log.DebugContext(ctx, "Determining route to database.")
-	routeToDatabase, err := s.getRouteToDatabaseWithImpersonation(ctx, roles)
+	routeToDatabase, err := s.getRouteToDatabaseWithImpersonation(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err)
 	}
@@ -134,7 +124,7 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	)
 
 	s.log.DebugContext(ctx, "Issuing initial certificate for local proxy.")
-	dbCert, err := s.issueCert(ctx, routeToDatabase, roles)
+	dbCert, err := s.issueCert(ctx, routeToDatabase)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err)
 	}
@@ -153,7 +143,7 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 				Username:    routeToDatabase.Username,
 			}); err != nil {
 				s.log.InfoContext(ctx, "Certificate for tunnel needs reissuing.", "reason", err.Error())
-				cert, err := s.issueCert(ctx, routeToDatabase, roles)
+				cert, err := s.issueCert(ctx, routeToDatabase)
 				if err != nil {
 					return trace.Wrap(err, "issuing cert")
 				}
@@ -253,29 +243,22 @@ func (s *DatabaseTunnelService) Run(ctx context.Context) error {
 // getRouteToDatabaseWithImpersonation fetches the route to the database with
 // impersonation of roles. This ensures that the user's selected roles actually
 // grant access to the database.
-func (s *DatabaseTunnelService) getRouteToDatabaseWithImpersonation(ctx context.Context, roles []string) (proto.RouteToDatabase, error) {
+func (s *DatabaseTunnelService) getRouteToDatabaseWithImpersonation(ctx context.Context) (proto.RouteToDatabase, error) {
 	ctx, span := tracer.Start(ctx, "DatabaseTunnelService/getRouteToDatabaseWithImpersonation")
 	defer span.End()
 
-	impersonatedIdentity, err := generateIdentity(
-		ctx,
-		s.botClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	impersonatedIdentity, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return proto.RouteToDatabase{}, trace.Wrap(err)
 	}
 
-	impersonatedClient, err := clientForFacade(
-		ctx,
-		s.log,
-		s.botCfg,
-		identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, impersonatedIdentity),
-		s.resolver,
-	)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, impersonatedIdentity)
 	if err != nil {
 		return proto.RouteToDatabase{}, trace.Wrap(err)
 	}
@@ -291,21 +274,19 @@ func (s *DatabaseTunnelService) getRouteToDatabaseWithImpersonation(ctx context.
 func (s *DatabaseTunnelService) issueCert(
 	ctx context.Context,
 	route proto.RouteToDatabase,
-	roles []string,
 ) (*tls.Certificate, error) {
 	ctx, span := tracer.Start(ctx, "DatabaseTunnelService/issueCert")
 	defer span.End()
 
 	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
-	ident, err := generateIdentity(
-		ctx,
-		s.botClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		func(req *proto.UserCertsRequest) {
-			req.RouteToDatabase = route
-		})
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	ident, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Options:         []identity.GenerateOption{identity.WithRouteToDatabase(route)},
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -30,12 +30,11 @@ import (
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/config/openssh"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -57,12 +56,13 @@ type IdentityOutputService struct {
 	log                *slog.Logger
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
-	executablePath   func() (string, error)
-	alpnUpgradeCache *alpnProxyConnUpgradeRequiredCache
+	executablePath    func() (string, error)
+	alpnUpgradeCache  *alpnProxyConnUpgradeRequiredCache
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 func (s *IdentityOutputService) String() string {
@@ -114,56 +114,41 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	var err error
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-		if err != nil {
-			return trace.Wrap(err, "fetching default roles")
-		}
-	}
-
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		effectiveLifetime.TTL,
-		func(req *proto.UserCertsRequest) {
-			req.ReissuableRoleImpersonation = s.cfg.AllowReissue
-		},
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Options:         []identity.GenerateOption{identity.WithReissuableRoleImpersonation(s.cfg.AllowReissue)},
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer impersonatedClient.Close()
 
 	if s.cfg.Cluster != "" {
-		id, err = generateIdentity(
-			ctx,
-			s.botAuthClient,
-			id,
-			roles,
-			cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-			func(req *proto.UserCertsRequest) {
-				req.RouteToCluster = s.cfg.Cluster
-				req.ReissuableRoleImpersonation = s.cfg.AllowReissue
+		id, err = s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+			Roles:           s.cfg.Roles,
+			TTL:             effectiveLifetime.TTL,
+			RenewalInterval: effectiveLifetime.RenewalInterval,
+			CurrentIdentity: id.Get(),
+			Logger:          s.log,
+			Options: []identity.GenerateOption{
+				identity.WithRouteToCluster(s.cfg.Cluster),
+				identity.WithReissuableRoleImpersonation(s.cfg.AllowReissue),
 			},
-		)
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
-
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
@@ -178,12 +163,12 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	if err := s.render(ctx, id, hostCAs, userCAs, databaseCAs); err != nil {
+	if err := s.render(ctx, id.Get(), hostCAs, userCAs, databaseCAs); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if s.cfg.SSHConfigMode == config.SSHConfigModeOn {
-		clusterNames, err := getClusterNames(ctx, impersonatedClient, id.ClusterName)
+		clusterNames, err := getClusterNames(ctx, impersonatedClient, id.Get().ClusterName)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -37,9 +37,9 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
-	"github.com/gravitational/teleport/lib/client"
+	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -62,11 +62,13 @@ type KubernetesOutputService struct {
 	log                *slog.Logger
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath func() (string, error)
+
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 func (s *KubernetesOutputService) String() string {
@@ -118,30 +120,16 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	var err error
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-		if err != nil {
-			return trace.Wrap(err, "fetching default roles")
-		}
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:  s.cfg.Roles,
+		TTL:    cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		Logger: s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
-	// create a client that uses the impersonated identity, so that when we
-	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -159,21 +147,17 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 	// offline.
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	routedIdentity, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		id,
-		roles,
-		effectiveLifetime.TTL,
-		func(req *proto.UserCertsRequest) {
-			req.KubernetesCluster = kubeClusterName
-		},
-	)
+	routedIdentity, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		CurrentIdentity: id.Get(),
+		Options:         []identity.GenerateOption{identity.WithKubernetesCluster(kubeClusterName)},
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	s.log.InfoContext(
 		ctx,
@@ -304,7 +288,7 @@ type kubernetesStatus struct {
 	teleportClusterName   string
 	kubernetesClusterName string
 	tlsServerName         string
-	credentials           *client.KeyRing
+	credentials           *libclient.KeyRing
 }
 
 func generateKubeConfigWithoutPlugin(ks *kubernetesStatus) (*clientcmdapi.Config, error) {
@@ -451,7 +435,7 @@ func selectKubeConnectionMethod(proxyPong *proxyPingResponse) (
 			return "", "", trace.Wrap(err, "parsing proxy public_addr")
 		}
 
-		return fmt.Sprintf("https://%s", addr), client.GetKubeTLSServerName(host), nil
+		return fmt.Sprintf("https://%s", addr), libclient.GetKubeTLSServerName(host), nil
 	}
 
 	// Next, we try to use the KubePublicAddr.

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -118,11 +118,10 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 	}
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -38,9 +38,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
-	"github.com/gravitational/teleport/lib/client"
+	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -61,11 +61,12 @@ type KubernetesV2OutputService struct {
 	log                *slog.Logger
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
-	executablePath func() (string, error)
+	executablePath    func() (string, error)
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 func (s *KubernetesV2OutputService) String() string {
@@ -116,30 +117,19 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return trace.Wrap(err, "fetching default roles")
-	}
-
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		effectiveLifetime.TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
 
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
-
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -161,7 +151,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 		ctx,
 		"Generated identity for Kubernetes access",
 		"matched_cluster_count", len(clusterNames),
-		"identity", describeTLSIdentity(ctx, s.log, id),
+		"identity", describeTLSIdentity(ctx, s.log, id.Get()),
 	)
 
 	// Ping the proxy to resolve connection addresses.
@@ -179,7 +169,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	keyRing, err := NewClientKeyRing(id, hostCAs)
+	keyRing, err := NewClientKeyRing(id.Get(), hostCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -192,7 +182,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 		kubernetesClusterNames: clusterNames,
 	}
 
-	return trace.Wrap(s.render(ctx, status, id, hostCAs))
+	return trace.Wrap(s.render(ctx, status, id.Get(), hostCAs))
 }
 
 // kubernetesStatus holds teleport client information necessary to populate a
@@ -201,7 +191,7 @@ type kubernetesStatusV2 struct {
 	clusterAddr            string
 	teleportClusterName    string
 	tlsServerName          string
-	credentials            *client.KeyRing
+	credentials            *libclient.KeyRing
 	kubernetesClusterNames []string
 }
 

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -36,7 +36,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -59,11 +59,12 @@ type SPIFFESVIDOutputService struct {
 	cfg            *config.SPIFFESVIDOutput
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
-	resolver       reversetunnelclient.Resolver
 	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
-	trustBundleCache *workloadidentity.TrustBundleCache
+	trustBundleCache  *workloadidentity.TrustBundleCache
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 func (s *SPIFFESVIDOutputService) String() string {
@@ -182,30 +183,19 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 	)
 	defer span.End()
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return nil, nil, nil, trace.Wrap(err, "fetching roles")
-	}
-
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		effectiveLifetime.TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "generating identity")
 	}
 
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
-
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -184,11 +184,10 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 	defer span.End()
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -55,7 +55,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
@@ -80,9 +80,9 @@ type SPIFFEWorkloadAPIService struct {
 	botCfg           *config.BotConfig
 	cfg              *config.SPIFFEWorkloadAPIService
 	log              *slog.Logger
-	resolver         reversetunnelclient.Resolver
 	trustBundleCache *workloadidentity.TrustBundleCache
 	statusReporter   readyz.Reporter
+	clientBuilder    *client.Builder
 
 	// client holds the impersonated client for the service
 	client           *apiclient.Client
@@ -109,9 +109,7 @@ func (s *SPIFFEWorkloadAPIService) setup(ctx context.Context) (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	client, err := clientForFacade(
-		ctx, s.log, s.botCfg, facade, s.resolver,
-	)
+	client, err := s.clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -105,12 +105,11 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 	}
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		Roles:           s.cfg.Roles,
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithRoles(s.cfg.Roles),
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -32,11 +32,11 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/client"
+	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -50,8 +50,9 @@ type SSHHostOutputService struct {
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 func (s *SSHHostOutputService) String() string {
@@ -103,39 +104,25 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	var err error
-	roles := s.cfg.Roles
-	if len(roles) == 0 {
-		roles, err = fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-		if err != nil {
-			return trace.Wrap(err, "fetching default roles")
-		}
-	}
-
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		effectiveLifetime.TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		Roles:           s.cfg.Roles,
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
 
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
-
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer impersonatedClient.Close()
-	clusterName := facade.Get().ClusterName
+	clusterName := id.Get().ClusterName
 
 	// generate a keypair
 	key, err := cryptosuites.GenerateKey(ctx,
@@ -163,7 +150,7 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	keyRing := &client.KeyRing{
+	keyRing := &libclient.KeyRing{
 		SSHPrivateKey: privKey,
 		Cert:          res.SshCertificate,
 	}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -359,11 +359,10 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 // the destination.
 func (s *SSHMultiplexerService) generateIdentity(ctx context.Context) (*identity.Identity, error) {
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.Generate(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -53,8 +53,8 @@ import (
 	"github.com/gravitational/teleport/lib/config/openssh"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/resumption"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -105,8 +105,10 @@ type SSHMultiplexerService struct {
 	log                *slog.Logger
 	proxyPingCache     *proxyPingCache
 	reloadBroadcaster  *channelBroadcaster
-	resolver           reversetunnelclient.Resolver
 	statusReporter     readyz.Reporter
+
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 
 	// Fields below here are initialized by the service itself on startup.
 	identity *identity.Facade
@@ -345,9 +347,7 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 		ALPNConnUpgradeRequired: connUpgradeRequired,
 	})
 
-	authClient, err := clientForFacade(
-		ctx, s.log, s.botCfg, s.identity, s.resolver,
-	)
+	authClient, err := s.clientBuilder.Build(ctx, s.identity)
 	if err != nil {
 		return nil, nil, "", nil, trace.Wrap(err)
 	}
@@ -358,19 +358,12 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 // generateIdentity generates our impersonated identity which we will write to
 // the destination.
 func (s *SSHMultiplexerService) generateIdentity(ctx context.Context) (*identity.Identity, error) {
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return nil, trace.Wrap(err, "fetching default roles")
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	id, err := s.identityGenerator.Generate(ctx, identity.GenerateParams{
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -46,7 +46,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
@@ -71,10 +71,10 @@ type WorkloadIdentityAPIService struct {
 	botCfg           *config.BotConfig
 	cfg              *config.WorkloadIdentityAPIService
 	log              *slog.Logger
-	resolver         reversetunnelclient.Resolver
 	trustBundleCache *workloadidentity.TrustBundleCache
 	crlCache         *workloadidentity.CRLCache
 	statusReporter   readyz.Reporter
+	clientBuilder    *client.Builder
 
 	// client holds the impersonated client for the service
 	client           *apiclient.Client
@@ -101,9 +101,7 @@ func (s *WorkloadIdentityAPIService) setup(ctx context.Context) (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	client, err := clientForFacade(
-		ctx, s.log, s.botCfg, facade, s.resolver,
-	)
+	client, err := s.clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_workload_identity_aws_ra.go
+++ b/lib/tbot/service_workload_identity_aws_ra.go
@@ -174,12 +174,12 @@ func (s *WorkloadIdentityAWSRAService) requestSVID(
 	)
 	defer span.End()
 
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+	id, err := s.identityGenerator.GenerateFacade(ctx,
 		// We only need this to issue the X509 SVID, so we don't need the full
 		// lifetime.
-		TTL:    time.Minute * 10,
-		Logger: s.log,
-	})
+		identity.WithLifetime(time.Minute*10, 0),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_workload_identity_aws_ra.go
+++ b/lib/tbot/service_workload_identity_aws_ra.go
@@ -34,8 +34,8 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -51,9 +51,10 @@ type WorkloadIdentityAWSRAService struct {
 	cfg                *config.WorkloadIdentityAWSRAService
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
-	resolver           reversetunnelclient.Resolver
 	reloadBroadcaster  *channelBroadcaster
 	statusReporter     readyz.Reporter
+	identityGenerator  *identity.Generator
+	clientBuilder      *client.Builder
 }
 
 // String returns a human-readable description of the service.
@@ -173,28 +174,18 @@ func (s *WorkloadIdentityAWSRAService) requestSVID(
 	)
 	defer span.End()
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return nil, nil, trace.Wrap(err, "fetching roles")
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
 		// We only need this to issue the X509 SVID, so we don't need the full
 		// lifetime.
-		time.Minute*10,
-		nil,
-	)
+		TTL:    time.Minute * 10,
+		Logger: s.log,
+	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -158,11 +158,10 @@ func (s *WorkloadIdentityJWTService) requestJWTSVID(
 	defer span.End()
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -29,7 +29,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -44,11 +44,12 @@ type WorkloadIdentityJWTService struct {
 	cfg            *config.WorkloadIdentityJWTService
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
-	resolver       reversetunnelclient.Resolver
 	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
-	trustBundleCache *workloadidentity.TrustBundleCache
+	trustBundleCache  *workloadidentity.TrustBundleCache
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 // String returns a human-readable description of the service.
@@ -156,32 +157,23 @@ func (s *WorkloadIdentityJWTService) requestJWTSVID(
 	)
 	defer span.End()
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return nil, trace.Wrap(err, "fetching roles")
-	}
-
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
-		nil,
-	)
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err, "generating identity")
 	}
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer impersonatedClient.Close()
 
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	credentials, err := workloadidentity.IssueJWTWorkloadIdentity(
 		ctx,
 		s.log,
@@ -194,8 +186,6 @@ func (s *WorkloadIdentityJWTService) requestJWTSVID(
 	if err != nil {
 		return nil, trace.Wrap(err, "generating JWT SVID")
 	}
-
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	var credential *workloadidentityv1pb.Credential
 	switch len(credentials) {

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -197,11 +197,10 @@ func (s *WorkloadIdentityX509Service) requestSVID(
 	defer span.End()
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
-		TTL:             effectiveLifetime.TTL,
-		RenewalInterval: effectiveLifetime.RenewalInterval,
-		Logger:          s.log,
-	})
+	id, err := s.identityGenerator.GenerateFacade(ctx,
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -33,7 +33,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -48,12 +48,13 @@ type WorkloadIdentityX509Service struct {
 	cfg            *config.WorkloadIdentityX509Service
 	getBotIdentity getBotIdentityFn
 	log            *slog.Logger
-	resolver       reversetunnelclient.Resolver
 	statusReporter readyz.Reporter
 	// trustBundleCache is the cache of trust bundles. It only needs to be
 	// provided when running in daemon mode.
-	trustBundleCache *workloadidentity.TrustBundleCache
-	crlCache         *workloadidentity.CRLCache
+	trustBundleCache  *workloadidentity.TrustBundleCache
+	crlCache          *workloadidentity.CRLCache
+	identityGenerator *identity.Generator
+	clientBuilder     *client.Builder
 }
 
 // String returns a human-readable description of the service.
@@ -195,30 +196,19 @@ func (s *WorkloadIdentityX509Service) requestSVID(
 	)
 	defer span.End()
 
-	roles, err := fetchDefaultRoles(ctx, s.botAuthClient, s.getBotIdentity())
-	if err != nil {
-		return nil, nil, trace.Wrap(err, "fetching roles")
-	}
-
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
-	id, err := generateIdentity(
-		ctx,
-		s.botAuthClient,
-		s.getBotIdentity(),
-		roles,
-		effectiveLifetime.TTL,
-		nil,
-	)
+	id, err := s.identityGenerator.GenerateFacade(ctx, identity.GenerateParams{
+		TTL:             effectiveLifetime.TTL,
+		RenewalInterval: effectiveLifetime.RenewalInterval,
+		Logger:          s.log,
+	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}
 
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
-
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
-	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)
-	impersonatedClient, err := clientForFacade(ctx, s.log, s.botCfg, facade, s.resolver)
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
In preparation for moving tbot's services into their own packages, this PR removes the `generateIdentity`, `clientForFacade`, and `fetchDefaultRoles` methods from `lib/tbot` and adds two new types:

- `lib/tbot/identity.Generator` for generating impersonated identities
- `lib/tbot/client.Builder` for building an API client from an identity
