### PR TITLE
Update top-bar related web test plan items to be based on the new side navigation

### DIFF
--- a/.github/ISSUE_TEMPLATE/webtestplan.md
+++ b/.github/ISSUE_TEMPLATE/webtestplan.md
@@ -722,13 +722,12 @@ spec:
 version: v3
 ```
 
-- [ ] Verify that the user has no `Access` top-level navigation item.
-- [ ] Verify that the `Audit` top-level navigation item only contains `Active Sessions`.
-- [ ] Verify that on Enterprise, the user has no `Policy` top-level navigation item, while the admin does.
-- [ ] Verify that on Enterprise, the `Identity` top-level navigation item only contains `Access Requests` and `Access Lists`.
-- [ ] Verify that on Enterprise, the `Add New` top-level navigation item only contains `Resource` and `Access List`.
-- [ ] Verify that on OSS, the user has no `Identity` top-level navigation item.
-- [ ] Verify that on OSS, the `Add New` top-level navigation item only contains `Resource`.
+- [ ] Verify that the `Audit` side navigation section only contains `Active Sessions`.
+- [ ] Verify that on Enterprise, the `Identity Governance` side navigation section only contains `Access Requests`, `Access Lists` and `Trusted Devices`.
+- [ ] Verify that on Enterprise, the `Machine & Workload ID` side navigation section only contains `Bots` and `Workload Identity`.
+- [ ] Verify that on OSS, the `Identity Governance` side navigation section contains `Access Requests` and `Trusted Devices` empty states with Enterprise CTA's.
+- [ ] Verify that on OSS, the `Add New` side navigation section contains `Resource` and `Integration`.
+- [ ] Verify that on OSS, there is no `Identity Security` side navigation section.
 - [ ] Verify the `Enroll New Resource` button is disabled on the Resources screen.
 
 Note: User has read/create access_request access to their own requests, despite resource settings


### PR DESCRIPTION
## Purpose

This PR updates the web test plan items to be based on the new side navigation. A few items were based on the old top-bar, however we have since moved to a sidenav which is setup differently. There are also some differences in the pages that should be showing up, since for a few pages, we no longer hide them completely but instead show an empty state or CTA.