### PR TITLE
Fix panic in Firestore backend

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -225,7 +225,6 @@ func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 			Timestamp:  br.Timestamp,
 			Expires:    br.Expires,
 			RevisionV2: br.RevisionV2,
-			snapShot:   doc,
 		}
 	default:
 		if err := doc.DataTo(&r); err != nil {
@@ -241,10 +240,11 @@ func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 				Value:     []byte(rl.Value),
 				Timestamp: rl.Timestamp,
 				Expires:   rl.Expires,
-				snapShot:  doc,
 			}
 		}
 	}
+
+	r.snapShot = doc
 
 	if r.RevisionV2 == "" {
 		r.RevisionV1 = toRevisionV1(doc.UpdateTime)


### PR DESCRIPTION
```
 panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5af856fc3494]

goroutine 62984 [running]:
github.com/gravitational/teleport/lib/backend/firestore.(*Backend).Items.func3-range1(0xc0001991f0, {0x0?, 0x0?})
        github.com/gravitational/teleport/lib/backend/firestore/firestorebk.go:586 +0x134
github.com/gravitational/teleport/lib/backend/firestore.(*Backend).Items.func3.(*Backend).mergedRecords.2-range1(0x5af85ed273a0?, {0x0, 0x0?})
        github.com/gravitational/teleport/lib/backend/firestore/firestorebk.go:655 +0x4f
github.com/gravitational/teleport/lib/itertools/stream.MergeStreams[...].func1()
        github.com/gravitational/teleport/lib/itertools/stream/stream.go:378 +0x236
github.com/gravitational/teleport/lib/backend/firestore.(*Backend).Items.func3.(*Backend).mergedRecords.2(0xc000e52500)
        github.com/gravitational/teleport/lib/backend/firestore/firestorebk.go:654 +0x89b
github.com/gravitational/teleport/lib/backend/firestore.(*Backend).Items.func3(0xc003bb4cc0)
        github.com/gravitational/teleport/lib/backend/firestore/firestorebk.go:579 +0x3bf
```

The above panic is caused by the snapShot not being set and thus resulting in a nil dereference. The snapShot is now assigned outside of the switch to ensure that all records that are successfully created contain a reference to a valid DocumentSnapshot.