### PR TITLE
[v15] Fix client_idle_timeout enforcement for desktop sessions

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -417,7 +417,19 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 			continue
 		}
 
-		c.UpdateClientActivity()
+		// If the message was due to user input, then we update client activity
+		// in order to refresh the client_idle_timeout checks.
+		//
+		// Note: we count some of the directory sharing messages as client activity
+		// because we don't want a session to be closed due to inactivity during a large
+		// file transfer.
+		switch msg.(type) {
+		case tdp.KeyboardButton, tdp.MouseMove, tdp.MouseButton, tdp.MouseWheel,
+			tdp.SharedDirectoryAnnounce, tdp.SharedDirectoryInfoResponse,
+			tdp.SharedDirectoryReadResponse, tdp.SharedDirectoryWriteResponse:
+
+			c.UpdateClientActivity()
+		}
 
 		if withheldResize != nil {
 			c.cfg.Log.Debug("Sending withheld screen size to client")

--- a/web/packages/teleport/src/lib/tdp/client.ts
+++ b/web/packages/teleport/src/lib/tdp/client.ts
@@ -267,7 +267,7 @@ export default class Client extends EventEmitterWebAuthnSender {
           this.handleRdpConnectionActivated(buffer);
           break;
         case MessageType.RDP_FASTPATH_PDU:
-          this.handleRdpFastPathPDU(buffer);
+          this.handleRdpFastPathPdu(buffer);
           break;
         case MessageType.CLIENT_SCREEN_SPEC:
           this.handleClientScreenSpec(buffer);
@@ -410,8 +410,8 @@ export default class Client extends EventEmitterWebAuthnSender {
     this.emit(TdpClientEvent.TDP_CLIENT_SCREEN_SPEC, spec);
   }
 
-  handleRdpFastPathPDU(buffer: ArrayBuffer) {
-    let rdpFastPathPDU = this.codec.decodeRdpFastPathPDU(buffer);
+  handleRdpFastPathPdu(buffer: ArrayBufferLike) {
+    let rdpFastPathPdu = this.codec.decodeRdpFastPathPdu(buffer);
 
     // This should never happen but let's catch it with an error in case it does.
     if (!this.fastPathProcessor)
@@ -422,13 +422,13 @@ export default class Client extends EventEmitterWebAuthnSender {
 
     try {
       this.fastPathProcessor.process(
-        rdpFastPathPDU,
+        rdpFastPathPdu,
         this,
         (bmpFrame: BitmapFrame) => {
           this.emit(TdpClientEvent.TDP_BMP_FRAME, bmpFrame);
         },
         (responseFrame: ArrayBuffer) => {
-          this.sendRdpResponsePDU(responseFrame);
+          this.sendRdpResponsePdu(responseFrame);
         },
         (data: ImageData | boolean, hotspot_x?: number, hotspot_y?: number) => {
           this.emit(TdpClientEvent.POINTER, { data, hotspot_x, hotspot_y });
@@ -765,8 +765,8 @@ export default class Client extends EventEmitterWebAuthnSender {
     this.sendClientScreenSpec(spec);
   }
 
-  sendRdpResponsePDU(responseFrame: ArrayBuffer) {
-    this.send(this.codec.encodeRdpResponsePDU(responseFrame));
+  sendRdpResponsePdu(responseFrame: ArrayBufferLike) {
+    this.send(this.codec.encodeRdpResponsePdu(responseFrame));
   }
 
   // Emits an errType event and closes the websocket connection.

--- a/web/packages/teleport/src/lib/tdp/codec.ts
+++ b/web/packages/teleport/src/lib/tdp/codec.ts
@@ -722,7 +722,7 @@ export default class Codec {
   }
 
   // | message type (30) | data_length uint32 | data []byte |
-  encodeRdpResponsePDU(responseFrame: ArrayBuffer): Message {
+  encodeRdpResponsePdu(responseFrame: ArrayBufferLike): Message {
     const bufLen = BYTE_LEN + UINT_32_LEN + responseFrame.byteLength;
     const buffer = new ArrayBuffer(bufLen);
     const view = new DataView(buffer);
@@ -871,7 +871,7 @@ export default class Codec {
   }
 
   // | message type (29) | data_length uint32 | data []byte |
-  decodeRdpFastPathPDU(buffer: ArrayBuffer): RdpFastPathPdu {
+  decodeRdpFastPathPdu(buffer: ArrayBufferLike): RdpFastPathPdu {
     const dv = new DataView(buffer);
     let offset = 0;
     offset += BYTE_LEN; // eat message type

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -209,7 +209,7 @@ export class PlayerClient extends Client {
   // RDP response PDUs to the server during playback, which is unnecessary
   // and breaks the playback system.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  sendRdpResponsePDU(responseFrame: ArrayBuffer) {
+  sendRdpResponsePdu(responseFrame: ArrayBuffer) {
     return;
   }
 


### PR DESCRIPTION
We had been updating the client activity tracker any time a message was sent from the client (browser or Teleport Connect) to the remote host. This approach was fine for the original RDP implmentation, as all messages sent in this direction were for user input (keypresses, mouse movement, scroll wheel, etc), but it is insufficient with the current RemoteFX implementation as there are some messages sent by the remote Windows hosts which require client acknowledgements. These acknowledgements were mistakenly being counted as client activity.

Closes #55691
Backports #55693

Changelog: fixed an issue that could prevent Windows desktop sessions from terminating when the idle timeout was exceeded.