### PR TITLE
mcputils refactor and new mcptest package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,8 @@ linters:
               desc: integration test should not be imported outside of intergation tests
             - pkg: github.com/gravitational/teleport/lib/srv/db/cassandra/testing
               desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/utils/mcptest
+              desc: testing packages should not be imported outside of _test.go files
         logging:
           deny:
             - pkg: github.com/sirupsen/logrus

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,6 +211,7 @@ linters:
             - '!**/lib/services/suite/**'
             - '!**/lib/tbot/workloadidentity/workloadattest/sigstore/sigstoretest/sigstoretest.go'
             - '!**/lib/teleterm/gatewaytest/**'
+            - '!**/lib/utils/mcptest/**'
             - '!**/lib/utils/testutils/**'
             - '!**/integration/appaccess/fixtures.go'
             - '!**/integration/appaccess/jwt.go'
@@ -271,6 +272,7 @@ linters:
             - '!**/lib/tbot/workloadidentity/workloadattest/sigstore/sigstoretest/sigstoretest.go'
             - '!**/lib/teleterm/gatewaytest/**'
             - '!**/lib/utils/cli.go'
+            - '!**/lib/utils/mcptest/**'
             - '!**/lib/utils/testutils/**'
             - '!**/tool/teleport/testenv/**'
           deny:

--- a/integration/appaccess/mcp_test.go
+++ b/integration/appaccess/mcp_test.go
@@ -19,17 +19,14 @@
 package appaccess
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"testing"
 
-	mcpclient "github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
 	libmcp "github.com/gravitational/teleport/lib/srv/mcp"
+	"github.com/gravitational/teleport/lib/utils/mcptest"
 )
 
 func testMCP(pack *Pack, t *testing.T) {
@@ -56,18 +53,9 @@ func testMCPDialStdio(t *testing.T, pack *Pack) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	clientTransport := transport.NewIO(serverConn, serverConn, io.NopCloser(bytes.NewReader(nil)))
-	stdioClient := mcpclient.NewClient(clientTransport)
-	defer stdioClient.Close()
-	require.NoError(t, stdioClient.Start(ctx))
+	stdioClient := mcptest.NewStdioClientFromConn(t, serverConn)
 
-	initReq := mcp.InitializeRequest{}
-	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initReq.Params.ClientInfo = mcp.Implementation{
-		Name:    "test-client",
-		Version: "1.0.0",
-	}
-	_, err = stdioClient.Initialize(ctx, initReq)
+	_, err = mcptest.InitializeClient(ctx, stdioClient)
 	require.NoError(t, err)
 
 	listTools, err := stdioClient.ListTools(ctx, mcp.ListToolsRequest{})

--- a/lib/utils/mcptest/test.go
+++ b/lib/utils/mcptest/test.go
@@ -1,0 +1,97 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcptest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gravitational/trace"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// NewServer creates an MCP test server that provides a "hello-server" tool that
+// always returns "hello-client".
+func NewServer() *mcpserver.MCPServer {
+	return NewServerWithVersion("1.0.0")
+}
+
+// NewServerWithVersion creates an MCP test server with the specified version
+// and provides a "hello-server" tool that always returns "hello-client".
+func NewServerWithVersion(version string) *mcpserver.MCPServer {
+	server := mcpserver.NewMCPServer("test-server", version)
+	server.AddTool(mcp.Tool{
+		Name: "hello-server",
+	}, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{mcp.NewTextContent("hello client")},
+		}, nil
+	})
+	return server
+}
+
+// NewStdioClient creates a new stdio client and ensures the client is closed
+// when testing is done.
+func NewStdioClient(t *testing.T, input io.Reader, output io.WriteCloser) *mcpclient.Client {
+	t.Helper()
+	stdioClientTransport := mcpclienttransport.NewIO(input, output, io.NopCloser(bytes.NewReader(nil)))
+	stdioClient := mcpclient.NewClient(stdioClientTransport)
+	t.Cleanup(func() {
+		stdioClient.Close()
+	})
+	require.NoError(t, stdioClient.Start(t.Context()))
+	return stdioClient
+}
+
+func NewStdioClientFromConn(t *testing.T, conn io.ReadWriteCloser) *mcpclient.Client {
+	t.Helper()
+	return NewStdioClient(t, conn, conn)
+}
+
+// InitializeClient starts initialize sequence and returns the initialize result
+// from the server.
+func InitializeClient(ctx context.Context, client *mcpclient.Client) (*mcp.InitializeResult, error) {
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}
+	resp, err := client.Initialize(ctx, initReq)
+	return resp, trace.Wrap(err)
+}
+
+// MustCallServerTool calls the "hello-server" tool and verifies the result.
+func MustCallServerTool(t *testing.T, ctx context.Context, client *mcpclient.Client) {
+	t.Helper()
+	callToolRequest := mcp.CallToolRequest{}
+	callToolRequest.Params.Name = "hello-server"
+	callToolResult, err := client.CallTool(ctx, callToolRequest)
+	require.NoError(t, err)
+	require.NotNil(t, callToolResult)
+	require.Equal(t, []mcp.Content{
+		mcp.NewTextContent("hello client"),
+	}, callToolResult.Content)
+}

