### PR TITLE
[Web] Fix minor visual bugs on auth connector edit page

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditorContent.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditorContent.tsx
@@ -88,15 +88,13 @@ export function AuthConnectorEditorContent({
             {saveAttempt.status === 'error' && (
               <Alert width="100%">{saveAttempt.statusText}</Alert>
             )}
-            <Flex height="600px" width="100%">
-              {content && (
-                <TextEditor
-                  bg="levels.deep"
-                  readOnly={false}
-                  data={[{ content, type: 'yaml' }]}
-                  onChange={setContent}
-                />
-              )}
+            <Flex height="100%" width="100%">
+              <TextEditor
+                bg="levels.deep"
+                readOnly={false}
+                data={[{ content, type: 'yaml' }]}
+                onChange={setContent}
+              />
             </Flex>
             <Box mt={3}>
               <ButtonPrimary disabled={isSaveDisabled} onClick={onSave} mr="3">


### PR DESCRIPTION
## Purpose

This PR fixes the following minor visual bugs on the auth editor page:

### 1. Deleting all text content from the editor would cause the YAML editor to disappear entirely.

#### Before fix
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/44691942-d1bc-4b59-bcbb-09c838d772dc" />

#### After fix
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/a1a2763e-b15d-433d-8412-539ae0777c77" />


### 2. Error banner would clip over title on smaller viewports.

#### Before fix

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/a170cf46-c80e-4336-8b26-6c3fd958b875" />


#### After fix 

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/8f00833f-4a0c-4ba8-9a8b-e996b7ed0e3e" />
