### PR TITLE
Add access_list.spec.type field

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -411,7 +411,11 @@ type AccessListSpec struct {
 	// title is a plaintext short description of the Access List.
 	Title string `protobuf:"bytes,8,opt,name=title,proto3" json:"title,omitempty"`
 	// owner_grants describes the access granted by owners to this Access List.
-	OwnerGrants   *AccessListGrants `protobuf:"bytes,11,opt,name=owner_grants,json=ownerGrants,proto3" json:"owner_grants,omitempty"`
+	OwnerGrants *AccessListGrants `protobuf:"bytes,11,opt,name=owner_grants,json=ownerGrants,proto3" json:"owner_grants,omitempty"`
+	// type can be currently "dynamic" (the default if empty string) which denotes a regular Access
+	// List, "scim" which represents an Access List created from SCIM group or "static" for Access
+	// Lists managed by IaC tools.
+	Type          string `protobuf:"bytes,12,opt,name=type,proto3" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -500,6 +504,13 @@ func (x *AccessListSpec) GetOwnerGrants() *AccessListGrants {
 		return x.OwnerGrants
 	}
 	return nil
+}
+
+func (x *AccessListSpec) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
 }
 
 // AccessListOwner is an owner of an Access List.
@@ -1389,7 +1400,7 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"AccessList\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2\".teleport.header.v1.ResourceHeaderR\x06header\x12:\n" +
 	"\x04spec\x18\x02 \x01(\v2&.teleport.accesslist.v1.AccessListSpecR\x04spec\x12@\n" +
-	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xc1\x04\n" +
+	"\x06status\x18\x03 \x01(\v2(.teleport.accesslist.v1.AccessListStatusR\x06status\"\xd5\x04\n" +
 	"\x0eAccessListSpec\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12?\n" +
 	"\x06owners\x18\x02 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\x12=\n" +
@@ -1398,7 +1409,8 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x12ownership_requires\x18\x05 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x11ownershipRequires\x12@\n" +
 	"\x06grants\x18\x06 \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\x06grants\x12\x14\n" +
 	"\x05title\x18\b \x01(\tR\x05title\x12K\n" +
-	"\fowner_grants\x18\v \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\vownerGrantsJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
+	"\fowner_grants\x18\v \x01(\v2(.teleport.accesslist.v1.AccessListGrantsR\vownerGrants\x12\x12\n" +
+	"\x04type\x18\f \x01(\tR\x04typeJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\vR\amembersR\n" +
 	"membershipR\townership\"\xef\x01\n" +

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -71,6 +71,11 @@ message AccessListSpec {
 
   // owner_grants describes the access granted by owners to this Access List.
   AccessListGrants owner_grants = 11;
+
+  // type can be currently "dynamic" (the default if empty string) which denotes a regular Access
+  // List, "scim" which represents an Access List created from SCIM group or "static" for Access
+  // Lists managed by IaC tools.
+  string type = 12;
 }
 
 // AccessListOwner is an owner of an Access List.

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -268,7 +268,25 @@ func TestAccessListDefaults(t *testing.T) {
 
 		err := uut.CheckAndSetDefaults()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "owners")
+		require.ErrorContains(t, err, "owners")
+	})
+
+	t.Run("type is defaulted to dynamic", func(t *testing.T) {
+		uut := newValidAccessList()
+		uut.Spec.Type = ""
+
+		err := uut.CheckAndSetDefaults()
+		require.NoError(t, err)
+		require.Equal(t, Dynamic, uut.Spec.Type)
+	})
+
+	t.Run("type is validated", func(t *testing.T) {
+		uut := newValidAccessList()
+		uut.Spec.Type = "test_unknown_type"
+
+		err := uut.CheckAndSetDefaults()
+		require.Error(t, err)
+		require.ErrorContains(t, err, `unknown access_list type "test_unknown_type"`)
 	})
 }
 

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -38,9 +38,15 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		return nil, trace.BadParameter("spec is missing")
 	}
 
+	accessListType, err := accesslist.NewTypeFromString(spec.GetType())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	metadata := headerv1.FromMetadataProto(msg.GetHeader().GetMetadata())
 
 	accessListSpec := accesslist.Spec{
+		Type:               accessListType,
 		Title:              spec.GetTitle(),
 		Description:        spec.GetDescription(),
 		Owners:             convertOwnersFromProto(spec.GetOwners()),
@@ -76,6 +82,7 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 	return &accesslistv1.AccessList{
 		Header: headerv1.ToResourceHeaderProto(accessList.ResourceHeader),
 		Spec: &accesslistv1.AccessListSpec{
+			Type:               string(accessList.Spec.Type),
 			Title:              accessList.Spec.Title,
 			Description:        accessList.Spec.Description,
 			Owners:             convertOwnersToProto(accessList.Spec.Owners),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -89,13 +89,35 @@ func TestWithOwnersIneligibleStatusField(t *testing.T) {
 }
 
 func TestRoundtrip(t *testing.T) {
+	t.Run("with custom subkind", func(t *testing.T) {
+		accessList := newAccessList(t, "access-list")
+		accessList.ResourceHeader.SetSubKind("access-list-subkind")
+
+		converted, err := FromProto(ToProto(accessList))
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff(accessList, converted))
+	})
+
+	t.Run("with non-default type", func(t *testing.T) {
+		accessList := newAccessList(t, "access-list")
+		accessList.Spec.Type = accesslist.Static
+
+		converted, err := FromProto(ToProto(accessList))
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff(accessList, converted))
+		require.Equal(t, accesslist.Static, converted.Spec.Type)
+	})
+}
+
+func Test_FromProto_withBadType(t *testing.T) {
 	accessList := newAccessList(t, "access-list")
-	accessList.ResourceHeader.SetSubKind("access-list-subkind")
+	accessList.Spec.Type = "test_bad_type"
 
-	converted, err := FromProto(ToProto(accessList))
-	require.NoError(t, err)
-
-	require.Empty(t, cmp.Diff(accessList, converted))
+	_, err := FromProto(ToProto(accessList))
+	require.Error(t, err)
+	require.ErrorContains(t, err, `unknown access_list type "test_bad_type"`)
 }
 
 // Make sure that we don't panic if any of the message fields are missing.
@@ -344,6 +366,10 @@ func TestConvAccessList(t *testing.T) {
 
 			got := ToProto(acl)
 			require.NoError(t, err)
+
+			if tt.input.Spec.Type == "" {
+				tt.input.Spec.Type = string(accesslist.Dynamic)
+			}
 
 			require.Equal(t, tt.input, got)
 		})

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -34,6 +34,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |owners|[][object](#specowners-items)|owners is a list of owners of the Access List.|
 |ownership_requires|[object](#specownership_requires)|ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list.|
 |title|string|title is a plaintext short description of the Access List.|
+|type|string|type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.|
 
 ### spec.audit
 

--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -62,6 +62,7 @@ Optional:
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
+- `type` (String) type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
 
 ### Nested Schema for `spec.audit`
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -107,6 +107,7 @@ Optional:
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
+- `type` (String) type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
 
 ### Nested Schema for `spec.audit`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -190,6 +190,12 @@ spec:
                 description: title is a plaintext short description of the Access
                   List.
                 type: string
+              type:
+                description: type can be currently "dynamic" (the default if empty
+                  string) which denotes a regular Access List, "scim" which represents
+                  an Access List created from SCIM group or "static" for Access Lists
+                  managed by IaC tools.
+                type: string
             type: object
           status:
             description: Status defines the observed state of the Teleport resource

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -118,6 +118,14 @@ export interface AccessListSpec {
      * @generated from protobuf field: teleport.accesslist.v1.AccessListGrants owner_grants = 11;
      */
     ownerGrants?: AccessListGrants;
+    /**
+     * type can be currently "dynamic" (the default if empty string) which denotes a regular Access
+     * List, "scim" which represents an Access List created from SCIM group or "static" for Access
+     * Lists managed by IaC tools.
+     *
+     * @generated from protobuf field: string type = 12;
+     */
+    type: string;
 }
 /**
  * AccessListOwner is an owner of an Access List.
@@ -695,7 +703,8 @@ class AccessListSpec$Type extends MessageType<AccessListSpec> {
             { no: 5, name: "ownership_requires", kind: "message", T: () => AccessListRequires },
             { no: 6, name: "grants", kind: "message", T: () => AccessListGrants },
             { no: 8, name: "title", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 11, name: "owner_grants", kind: "message", T: () => AccessListGrants }
+            { no: 11, name: "owner_grants", kind: "message", T: () => AccessListGrants },
+            { no: 12, name: "type", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AccessListSpec>): AccessListSpec {
@@ -703,6 +712,7 @@ class AccessListSpec$Type extends MessageType<AccessListSpec> {
         message.description = "";
         message.owners = [];
         message.title = "";
+        message.type = "";
         if (value !== undefined)
             reflectionMergePartial<AccessListSpec>(this, message, value);
         return message;
@@ -735,6 +745,9 @@ class AccessListSpec$Type extends MessageType<AccessListSpec> {
                     break;
                 case /* teleport.accesslist.v1.AccessListGrants owner_grants */ 11:
                     message.ownerGrants = AccessListGrants.internalBinaryRead(reader, reader.uint32(), options, message.ownerGrants);
+                    break;
+                case /* string type */ 12:
+                    message.type = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -772,6 +785,9 @@ class AccessListSpec$Type extends MessageType<AccessListSpec> {
         /* teleport.accesslist.v1.AccessListGrants owner_grants = 11; */
         if (message.ownerGrants)
             AccessListGrants.internalBinaryWrite(message.ownerGrants, writer.tag(11, WireType.LengthDelimited).fork(), options).join();
+        /* string type = 12; */
+        if (message.type !== "")
+            writer.tag(12, WireType.LengthDelimited).string(message.type);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -190,6 +190,12 @@ spec:
                 description: title is a plaintext short description of the Access
                   List.
                 type: string
+              type:
+                description: type can be currently "dynamic" (the default if empty
+                  string) which denotes a regular Access List, "scim" which represents
+                  an Access List created from SCIM group or "static" for Access Lists
+                  managed by IaC tools.
+                type: string
             type: object
           status:
             description: Status defines the observed state of the Teleport resource

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -297,6 +297,11 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
+				"type": {
+					Description: "type can be currently \"dynamic\" (the default if empty string) which denotes a regular Access List, \"scim\" which represents an Access List created from SCIM group or \"static\" for Access Lists managed by IaC tools.",
+					Optional:    true,
+					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+				},
 			}),
 			Description: "spec is the specification for the Access List.",
 			Optional:    true,
@@ -1195,6 +1200,23 @@ func CopyAccessListFromTerraform(_ context.Context, tf github_com_hashicorp_terr
 										}
 									}
 								}
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["type"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"AccessList.spec.type"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"AccessList.spec.type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+							} else {
+								var t string
+								if !v.Null && !v.Unknown {
+									t = string(v.Value)
+								}
+								obj.Type = t
 							}
 						}
 					}
@@ -2712,6 +2734,28 @@ func CopyAccessListToTerraform(ctx context.Context, obj *github_com_gravitationa
 								v.Unknown = false
 								tf.Attrs["owner_grants"] = v
 							}
+						}
+					}
+					{
+						t, ok := tf.AttrTypes["type"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"AccessList.spec.type"})
+						} else {
+							v, ok := tf.Attrs["type"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+							if !ok {
+								i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+								if err != nil {
+									diags.Append(attrWriteGeneralError{"AccessList.spec.type", err})
+								}
+								v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+								if !ok {
+									diags.Append(attrWriteConversionFailureDiag{"AccessList.spec.type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+								}
+								v.Null = string(obj.Type) == ""
+							}
+							v.Value = string(obj.Type)
+							v.Unknown = false
+							tf.Attrs["type"] = v
 						}
 					}
 				}


### PR DESCRIPTION
This adds a new filed access_list.spec.type with 3 possible values:

- "dynamic" - the default if empty
- "static" - for members management with Terraform
- "scim" - for SCIM integration

More details on [Slack](https://gravitational.slack.com/archives/C03PJTF5BPD/p1750438884951129) (sorry, private)

Backports:

- [x] https://github.com/gravitational/teleport/pull/56640
- [x] https://github.com/gravitational/teleport/pull/56322