### PR TITLE
[vnet] feat: automatic SSH client configuration

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -128,9 +128,6 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
     FuzzReadProxyLineV2 fuzz_read_proxy_linec_v2
 
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/vnet/diag \
-    FuzzOpenSSHConfigIncludesPath fuzz_openssh_config_includes_path
-
 }
 
 build_teleport_api_fuzzers() {

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -128,6 +128,9 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
     FuzzReadProxyLineV2 fuzz_read_proxy_linec_v2
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/vnet/diag \
+    FuzzOpenSSHConfigIncludesPath fuzz_openssh_config_includes_path
+
 }
 
 build_teleport_api_fuzzers() {

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
@@ -137,7 +138,7 @@ func NewSSHConfigChecker(profilePath string) (*SSHConfigChecker, error) {
 		userHome:              userHome,
 		UserOpenSSHConfigPath: userOpenSSHConfigPath,
 		VNetSSHConfigPath:     vnetSSHConfigPath,
-		isWindows:             runtime.GOOS == "windows",
+		isWindows:             runtime.GOOS == constants.WindowsOS,
 	}, nil
 }
 

--- a/lib/vnet/diag/ssh.go
+++ b/lib/vnet/diag/ssh.go
@@ -159,7 +159,7 @@ func (c *SSHConfigChecker) OpenSSHConfigIncludesVNetSSHConfig() ([]byte, bool, e
 		return nil, false, trace.Wrap(trace.ConvertSystemError(err), "reading %s", c.UserOpenSSHConfigPath)
 	}
 	if len(userOpenSSHConfigContents) == maxOpenSSHConfigFileSize {
-		return nil, false, trace.Errorf("%s is too large to (max size %s)",
+		return nil, false, trace.Errorf("%s is too large to read (max size %s)",
 			c.UserOpenSSHConfigPath, humanize.Bytes(maxOpenSSHConfigFileSize))
 	}
 

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -200,9 +200,9 @@ Include /Users/user/.tsh/vnet_ssh_config
 			userOpenSSHConfigPath := filepath.Join(t.TempDir(), "test_ssh_config")
 
 			// Override isWindows and paths for the purpose of the test.
-			diag.isWindows = tc.isWindows
-			diag.userHome = tc.userHome
-			diag.userOpenSSHConfigPath = userOpenSSHConfigPath
+			diag.sshConfigChecker.isWindows = tc.isWindows
+			diag.sshConfigChecker.userHome = tc.userHome
+			diag.sshConfigChecker.UserOpenSSHConfigPath = userOpenSSHConfigPath
 
 			if len(tc.input) > 0 {
 				require.NoError(t, os.WriteFile(userOpenSSHConfigPath, []byte(tc.input), 0o600))

--- a/lib/vnet/diag/ssh_test.go
+++ b/lib/vnet/diag/ssh_test.go
@@ -19,6 +19,7 @@ package diag
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,171 +28,173 @@ import (
 	diagv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/diag/v1"
 )
 
-// TestSSHDiag tests the SSH configuration diagnostic, specifically its ability
-// to check whether an OpenSSH config file includes the VNet SSH config file.
-func TestSSHDiag(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		desc        string
-		profilePath string
-		userHome    string
-		isWindows   bool
-		input       string
-		expect      bool
-	}{
-		{
-			desc:        "empty",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-		},
-		{
-			desc:        "macos tsh",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include /Users/user/.tsh/vnet_ssh_config`,
-			expect:      true,
-		},
-		{
-			desc:        "macos tsh ~",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include ~/.tsh/vnet_ssh_config`,
-			expect:      true,
-		},
-		{
-			desc:        "macos connect",
-			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "macos connect ~",
-			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include "~/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "macos tsh not match connect",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
-		},
-		{
-			desc:        "macos connect not match tsh",
-			profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include /Users/user/.tsh/vnet_ssh_config`,
-		},
-		{
-			desc:        "windows tsh",
-			profilePath: `C:\Users\User\.tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows tsh unescaped",
-			profilePath: `C:\Users\User\.tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\Users\User\.tsh\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows tsh unix path",
-			profilePath: `C:\Users\User\.tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:/Users/User/.tsh/vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows tsh ~",
-			profilePath: `C:\Users\User\.tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "~\\.tsh\\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows connect",
-			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows connect unescaped",
-			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\Users\User\AppData\Roaming\Teleport Connect\tsh\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows connect unix path",
-			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:/Users/User/AppData/Roaming/Teleport\ Connect/tsh/vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows connect ~",
-			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "~\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
-			expect:      true,
-		},
-		{
-			desc:        "windows tsh not match connect",
-			profilePath: `C:\Users\User\.tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
-		},
-		{
-			desc:        "windows connect not match tsh",
-			profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
-			userHome:    `C:\Users\User`,
-			isWindows:   true,
-			input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
-		},
-		{
-			desc:        "some other file",
-			profilePath: `/Users/user/.tsh`,
-			input:       `Include /Users/user/.tsh/ssh_config`,
-		},
-		{
-			desc:        "multiple includes",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input: `
+var sshDiagTestCases = []struct {
+	desc        string
+	profilePath string
+	userHome    string
+	isWindows   bool
+	input       string
+	expect      bool
+}{
+	{
+		desc:        "empty",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+	},
+	{
+		desc:        "macos tsh",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include /Users/user/.tsh/vnet_ssh_config`,
+		expect:      true,
+	},
+	{
+		desc:        "macos tsh ~",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include ~/.tsh/vnet_ssh_config`,
+		expect:      true,
+	},
+	{
+		desc:        "macos connect",
+		profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "macos connect ~",
+		profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include "~/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "macos tsh not match connect",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include "/Users/user/Application Support/Teleport Connect/tsh/vnet_ssh_config"`,
+	},
+	{
+		desc:        "macos connect not match tsh",
+		profilePath: `/Users/user/Application Support/Teleport Connect/tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include /Users/user/.tsh/vnet_ssh_config`,
+	},
+	{
+		desc:        "windows tsh",
+		profilePath: `C:\Users\User\.tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows tsh unescaped",
+		profilePath: `C:\Users\User\.tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\Users\User\.tsh\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows tsh unix path",
+		profilePath: `C:\Users\User\.tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:/Users/User/.tsh/vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows tsh ~",
+		profilePath: `C:\Users\User\.tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "~\\.tsh\\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows connect",
+		profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows connect unescaped",
+		profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\Users\User\AppData\Roaming\Teleport Connect\tsh\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows connect unix path",
+		profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:/Users/User/AppData/Roaming/Teleport\ Connect/tsh/vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows connect ~",
+		profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "~\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+		expect:      true,
+	},
+	{
+		desc:        "windows tsh not match connect",
+		profilePath: `C:\Users\User\.tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\\Users\\User\\AppData\\Roaming\\Teleport\ Connect\\tsh\\vnet_ssh_config"`,
+	},
+	{
+		desc:        "windows connect not match tsh",
+		profilePath: `C:\Users\User\AppData\Roaming\Teleport Connect\tsh`,
+		userHome:    `C:\Users\User`,
+		isWindows:   true,
+		input:       `Include "C:\\Users\\User\\.tsh\\vnet_ssh_config"`,
+	},
+	{
+		desc:        "some other file",
+		profilePath: `/Users/user/.tsh`,
+		input:       `Include /Users/user/.tsh/ssh_config`,
+	},
+	{
+		desc:        "multiple includes",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input: `
 Include ~/.ssh/include/*
 Include /Users/user/ssh_config
 Include /Users/user/.tsh/vnet_ssh_config
 `,
-			expect: true,
-		},
-		{
-			desc:        "commented",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include #/Users/user/.tsh/vnet_ssh_config`,
-		},
-		{
-			desc:        "single quotes",
-			profilePath: `/Users/user/.tsh`,
-			userHome:    `/Users/user`,
-			input:       `Include '/Users/user/.tsh/vnet_ssh_config'`,
-			expect:      true,
-		},
-	} {
+		expect: true,
+	},
+	{
+		desc:        "commented",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include #/Users/user/.tsh/vnet_ssh_config`,
+	},
+	{
+		desc:        "single quotes",
+		profilePath: `/Users/user/.tsh`,
+		userHome:    `/Users/user`,
+		input:       `Include '/Users/user/.tsh/vnet_ssh_config'`,
+		expect:      true,
+	},
+}
+
+// TestSSHDiag tests the SSH configuration diagnostic, specifically its ability
+// to check whether an OpenSSH config file includes the VNet SSH config file.
+func TestSSHDiag(t *testing.T) {
+	t.Parallel()
+	for _, tc := range sshDiagTestCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			diag, err := NewSSHDiag(&SSHConfig{
 				ProfilePath: tc.profilePath,
@@ -226,4 +229,22 @@ Include /Users/user/.tsh/vnet_ssh_config
 			require.Equal(t, expectReport, report)
 		})
 	}
+}
+
+// FuzzOpenSSHConfigIncludesPath fuzzes [SSHConfigChecker.openSSHConfigIncludesVNetSSHConfig]
+// to make sure it won't panic on arbitrary input.
+func FuzzOpenSSHConfigIncludesPath(f *testing.F) {
+	// Add all test cases as the base test corpus.
+	for _, tc := range sshDiagTestCases {
+		f.Add(tc.isWindows, tc.profilePath, tc.input)
+	}
+	f.Fuzz(func(t *testing.T, isWindows bool, profilePath, input string) {
+		vnetSSHConfigPath := keypaths.VNetSSHConfigPath(profilePath)
+		sshConfigChecker := &SSHConfigChecker{
+			VNetSSHConfigPath: vnetSSHConfigPath,
+			isWindows:         isWindows,
+		}
+		// Can't deterministically check the result for fuzzed inputs but it shouldn't panic.
+		sshConfigChecker.openSSHConfigIncludesVNetSSHConfig(strings.NewReader(input))
+	})
 }

