### PR TITLE
fix: data race in vnet.TestSSH

### DIFF
--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1357,7 +1357,7 @@ func TestSSH(t *testing.T) {
 				// catch the error at the right step.
 				resolvedAddrs, err := p.lookupHost(ctx, tc.dialAddr)
 				require.NoError(t, err)
-				require.Greater(t, len(resolvedAddrs), 0)
+				require.NotEmpty(t, resolvedAddrs)
 
 				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 				defer cancel()

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -1158,8 +1158,7 @@ func testWithAlgorithmSuite(t *testing.T, suite types.SignatureAlgorithmSuite) {
 
 // TestSSH tests basic VNet SSH functionality.
 func TestSSH(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	clock := clockwork.NewRealClock()
 	homePath := t.TempDir()
 
@@ -1343,41 +1342,43 @@ func TestSSH(t *testing.T) {
 		t.Run(fmt.Sprintf("%s@%s:%d", tc.sshUser, tc.dialAddr, tc.dialPort), func(t *testing.T) {
 			t.Parallel()
 
-			lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-			defer cancel()
-			// The DNS lookup for *.<cluster-name> should resolve to an IP in
-			// the expected CIDR range for the cluster.
-			resolvedAddrs, err := p.lookupHost(lookupCtx, tc.dialAddr)
 			if tc.expectLookupToFail {
+				// In these cases the DNS lookup is expected to fail, just run the DNS lookup.
+				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+				_, err := p.lookupHost(ctx, tc.dialAddr)
 				require.Error(t, err)
 				return
 			}
-			require.NoError(t, err)
 
-			_, expectNet, err := net.ParseCIDR(tc.expectCIDR)
-			require.NoError(t, err)
-
-			for _, resolvedAddr := range resolvedAddrs {
-				resolvedIP := net.ParseIP(resolvedAddr)
-				// The query may have resolved to a v4 or v6 address or both,
-				// either way the 4-byte suffix should be a valid IPv4 address
-				// in the expected CIDR range.
-				resolvedIPSuffix := resolvedIP[len(resolvedIP)-4:]
-				assert.True(t, expectNet.Contains(resolvedIPSuffix),
-					"expected CIDR range %s does not include resolved IP %s", expectNet, resolvedIPSuffix)
-			}
-
-			// TCP dial the target address, it should fail if the node doesn't
-			// exist.
-			dialCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-			defer cancel()
-			conn, err := p.dialHost(dialCtx, tc.dialAddr, tc.dialPort)
 			if tc.expectDialToFail {
+				// In these cases the DNS lookup should succeed but then the
+				// TCP dial should fail, do each separately to make sure we
+				// catch the error at the right step.
+				resolvedAddrs, err := p.lookupHost(ctx, tc.dialAddr)
+				require.NoError(t, err)
+				require.Greater(t, len(resolvedAddrs), 0)
+
+				ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+				_, err = p.dialHost(ctx, resolvedAddrs[0], tc.dialPort)
 				require.Error(t, err)
 				return
 			}
+
+			conn, err := p.dialHost(ctx, tc.dialAddr, tc.dialPort)
 			require.NoError(t, err)
 			defer conn.Close()
+
+			// The DNS query may have resolved to a v4 or v6 address, either
+			// way the 4-byte suffix should be a valid IPv4 address in the
+			// expected CIDR range.
+			resolvedIP := conn.RemoteAddr().(*net.TCPAddr).IP
+			resolvedIPSuffix := resolvedIP[len(resolvedIP)-4:]
+			_, expectNet, err := net.ParseCIDR(tc.expectCIDR)
+			require.NoError(t, err)
+			assert.True(t, expectNet.Contains(resolvedIPSuffix),
+				"expected CIDR range %s does not include resolved IP %s", expectNet, resolvedIPSuffix)
 
 			// Initiate an SSH connection to the target. At this point the
 			// handshake should complete successfully as long as the right keys
@@ -1414,6 +1415,7 @@ func TestSSH(t *testing.T) {
 
 	// Test that a fresh SSH host cert is used on each connection.
 	t.Run("ephemeral certs", func(t *testing.T) {
+		t.Parallel()
 		// Set up the SSH client config to capture the host certs it sees.
 		var checkedHostCerts []*ssh.Certificate
 		clientConfig := &ssh.ClientConfig{


### PR DESCRIPTION
Fixes #55979

Flaky test detector caught a data race in VNet's TestSSH
```
==================
WARNING: DATA RACE
Write at 0x00c000f92870 by goroutine 393:
  github.com/gravitational/teleport/lib/vnet.(*sshAgent).setSessionKey()
      /__w/teleport.e/teleport.e/lib/vnet/ssh_agent.go:55 +0x99c
  github.com/gravitational/teleport/lib/vnet.(*sshProvider).sessionSSHConfig()
      /__w/teleport.e/teleport.e/lib/vnet/ssh_provider.go:219 +0x8be
  github.com/gravitational/teleport/lib/vnet.(*clientApplicationServiceClient).SessionSSHConfig()
      /__w/teleport.e/teleport.e/lib/vnet/client_application_service_client.go:193 +0x2f9
...

Previous read at 0x00c000f92870 by goroutine 405:
  github.com/gravitational/teleport/lib/vnet.(*sshAgent).List()
      /__w/teleport.e/teleport.e/lib/vnet/ssh_agent.go:62 +0x84
  github.com/gravitational/teleport/lib/vnet.(*forwardedAgents).forwarded()
      /__w/teleport.e/teleport.e/lib/vnet/vnet_test.go:1794 +0x168
  github.com/gravitational/teleport/lib/vnet.mustStartFakeWebProxy.func2.2()
      /__w/teleport.e/teleport.e/lib/vnet/vnet_test.go:1687 +0xd6
```

The changes in ssh_agent.go here fix the issue by adding a mutex around access to `sshAgent.signer`. The mutex isn't strictly necessary in real product code because the signer is always set before it could be read, but the test keeps a collection of `sshAgent`s and may read them at any time, so the added mutex should resolve it.

The changes in vnet_test.go don't directly address the data race, but they were necessary for me to get TestSSH to pass at all under the race detector on my local PC. The race detector makes gVisor code extremely slow. The difference is the test no longer sets a 100ms timeout on gVisor DNS lookups and TCP dials that are required to succeed for the test to pass.