### PR TITLE
[Web] Implement identifier-first login frontend

### DIFF
--- a/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+
+import { storageService } from 'teleport/services/storageService';
+
+import { FormIdentifierFirst } from './FormIdentifierFirst';
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('no user remembered in localstorage renders username input form', () => {
+  storageService.setRememberedSsoUsername('');
+
+  render(
+    <FormIdentifierFirst
+      onLoginWithSso={jest.fn()}
+      onUseLocalLogin={jest.fn()}
+      isLocalAuthEnabled={true}
+    />
+  );
+
+  expect(
+    screen.getByPlaceholderText('Username or email address')
+  ).toBeVisible();
+});
+
+test('user remembered in localstorage shows welcome screen with connectors', async () => {
+  storageService.setRememberedSsoUsername('joe@example.com');
+
+  server.use(
+    http.post('/v1/webapi/authconnectors', () =>
+      HttpResponse.json(connectorsResp)
+    )
+  );
+
+  render(
+    <FormIdentifierFirst
+      onLoginWithSso={jest.fn()}
+      onUseLocalLogin={jest.fn()}
+      isLocalAuthEnabled={true}
+    />
+  );
+
+  await expect(screen.getByText('Welcome, joe@example.com')).toBeVisible();
+  await waitFor(() => {
+    expect(screen.getByText(/Okta SSO/i)).toBeVisible();
+  });
+});
+
+test('if there is only one connector returned after submitting username, the user is taken there immediately', async () => {
+  storageService.setRememberedSsoUsername('');
+  server.use(
+    http.post('/v1/webapi/authconnectors', () =>
+      HttpResponse.json(connectorsResp)
+    )
+  );
+
+  const mockOnLoginWithSso = jest.fn();
+
+  const user = userEvent.setup();
+
+  render(
+    <FormIdentifierFirst
+      onLoginWithSso={mockOnLoginWithSso}
+      onUseLocalLogin={jest.fn()}
+      isLocalAuthEnabled={true}
+    />
+  );
+
+  const input = screen.getByPlaceholderText('Username or email address');
+  await user.type(input, 'joe@example.com');
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+
+  await waitFor(() => {
+    expect(mockOnLoginWithSso).toHaveBeenCalled();
+  });
+});
+
+const connectorsResp = {
+  connectors: [
+    {
+      name: 'Okta',
+      type: 'saml',
+      displayName: 'Okta SSO',
+      url: 'http://localhost/okta/login/web?redirect_url=http:%2F%2Flocalhost%2Fwebconnector_id=okta',
+    },
+  ],
+};

