### PR TITLE
VNet diag notification: Do not show button to open report if there's no workspace selected

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -20,8 +20,8 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   ComponentType,
   createRef,
-  MutableRefObject,
   PropsWithChildren,
+  RefObject,
   useEffect,
   useImperativeHandle,
 } from 'react';
@@ -218,12 +218,12 @@ describe('diag notification', () => {
   const tests: Array<{
     it: string;
     /** Ref for opening/closing the connections panel. If provided, the panel will be open by default. */
-    controlConnectionsRef?: MutableRefObject<ControlConnections>;
+    controlConnectionsRef?: RefObject<ControlConnections>;
     mockAppContext: (appContext: MockAppContext) => void;
     verify: (
       appContext: MockAppContext,
       result: { current: VnetContext },
-      controlConnectionsRef?: MutableRefObject<ControlConnections>
+      controlConnectionsRef?: RefObject<ControlConnections>
     ) => Promise<void>;
   }> = [
     {
@@ -476,7 +476,7 @@ describe('diag notification', () => {
 const Wrapper = (
   props: PropsWithChildren<{
     appContext: IAppContext;
-    controlConnectionsRef?: MutableRefObject<ControlConnections>;
+    controlConnectionsRef?: RefObject<ControlConnections>;
   }>
 ) => {
   return (
@@ -511,7 +511,7 @@ function createWrapper<Props>(
 }
 
 const OpenConnections = (props: {
-  controlConnectionsRef: MutableRefObject<ControlConnections>;
+  controlConnectionsRef: RefObject<ControlConnections>;
 }) => {
   const { open, close } = useConnectionsContext();
   useImperativeHandle(props.controlConnectionsRef, () => ({ open, close }));

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -257,13 +257,14 @@ export const VnetContextProvider: FC<
     [status.value]
   );
 
-  const rootClusterUri = useStoreSelector(
+  const isWorkspaceSelected = useStoreSelector(
     'workspacesService',
-    useCallback(state => state.rootClusterUri, [])
+    useCallback(state => !!state.rootClusterUri, [])
   );
 
   const openReport = useCallback(
     (report: Report) => {
+      const rootClusterUri = workspacesService.getRootClusterUri();
       if (!rootClusterUri) {
         return;
       }
@@ -295,7 +296,7 @@ export const VnetContextProvider: FC<
       // upon on the next run of runDiagnosticsAndShowNotification.
       notificationsService.removeNotification(diagNotificationIdRef.current);
     },
-    [rootClusterUri, workspacesService, notificationsService]
+    [workspacesService, notificationsService]
   );
 
   const showDiagWarningIndicator: boolean = useMemo(
@@ -481,7 +482,7 @@ export const VnetContextProvider: FC<
         dismissDiagnosticsAlert,
         hasDismissedDiagnosticsAlert,
         reinstateDiagnosticsAlert,
-        openReport: rootClusterUri ? openReport : undefined,
+        openReport: isWorkspaceSelected ? openReport : undefined,
         showDiagWarningIndicator,
         hasEverStarted,
       }}

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -28,6 +28,7 @@ import {
   useState,
 } from 'react';
 
+import { Action } from 'design/Alert';
 import {
   BackgroundItemStatus,
   GetServiceInfoResponse,
@@ -396,10 +397,10 @@ export const VnetContextProvider: FC<
         return;
       }
 
-      diagNotificationIdRef.current = notificationsService.notifyWarning({
-        isAutoRemovable: false,
-        title: 'Other software on your device might interfere with VNet.',
-        action: {
+      let action: Action;
+      let description: string;
+      if (workspacesService.getRootClusterUri()) {
+        action = {
           content: 'Open Diag Report',
           onClick: () => {
             openReport(report);
@@ -409,7 +410,17 @@ export const VnetContextProvider: FC<
               diagNotificationIdRef.current
             );
           },
-        },
+        };
+      } else {
+        description =
+          'Log in to a cluster to open the diag report from the VNet panel.';
+      }
+
+      diagNotificationIdRef.current = notificationsService.notifyWarning({
+        isAutoRemovable: false,
+        title: 'Other software on your device might interfere with VNet.',
+        description,
+        action,
       });
     },
     [
@@ -419,6 +430,7 @@ export const VnetContextProvider: FC<
       hasDismissedDiagnosticsAlertRef,
       resetHasActedOnPreviousNotification,
       isConnectionsPanelOpenRef,
+      workspacesService,
     ]
   );
 


### PR DESCRIPTION
![VNet notification no button](https://github.com/user-attachments/assets/b3d1eec3-27f6-4262-a55d-ad5fbab1cd96)

While testing Nic's changes on Windows, I ran into a situation where I wasn't logged in to any workspace but Connect showed the diag notification which always includes a button to open the diag report in a new tab. However, at that point it's not possible to open a new tab since no workspace is selected. So the button just wouldn't do anything.

This is all possible in the first place since VNet does not depend on the user being logged in to any workspace. Once you start it once, on the next app launch it's going to start immediately after launch, even before you had a chance to re-login to your workspace. At that point there's no workspace selected which causes a notification to show up with a button that doesn't do anything.

I made it so that before showing the notification we check if there's a workspace selected. If there's not, instead of the button we show an extra description with instructions to the user.

---

Also, I made it so that the `openReport` function does not depend on `rootClusterUri`. `openReport` is used in the effect that sets up an interval for running a diag report every 30s. When the identity of `openReport` changes, the whole effect is re-run. This means that if the diag notification gets shown, you close it (or not) and then change workspaces, the whole interval is set up from scratch and the notification is shown again.