### PR TITLE
[v18] Remove unused C import from lib/bpf/common.go

### DIFF
--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -18,8 +18,6 @@
 
 package bpf
 
-import "C"
-
 import (
 	"context"
 


### PR DESCRIPTION
Backport #55944 to branch/v18