### PR TITLE
[v17] Fix client_idle_timeout enforcement for desktop sessions

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -470,7 +470,19 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 			continue
 		}
 
-		c.UpdateClientActivity()
+		// If the message was due to user input, then we update client activity
+		// in order to refresh the client_idle_timeout checks.
+		//
+		// Note: we count some of the directory sharing messages as client activity
+		// because we don't want a session to be closed due to inactivity during a large
+		// file transfer.
+		switch msg.(type) {
+		case tdp.KeyboardButton, tdp.MouseMove, tdp.MouseButton, tdp.MouseWheel,
+			tdp.SharedDirectoryAnnounce, tdp.SharedDirectoryInfoResponse,
+			tdp.SharedDirectoryReadResponse, tdp.SharedDirectoryWriteResponse:
+
+			c.UpdateClientActivity()
+		}
 
 		if withheldResize != nil {
 			c.cfg.Logger.DebugContext(context.Background(), "Sending withheld screen size to client")

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -507,7 +507,6 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 
 		go monitorLatency(ctx, clockwork.NewRealClock(), ws, pinger,
 			latency.ReporterFunc(func(ctx context.Context, stats latency.Statistics) error {
-				log.Debug("sending latency stats", "client", stats.Client, "server", stats.Server)
 				return trace.Wrap(tdpConnProxy.SendToClient(tdp.LatencyStats{
 					ClientLatency: uint32(stats.Client),
 					ServerLatency: uint32(stats.Server),

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -330,7 +330,7 @@ export class TdpClient extends EventEmitter<EventMap> {
         this.handleRdpConnectionActivated(buffer);
         break;
       case MessageType.RDP_FASTPATH_PDU:
-        this.handleRdpFastPathPDU(buffer);
+        this.handleRdpFastPathPdu(buffer);
         break;
       case MessageType.CLIENT_SCREEN_SPEC:
         this.handleClientScreenSpec(buffer);
@@ -472,8 +472,8 @@ export class TdpClient extends EventEmitter<EventMap> {
     this.emit(TdpClientEvent.TDP_CLIENT_SCREEN_SPEC, spec);
   }
 
-  handleRdpFastPathPDU(buffer: ArrayBufferLike) {
-    let rdpFastPathPDU = this.codec.decodeRdpFastPathPDU(buffer);
+  handleRdpFastPathPdu(buffer: ArrayBufferLike) {
+    let rdpFastPathPdu = this.codec.decodeRdpFastPathPdu(buffer);
 
     // This should never happen but let's catch it with an error in case it does.
     if (!this.fastPathProcessor) {
@@ -481,13 +481,13 @@ export class TdpClient extends EventEmitter<EventMap> {
     }
 
     this.fastPathProcessor.process(
-      rdpFastPathPDU,
+      rdpFastPathPdu,
       this,
       (bmpFrame: BitmapFrame) => {
         this.emit(TdpClientEvent.TDP_BMP_FRAME, bmpFrame);
       },
       (responseFrame: ArrayBuffer) => {
-        this.sendRdpResponsePDU(responseFrame);
+        this.sendRdpResponsePdu(responseFrame);
       },
       (data: ImageData | boolean, hotspot_x?: number, hotspot_y?: number) => {
         this.emit(TdpClientEvent.POINTER, { data, hotspot_x, hotspot_y });
@@ -805,8 +805,8 @@ export class TdpClient extends EventEmitter<EventMap> {
     this.sendClientScreenSpec(spec);
   };
 
-  sendRdpResponsePDU(responseFrame: ArrayBufferLike) {
-    this.send(this.codec.encodeRdpResponsePDU(responseFrame));
+  sendRdpResponsePdu(responseFrame: ArrayBufferLike) {
+    this.send(this.codec.encodeRdpResponsePdu(responseFrame));
   }
 
   // Emits a warning event, but keeps the socket open.

--- a/web/packages/shared/libs/tdp/codec.ts
+++ b/web/packages/shared/libs/tdp/codec.ts
@@ -729,7 +729,7 @@ export default class Codec {
   }
 
   // | message type (30) | data_length uint32 | data []byte |
-  encodeRdpResponsePDU(responseFrame: ArrayBufferLike): Message {
+  encodeRdpResponsePdu(responseFrame: ArrayBufferLike): Message {
     const bufLen = BYTE_LEN + UINT_32_LEN + responseFrame.byteLength;
     const buffer = new ArrayBuffer(bufLen);
     const view = new DataView(buffer);
@@ -878,7 +878,7 @@ export default class Codec {
   }
 
   // | message type (29) | data_length uint32 | data []byte |
-  decodeRdpFastPathPDU(buffer: ArrayBufferLike): RdpFastPathPdu {
+  decodeRdpFastPathPdu(buffer: ArrayBufferLike): RdpFastPathPdu {
     const dv = new DataView(buffer);
     let offset = 0;
     offset += BYTE_LEN; // eat message type

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -208,7 +208,7 @@ export class PlayerClient extends TdpClient {
   // RDP response PDUs to the server during playback, which is unnecessary
   // and breaks the playback system.
   // eslint-disable-next-line unused-imports/no-unused-vars
-  sendRdpResponsePDU(responseFrame: ArrayBuffer) {
+  sendRdpResponsePdu(responseFrame: ArrayBuffer) {
     return;
   }
 


### PR DESCRIPTION
We had been updating the client activity tracker any time a message was sent from the client (browser or Teleport Connect) to the remote host. This approach was fine for the original RDP implmentation, as all messages sent in this direction were for user input (keypresses, mouse movement, scroll wheel, etc), but it is insufficient with the current RemoteFX implementation as there are some messages sent by the remote Windows hosts which require client acknowledgements. These acknowledgements were mistakenly being counted as client activity.

Closes #55691
Backports #55693

Changelog: fixed an issue that could prevent Windows desktop sessions from terminating when the idle timeout was exceeded.