### PR TITLE
tsh: Add wrapper for syscall.Dup2 for linux/arm64

### DIFF
--- a/tool/tsh/common/dup2_linux.go
+++ b/tool/tsh/common/dup2_linux.go
@@ -14,16 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build linux && arm64
+//go:build linux
 
 package common
 
 import "syscall"
 
-// dup2 implements syscall.Dup2(oldfd, newfd) on Linux ARM64, as that platform
-// does not have syscall.Dup2(). Instead syscall.Dup3() must be used.
-// syscall.Dup3() is not available on all unix platforms so it cannot be used
-// unconditionally.
+// dup2 implements syscall.Dup2(oldfd, newfd) in a way that works on all
+// current Linux platforms, and likely on any new platforms. New platforms
+// such as ARM64 do not implement syscall.Dup2() instead implementing
+// syscall.Dup3() which is largely a superset, with one special case.
 func dup2(oldfd, newfd int) error {
 	if oldfd == newfd {
 		// dup2 would do nothing in this case, but dup3 returns an error.

--- a/tool/tsh/common/dup2_linux_arm64.go
+++ b/tool/tsh/common/dup2_linux_arm64.go
@@ -1,0 +1,34 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux && arm64
+
+package common
+
+import "syscall"
+
+// dup2 implements syscall.Dup2(oldfd, newfd) on Linux ARM64, as that platform
+// does not have syscall.Dup2(). Instead syscall.Dup3() must be used.
+// syscall.Dup3() is not available on all unix platforms so it cannot be used
+// unconditionally.
+func dup2(oldfd, newfd int) error {
+	if oldfd == newfd {
+		// dup2 would do nothing in this case, but dup3 returns an error.
+		// Emulate dup2 behavior.
+		return nil
+	}
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/tool/tsh/common/dup2_unix.go
+++ b/tool/tsh/common/dup2_unix.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !linux
+//go:build unix && !linux
 
 package common
 

--- a/tool/tsh/common/dup2_unix.go
+++ b/tool/tsh/common/dup2_unix.go
@@ -14,14 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !(linux && arm64)
+//go:build !linux
 
 package common
 
 import "syscall"
 
-// dup2 wraps syscall.Dup2(oldfd, newfd) on platforms that have it, allowing
-// platforms that do not to implement dup2() with syscall.Dup3() instead.
+// dup2 wraps syscall.Dup2(oldfd, newfd) on non-linux unix platforms. The
+// linux implementation uses syscall.Dup3() as Dup2() is not available
+// on all linux platforms.
 func dup2(oldfd, newfd int) error {
 	return syscall.Dup2(oldfd, newfd)
 }

--- a/tool/tsh/common/dup2_unix.go
+++ b/tool/tsh/common/dup2_unix.go
@@ -1,0 +1,27 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !(linux && arm64)
+
+package common
+
+import "syscall"
+
+// dup2 wraps syscall.Dup2(oldfd, newfd) on platforms that have it, allowing
+// platforms that do not to implement dup2() with syscall.Dup3() instead.
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/tool/tsh/common/reexec_unix.go
+++ b/tool/tsh/common/reexec_unix.go
@@ -52,9 +52,10 @@ func replaceStdin() (*os.File, error) {
 	var dupErr error
 	if ctrlErr := rc.Control(func(fd uintptr) {
 		dupErr = dup2(int(fd), syscall.Stdin)
-		// stdin is not O_CLOEXEC after dup2 but thankfully the three stdio
-		// file descriptors must be not O_CLOEXEC anyway, so we can avoid
-		// a linux-specific implementation or syscall.ForkLock shenanigans
+		// dup2() is sufficient here as the three stdio file
+		// descriptors must not be O_CLOEXEC. Darwin does not have
+		// dup3(), so would need to resort to syscall.ForkLock
+		// shenanigans if we did need to set O_CLOEXEC.
 	}); ctrlErr != nil {
 		_ = devNull.Close()
 		return nil, trace.Wrap(ctrlErr)

--- a/tool/tsh/common/reexec_unix.go
+++ b/tool/tsh/common/reexec_unix.go
@@ -51,7 +51,7 @@ func replaceStdin() (*os.File, error) {
 	}
 	var dupErr error
 	if ctrlErr := rc.Control(func(fd uintptr) {
-		dupErr = syscall.Dup2(int(fd), syscall.Stdin)
+		dupErr = dup2(int(fd), syscall.Stdin)
 		// stdin is not O_CLOEXEC after dup2 but thankfully the three stdio
 		// file descriptors must be not O_CLOEXEC anyway, so we can avoid
 		// a linux-specific implementation or syscall.ForkLock shenanigans
@@ -60,7 +60,7 @@ func replaceStdin() (*os.File, error) {
 		return nil, trace.Wrap(ctrlErr)
 	}
 	if dupErr != nil {
-		// this is the error from Dup2
+		// this is the error from dup2
 		_ = devNull.Close()
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Add a wrapper for `syscall.Dup2()` as linux ARM64 does not have that
syscall. On that platform, `syscall.Dup3()` needs to be used instead.

Fixes: 57c909dab1b8f7f0a8ba7e3199a902775f82f42a
Related: https://github.com/gravitational/teleport/pull/54696
