### PR TITLE
Heartbeat database server on target health changes

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -247,6 +247,14 @@ func compareDatabaseServers(a, b types.DatabaseServer) int {
 	if !slices.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {
 		return Different
 	}
+
+	// compareTargetHealth can return OnlyTimestampsDifferent, so it must only be
+	// called after all Different checks.
+	healthDiff := compareTargetHealth(a.GetTargetHealth(), b.GetTargetHealth())
+	if healthDiff != Equal {
+		return healthDiff
+	}
+
 	// OnlyTimestampsDifferent check must be after all Different checks.
 	if !a.Expiry().Equal(b.Expiry()) {
 		return OnlyTimestampsDifferent
@@ -272,6 +280,23 @@ func compareWindowsDesktopServices(a, b types.WindowsDesktopService) int {
 	}
 	// OnlyTimestampsDifferent check must be after all Different checks.
 	if !a.Expiry().Equal(b.Expiry()) {
+		return OnlyTimestampsDifferent
+	}
+	return Equal
+}
+
+// compareTargetHealth can return OnlyTimestampsDifferent, so it must only be
+// called after all Different checks.
+func compareTargetHealth(a, b types.TargetHealth) int {
+	if a.Address != b.Address ||
+		a.Protocol != b.Protocol ||
+		a.Status != b.Status ||
+		a.TransitionReason != b.TransitionReason ||
+		a.TransitionError != b.TransitionError ||
+		a.Message != b.Message {
+		return Different
+	}
+	if !a.GetTransitionTimestamp().Equal(b.GetTransitionTimestamp()) {
 		return OnlyTimestampsDifferent
 	}
 	return Equal


### PR DESCRIPTION
This PR makes changes in target health trigger an early announcement of the heartbeat.

Should not be merged until https://github.com/gravitational/teleport/pull/56022 is merged, as a precaution against some unforeseen bug causing excessive pressure on the backend.
- https://github.com/gravitational/teleport/pull/56022