### PR TITLE
Use hash pinning for base container images in Dockerfiles

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -18,7 +18,7 @@
 ## LIBFIDO2 ###################################################################
 
 # Build libfido2 separately for isolation, speed and flexibility.
-FROM buildpack-deps:22.04 AS libfido2
+FROM buildpack-deps:22.04@sha256:d4dd8c4891377f710f1509f5a3aa777e9d64f3c93f9b3be198a10cdd497c8ac4 AS libfido2
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends cmake && \
@@ -72,7 +72,7 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.15.0 && \
 
 ## LIBBPF #####################################################################
 
-FROM buildpack-deps:22.04 AS libbpf
+FROM buildpack-deps:22.04@sha256:d4dd8c4891377f710f1509f5a3aa777e9d64f3c93f9b3be198a10cdd497c8ac4 AS libbpf
 
 # Install required dependencies
 RUN apt-get update -y --fix-missing && \
@@ -107,7 +107,7 @@ RUN mkdir -p /opt && cd /opt &&  \
 # 4. Fast, language-dependent dependencies
 # 5. Multi-stage layer copies
 
-FROM ubuntu:22.04 AS buildbox
+FROM ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee AS buildbox
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -6,7 +6,7 @@
 # The binaries also run in the OCI containers we produce,
 # both "heavy" and distroless.
 #
-FROM docker.io/library/debian:11
+FROM docker.io/library/debian:11@sha256:0d3279ff38fb2024358b2f24fbb99122f9a9a40618bb526b614527e998bcda28
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -6,7 +6,7 @@ FROM ${BUILDBOX_CENTOS7_ASSETS} AS teleport-buildbox-centos7-assets
 
 ## BASE ###################################################################
 
-FROM --platform=$BUILDPLATFORM centos:7 AS base
+FROM --platform=$BUILDPLATFORM centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4 AS base
 
 # devtoolset-12 is only in CentOS buildlogs. The rpms are unsigned since they never were
 # published to the official CentOS SCL repos.

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM centos:7 AS centos-devtoolset
+FROM --platform=$BUILDPLATFORM centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4 AS centos-devtoolset
 
 ARG BUILDARCH
 ARG DEVTOOLSET

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.4
+FROM docker.io/golang:1.24.4@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -4,7 +4,7 @@
 # TODO(hugoShaka): cleanup the Makefile docker/image targets and remove this file.
 
 # Stage to build the image, without FIPS entrypoint argument
-FROM ubuntu:20.04 AS teleport
+FROM ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214 AS teleport
 
 # Install dumb-init and ca-certificates. The dumb-init package is to ensure
 # signals and orphaned processes are handled correctly. The ca-certificates

--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:12 AS staging
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS staging
 RUN apt-get update
 COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
-FROM debian:12 AS teleport
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/build.assets/charts/Dockerfile-distroless-fips
+++ b/build.assets/charts/Dockerfile-distroless-fips
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:12 AS staging
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS staging
 RUN apt-get update
 COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
-FROM debian:12 AS teleport
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:12 AS teleport
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/build.assets/charts/Dockerfile-tbot-distroless-fips
+++ b/build.assets/charts/Dockerfile-tbot-distroless-fips
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
-FROM debian:12 AS teleport
+FROM debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note
 # that we cannot simply pass a ready-made package filename in as a build-arg, as
 # this dockerfile is used for a multiarch build and any build-args will be

--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
-FROM golang:1.22-bookworm as builder
+FROM golang:1.22-bookworm@sha256:3d699e4d15d0f8f13c9195c0632a16702b8cbdece2955af1c23b37ae5d55a253 as builder
 
 WORKDIR /go/src/github.com/gravitational/teleport/examples/teleport-usage
 

--- a/integrations/access/Dockerfile
+++ b/integrations/access/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
 # Extract the built tarball to reduce the final image size
-FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
+FROM --platform=${BUILDPLATFORM} alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd as extractor
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/integrations/event-handler/Dockerfile
+++ b/integrations/event-handler/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
 # Extract the built tarball to reduce the final image size
-FROM --platform=${BUILDPLATFORM} alpine:3.20.0 as extractor
+FROM --platform=${BUILDPLATFORM} alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd as extractor
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM docker.io/debian:12 as builder
+FROM --platform=$BUILDPLATFORM docker.io/debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe as builder
 ARG BUILDARCH
 
 ## Install dependencies.

--- a/integrations/operator/Dockerfile.gha
+++ b/integrations/operator/Dockerfile.gha
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM docker.io/debian:12 as builder
+FROM --platform=$BUILDPLATFORM docker.io/debian:12@sha256:0d8498a0e9e6a60011df39aab78534cfe940785e7c59d19dfae1eb53ea59babe as builder
 ARG BUILDARCH
 
 ## Install dependencies.


### PR DESCRIPTION
# Overview

Using hash pinning for our base container image references in our Dockerfiles. This is in a similar vein as hash pinning our workflow references. Container image tags are mutable references that an attacker could overwrite to run malicious code in our pipelines.

This doesn't encompass all references. Some of our references are not hardcoded (ie `FROM node:${NODE_VERSION}`) and are therefore not pinned.

It's also important to note that this uses the index digest hash. This allows for multi-platform references which are variable in our Dockerfiles (ie `FROM --platform ${BUILD_PLATFORM} alpine`). The 

Some of the changes introduced here are used for examples and aren't actually used in any of our automation. These are included simply to reduce noise for any future automation.

# Impact

* Our automated dependency management tooling needs to be checked to ensure it can support this. Renovate does support this but not sure about dependabot.
* Hash pinning can be an annoying extra step to managing updates manually. However this is tooling to automate this (I just created a quick script for it).
* These changes will likely not be "backportable". This means we need to manually do these initial updates on each branch.