--- a/lib/utils/mcputils/reader.go
+++ b/lib/utils/mcputils/reader.go
@@ -1,0 +1,219 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcputils
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/gravitational/teleport"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// HandleParseErrorFunc handles parse errors.
+type HandleParseErrorFunc func(context.Context, *mcp.JSONRPCError) error
+
+// HandleRequestFunc handles a request.
+type HandleRequestFunc func(context.Context, *JSONRPCRequest) error
+
+// HandleResponseFunc handles a response.
+type HandleResponseFunc func(context.Context, *JSONRPCResponse) error
+
+// HandleNotificationFunc handles a notification.
+type HandleNotificationFunc func(context.Context, *JSONRPCNotification) error
+
+// ReplyParseError returns a HandleParseErrorFunc that forwards the error to
+// provided writer.
+func ReplyParseError(w MessageWriter) HandleParseErrorFunc {
+	return func(ctx context.Context, parseError *mcp.JSONRPCError) error {
+		return trace.Wrap(w.WriteMessage(ctx, parseError))
+	}
+}
+
+// LogAndIgnoreParseError returns a HandleParseErrorFunc that logs the parse
+// error.
+func LogAndIgnoreParseError(log *slog.Logger) HandleParseErrorFunc {
+	return func(ctx context.Context, parseError *mcp.JSONRPCError) error {
+		log.DebugContext(ctx, "Ignore parse error", "error", parseError)
+		return nil
+	}
+}
+
+// TransportReader defines an interface for reading next raw/unmarshalled
+// message from the MCP transport.
+type TransportReader interface {
+	// Type is the transport type for logging purpose.
+	Type() string
+	// ReadMessage reads the next raw message.
+	ReadMessage(context.Context) (string, error)
+	// Close closes the transport.
+	Close() error
+}
+
+// MessageReaderConfig is the config for MessageReader.
+type MessageReaderConfig struct {
+	// Transport is the input to the read the raw/unmarshalled messages from.
+	// Transport will be closed when reader finishes.
+	Transport TransportReader
+	// Logger is the slog.Logger.
+	Logger *slog.Logger
+	// ParentContext is the parent's context. Used for logging during tear down.
+	ParentContext context.Context
+
+	// OnClose is an optional callback when reader finishes.
+	OnClose func()
+	// OnParseError specifies the handler for handling parse error. Any error
+	// returned by the handler stops this message reader.
+	OnParseError HandleParseErrorFunc
+	// OnRequest specifies the handler for handling request. Any error by the
+	// handler stops this message reader.
+	OnRequest HandleRequestFunc
+	// OnResponse specifies the handler for handling response. Any error by the
+	// handler stops this message reader.
+	OnResponse HandleResponseFunc
+	// OnNotification specifies the handler for handling notification. Any error
+	// returned by the handler stops this message reader.
+	OnNotification HandleNotificationFunc
+}
+
+// CheckAndSetDefaults checks values and sets defaults.
+func (c *MessageReaderConfig) CheckAndSetDefaults() error {
+	if c.Transport == nil {
+		return trace.BadParameter("missing parameter Transport")
+	}
+	if c.OnParseError == nil {
+		return trace.BadParameter("missing parameter OnParseError")
+	}
+	if c.OnNotification == nil {
+		return trace.BadParameter("missing parameter OnNotification")
+	}
+	if c.OnRequest == nil && c.OnResponse == nil {
+		return trace.BadParameter("one of OnRequest or OnResponse must be set")
+	}
+	if c.ParentContext == nil {
+		return trace.BadParameter("missing parameter ParentContext")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "mcp")
+	}
+	return nil
+}
+
+// MessageReader reads requests from provided reader.
+type MessageReader struct {
+	cfg MessageReaderConfig
+}
+
+// NewMessageReader creates a new MessageReader. Must call "Start" to
+// start the processing.
+func NewMessageReader(cfg MessageReaderConfig) (*MessageReader, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &MessageReader{
+		cfg: cfg,
+	}, nil
+}
+
+// Run starts reading requests from provided reader. Run blocks until an
+// error happens from the provided reader or any of the handler.
+func (r *MessageReader) Run(ctx context.Context) {
+	r.cfg.Logger.InfoContext(ctx, "Start processing messages", "transport", r.cfg.Transport.Type())
+
+	finished := make(chan struct{})
+	go func() {
+		r.startProcess(ctx)
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-ctx.Done():
+	}
+
+	r.cfg.Logger.InfoContext(r.cfg.ParentContext, "Finished processing messages", "transport", r.cfg.Transport.Type())
+	if err := r.cfg.Transport.Close(); err != nil && !IsOKCloseError(err) {
+		r.cfg.Logger.ErrorContext(r.cfg.ParentContext, "Failed to close reader", "error", err)
+	}
+	if r.cfg.OnClose != nil {
+		r.cfg.OnClose()
+	}
+}
+
+func (r *MessageReader) startProcess(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err := r.processNextLine(ctx); err != nil {
+			if !IsOKCloseError(err) {
+				r.cfg.Logger.ErrorContext(ctx, "Failed to process line", "error", err)
+			}
+			return
+		}
+	}
+}
+
+func (r *MessageReader) processNextLine(ctx context.Context) error {
+	rawMessage, err := r.cfg.Transport.ReadMessage(ctx)
+	if err != nil {
+		// TODO(greedy52) handle ParseError from Transport.ReadMessage.
+		return trace.Wrap(err, "reading line")
+	}
+
+	r.cfg.Logger.Log(ctx, logutils.TraceLevel, "Trace read", "raw", rawMessage)
+
+	var base baseJSONRPCMessage
+	if parseError := json.Unmarshal([]byte(rawMessage), &base); parseError != nil {
+		rpcError := mcp.NewJSONRPCError(mcp.NewRequestId(nil), mcp.PARSE_ERROR, parseError.Error(), nil)
+		if err := r.cfg.OnParseError(ctx, &rpcError); err != nil {
+			return trace.Wrap(err, "handling JSON unmarshal error")
+		}
+	}
+
+	switch {
+	case base.isNotification():
+		return trace.Wrap(r.cfg.OnNotification(ctx, base.makeNotification()), "handling notification")
+	case base.isRequest():
+		if r.cfg.OnRequest != nil {
+			return trace.Wrap(r.cfg.OnRequest(ctx, base.makeRequest()), "handling request")
+		}
+		// Should not happen. Log something just in case.
+		r.cfg.Logger.DebugContext(ctx, "Skipping request", "id", base.ID)
+		return nil
+	case base.isResponse():
+		if r.cfg.OnResponse != nil {
+			return trace.Wrap(r.cfg.OnResponse(ctx, base.makeResponse()), "handling response")
+		}
+		// Should not happen. Log something just in case.
+		r.cfg.Logger.DebugContext(ctx, "Skipping response", "id", base.ID)
+		return nil
+	default:
+		rpcError := mcp.NewJSONRPCError(base.ID, mcp.PARSE_ERROR, "unknown message type", rawMessage)
+		return trace.Wrap(
+			r.cfg.OnParseError(ctx, &rpcError),
+			"handling unknown message type error",
+		)
+	}
+}

