### PR TITLE
Add UID and GID arguments to grpcbox Docker build for user permissions

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -40,3 +40,8 @@ RUN \
   go -C /teleport-module run -exec true google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
   go -C /teleport-module run -exec true google.golang.org/protobuf/cmd/protoc-gen-go && \
   rm -rf /teleport-module
+
+  ARG UID
+  ARG GID
+  RUN mkdir -p /.cache /.npm && \
+    chown -R $UID:$GID /.cache /.npm /go/pkg/mod/

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -19,7 +19,9 @@ DOCKER ?= docker
 
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.
-GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
+UID := $$(id -u)
+GID := $$(id -g)
+GRPCBOX_RUN := $(DOCKER) run -it --rm -u $(UID):$(GID) -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
 
 # grpcbox builds a codegen-focused buildbox.
 # It's leaner, meaner, faster and not supposed to compile code.
@@ -27,6 +29,7 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 grpcbox:
 	$(DOCKER) build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
+		--build-arg UID=$(UID) --build-arg GID=$(GID) \
 		-f Dockerfile-grpcbox \
 		-t "$(GRPCBOX)" \
 		../


### PR DESCRIPTION
When building on Linux, often git fails to switch to between branches because generated files aren't owned by the user. 

This PR fixes that by injecting the UID and GID into the docker container