### PR TITLE
Remove Openssh checkpoint from hardware key test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1224,16 +1224,15 @@ release/dev build. If you are building Teleport Connect in development mode, you
 config option `hardwareKeyAgent.enabled: true` and restart Connect. You can run a non-login `tsh`
 command to check if the agent is running.
 
-Before logging in to Teleport Connect:
+In `tsh`, without logging into Teleport Connect:
 
 - [ ] `tsh login` prompts for PIV PIN and touch without using the Hardware Key Agent
 - [ ] All other `tsh` commands prompt for PIN and touch via the Hardware Key Agent
   - [ ] Test a subset of the `tsh` commands from the test above
     - [ ] The command is displayed in the PIN and touch prompts
-- [ ] Connecting with OpenSSH `ssh` prompts for PIN and touch via the hardware key agent
 - [ ] The PIN is cached for the configured duration between basic `tsh` commands (set `pin_cache_ttl` to something longer that 15s if needed)
 
-After logging in to Teleport Connect:
+In Teleport Connect:
 
 - [ ] Login prompts for PIN and touch
 - [ ] Server Access


### PR DESCRIPTION
Removes OpenSSH checkpoint as it has never worked.

For context: during hardware key agent testing, I mistakenly thought it solved the issue with Hardware Key support and the OpenSSH client described [here](https://github.com/gravitational/teleport/issues/39339#issuecomment-2002120375). What actually changed is that `tsh proxy ssh` is now able to prompt for PIN through the agent whereas before you would get the following error:

```
> ssh server01.root.example.com 
Enter your YubiKey PIV PIN:
ERROR: failed to perform warmup signature with hardware private key
	pin cannot be empty

Connection closed by UNKNOWN port 65535
```

If you run the hardware key agent, you can now get one step further, entering the PIN through the agent, but ultimately failing the key exchange:

```
> ssh server01.root.example.com
Load key "/Users/bjoerger/.tsh/keys/root.example.com/dev-ssh/root.example.com-cert.pub": error in libcrypto
bjoerger@server01.root.example.com: Permission denied (publickey).
```

As described in https://github.com/gravitational/teleport/issues/39339#issuecomment-2002120375, we still need a way to inject a teleport client aware of hardware keys into the key exchange. SSH Vnet has been chosen for that job as an alternative.