--- a/lib/utils/mcputils/stdio.go
+++ b/lib/utils/mcputils/stdio.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/gravitational/teleport"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -79,170 +78,37 @@ func (w *StdioMessageWriter) WriteMessage(_ context.Context, resp mcp.JSONRPCMes
 	return trace.Wrap(err)
 }
 
-// HandleParseErrorFunc handles parse errors.
-type HandleParseErrorFunc func(context.Context, *mcp.JSONRPCError) error
+// NewSyncStdioMessageWriter returns a MessageWriter using stdio transport, the
+// "sync" version.
+func NewSyncStdioMessageWriter(w io.Writer) MessageWriter {
+	return NewSyncMessageWriter(NewStdioMessageWriter(w))
+}
 
-// ReplyParseError returns a HandleParseErrorFunc that forwards the error to
-// provided writer.
-func ReplyParseError(w *StdioMessageWriter) HandleParseErrorFunc {
-	return func(ctx context.Context, parseError *mcp.JSONRPCError) error {
-		return trace.Wrap(w.WriteMessage(ctx, parseError))
+// StdioReader implements TransportReader for stdio transport
+type StdioReader struct {
+	io.Closer
+	br *bufio.Reader
+}
+
+// NewStdioReader creates a new StdioReader. Input reader can be either stdin or
+// stdout.
+func NewStdioReader(readCloser io.ReadCloser) *StdioReader {
+	return &StdioReader{
+		Closer: readCloser,
+		br:     bufio.NewReader(readCloser),
 	}
 }
 
-// LogAndIgnoreParseError returns a HandleParseErrorFunc that logs the parse
-// error.
-func LogAndIgnoreParseError(log *slog.Logger) HandleParseErrorFunc {
-	return func(ctx context.Context, parseError *mcp.JSONRPCError) error {
-		log.DebugContext(ctx, "Ignore parse error", "error", parseError)
-		return nil
-	}
-}
-
-// StdioMessageReaderConfig is the config for StdioMessageReader.
-type StdioMessageReaderConfig struct {
-	// SourceReadCloser is the input to the read the message from.
-	// SourceReadCloser will be closed when reader finishes.
-	SourceReadCloser io.ReadCloser
-	// Logger is the slog.Logger.
-	Logger *slog.Logger
-	// ParentContext is the parent's context. Used for logging during tear down.
-	ParentContext context.Context
-
-	// OnClose is an optional callback when reader finishes.
-	OnClose func()
-	// OnParseError specifies the handler for handling parse error. Any error
-	// returned by the handler stops this message reader.
-	OnParseError HandleParseErrorFunc
-	// OnRequest specifies the handler for handling request. Any error by the
-	// handler stops this message reader.
-	OnRequest func(context.Context, *JSONRPCRequest) error
-	// OnResponse specifies the handler for handling response. Any error by the
-	// handler stops this message reader.
-	OnResponse func(context.Context, *JSONRPCResponse) error
-	// OnNotification specifies the handler for handling notification. Any error
-	// returned by the handler stops this message reader.
-	OnNotification func(context.Context, *JSONRPCNotification) error
-}
-
-// CheckAndSetDefaults checks values and sets defaults.
-func (c *StdioMessageReaderConfig) CheckAndSetDefaults() error {
-	if c.SourceReadCloser == nil {
-		return trace.BadParameter("missing parameter SourceReadCloser")
-	}
-	if c.OnParseError == nil {
-		return trace.BadParameter("missing parameter OnParseError")
-	}
-	if c.OnNotification == nil {
-		return trace.BadParameter("missing parameter OnNotification")
-	}
-	if c.OnRequest == nil && c.OnResponse == nil {
-		return trace.BadParameter("one of OnRequest or OnResponse must be set")
-	}
-	if c.ParentContext == nil {
-		return trace.BadParameter("missing parameter ParentContext")
-	}
-	if c.Logger == nil {
-		c.Logger = slog.With(teleport.ComponentKey, "mcp")
-	}
-	return nil
-}
-
-// StdioMessageReader reads requests from provided reader.
-type StdioMessageReader struct {
-	cfg StdioMessageReaderConfig
-}
-
-// NewStdioMessageReader creates a new StdioMessageReader. Must call "Start" to
-// start the processing.
-func NewStdioMessageReader(cfg StdioMessageReaderConfig) (*StdioMessageReader, error) {
-	if err := cfg.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &StdioMessageReader{
-		cfg: cfg,
-	}, nil
-}
-
-// Run starts reading requests from provided reader. Run blocks until an
-// error happens from the provided reader or any of the handler.
-func (r *StdioMessageReader) Run(ctx context.Context) {
-	r.cfg.Logger.InfoContext(ctx, "Start processing stdio messages")
-
-	finished := make(chan struct{})
-	go func() {
-		r.startProcess(ctx)
-		close(finished)
-	}()
-
-	select {
-	case <-finished:
-	case <-ctx.Done():
-	}
-
-	r.cfg.Logger.InfoContext(r.cfg.ParentContext, "Finished processing stdio messages")
-	if err := r.cfg.SourceReadCloser.Close(); err != nil && !IsOKCloseError(err) {
-		r.cfg.Logger.ErrorContext(r.cfg.ParentContext, "Failed to close reader", "error", err)
-	}
-	if r.cfg.OnClose != nil {
-		r.cfg.OnClose()
-	}
-}
-
-func (r *StdioMessageReader) startProcess(ctx context.Context) {
-	lineReader := bufio.NewReader(r.cfg.SourceReadCloser)
-	for {
-		if ctx.Err() != nil {
-			return
-		}
-
-		if err := r.processNextLine(ctx, lineReader); err != nil {
-			if !IsOKCloseError(err) {
-				r.cfg.Logger.ErrorContext(ctx, "Failed to process line", "error", err)
-			}
-			return
-		}
-	}
-}
-
-func (r *StdioMessageReader) processNextLine(ctx context.Context, lineReader *bufio.Reader) error {
-	line, err := lineReader.ReadString('\n')
+// ReadMessage reads the next line.
+func (r *StdioReader) ReadMessage(context.Context) (string, error) {
+	line, err := r.br.ReadString('\n')
 	if err != nil {
-		return trace.Wrap(err, "reading line")
+		return "", trace.Wrap(err)
 	}
+	return line, nil
+}
 
-	r.cfg.Logger.Log(ctx, logutils.TraceLevel, "Trace stdio", "line", line)
-
-	var base baseJSONRPCMessage
-	if parseError := json.Unmarshal([]byte(line), &base); parseError != nil {
-		rpcError := mcp.NewJSONRPCError(mcp.NewRequestId(nil), mcp.PARSE_ERROR, parseError.Error(), nil)
-		if err := r.cfg.OnParseError(ctx, &rpcError); err != nil {
-			return trace.Wrap(err, "handling JSON unmarshal error")
-		}
-	}
-
-	switch {
-	case base.isNotification():
-		return trace.Wrap(r.cfg.OnNotification(ctx, base.makeNotification()), "handling notification")
-	case base.isRequest():
-		if r.cfg.OnRequest != nil {
-			return trace.Wrap(r.cfg.OnRequest(ctx, base.makeRequest()), "handling request")
-		}
-		// Should not happen. Log something just in case.
-		r.cfg.Logger.DebugContext(ctx, "Skipping request", "id", base.ID)
-		return nil
-	case base.isResponse():
-		if r.cfg.OnResponse != nil {
-			return trace.Wrap(r.cfg.OnResponse(ctx, base.makeResponse()), "handling response")
-		}
-		// Should not happen. Log something just in case.
-		r.cfg.Logger.DebugContext(ctx, "Skipping response", "id", base.ID)
-		return nil
-	default:
-		rpcError := mcp.NewJSONRPCError(base.ID, mcp.PARSE_ERROR, "unknown message type", line)
-		return trace.Wrap(
-			r.cfg.OnParseError(ctx, &rpcError),
-			"handling unknown message type error",
-		)
-	}
+// Type returns "stdio".
+func (r *StdioReader) Type() string {
+	return "stdio"
 }

--- a/lib/utils/mcputils/stdio_test.go
+++ b/lib/utils/mcputils/stdio_test.go
@@ -19,7 +19,6 @@
 package mcputils
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log"
@@ -29,12 +28,11 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	mcpclient "github.com/mark3labs/mcp-go/client"
-	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
-	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/mcptest"
 )
 
 // TestStdioHelpers tests MessageReader and StdioMessageWriter by
@@ -114,36 +112,20 @@ func TestStdioHelpers(t *testing.T) {
 
 	// Make "high-level" MCP client and server with stdio transport as the two
 	// ends.
-	stdioClientTransport := mcpclienttransport.NewIO(clientStdin, clientStdout, io.NopCloser(bytes.NewReader(nil)))
-	stdioClient := mcpclient.NewClient(stdioClientTransport)
-	defer stdioClient.Close()
-	require.NoError(t, stdioClient.Start(ctx))
+	stdioClient := mcptest.NewStdioClient(t, clientStdin, clientStdout)
 
-	stdioServer := mcpserver.NewStdioServer(makeTestMCPServer())
+	stdioServer := mcpserver.NewStdioServer(mcptest.NewServer())
 	stdioServer.SetErrorLogger(log.New(io.Discard, "", log.LstdFlags))
 	go stdioServer.Listen(ctx, serverStdin, serverStdout)
 
 	// Test things out.
 	t.Run("client initialize", func(t *testing.T) {
-		initReq := mcp.InitializeRequest{}
-		initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-		initReq.Params.ClientInfo = mcp.Implementation{
-			Name:    "test-client",
-			Version: "1.0.0",
-		}
-		_, err = stdioClient.Initialize(ctx, initReq)
+		_, err := mcptest.InitializeClient(ctx, stdioClient)
 		require.NoError(t, err)
 	})
 
 	t.Run("client call tool", func(t *testing.T) {
-		callToolRequest := mcp.CallToolRequest{}
-		callToolRequest.Params.Name = "hello-server"
-		callToolResult, err := stdioClient.CallTool(ctx, callToolRequest)
-		require.NoError(t, err)
-		require.NotNil(t, callToolResult)
-		require.Equal(t, []mcp.Content{
-			mcp.NewTextContent("hello client"),
-		}, callToolResult.Content)
+		mcptest.MustCallServerTool(t, ctx, stdioClient)
 	})
 
 	t.Run("reader closed by closing stdin", func(t *testing.T) {
@@ -175,16 +157,4 @@ func TestStdioHelpers(t *testing.T) {
 		assert.Equal(t, int32(0), atomic.LoadInt32(&readServerNotifications))
 		assert.Equal(t, int32(2), atomic.LoadInt32(&readServerResponses))
 	})
-}
-
-func makeTestMCPServer() *mcpserver.MCPServer {
-	server := mcpserver.NewMCPServer("test-server", "1.0.0")
-	server.AddTool(mcp.Tool{
-		Name: "hello-server",
-	}, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{mcp.NewTextContent("hello client")},
-		}, nil
-	})
-	return server
 }

--- a/lib/utils/mcputils/writer.go
+++ b/lib/utils/mcputils/writer.go
@@ -1,0 +1,52 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcputils
+
+import (
+	"context"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// MessageWriter defines an interface for writing JSON RPC messages.
+type MessageWriter interface {
+	// WriteMessage writes an JSON RPC message.
+	WriteMessage(context.Context, mcp.JSONRPCMessage) error
+}
+
+// SyncMessageWriter process goroutine safety for MessageWriter
+type SyncMessageWriter struct {
+	w  MessageWriter
+	mu sync.Mutex
+}
+
+// NewSyncMessageWriter returns a SyncMessageWriter.
+func NewSyncMessageWriter(w MessageWriter) *SyncMessageWriter {
+	return &SyncMessageWriter{
+		w: w,
+	}
+}
+
+// WriteMessage acquires a lock then writes the message.
+func (s *SyncMessageWriter) WriteMessage(ctx context.Context, msg mcp.JSONRPCMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.WriteMessage(ctx, msg)
+}


### PR DESCRIPTION
changes:
- Renamed `StdioMessageReader` to `MessageReader`, and replaced input stdio reader with new `TransportReader` interface (to prepare for **SSE reader** next)
- Refactor the reader callbacks a little
- Made a new `MessageWriter` interface and a new `SyncMessageWriter`
- Moved some test functions to `mcptest`

No logic change, existing tests all pass