### PR TITLE
[v17] Restructuring agent homepage links

### DIFF
--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,4 +3,17 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 ---
 
-<DocCardList />
+## Getting started
+- [Introduction to Enrolling Applications](./introduction.mdx): How to set up Teleport to protect applications and cloud provider APIs
+- [Protect a Web Application with Teleport](./getting-started.mdx): Provides instructions to set up the Teleport Application Service and enable secure access to a web application.
+
+## Guides
+- [Application Access Guides (section)](./guides/): Guides for configuring Teleport application access.
+- [Securing Access to Cloud APIs (section)](./cloud-apis/): How to use Teleport to achieve secure access while managing your cloud-based infrastructure.
+- [Application Access JWT Authentication (section)](./jwt/): Guides for using Teleport application access JWT authentication.
+
+## Configuration & management
+- [Application Access Role-Based Access Control](./controls.mdx): Role-Based Access Control (RBAC) for Teleport application access.
+
+## Troubleshooting & support
+- [Troubleshooting Application Access](./troubleshooting-apps.mdx): Describes common issues and solutions for access to applications protected by Teleport.

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -17,4 +17,9 @@ registered on the Auth Service backend.
 
 Set up Teleport auto-discovery for resources in your infrastructure:
 
-<DocCardList />
+## Guides
+
+- [Database Discovery (section)](./databases/): Detailed guides for configuring database discovery.
+- [Enroll Kubernetes Services as Teleport Applications (section)](./kubernetes-applications/): Teleport can automatically detect applications running in your Kubernetes clusters and register them with Teleport for secure access.
+- [Kubernetes Clusters Discovery (section)](./kubernetes/): Detailed guides for configuring Kubernetes Clusters Discovery.
+- [Server Auto-Discovery (section)](./servers/): You can set up the Teleport Discovery Service to automatically enroll servers in your infrastructure.

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -22,4 +22,25 @@ agent services.
 
 ![Architecture diagram for enrolling databases with Teleport](../../../img/database-access/architecture.svg)
 
