### PR TITLE
[Web] Fix users not being redirected back to the login page when their session expires

### DIFF
--- a/.github/ISSUE_TEMPLATE/webtestplan.md
+++ b/.github/ISSUE_TEMPLATE/webtestplan.md
@@ -132,6 +132,8 @@ For each, test the invite, reset, and login flows
 - [ ] Verify that error message is shown if an invite/reset is expired/invalid
 - [ ] Verify that account is locked after several unsuccessful login attempts
 
+- [ ] Verify that after logging in, user is automatically redirected to the login page when the session expires.
+
 #### Auth Connectors
 
 For help with setting up auth connectors, check out the [Quick GitHub/SAML/OIDC Setup Tips]

--- a/web/packages/teleport/src/services/websession/websession.test.ts
+++ b/web/packages/teleport/src/services/websession/websession.test.ts
@@ -16,27 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { waitFor } from '@testing-library/react';
+
 import history from 'teleport/services/history';
 
 import websession from '.';
 import api from '../api';
 
 test('user should be redirected to login even if session delete call fails', async () => {
-  const mockPromise = {
-    then: jest.fn().mockReturnThis(),
-    catch: jest.fn().mockReturnThis(),
-    finally: jest.fn().mockImplementation(callback => {
-      callback();
-      return mockPromise;
-    }),
-    [Symbol.toStringTag]: 'Promise',
-  };
-
-  jest.spyOn(api, 'delete').mockReturnValue(mockPromise as any);
+  jest.spyOn(console, 'error').mockImplementation();
+  jest.spyOn(api, 'delete').mockRejectedValue(new Error('some error'));
   const goToLoginSpy = jest.spyOn(history, 'goToLogin').mockImplementation();
   jest.spyOn(websession, 'clear').mockImplementation();
 
   websession.logout();
 
-  expect(goToLoginSpy).toHaveBeenCalled();
+  await waitFor(() => expect(goToLoginSpy).toHaveBeenCalled());
 });

--- a/web/packages/teleport/src/services/websession/websession.test.ts
+++ b/web/packages/teleport/src/services/websession/websession.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import history from 'teleport/services/history';
+
+import websession from '.';
+import api from '../api';
+
+test('user should be redirected to login even if session delete call fails', async () => {
+  const mockPromise = {
+    then: jest.fn().mockReturnThis(),
+    catch: jest.fn().mockReturnThis(),
+    finally: jest.fn().mockImplementation(callback => {
+      callback();
+      return mockPromise;
+    }),
+    [Symbol.toStringTag]: 'Promise',
+  };
+
+  jest.spyOn(api, 'delete').mockReturnValue(mockPromise as any);
+  const goToLoginSpy = jest.spyOn(history, 'goToLogin').mockImplementation();
+  jest.spyOn(websession, 'clear').mockImplementation();
+
+  websession.logout();
+
+  expect(goToLoginSpy).toHaveBeenCalled();
+});

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -36,14 +36,21 @@ let sesstionCheckerTimerId = null;
 
 const session = {
   logout(rememberLocation = false) {
-    api.delete(cfg.api.webSessionPath).then(response => {
-      this.clear();
-      if (response.samlSloUrl) {
-        window.open(response.samlSloUrl, '_self');
-      } else {
-        history.goToLogin({ rememberLocation });
-      }
-    });
+    let samlSloUrl = '';
+
+    api
+      .delete(cfg.api.webSessionPath)
+      .then(response => {
+        samlSloUrl = response.samlSloUrl;
+      })
+      .finally(() => {
+        this.clear();
+        if (samlSloUrl) {
+          window.open(samlSloUrl, '_self');
+        } else {
+          history.goToLogin({ rememberLocation });
+        }
+      });
   },
 
   logoutWithoutSlo({

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -41,7 +41,14 @@ const session = {
     api
       .delete(cfg.api.webSessionPath)
       .then(response => {
-        samlSloUrl = response.samlSloUrl;
+        samlSloUrl = response?.samlSloUrl;
+      })
+      .catch(err => {
+        // This request can fail if the session is already expired, which isn't an issue, but we should still catch the error.
+        logger.error(
+          'Failed to delete session. This can happen if the session has already expired.',
+          err
+        );
       })
       .finally(() => {
         this.clear();


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/50431

This PR fixes an issue where if a user's session expired, they would not automatically be logged out in the UI and taken back to the login page. The user is now redirected to the login page even if the `api.delete()` call returns an error, which happens if the session is expired/invalid.