### PR TITLE
Adding VPN reference in VNet doc for search purposes

### DIFF
--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -19,6 +19,8 @@ address managed by VNet that will forward the connection to your application.
 
 ![Diagram showing VNet architecture](../../img/vnet/how-it-works.svg)
 
+VNet delivers an experience like a VPN for your TCP applications through this local virtual network, while maintaining all of Teleport's identity verification and zero trust features that traditional VPNs cannot provide.
+
 VNet is available on macOS and Windows in Teleport Connect and tsh, with plans
 for Linux support in a future version.
 


### PR DESCRIPTION
We want docs users looking for a VPN capability in Teleport to be guided to VNet. This small PR adds a blurb about VPN to the "Using VNet" doc in order to help move it up in the search a bit. 