### PR TITLE
Raise Oneshot mode log message from Debug to Info

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -673,7 +673,10 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			svc, ok := svc.(OneShotService)
 			// We ignore services with no one-shot implementation
 			if !ok {
-				log.DebugContext(ctx, "Service does not support oneshot mode, ignoring")
+				log.InfoContext(
+					ctx,
+					"Service does not support oneshot mode, it will not run",
+				)
 				continue
 			}
 			eg.Go(func() error {


### PR DESCRIPTION
Had a customer run into an issue where they had tunnels configured but were running in oneshot mode, I realised that in non-debug mode, the fact that these services are not running is completely concealed. I can't recall any reason why I made this Debug originally so raising to Info.