### PR TITLE
Fix health check config equivalence check

### DIFF
--- a/lib/healthcheck/config.go
+++ b/lib/healthcheck/config.go
@@ -68,6 +68,7 @@ func (h *healthCheckConfig) equivalent(other *healthCheckConfig) bool {
 			h.name == other.name &&
 			h.protocol == other.protocol &&
 			h.interval == other.interval &&
+			h.timeout == other.timeout &&
 			h.healthyThreshold == other.healthyThreshold &&
 			h.unhealthyThreshold == other.unhealthyThreshold
 }

--- a/lib/healthcheck/config_test.go
+++ b/lib/healthcheck/config_test.go
@@ -124,6 +124,12 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			want: true,
 		},
 		{
+			desc: "both empty",
+			a:    &healthCheckConfig{},
+			b:    &healthCheckConfig{},
+			want: true,
+		},
+		{
 			desc: "one nil, one non-nil",
 			a:    &healthCheckConfig{},
 			b:    nil,
@@ -135,6 +141,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				name:               "test",
 				protocol:           "http",
 				interval:           time.Second,
+				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
 				unhealthyThreshold: 5,
 			},
@@ -142,6 +149,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				name:               "test",
 				protocol:           "http",
 				interval:           time.Second,
+				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
 				unhealthyThreshold: 5,
 			},
@@ -153,6 +161,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				name:                  "test",
 				protocol:              "http",
 				interval:              time.Second,
+				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
 				unhealthyThreshold:    5,
 				databaseLabelMatchers: types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
@@ -161,6 +170,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				name:                  "test",
 				protocol:              "http",
 				interval:              time.Second,
+				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
 				unhealthyThreshold:    5,
 				databaseLabelMatchers: types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
@@ -194,6 +204,16 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				interval: 2 * time.Second,
+			},
+			want: false,
+		},
+		{
+			desc: "different timeout",
+			a: &healthCheckConfig{
+				timeout: time.Second,
+			},
+			b: &healthCheckConfig{
+				timeout: 2 * time.Second,
 			},
 			want: false,
 		},


### PR DESCRIPTION
The config timeout was not compared for equivalence before, but the only consequence of this was that the health check worker would not log a debug message about the config update if only the timeout setting changed.

Related: https://github.com/gravitational/teleport/issues/55231
- https://github.com/gravitational/teleport/issues/55231