### PR TITLE
grpcbuildbox: drop usage of buildx when building grpcbox locally

### DIFF
--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -25,7 +25,7 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 # It's leaner, meaner, faster and not supposed to compile code.
 .PHONY: grpcbox
 grpcbox:
-	$(DOCKER) buildx build \
+	$(DOCKER) build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		-f Dockerfile-grpcbox \
 		-t "$(GRPCBOX)" \


### PR DESCRIPTION
On Linux, docker buildx plugin doesn't automatically load images into the registry so it never rebuilds the image on go version changes or buf changes. This causes buf to fail because the image go base version differs from the Teleport required version.

Since we do not need any cross-compilation here, we can safely drop `buildx` plugin usage.