### PR TITLE
Add `--listen` and `--insecure-listen-anywhere` flags to `tsh proxy db`

### DIFF
--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -180,14 +180,14 @@ func onProxyCommandDB(cf *CLIConf) error {
 	addr := "localhost:0"
 	randomPort := true
 	if cf.LocalProxyAddr != "" {
-		host, port, err := net.SplitHostPort(cf.LocalProxyAddr)
+		host, _, err := net.SplitHostPort(cf.LocalProxyAddr)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		if !cf.InsecureListenAnywhere && !apiutils.IsLoopback(host) {
 			return trace.BadParameter("only loopback addresses are allowed for listener without the insecure switch, got %q", cf.LocalProxyAddr)
 		}
-		randomPort = port == "0"
+		randomPort = false
 		addr = cf.LocalProxyAddr
 	} else if cf.LocalProxyPort != "" {
 		randomPort = false

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -174,6 +174,9 @@ func onProxyCommandDB(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	if cf.LocalProxyAddr != "" && cf.LocalProxyPort != "" {
+		return trace.BadParameter("either the address or port for the local proxy can be specified, not both")
+	}
 	addr := "localhost:0"
 	randomPort := true
 	if cf.LocalProxyAddr != "" {

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -185,7 +185,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 		if !cf.InsecureListenAnywhere && !apiutils.IsLoopback(host) {
-			return trace.BadParameter("only loopback addresses are allowed for listener without the insecure switch, got %q", cf.LocalProxyAddr)
+			return trace.BadParameter("only loopback addresses are allowed for listener without --insecure-listen-anywhere switch, got %q", cf.LocalProxyAddr)
 		}
 		randomPort = false
 		addr = cf.LocalProxyAddr

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -176,15 +177,15 @@ func onProxyCommandDB(cf *CLIConf) error {
 	addr := "localhost:0"
 	randomPort := true
 	if cf.LocalProxyAddr != "" {
-		netAddr, err := utils.ParseAddr(cf.LocalProxyAddr)
+		host, port, err := net.SplitHostPort(cf.LocalProxyAddr)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if !cf.InsecureListenAnywhere && !netAddr.IsLoopback() {
+		if !cf.InsecureListenAnywhere && !apiutils.IsLoopback(host) {
 			return trace.BadParameter("only loopback addresses are allowed for listener without the insecure switch, got %q", cf.LocalProxyAddr)
 		}
+		randomPort = port == "0"
 		addr = cf.LocalProxyAddr
-		randomPort = strings.HasSuffix(addr, ":0")
 	} else if cf.LocalProxyPort != "" {
 		randomPort = false
 		addr = fmt.Sprintf("127.0.0.1:%s", cf.LocalProxyPort)

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -175,7 +175,17 @@ func onProxyCommandDB(cf *CLIConf) error {
 
 	addr := "localhost:0"
 	randomPort := true
-	if cf.LocalProxyPort != "" {
+	if cf.LocalProxyAddr != "" {
+		netAddr, err := utils.ParseAddr(cf.LocalProxyAddr)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !cf.InsecureListenAnywhere && !netAddr.IsLoopback() {
+			return trace.BadParameter("only loopback addresses are allowed for listener without the insecure switch, got %q", cf.LocalProxyAddr)
+		}
+		addr = cf.LocalProxyAddr
+		randomPort = strings.HasSuffix(addr, ":0")
+	} else if cf.LocalProxyPort != "" {
 		randomPort = false
 		addr = fmt.Sprintf("127.0.0.1:%s", cf.LocalProxyPort)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1025,7 +1025,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
 	proxyDB.Arg("db", "The name of the database to start local proxy for.").StringVar(&cf.DatabaseService)
-	proxyDB.Flag("insecure-listen-anywhere", "Allows the local proxy to listen on any address other than loopbacks. Use with caution.").BoolVar(&cf.InsecureListenAnywhere)
+	proxyDB.Flag("insecure-listen-anywhere", "Allows the local proxy to listen on any address without restrictions. WARNING: this will expose unsecured listener to anyone in the network. Only use when network access is otherwise restricted.").BoolVar(&cf.InsecureListenAnywhere)
 	proxyDB.Flag("listen", "Specifies the source address used by proxy db listener. Mutually exclusive with --port.").StringVar(&cf.LocalProxyAddr)
 	proxyDB.Flag("port", "Specifies the source port used by proxy db listener.").Short('p').StringVar(&cf.LocalProxyPort)
 	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").BoolVar(&cf.LocalProxyTunnel)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1025,8 +1025,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
 	proxyDB.Arg("db", "The name of the database to start local proxy for.").StringVar(&cf.DatabaseService)
-	proxyDB.Flag("insecure-listen-anywhere", "Allow proxy to listen on any address other than loopbacks. Use with caution!").BoolVar(&cf.InsecureListenAnywhere)
-	proxyDB.Flag("listen", "Specifies the source address used by proxy db listener").StringVar(&cf.LocalProxyAddr)
+	proxyDB.Flag("insecure-listen-anywhere", "Allows the local proxy to listen on any address other than loopbacks. Use with caution.").BoolVar(&cf.InsecureListenAnywhere)
+	proxyDB.Flag("listen", "Specifies the source address used by proxy db listener. Mutually exclusive with --port.").StringVar(&cf.LocalProxyAddr)
 	proxyDB.Flag("port", "Specifies the source port used by proxy db listener.").Short('p').StringVar(&cf.LocalProxyPort)
 	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").BoolVar(&cf.LocalProxyTunnel)
 	proxyDB.Flag("db-user", "Database user to log in as.").Short('u').StringVar(&cf.DatabaseUser)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -440,6 +440,10 @@ type CLIConf struct {
 	// GlobalTshConfigPath is a path to global TSH config. Can be overridden with TELEPORT_GLOBAL_TSH_CONFIG.
 	GlobalTshConfigPath string
 
+	// InsecureListenAnywhere, when set, allows local proxy listener to use any address other than loopback addresses (127/8).
+	InsecureListenAnywhere bool
+	// LocalProxyAddr is an address used by local proxy listener.
+	LocalProxyAddr string
 	// LocalProxyPort is a port used by local proxy listener.
 	LocalProxyPort string
 	// LocalProxyPortMapping is a listening port and an optional target port used by local proxy
@@ -1021,6 +1025,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
 	proxyDB.Arg("db", "The name of the database to start local proxy for.").StringVar(&cf.DatabaseService)
+	proxyDB.Flag("insecure-listen-anywhere", "Allow proxy to listen on any address other than loopbacks. Use with caution!").BoolVar(&cf.InsecureListenAnywhere)
+	proxyDB.Flag("listen", "Specifies the source address used by proxy db listener").StringVar(&cf.LocalProxyAddr)
 	proxyDB.Flag("port", "Specifies the source port used by proxy db listener.").Short('p').StringVar(&cf.LocalProxyPort)
 	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").BoolVar(&cf.LocalProxyTunnel)
 	proxyDB.Flag("db-user", "Database user to log in as.").Short('u').StringVar(&cf.DatabaseUser)


### PR DESCRIPTION
The PR adds two flags, `--listen` and `--insecure-listen-anywhere`, to `tsh proxy db` command. `--listen HOSTNAME:PORT` makes the proxy listen on `HOSTNAME:PORT`. Only loopback addresses are allowed unless `--insecure-listen-anywhere` is present.

Note that this PR covers only `tsh proxy db`.

Updates #40509. 