### PR TITLE
[v15] grpcbuildbox: drop usage of buildx when building grpcbox locally

### DIFF
--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -25,7 +25,7 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 # It's leaner, meaner, faster and not supposed to compile code.
 .PHONY: grpcbox
 grpcbox:
-	$(DOCKER) buildx build \
+	$(DOCKER) build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \


### PR DESCRIPTION
Backport #56002 to branch/v15