### PR TITLE
Fix aws oidc tasks story

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -26,6 +26,7 @@ import {
   Link as ExternalLink,
   Flex,
   H2,
+  Indicator,
 } from 'design';
 import { Danger } from 'design/Alert';
 import Table, { Cell } from 'design/DataTable';
@@ -74,6 +75,14 @@ export function Task({
     return (
       <SidePanel onClose={() => close(false)}>
         <Danger>{taskAttempt.statusText}</Danger>
+      </SidePanel>
+    );
+  }
+
+  if (taskAttempt.status === 'processing') {
+    return (
+      <SidePanel onClose={() => close(false)}>
+        <Indicator />
       </SidePanel>
     );
   }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -88,9 +88,35 @@ TaskView.parameters = {
                 name: 'rds-detail',
                 taskType: 'discover-rds',
                 state: TaskState.Open,
-                issueType: 'rds-generic',
+                issueType: 'rds-auth-disabled',
                 integration: integrationName,
                 lastStateChange: '2022-02-12T20:32:19.482607921Z',
+                // lib/usertasks/descriptions/rds-iam-auth-disabled.md
+                description: `
+                # IAM Auth disabled
+The Teleport Database Service uses [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) to communicate with RDS.
+
+The following RDS databases do not have IAM authentication enabled.
+
+You can enable by modifying the IAM DB Authentication property of the database.
+                `,
+                title: 'rds-auth-disabled',
+                discoverRds: {
+                  databases: {
+                    'i-01568fcc52b7071cd': {
+                      name: 'i-01568fcc52b7071cd',
+                      is_cluster: true,
+                      engine: 'aurora',
+                      discovery_config: 'ee2f2480-09d3-4409-80f5-183549706446',
+                      discovery_group: 'cloud-discovery-group',
+                      sync_time: {
+                        seconds: -62135596800,
+                      },
+                      resourceUrl:
+                        'https://console.aws.amazon.com/ec2/home?region=us-east-2#InstanceDetails:instanceId=i-01568fcc52b7071cd',
+                    },
+                  },
+                },
               },
               {
                 name: 'ec2-detail',
@@ -99,29 +125,99 @@ TaskView.parameters = {
                 issueType: 'ec2-ssm-invocation-failure',
                 integration: integrationName,
                 lastStateChange: '2025-02-11T20:32:19.482607921Z',
-              },
-              {
-                name: 'ec2-detail',
-                taskType: 'discover-ec2',
-                state: TaskState.Open,
-                issueType: 'ec2-ssm-agent-not-registered',
-                integration: integrationName,
-                lastStateChange: '2025-02-11T20:32:13.61608091Z',
+                title: 'ec2-detail',
+                // lib/usertasks/descriptions/ec2-ssm-invocation-failure.md
+                description: `
+                # SSM Invocation failed
+Teleport failed to access the SSM Agent to auto enroll the instance.
+Some instances failed to communicate with the AWS Systems Manager service to execute the install script.
+
+Usually this happens when:
+
+**Missing policies**
+
+The IAM Role used by the integration might be missing some required permissions.
+Ensure the following actions are allowed in the IAM Role used by the integration:
+- \`ec2:DescribeInstances\`
+- \`ssm:DescribeInstanceInformation\`
+- \`ssm:GetCommandInvocation\`
+- \`ssm:ListCommandInvocations\`
+- \`ssm:SendCommand\`
+
+**SSM Document is invalid**
+
+Teleport uses an SSM Document to run an installation script.
+If the document is changed or removed, it might no longer work.
+`,
+                discoverEc2: {
+                  instances: {
+                    'i-01568fcc52b7071cd': {
+                      instance_id: 'i-01568fcc52b7071cd',
+                      discovery_config: 'ee2f2480-09d3-4409-80f5-183549706446',
+                      discovery_group: 'cloud-discovery-group',
+                      sync_time: {
+                        seconds: -62135596800,
+                      },
+                      resourceUrl:
+                        'https://console.aws.amazon.com/ec2/home?region=us-east-2#InstanceDetails:instanceId=i-01568fcc52b7071cd',
+                    },
+                    'i-019e54b3f58bfa9fd': {
+                      instance_id: 'i-019e54b3f58bfa9fd',
+                      name: 'travis-test-tcp4',
+                      discovery_config: 'ee2f2480-09d3-4409-80f5-183549706446',
+                      discovery_group: 'cloud-discovery-group',
+                      sync_time: {
+                        seconds: -62135596800,
+                      },
+                      resourceUrl:
+                        'https://console.aws.amazon.com/ec2/home?region=us-east-2#InstanceDetails:instanceId=i-019e54b3f58bfa9fd',
+                    },
+                  },
+                },
               },
               {
                 name: 'no match',
                 state: TaskState.Open,
                 issueType: 'side panel error',
                 integration: integrationName,
+                title: 'no match',
                 lastStateChange: '0',
+                instances: [],
               },
               {
                 name: 'eks-detail',
                 taskType: 'discover-eks',
                 state: TaskState.Open,
-                issueType: 'eks-failure',
+                issueType: 'esk-agent-not-connecting',
                 integration: integrationName,
                 lastStateChange: '2025-02-11T20:32:13.61608091Z',
+                title: 'esk-agent-not-connecting',
+                // lib/usertasks/descriptions/eks-agent-not-connecting.md
+                description: `
+                # Teleport Agent not connecting
+The process of automatically enrolling EKS Clusters into Teleport, starts by installing the [\`teleport-kube-agent\`](https://goteleport.com/docs/reference/helm-reference/teleport-kube-agent/) to the cluster.
+
+If the installation is successful, the EKS Cluster will appear in your Resources list.
+
+However, the following EKS Clusters did not automatically enrolled.
+This usually happens when the installation is taking too long or there was an error preventing the HELM chart installation.
+
+Open the Teleport Agent to get more information.
+`,
+                discoverEks: {
+                  clusters: {
+                    'i-01568fcc52b7071cd': {
+                      name: 'i-01568fcc52b7071cd',
+                      discovery_config: 'ee2f2480-09d3-4409-80f5-183549706446',
+                      discovery_group: 'cloud-discovery-group',
+                      sync_time: {
+                        seconds: -62135596800,
+                      },
+                      resourceUrl:
+                        'https://console.aws.amazon.com/ec2/home?region=us-east-2#InstanceDetails:instanceId=i-01568fcc52b7071cd',
+                    },
+                  },
+                },
               },
             ],
             nextKey: '1',

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -188,10 +188,10 @@ If the document is changed or removed, it might no longer work.
                 name: 'eks-detail',
                 taskType: 'discover-eks',
                 state: TaskState.Open,
-                issueType: 'esk-agent-not-connecting',
+                issueType: 'eks-agent-not-connecting',
                 integration: integrationName,
                 lastStateChange: '2025-02-11T20:32:13.61608091Z',
-                title: 'esk-agent-not-connecting',
+                title: 'eks-agent-not-connecting',
                 // lib/usertasks/descriptions/eks-agent-not-connecting.md
                 description: `
                 # Teleport Agent not connecting

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from 'react';
-import { useHistory } from 'react-router';
+import { useEffect, useMemo, useState } from 'react';
+import { useHistory, useLocation } from 'react-router';
 import styled, { useTheme } from 'styled-components';
 
 import { Flex, Indicator } from 'design';
@@ -38,7 +38,8 @@ import { integrationService, UserTask } from 'teleport/services/integrations';
 export function Tasks() {
   const theme = useTheme();
   const history = useHistory();
-  const searchParams = new URLSearchParams(history.location.search);
+  const { search } = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
   const [notification, setNotification] = useState<NotificationItem>();
 
   const { integrationAttempt } = useAwsOidcStatus();

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -16,8 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { createMemoryHistory } from 'history';
 import React from 'react';
-import { MemoryRouter } from 'react-router';
+import { Router } from 'react-router';
 
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
@@ -41,16 +42,25 @@ export const MockAwsOidcStatusProvider = ({
   initialEntries?: string[];
 }) => {
   const ctx = createTeleportContext();
+  const history = createMemoryHistory({
+    initialEntries: initialEntries,
+    initialIndex: 0,
+  });
 
   return (
-    <MemoryRouter initialEntries={initialEntries}>
+    <Router history={history}>
       <ContextProvider ctx={ctx}>
         <InfoGuidePanelProvider>
           <awsOidcStatusContext.Provider value={value}>
-            <Route path={path} render={() => <>{children}</>} />
+            <Route
+              path={path}
+              render={() => (
+                <span key={history.location.search}>{children}</span>
+              )}
+            />
           </awsOidcStatusContext.Provider>
         </InfoGuidePanelProvider>
       </ContextProvider>
-    </MemoryRouter>
+    </Router>
   );
 };

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -16,9 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createMemoryHistory } from 'history';
 import React from 'react';
-import { Router } from 'react-router';
+import { MemoryRouter } from 'react-router';
 
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
@@ -42,25 +41,16 @@ export const MockAwsOidcStatusProvider = ({
   initialEntries?: string[];
 }) => {
   const ctx = createTeleportContext();
-  const history = createMemoryHistory({
-    initialEntries: initialEntries,
-    initialIndex: 0,
-  });
 
   return (
-    <Router history={history}>
+    <MemoryRouter initialEntries={initialEntries}>
       <ContextProvider ctx={ctx}>
         <InfoGuidePanelProvider>
           <awsOidcStatusContext.Provider value={value}>
-            <Route
-              path={path}
-              render={() => (
-                <span key={history.location.search}>{children}</span>
-              )}
-            />
+            <Route path={path} render={() => <>{children}</>} />
           </awsOidcStatusContext.Provider>
         </InfoGuidePanelProvider>
       </ContextProvider>
-    </Router>
+    </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -514,13 +514,13 @@ export const integrationService = {
           installer_script: resp.discoverEc2?.installer_script,
         },
         discoverEks: {
-          clusters: resp.discoverEks?.instances,
+          clusters: resp.discoverEks?.clusters,
           account_id: resp.discoverEks?.account_id,
           region: resp.discoverEks?.region,
           app_auto_discover: resp.discoverEks?.app_auto_discover,
         },
         discoverRds: {
-          databases: resp.discoverRds?.instances,
+          databases: resp.discoverRds?.databases,
           account_id: resp.discoverRds?.account_id,
           region: resp.discoverRds?.region,
         },


### PR DESCRIPTION
@ryanclark opened #56035 and testing uncovered that the aws oidc user tasks story wasn't functional anymore.

The update to query params wasn't reloading the view due to using `useHistory`; swapping out for `useLocation` fixes the issue

A side effect of this is also realizing the impacted instances being read in the API response were mapped incorrectly. Each type has it's own key, they do not all live at `.instances`