### PR TITLE
[Web] Update bot instances page to use empty state if user doesn't have permission

### DIFF
--- a/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
@@ -34,12 +34,14 @@ import {
 } from 'design/utils/testing';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
+import { createTeleportContext } from 'teleport/mocks/contexts';
 import { listBotInstances } from 'teleport/services/bot/bot';
 import {
   listBotInstancesError,
   listBotInstancesSuccess,
 } from 'teleport/test/helpers/botInstances';
 
+import { ContextProvider } from '..';
 import { BotInstances } from './BotInstances';
 
 jest.mock('teleport/services/bot/bot', () => {
@@ -266,12 +268,13 @@ describe('BotInstances', () => {
 });
 
 function Wrapper({ children }: PropsWithChildren) {
+  const ctx = createTeleportContext();
   return (
     <MemoryRouter>
       <QueryClientProvider client={testQueryClient}>
         <ConfiguredThemeProvider theme={darkTheme}>
           <InfoGuidePanelProvider data-testid="blah">
-            {children}
+            <ContextProvider ctx={ctx}>{children}</ContextProvider>
           </InfoGuidePanelProvider>
         </ConfiguredThemeProvider>
       </QueryClientProvider>

--- a/web/packages/teleport/src/BotInstances/BotInstances.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.tsx
@@ -31,6 +31,7 @@ import {
   ReferenceLinks,
 } from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
 
+import { EmptyState } from 'teleport/Bots/List/EmptyState/EmptyState';
 import {
   FeatureBox,
   FeatureHeader,
@@ -39,6 +40,7 @@ import {
 import cfg from 'teleport/config';
 import { listBotInstances } from 'teleport/services/bot/bot';
 import { BotInstanceSummary } from 'teleport/services/bot/types';
+import useTeleport from 'teleport/useTeleport';
 
 import { BotInstancesList } from './List/BotInstancesList';
 
@@ -49,7 +51,12 @@ export function BotInstances() {
   const pageToken = queryParams.get('page') ?? '';
   const searchTerm = queryParams.get('search') ?? '';
 
+  const ctx = useTeleport();
+  const flags = ctx.getFeatureFlags();
+  const canListInstances = flags.listBotInstances;
+
   const { isPending, isFetching, isSuccess, isError, error, data } = useQuery({
+    enabled: canListInstances,
     queryKey: ['bot_instances', 'list', searchTerm, pageToken],
     queryFn: () =>
       listBotInstances({
@@ -100,6 +107,18 @@ export function BotInstances() {
     },
     [history]
   );
+
+  if (!canListInstances) {
+    return (
+      <FeatureBox>
+        <Alert kind="info" mt={4}>
+          You do not have permission to access Bot instances. Missing role
+          permissions: <code>bot_instance.list</code>
+        </Alert>
+        <EmptyState />
+      </FeatureBox>
+    );
+  }
 
   return (
     <FeatureBox>


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/56135

This PR adds an empty state to the "Bot Instances" if the user has no permissions. This is currently just a duplicate of the empty state for the `Bots`.

![image](https://github.com/user-attachments/assets/3f4e1a5b-e217-43ba-973f-14a640671f58)


