### PR TITLE
Adjust docs on app/database tunnel service and one-shot mode

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/access-guides/applications.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/applications.mdx
@@ -102,6 +102,9 @@ Replace:
 - `dumper` with the name of the application you registered in Teleport.
 - `listen` with the address and port you wish the service to bind to.
 
+Ensure that `tbot` is not configured to run in one-shot mode, as the application
+tunnel will not start in this mode.
+
 Restart `tbot` to apply the new configuration.
 </TabItem>
 <TabItem label="application output">

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -599,6 +599,9 @@ workload identity API, intended to serve workload identity credentials
 For more information about this, see the
 [Workload Identity API and Workload Attestation reference](../workload-identity/workload-identity-api-and-workload-attestation.mdx)
 
+The `workload-identity-api` service will not start if `tbot` has been configured
+to run in one-shot mode.
+
 ### `spiffe-workload-api`
 
 <Admonition type="warning" >
@@ -946,6 +949,9 @@ database: postgres
 username: postgres
 ```
 
+The `database-tunnel` service will not start if `tbot` has been configured
+to run in one-shot mode.
+
 ### `application-tunnel`
 
 The `application-tunnel` service opens a listener that tunnels connections to
@@ -973,6 +979,9 @@ listen: tcp://127.0.0.1:8084
 # the service should open a tunnel to.
 app_name: my-application
 ```
+
+The `application-tunnel` service will not start if `tbot` has been configured
+to run in one-shot mode.
 
 ### `ssh-multiplexer`
 
@@ -1038,6 +1047,9 @@ destination:
    a server's identity.
 - `v1.sock`: the Unix socket that the multiplexer listens on.
 - `agent.sock`: the Unix socket that the SSH agent listens on.
+
+The `ssh-multiplexer` service will not start if `tbot` has been configured
+to run in one-shot mode.
 
 #### Using the SSH multiplexer programmatically
 


### PR DESCRIPTION
Customer ran into a failure when using one-shot mode with these services - I've updated the the docs to mention this behaviour more explicitly.