--- a/lib/vnet/opensshconfig_test.go
+++ b/lib/vnet/opensshconfig_test.go
@@ -186,7 +186,7 @@ Include "%s"
 					[]byte(tc.userOpenSSHConfigContents), filePerms))
 			}
 
-			err := AutoConfigureOpenSSH(t.Context(), profilePath, userOpenSSHConfigPath)
+			err := AutoConfigureOpenSSH(t.Context(), profilePath, withUserSSHConfigPathOverride(userOpenSSHConfigPath))
 
 			if tc.expectAlreadyIncludedError {
 				assert.ErrorIs(t, err, trace.AlreadyExists("%s is already included in %s",

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1361,6 +1361,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	workloadIdentityCmd := newWorkloadIdentityCommands(app)
 
 	vnetCommand := newVnetCommand(app)
+	vnetSSHAutoConfigCommand := newVnetSSHAutoConfigCommand(app)
 	vnetAdminSetupCommand := newVnetAdminSetupCommand(app)
 	vnetDaemonCommand := newVnetDaemonCommand(app)
 	vnetServiceCommand := newVnetServiceCommand(app)
@@ -1781,6 +1782,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = workloadIdentityCmd.issueX509.run(&cf)
 	case vnetCommand.FullCommand():
 		err = vnetCommand.run(&cf)
+	case vnetSSHAutoConfigCommand.FullCommand():
+		err = vnetSSHAutoConfigCommand.run(&cf)
 	case vnetAdminSetupCommand.FullCommand():
 		err = vnetAdminSetupCommand.run(&cf)
 	case vnetDaemonCommand.FullCommand():

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/lib/vnet"
 )
 
@@ -77,6 +78,22 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 	return trace.Wrap(vnetProcess.Wait())
 }
 
+type vnetSSHAutoConfigCommand struct {
+	*kingpin.CmdClause
+}
+
+func newVnetSSHAutoConfigCommand(app *kingpin.Application) *vnetSSHAutoConfigCommand {
+	cmd := &vnetSSHAutoConfigCommand{
+		CmdClause: app.Command("vnet-ssh-autoconfig", "Automatically include VNet's generated OpenSSH-compatible config file in ~/.ssh/config."),
+	}
+	return cmd
+}
+
+func (c *vnetSSHAutoConfigCommand) run(cf *CLIConf) error {
+	err := vnet.AutoConfigureOpenSSH(cf.Context, profile.FullProfilePath(cf.HomePath))
+	return trace.Wrap(err)
+}
+
 func newVnetAdminSetupCommand(app *kingpin.Application) vnetCLICommand {
 	return newPlatformVnetAdminSetupCommand(app)
 }
@@ -104,6 +121,7 @@ type vnetCommandNotSupported struct{}
 func (vnetCommandNotSupported) FullCommand() string {
 	return ""
 }
+
 func (vnetCommandNotSupported) run(*CLIConf) error {
 	panic("vnetCommandNotSupported.run should never be called, this is a bug")
 }


### PR DESCRIPTION
This commit adds a function that automatically adds `Include $TELEPORT_HOME/tsh/vnet_ssh_config` to the user's `~/.ssh/config` file when they run the new command `tsh vnet-ssh-autoconfig`.

A follow-up PR will add a button to call this from Connect.

The changes in lib/vnet/diag/ssh.go are mechanical, I just factored SSHConfigChecker out of SSHDiag.