### PR TITLE
Fix error handling in firestore record creation

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -206,7 +206,7 @@ func newRecord(from backend.Item, clock clockwork.Clock) record {
 func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 	k, err := doc.DataAt(keyDocProperty)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, ConvertGRPCError(err)
 	}
 
 	var r record
@@ -215,7 +215,7 @@ func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 		// If the key is a slice of any, then the key was mistakenly persisted
 		// as a backend.Key directly.
 		var br brokenRecord
-		if doc.DataTo(&br) != nil {
+		if err := doc.DataTo(&br); err != nil {
 			return nil, ConvertGRPCError(err)
 		}
 
@@ -232,8 +232,8 @@ func newRecordFromDoc(doc *firestore.DocumentSnapshot) (*record, error) {
 			// Value was a string. This document could've been written by an older
 			// version of our code.
 			var rl legacyRecord
-			if doc.DataTo(&rl) != nil {
-				return nil, ConvertGRPCError(err)
+			if legacyErr := doc.DataTo(&rl); legacyErr != nil {
+				return nil, trace.NewAggregate(ConvertGRPCError(err), ConvertGRPCError(legacyErr))
 			}
 			r = record{
 				Key:       []byte(rl.Key),


### PR DESCRIPTION
The error checks were performed against error returned from functions without assigning them to a local variable which resulted in a return of nil, nil instead of returning the appropriate error. In practice this isn't very likely to be hit since most keys should be neither the legacy or broken format.