### PR TITLE
AWS IAM Roles Anywhere: implement client / `tsh` access

### DIFF
--- a/lib/auth/app_access_aws_credentials.go
+++ b/lib/auth/app_access_aws_credentials.go
@@ -1,0 +1,138 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsra"
+)
+
+var errNotIntegrationApp = errors.New("target resource is not an application with an associated integration")
+
+// generateAWSConfigCredentialProcessCredentials generates AWS Credentials for the given application.
+// If the target resource is not an application with an associated integration, it returns errNotIntegrationApp error,
+// which should be handled gracefully by the caller.
+//
+// The AWS Credentials returned are in the format expected by the AWS CLI/SDK config file `credential_process` (usually located at ~/.aws/config).
+// Expected format documentation: https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html
+func generateAWSConfigCredentialProcessCredentials(
+	ctx context.Context,
+	a *Server,
+	req certRequest,
+	notAfter time.Time,
+) (string, error) {
+	if req.appName == "" || req.awsRoleARN == "" {
+		return "", errNotIntegrationApp
+	}
+
+	appInfo, err := getAppServerByName(ctx, a, req.appName)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Only integrations can generate credentials.
+	integrationName := appInfo.GetIntegration()
+	if integrationName == "" {
+		return "", errNotIntegrationApp
+	}
+
+	integration, err := a.GetIntegration(ctx, integrationName)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	switch integration.GetSubKind() {
+	case types.IntegrationSubKindAWSRolesAnywhere:
+		// Only AWS Roles Anywhere integrations can generate credentials.
+		return generateAWSRolesAnywhereCredentials(ctx, a, req, appInfo, integration, notAfter)
+
+	default:
+		return "", trace.BadParameter("application %q is using integration %q for access, which does not support AWS credential generation", req.appName, integrationName)
+	}
+}
+
+func getAppServerByName(ctx context.Context, a *Server, appServerName string) (types.Application, error) {
+	appServers, err := a.GetApplicationServers(ctx, apidefaults.Namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, s := range appServers {
+		if s.GetName() == appServerName {
+			return s.GetApp(), nil
+		}
+	}
+	return nil, trace.NotFound("application %q not found", appServerName)
+}
+
+func generateAWSRolesAnywhereCredentials(
+	ctx context.Context,
+	a *Server,
+	req certRequest,
+	appInfo types.Application,
+	integration types.Integration,
+	notAfter time.Time,
+) (string, error) {
+	integrationSpec := integration.GetAWSRolesAnywhereIntegrationSpec()
+	if integrationSpec == nil || integrationSpec.TrustAnchorARN == "" {
+		return "", trace.BadParameter("roles anywhere integration %q does not have a valid spec", integration.GetName())
+	}
+
+	awsProfileARN := appInfo.GetAWSRolesAnywhereProfileARN()
+	acceptRoleSessionName := appInfo.GetAWSRolesAnywhereAcceptRoleSessionName()
+	if awsProfileARN == "" {
+		return "", trace.BadParameter("application %q does not have a valid AWS Roles Anywhere Profile ARN", req.appName)
+	}
+
+	durationSeconds := int(notAfter.Sub(a.clock.Now()).Seconds())
+
+	generateCredentialsRequest := awsra.GenerateCredentialsRequest{
+		Clock:                 a.clock,
+		TrustAnchorARN:        integrationSpec.TrustAnchorARN,
+		ProfileARN:            awsProfileARN,
+		RoleARN:               req.awsRoleARN,
+		SubjectCommonName:     req.user.GetName(),
+		KeyStoreManager:       a.keyStore,
+		AcceptRoleSessionName: acceptRoleSessionName,
+		DurationSeconds:       &durationSeconds,
+		Cache:                 a.Cache,
+	}
+
+	// Replace by the override function if it is set.
+	// This method does an HTTP call to AWS services, so this is useful for mocking that call.
+	// Only used in tests.
+	if a.AWSRolesAnywhereCreateSessionOverride != nil {
+		generateCredentialsRequest.CreateSession = a.AWSRolesAnywhereCreateSessionOverride
+	}
+
+	resp, err := awsra.GenerateCredentials(ctx, generateCredentialsRequest)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	encodedCredentials, err := resp.EncodeCredentialProcessFormat()
+	return encodedCredentials, trace.Wrap(err)
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -111,7 +111,6 @@ import (
 	"github.com/gravitational/teleport/lib/gcp"
 	"github.com/gravitational/teleport/lib/githubactions"
 	"github.com/gravitational/teleport/lib/gitlab"
-	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/inventory"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
@@ -3602,108 +3601,6 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	userCertificatesGeneratedMetric.WithLabelValues(string(attestedKeyPolicy)).Inc()
 
 	return certs, nil
-}
-
-var (
-	errNotIntegrationApp = fmt.Errorf("target resource is not an application with an associated integration")
-)
-
-func generateAWSConfigCredentialProcessCredentials(ctx context.Context,
-	a *Server,
-	req certRequest,
-	notAfter time.Time,
-) (string, error) {
-	if req.appName == "" || req.awsRoleARN == "" {
-		return "", errNotIntegrationApp
-	}
-
-	appInfo, err := getAppServerByName(ctx, a, req.appName)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	// Only integrations can generate credentials.
-	integrationName := appInfo.GetIntegration()
-	if integrationName == "" {
-		return "", errNotIntegrationApp
-	}
-
-	integration, err := a.GetIntegration(ctx, integrationName)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	switch integration.GetSubKind() {
-	case types.IntegrationSubKindAWSRolesAnywhere:
-		// Only AWS Roles Anywhere integrations can generate credentials.
-		return generateAWSRolesAnywhereCredentials(ctx, a, req, appInfo, integration, notAfter)
-
-	default:
-		return "", trace.BadParameter("application %q is using integration %q for access, which does not support credential generation", req.appName, integrationName)
-	}
-}
-
-func getAppServerByName(ctx context.Context, a *Server, appServerName string) (types.Application, error) {
-	appServers, err := a.GetApplicationServers(ctx, apidefaults.Namespace)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	for _, s := range appServers {
-		if s.GetName() == appServerName {
-			return s.GetApp(), nil
-		}
-	}
-	return nil, trace.NotFound("application %q not found", appServerName)
-}
-
-func generateAWSRolesAnywhereCredentials(
-	ctx context.Context,
-	a *Server,
-	req certRequest,
-	appInfo types.Application,
-	integration types.Integration,
-	notAfter time.Time,
-) (string, error) {
-	integrationSpec := integration.GetAWSRolesAnywhereIntegrationSpec()
-	if integrationSpec == nil || integrationSpec.TrustAnchorARN == "" {
-		return "", trace.BadParameter("roles anywhere integration %q does not have a valid spec", integration.GetName())
-	}
-
-	awsProfileARN := appInfo.GetAWSRolesAnywhereProfileARN()
-	acceptRoleSessionName := appInfo.GetAWSRolesAnywhereAcceptRoleSessionName()
-	if awsProfileARN == "" {
-		return "", trace.BadParameter("application %q does not have a valid AWS Roles Anywhere Profile ARN", req.appName)
-	}
-
-	durationSeconds := int(notAfter.Sub(a.clock.Now()).Seconds())
-
-	generateCredentialsRequest := awsra.GenerateCredentialsRequest{
-		Clock:                 a.clock,
-		TrustAnchorARN:        integrationSpec.TrustAnchorARN,
-		ProfileARN:            awsProfileARN,
-		RoleARN:               req.awsRoleARN,
-		SubjectCommonName:     req.user.GetName(),
-		KeyStoreManager:       a.keyStore,
-		AcceptRoleSessionName: acceptRoleSessionName,
-		DurationSeconds:       &durationSeconds,
-		Cache:                 a.Cache,
-	}
-
-	// Replace by the override function if it is set.
-	// This method does an HTTP call to AWS services, so this is useful for mocking that call.
-	// Only used in tests.
-	if a.AWSRolesAnywhereCreateSessionOverride != nil {
-		generateCredentialsRequest.CreateSession = a.AWSRolesAnywhereCreateSessionOverride
-	}
-
-	resp, err := awsra.GenerateCredentials(ctx, generateCredentialsRequest)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	encodedCredentials, err := resp.EncodeCredentialProcessFormat()
-	return encodedCredentials, trace.Wrap(err)
 }
 
 type attestHardwareKeyParams struct {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3677,14 +3677,6 @@ func generateAWSRolesAnywhereCredentials(
 	}
 
 	durationSeconds := int(notAfter.Sub(a.clock.Now()).Seconds())
-	createSession := createsession.CreateSession
-
-	// Replace by the override function if it is set.
-	// This method does an HTTP call to AWS services, so this is useful for mocking that call.
-	// Only used in tests.
-	if a.AWSRolesAnywhereCreateSessionOverride != nil {
-		createSession = a.AWSRolesAnywhereCreateSessionOverride
-	}
 
 	generateCredentialsRequest := awsra.GenerateCredentialsRequest{
 		Clock:                 a.clock,
@@ -3696,7 +3688,13 @@ func generateAWSRolesAnywhereCredentials(
 		AcceptRoleSessionName: acceptRoleSessionName,
 		DurationSeconds:       &durationSeconds,
 		Cache:                 a.Cache,
-		CreateSession:         createSession,
+	}
+
+	// Replace by the override function if it is set.
+	// This method does an HTTP call to AWS services, so this is useful for mocking that call.
+	// Only used in tests.
+	if a.AWSRolesAnywhereCreateSessionOverride != nil {
+		generateCredentialsRequest.CreateSession = a.AWSRolesAnywhereCreateSessionOverride
 	}
 
 	resp, err := awsra.GenerateCredentials(ctx, generateCredentialsRequest)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -863,7 +863,7 @@ func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, roleARN, identity.AWSRoleARNs[0], "Expected AWS Role ARN to match the one requested")
-	require.Equal(t, `{"Version":1,"AccessKeyId":"aki","SecretAccessKey":"sak","SessionToken":"st","Expiration":"2025-06-25T12:07:02.474135Z"}`, identity.RouteToApp.AWSCredentialProcessCredentials)
+	require.JSONEq(t, `{"Version":1,"AccessKeyId":"aki","SecretAccessKey":"sak","SessionToken":"st","Expiration":"2025-06-25T12:07:02.474135Z"}`, identity.RouteToApp.AWSCredentialProcessCredentials)
 }
 
 func TestSSODiagnosticInfo(t *testing.T) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/okta/oktatest"
 	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
@@ -760,6 +761,109 @@ func TestGithubAuthCompat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAWSRolesAnywhereCredentialGenerationForApps(t *testing.T) {
+	ctx := t.Context()
+	srv := newTestTLSServer(t)
+
+	// Set up a new Integration for AWS Roles Anywhere.
+	awsRAIntegration := "awsra-integration"
+	ig, err := types.NewIntegrationAWSRA(types.Metadata{Name: awsRAIntegration}, &types.AWSRAIntegrationSpecV1{
+		TrustAnchorARN: "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/ExampleTrustAnchor",
+		ProfileSyncConfig: &types.AWSRolesAnywhereProfileSyncConfig{
+			Enabled:                       true,
+			ProfileARN:                    "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2",
+			ProfileAcceptsRoleSessionName: true,
+			RoleARN:                       "arn:aws:iam::123456789012:role/SyncRole",
+		},
+	})
+	require.NoError(t, err)
+	_, err = srv.Auth().Integrations.CreateIntegration(ctx, ig)
+	require.NoError(t, err)
+
+	// Set up a new AWS App created from a Roles Anywhere Profile.
+	appName := "my-aws-access"
+	app, err := types.NewAppServerV3(
+		types.Metadata{Name: appName},
+		types.AppServerSpecV3{
+			HostID: uuid.NewString(),
+			App: &types.AppV3{
+				Metadata: types.Metadata{Name: appName},
+				Spec: types.AppSpecV3{
+					URI:         constants.AWSConsoleURL,
+					Integration: awsRAIntegration,
+					PublicAddr:  "my-app.example.com",
+					AWS: &types.AppAWS{
+						RolesAnywhereProfile: &types.AppAWSRolesAnywhereProfile{
+							ProfileARN:            "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
+							AcceptRoleSessionName: true,
+						},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	_, err = srv.Auth().UpsertApplicationServer(ctx, app)
+	require.NoError(t, err)
+
+	// Mock the credential generation function to return fixed credentials.
+	// This is required because the generator calls AWS endpoints to convert a teleport created certificate into valid AWS credentials.
+	srv.Auth().AWSRolesAnywhereCreateSessionOverride = func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
+		return &createsession.CreateSessionResponse{
+			Version:         1,
+			AccessKeyID:     "aki",
+			SecretAccessKey: "sak",
+			SessionToken:    "st",
+			Expiration:      "2025-06-25T12:07:02.474135Z",
+		}, nil
+	}
+
+	// Set up a user with the necessary roles to access the AWS App.
+	username := "aws-access-user"
+	roleARN := "arn:aws:iam::123456789012:role/MyRole"
+	awsAccessRole, err := CreateRole(ctx, srv.Auth(), "aws-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			AWSRoleARNs: []string{roleARN},
+		},
+	})
+	require.NoError(t, err)
+
+	user, err := CreateUser(ctx, srv.Auth(), username, awsAccessRole)
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(TestUser(user.GetName()))
+	require.NoError(t, err)
+
+	// Create credentials for the AWS App
+	priv, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	pub, err := keys.MarshalPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	certs, err := client.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		TLSPublicKey: pub,
+		Username:     user.GetName(),
+		Expires:      time.Now().Add(time.Hour),
+		RouteToApp: proto.RouteToApp{
+			Name:       app.GetApp().GetName(),
+			AWSRoleARN: roleARN,
+		},
+	})
+	require.NoError(t, err)
+
+	// Parse the Identity and check the AWS Role ARN and credentials.
+	tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
+	require.NoError(t, err)
+	identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+	require.NoError(t, err)
+
+	require.Equal(t, roleARN, identity.AWSRoleARNs[0], "Expected AWS Role ARN to match the one requested")
+	require.Equal(t, `{"Version":1,"AccessKeyId":"aki","SecretAccessKey":"sak","SessionToken":"st","Expiration":"2025-06-25T12:07:02.474135Z"}`, identity.RouteToApp.AWSCredentialProcessCredentials)
 }
 
 func TestSSODiagnosticInfo(t *testing.T) {

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -132,10 +132,6 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 		s.Clock = clockwork.NewRealClock()
 	}
 
-	if s.awsRolesAnywhereCreateSessionFn == nil {
-		s.awsRolesAnywhereCreateSessionFn = createsession.CreateSession
-	}
-
 	return nil
 }
 

--- a/lib/integrations/awsra/generate_credentials.go
+++ b/lib/integrations/awsra/generate_credentials.go
@@ -24,6 +24,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -143,6 +144,18 @@ type Credentials struct {
 	// Otherwise, the serial number is logged.
 	// This field is not part of the credential_process schema.
 	SerialNumber string `json:"-"`
+}
+
+// EncodeCredentialProcessFormat encodes the credentials in the format expected by the AWS CLI credential_process.
+// See https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html#feature-process-credentials-output
+func (c *Credentials) EncodeCredentialProcessFormat() (string, error) {
+	var bs []byte
+	bs, err := json.Marshal(c)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return string(bs), nil
 }
 
 // GenerateCredentials generates AWS IAM Roles Anywhere credentials for the Application (IAM Roles Anywhere Profile) and Role ARN.

--- a/lib/integrations/awsra/generate_credentials.go
+++ b/lib/integrations/awsra/generate_credentials.go
@@ -149,7 +149,6 @@ type Credentials struct {
 // EncodeCredentialProcessFormat encodes the credentials in the format expected by the AWS CLI credential_process.
 // See https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html#feature-process-credentials-output
 func (c *Credentials) EncodeCredentialProcessFormat() (string, error) {
-	var bs []byte
 	bs, err := json.Marshal(c)
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -154,5 +154,5 @@ func TestEncodeCredentialProcessFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := `{"Version":1,"AccessKeyId":"mock-access-key-id","SecretAccessKey":"mock-secret-access-key","SessionToken":"mock-session-token","Expiration":"2030-06-24T00:00:00Z"}`
-	require.Equal(t, expected, encoded)
+	require.JSONEq(t, expected, encoded)
 }

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -141,3 +141,18 @@ func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) ty
 
 	return ca
 }
