### PR TITLE
Add react-error-boundary to Jest ES modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ const esModules = [
   'd3-path',
   'internmap',
   '@nivo/bar',
+  'react-error-boundary',
 ].join('|');
 
 /** @type {import('@jest/types').Config.InitialOptions} */


### PR DESCRIPTION
Tests won't pass otherwise