### PR TITLE
Web: fix topbar nav covering resource lock checkout panel

### DIFF
--- a/web/packages/teleport/src/LocksV2/NewLock/LockCheckout/LockCheckout.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/LockCheckout/LockCheckout.tsx
@@ -42,6 +42,7 @@ import { pluralize } from 'shared/utils/text';
 import shieldCheck from 'teleport/assets/shield-check.png';
 import cfg from 'teleport/config';
 import { TrashButton } from 'teleport/LocksV2/common';
+import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 import { lockService } from 'teleport/services/locks';
 
 import {
@@ -200,6 +201,7 @@ export const LockCheckout = forwardRef<HTMLDivElement, Props>(
           top: 0;
           left: 0;
           overflow: hidden;
+          z-index: ${zIndexMap.checkoutSidePanel};
         `}
       >
         <Dimmer className={transitionState} />

--- a/web/packages/teleport/src/Navigation/zIndexMap.ts
+++ b/web/packages/teleport/src/Navigation/zIndexMap.ts
@@ -17,6 +17,11 @@
  */
 
 export const zIndexMap = {
+  // "checkoutSidePanel" z-index must be a higher value than "topBar" z-index.
+  // checkoutSidePanel encompasses entire height of the browser and
+  // the high z-index prevents navigational bits from rendering over
+  // the panel.
+  checkoutSidePanel: 100,
   topBar: 19,
   sideNavButtons: 18,
   sideNavContainer: 17,


### PR DESCRIPTION
fixes top bar nav rendering over the LockCheckout panel (for session & identity lock).

before:
<img width="546" alt="image" src="https://github.com/user-attachments/assets/4aeb0564-248b-4b46-8db2-00b9edbb939a" />

after:
<img width="523" alt="image" src="https://github.com/user-attachments/assets/df48b1d3-bd71-487d-9a44-23fcb8ccc6d5" />