--- a/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.tsx
@@ -1,0 +1,300 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import {
+  Box,
+  ButtonPrimary,
+  ButtonText,
+  Card,
+  Flex,
+  Indicator,
+  Input,
+  LabelInput,
+  Text,
+} from 'design';
+import * as Alerts from 'design/Alert';
+import ButtonSso, { guessProviderType } from 'shared/components/ButtonSso';
+import { useRefAutoFocus } from 'shared/hooks';
+import { Attempt, useAsync } from 'shared/hooks/useAsync';
+import { AuthProvider } from 'shared/services';
+
+import ResourceService from 'teleport/services/resources';
+import { storageService } from 'teleport/services/storageService';
+
+type Props = {
+  onLoginWithSso(provider: AuthProvider): void;
+  /**
+   * onUseLocalLogin is called to switch the view to the local login form.
+   */
+  onUseLocalLogin(): void;
+  /**
+   * isLocalAuthEnabled is whether local auth is enabled. If not, the identifier first login screen should be the only possible screen.
+   */
+  isLocalAuthEnabled: boolean;
+};
+
+/**
+ * FormIdentifierFirst is the login form for identifier-first login.
+ */
+export function FormIdentifierFirst({
+  onLoginWithSso,
+  onUseLocalLogin,
+  isLocalAuthEnabled,
+}: Props) {
+  const [resourceService] = useState(() => new ResourceService());
+
+  const [rememberedUsername, setRememberedUsername] = useState<string>(
+    storageService.getRememberedSsoUsername().trim()
+  );
+  const [username, setUsername] = useState<string>(rememberedUsername);
+  const [connectors, setConnectors] = useState<AuthProvider[]>([]);
+
+  useEffect(() => {
+    if (rememberedUsername) {
+      fetchMatchingConnectors(rememberedUsername);
+    }
+  }, [rememberedUsername]);
+
+  const [fetchAttempt, fetchMatchingConnectors] = useAsync(
+    useCallback(
+      async (username: string) => {
+        const matchedConnectors =
+          await resourceService.getUserMatchedAuthConnectors(username);
+        if (matchedConnectors.length === 0) {
+          if (rememberedUsername) {
+            // If we have a remembered username but no connectors, we clear the remembered username.
+            storageService.clearRememberedSsoUsername();
+            setRememberedUsername('');
+            setUsername('');
+            return;
+          }
+          throw new Error(`No SSO connectors found for user: ${username}`);
+        }
+        // If there isn't a remembered username, and there is only one matching connector, we take them straight to the IdP.
+        if (matchedConnectors.length === 1 && !rememberedUsername) {
+          onLoginWithSso(matchedConnectors[0]);
+          storageService.setRememberedSsoUsername(username);
+          setRememberedUsername(username);
+          return;
+        }
+        setConnectors(matchedConnectors);
+        setRememberedUsername(username);
+        storageService.setRememberedSsoUsername(username);
+        return;
+      },
+      [username]
+    )
+  );
+
+  const onSubmitUsername = () => {
+    fetchMatchingConnectors(username);
+  };
+
+  const onNotYou = () => {
+    storageService.clearRememberedSsoUsername();
+    setUsername('');
+    setRememberedUsername('');
+    setConnectors([]);
+  };
+
+  return (
+    <Card my="5" mx="auto" width={650} p={4}>
+      <Flex flexDirection="column" alignItems="center">
+        <Text typography="h1" textAlign="center">
+          {rememberedUsername
+            ? 'Sign in to Teleport'
+            : 'Sign in to Teleport with SSO'}
+        </Text>
+        {fetchAttempt.status === 'error' && (
+          <Alerts.Danger mt={3}>{fetchAttempt.statusText}</Alerts.Danger>
+        )}
+        <Flex flexDirection="column" alignItems="center" width="100%">
+          {rememberedUsername ? (
+            <Text typography="h2" textAlign="center" mt={1}>
+              Welcome, {username}
+            </Text>
+          ) : (
+            <>
+              <UsernamePrompt
+                onSubmitUsername={onSubmitUsername}
+                username={username}
+                setUsername={setUsername}
+                fetchAttempt={fetchAttempt}
+              />
+              {isLocalAuthEnabled && (
+                <ViewSwitchButton
+                  onClick={onUseLocalLogin}
+                  disabled={fetchAttempt.status === 'processing'}
+                >
+                  Other Sign-in Options
+                </ViewSwitchButton>
+              )}
+            </>
+          )}
+          {fetchAttempt.status === 'processing' && !!rememberedUsername && (
+            <Box textAlign="center" m={4}>
+              <Indicator delay="none" />
+            </Box>
+          )}
+          {fetchAttempt.status === 'success' && connectors.length > 0 && (
+            <ConnectorList
+              providers={connectors}
+              onLoginWithSso={onLoginWithSso}
+              onNotYou={onNotYou}
+            />
+          )}
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}
+
+function UsernamePrompt({
+  onSubmitUsername,
+  username,
+  setUsername,
+  fetchAttempt,
+}: {
+  onSubmitUsername(): void;
+  username: string;
+  setUsername: (username: string) => void;
+  fetchAttempt: Attempt<void>;
+}) {
+  const inputRef = useRefAutoFocus<HTMLInputElement>({
+    shouldFocus: true,
+  });
+
+  return (
+    <Flex
+      as="form"
+      alignItems="center"
+      justifyContent="center"
+      flexDirection="column"
+      onSubmit={e => {
+        e.preventDefault();
+        onSubmitUsername();
+      }}
+      width="100%"
+      gap={3}
+      mb={3}
+      mt={5}
+    >
+      <Flex flexDirection="column" alignItems="flex-start" width="100%">
+        <LabelInput>Username</LabelInput>
+        <Input
+          ref={inputRef}
+          value={username}
+          onChange={e => setUsername(e.target.value?.trim())}
+          placeholder="Username or email address"
+          width="100%"
+          autoFocus={true}
+        />
+      </Flex>
+      <ButtonPrimary
+        type="submit"
+        size="extra-large"
+        disabled={fetchAttempt.status === 'processing' || !username}
+        width="100%"
+      >
+        Next
+      </ButtonPrimary>
+    </Flex>
+  );
+}
+
+function ConnectorList({
+  providers,
+  onLoginWithSso,
+  onNotYou,
+}: {
+  providers: AuthProvider[];
+  onLoginWithSso(provider: AuthProvider): void;
+  onNotYou(): void;
+}) {
+  const $btns = providers.map((item, index) => {
+    let { name, type, displayName } = item;
+    const title = displayName || name;
+    const ssoType = guessProviderType(title, type);
+    return (
+      <StyledButtonSso
+        px={5}
+        size="extra-large"
+        key={index}
+        title={`Sign in with ${title}`}
+        ssoType={ssoType}
+        onClick={e => {
+          e.preventDefault();
+          onLoginWithSso(item);
+        }}
+      />
+    );
+  });
+
+  return (
+    <Flex flexDirection="column" gap={2} mt={5} width="100%">
+      <Text textAlign="start" typography="subtitle1" color="text.muted">
+        Select an identity provider to continue:
+      </Text>
+      {$btns}
+      <Flex justifyContent="center" mt={3}>
+        <ViewSwitchButton onClick={onNotYou} disabled={false}>
+          Sign in with a different account
+        </ViewSwitchButton>
+      </Flex>
+    </Flex>
+  );
+}
+
+/**
+ * ViewSwitch button is the button used to switch between login form views.
+ */
+export function ViewSwitchButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick(): void;
+  disabled: boolean;
+} & React.PropsWithChildren) {
+  return (
+    <ButtonText
+      size="large"
+      onClick={onClick}
+      disabled={disabled}
+      css={`
+        color: ${props => props.theme.colors.text.muted};
+        background: transparent;
+        &:hover {
+          background: transparent;
+        }
+      `}
+    >
+      {children}
+    </ButtonText>
+  );
+}
+
+const StyledButtonSso = styled(ButtonSso)`
+  width: 100%;
+  justify-content: flex-start;
+  padding-top: 12px;
+  padding-bottom: 12px;
+`;

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
@@ -16,6 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { delay, http, HttpResponse } from 'msw';
+import { useEffect, useState } from 'react';
+
+import cfg from 'teleport/config';
+import { storageService } from 'teleport/services/storageService';
+
 import FormLogin, { Props } from './FormLogin';
 
 const props: Props = {
@@ -224,4 +230,74 @@ export const PrimaryPwdlessWithNoSso = () => {
       auth2faType="optional"
     />
   );
+};
+
+export const IdentifierFirst = () => {
+  const ssoProviders = [
+    { name: 'github', type: 'oidc', url: '' } as const,
+    { name: 'google', type: 'oidc', url: '' } as const,
+  ];
+  const [key, setKey] = useState(0);
+
+  useEffect(() => {
+    const defaultIdentifierFirst = cfg.auth.identifierFirstLoginEnabled;
+    cfg.auth.identifierFirstLoginEnabled = true;
+    setKey(prev => prev + 1); // Force remount the component with new cfg state.
+
+    return () => {
+      cfg.auth.identifierFirstLoginEnabled = defaultIdentifierFirst;
+    };
+  }, []);
+
+  return <FormLogin {...props} authProviders={ssoProviders} key={key} />;
+};
+
+export const IdentifierFirstRememberedUser = () => {
+  const [key, setKey] = useState(0);
+  const ssoProviders = [
+    { name: 'github', type: 'oidc', url: '' } as const,
+    { name: 'google', type: 'oidc', url: '' } as const,
+  ];
+
+  useEffect(() => {
+    storageService.setRememberedSsoUsername('joe@goteleport.com');
+    const defaultIdentifierFirst = cfg.auth.identifierFirstLoginEnabled;
+    cfg.auth.identifierFirstLoginEnabled = true;
+    setKey(prev => prev + 1); // Force remount the component with new cfg state.
+
+    return () => {
+      cfg.auth.identifierFirstLoginEnabled = defaultIdentifierFirst;
+      storageService.clearRememberedSsoUsername();
+    };
+  }, []);
+
+  return <FormLogin {...props} authProviders={ssoProviders} key={key} />;
+};
+
+IdentifierFirstRememberedUser.parameters = {
+  msw: {
+    handlers: [
+      http.post(cfg.api.authConnectorsPath, async () => {
+        await delay(600); // Simulate loading state
+        return HttpResponse.json([connectorsResp]);
+      }),
+    ],
+  },
+};
+
+const connectorsResp = {
+  connectors: [
+    {
+      name: 'Okta',
+      type: 'saml',
+      displayName: 'Okta',
+      url: 'http://localhost/okta/login/web?redirect_url=http:%2F%2Flocalhost%2Fwebconnector_id=okta',
+    },
+    {
+      name: 'Entra',
+      type: 'saml',
+      displayName: 'Entra',
+      url: 'http://localhost/okta/login/web?redirect_url=http:%2F%2Flocalhost%2Fwebconnector_id=okta',
+    },
+  ],
 };

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -138,6 +138,7 @@ const cfg = {
     preferredLocalMfa: '' as PreferredMfaType,
     // motd is the message of the day, displayed to users before login.
     motd: '',
+    identifierFirstLoginEnabled: false,
   },
 
   proxyCluster: 'localhost',
