### PR TITLE
[vnet] feat: automatic SSH client configuration in Connect

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/vnet/v1/vnet_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/vnet/v1/vnet_service.pb.go
@@ -296,8 +296,11 @@ type GetServiceInfoResponse struct {
 	// ssh_configured is true if the user's SSH config file includes VNet's
 	// generated SSH config necessary for SSH access.
 	SshConfigured bool `protobuf:"varint,3,opt,name=ssh_configured,json=sshConfigured,proto3" json:"ssh_configured,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// vnet_ssh_config_path is the path of VNet's generated OpenSSH-compatible
+	// config file.
+	VnetSshConfigPath string `protobuf:"bytes,4,opt,name=vnet_ssh_config_path,json=vnetSshConfigPath,proto3" json:"vnet_ssh_config_path,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *GetServiceInfoResponse) Reset() {
@@ -349,6 +352,13 @@ func (x *GetServiceInfoResponse) GetSshConfigured() bool {
 		return x.SshConfigured
 	}
 	return false
+}
+
+func (x *GetServiceInfoResponse) GetVnetSshConfigPath() string {
+	if x != nil {
+		return x.VnetSshConfigPath
+	}
+	return ""
 }
 
 // Request for GetBackgroundItemStatus.
@@ -515,6 +525,80 @@ func (x *RunDiagnosticsResponse) GetReport() *v1.Report {
 	return nil
 }
 
