### PR TITLE
[v17] Web: fix error when creating IAM token during ec2 ssm flow

### DIFF
--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -41,7 +41,8 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
       suggested_agent_matcher_labels: {},
       suggested_labels: {},
     },
-    null
+    null,
+    undefined
   );
 });
 
@@ -65,6 +66,7 @@ test('fetchJoinToken request fields are set as requested', () => {
       suggested_agent_matcher_labels: { env: ['dev'] },
       suggested_labels: {},
     },
-    null
+    null,
+    undefined
   );
 });

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -36,7 +36,8 @@ class JoinTokenService {
   // TODO (avatus) refactor this code to eventually use `createJoinToken`
   fetchJoinTokenV2(
     req: JoinTokenRequest,
-    signal: AbortSignal = null
+    signal: AbortSignal = null,
+    mfaResponse?: MfaChallengeResponse
   ): Promise<JoinToken> {
     return (
       api
@@ -51,7 +52,8 @@ class JoinTokenService {
             ),
             suggested_labels: makeLabelMapOfStrArrs(req.suggestedLabels),
           },
-          signal
+          signal,
+          mfaResponse
         )
         .then(makeJoinToken)
         // TODO(kimlisa): DELETE IN 19.0
@@ -63,7 +65,8 @@ class JoinTokenService {
   // replaced by fetchJoinTokenV2 that accepts labels.
   fetchJoinToken(
     req: Omit<JoinTokenRequest, 'suggestedLabels'>,
-    signal: AbortSignal = null
+    signal: AbortSignal = null,
+    mfaResponse?: MfaChallengeResponse
   ): Promise<JoinToken> {
     return api
       .post(
@@ -76,7 +79,8 @@ class JoinTokenService {
             req.suggestedAgentMatcherLabels
           ),
         },
-        signal
+        signal,
+        mfaResponse
       )
       .then(makeJoinToken);
   }


### PR DESCRIPTION
Backport #55970 to branch/v17

changelog: Fixed error on setting up Teleport Discovery Service step of the EC2 SSM web UI flow when admin action is enabled (webauthn). 
