### PR TITLE
Rate limit DB server heartbeats

### DIFF
--- a/api/client/proto/inventory.pb.go
+++ b/api/client/proto/inventory.pb.go
@@ -528,7 +528,9 @@ type UpstreamInventoryHello struct {
 	// ExternalUpgraderVersion identifies the external upgrader version. Empty if no upgrader is defined.
 	ExternalUpgraderVersion string `protobuf:"bytes,6,opt,name=ExternalUpgraderVersion,proto3" json:"ExternalUpgraderVersion,omitempty"`
 	// UpdaterInfo is used by Teleport to send information about how the Teleport updater is doing.
-	UpdaterInfo   *types.UpdaterV2Info `protobuf:"bytes,8,opt,name=UpdaterInfo,proto3" json:"UpdaterInfo,omitempty"`
+	UpdaterInfo *types.UpdaterV2Info `protobuf:"bytes,8,opt,name=UpdaterInfo,proto3" json:"UpdaterInfo,omitempty"`
+	// SupportedCapabilities advertises the supported features of the instance.
+	Capabilities  *UpstreamInventoryHello_SupportedCapabilities `protobuf:"bytes,9,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -608,6 +610,13 @@ func (x *UpstreamInventoryHello) GetExternalUpgraderVersion() string {
 func (x *UpstreamInventoryHello) GetUpdaterInfo() *types.UpdaterV2Info {
 	if x != nil {
 		return x.UpdaterInfo
+	}
+	return nil
+}
+
+func (x *UpstreamInventoryHello) GetCapabilities() *UpstreamInventoryHello_SupportedCapabilities {
+	if x != nil {
+		return x.Capabilities
 	}
 	return nil
 }
@@ -1238,6 +1247,54 @@ func (x *UpstreamInventoryStopHeartbeat) GetName() string {
 }
 
 // SupportedCapabilities indicate which features of the ICS that
+// the connected instance supports. This allows the auth server to determine
+// how it should interact with the instance to maintain compatibility.
+type UpstreamInventoryHello_SupportedCapabilities struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// DatabaseHeartbeatGracefulStop indicates the instance supports stopping an individual database heartbeat.
+	DatabaseHeartbeatGracefulStop bool `protobuf:"varint,1,opt,name=database_heartbeat_graceful_stop,json=databaseHeartbeatGracefulStop,proto3" json:"database_heartbeat_graceful_stop,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
+}
+
+func (x *UpstreamInventoryHello_SupportedCapabilities) Reset() {
+	*x = UpstreamInventoryHello_SupportedCapabilities{}
+	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpstreamInventoryHello_SupportedCapabilities) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpstreamInventoryHello_SupportedCapabilities) ProtoMessage() {}
+
+func (x *UpstreamInventoryHello_SupportedCapabilities) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpstreamInventoryHello_SupportedCapabilities.ProtoReflect.Descriptor instead.
+func (*UpstreamInventoryHello_SupportedCapabilities) Descriptor() ([]byte, []int) {
+	return file_teleport_legacy_client_proto_inventory_proto_rawDescGZIP(), []int{4, 0}
+}
+
+func (x *UpstreamInventoryHello_SupportedCapabilities) GetDatabaseHeartbeatGracefulStop() bool {
+	if x != nil {
+		return x.DatabaseHeartbeatGracefulStop
+	}
+	return false
+}
+
+// SupportedCapabilities indicate which features of the ICS that
 // the connect auth server supports. This allows agents to determine
 // how they should interact with the auth server to maintain compatibility.
 type DownstreamInventoryHello_SupportedCapabilities struct {
@@ -1288,7 +1345,7 @@ type DownstreamInventoryHello_SupportedCapabilities struct {
 
 func (x *DownstreamInventoryHello_SupportedCapabilities) Reset() {
 	*x = DownstreamInventoryHello_SupportedCapabilities{}
-	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[14]
+	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1300,7 +1357,7 @@ func (x *DownstreamInventoryHello_SupportedCapabilities) String() string {
 func (*DownstreamInventoryHello_SupportedCapabilities) ProtoMessage() {}
 
 func (x *DownstreamInventoryHello_SupportedCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[14]
+	mi := &file_teleport_legacy_client_proto_inventory_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1478,7 +1535,7 @@ const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\x02ID\x18\x01 \x01(\x04R\x02ID\"e\n" +
 	"\x15UpstreamInventoryPong\x12\x0e\n" +
 	"\x02ID\x18\x01 \x01(\x04R\x02ID\x12<\n" +
-	"\vSystemClock\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vSystemClock\"\xb9\x02\n" +
+	"\vSystemClock\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vSystemClock\"\xf4\x03\n" +
 	"\x16UpstreamInventoryHello\x12\x18\n" +
 	"\aVersion\x18\x01 \x01(\tR\aVersion\x12\x1a\n" +
 	"\bServerID\x18\x02 \x01(\tR\bServerID\x12\x1a\n" +
@@ -1486,7 +1543,10 @@ const file_teleport_legacy_client_proto_inventory_proto_rawDesc = "" +
 	"\bHostname\x18\x04 \x01(\tR\bHostname\x12*\n" +
 	"\x10ExternalUpgrader\x18\x05 \x01(\tR\x10ExternalUpgrader\x128\n" +
 	"\x17ExternalUpgraderVersion\x18\x06 \x01(\tR\x17ExternalUpgraderVersion\x126\n" +
-	"\vUpdaterInfo\x18\b \x01(\v2\x14.types.UpdaterV2InfoR\vUpdaterInfoJ\x04\b\a\x10\bR\rUpdaterV2Info\"\xd4\x02\n" +
+	"\vUpdaterInfo\x18\b \x01(\v2\x14.types.UpdaterV2InfoR\vUpdaterInfo\x12W\n" +
+	"\fcapabilities\x18\t \x01(\v23.proto.UpstreamInventoryHello.SupportedCapabilitiesR\fcapabilities\x1a`\n" +
+	"\x15SupportedCapabilities\x12G\n" +
+	" database_heartbeat_graceful_stop\x18\x01 \x01(\bR\x1ddatabaseHeartbeatGracefulStopJ\x04\b\a\x10\bR\rUpdaterV2Info\"\xd4\x02\n" +
 	"\x1eUpstreamInventoryAgentMetadata\x12\x0e\n" +
 	"\x02OS\x18\x01 \x01(\tR\x02OS\x12\x1c\n" +
 	"\tOSVersion\x18\x02 \x01(\tR\tOSVersion\x12*\n" +
@@ -1588,7 +1648,7 @@ func file_teleport_legacy_client_proto_inventory_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_legacy_client_proto_inventory_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_teleport_legacy_client_proto_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_teleport_legacy_client_proto_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_teleport_legacy_client_proto_inventory_proto_goTypes = []any{
 	(LabelUpdateKind)(0),                                   // 0: proto.LabelUpdateKind
 	(StopHeartbeatKind)(0),                                 // 1: proto.StopHeartbeatKind
@@ -1606,19 +1666,20 @@ var file_teleport_legacy_client_proto_inventory_proto_goTypes = []any{
 	(*InventoryStatusRequest)(nil),                         // 13: proto.InventoryStatusRequest
 	(*InventoryStatusSummary)(nil),                         // 14: proto.InventoryStatusSummary
 	(*UpstreamInventoryStopHeartbeat)(nil),                 // 15: proto.UpstreamInventoryStopHeartbeat
-	(*DownstreamInventoryHello_SupportedCapabilities)(nil), // 16: proto.DownstreamInventoryHello.SupportedCapabilities
-	nil,                              // 17: proto.InventoryUpdateLabelsRequest.LabelsEntry
-	nil,                              // 18: proto.DownstreamInventoryUpdateLabels.LabelsEntry
-	nil,                              // 19: proto.InventoryStatusSummary.VersionCountsEntry
-	nil,                              // 20: proto.InventoryStatusSummary.UpgraderCountsEntry
-	nil,                              // 21: proto.InventoryStatusSummary.ServiceCountsEntry
-	(*timestamppb.Timestamp)(nil),    // 22: google.protobuf.Timestamp
-	(*types.UpdaterV2Info)(nil),      // 23: types.UpdaterV2Info
-	(*types.ServerV2)(nil),           // 24: types.ServerV2
-	(*types.AppServerV3)(nil),        // 25: types.AppServerV3
-	(*types.DatabaseServerV3)(nil),   // 26: types.DatabaseServerV3
-	(*types.KubernetesServerV3)(nil), // 27: types.KubernetesServerV3
-	(*v1.RelayServer)(nil),           // 28: teleport.presence.v1.RelayServer
+	(*UpstreamInventoryHello_SupportedCapabilities)(nil),   // 16: proto.UpstreamInventoryHello.SupportedCapabilities
+	(*DownstreamInventoryHello_SupportedCapabilities)(nil), // 17: proto.DownstreamInventoryHello.SupportedCapabilities
+	nil,                              // 18: proto.InventoryUpdateLabelsRequest.LabelsEntry
+	nil,                              // 19: proto.DownstreamInventoryUpdateLabels.LabelsEntry
+	nil,                              // 20: proto.InventoryStatusSummary.VersionCountsEntry
+	nil,                              // 21: proto.InventoryStatusSummary.UpgraderCountsEntry
+	nil,                              // 22: proto.InventoryStatusSummary.ServiceCountsEntry
+	(*timestamppb.Timestamp)(nil),    // 23: google.protobuf.Timestamp
+	(*types.UpdaterV2Info)(nil),      // 24: types.UpdaterV2Info
+	(*types.ServerV2)(nil),           // 25: types.ServerV2
+	(*types.AppServerV3)(nil),        // 26: types.AppServerV3
+	(*types.DatabaseServerV3)(nil),   // 27: types.DatabaseServerV3
+	(*types.KubernetesServerV3)(nil), // 28: types.KubernetesServerV3
+	(*v1.RelayServer)(nil),           // 29: teleport.presence.v1.RelayServer
 }
 var file_teleport_legacy_client_proto_inventory_proto_depIdxs = []int32{
 	6,  // 0: proto.UpstreamInventoryOneOf.Hello:type_name -> proto.UpstreamInventoryHello
@@ -1630,28 +1691,29 @@ var file_teleport_legacy_client_proto_inventory_proto_depIdxs = []int32{
 	8,  // 6: proto.DownstreamInventoryOneOf.Hello:type_name -> proto.DownstreamInventoryHello
 	4,  // 7: proto.DownstreamInventoryOneOf.Ping:type_name -> proto.DownstreamInventoryPing
 	10, // 8: proto.DownstreamInventoryOneOf.UpdateLabels:type_name -> proto.DownstreamInventoryUpdateLabels
-	22, // 9: proto.UpstreamInventoryPong.SystemClock:type_name -> google.protobuf.Timestamp
-	23, // 10: proto.UpstreamInventoryHello.UpdaterInfo:type_name -> types.UpdaterV2Info
-	16, // 11: proto.DownstreamInventoryHello.Capabilities:type_name -> proto.DownstreamInventoryHello.SupportedCapabilities
-	0,  // 12: proto.InventoryUpdateLabelsRequest.Kind:type_name -> proto.LabelUpdateKind
-	17, // 13: proto.InventoryUpdateLabelsRequest.Labels:type_name -> proto.InventoryUpdateLabelsRequest.LabelsEntry
-	0,  // 14: proto.DownstreamInventoryUpdateLabels.Kind:type_name -> proto.LabelUpdateKind
-	18, // 15: proto.DownstreamInventoryUpdateLabels.Labels:type_name -> proto.DownstreamInventoryUpdateLabels.LabelsEntry
-	24, // 16: proto.InventoryHeartbeat.SSHServer:type_name -> types.ServerV2
-	25, // 17: proto.InventoryHeartbeat.AppServer:type_name -> types.AppServerV3
-	26, // 18: proto.InventoryHeartbeat.DatabaseServer:type_name -> types.DatabaseServerV3
-	27, // 19: proto.InventoryHeartbeat.KubernetesServer:type_name -> types.KubernetesServerV3
-	28, // 20: proto.InventoryHeartbeat.relay_server:type_name -> teleport.presence.v1.RelayServer
-	6,  // 21: proto.InventoryStatusSummary.Connected:type_name -> proto.UpstreamInventoryHello
-	19, // 22: proto.InventoryStatusSummary.VersionCounts:type_name -> proto.InventoryStatusSummary.VersionCountsEntry
-	20, // 23: proto.InventoryStatusSummary.UpgraderCounts:type_name -> proto.InventoryStatusSummary.UpgraderCountsEntry
-	21, // 24: proto.InventoryStatusSummary.ServiceCounts:type_name -> proto.InventoryStatusSummary.ServiceCountsEntry
-	1,  // 25: proto.UpstreamInventoryStopHeartbeat.kind:type_name -> proto.StopHeartbeatKind
-	26, // [26:26] is the sub-list for method output_type
-	26, // [26:26] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	23, // 9: proto.UpstreamInventoryPong.SystemClock:type_name -> google.protobuf.Timestamp
+	24, // 10: proto.UpstreamInventoryHello.UpdaterInfo:type_name -> types.UpdaterV2Info
+	16, // 11: proto.UpstreamInventoryHello.capabilities:type_name -> proto.UpstreamInventoryHello.SupportedCapabilities
+	17, // 12: proto.DownstreamInventoryHello.Capabilities:type_name -> proto.DownstreamInventoryHello.SupportedCapabilities
+	0,  // 13: proto.InventoryUpdateLabelsRequest.Kind:type_name -> proto.LabelUpdateKind
+	18, // 14: proto.InventoryUpdateLabelsRequest.Labels:type_name -> proto.InventoryUpdateLabelsRequest.LabelsEntry
+	0,  // 15: proto.DownstreamInventoryUpdateLabels.Kind:type_name -> proto.LabelUpdateKind
+	19, // 16: proto.DownstreamInventoryUpdateLabels.Labels:type_name -> proto.DownstreamInventoryUpdateLabels.LabelsEntry
+	25, // 17: proto.InventoryHeartbeat.SSHServer:type_name -> types.ServerV2
+	26, // 18: proto.InventoryHeartbeat.AppServer:type_name -> types.AppServerV3
+	27, // 19: proto.InventoryHeartbeat.DatabaseServer:type_name -> types.DatabaseServerV3
+	28, // 20: proto.InventoryHeartbeat.KubernetesServer:type_name -> types.KubernetesServerV3
+	29, // 21: proto.InventoryHeartbeat.relay_server:type_name -> teleport.presence.v1.RelayServer
+	6,  // 22: proto.InventoryStatusSummary.Connected:type_name -> proto.UpstreamInventoryHello
+	20, // 23: proto.InventoryStatusSummary.VersionCounts:type_name -> proto.InventoryStatusSummary.VersionCountsEntry
+	21, // 24: proto.InventoryStatusSummary.UpgraderCounts:type_name -> proto.InventoryStatusSummary.UpgraderCountsEntry
+	22, // 25: proto.InventoryStatusSummary.ServiceCounts:type_name -> proto.InventoryStatusSummary.ServiceCountsEntry
+	1,  // 26: proto.UpstreamInventoryStopHeartbeat.kind:type_name -> proto.StopHeartbeatKind
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_inventory_proto_init() }
@@ -1678,7 +1740,7 @@ func file_teleport_legacy_client_proto_inventory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_legacy_client_proto_inventory_proto_rawDesc), len(file_teleport_legacy_client_proto_inventory_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   20,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/legacy/client/proto/inventory.proto
+++ b/api/proto/teleport/legacy/client/proto/inventory.proto
@@ -99,6 +99,17 @@ message UpstreamInventoryHello {
   string ExternalUpgraderVersion = 6;
   // UpdaterInfo is used by Teleport to send information about how the Teleport updater is doing.
   types.UpdaterV2Info UpdaterInfo = 8;
+
+  // SupportedCapabilities indicate which features of the ICS that
+  // the connected instance supports. This allows the auth server to determine
+  // how it should interact with the instance to maintain compatibility.
+  message SupportedCapabilities {
+    // DatabaseHeartbeatGracefulStop indicates the instance supports stopping an individual database heartbeat.
+    bool database_heartbeat_graceful_stop = 1;
+  }
+
+  // SupportedCapabilities advertises the supported features of the instance.
+  SupportedCapabilities capabilities = 9;
 }
 
 // UpstreamInventoryAgentMetadata is the message sent up the inventory control stream containing

--- a/api/utils/retryutils/jitter.go
+++ b/api/utils/retryutils/jitter.go
@@ -110,3 +110,20 @@ func SeventhJitter(d time.Duration) time.Duration {
 
 	return d - frac + rand.N(frac)
 }
+
+// AdditiveSeventhJitter returns a jitter on the range [d, 8d/7).
+// Not suitable for use with things that enforce a max duration (like [Linear]).
+// Prefer this when jittering a rate-limit delay, to ensure that the caller
+// will not be rate-limited again.
+func AdditiveSeventhJitter(d time.Duration) time.Duration {
+	if d < 1 {
+		return 0
+	}
+
+	frac := d / 7
+	if frac < 1 {
+		return d
+	}
+
+	return d + rand.N(frac)
+}

--- a/api/utils/retryutils/jitter_test.go
+++ b/api/utils/retryutils/jitter_test.go
@@ -54,6 +54,12 @@ func TestNewJitter(t *testing.T) {
 			expectFloor:   baseDuration - baseDuration/7,
 			expectCeiling: baseDuration - 1,
 		},
+		{
+			desc:          "AdditiveSeventhJitter",
+			jitter:        AdditiveSeventhJitter,
+			expectFloor:   baseDuration,
+			expectCeiling: baseDuration + baseDuration/7 - 1,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -1161,6 +1161,9 @@ func (c *Controller) handleDatabaseServerHB(handle *upstreamHandle, databaseServ
 		srv.lease = nil
 		srv.resource = databaseServer
 		return nil
+	} else {
+		// rate limit allows the upsert, blank the reservation now.
+		srv.heartbeatReservation = nil
 	}
 
 	databaseServer.SetExpiry(now.Add(c.serverTTL).UTC())

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -96,11 +96,15 @@ const (
 	dbKeepAliveErr testEvent = "db-keep-alive-err"
 	dbKeepAliveDel testEvent = "db-keep-alive-del"
 
-	dbUpsertOk  testEvent = "db-upsert-ok"
-	dbUpsertErr testEvent = "db-upsert-err"
+	dbUpsertOk          testEvent = "db-upsert-ok"
+	dbUpsertErr         testEvent = "db-upsert-err"
+	dbUpsertRateLimited testEvent = "db-upsert-limited"
 
 	dbUpsertRetryOk  testEvent = "db-upsert-retry-ok"
 	dbUpsertRetryErr testEvent = "db-upsert-retry-err"
+
+	dbUpsertRateLimitedRetryOk  testEvent = "db-upsert-limited-retry-ok"
+	dbUpsertRateLimitedRetryErr testEvent = "db-upsert-limited-retry-err"
 
 	dbDelOk  testEvent = "db-del-ok"
 	dbDelErr testEvent = "db-del-err"
@@ -142,16 +146,19 @@ const (
 const heartbeatStepSize = 1024
 
 type controllerOptions struct {
-	serverKeepAlive    time.Duration
-	instanceHBInterval time.Duration
-	testEvents         chan testEvent
-	maxKeepAliveErrs   int
-	authID             string
-	onConnectFunc      func(string)
-	onDisconnectFunc   func(string, int)
-	cleanupLimiter     *rate.Limiter
-	cleanupTimeout     time.Duration
-	clock              clockwork.Clock
+	serverKeepAlive         time.Duration
+	serverTTL               time.Duration
+	serverHBLimiterInterval time.Duration
+	serverHBLimiterBurst    int
+	instanceHBInterval      time.Duration
+	testEvents              chan testEvent
+	maxKeepAliveErrs        int
+	authID                  string
+	onConnectFunc           func(string)
+	onDisconnectFunc        func(string, int)
+	cleanupLimiter          *rate.Limiter
+	cleanupTimeout          time.Duration
+	clock                   clockwork.Clock
 }
 
 func (options *controllerOptions) SetDefaults() {
@@ -160,6 +167,26 @@ func (options *controllerOptions) SetDefaults() {
 		// use 1.5x standard server keep alive since we use a jitter that
 		// shortens the actual average interval.
 		options.serverKeepAlive = baseKeepAlive + (baseKeepAlive / 2)
+	}
+
+	if options.serverTTL == 0 {
+		if variableRateHeartbeatsDisabledEnv() {
+			options.serverTTL = apidefaults.ServerAnnounceTTL
+		} else {
+			// by default, keepalives will scale from 1.5 to 6 minutes, and
+			// heartbeats will have a TTL of 15 minutes
+			options.serverTTL = (apidefaults.ServerAnnounceTTL * 3) / 2
+		}
+	}
+
+	if options.serverHBLimiterInterval == 0 {
+		// limit each server's heartbeat announcement to once per minute.
+		options.serverHBLimiterInterval = time.Minute
+	}
+	if options.serverHBLimiterBurst == 0 {
+		// this is arbitrary, but allows an occasional fast update shortly after
+		// a full server heartbeat.
+		options.serverHBLimiterBurst = 2
 	}
 
 	if options.instanceHBInterval == 0 {
@@ -231,6 +258,18 @@ func withServerKeepAlive(d time.Duration) ControllerOption {
 	}
 }
 
+func withServerHBLimiterInterval(d time.Duration) ControllerOption {
+	return func(opts *controllerOptions) {
+		opts.serverHBLimiterInterval = d
+	}
+}
+
+func withServerHBLimiterBurst(burst int) ControllerOption {
+	return func(opts *controllerOptions) {
+		opts.serverHBLimiterBurst = burst
+	}
+}
+
 func withInstanceHBInterval(d time.Duration) ControllerOption {
 	return func(opts *controllerOptions) {
 		opts.instanceHBInterval = d
@@ -259,6 +298,8 @@ type Controller struct {
 	authID                     string
 	serverKeepAlive            time.Duration
 	serverTTL                  time.Duration
+	serverHBLimiterInterval    time.Duration
+	serverHBLimiterBurst       int
 	instanceTTL                time.Duration
 	instanceHBEnabled          bool
 	instanceHBVariableDuration *interval.VariableDuration
@@ -301,11 +342,9 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 
 		relayHBVariableDuration *interval.VariableDuration
 	)
-	serverTTL := apidefaults.ServerAnnounceTTL
 	if !variableRateHeartbeatsDisabledEnv() {
-		// by default, heartbeats will scale from 1.5 to 6 minutes, and will
-		// have a TTL of 15 minutes
-		serverTTL = apidefaults.ServerAnnounceTTL * 3 / 2
+		// by default, keepalives will scale from 1.5 to 6 minutes, and
+		// heartbeats will have a TTL of 15 minutes
 		sshHBVariableDuration = interval.NewVariableDuration(interval.VariableDurationConfig{
 			MinDuration: options.serverKeepAlive,
 			MaxDuration: options.serverKeepAlive * 4,
@@ -338,7 +377,9 @@ func NewController(auth Auth, usageReporter usagereporter.UsageReporter, opts ..
 		store:                      NewStore(),
 		serviceCounter:             &serviceCounter{},
 		serverKeepAlive:            options.serverKeepAlive,
-		serverTTL:                  serverTTL,
+		serverTTL:                  options.serverTTL,
+		serverHBLimiterInterval:    options.serverHBLimiterInterval,
+		serverHBLimiterBurst:       options.serverHBLimiterBurst,
 		instanceTTL:                apidefaults.InstanceHeartbeatTTL,
 		instanceHBEnabled:          !instanceHeartbeatsDisabledEnv(),
 		instanceHBVariableDuration: instanceHBVariableDuration,
@@ -1093,11 +1134,34 @@ func (c *Controller) handleDatabaseServerHB(handle *upstreamHandle, databaseServ
 		if c.dbHBVariableDuration != nil {
 			c.dbHBVariableDuration.Inc()
 		}
-		handle.databaseServers[dbKey] = &heartBeatInfo[*types.DatabaseServerV3]{}
+		hbInfo := &heartBeatInfo[*types.DatabaseServerV3]{}
+		if handle.Hello().GetCapabilities().GetDatabaseHeartbeatGracefulStop() {
+			// graceful stop for individual heartbeats is necessary to enforce
+			// rate limiting without dropping upserts.
+			// otherwise a client may unregister a single server and delete its
+			// backend heartbeat directly, but a rate limit delayed upsert would
+			// reverse the deletion and keepalive the server indefinitely
+			hbInfo.heartbeatLimiter = c.newServerHBRateLimiter()
+		}
+		handle.databaseServers[dbKey] = hbInfo
 		handle.dbKeepAliveDelay.Add(dbKey)
 	}
 
 	now := time.Now()
+	srv := handle.databaseServers[dbKey]
+	if delay := srv.delayUpsertFrom(now); delay > 0 {
+		c.testEvent(dbUpsertRateLimited)
+		slog.DebugContext(c.closeContext, "Database heartbeat rate limit exceeded",
+			"server_id", handle.Hello().ServerID,
+			"name", dbKey.name,
+			"wait_for", logutils.StringerAttr(delay),
+		)
+		// reset the keepalive to upsert at reservation time
+		handle.dbKeepAliveDelay.Reset(dbKey, delay)
+		srv.lease = nil
+		srv.resource = databaseServer
+		return nil
+	}
 
 	databaseServer.SetExpiry(now.Add(c.serverTTL).UTC())
 
@@ -1105,7 +1169,6 @@ func (c *Controller) handleDatabaseServerHB(handle *upstreamHandle, databaseServ
 	if err == nil {
 		c.testEvent(dbUpsertOk)
 		// store the new lease and reset retry state
-		srv := handle.databaseServers[dbKey]
 		srv.lease = lease
 		srv.retryUpsert = false
 		srv.resource = databaseServer
@@ -1118,7 +1181,6 @@ func (c *Controller) handleDatabaseServerHB(handle *upstreamHandle, databaseServ
 
 		// blank old lease if any and set retry state. next time handleKeepAlive is called
 		// we will attempt to upsert the server again.
-		srv := handle.databaseServers[dbKey]
 		srv.lease = nil
 		srv.retryUpsert = true
 		srv.resource = databaseServer
@@ -1299,10 +1361,24 @@ func (c *Controller) keepAliveDatabaseServer(handle *upstreamHandle, now time.Ti
 			srv.keepAliveErrs = 0
 			c.testEvent(dbKeepAliveOk)
 		}
-	} else if srv.retryUpsert {
-		srv.resource.SetExpiry(time.Now().Add(c.serverTTL).UTC())
+
+	} else if srv.retryUpsert || srv.heartbeatReservation != nil {
+		srv.resource.SetExpiry(now.Add(c.serverTTL).UTC())
 		lease, err := c.auth.UpsertDatabaseServer(c.closeContext, srv.resource)
 		if err != nil {
+			if !srv.retryUpsert {
+				c.testEvent(dbUpsertRateLimitedRetryErr)
+				// this must be a retry due to rate limiting, meaning there
+				// wasn't a failed lease write prior to this failure, so we can
+				// retry again
+				slog.WarnContext(c.closeContext, "Failed to upsert database server on rate limit retry",
+					"server_id", handle.Hello().ServerID,
+					"error", err,
+				)
+				srv.retryUpsert = true
+				return nil
+			}
+
 			c.testEvent(dbUpsertRetryErr)
 			slog.WarnContext(c.closeContext, "Failed to upsert database server on retry",
 				"server_id", handle.Hello().ServerID,
@@ -1313,7 +1389,12 @@ func (c *Controller) keepAliveDatabaseServer(handle *upstreamHandle, now time.Ti
 			// attempting a third time.
 			return trace.Errorf("failed to upsert database server on retry: %v", err)
 		}
-		c.testEvent(dbUpsertRetryOk)
+
+		if srv.retryUpsert {
+			c.testEvent(dbUpsertRetryOk)
+		} else {
+			c.testEvent(dbUpsertRateLimitedRetryOk)
+		}
 
 		srv.lease = lease
 		srv.retryUpsert = false
@@ -1522,6 +1603,7 @@ func (c *Controller) createKeepAliveMultiDelay(variableDuration *interval.Variab
 		VariableInterval: variableDuration,
 		FirstJitter:      retryutils.HalfJitter,
 		Jitter:           retryutils.SeventhJitter,
+		ResetJitter:      retryutils.AdditiveSeventhJitter,
 	})
 }
 
@@ -1530,4 +1612,9 @@ func (c *Controller) createKeepAliveMultiDelay(variableDuration *interval.Variab
 func (c *Controller) Close() error {
 	c.cancel()
 	return nil
+}
+
+// newServerHBRateLimiter returns a new heartbeat upsert rate limiter.
+func (c *Controller) newServerHBRateLimiter() *rate.Limiter {
+	return rate.NewLimiter(rate.Every(c.serverHBLimiterInterval), c.serverHBLimiterBurst)
 }

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -654,8 +654,7 @@ func TestDatabaseServerBasics(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	events := make(chan testEvent, 1024)
 
@@ -665,6 +664,8 @@ func TestDatabaseServerBasics(t *testing.T) {
 	controller := NewController(
 		auth,
 		usagereporter.DiscardUsageReporter{},
+		withServerHBLimiterInterval(500*time.Millisecond),
+		withServerHBLimiterBurst(1),
 		withServerKeepAlive(time.Millisecond*200),
 		withTestEventsChannel(events),
 		WithOnConnect(rc.onConnect),
@@ -700,6 +701,9 @@ func TestDatabaseServerBasics(t *testing.T) {
 		ServerID: serverID,
 		Version:  teleport.Version,
 		Services: types.SystemRoles{types.RoleDatabase}.StringSlice(),
+		Capabilities: &proto.UpstreamInventoryHello_SupportedCapabilities{
+			DatabaseHeartbeatGracefulStop: true,
+		},
 	})
 
 	// verify that control stream handle is now accessible
@@ -714,7 +718,7 @@ func TestDatabaseServerBasics(t *testing.T) {
 		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
 			DatabaseServer: &types.DatabaseServerV3{
 				Metadata: types.Metadata{
-					Name: serverID,
+					Name: fmt.Sprintf("db-%d", i),
 				},
 				Spec: types.DatabaseServerSpecV3{
 					HostID:   serverID,
@@ -739,6 +743,73 @@ func TestDatabaseServerBasics(t *testing.T) {
 		deny(dbUpsertErr, dbKeepAliveErr, handlerClose),
 	)
 
+	// re-upsert one db to trigger rate limiting for it
+	for range 3 {
+		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+			DatabaseServer: &types.DatabaseServerV3{
+				Metadata: types.Metadata{
+					Name: "db-0",
+				},
+				Spec: types.DatabaseServerSpecV3{
+					HostID:   serverID,
+					Hostname: serverID,
+					Database: &types.DatabaseV3{
+						Kind:    types.KindDatabase,
+						Version: types.V3,
+						Metadata: types.Metadata{
+							Name: "db-0",
+						},
+						Spec: types.DatabaseSpecV3{},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	awaitEvents(t, events,
+		expect(dbUpsertRateLimited, dbUpsertRateLimitedRetryOk),
+		deny(dbUpsertOk, dbUpsertErr, dbUpsertRetryErr, dbUpsertRateLimitedRetryErr, dbKeepAliveErr, handlerClose),
+	)
+
+	for range 3 {
+		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+			DatabaseServer: &types.DatabaseServerV3{
+				Metadata: types.Metadata{
+					Name: "db-0",
+				},
+				Spec: types.DatabaseServerSpecV3{
+					HostID:   serverID,
+					Hostname: serverID,
+					Database: &types.DatabaseV3{
+						Kind:    types.KindDatabase,
+						Version: types.V3,
+						Metadata: types.Metadata{
+							Name: "db-0",
+						},
+						Spec: types.DatabaseSpecV3{},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	awaitEvents(t, events,
+		expect(dbUpsertOk, dbUpsertRateLimited),
+		deny(dbUpsertErr, dbUpsertRetryErr, dbUpsertRateLimitedRetryOk, dbUpsertRateLimitedRetryErr, dbKeepAliveErr, handlerClose),
+	)
+
+	// induce a failure on rate limit delayed upsert, but the upsert should succeed on retry
+	auth.mu.Lock()
+	auth.failUpserts = 1
+	auth.mu.Unlock()
+
+	awaitEvents(t, events,
+		expect(dbUpsertRateLimitedRetryErr, dbUpsertRetryOk),
+		deny(dbUpsertOk, dbUpsertErr, dbUpsertRetryErr, dbKeepAliveErr, handlerClose),
+	)
+
 	// set up to induce delete failure
 	auth.mu.Lock()
 	auth.failDeletes = 1
@@ -754,7 +825,7 @@ func TestDatabaseServerBasics(t *testing.T) {
 	// verify that keep alive stops, even if the heartbeat couldn't be deleted
 	awaitEvents(t, events,
 		expect(dbKeepAliveDel, dbDelErr),
-		deny(dbDelOk, dbUpsertErr, dbKeepAliveErr, handlerClose),
+		deny(dbDelOk, dbUpsertErr, dbKeepAliveErr, handlerClose, dbUpsertRateLimited, dbUpsertRateLimitedRetryOk, dbUpsertRateLimitedRetryErr),
 	)
 	require.Equal(t, dbCount-1, rc.count())
 
@@ -824,7 +895,7 @@ func TestDatabaseServerBasics(t *testing.T) {
 	// we should now see an upsert failure, but no additional
 	// keepalive failures, and the upsert should succeed on retry.
 	awaitEvents(t, events,
-		expect(dbUpsertErr, dbUpsertRetryOk),
+		expect(dbUpsertOk, dbUpsertOk, dbUpsertErr, dbUpsertRetryOk),
 		deny(dbKeepAliveErr, handlerClose),
 	)
 
@@ -911,6 +982,91 @@ func TestDatabaseServerBasics(t *testing.T) {
 
 	// verify that metrics have been updated correctly
 	require.Zero(t, rc.count())
+}
+
+func TestDatabaseServer_RateLimitDisabled(t *testing.T) {
+	const serverID = "test-server"
+
+	t.Parallel()
+
+	ctx := t.Context()
+
+	events := make(chan testEvent, 1024)
+
+	auth := &fakeAuth{}
+
+	rc := &resourceCounter{}
+	controller := NewController(
+		auth,
+		usagereporter.DiscardUsageReporter{},
+		withServerHBLimiterInterval(time.Second),
+		withServerHBLimiterBurst(1),
+		withServerKeepAlive(time.Millisecond*200),
+		withTestEventsChannel(events),
+		WithOnConnect(rc.onConnect),
+		WithOnDisconnect(rc.onDisconnect),
+	)
+	defer controller.Close()
+
+	// set up fake in-memory control stream
+	upstream, downstream := client.InventoryControlStreamPipe()
+	t.Cleanup(func() {
+		controller.Close()
+		upstream.Close()
+		downstream.Close()
+	})
+
+	controller.RegisterControlStream(upstream, &proto.UpstreamInventoryHello{
+		ServerID: serverID,
+		Version:  teleport.Version,
+		Services: types.SystemRoles{types.RoleDatabase}.StringSlice(),
+	})
+
+	// verify that control stream handle is now accessible
+	handle, ok := controller.GetControlStream(serverID)
+	require.True(t, ok)
+	t.Cleanup(func() {
+		require.NoError(t, handle.Close())
+	})
+
+	// verify that hb counter has been incremented
+	require.Equal(t, int64(1), controller.instanceHBVariableDuration.Count())
+
+	// upsert the same db repeatedly
+	for range 100 {
+		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+			DatabaseServer: &types.DatabaseServerV3{
+				Metadata: types.Metadata{
+					Name: "db-1",
+				},
+				Spec: types.DatabaseServerSpecV3{
+					HostID:   serverID,
+					Hostname: serverID,
+					Database: &types.DatabaseV3{
+						Kind:    types.KindDatabase,
+						Version: types.V3,
+						Metadata: types.Metadata{
+							Name: "db-1",
+						},
+						Spec: types.DatabaseSpecV3{},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	// verify that heartbeat creates both an upsert and a keepalive
+	for range 100 {
+		awaitEvents(t, events,
+			expect(dbUpsertOk),
+			deny(dbUpsertRateLimited, dbUpsertErr, dbKeepAliveErr, handlerClose),
+		)
+	}
+	awaitEvents(t, events,
+		expect(dbKeepAliveOk),
+		deny(dbUpsertRateLimited, dbUpsertErr, dbKeepAliveErr, handlerClose),
+	)
 }
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.

--- a/lib/inventory/internal/delay/heap_test.go
+++ b/lib/inventory/internal/delay/heap_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestHeapBasics(t *testing.T) {
+	t.Parallel()
 	heap := heap[entry[int]]{
 		Less: entryLess[int],
 	}
@@ -54,13 +55,18 @@ func TestHeapBasics(t *testing.T) {
 	require.NotNil(t, newRoot)
 	require.Equal(t, 1, newRoot.key)
 
+	// 43ms -> 22ms replacement should be sifted up
+	heap.Slice[42].tick = now.Add(22 * time.Millisecond)
+	heap.Fix(42)
+	// 14ms -> 33ms replacement should be sifted down
+	heap.Slice[13].tick = now.Add(33 * time.Millisecond)
+	heap.Fix(13)
 	var prev *entry[int]
-	for i := range 100 {
+	for range 100 {
 		next := heap.Pop()
 		if prev != nil {
-			require.True(t, prev.tick.Before(next.tick), "prev: %v, next: %v", prev, next)
+			require.False(t, next.tick.Before(prev.tick), "prev: %v, next: %v", prev, next)
 		}
-		require.Equal(t, (i+1)%100, next.key)
 		prev = &next
 	}
 

--- a/lib/inventory/internal/delay/multi.go
+++ b/lib/inventory/internal/delay/multi.go
@@ -145,19 +145,20 @@ func (h *Multi[T]) Remove(key T) {
 // Reset resets the next tick for the given key to the current time plus a delay.
 func (h *Multi[T]) Reset(key T, delay time.Duration) {
 	for i, item := range h.heap.Slice {
-		if item.key == key {
-			h.heap.Slice[i] = entry[T]{
-				key:  key,
-				tick: h.clock.Now().Add(h.resetJitter(delay)),
-			}
-			h.heap.Fix(i)
-			if i == 0 {
-				// if the adjusted entry was the root of the heap, then our target
-				// has changed and we need to reset the timer to a new target.
-				h.reset(h.clock.Now(), false /* fired */)
-			}
-			return
+		if item.key != key {
+			continue
 		}
+		h.heap.Slice[i] = entry[T]{
+			key:  key,
+			tick: h.clock.Now().Add(h.resetJitter(delay)),
+		}
+		h.heap.Fix(i)
+		if i == 0 {
+			// if the adjusted entry was the root of the heap, then our target
+			// has changed and we need to reset the timer to a new target.
+			h.reset(h.clock.Now(), false /* fired */)
+		}
+		return
 	}
 }
 

--- a/lib/inventory/internal/delay/multi.go
+++ b/lib/inventory/internal/delay/multi.go
@@ -153,9 +153,9 @@ func (h *Multi[T]) Reset(key T, delay time.Duration) {
 			tick: h.clock.Now().Add(h.resetJitter(delay)),
 		}
 		h.heap.Fix(i)
-		if i == 0 {
-			// if the adjusted entry was the root of the heap, then our target
-			// has changed and we need to reset the timer to a new target.
+		if i == 0 || h.heap.Slice[0].key == key {
+			// if the adjusted entry was or is the root of the heap, then our
+			// target has changed and we need to reset the timer to a new target.
 			h.reset(h.clock.Now(), false /* fired */)
 		}
 		return

--- a/lib/inventory/inventory.go
+++ b/lib/inventory/inventory.go
@@ -765,12 +765,7 @@ func (h *heartBeatInfo[_]) delayUpsertFrom(now time.Time) time.Duration {
 		// a token within a finite duration of time.
 		h.heartbeatReservation = h.heartbeatLimiter.ReserveN(now, 1)
 	}
-	delay := h.heartbeatReservation.DelayFrom(now)
-	if delay == 0 {
-		// rate limit allows the upsert, blank the reservation now.
-		h.heartbeatReservation = nil
-	}
-	return delay
+	return h.heartbeatReservation.DelayFrom(now)
 }
 
 func newUpstreamHandle(stream client.UpstreamInventoryControlStream, hello *proto.UpstreamInventoryHello, now time.Time) *upstreamHandle {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1316,6 +1316,9 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 			Services:         services,
 			Hostname:         cfg.Hostname,
 			ExternalUpgrader: externalUpgrader,
+			Capabilities: &proto.UpstreamInventoryHello_SupportedCapabilities{
+				DatabaseHeartbeatGracefulStop: true,
+			},
 		}
 
 		if upgraderVersion != nil {


### PR DESCRIPTION
Add client capabilities to the upstream inventory hello message.

The inventory controller will buffer rate limited heartbeats to be upserted at a later time allowed by its rate limiter.

The controller will only rate limit database heartbeats if the database service supports stopping an individual database heartbeat in the inventory control stream (a so-called "graceful DB heartbeat stop" capability).

The capability check is necessary becauase a database agent that does not support "graceful DB heartbeat stop" will unregister and delete a DB heartbeat directly from the backend, but that could be reversed by a buffered database upsert induced by rate limiting.

This PR depends on and is stacked on top of the PR that adds graceful stop support for an individual DB heartbeat:
- #55700