### PR TITLE
AWS Roles Anywhere: add ping and list profiles implementation

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5577,6 +5577,16 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	integrationv1pb.RegisterAWSOIDCServiceServer(server, integrationAWSOIDCServiceServer)
 
+	integrationAWSRolesAnywhereServiceServer, err := integrationv1.NewAWSRolesAnywhereService(&integrationv1.AWSRolesAnywhereServiceConfig{
+		Authorizer:         cfg.Authorizer,
+		IntegrationService: integrationServiceServer,
+		Clock:              cfg.AuthServer.clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	integrationv1pb.RegisterAWSRolesAnywhereServiceServer(server, integrationAWSRolesAnywhereServiceServer)
+
 	userTask, err := usertasksv1.NewService(usertasksv1.ServiceConfig{
 		Authorizer: cfg.Authorizer,
 		Backend:    cfg.AuthServer.Services,

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -20,10 +20,14 @@ package integrationv1
 
 import (
 	"context"
+	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -39,7 +43,7 @@ func (s *Service) GenerateAWSRACredentials(ctx context.Context, req *integration
 
 	for _, allowedRole := range []types.SystemRole{types.RoleAuth, types.RoleProxy} {
 		if authz.HasBuiltinRole(*authCtx, string(allowedRole)) {
-			return s.generateAWSRACredentialsWithoutAuthZ(ctx, req)
+			return s.generateAWSRACredentialsWithoutAuthZ(ctx, req, "" /* trustAnchor */)
 		}
 	}
 
@@ -48,14 +52,14 @@ func (s *Service) GenerateAWSRACredentials(ctx context.Context, req *integration
 
 // generateAWSRACredentialsWithoutAuthZ generates a set of AWS credentials which uses the AWS Roles Anywhere integration.
 // Bypasses authz and should only be used by other methods that validate AuthZ.
-func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req *integrationpb.GenerateAWSRACredentialsRequest) (*integrationpb.GenerateAWSRACredentialsResponse, error) {
-	integration, err := s.cache.GetIntegration(ctx, req.GetIntegration())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	spec := integration.GetAWSRolesAnywhereIntegrationSpec()
-	if spec == nil {
-		return nil, trace.BadParameter("integration %q is not an AWSRA integration", req.Integration)
+func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req *integrationpb.GenerateAWSRACredentialsRequest, trustAnchor string) (*integrationpb.GenerateAWSRACredentialsResponse, error) {
+	if trustAnchor == "" {
+		spec, err := s.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		trustAnchor = spec.TrustAnchorARN
 	}
 
 	var durationSeconds *int
@@ -66,7 +70,7 @@ func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req 
 
 	awsCredentials, err := awsra.GenerateCredentials(ctx, awsra.GenerateCredentialsRequest{
 		Clock:                 s.clock,
-		TrustAnchorARN:        spec.TrustAnchorARN,
+		TrustAnchorARN:        trustAnchor,
 		ProfileARN:            req.GetProfileArn(),
 		RoleARN:               req.GetRoleArn(),
 		SubjectCommonName:     req.GetSubjectName(),
@@ -85,5 +89,214 @@ func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req 
 		SecretAccessKey: awsCredentials.SecretAccessKey,
 		SessionToken:    awsCredentials.SessionToken,
 		Expiration:      timestamppb.New(awsCredentials.Expiration),
+	}, nil
+}
+
+func (s *Service) getAWSRolesAnywhereIntegrationSpec(ctx context.Context, integrationName string) (*types.AWSRAIntegrationSpecV1, error) {
+	integration, err := s.cache.GetIntegration(ctx, integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	spec := integration.GetAWSRolesAnywhereIntegrationSpec()
+	if spec == nil {
+		return nil, trace.BadParameter("integration %q is not an AWSRA integration", integrationName)
+	}
+
+	return spec, nil
+}
+
+// AWSRolesAnywhereServiceConfig holds configuration options for the AWSRolesAnywhere Integration gRPC service.
+type AWSRolesAnywhereServiceConfig struct {
+	// IntegrationService is the service that provides access to integration credentials.
+	IntegrationService *Service
+	// Authorizer is the authorizer used to check access to the integration.
+	Authorizer authz.Authorizer
+
+	Clock  clockwork.Clock
+	Logger *slog.Logger
+}
+
+// CheckAndSetDefaults checks the AWSRolesAnywhereServiceConfig fields and returns an error if a required param is not provided.
+// Authorizer and IntegrationService are required params.
+func (s *AWSRolesAnywhereServiceConfig) CheckAndSetDefaults() error {
+	if s.Authorizer == nil {
+		return trace.BadParameter("authorizer is required")
+	}
+
+	if s.IntegrationService == nil {
+		return trace.BadParameter("integration service is required")
+	}
+
+	if s.Clock == nil {
+		s.Clock = clockwork.NewRealClock()
+	}
+
+	if s.Logger == nil {
+		s.Logger = slog.With(teleport.ComponentKey, "integrations.awsra.service")
+	}
+
+	return nil
+}
+
+// AWSRolesAnywhereService implements the teleport.integration.v1.AWSRolesAnywhereService RPC service.
+type AWSRolesAnywhereService struct {
+	integrationpb.UnimplementedAWSRolesAnywhereServiceServer
+
+	integrationService *Service
+	authorizer         authz.Authorizer
+	logger             *slog.Logger
+	clock              clockwork.Clock
+}
+
+// NewAWSRolesAnywhereService returns a new AWSRolesAnywhereService.
+func NewAWSRolesAnywhereService(cfg *AWSRolesAnywhereServiceConfig) (*AWSRolesAnywhereService, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &AWSRolesAnywhereService{
+		integrationService: cfg.IntegrationService,
+		logger:             cfg.Logger,
+		authorizer:         cfg.Authorizer,
+		clock:              cfg.Clock,
+	}, nil
+}
+
+var _ integrationpb.AWSRolesAnywhereServiceServer = (*AWSRolesAnywhereService)(nil)
+
+// ListRolesAnywhereProfiles returns a paginated list of Roles Anywhere Profiles.
+func (s *AWSRolesAnywhereService) ListRolesAnywhereProfiles(ctx context.Context, req *integrationpb.ListRolesAnywhereProfilesRequest) (*integrationpb.ListRolesAnywhereProfilesResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// ListRolesAnywhereProfiles uses the ProfileSync config's Profile and Role.
+	spec, err := s.integrationService.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	trustAnchor := spec.TrustAnchorARN
+
+	credentials, err := s.integrationService.generateAWSRACredentialsWithoutAuthZ(ctx, &integrationpb.GenerateAWSRACredentialsRequest{
+		ProfileArn:                    spec.ProfileSyncConfig.ProfileARN,
+		RoleArn:                       spec.ProfileSyncConfig.RoleARN,
+		ProfileAcceptsRoleSessionName: spec.ProfileSyncConfig.ProfileAcceptsRoleSessionName,
+		SubjectName:                   authCtx.Identity.GetIdentity().Username,
+	}, trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	trustAnchorARNParsed, err := arn.Parse(trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	trustAnchorRegion := trustAnchorARNParsed.Region
+
+	listRolesAnywhereClient, err := awsra.NewListRolesAnywhereProfilesClient(ctx, &awsra.AWSClientConfig{
+		Credentials: awsra.Credentials{
+			AccessKeyID:     credentials.AccessKeyId,
+			SecretAccessKey: credentials.SecretAccessKey,
+			SessionToken:    credentials.SessionToken,
+			Expiration:      credentials.Expiration.AsTime(),
+			Version:         1,
+		},
+		Region: trustAnchorRegion,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	profileList, err := awsra.ListRolesAnywhereProfiles(ctx, listRolesAnywhereClient, awsra.ListRolesAnywhereProfilesRequest{
+		NextToken: req.GetNextPageToken(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &integrationpb.ListRolesAnywhereProfilesResponse{
+		Profiles:      profileList.Profiles,
+		NextPageToken: profileList.NextToken,
+	}, nil
+}
+
+// AWSRolesAnywherePing performs a health check for the AWS Roles Anywhere integration.
+// If the integration is absent from the request, then it will use the trust anchor, profile and role from the request.
+// This is useful for testing an integration that was not yet created.
+//
+// If the integration is present in the request, it will use the trust anchor and the profile, role from the integration's ProfileSync config.
+//
+// It returns the caller identity and the number of AWS Roles Anywhere Profiles that are active.
+func (s *AWSRolesAnywhereService) AWSRolesAnywherePing(ctx context.Context, req *integrationpb.AWSRolesAnywherePingRequest) (*integrationpb.AWSRolesAnywherePingResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	trustAnchor := req.GetTrustAnchorArn()
+	profileARN := req.GetProfileArn()
+	roleARN := req.GetRoleArn()
+
+	// If integration was provided, it uses the Trust Anchor configured and the Profile/Role configured for ProfileSync.
+	if req.Integration != "" {
+		spec, err := s.integrationService.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		trustAnchor = spec.TrustAnchorARN
+		profileARN = spec.ProfileSyncConfig.ProfileARN
+		roleARN = spec.ProfileSyncConfig.RoleARN
+	}
+
+	credentialsRequest := &integrationpb.GenerateAWSRACredentialsRequest{
+		ProfileArn:  profileARN,
+		RoleArn:     roleARN,
+		SubjectName: authCtx.Identity.GetIdentity().Username,
+	}
+
+	trustAnchorARNParsed, err := arn.Parse(trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	trustAnchorRegion := trustAnchorARNParsed.Region
+
+	credentials, err := s.integrationService.generateAWSRACredentialsWithoutAuthZ(ctx, credentialsRequest, trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pingClient, err := awsra.NewPingClient(ctx, &awsra.AWSClientConfig{
+		Credentials: awsra.Credentials{
+			AccessKeyID:     credentials.AccessKeyId,
+			SecretAccessKey: credentials.SecretAccessKey,
+			SessionToken:    credentials.SessionToken,
+			Expiration:      credentials.Expiration.AsTime(),
+			Version:         1,
+		},
+		Region: trustAnchorRegion,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pingResp, err := awsra.Ping(ctx, pingClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &integrationpb.AWSRolesAnywherePingResponse{
+		ProfileCount: int32(pingResp.EnabledProfileCounter),
+		AccountId:    pingResp.AccountID,
+		Arn:          pingResp.ARN,
+		UserId:       pingResp.UserID,
 	}, nil
 }

--- a/lib/integrations/awsra/client.go
+++ b/lib/integrations/awsra/client.go
@@ -1,0 +1,81 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/gravitational/trace"
+
+	awsutils "github.com/gravitational/teleport/api/utils/aws"
+)
+
+// AWSClientConfig contains the required fields to set up an AWS SDK Clients.
+type AWSClientConfig struct {
+	// Credentials contains the AWS credentials to use.
+	Credentials Credentials
+
+	// Region where the API call should be made.
+	Region string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *AWSClientConfig) checkAndSetDefaults() error {
+	if req.Credentials.AccessKeyID == "" ||
+		req.Credentials.SecretAccessKey == "" ||
+		req.Credentials.SessionToken == "" {
+
+		return trace.BadParameter("credentials are missing")
+	}
+
+	if req.Region != "" {
+		if err := awsutils.IsValidRegion(req.Region); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// newAWSConfig creates a new [aws.Config] using the [AWSClientRequest] fields.
+func newAWSConfig(ctx context.Context, req *AWSClientConfig) (aws.Config, error) {
+	if err := req.checkAndSetDefaults(); err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(req.Region),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				req.Credentials.AccessKeyID,
+				req.Credentials.SecretAccessKey,
+				req.Credentials.SessionToken,
+			),
+		),
+	)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	return awsConfig, nil
+}

--- a/lib/integrations/awsra/list_rolesanywhere_profiles.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles.go
@@ -1,0 +1,132 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	"github.com/gravitational/trace"
+
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+)
+
+// ListRolesAnywhereProfilesRequest contains the required fields to list the Roles Anywhere Profiles in Amazon IAM.
+type ListRolesAnywhereProfilesRequest struct {
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string
+}
+
+// ListRolesAnywhereProfilesResponse contains a page of Roles Anywhere Profiles.
+type ListRolesAnywhereProfilesResponse struct {
+	// Profiles contains the page of Roles Anywhere Profiles.
+	Profiles []*integrationv1.RolesAnywhereProfile `json:"profiles"`
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string `json:"nextToken"`
+}
+
+// RolesAnywhereProfilesLister is an interface that defines methods to interact with the AWS IAM Roles Anywhere service.
+type RolesAnywhereProfilesLister interface {
+	// Lists all profiles in the authenticated account and Amazon Web Services Region.
+	ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error)
+
+	// Lists the tags attached to the resource.
+	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
+}
+
+// ListRolesAnywhereProfilesClient describes the required methods to list AWS VPCs.
+type ListRolesAnywhereProfilesClient interface {
+	RolesAnywhereProfilesLister
+}
+
+type defaultListRolesAnywhereProfilesClient struct {
+	RolesAnywhereProfilesLister
+}
+
+// NewListRolesAnywhereProfilesClient creates a new ListRolesAnywhereProfilesClient using an AWSClientRequest.
+func NewListRolesAnywhereProfilesClient(ctx context.Context, req *AWSClientConfig) (ListRolesAnywhereProfilesClient, error) {
+	awsConfig, err := newAWSConfig(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListRolesAnywhereProfilesClient{
+		RolesAnywhereProfilesLister: rolesanywhere.NewFromConfig(awsConfig),
+	}, nil
+}
+
+// ListRolesAnywhereProfiles calls the following AWS API:
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+// It returns a list of Roles Anywhere Profiles and an optional NextToken that can be used to fetch the next page.
+func ListRolesAnywhereProfiles(ctx context.Context, clt ListRolesAnywhereProfilesClient, req ListRolesAnywhereProfilesRequest) (*ListRolesAnywhereProfilesResponse, error) {
+	var nextToken *string
+	if req.NextToken != "" {
+		nextToken = aws.String(req.NextToken)
+	}
+	profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, nextToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ListRolesAnywhereProfilesResponse{
+		Profiles:  profiles,
+		NextToken: aws.ToString(nextPageToken),
+	}, nil
+}
+
+func listRolesAnywhereProfilesPage(ctx context.Context, raClient RolesAnywhereProfilesLister, nextPage *string) ([]*integrationv1.RolesAnywhereProfile, *string, error) {
+	var ret []*integrationv1.RolesAnywhereProfile
+
+	profilesListResp, err := raClient.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
+		NextToken: nextPage,
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	for _, profile := range profilesListResp.Profiles {
+		profileTags, err := raClient.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
+			ResourceArn: profile.ProfileArn,
+		})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		labels := make(map[string]string, len(profileTags.Tags))
+		for _, tag := range profileTags.Tags {
+			labels[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+		}
+
+		ret = append(ret, &integrationv1.RolesAnywhereProfile{
+			Arn:                   aws.ToString(profile.ProfileArn),
+			Name:                  aws.ToString(profile.Name),
+			Enabled:               aws.ToBool(profile.Enabled),
+			AcceptRoleSessionName: aws.ToBool(profile.AcceptRoleSessionName),
+			Roles:                 profile.RoleArns,
+			Tags:                  labels,
+		})
+	}
+
+	return ret, profilesListResp.NextToken, nil
+}

--- a/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRolesAnywhereProfiles(t *testing.T) {
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	syncProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	disabledProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3"),
+		Enabled:               aws.Bool(false),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	t.Run("listing returns 3 profiles", func(t *testing.T) {
+		client := &mockListRolesAnywhereProfiles{
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+				syncProfile,
+				disabledProfile,
+			},
+		}
+		resp, err := ListRolesAnywhereProfiles(t.Context(), client, ListRolesAnywhereProfilesRequest{})
+		require.NoError(t, err)
+
+		require.Len(t, resp.Profiles, 3)
+	})
+}
+
+type mockListRolesAnywhereProfiles struct {
+	profiles []ratypes.ProfileDetail
+}
+
+func (m *mockListRolesAnywhereProfiles) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles:  m.profiles,
+		NextToken: nil,
+	}, nil
+}
+
+func (m *mockListRolesAnywhereProfiles) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: []ratypes.Tag{
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}, nil
+}

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -1,0 +1,107 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+)
+
+// PingResponse contains the identity information and how many Roles Anywhere Profiles are active and have at least one Role.
+type PingResponse struct {
+	// AccountID is the AWS account ID of the caller.
+	AccountID string
+	// ARN is the ARN of the caller.
+	ARN string
+	// UserID is the user ID of the caller.
+	UserID string
+	// EnabledProfileCounter is the number of Roles Anywhere Profiles that are enabled and have at least one Role.
+	EnabledProfileCounter int
+}
+
+// PingClient describes the required methods to list AWS VPCs.
+type PingClient interface {
+	RolesAnywhereProfilesLister
+	CallerIdentityGetter
+}
+
+type defaultPingClient struct {
+	RolesAnywhereProfilesLister
+	stsClient CallerIdentityGetter
+}
+
+// GetCallerIdentity returns information about the caller identity.
+func (c *defaultPingClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return c.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+// NewPingClient creates a new PingClient using an AWSClientCredentials.
+func NewPingClient(ctx context.Context, req *AWSClientConfig) (PingClient, error) {
+	awsConfig, err := newAWSConfig(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultPingClient{
+		RolesAnywhereProfilesLister: rolesanywhere.NewFromConfig(awsConfig),
+		stsClient:                   stsutils.NewFromConfig(awsConfig),
+	}, nil
+}
+
+// Ping calls the following AWS API:
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+// It returns a list of Roles Anywhere Profiles that are enabled.
+func Ping(ctx context.Context, clt PingClient) (*PingResponse, error) {
+	profileCounter := 0
+	var nextToken *string
+	for {
+		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, nextToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, profile := range profiles {
+			if profile.Enabled && len(profile.Roles) > 0 {
+				profileCounter++
+			}
+		}
+		if aws.ToString(nextPageToken) == "" {
+			break
+		}
+		nextToken = nextPageToken
+	}
+
+	callerIdentity, err := clt.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &PingResponse{
+		EnabledProfileCounter: profileCounter,
+		AccountID:             aws.ToString(callerIdentity.Account),
+		ARN:                   aws.ToString(callerIdentity.Arn),
+		UserID:                aws.ToString(callerIdentity.UserId),
+	}, nil
+}

--- a/lib/integrations/awsra/ping_test.go
+++ b/lib/integrations/awsra/ping_test.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPing(t *testing.T) {
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+		RoleArns: []string{
+			"arn:aws:iam::123456789012:role/ExampleRole",
+			"arn:aws:iam::123456789012:role/SyncRole",
+		},
+	}
+
+	syncProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+		RoleArns: []string{
+			"arn:aws:iam::123456789012:role/ExampleRole",
+			"arn:aws:iam::123456789012:role/SyncRole",
+		},
+	}
+
+	disabledProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3"),
+		Enabled:               aws.Bool(false),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	profileWithoutRoles := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid4"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	t.Run("ping returns the caller identity and 2 enabled profiles", func(t *testing.T) {
+		resp, err := Ping(t.Context(), &mockPingClient{
+			accountID: "123456789012",
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+				syncProfile,
+				disabledProfile,
+				profileWithoutRoles,
+			},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "123456789012", resp.AccountID)
+		require.Equal(t, 2, resp.EnabledProfileCounter)
+	})
+
+}
+
+type mockPingClient struct {
+	accountID string
+	profiles  []ratypes.ProfileDetail
+}
+
+func (m *mockPingClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles:  m.profiles,
+		NextToken: nil,
+	}, nil
+}
+
+func (m *mockPingClient) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: []ratypes.Tag{
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}, nil
+}
+
+func (m *mockPingClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String(m.accountID),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test-user"),
+		UserId:  aws.String("USERID1234567890"),
+	}, nil
+}

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -30,12 +30,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
-	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/constants"
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/utils"
@@ -279,14 +279,12 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 
 	var nextPage *string
 	for {
-		profilesListResp, err := raClient.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
-			NextToken: nextPage,
-		})
+		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, nextPage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		for _, profile := range profilesListResp.Profiles {
+		for _, profile := range profilesListResp {
 			err := processProfile(ctx, processProfileRequest{
 				Params:          params,
 				Profile:         profile,
@@ -296,18 +294,18 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 			})
 			if err != nil {
 				if errors.Is(err, errDisabledProfile) || errors.Is(err, errProfileIsUsedForSync) {
-					logger.DebugContext(ctx, "Skipping profile", "profile_name", aws.ToString(profile.Name), "error", err.Error())
+					logger.DebugContext(ctx, "Skipping profile", "profile_name", profile.Name, "error", err.Error())
 					continue
 				}
 
-				logger.WarnContext(ctx, "Failed to process profile", "profile_name", aws.ToString(profile.Name), "error", err)
+				logger.WarnContext(ctx, "Failed to process profile", "profile_name", profile.Name, "error", err)
 			}
 		}
 
-		if aws.ToString(profilesListResp.NextToken) == "" {
+		if aws.ToString(respNextToken) == "" {
 			break
 		}
-		nextPage = profilesListResp.NextToken
+		nextPage = respNextToken
 	}
 
 	return nil
@@ -320,7 +318,7 @@ var (
 
 type processProfileRequest struct {
 	Params          AWSRolesAnywherProfileSyncerParams
-	Profile         ratypes.ProfileDetail
+	Profile         *integrationv1.RolesAnywhereProfile
 	RAClient        RolesAnywhereClient
 	Integration     types.Integration
 	ProxyPublicAddr string
@@ -329,22 +327,15 @@ type processProfileRequest struct {
 func processProfile(ctx context.Context, req processProfileRequest) error {
 	profileSyncProfileARN := req.Integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
 
-	if aws.ToString(req.Profile.ProfileArn) == profileSyncProfileARN {
+	if req.Profile.Arn == profileSyncProfileARN {
 		return errProfileIsUsedForSync
 	}
 
-	if !aws.ToBool(req.Profile.Enabled) {
+	if !req.Profile.Enabled {
 		return errDisabledProfile
 	}
 
-	profileTags, err := req.RAClient.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
-		ResourceArn: req.Profile.ProfileArn,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), profileTags.Tags, req.ProxyPublicAddr)
+	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), req.ProxyPublicAddr)
 	if err != nil {
 		return trace.BadParameter("failed to convert Profile to AppServer: %v", err)
 	}
@@ -356,22 +347,20 @@ func processProfile(ctx context.Context, req processProfileRequest) error {
 	return nil
 }
 
-func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.ProfileDetail, integrationName string, profileTags []ratypes.Tag, proxyPublicAddr string) (types.AppServer, error) {
-	profileName := aws.ToString(profile.Name)
-	profileARN := aws.ToString(profile.ProfileArn)
-	parsedProfileARN, err := arn.Parse(profileARN)
+func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile *integrationv1.RolesAnywhereProfile, integrationName string, proxyPublicAddr string) (types.AppServer, error) {
+	parsedProfileARN, err := arn.Parse(profile.Arn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	applicationName := profileName + "-" + integrationName
+	applicationName := profile.Name + "-" + integrationName
 
-	labels := make(map[string]string, len(profileTags))
-	for _, tag := range profileTags {
-		labels["aws/"+aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	labels := make(map[string]string, len(profile.Tags))
+	for tagKey, tagValue := range profile.Tags {
+		labels["aws/"+tagKey] = tagValue
 
-		if aws.ToString(tag.Key) == types.AWSRolesAnywhereProfileNameOverrideLabel {
-			applicationName = aws.ToString(tag.Value)
+		if tagKey == types.AWSRolesAnywhereProfileNameOverrideLabel {
+			applicationName = tagValue
 		}
 	}
 
@@ -380,7 +369,7 @@ func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.P
 	labels[types.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[constants.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[types.IntegrationLabel] = integrationName
-	labels[types.AWSRolesAnywhereProfileARNLabel] = profileARN
+	labels[types.AWSRolesAnywhereProfileARNLabel] = profile.Arn
 
 	// TODO(marco): add origin label in v19: teleport.dev/origin: integration_awsrolesanywhere
 	// types.Metadata.CheckAndSetDefaults in v17 returns an error if the origin label is set to AWS Roles Anywhere.
@@ -405,8 +394,8 @@ func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.P
 				PublicAddr:  appURL,
 				AWS: &types.AppAWS{
 					RolesAnywhereProfile: &types.AppAWSRolesAnywhereProfile{
-						ProfileARN:            aws.ToString(profile.ProfileArn),
-						AcceptRoleSessionName: aws.ToBool(profile.AcceptRoleSessionName),
+						ProfileARN:            profile.Arn,
+						AcceptRoleSessionName: profile.AcceptRoleSessionName,
 					},
 				},
 			},

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1060,6 +1060,8 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// AWS IAM Roles Anywhere Integration Actions
 	h.GET("/webapi/scripts/integrations/configure/awsra-trust-anchor.sh", h.WithLimiter(h.awsRolesAnywhereConfigureTrustAnchor))
+	h.POST("/webapi/sites/:site/integrations/aws-ra/:name/ping", h.WithClusterAuth(h.awsRolesAnywherePing))
+	h.POST("/webapi/sites/:site/integrations/aws-ra/:name/listprofiles", h.WithClusterAuth(h.awsRolesAnywhereListProfiles))
 
 	// SAML IDP integration endpoints
 	h.GET("/webapi/scripts/integrations/configure/gcp-workforce-saml.sh", h.WithLimiter(h.gcpWorkforceConfigScript))

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -669,3 +669,59 @@ type AWSOIDCCreateAWSAppAccessRequest struct {
 	// Labels added to the app server resource that will be created.
 	Labels map[string]string `json:"labels"`
 }
+
+// AWSRolesAnywherePingRequest contains ping request fields.
+type AWSRolesAnywherePingRequest struct {
+	// TrustAnchorARN is the ARN of the IAM Roles Anywhere Trust Anchor.
+	TrustAnchorARN string `json:"trustAnchorArn"`
+	// SyncProfileARN is the ARN of the IAM Roles Anywhere Profile that is used to sync profiles.
+	SyncProfileARN string `json:"syncProfileArn"`
+	// SyncRoleARN is the ARN of the IAM Role that is used to sync profiles.
+	SyncRoleARN string `json:"syncRoleArn"`
+}
+
+// AWSRolesAnywherePingResponse contains the result of the Ping request.
+// This response contains meta information about the current state of the Integration.
+type AWSRolesAnywherePingResponse struct {
+	// ProfileCount is the number of IAM Roles Anywhere Profiles that can be accessed by the Integration.
+	// Profiles that are disabled or don't have any IAM Role associated with them are not counted.
+	ProfileCount int `json:"profileCount"`
+	// AccountID number of the account that owns or contains the calling entity.
+	AccountID string `json:"accountId"`
+	// ARN associated with the calling entity.
+	ARN string `json:"arn"`
+	// UserID is the unique identifier of the calling entity.
+	UserID string `json:"userId"`
+}
+
+// AWSRolesAnywhereListProfilesRequest contains the list of Roles Anywhere Profiles.
+type AWSRolesAnywhereListProfilesRequest struct {
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken"`
+}
+
+// AWSRolesAnywhereListProfilesResponse contains the result of the ListProfiles request.
+type AWSRolesAnywhereListProfilesResponse struct {
+	// Profiles contains the list of Roles Anywhere Profiles.
+	Profiles []AWSRolesAnywhereListProfile `json:"profiles"`
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken,omitempty"`
+}
+
+// AWSRolesAnywhereListProfile represents a single IAM Roles Anywhere Profile.
+type AWSRolesAnywhereListProfile struct {
+	// The AWS Roles Anywhere Profile ARN.
+	ARN string `json:"arn,omitempty"`
+	// Whether the AWS Roles Anywhere Profile is enabled.
+	Enabled bool `json:"enabled,omitempty"`
+	// The name of the AWS Roles Anywhere Profile.
+	Name string `json:"name,omitempty"`
+	// Whether the profile accepts role session names.
+	AcceptRoleSessionName bool `json:"acceptRoleSessionName,omitempty"`
+	// The tags associated with the AWS Roles Anywhere Profile.
+	Tags []ui.Label `json:"tags,omitempty"`
+	// The roles accessible from this AWS Roles Anywhere Profile.
+	Roles []string `json:"roles,omitempty"`
+}


### PR DESCRIPTION
This adds the implementation of the two new endpoints:
- ping
- list roles anywhere profiles (does not support filters yet)

Here's an example of how you can call both
```bash
$ curl 'https://proxy.example.com/v1/webapi/sites/my-cluster/integrations/aws-ra/my-integration/ping' ... --data-raw '{}' | jq
{
  "profileCount": 5,
  "accountId": "123456789012",
  "arn": "arn:aws:sts::123456789012:assumed-role/MyRole/some-id",
  "userId": "ALLCAPS:hexvalue"
}
```

```bash
$ curl 'https://proxy.example.com/v1/webapi/sites/my-cluster/integrations/aws-ra/my-integration/listprofiles' --data-raw '{}' | jq
{
  "profiles": [
    {
      "arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/an-uuid",
      "enabled": true,
      "name": "MyRole",
      "tags": [
        {
          "name": "teleport.dev/creator",
          "value": "marco.dinis@goteleport.com"
        }
      ],
      "roles": [
        "arn:aws:iam::123456789012:role/MyRole"
      ]
    }
  ],
  "nextToken": ""
}
```