-<DocCardList />
+## Getting started
+
+- [Database Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport database access and AWS Aurora PostgreSQL.
+
+## Guides
+
+- [Enroll AWS Databases (section)](./enroll-aws-databases/): Provides instructions on protecting databases in your AWS-managed infrastructure with Teleport.
+- [Enroll Azure Databases (section)](./enroll-azure-databases/): Provides instructions on protecting databases in your Azure-managed infrastructure with Teleport.
+- [Enroll Google Cloud Databases (section)](./enroll-google-cloud-databases/): Provides instructions on protecting databases in your Google Cloud-managed infrastructure with Teleport.
+- [Enroll Cloud-Hosted Database Platforms (section)](./enroll-managed-databases/): Provides instructions on protecting managed databases in your infrastructure with Teleport.
+- [Enroll Self-Hosted Databases (section)](./enroll-self-hosted-databases/): Provides instructions on protecting self-hosted databases in your infrastructure with Teleport.
+- [Database Automatic User Provisioning (section)](./auto-user-provisioning/): Configure automatic user provisioning for databases.
+
+## Configuration & management
+
+- [Database Access Controls](./rbac.mdx): Role-based access control (RBAC) for Teleport database access.
+- [Using the Teleport Database Service (section)](./guides/): Guides to possibilities for running the Teleport Database Service.
+
+## Troubleshooting & support
+
+- [Database Access FAQ](./faq.mdx): Frequently asked questions about Teleport database access.
+- [Troubleshooting Database Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's Database Access

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,4 +3,21 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
-<DocCardList />
+## Getting started
+
+- [Manage Access to Windows Resources](./introduction.mdx): Demonstrates how you can manage access to Windows desktops with Teleport.
+
+## Guides
+
+- [Configure access for local Windows users](./getting-started.mdx): Use Teleport to configure passwordless access for local Windows users.
+- [Configure access for Active Directory manually](./active-directory.mdx): Explains how to manually connect Teleport to an Active Directory domain.
+- [Directory Sharing](./directory-sharing.mdx): Teleport desktop Directory Sharing lets you easily send files to a remote desktop.
+- [Dynamic Windows Desktop Registration](./dynamic-registration.mdx): Register/unregister Windows desktops without restarting Teleport.
+
+## Configuration & management
+
+- [Role-Based Access Control for Desktops](./rbac.mdx): Role-based access control (RBAC) for desktops protected by Teleport.
+
+## Troubleshooting & support
+
+- [Troubleshooting Desktop Access](./troubleshooting.mdx): Common issues and resolutions for Teleport's desktop access

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,4 +3,21 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 ---
 
-<DocCardList />
+## Getting started
+
+- [Introduction to Enrolling Kubernetes Clusters](./introduction.mdx): Learn how Teleport can protect your Kubernetes clusters with RBAC, audit logging, and more.
+- [Enroll a Kubernetes Cluster](./getting-started.mdx): Demonstrates how to enroll a Kubernetes cluster as a resource protected by Teleport.
+
+## Guides
+
+- [Registering Kubernetes Clusters with Teleport (section)](./register-clusters/): How to manually add a Kubernetes cluster to Teleport after creating it.
+- [Setting Up Access Controls for Kubernetes](./manage-access.mdx): How to configure Teleport roles to access clusters, groups, users, and resources in Kubernetes.
+
+## Configuration & management
+
+- [Teleport Kubernetes Access Controls](./controls.mdx): How the Teleport Kubernetes Service applies RBAC to manage access to Kubernetes
+
+## Troubleshooting & support
+
+- [Kubernetes Access FAQ](./faq.mdx): Frequently asked questions about Teleport Kubernetes Access
+- [Kubernetes Access Troubleshooting](./troubleshooting.mdx): Troubleshooting common issues with Kubernetes access

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,4 +3,20 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 ---
 
-<DocCardList />
+## Getting started
+
+- [Introduction to Enrolling Servers](./introduction.mdx): Teleport server access features and introduction.
+- [Server Access Getting Started Guide](./getting-started.mdx): Getting started with Teleport server access.
+
+## Guides
+
+- [Server Access Guides (section)](./guides/): Teleport server access guides.
+- [OpenSSH Guides (section)](./openssh/): Teleport Agentless OpenSSH integration guides.
+
+## Configuration & management
+
+- [Access Controls for Servers](./rbac.mdx): Role-based access control (RBAC) for Teleport server access.
+
+## Troubleshooting & support
+
+- [Troubleshooting Server Access](./troubleshooting-server.mdx): Describes common issues and solutions for access to servers.

--- a/docs/pages/machine-workload-identity/machine-id/machine-id.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/machine-id.mdx
@@ -3,4 +3,18 @@ title: Machine ID
 description: Guides to using Machine ID, which allows you to provide secure access to your infrastructure from automated services.
 ---
 
-<DocCardList />
+## Getting started
+
+- [Introduction to Machine ID](./introduction.mdx): Teleport Machine ID introduction, demo and resources.
+- [Machine ID Getting Started Guide](./getting-started.mdx): Getting started with Teleport Machine ID
+- [Machine ID Manifesto](./manifesto.mdx): A manifesto for Machine Identity
+
+## Guides
+
+- [Access your Infrastructure with Machine ID](./access-guides/) (section): How to use Machine ID to enable secure access to Teleport resources.
+- [Deploy Machine ID](./deployment/) (section): Explains how to deploy Machine ID on your platform and join it to your Teleport cluster.
+
+## Troubleshooting & support
+
+- [Machine ID FAQ](./faq.mdx): Frequently asked questions about Teleport Machine ID
+- [Machine ID Troubleshooting Guide](./troubleshooting.mdx): Troubleshooting common issues with Machine ID

--- a/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
@@ -3,4 +3,20 @@ title: Workload Identity
 description: Securely issue flexible short-lived identities to your workloads
 ---
 
-<DocCardList />
+## Getting started
+- [Introduction to Workload Identity](./introduction.mdx): Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
+- [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
+- [Getting Started with Workload Identity](./getting-started.mdx): Getting started with Teleport Workload Identity for SPIFFE and Machine ID
+
+## Guides
+- [Configuring Workload Identity and AWS OIDC Federation](./aws-oidc-federation.mdx): Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
+- [Configuring Workload Identity and AWS Roles Anywhere](./aws-roles-anywhere.mdx): Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
+- [Configuring Workload Identity and Azure Federated Credentials](./azure-federated-credentials.mdx): Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
+- [Configuring Workload Identity and GCP Workload Identity Federation with JWTs](./gcp-workload-identity-federation-jwt.mdx): Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
+- [Workload Identity and tsh](./tsh.mdx): Issuing SPIFFE SVIDs using Workload Identity and tsh
+
+## Configuration & management
+- [Best Practices for Teleport Workload Identity](./best-practices.mdx): Answers common questions and describes best practices for using Teleport Workload Identity in production.
+- [JWT SVIDs](./jwt-svids.mdx): An overview of the JWT SVIDs issued by Teleport Workload Identity
+- [SPIFFE Federation](./federation.mdx): An overview of the Teleport Workload Identity SPIFFE Federation feature.
+- [Workload Attestation](./workload-attestation.mdx): An overview of the Teleport Workload Identity Workload Attestation feature.


### PR DESCRIPTION
I missed the backport to v17 so am creating this one manually since the original is closed. 

Cherry picked from original - [55622](https://github.com/gravitational/teleport/pull/55622)

* restructured agent homepages
* fixed heading and sentence case
* rearranging for clarity