@@ -468,6 +469,8 @@ const cfg = {
       '/v1/webapi/sites/:clusterId/plugins/:plugin/files/msteams_app.zip',
 
     defaultConnectorPath: '/v1/webapi/authconnector/default',
+
+    authConnectorsPath: '/v1/webapi/authconnectors',
 
     yaml: {
       parse: '/v1/webapi/yaml/parse/:kind',

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { AuthProvider } from 'shared/services';
+
 import cfg, { UrlListRolesParams, UrlResourcesParams } from 'teleport/config';
 import api from 'teleport/services/api';
 
@@ -104,6 +106,14 @@ class ResourceService {
     const challengeResponse = await auth.getMfaChallengeResponse(challenge);
 
     return api.put(cfg.api.defaultConnectorPath, req, challengeResponse);
+  }
+
+  async getUserMatchedAuthConnectors(
+    username: string
+  ): Promise<AuthProvider[]> {
+    return api
+      .post(cfg.api.authConnectorsPath, { username })
+      .then(res => res.connectors || []);
   }
 
   async fetchRoles(params?: UrlListRolesParams): Promise<{

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -43,6 +43,7 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
   KeysEnum.USERS_NOT_EQUAL_TO_MAU_ACKNOWLEDGED,
   KeysEnum.USE_NEW_ROLE_EDITOR,
   KeysEnum.RECENT_HISTORY,
+  KeysEnum.REMEMBERED_SSO_USERNAME,
 ];
 
 const RECENT_HISTORY_MAX_LENGTH = 10;
@@ -337,5 +338,17 @@ export const storageService = {
     );
 
     return newHistory;
+  },
+
+  setRememberedSsoUsername(username: string) {
+    window.localStorage.setItem(KeysEnum.REMEMBERED_SSO_USERNAME, username);
+  },
+
+  getRememberedSsoUsername(): string {
+    return window.localStorage.getItem(KeysEnum.REMEMBERED_SSO_USERNAME) || '';
+  },
+
+  clearRememberedSsoUsername() {
+    window.localStorage.removeItem(KeysEnum.REMEMBERED_SSO_USERNAME);
   },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -42,6 +42,7 @@ export const KeysEnum = {
   LOCAL_NOTIFICATION_STATES: 'grv_teleport_notification_states',
   RECENT_HISTORY: 'grv_teleport_sidenav_recent_history',
   LOGIN_TIME: 'grv_teleport_login_time',
+  REMEMBERED_SSO_USERNAME: 'grv_teleport_remembered_sso_username',
 
   // TODO(bl-nero): Remove once the new role editor is in acceptable state.
   USE_NEW_ROLE_EDITOR: 'grv_teleport_use_new_role_editor',


### PR DESCRIPTION
## Purpose

This PR includes the frontend changes for identifier-first login. If identifier-first login is flagged as enabled in the webconfig, a new form in the UI is rendered.

This relies on backend changes in https://github.com/gravitational/teleport/pull/55932

[Figma mockup](https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Zero-Trust-Access?node-id=9746-53247&m=dev)

RFD for this feature: https://github.com/gravitational/teleport/blob/master/rfd/0214-identifier-first-login.md

Doc changes for this feature: https://github.com/gravitational/teleport/pull/56149

## Demo

### Initial screen w/ no remembered user
![image](https://github.com/user-attachments/assets/e842896d-66cd-4fad-a1e9-3d272f3facf4)


### With remembered user and multiple connectors
![image](https://github.com/user-attachments/assets/888f0584-5183-4374-b151-881c2c0bdd65)


### With remembered user and only one match
![image](https://github.com/user-attachments/assets/2d3c19f3-93d9-431b-9010-94552566b38a)


changelog: Add support for identifier-first login