### PR TITLE
Update notices related to Managed Updates rollout status

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -4,16 +4,19 @@ description: Describes how to set up Managed Updates for Teleport Agents (v1)
 ---
 
 <Admonition type="warning">
-This document describes Managed Updates for Agents (v1), which is
-currently supported but will be deprecated after [Managed Updates for
-Agents (v2)](./agent-managed-updates.mdx) is generally available.
+This document describes Managed Updates for Agents (v1), which
+is currently supported but may be removed in future versions of Teleport.
+
+For Managed Updates v2 instructions, see [Managed Updates for
+Agents (v2)](./agent-managed-updates.mdx).
 </Admonition>
 
 Managed Updates v1 uses a script called `teleport-upgrade` that is provided by
 the `teleport-ent-updater` package and configured by the `cluster_maintenance_config`
 Teleport resource. Managed Updates v2 uses a binary called `teleport-update` that is
 provided by the `teleport` package and configured by the `autoupdate_version` and
-`autoupdate_config`. The original updater and resource are described in this document.
+`autoupdate_config` resources. The original updater and resource are described in
+this document.
 
 Only Enterprise versions of Teleport can use Managed Updates v1.
 

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -4,7 +4,7 @@ description: Describes how to set up Managed Updates (v2) for Teleport Agents
 ---
 
 <Admonition type="warning">
-This document describes Managed Updates for Agents (v2), which is gradually being rolled out to Cloud.
+This document describes Managed Updates for Agents (v2), which replaces Managed Updates v1.
 
 For Managed Updates v1 instructions, see
 [Managed Updates for Agents (v1)](./agent-managed-updates-v1.mdx).


### PR DESCRIPTION
This PR updates warnings on both Managed Updates pages to reflect that Managed Updates v2 is fully supported and Managed Updates v1 may be removed in the future.

---

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856