+
+func TestEncodeCredentialProcessFormat(t *testing.T) {
+	credentials := Credentials{
+		Version:         1,
+		AccessKeyID:     "mock-access-key-id",
+		SecretAccessKey: "mock-secret-access-key",
+		SessionToken:    "mock-session-token",
+		Expiration:      time.Date(2030, 6, 24, 0, 0, 0, 0, time.UTC),
+	}
+	encoded, err := credentials.EncodeCredentialProcessFormat()
+	require.NoError(t, err)
+
+	expected := `{"Version":1,"AccessKeyId":"mock-access-key-id","SecretAccessKey":"mock-secret-access-key","SessionToken":"mock-session-token","Expiration":"2030-06-24T00:00:00Z"}`
+	require.Equal(t, expected, encoded)
+}

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -255,7 +255,7 @@ credential_process=tsh apps config --format aws-credential-process aws-profile
 		setCopyStdout(appsConfigcommandOutput),
 	)
 	require.NoError(t, err)
-	require.Equal(t, expectedAWSCredentials, appsConfigcommandOutput.String())
+	require.JSONEq(t, expectedAWSCredentials, appsConfigcommandOutput.String())
 
 	// Profile is removed after logout.
 	err = Run(


### PR DESCRIPTION
When a given user logs in into an AWS App, they will receive the credentials if the AWS App is using an AWS Roles Anywhere integration for giving access.

This allows them to access AWS directly.

See https://github.com/gravitational/teleport/issues/53192