+// Request for AutoConfigureSSH.
+type AutoConfigureSSHRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AutoConfigureSSHRequest) Reset() {
+	*x = AutoConfigureSSHRequest{}
+	mi := &file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AutoConfigureSSHRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AutoConfigureSSHRequest) ProtoMessage() {}
+
+func (x *AutoConfigureSSHRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AutoConfigureSSHRequest.ProtoReflect.Descriptor instead.
+func (*AutoConfigureSSHRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDescGZIP(), []int{10}
+}
+
+// Response for AutoConfigureSSH.
+type AutoConfigureSSHResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AutoConfigureSSHResponse) Reset() {
+	*x = AutoConfigureSSHResponse{}
+	mi := &file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AutoConfigureSSHResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AutoConfigureSSHResponse) ProtoMessage() {}
+
+func (x *AutoConfigureSSHResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AutoConfigureSSHResponse.ProtoReflect.Descriptor instead.
+func (*AutoConfigureSSHResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDescGZIP(), []int{11}
+}
+
 var File_teleport_lib_teleterm_vnet_v1_vnet_service_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDesc = "" +
@@ -524,30 +608,34 @@ const file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDesc = "" +
 	"\rStartResponse\"\r\n" +
 	"\vStopRequest\"\x0e\n" +
 	"\fStopResponse\"\x17\n" +
-	"\x15GetServiceInfoRequest\"\x7f\n" +
+	"\x15GetServiceInfoRequest\"\xb0\x01\n" +
 	"\x16GetServiceInfoResponse\x12\"\n" +
 	"\rapp_dns_zones\x18\x01 \x03(\tR\vappDnsZones\x12\x1a\n" +
 	"\bclusters\x18\x02 \x03(\tR\bclusters\x12%\n" +
-	"\x0essh_configured\x18\x03 \x01(\bR\rsshConfigured\" \n" +
+	"\x0essh_configured\x18\x03 \x01(\bR\rsshConfigured\x12/\n" +
+	"\x14vnet_ssh_config_path\x18\x04 \x01(\tR\x11vnetSshConfigPath\" \n" +
 	"\x1eGetBackgroundItemStatusRequest\"n\n" +
 	"\x1fGetBackgroundItemStatusResponse\x12K\n" +
 	"\x06status\x18\x01 \x01(\x0e23.teleport.lib.teleterm.vnet.v1.BackgroundItemStatusR\x06status\"\x17\n" +
 	"\x15RunDiagnosticsRequest\"S\n" +
 	"\x16RunDiagnosticsResponse\x129\n" +
-	"\x06report\x18\x01 \x01(\v2!.teleport.lib.vnet.diag.v1.ReportR\x06report*\x8b\x02\n" +
+	"\x06report\x18\x01 \x01(\v2!.teleport.lib.vnet.diag.v1.ReportR\x06report\"\x19\n" +
+	"\x17AutoConfigureSSHRequest\"\x1a\n" +
+	"\x18AutoConfigureSSHResponse*\x8b\x02\n" +
 	"\x14BackgroundItemStatus\x12&\n" +
 	"\"BACKGROUND_ITEM_STATUS_UNSPECIFIED\x10\x00\x12)\n" +
 	"%BACKGROUND_ITEM_STATUS_NOT_REGISTERED\x10\x01\x12\"\n" +
 	"\x1eBACKGROUND_ITEM_STATUS_ENABLED\x10\x02\x12,\n" +
 	"(BACKGROUND_ITEM_STATUS_REQUIRES_APPROVAL\x10\x03\x12$\n" +
 	" BACKGROUND_ITEM_STATUS_NOT_FOUND\x10\x04\x12(\n" +
-	"$BACKGROUND_ITEM_STATUS_NOT_SUPPORTED\x10\x052\xeb\x04\n" +
+	"$BACKGROUND_ITEM_STATUS_NOT_SUPPORTED\x10\x052\xf1\x05\n" +
 	"\vVnetService\x12b\n" +
 	"\x05Start\x12+.teleport.lib.teleterm.vnet.v1.StartRequest\x1a,.teleport.lib.teleterm.vnet.v1.StartResponse\x12_\n" +
 	"\x04Stop\x12*.teleport.lib.teleterm.vnet.v1.StopRequest\x1a+.teleport.lib.teleterm.vnet.v1.StopResponse\x12}\n" +
 	"\x0eGetServiceInfo\x124.teleport.lib.teleterm.vnet.v1.GetServiceInfoRequest\x1a5.teleport.lib.teleterm.vnet.v1.GetServiceInfoResponse\x12\x98\x01\n" +
 	"\x17GetBackgroundItemStatus\x12=.teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusRequest\x1a>.teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusResponse\x12}\n" +
-	"\x0eRunDiagnostics\x124.teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest\x1a5.teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponseBUZSgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1;vnetv1b\x06proto3"
+	"\x0eRunDiagnostics\x124.teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest\x1a5.teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse\x12\x83\x01\n" +
+	"\x10AutoConfigureSSH\x126.teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest\x1a7.teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponseBUZSgithub.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1;vnetv1b\x06proto3"
 
 var (
 	file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDescOnce sync.Once
@@ -562,7 +650,7 @@ func file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDescGZIP() []byte 
 }
 
 var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_goTypes = []any{
 	(BackgroundItemStatus)(0),               // 0: teleport.lib.teleterm.vnet.v1.BackgroundItemStatus
 	(*StartRequest)(nil),                    // 1: teleport.lib.teleterm.vnet.v1.StartRequest
@@ -575,23 +663,27 @@ var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_goTypes = []any{
 	(*GetBackgroundItemStatusResponse)(nil), // 8: teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusResponse
 	(*RunDiagnosticsRequest)(nil),           // 9: teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest
 	(*RunDiagnosticsResponse)(nil),          // 10: teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse
-	(*v1.Report)(nil),                       // 11: teleport.lib.vnet.diag.v1.Report
+	(*AutoConfigureSSHRequest)(nil),         // 11: teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest
+	(*AutoConfigureSSHResponse)(nil),        // 12: teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse
+	(*v1.Report)(nil),                       // 13: teleport.lib.vnet.diag.v1.Report
 }
 var file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_depIdxs = []int32{
 	0,  // 0: teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusResponse.status:type_name -> teleport.lib.teleterm.vnet.v1.BackgroundItemStatus
-	11, // 1: teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse.report:type_name -> teleport.lib.vnet.diag.v1.Report
+	13, // 1: teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse.report:type_name -> teleport.lib.vnet.diag.v1.Report
 	1,  // 2: teleport.lib.teleterm.vnet.v1.VnetService.Start:input_type -> teleport.lib.teleterm.vnet.v1.StartRequest
 	3,  // 3: teleport.lib.teleterm.vnet.v1.VnetService.Stop:input_type -> teleport.lib.teleterm.vnet.v1.StopRequest
 	5,  // 4: teleport.lib.teleterm.vnet.v1.VnetService.GetServiceInfo:input_type -> teleport.lib.teleterm.vnet.v1.GetServiceInfoRequest
 	7,  // 5: teleport.lib.teleterm.vnet.v1.VnetService.GetBackgroundItemStatus:input_type -> teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusRequest
 	9,  // 6: teleport.lib.teleterm.vnet.v1.VnetService.RunDiagnostics:input_type -> teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest
-	2,  // 7: teleport.lib.teleterm.vnet.v1.VnetService.Start:output_type -> teleport.lib.teleterm.vnet.v1.StartResponse
-	4,  // 8: teleport.lib.teleterm.vnet.v1.VnetService.Stop:output_type -> teleport.lib.teleterm.vnet.v1.StopResponse
-	6,  // 9: teleport.lib.teleterm.vnet.v1.VnetService.GetServiceInfo:output_type -> teleport.lib.teleterm.vnet.v1.GetServiceInfoResponse
-	8,  // 10: teleport.lib.teleterm.vnet.v1.VnetService.GetBackgroundItemStatus:output_type -> teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusResponse
-	10, // 11: teleport.lib.teleterm.vnet.v1.VnetService.RunDiagnostics:output_type -> teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse
-	7,  // [7:12] is the sub-list for method output_type
-	2,  // [2:7] is the sub-list for method input_type
+	11, // 7: teleport.lib.teleterm.vnet.v1.VnetService.AutoConfigureSSH:input_type -> teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest
+	2,  // 8: teleport.lib.teleterm.vnet.v1.VnetService.Start:output_type -> teleport.lib.teleterm.vnet.v1.StartResponse
+	4,  // 9: teleport.lib.teleterm.vnet.v1.VnetService.Stop:output_type -> teleport.lib.teleterm.vnet.v1.StopResponse
+	6,  // 10: teleport.lib.teleterm.vnet.v1.VnetService.GetServiceInfo:output_type -> teleport.lib.teleterm.vnet.v1.GetServiceInfoResponse
+	8,  // 11: teleport.lib.teleterm.vnet.v1.VnetService.GetBackgroundItemStatus:output_type -> teleport.lib.teleterm.vnet.v1.GetBackgroundItemStatusResponse
+	10, // 12: teleport.lib.teleterm.vnet.v1.VnetService.RunDiagnostics:output_type -> teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse
+	12, // 13: teleport.lib.teleterm.vnet.v1.VnetService.AutoConfigureSSH:output_type -> teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse
+	8,  // [8:14] is the sub-list for method output_type
+	2,  // [2:8] is the sub-list for method input_type
 	2,  // [2:2] is the sub-list for extension type_name
 	2,  // [2:2] is the sub-list for extension extendee
 	0,  // [0:2] is the sub-list for field type_name
@@ -608,7 +700,7 @@ func file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDesc), len(file_teleport_lib_teleterm_vnet_v1_vnet_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/teleterm/vnet/v1/vnet_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/vnet/v1/vnet_service_grpc.pb.go
@@ -40,6 +40,7 @@ const (
 	VnetService_GetServiceInfo_FullMethodName          = "/teleport.lib.teleterm.vnet.v1.VnetService/GetServiceInfo"
 	VnetService_GetBackgroundItemStatus_FullMethodName = "/teleport.lib.teleterm.vnet.v1.VnetService/GetBackgroundItemStatus"
 	VnetService_RunDiagnostics_FullMethodName          = "/teleport.lib.teleterm.vnet.v1.VnetService/RunDiagnostics"
+	VnetService_AutoConfigureSSH_FullMethodName        = "/teleport.lib.teleterm.vnet.v1.VnetService/AutoConfigureSSH"
 )
 
 // VnetServiceClient is the client API for VnetService service.
@@ -60,6 +61,9 @@ type VnetServiceClient interface {
 	// RunDiagnostics runs a set of heuristics to determine if VNet actually works on the device, that
 	// is receives network traffic and DNS queries. RunDiagnostics requires VNet to be started.
 	RunDiagnostics(ctx context.Context, in *RunDiagnosticsRequest, opts ...grpc.CallOption) (*RunDiagnosticsResponse, error)
+	// AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+	// connections to Teleport SSH hosts.
+	AutoConfigureSSH(ctx context.Context, in *AutoConfigureSSHRequest, opts ...grpc.CallOption) (*AutoConfigureSSHResponse, error)
 }
 
 type vnetServiceClient struct {
@@ -120,6 +124,16 @@ func (c *vnetServiceClient) RunDiagnostics(ctx context.Context, in *RunDiagnosti
 	return out, nil
 }
 
+func (c *vnetServiceClient) AutoConfigureSSH(ctx context.Context, in *AutoConfigureSSHRequest, opts ...grpc.CallOption) (*AutoConfigureSSHResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AutoConfigureSSHResponse)
+	err := c.cc.Invoke(ctx, VnetService_AutoConfigureSSH_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // VnetServiceServer is the server API for VnetService service.
 // All implementations must embed UnimplementedVnetServiceServer
 // for forward compatibility.
@@ -138,6 +152,9 @@ type VnetServiceServer interface {
 	// RunDiagnostics runs a set of heuristics to determine if VNet actually works on the device, that
 	// is receives network traffic and DNS queries. RunDiagnostics requires VNet to be started.
 	RunDiagnostics(context.Context, *RunDiagnosticsRequest) (*RunDiagnosticsResponse, error)
+	// AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+	// connections to Teleport SSH hosts.
+	AutoConfigureSSH(context.Context, *AutoConfigureSSHRequest) (*AutoConfigureSSHResponse, error)
 	mustEmbedUnimplementedVnetServiceServer()
 }
 
@@ -162,6 +179,9 @@ func (UnimplementedVnetServiceServer) GetBackgroundItemStatus(context.Context, *
 }
 func (UnimplementedVnetServiceServer) RunDiagnostics(context.Context, *RunDiagnosticsRequest) (*RunDiagnosticsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RunDiagnostics not implemented")
+}
+func (UnimplementedVnetServiceServer) AutoConfigureSSH(context.Context, *AutoConfigureSSHRequest) (*AutoConfigureSSHResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AutoConfigureSSH not implemented")
 }
 func (UnimplementedVnetServiceServer) mustEmbedUnimplementedVnetServiceServer() {}
 func (UnimplementedVnetServiceServer) testEmbeddedByValue()                     {}
@@ -274,6 +294,24 @@ func _VnetService_RunDiagnostics_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _VnetService_AutoConfigureSSH_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AutoConfigureSSHRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VnetServiceServer).AutoConfigureSSH(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VnetService_AutoConfigureSSH_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VnetServiceServer).AutoConfigureSSH(ctx, req.(*AutoConfigureSSHRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // VnetService_ServiceDesc is the grpc.ServiceDesc for VnetService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -300,6 +338,10 @@ var VnetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RunDiagnostics",
 			Handler:    _VnetService_RunDiagnostics_Handler,
+		},
+		{
+			MethodName: "AutoConfigureSSH",
+			Handler:    _VnetService_AutoConfigureSSH_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.client.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.client.ts
@@ -23,6 +23,8 @@
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { VnetService } from "./vnet_service_pb";
+import type { AutoConfigureSSHResponse } from "./vnet_service_pb";
+import type { AutoConfigureSSHRequest } from "./vnet_service_pb";
 import type { RunDiagnosticsResponse } from "./vnet_service_pb";
 import type { RunDiagnosticsRequest } from "./vnet_service_pb";
 import type { GetBackgroundItemStatusResponse } from "./vnet_service_pb";
@@ -74,6 +76,13 @@ export interface IVnetServiceClient {
      * @generated from protobuf rpc: RunDiagnostics(teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest) returns (teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse);
      */
     runDiagnostics(input: RunDiagnosticsRequest, options?: RpcOptions): UnaryCall<RunDiagnosticsRequest, RunDiagnosticsResponse>;
+    /**
+     * AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+     * connections to Teleport SSH hosts.
+     *
+     * @generated from protobuf rpc: AutoConfigureSSH(teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest) returns (teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse);
+     */
+    autoConfigureSSH(input: AutoConfigureSSHRequest, options?: RpcOptions): UnaryCall<AutoConfigureSSHRequest, AutoConfigureSSHResponse>;
 }
 /**
  * VnetService provides methods to manage a VNet instance.
@@ -132,5 +141,15 @@ export class VnetServiceClient implements IVnetServiceClient, ServiceInfo {
     runDiagnostics(input: RunDiagnosticsRequest, options?: RpcOptions): UnaryCall<RunDiagnosticsRequest, RunDiagnosticsResponse> {
         const method = this.methods[4], opt = this._transport.mergeOptions(options);
         return stackIntercept<RunDiagnosticsRequest, RunDiagnosticsResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+     * connections to Teleport SSH hosts.
+     *
+     * @generated from protobuf rpc: AutoConfigureSSH(teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest) returns (teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse);
+     */
+    autoConfigureSSH(input: AutoConfigureSSHRequest, options?: RpcOptions): UnaryCall<AutoConfigureSSHRequest, AutoConfigureSSHResponse> {
+        const method = this.methods[5], opt = this._transport.mergeOptions(options);
+        return stackIntercept<AutoConfigureSSHRequest, AutoConfigureSSHResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.grpc-server.ts
@@ -20,6 +20,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+import { AutoConfigureSSHResponse } from "./vnet_service_pb";
+import { AutoConfigureSSHRequest } from "./vnet_service_pb";
 import { RunDiagnosticsResponse } from "./vnet_service_pb";
 import { RunDiagnosticsRequest } from "./vnet_service_pb";
 import { GetBackgroundItemStatusResponse } from "./vnet_service_pb";
@@ -69,6 +71,13 @@ export interface IVnetService extends grpc.UntypedServiceImplementation {
      * @generated from protobuf rpc: RunDiagnostics(teleport.lib.teleterm.vnet.v1.RunDiagnosticsRequest) returns (teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse);
      */
     runDiagnostics: grpc.handleUnaryCall<RunDiagnosticsRequest, RunDiagnosticsResponse>;
+    /**
+     * AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+     * connections to Teleport SSH hosts.
+     *
+     * @generated from protobuf rpc: AutoConfigureSSH(teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest) returns (teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse);
+     */
+    autoConfigureSSH: grpc.handleUnaryCall<AutoConfigureSSHRequest, AutoConfigureSSHResponse>;
 }
 /**
  * @grpc/grpc-js definition for the protobuf service teleport.lib.teleterm.vnet.v1.VnetService.
@@ -131,5 +140,15 @@ export const vnetServiceDefinition: grpc.ServiceDefinition<IVnetService> = {
         requestDeserialize: bytes => RunDiagnosticsRequest.fromBinary(bytes),
         responseSerialize: value => Buffer.from(RunDiagnosticsResponse.toBinary(value)),
         requestSerialize: value => Buffer.from(RunDiagnosticsRequest.toBinary(value))
+    },
+    autoConfigureSSH: {
+        path: "/teleport.lib.teleterm.vnet.v1.VnetService/AutoConfigureSSH",
+        originalName: "AutoConfigureSSH",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => AutoConfigureSSHResponse.fromBinary(bytes),
+        requestDeserialize: bytes => AutoConfigureSSHRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(AutoConfigureSSHResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(AutoConfigureSSHRequest.toBinary(value))
     }
 };

--- a/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb.ts
@@ -92,6 +92,13 @@ export interface GetServiceInfoResponse {
      * @generated from protobuf field: bool ssh_configured = 3;
      */
     sshConfigured: boolean;
+    /**
+     * vnet_ssh_config_path is the path of VNet's generated OpenSSH-compatible
+     * config file.
+     *
+     * @generated from protobuf field: string vnet_ssh_config_path = 4;
+     */
+    vnetSshConfigPath: string;
 }
 /**
  * Request for GetBackgroundItemStatus.
@@ -128,6 +135,20 @@ export interface RunDiagnosticsResponse {
      * @generated from protobuf field: teleport.lib.vnet.diag.v1.Report report = 1;
      */
     report?: Report;
+}
+/**
+ * Request for AutoConfigureSSH.
+ *
+ * @generated from protobuf message teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest
+ */
+export interface AutoConfigureSSHRequest {
+}
+/**
+ * Response for AutoConfigureSSH.
+ *
+ * @generated from protobuf message teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse
+ */
+export interface AutoConfigureSSHResponse {
 }
 /**
  * BackgroundItemStatus maps to SMAppServiceStatus of the Service Management framework in macOS.
@@ -295,7 +316,8 @@ class GetServiceInfoResponse$Type extends MessageType<GetServiceInfoResponse> {
         super("teleport.lib.teleterm.vnet.v1.GetServiceInfoResponse", [
             { no: 1, name: "app_dns_zones", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "clusters", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "ssh_configured", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 3, name: "ssh_configured", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "vnet_ssh_config_path", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<GetServiceInfoResponse>): GetServiceInfoResponse {
@@ -303,6 +325,7 @@ class GetServiceInfoResponse$Type extends MessageType<GetServiceInfoResponse> {
         message.appDnsZones = [];
         message.clusters = [];
         message.sshConfigured = false;
+        message.vnetSshConfigPath = "";
         if (value !== undefined)
             reflectionMergePartial<GetServiceInfoResponse>(this, message, value);
         return message;
@@ -320,6 +343,9 @@ class GetServiceInfoResponse$Type extends MessageType<GetServiceInfoResponse> {
                     break;
                 case /* bool ssh_configured */ 3:
                     message.sshConfigured = reader.bool();
+                    break;
+                case /* string vnet_ssh_config_path */ 4:
+                    message.vnetSshConfigPath = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -342,6 +368,9 @@ class GetServiceInfoResponse$Type extends MessageType<GetServiceInfoResponse> {
         /* bool ssh_configured = 3; */
         if (message.sshConfigured !== false)
             writer.tag(3, WireType.Varint).bool(message.sshConfigured);
+        /* string vnet_ssh_config_path = 4; */
+        if (message.vnetSshConfigPath !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.vnetSshConfigPath);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -495,6 +524,56 @@ class RunDiagnosticsResponse$Type extends MessageType<RunDiagnosticsResponse> {
  * @generated MessageType for protobuf message teleport.lib.teleterm.vnet.v1.RunDiagnosticsResponse
  */
 export const RunDiagnosticsResponse = new RunDiagnosticsResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AutoConfigureSSHRequest$Type extends MessageType<AutoConfigureSSHRequest> {
+    constructor() {
+        super("teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest", []);
+    }
+    create(value?: PartialMessage<AutoConfigureSSHRequest>): AutoConfigureSSHRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AutoConfigureSSHRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AutoConfigureSSHRequest): AutoConfigureSSHRequest {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: AutoConfigureSSHRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.teleterm.vnet.v1.AutoConfigureSSHRequest
+ */
+export const AutoConfigureSSHRequest = new AutoConfigureSSHRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AutoConfigureSSHResponse$Type extends MessageType<AutoConfigureSSHResponse> {
+    constructor() {
+        super("teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse", []);
+    }
+    create(value?: PartialMessage<AutoConfigureSSHResponse>): AutoConfigureSSHResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AutoConfigureSSHResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AutoConfigureSSHResponse): AutoConfigureSSHResponse {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: AutoConfigureSSHResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.teleterm.vnet.v1.AutoConfigureSSHResponse
+ */
+export const AutoConfigureSSHResponse = new AutoConfigureSSHResponse$Type();
 /**
  * @generated ServiceType for protobuf service teleport.lib.teleterm.vnet.v1.VnetService
  */
@@ -503,5 +582,6 @@ export const VnetService = new ServiceType("teleport.lib.teleterm.vnet.v1.VnetSe
     { name: "Stop", options: {}, I: StopRequest, O: StopResponse },
     { name: "GetServiceInfo", options: {}, I: GetServiceInfoRequest, O: GetServiceInfoResponse },
     { name: "GetBackgroundItemStatus", options: {}, I: GetBackgroundItemStatusRequest, O: GetBackgroundItemStatusResponse },
-    { name: "RunDiagnostics", options: {}, I: RunDiagnosticsRequest, O: RunDiagnosticsResponse }
+    { name: "RunDiagnostics", options: {}, I: RunDiagnosticsRequest, O: RunDiagnosticsResponse },
+    { name: "AutoConfigureSSH", options: {}, I: AutoConfigureSSHRequest, O: AutoConfigureSSHResponse }
 ]);

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -248,9 +248,10 @@ func (s *Service) GetServiceInfo(ctx context.Context, _ *api.GetServiceInfoReque
 	}
 
 	return &api.GetServiceInfoResponse{
-		AppDnsZones:   unifiedClusterConfig.AppDNSZones(),
-		Clusters:      unifiedClusterConfig.ClusterNames,
-		SshConfigured: sshConfigured,
+		AppDnsZones:       unifiedClusterConfig.AppDNSZones(),
+		Clusters:          unifiedClusterConfig.ClusterNames,
+		SshConfigured:     sshConfigured,
+		VnetSshConfigPath: sshConfigChecker.VNetSSHConfigPath,
 	}, nil
 }
 
@@ -311,6 +312,13 @@ func (s *Service) getNetworkStack(ctx context.Context) (*diagv1.NetworkStack, er
 		Ipv4CidrRanges: unifiedClusterConfig.IPv4CidrRanges,
 		DnsZones:       unifiedClusterConfig.AllDNSZones(),
 	}, nil
+}
+
+// AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+// connections to Teleport SSH servers through VNet.
+func (s *Service) AutoConfigureSSH(ctx context.Context, _ *api.AutoConfigureSSHRequest) (*api.AutoConfigureSSHResponse, error) {
+	err := vnet.AutoConfigureOpenSSH(ctx, s.cfg.profilePath)
+	return nil, trace.Wrap(err)
 }
 
 func (s *Service) stopLocked() error {

--- a/proto/teleport/lib/teleterm/vnet/v1/vnet_service.proto
+++ b/proto/teleport/lib/teleterm/vnet/v1/vnet_service.proto
@@ -40,6 +40,10 @@ service VnetService {
   // RunDiagnostics runs a set of heuristics to determine if VNet actually works on the device, that
   // is receives network traffic and DNS queries. RunDiagnostics requires VNet to be started.
   rpc RunDiagnostics(RunDiagnosticsRequest) returns (RunDiagnosticsResponse);
+
+  // AutoConfigureSSH automatically configures OpenSSH-compatible clients for
+  // connections to Teleport SSH hosts.
+  rpc AutoConfigureSSH(AutoConfigureSSHRequest) returns (AutoConfigureSSHResponse);
 }
 
 // Request for Start.
@@ -67,6 +71,9 @@ message GetServiceInfoResponse {
   // ssh_configured is true if the user's SSH config file includes VNet's
   // generated SSH config necessary for SSH access.
   bool ssh_configured = 3;
+  // vnet_ssh_config_path is the path of VNet's generated OpenSSH-compatible
+  // config file.
+  string vnet_ssh_config_path = 4;
 }
 
 // Request for GetBackgroundItemStatus.
@@ -97,3 +104,9 @@ message RunDiagnosticsRequest {}
 message RunDiagnosticsResponse {
   teleport.lib.vnet.diag.v1.Report report = 1;
 }
+
+// Request for AutoConfigureSSH.
+message AutoConfigureSSHRequest {}
+
+// Response for AutoConfigureSSH.
+message AutoConfigureSSHResponse {}

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -123,9 +123,10 @@ export class MockVnetClient implements VnetClient {
       appDnsZones: [],
       clusters: [],
       sshConfigured: false,
+      vnetSshConfigPath:
+        '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
     });
   getBackgroundItemStatus = () => new MockedUnaryCall({ status: 0 });
-
   runDiagnostics() {
     return new MockedUnaryCall({
       report: {
@@ -134,4 +135,5 @@ export class MockVnetClient implements VnetClient {
       },
     });
   }
+  autoConfigureSSH = () => new MockedUnaryCall({});
 }

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -27,6 +27,7 @@ import { Dialog } from 'teleterm/ui/services/modals';
 import { ClusterLogout } from '../ClusterLogout';
 import { ResourceSearchErrors } from '../Search/ResourceSearchErrors';
 import { assertUnreachable } from '../utils';
+import { ConfigureSSHClients } from '../Vnet/ConfigureSSHClients';
 import { ChangeAccessRequestKind } from './modals/ChangeAccessRequestKind';
 import { AskPin, ChangePin, OverwriteSlot, Touch } from './modals/HardwareKeys';
 import { ReAuthenticate } from './modals/ReAuthenticate';
@@ -278,6 +279,17 @@ function renderDialog({
             handleClose();
             dialog.onCancel();
           }}
+        />
+      );
+    }
+    case 'configure-ssh-clients': {
+      return (
+        <ConfigureSSHClients
+          hidden={hidden}
+          onConfirm={dialog.onConfirm}
+          onClose={handleClose}
+          vnetSSHConfigPath={dialog.vnetSSHConfigPath}
+          host={dialog.host}
         />
       );
     }

--- a/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.story.tsx
@@ -1,0 +1,51 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ConfigureSSHClients } from './ConfigureSSHClients';
+
+export default {
+  title: 'Teleterm/Vnet/ConfigureSSHClients',
+  argTypes: {
+    simulateError: {
+      name: 'simulate error',
+      control: 'boolean',
+      defaultValue: false,
+    },
+    host: {
+      name: 'set specific SSH host',
+      control: 'text',
+    },
+  },
+};
+
+export const Story = ({ simulateError, host }) => (
+  <ConfigureSSHClients
+    onClose={() => console.log('closed')}
+    onConfirm={() =>
+      new Promise<void>((resolve, reject) => {
+        setTimeout(
+          () =>
+            simulateError ? reject(new Error('test error')) : resolve(null),
+          1000
+        );
+      })
+    }
+    host={host}
+    vnetSSHConfigPath="/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config"
+  />
+);

--- a/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
@@ -1,0 +1,100 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Alert, ButtonIcon, ButtonPrimary, Flex, H2, Text } from 'design';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from 'design/Dialog';
+import { Cross } from 'design/Icon';
+import { TextSelectCopy } from 'shared/components/TextSelectCopy';
+import { useAsync } from 'shared/hooks/useAsync';
+
+export function ConfigureSSHClients(props: {
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  vnetSSHConfigPath: string;
+  host?: string;
+  hidden?: boolean;
+}) {
+  const [confirmAttempt, onConfirm] = useAsync(props.onConfirm);
+  const host = props.host || '<hostname>.<cluster>';
+  return (
+    <Dialog
+      open={!props.hidden}
+      dialogCss={() => ({
+        maxWidth: '800px',
+        width: '100%',
+      })}
+    >
+      <DialogHeader justifyContent="space-between" alignItems="baseline">
+        <H2>Configure SSH clients for VNet</H2>
+        <ButtonIcon
+          type="button"
+          onClick={props.onClose}
+          color="text.slightlyMuted"
+        >
+          <Cross size="medium" />
+        </ButtonIcon>
+      </DialogHeader>
+      <DialogContent mb={4}>
+        <Text typography="body2">
+          Compatible SSH clients can connect to SSH servers with Teleport
+          features like per-session MFA without complex configuration. Teleport
+          VNet will handle the connection and manage SSH certificates
+          automatically, simply connect with
+        </Text>
+        <TextSelectCopy text={`ssh <username>@${host}`} mt={2} />
+        <Text typography="body2" mt={2}>
+          To enable this for any OpenSSH-compatible client that reads
+          configuration from <code>~/.ssh/config</code> add the following line
+          at the top of the file or click the button below to add it
+          automatically.
+        </Text>
+        <TextSelectCopy
+          text={`Include "${props.vnetSSHConfigPath}"`}
+          bash={false}
+          mt={2}
+        />
+      </DialogContent>
+      <DialogFooter>
+        <Flex>
+          <ButtonPrimary
+            ml="auto"
+            mr={1}
+            onClick={() =>
+              onConfirm().then(([, err]) => !err && props.onClose())
+            }
+            disabled={confirmAttempt.status === 'processing'}
+          >
+            Configure Automatically
+          </ButtonPrimary>
+        </Flex>
+        {confirmAttempt.status === 'error' && (
+          <Alert
+            mt={4}
+            mb={0}
+            dismissible
+            children={confirmAttempt.statusText}
+          />
+        )}
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
@@ -58,13 +58,13 @@ export function ConfigureSSHClients(props: {
           Compatible SSH clients can connect to SSH servers with Teleport
           features like per-session MFA without complex configuration. Teleport
           VNet will handle the connection and manage SSH certificates
-          automatically, simply connect with
+          automatically, simply connect with:
         </Text>
         <TextSelectCopy text={`ssh <username>@${host}`} mt={1} />
         <Text typography="body2" mt={2}>
           To enable this for any OpenSSH-compatible client that reads
-          configuration from <code>~/.ssh/config</code> add the following line
-          at the top of the file or click the button below to add it
+          configuration from <code>~/.ssh/config</code>, add the following line
+          at the top of the file, or click the button below to add it
           automatically.
         </Text>
         <TextSelectCopy

--- a/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/ConfigureSSHClients.tsx
@@ -60,7 +60,7 @@ export function ConfigureSSHClients(props: {
           VNet will handle the connection and manage SSH certificates
           automatically, simply connect with
         </Text>
-        <TextSelectCopy text={`ssh <username>@${host}`} mt={2} />
+        <TextSelectCopy text={`ssh <username>@${host}`} mt={1} />
         <Text typography="body2" mt={2}>
           To enable this for any OpenSSH-compatible client that reads
           configuration from <code>~/.ssh/config</code> add the following line
@@ -70,7 +70,7 @@ export function ConfigureSSHClients(props: {
         <TextSelectCopy
           text={`Include "${props.vnetSSHConfigPath}"`}
           bash={false}
-          mt={2}
+          mt={1}
         />
       </DialogContent>
       <DialogFooter>
@@ -87,12 +87,9 @@ export function ConfigureSSHClients(props: {
           </ButtonPrimary>
         </Flex>
         {confirmAttempt.status === 'error' && (
-          <Alert
-            mt={4}
-            mb={0}
-            dismissible
-            children={confirmAttempt.statusText}
-          />
+          <Alert mt={4} mb={0} dismissible>
+            {confirmAttempt.statusText}
+          </Alert>
         )}
       </DialogFooter>
     </Dialog>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -35,7 +35,6 @@ import { HoverTooltip } from 'design/Tooltip';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
-import { TextSelectCopy } from 'shared/components/TextSelectCopy';
 import { CanceledError, useAsync } from 'shared/hooks/useAsync';
 import { pluralize } from 'shared/utils/text';
 
@@ -433,6 +432,7 @@ function CheckReportSSHConfiguration({
       </>
     );
   }
+  const { openSSHConfigurationModal } = useVnetContext();
   return (
     <>
       <Stack>
@@ -442,11 +442,17 @@ function CheckReportSSHConfiguration({
         <P2 m={0}>
           The user's default SSH configuration file does not include VNet's
           generated SSH configuration file. SSH clients will not be able to make
-          connections to VNet SSH addresses by default. Add the following line
-          to <code>{userOpensshConfigPath}</code> to configure
-          OpenSSH-compatible clients for VNet:
+          connections to VNet SSH addresses by default.{' '}
+          <Link
+            href="#"
+            onClick={e => {
+              e.preventDefault();
+              openSSHConfigurationModal(vnetSshConfigPath);
+            }}
+          >
+            Resolve
+          </Link>
         </P2>
-        <TextSelectCopy text={`Include "${vnetSshConfigPath}"`} bash={false} />
       </Stack>
       {userOpensshConfigExists ? (
         <details>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -20,6 +20,7 @@ import { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 
 import { Button, Alert as DesignAlert, Flex, H1, Link, Stack } from 'design';
+import { ActionButton } from 'design/Alert';
 import { AlertProps } from 'design/Alert/Alert';
 import Table, { Cell, TextCell } from 'design/DataTable';
 import { displayDateTime } from 'design/datetime';
@@ -443,18 +444,16 @@ function CheckReportSSHConfiguration({
           The user's default SSH configuration file does not include VNet's
           generated SSH configuration file. SSH clients will not be able to make
           connections to VNet SSH addresses by default.{' '}
-          <Link
-            href="#"
-            onClick={e => {
-              e.preventDefault();
+        </P2>
+        <ActionButton
+          action={{
+            onClick: () =>
               openSSHConfigurationModal({
                 vnetSSHConfigPath: vnetSshConfigPath,
-              });
-            }}
-          >
-            Resolve
-          </Link>
-        </P2>
+              }),
+            content: 'Resolve',
+          }}
+        />
       </Stack>
       {userOpensshConfigExists ? (
         <details>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -20,7 +20,6 @@ import { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 
 import { Button, Alert as DesignAlert, Flex, H1, Link, Stack } from 'design';
-import { ActionButton } from 'design/Alert';
 import { AlertProps } from 'design/Alert/Alert';
 import Table, { Cell, TextCell } from 'design/DataTable';
 import { displayDateTime } from 'design/datetime';
@@ -380,6 +379,7 @@ function CheckReportSSHConfiguration({
 }: {
   checkReport: diag.CheckReport;
 }) {
+  const { openSSHConfigurationModal } = useVnetContext();
   if (!reportOneOfIsSSHConfigurationReport(report)) {
     return null;
   }
@@ -433,7 +433,6 @@ function CheckReportSSHConfiguration({
       </>
     );
   }
-  const { openSSHConfigurationModal } = useVnetContext();
   return (
     <>
       <Stack>
@@ -445,15 +444,16 @@ function CheckReportSSHConfiguration({
           generated SSH configuration file. SSH clients will not be able to make
           connections to VNet SSH addresses by default.{' '}
         </P2>
-        <ActionButton
-          action={{
-            onClick: () =>
-              openSSHConfigurationModal({
-                vnetSSHConfigPath: vnetSshConfigPath,
-              }),
-            content: 'Resolve',
-          }}
-        />
+        <Button
+          intent="neutral"
+          onClick={() =>
+            openSSHConfigurationModal({
+              vnetSSHConfigPath: vnetSshConfigPath,
+            })
+          }
+        >
+          Resolve
+        </Button>
       </Stack>
       {userOpensshConfigExists ? (
         <details>

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -447,7 +447,9 @@ function CheckReportSSHConfiguration({
             href="#"
             onClick={e => {
               e.preventDefault();
-              openSSHConfigurationModal(vnetSshConfigPath);
+              openSSHConfigurationModal({
+                vnetSSHConfigPath: vnetSshConfigPath,
+              });
             }}
           >
             Resolve

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -165,6 +165,8 @@ function VnetSliderStep(props: StoryProps) {
             appDnsZones: props.appDnsZones,
             clusters: props.clusters,
             sshConfigured: props.sshConfigured,
+            vnetSshConfigPath:
+              '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
           });
         }
         return pendingPromise;
@@ -175,6 +177,8 @@ function VnetSliderStep(props: StoryProps) {
           appDnsZones: props.appDnsZones,
           clusters: props.clusters,
           sshConfigured: props.sshConfigured,
+          vnetSshConfigPath:
+            '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
         },
         props.fetchStatus === 'error'
           ? new Error('something went wrong')

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -239,13 +239,13 @@ function VnetSliderStep(props: StoryProps) {
 }
 
 const RerequestServiceInfo = () => {
-  const { getServiceInfo, serviceInfoAttempt } = useVnetContext();
+  const { serviceInfoAttempt, refreshServiceInfoAttempt } = useVnetContext();
 
   useEffect(() => {
     if (serviceInfoAttempt.status === 'success') {
-      getServiceInfo();
+      refreshServiceInfoAttempt();
     }
-  }, [serviceInfoAttempt, getServiceInfo]);
+  }, [serviceInfoAttempt, refreshServiceInfoAttempt]);
 
   return null;
 };

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -18,7 +18,7 @@
 
 import { PropsWithChildren, useCallback, useEffect, useRef } from 'react';
 
-import { Box, ButtonSecondary, Flex, Text } from 'design';
+import { Box, ButtonSecondary, Flex, Link, Text } from 'design';
 import { StepComponentProps } from 'design/StepSlider';
 import { useRefAutoFocus } from 'shared/hooks';
 import { useDelayedRepeatedAttempt } from 'shared/hooks/useAsync';
@@ -141,8 +141,11 @@ const ErrorText = (props: PropsWithChildren) => (
  * optimistically displays previously fetched results while fetching new list.
  */
 const VnetStatus = () => {
-  const { getServiceInfo, serviceInfoAttempt: eagerServiceInfoAttempt } =
-    useVnetContext();
+  const {
+    getServiceInfo,
+    serviceInfoAttempt: eagerServiceInfoAttempt,
+    openSSHConfigurationModal,
+  } = useVnetContext();
   const serviceInfoAttempt = useDelayedRepeatedAttempt(eagerServiceInfoAttempt);
   const serviceInfoRefreshRequestedRef = useRef(false);
 
@@ -205,7 +208,18 @@ const VnetStatus = () => {
   const sshConfiguredIndicator = serviceInfo.sshConfigured ? null : (
     <Flex>
       <ConnectionStatusIndicator status={'warning'} inline mr={2} />
-      SSH clients are not configured to use VNet (see diag report).
+      <Text>
+        SSH clients are not configured to use VNet{' '}
+        <Link
+          href="#"
+          onClick={e => {
+            e.preventDefault();
+            return openSSHConfigurationModal(serviceInfo.vnetSshConfigPath);
+          }}
+        >
+          Resolve
+        </Link>
+      </Text>
     </Flex>
   );
 

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -18,7 +18,8 @@
 
 import { PropsWithChildren, useCallback, useEffect, useRef } from 'react';
 
-import { Box, ButtonSecondary, Flex, Link, Text } from 'design';
+import { Box, ButtonSecondary, Flex, Text } from 'design';
+import { ActionButton } from 'design/Alert';
 import { StepComponentProps } from 'design/StepSlider';
 import { useRefAutoFocus } from 'shared/hooks';
 import { useDelayedRepeatedAttempt } from 'shared/hooks/useAsync';
@@ -208,20 +209,18 @@ const VnetStatus = () => {
   const sshConfiguredIndicator = serviceInfo.sshConfigured ? null : (
     <Flex>
       <ConnectionStatusIndicator status={'warning'} inline mr={2} />
-      <Text>
-        SSH clients are not configured to use VNet{' '}
-        <Link
-          href="#"
-          onClick={e => {
-            e.preventDefault();
-            return openSSHConfigurationModal({
-              vnetSSHConfigPath: serviceInfo.vnetSshConfigPath,
-            });
+      <Text>SSH clients are not configured to use VNet</Text>
+      <Box alignSelf={'center'}>
+        <ActionButton
+          action={{
+            onClick: () =>
+              openSSHConfigurationModal({
+                vnetSSHConfigPath: serviceInfo.vnetSshConfigPath,
+              }),
+            content: 'Resolve',
           }}
-        >
-          Resolve
-        </Link>
-      </Text>
+        />
+      </Box>
     </Flex>
   );
 

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -212,6 +212,9 @@ const VnetStatus = () => {
       <Text>SSH clients are not configured to use VNet</Text>
       <Box alignSelf={'center'}>
         <ActionButton
+          fill="minimal"
+          intent="neutral"
+          inputAlignment
           action={{
             onClick: () =>
               openSSHConfigurationModal({

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -142,7 +142,7 @@ const ErrorText = (props: PropsWithChildren) => (
  */
 const VnetStatus = () => {
   const {
-    getServiceInfo,
+    refreshServiceInfoAttempt,
     serviceInfoAttempt: eagerServiceInfoAttempt,
     openSSHConfigurationModal,
   } = useVnetContext();
@@ -153,10 +153,10 @@ const VnetStatus = () => {
     function refreshListOnOpen() {
       if (!serviceInfoRefreshRequestedRef.current) {
         serviceInfoRefreshRequestedRef.current = true;
-        getServiceInfo();
+        refreshServiceInfoAttempt();
       }
     },
-    [getServiceInfo]
+    [refreshServiceInfoAttempt]
   );
 
   if (serviceInfoAttempt.status === 'error') {
@@ -169,7 +169,7 @@ const VnetStatus = () => {
           ml={2}
           size="small"
           type="button"
-          onClick={getServiceInfo}
+          onClick={refreshServiceInfoAttempt}
         >
           Retry
         </ButtonSecondary>
@@ -214,7 +214,9 @@ const VnetStatus = () => {
           href="#"
           onClick={e => {
             e.preventDefault();
-            return openSSHConfigurationModal(serviceInfo.vnetSshConfigPath);
+            return openSSHConfigurationModal({
+              vnetSSHConfigPath: serviceInfo.vnetSshConfigPath,
+            });
           }}
         >
           Resolve

--- a/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
@@ -93,6 +93,8 @@ test.each(tests)(
         appDnsZones: [proxyHostname(rootCluster.proxyHost)],
         clusters: [rootCluster.name],
         sshConfigured: true,
+        vnetSshConfigPath:
+          '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
       })
     );
 
@@ -189,6 +191,8 @@ test.each(tests)(
         appDnsZones: [proxyHostname(rootCluster.proxyHost)],
         clusters: [rootCluster.name],
         sshConfigured: true,
+        vnetSshConfigPath:
+          '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
       })
     );
 
@@ -250,6 +254,8 @@ test('launching VNet for the first time from the connections panel does not open
       appDnsZones: [proxyHostname(rootCluster.proxyHost)],
       clusters: [rootCluster.name],
       sshConfigured: true,
+      vnetSshConfigPath:
+        '/Users/user/Library/Application Support/Teleport Connect/tsh/vnet_ssh_config',
     })
   );
 

--- a/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetLauncher.tsx
@@ -144,7 +144,12 @@ export const useVnetLauncher = (): {
 
       notificationsService.notifyInfo(msg);
     },
-    [launchVnet, notificationsService, currentServiceInfo]
+    [
+      launchVnet,
+      notificationsService,
+      currentServiceInfo,
+      openSSHConfigurationModal,
+    ]
   );
 
   return useMemo(

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -106,6 +106,12 @@ export type VnetContext = {
    * Whether VNet has started successfully at least once.
    */
   hasEverStarted: boolean;
+  /**
+   * Opens a modal that handles SSH client configuration.
+   *
+   * Optionally pass a specific host that will be used for example text.
+   */
+  openSSHConfigurationModal: (vnetSSHConfigPath: string, host?: string) => void;
 };
 
 export type VnetStatus =
@@ -465,6 +471,23 @@ export const VnetContextProvider: FC<
     ]
   );
 
+  const autoConfigureSSH = useCallback(async (): Promise<void> => {
+    await vnet.autoConfigureSSH({});
+    // Refresh the service info because SSH is now configured.
+    getServiceInfo();
+  }, [vnet]);
+  const openSSHConfigurationModal = useCallback(
+    (vnetSSHConfigPath: string, host?: string) => {
+      appCtx.modalsService.openRegularDialog({
+        kind: 'configure-ssh-clients',
+        onConfirm: autoConfigureSSH,
+        vnetSSHConfigPath,
+        host,
+      });
+    },
+    [appCtx.modalsService, autoConfigureSSH]
+  );
+
   return (
     <VnetContext.Provider
       value={{
@@ -485,6 +508,7 @@ export const VnetContextProvider: FC<
         openReport: isWorkspaceSelected ? openReport : undefined,
         showDiagWarningIndicator,
         hasEverStarted,
+        openSSHConfigurationModal,
       }}
     >
       {children}

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -60,8 +60,18 @@ export type VnetContext = {
   startAttempt: Attempt<void>;
   stop: () => Promise<[void, Error]>;
   stopAttempt: Attempt<void>;
-  getServiceInfo: () => Promise<[GetServiceInfoResponse, Error]>;
+  /**
+   * Always returns the current VNet service info by making a gRPC call to the service.
+   */
+  currentServiceInfo: () => Promise<GetServiceInfoResponse>;
+  /**
+   * The current attempt to get the VNet service info.
+   */
   serviceInfoAttempt: Attempt<GetServiceInfoResponse>;
+  /**
+   * Refreshes serviceInfoAttempt by making a new gRPC call to the service.
+   */
+  refreshServiceInfoAttempt: () => Promise<[GetServiceInfoResponse, Error]>;
   runDiagnostics: () => Promise<[Report, Error]>;
   diagnosticsAttempt: Attempt<Report>;
   /**
@@ -108,10 +118,16 @@ export type VnetContext = {
   hasEverStarted: boolean;
   /**
    * Opens a modal that handles SSH client configuration.
-   *
-   * Optionally pass a specific host that will be used for example text.
    */
-  openSSHConfigurationModal: (vnetSSHConfigPath: string, host?: string) => void;
+  openSSHConfigurationModal: (params: {
+    /** The path to the user's generated VNet SSH config, available in the
+     * service info and diagnostic report. */
+    vnetSSHConfigPath: string;
+    /** Optional host address that will be used for example text. */
+    host?: string;
+    /** Optional callback that will be invoked after SSH clients are configured. */
+    onSuccess?: () => void;
+  }) => void;
 };
 
 export type VnetStatus =
@@ -239,12 +255,12 @@ export const VnetContextProvider: FC<
     ])
   );
 
-  const [serviceInfoAttempt, getServiceInfo] = useAsync(
-    useCallback(
-      () => vnet.getServiceInfo({}).then(({ response }) => response),
-      [vnet]
-    )
+  const currentServiceInfo = useCallback(
+    () => vnet.getServiceInfo({}).then(({ response }) => response),
+    [vnet]
   );
+  const [serviceInfoAttempt, refreshServiceInfoAttempt] =
+    useAsync(currentServiceInfo);
 
   /**
    * Calculates whether the button for running diagnostics should be disabled. If it should be
@@ -473,14 +489,19 @@ export const VnetContextProvider: FC<
 
   const autoConfigureSSH = useCallback(async (): Promise<void> => {
     await vnet.autoConfigureSSH({});
-    // Refresh the service info because SSH is now configured.
-    getServiceInfo();
+    // Refresh the service info attempt because SSH is now configured.
+    refreshServiceInfoAttempt();
   }, [vnet]);
   const openSSHConfigurationModal = useCallback(
-    (vnetSSHConfigPath: string, host?: string) => {
+    ({ vnetSSHConfigPath, host, onSuccess }) => {
       appCtx.modalsService.openRegularDialog({
         kind: 'configure-ssh-clients',
-        onConfirm: autoConfigureSSH,
+        onConfirm: async () => {
+          await autoConfigureSSH();
+          if (onSuccess) {
+            onSuccess();
+          }
+        },
         vnetSSHConfigPath,
         host,
       });
@@ -497,8 +518,9 @@ export const VnetContextProvider: FC<
         startAttempt,
         stop,
         stopAttempt,
-        getServiceInfo,
+        currentServiceInfo,
         serviceInfoAttempt,
+        refreshServiceInfoAttempt,
         runDiagnostics,
         diagnosticsAttempt,
         getDisabledDiagnosticsReason,

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -489,25 +489,27 @@ export const VnetContextProvider: FC<
 
   const autoConfigureSSH = useCallback(async (): Promise<void> => {
     await vnet.autoConfigureSSH({});
-    // Refresh the service info attempt because SSH is now configured.
+    // Refresh the service info and diagnostic attempts because SSH is now configured.
     refreshServiceInfoAttempt();
+    runDiagnostics();
   }, [vnet, refreshServiceInfoAttempt]);
-  const openSSHConfigurationModal = useCallback(
-    ({ vnetSSHConfigPath, host, onSuccess }) => {
-      appCtx.modalsService.openRegularDialog({
-        kind: 'configure-ssh-clients',
-        onConfirm: async () => {
-          await autoConfigureSSH();
-          if (onSuccess) {
-            onSuccess();
-          }
-        },
-        vnetSSHConfigPath,
-        host,
-      });
-    },
-    [appCtx.modalsService, autoConfigureSSH]
-  );
+  const openSSHConfigurationModal: VnetContext['openSSHConfigurationModal'] =
+    useCallback(
+      ({ vnetSSHConfigPath, host, onSuccess }) => {
+        appCtx.modalsService.openRegularDialog({
+          kind: 'configure-ssh-clients',
+          onConfirm: async () => {
+            await autoConfigureSSH();
+            if (onSuccess) {
+              onSuccess();
+            }
+          },
+          vnetSSHConfigPath,
+          host,
+        });
+      },
+      [appCtx.modalsService, autoConfigureSSH]
+    );
 
   return (
     <VnetContext.Provider

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -491,7 +491,7 @@ export const VnetContextProvider: FC<
     await vnet.autoConfigureSSH({});
     // Refresh the service info attempt because SSH is now configured.
     refreshServiceInfoAttempt();
-  }, [vnet]);
+  }, [vnet, refreshServiceInfoAttempt]);
   const openSSHConfigurationModal = useCallback(
     ({ vnetSSHConfigPath, host, onSuccess }) => {
       appCtx.modalsService.openRegularDialog({

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -298,9 +298,17 @@ export interface DialogHardwareKeySlotOverwrite {
   onCancel(): void;
 }
 
+export interface DialogConfigureSSHClients {
+  kind: 'configure-ssh-clients';
+  onConfirm(): Promise<void>;
+  vnetSSHConfigPath: string;
+  host?: string;
+}
+
 export type Dialog =
   | DialogClusterConnect
   | DialogClusterLogout
+  | DialogConfigureSSHClients
   | DialogDocumentsReopen
   | DialogUsageData
   | DialogUserJobRole

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -300,6 +300,11 @@ export interface DialogHardwareKeySlotOverwrite {
 
 export interface DialogConfigureSSHClients {
   kind: 'configure-ssh-clients';
+  /**
+   * onConfirm will be called when the user clicks the button to confirm automatic configuration
+   * for SSH clients. Any errors thrown by onConfirm will be captured and shown in the modal, the
+   * modal will only close if the promise resolves successfully.
+   */
   onConfirm(): Promise<void>;
   vnetSSHConfigPath: string;
   host?: string;


### PR DESCRIPTION
This PR adds a modal in Connect that explains the configuration necessary so that OpenSSH-compatible clients can automatically use VNet, and builds on https://github.com/gravitational/teleport/pull/55923 to add a one-click button to automatically add the configuration.

The modal can be opened from three places:
- it automatically opens when the user clicks "Connect with VNet" next to an SSH server but SSH clients are not already configured
- VNet's connection slider, which will display a warning if SSH clients are not configured and a new [Resolve] button to open the modal
- the VNet diagnostic page, which also displays a warning and the new [Resolve] button

<details><summary>Screenshots</summary>
<img width="1234" alt="Screenshot 2025-06-24 at 2 41 00 PM" src="https://github.com/user-attachments/assets/899233bf-2915-496b-b62f-d39a3ae6d5e6" />
<img width="461" alt="Screenshot 2025-06-24 at 2 41 12 PM" src="https://github.com/user-attachments/assets/f8f3d59b-eec0-4b27-b7a6-36b8eb865a6d" />
<img width="747" alt="Screenshot 2025-06-24 at 2 41 26 PM" src="https://github.com/user-attachments/assets/50222b83-6d5e-4762-992a-bac001d8c6f2" />
</details>

https://github.com/user-attachments/assets/65f2a51d-2916-4c92-af5d-214794ab19f5

