### PR TITLE
[vnet] feat: mention SSH on VNet info page

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
@@ -39,7 +39,7 @@ export function DocumentVnetInfo(props: {
   doc: docTypes.DocumentVnetInfo;
 }) {
   const { doc } = props;
-  const { mainProcessClient } = useAppContext();
+  const { mainProcessClient, clustersService } = useAppContext();
   const {
     startAttempt,
     stop: stopVnet,
@@ -47,12 +47,14 @@ export function DocumentVnetInfo(props: {
     status,
   } = useVnetContext();
   const { launchVnetWithoutFirstTimeCheck } = useVnetLauncher();
-  const userAtHost = useMemo(() => {
-    const { hostname, username } = mainProcessClient.getRuntimeSettings();
-    return `${username}@${hostname}`;
+  const { username, hostname } = useMemo(() => {
+    const { username, hostname } = mainProcessClient.getRuntimeSettings();
+    return { username, hostname };
   }, [mainProcessClient]);
+  const userAtHost = `${username}@${hostname}`;
   const { rootClusterUri, documentsService } = useWorkspaceContext();
   const proxyHostname = routing.parseClusterName(rootClusterUri);
+  const clusterName = clustersService.findCluster(rootClusterUri).name;
 
   const startVnet = async () => {
     await launchVnetWithoutFirstTimeCheck(doc.launcherArgs);
@@ -229,6 +231,60 @@ export function DocumentVnetInfo(props: {
             </DemoPart>
           </ComparisonOption>
         </UseCaseSection>
+
+        {/* VNet SSH */}
+        <UseCaseSection>
+          <TitleAndLearnMoreContainer>
+            <H2>SSH Servers With 3rd-Party SSH Clients</H2>
+            {/* TODO(nklaassen): link to new VNet SSH docs */}
+            <LearnMoreButton href="#">Learn More</LearnMoreButton>
+          </TitleAndLearnMoreContainer>
+
+          <ComparisonOption>
+            <TextPart>
+              <H3>With VNet</H3>
+              <P2>
+                Connect directly to Teleport SSH servers with any
+                OpenSSH-compatible client or your preferred editor's remote SSH
+                extension. VNet will intercept the connection to authenticate
+                with your SSH certificate and handle Teleport features like
+                hardware keys and per-session MFA with prompts displayed in
+                Connect.
+              </P2>
+            </TextPart>
+
+            <DemoTerminal
+              flex={demoFlex}
+              title={userAtHost}
+              text={sshWithVNet(username, clusterName)}
+              width="100%"
+              boxShadow={2}
+            />
+          </ComparisonOption>
+
+          <ComparisonOption>
+            <TextPart>
+              <H3>Without VNet</H3>
+              <P2>
+                You can still connect to Teleport SSH servers with many
+                OpenSSH-compatible clients, but you'll need to configure the
+                client to use your Teleport user SSH certificate and use a
+                ProxyCommand to make the connection, and Teleport features like
+                hardware keys and per-session MFA are not supported.
+              </P2>
+            </TextPart>
+
+            <Stack flex={demoFlex} gap={2} fullWidth>
+              <DemoTerminal
+                flex={demoFlex}
+                title={userAtHost}
+                text={sshWithoutVNet(username, clusterName)}
+                width="100%"
+                boxShadow={2}
+              />
+            </Stack>
+          </ComparisonOption>
+        </UseCaseSection>
       </Stack>
     </Document>
   );
@@ -298,3 +354,16 @@ const curlWithoutVnet = `$ curl http://127.0.0.1:61397
   "body": ""
 }
 `;
+
+const sshWithVNet = (
+  username: string,
+  clusterName: string
+) => `$ ssh ${username}@server.${clusterName}
+${username}@server:~$ `;
+
+const sshWithoutVNet = (
+  username: string,
+  clusterName: string
+) => `$ tsh config > teleport_ssh_config
+$ ssh -F ./teleport_ssh_config ${username}@server.${clusterName}
+${username}@server:~$ `;


### PR DESCRIPTION
This PR adds a mention of VNet SSH to Connect's VNet info page.

<img width="1212" alt="Screenshot 2025-06-20 at 5 39 33 PM" src="https://github.com/user-attachments/assets/63335c11-fa2a-4530-b1b6-d26fb5fd41ba" />
