### PR TITLE
ami: Disable ec2-user password expiry to prevent unexpected auth/proxy SSH lockouts

### DIFF
--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -19,6 +19,8 @@ ln -s /opt/certbot/bin/certbot /usr/local/bin/certbot
 useradd -r teleport -u "${TELEPORT_UID}" -d /var/lib/teleport
 # Add teleport to adm group to read and write logs
 usermod -a -G adm teleport
+# Disable password age on ec2-user account to prevent users being locked out (V-230367)
+chage --maxdays -1 ec2-user
 
 # Setup teleport run dir for pid files
 install -d -m 0700 -o teleport -g adm /var/lib/teleport

--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -62,6 +62,3 @@ rm -rf /var/cache/dnf /var/cache/yum
 # Enable Teleport services to start on boot
 systemctl enable teleport-generate-config.service
 systemctl enable teleport.service
-
-# Disable password age on ec2-user account to prevent users being locked out (V-230367)
-chage -M -1 ec2-user

--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -60,3 +60,6 @@ rm -rf /var/cache/dnf /var/cache/yum
 # Enable Teleport services to start on boot
 systemctl enable teleport-generate-config.service
 systemctl enable teleport.service
+
+# Disable password age on ec2-user account to prevent users being locked out (V-230367)
+chage -M -1 ec2-user


### PR DESCRIPTION
It looks like at some point between when we started making hardened AMIs and now, the STIG RHEL 8 hardening guidelines (which are [also used by Amazon Linux 2023](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/awsec2-configure-stig.html#ec2-linux-os-stig)) started to enforce a maximum 60-day password lifetime restriction. This appears to be detailed in finding [V-230367](https://stigviewer.com/stigs/red_hat_enterprise_linux_8/2025-03-26/finding/V-230367).

This can cause users of Teleport AMIs to get locked out of their auth/proxy deployments; after 60 days, they will be forced to change the password for `ec2-user` on login (even when using SSH with a public key), but AWS AMIs do not set a default password for the `ec2-user` account:

```
[ec2-user@ip-172-31-7-213 ~]$ sudo grep ec2-user /etc/shadow
ec2-user:!!:20226:1::7:::
```

This PR explicitly sets the password for `ec2-user` to not expire in order to prevent this issue.

Out of the box, it's only possible to log into these instances as `ec2-user` with a public key anyway - the use of password lifetime restrictions is arcane and unnecessary here.

```
[ec2-user@ip-172-31-7-213 ~]$ sudo grep -E "^PasswordAuthentication" /etc/ssh/sshd_config
PasswordAuthentication no
```

Before:
```
[ec2-user@ip-172-31-3-192 ~]$ sudo chage -l ec2-user
Last password change					: May 18, 2025
Password expires					: Jul 17, 2025
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 1
Maximum number of days between password change		: 60
Number of days of warning before password expires	: 7
```

After:
```
[ec2-user@ip-172-31-7-213 ~]$ sudo chage -l ec2-user
Last password change					: May 18, 2025
Password expires					: never
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 1
Maximum number of days between password change		: -1
Number of days of warning before password expires	: 7
```

In the meantime, anyone with a Teleport deployment affected by this issue can do an [instance refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html) to redeploy their auth/proxy servers with a "fresh" AMI that does not have an expired password. Assuming the Teleport [`starter-cluster`](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/starter-cluster) or [`ha-autoscale-cluster`](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster) Terraform example is being used, all Teleport backend data, audit logs and session recordings should be preserved in DynamoDB/S3 and no data loss will occur.