### PR TITLE
[v16] Add a CLI reference generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -851,7 +851,7 @@ test-go-prepare: ensure-webassets bpf-bytecode $(TEST_LOG_DIR) ensure-gotestsum 
 test-go-unit: FLAGS ?= -race -shuffle on
 test-go-unit: SUBJECT ?= $(shell go list ./... | grep -vE 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
-	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG) $(ADDTAGS)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 
@@ -1813,3 +1813,11 @@ create-github-release:
 	--latest=$(LATEST) \
 	--verify-tag \
 	-F - <<< "$$NOTES"
+
+.PHONY: cli-docs-tsh
+cli-docs-tsh:
+	# Not executing go run since we don't want to redirect linker warnings
+	# along with the docs page content.
+	go build -o $(BUILDDIR)/tshdocs -tags docs ./tool/tsh && \
+	$(BUILDDIR)/tshdocs help 2>docs/pages/reference/cli/tsh.mdx && \
+	rm $(BUILDDIR)/tshdocs

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -389,54 +389,6 @@ func createUsageTemplate(opts ...func(*usageTemplateOptions)) string {
 	return fmt.Sprintf(defaultUsageTemplate, opt.commandPrintfWidth)
 }
 
-// UpdateAppUsageTemplate updates usage template for kingpin applications by
-// pre-parsing the arguments then applying any changes to the usage template if
-// necessary.
-func UpdateAppUsageTemplate(app *kingpin.Application, args []string) {
-	app.UsageTemplate(createUsageTemplate(
-		withCommandPrintfWidth(app, args),
-	))
-}
-
-// withCommandPrintfWidth returns a usage template option that
-// updates command printf width if longer than default.
-func withCommandPrintfWidth(app *kingpin.Application, args []string) func(*usageTemplateOptions) {
-	return func(opt *usageTemplateOptions) {
-		var commands []*kingpin.CmdModel
-
-		// When selected command is "help", skip the "help" arg
-		// so the intended command is selected for calculation.
-		if len(args) > 0 && args[0] == "help" {
-			args = args[1:]
-		}
-
-		appContext, err := app.ParseContext(args)
-		switch {
-		case appContext == nil:
-			slog.WarnContext(context.Background(), "No application context found")
-			return
-
-		// Note that ParseContext may return the current selected command that's
-		// causing the error. We should continue in those cases when appContext is
-		// not nil.
-		case err != nil:
-			slog.InfoContext(context.Background(), "Error parsing application context", "error", err)
-		}
-
-		if appContext.SelectedCommand != nil {
-			commands = appContext.SelectedCommand.Model().FlattenedCommands()
-		} else {
-			commands = app.Model().FlattenedCommands()
-		}
-
-		for _, command := range commands {
-			if !command.Hidden && len(command.FullCommand) > opt.commandPrintfWidth {
-				opt.commandPrintfWidth = len(command.FullCommand)
-			}
-		}
-	}
-}
-
 // SplitIdentifiers splits list of identifiers by commas/spaces/newlines.  Helpful when
 // accepting lists of identifiers in CLI (role names, request IDs, etc).
 func SplitIdentifiers(s string) []string {

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -19,14 +19,11 @@
 package utils
 
 import (
-	"bytes"
 	"crypto/x509"
 	"fmt"
-	"io"
 	"log/slog"
 	"testing"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -163,84 +160,5 @@ func TestAllowWhitespace(t *testing.T) {
 
 	for i, tt := range tests {
 		require.Equal(t, tt.out, AllowWhitespace(tt.in), fmt.Sprintf("test case %v", i))
-	}
-}
-
-func TestUpdateAppUsageTemplate(t *testing.T) {
-	makeApp := func(usageWriter io.Writer) *kingpin.Application {
-		app := InitCLIParser("TestUpdateAppUsageTemplate", "some help message")
-		app.UsageWriter(usageWriter)
-		app.Terminate(func(int) {})
-
-		app.Command("hello", "Hello.")
-
-		create := app.Command("create", "Create.")
-		create.Command("box", "Box.")
-		create.Command("rocket", "Rocket.")
-		return app
-	}
-
-	tests := []struct {
-		name           string
-		inputArgs      []string
-		outputContains string
-	}{
-		{
-			name:      "command width aligned for app help",
-			inputArgs: []string{},
-			outputContains: `
-Commands:
-  help          Show help.
-  hello         Hello.
-  create box    Box.
-  create rocket Rocket.
-`,
-		},
-		{
-			name:      "command width aligned for command help",
-			inputArgs: []string{"create"},
-			outputContains: `
-Commands:
-  create box    Box.
-  create rocket Rocket.
-`,
-		},
-		{
-			name:      "command width aligned for unknown command error",
-			inputArgs: []string{"unknown"},
-			outputContains: `
-Commands:
-  help          Show help.
-  hello         Hello.
-  create box    Box.
-  create rocket Rocket.
-`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Run("help flag", func(t *testing.T) {
-				var buffer bytes.Buffer
-				app := makeApp(&buffer)
-				args := append(tt.inputArgs, "--help")
-				UpdateAppUsageTemplate(app, args)
-
-				app.Usage(args)
-				require.Contains(t, buffer.String(), tt.outputContains)
-			})
-
-			t.Run("help command", func(t *testing.T) {
-				var buffer bytes.Buffer
-				app := makeApp(&buffer)
-				args := append([]string{"help"}, tt.inputArgs...)
-				UpdateAppUsageTemplate(app, args)
-
-				// HelpCommand is triggered on PreAction during Parse.
-				// See kingpin.Application.init for more details.
-				_, err := app.Parse(args)
-				require.NoError(t, err)
-				require.Contains(t, buffer.String(), tt.outputContains)
-			})
-		})
 	}
 }

--- a/lib/utils/docs-usage.md.tmpl
+++ b/lib/utils/docs-usage.md.tmpl
@@ -1,0 +1,91 @@
+{{define "FormatCommand" -}}
+{{if .Flags|AnyVisibleFlags}}{{if .FlagSummary }} {{.FlagSummary}}{{end}}{{end -}}
+    {{range .Args}}{{if not .Hidden}} {{ .|FormatUsageArg}}{{end}}{{end -}}
+{{end -}}
+
+{{ define "FormatCommands" -}}
+{{$appName := .Name -}}
+{{range .FlattenedCommands|SortCommandsByName -}}
+{{if not .Hidden -}}
+## {{$appName}} {{.FullCommand}}
+
+{{.Help|Wrap 0 }}
+Usage:
+
+```code
+$ {{$appName}} {{.FullCommand}}{{template "FormatCommand" .}}
+```
+
+{{if AnyEnvVarsForCmd .Args .Flags -}}
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+{{- EnvVarsToRows .Args .Flags|FormatThreeColMarkdownTable}}
+
+{{end -}}
+
+{{ if .Flags|AnyVisibleFlags -}}
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+{{- .Flags|FlagsToRows|FormatThreeColMarkdownTable }}
+
+{{end -}}
+{{ if .Args -}}
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+{{- .Args|ArgsToRows|FormatThreeColMarkdownTable }}
+
+{{end -}}
+{{end -}}
+{{end -}}
+{{end -}}
+
+{{define "FormatUsage" -}}
+```code
+$ {{.Name}}{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
+```
+
+{{end -}}
+---
+title: {{.App.Name}} Reference
+description: Provides a comprehensive list of commands, arguments, and flags for {{.App.Name}}.
+---
+
+This guide provides a comprehensive list of commands, arguments, and flags for
+{{.App.Name}}: {{ if .App.Help -}}
+{{- .App.Help|Wrap 0 }}
+{{ end -}}
+
+{{template "FormatUsage" .App -}}
+{{if .Context.Flags -}}
+Global flags:
+
+|Flag|Default|Description|
+|---|---|---|
+{{- .Context.Flags|FlagsToRows|FormatThreeColMarkdownTable}}
+
+{{end -}}
+{{if AnyEnvVarsForCmd .Context.Args .Context.Flags -}}
+Global environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+{{- EnvVarsToRows .Context.Args .Context.Flags|FormatThreeColMarkdownTable}}
+
+{{end -}}
+{{if .Context.Args -}}
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+{{- .Context.Args|ArgsToRows|FormatThreeColMarkdownTable}}
+
+{{end -}}
+{{if .App.Commands -}}
+{{template "FormatCommands" .App -}}
+{{end -}}

--- a/lib/utils/usage.go
+++ b/lib/utils/usage.go
@@ -1,0 +1,74 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !docs
+
+package utils
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+// UpdateAppUsageTemplate updates usage template for kingpin applications by
+// pre-parsing the arguments then applying any changes to the usage template if
+// necessary.
+func UpdateAppUsageTemplate(app *kingpin.Application, args []string) {
+	app.UsageTemplate(createUsageTemplate(
+		withCommandPrintfWidth(app, args),
+	))
+}
+
+// withCommandPrintfWidth returns a usage template option that
+// updates command printf width if longer than default.
+func withCommandPrintfWidth(app *kingpin.Application, args []string) func(*usageTemplateOptions) {
+	return func(opt *usageTemplateOptions) {
+		var commands []*kingpin.CmdModel
+
+		// When selected command is "help", skip the "help" arg
+		// so the intended command is selected for calculation.
+		if len(args) > 0 && args[0] == "help" {
+			args = args[1:]
+		}
+
+		appContext, err := app.ParseContext(args)
+		switch {
+		case appContext == nil:
+			slog.WarnContext(context.Background(), "No application context found")
+			return
+
+		// Note that ParseContext may return the current selected command that's
+		// causing the error. We should continue in those cases when appContext is
+		// not nil.
+		case err != nil:
+			slog.InfoContext(context.Background(), "Error parsing application context", "error", err)
+		}
+
+		if appContext.SelectedCommand != nil {
+			commands = appContext.SelectedCommand.Model().FlattenedCommands()
+		} else {
+			commands = app.Model().FlattenedCommands()
+		}
+
+		for _, command := range commands {
+			if !command.Hidden && len(command.FullCommand) > opt.commandPrintfWidth {
+				opt.commandPrintfWidth = len(command.FullCommand)
+			}
+		}
+	}
+}

--- a/lib/utils/usage_docs.go
+++ b/lib/utils/usage_docs.go
@@ -1,0 +1,278 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build docs
+
+package utils
+
+import (
+	"bytes"
+	"cmp"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+// formatThreeColMarkdownTable formats the provided row data into a three-column
+// Markdown table, minus the header.
+func formatThreeColMarkdownTable(rows [][3]string) string {
+	var buf bytes.Buffer
+
+	for _, r := range rows {
+		fmt.Fprintf(&buf, "\n|%v|%v|%v|", r[0], r[1], r[2])
+	}
+	return buf.String()
+}
+
+// flagsToRows outputs data for a table that lists flags, their default
+// values, and help texts.
+func flagsToRows(f []*kingpin.FlagModel) [][3]string {
+	rows := [][3]string{}
+
+	for _, flag := range f {
+		if flag.Hidden {
+			continue
+		}
+		flagString := ""
+		flagName := flag.Name
+		if flag.IsBoolFlag() {
+			flagName = "[no-]" + flagName
+		}
+		if flag.Short != 0 {
+			flagString += fmt.Sprintf("`-%c`, `--%s`", flag.Short, flagName)
+		} else {
+			flagString += fmt.Sprintf("`--%s`", flagName)
+		}
+
+		rows = append(rows, [3]string{
+			flagString,
+			formatDefaultFlagValue(flag),
+			formatHelp(flag.Help),
+		})
+	}
+	return rows
+}
+
+// anyVisibleFlags returns whether any flags in f are visible, i.e., should be
+// included in a table of flags.
+func anyVisibleFlags(f []*kingpin.FlagModel) bool {
+	return slices.ContainsFunc(f, func(m *kingpin.FlagModel) bool {
+		return !m.Hidden
+	})
+}
+
+// anyEnvVarsForCmd indicates whether at least one of the arguments and flags
+// provided exposes an environment variable for configuration.
+func anyEnvVarsForCmd(args []*kingpin.ArgModel, flags []*kingpin.FlagModel) bool {
+	return slices.ContainsFunc(args, func(arg *kingpin.ArgModel) bool {
+		return arg.Envar != ""
+	}) || slices.ContainsFunc(flags, func(flag *kingpin.FlagModel) bool {
+		return flag.Envar != ""
+	})
+}
+
+// argsToRows outputs data for a table that lists arguments, their default
+// values, and help texts.
+func argsToRows(a []*kingpin.ArgModel) [][3]string {
+	rows := [][3]string{}
+	for _, arg := range a {
+		if arg.Hidden {
+			continue
+		}
+
+		// Some commands declare empty argument names and help texts as
+		// a hack to allow arbitrary values. Indicate this in the table
+		// as a special case.
+		argName := cmp.Or(arg.Name, "args")
+
+		help := "Arbitrary arguments"
+		if arg.Help != "" {
+			help = formatHelp(arg.Help)
+		}
+
+		rows = append(rows, [3]string{
+			argName,
+			formatDefaultArgValue(arg),
+			help,
+		})
+	}
+	return rows
+}
+
+// envVarsToRows prints table data for a list of environment variables, their
+// default values, and help texts.
+func envVarsToRows(args []*kingpin.ArgModel, flags []*kingpin.FlagModel) [][3]string {
+	rows := [][3]string{}
+	for _, arg := range args {
+		if arg.Hidden || arg.Envar == "" {
+			continue
+		}
+
+		rows = append(rows, [3]string{
+			fmt.Sprintf("`%v`", arg.Envar),
+			formatDefaultArgValue(arg),
+			arg.Help,
+		})
+	}
+	for _, flg := range flags {
+		if flg.Hidden || flg.Envar == "" {
+			continue
+		}
+
+		rows = append(rows, [3]string{
+			fmt.Sprintf("`%v`", flg.Envar),
+			formatDefaultFlagValue(flg),
+			flg.Help,
+		})
+	}
+	return rows
+}
+
+// sortcommandsByName sorts the commands in cmds by their full command names,
+// including all subcommands.
+func sortCommandsByName(cmds []*kingpin.CmdModel) []*kingpin.CmdModel {
+	slices.SortStableFunc(cmds, func(a, b *kingpin.CmdModel) int {
+		switch {
+		case a.FullCommand < b.FullCommand:
+			return -1
+		case a.FullCommand > b.FullCommand:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return cmds
+}
+
+// formatDefaultFlagValue returns the default value of flag to display in a
+// table of flags. Assumes that a Boolean flag is false unless it is true by
+// default.
+func formatDefaultFlagValue(flag *kingpin.FlagModel) string {
+	switch {
+	case len(flag.Default) == 0 && flag.IsBoolFlag():
+		return "`false`"
+	case len(flag.Default) > 0:
+		ret := make([]string, len(flag.Default))
+		for i, v := range flag.Default {
+			ret[i] = fmt.Sprintf("`%v`", v)
+		}
+		return strings.Join(ret, ",")
+	default:
+		return "none"
+	}
+}
+
+// formatDefaultArgValue returns the default value of arg to display in a table
+// of flags. It also indicates whether the value is optional or required.
+func formatDefaultArgValue(arg *kingpin.ArgModel) string {
+	var ret string
+	if len(arg.Default) > 0 {
+		def := make([]string, len(arg.Default))
+		for i, v := range arg.Default {
+			def[i] = fmt.Sprintf("`%v`", v)
+		}
+		ret = strings.Join(def, ",")
+	} else {
+		ret = "none"
+	}
+	if arg.Required {
+		ret += " (required)"
+	} else {
+		ret += " (optional)"
+	}
+
+	return ret
+}
+
+// repeatableFlag is an interface for flags that can be repeated. Unexported
+// type in github.com/alecthomas/kingpin/v2.
+type repeatableFlag interface {
+	IsCumulative() bool
+}
+
+// formatUsageArg prints a command argument to include in a usage snippet.
+func formatUsageArg(arg *kingpin.ArgModel) string {
+	var ret string
+	switch {
+	case arg.PlaceHolder != "":
+		ret = arg.PlaceHolder
+	// Some special cases have empty arg names
+	case arg.Name == "":
+		ret = "args"
+	default:
+		ret = "<" + arg.Name + ">"
+	}
+	if v, ok := arg.Value.(repeatableFlag); ok && v.IsCumulative() {
+		ret += "..."
+	}
+	if !arg.Required {
+		ret = "[" + ret + "]"
+	}
+	return ret
+}
+
+// formatHelp prints help text to include in a Markdown table cell. It escapes
+// curly braces to avoid breaking the MDX parser, and it escapes pipes to
+// avoid breaking the cell.
+func formatHelp(help string) string {
+	return strings.NewReplacer("{", `\{`, "}", `\}`, "|", `\|`).Replace(help)
+}
+
+// docsUsageTemplatePath points to a help text template for CLI reference
+// documentation. Intended to be used as the argument to
+// *kingpin.Application.UsageTemplate.
+var docsUsageTemplatePath = filepath.Join("lib", "utils", "docs-usage.md.tmpl")
+
+// updateAppUsageTemplatePath updates the app usage template to print a reference
+// guide for the CLI application. It reads the template from r.
+func updateAppUsageTemplate(r io.Reader, app *kingpin.Application) {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		panic(fmt.Sprintf("unable to read from the docs usage template: %v", err))
+	}
+
+	app.UsageFuncs(map[string]any{
+		"AnyEnvVarsForCmd":            anyEnvVarsForCmd,
+		"AnyVisibleFlags":             anyVisibleFlags,
+		"ArgsToRows":                  argsToRows,
+		"EnvVarsToRows":               envVarsToRows,
+		"FlagsToRows":                 flagsToRows,
+		"FormatThreeColMarkdownTable": formatThreeColMarkdownTable,
+		"FormatUsageArg":              formatUsageArg,
+		"SortCommandsByName":          sortCommandsByName,
+	})
+	app.UsageTemplate(buf.String())
+}
+
+// UpdateAppUsageTemplate updates the app usage template to print a reference
+// guide for the CLI application.
+func UpdateAppUsageTemplate(app *kingpin.Application, _ []string) {
+	// Panic when failing to open or read from the docs usage template since
+	// we need to keep the signature of UpdateAppUsageTemplate consistent
+	// with the one included without build tags, i.e., with no return value.
+	f, err := os.Open(docsUsageTemplatePath)
+	if err != nil {
+		panic(fmt.Sprintf("unable to open the docs usage template at %v: %v", docsUsageTemplatePath, err))
+	}
+
+	updateAppUsageTemplate(f, app)
+}

--- a/lib/utils/usage_docs_test.go
+++ b/lib/utils/usage_docs_test.go
@@ -1,0 +1,445 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build docs
+
+package utils
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAppUsageTemplate(t *testing.T) {
+	tests := []struct {
+		name            string
+		makeApp         func() *kingpin.Application
+		expectSubstring string // The @ character is replaced with a backtick
+	}{
+		{
+			name: "subcommand flags and global flags",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				app.Command("hello", "Hello.")
+				create := app.Command("create", "Create.")
+				create.Flag("name", "The name of the resource").Default("myresource").String()
+				createRocket := create.Command("rocket", "Rocket.")
+				createRocket.Flag("launch", "Whether to launch the Rocket").Bool()
+				return app
+			},
+			expectSubstring: `---
+title: myapp Reference
+description: Provides a comprehensive list of commands, arguments, and flags for myapp.
+---
+
+This guide provides a comprehensive list of commands, arguments, and flags for
+myapp: This is the main CLI tool.
+
+@@@code
+$ myapp [<flags>] <command> [<args> ...]
+@@@
+
+Global flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--config@|@config.yaml@|The location of the config file|
+
+## myapp create rocket
+
+Rocket.
+
+Usage:
+
+@@@code
+$ myapp create rocket [<flags>]
+@@@
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--[no-]launch@|@false@|Whether to launch the Rocket|
+
+## myapp hello
+
+Hello.
+
+Usage:
+
+@@@code
+$ myapp hello
+@@@
+
+## myapp help
+
+Show help.
+
+Usage:
+
+@@@code
+$ myapp help [<command>...]
+@@@
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Show help on command.|
+
+`,
+		},
+		{
+			name: "multiple main command flags",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				app.Flag("verbosity", "Verbosity level.").Default("3").Int()
+				app.Flag("dry-run", "Whether to use dry-run mode").Default("false").Bool()
+				return app
+			},
+			expectSubstring: `This guide provides a comprehensive list of commands, arguments, and flags for
+myapp: This is the main CLI tool.
+
+@@@code
+$ myapp [<flags>] <command> [<args> ...]
+@@@
+
+Global flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--config@|@config.yaml@|The location of the config file|
+|@--verbosity@|@3@|Verbosity level.|
+|@--[no-]dry-run@|@false@|Whether to use dry-run mode|
+
+`,
+		},
+		{
+			name: "multiple subcommand flags",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				create := app.Command("create", "Create a resource.")
+				create.Flag("verbosity", "Verbosity level.").Default("3").Int()
+				create.Flag("dry-run", "Whether to use dry-run mode").Default("false").Bool()
+				return app
+			},
+			expectSubstring: `## myapp create
+
+Create a resource.
+
+Usage:
+
+@@@code
+$ myapp create [<flags>]
+@@@
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--verbosity@|@3@|Verbosity level.|
+|@--[no-]dry-run@|@false@|Whether to use dry-run mode|
+
+`,
+		},
+		{
+			name: "multiple sub-command args",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				create := app.Command("create", "Create.")
+				create.Arg("verbosity", "Verbosity level.").Default("3").Int()
+				create.Arg("dry-run", "Whether to use dry-run mode").Default("false").Bool()
+				return app
+			},
+			expectSubstring: `## myapp create
+
+Create.
+
+Usage:
+
+@@@code
+$ myapp create [<verbosity>] [<dry-run>]
+@@@
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|verbosity|@3@ (optional)|Verbosity level.|
+|dry-run|@false@ (optional)|Whether to use dry-run mode|
+
+`,
+		},
+		{
+			name: "sub-command order",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				app.Command("create", "Create a resource.")
+				app.Command("validate", "Validate the config.")
+				app.Command("connect", "Connect to a server.")
+				return app
+			},
+			expectSubstring: `## myapp connect
+
+Connect to a server.
+
+Usage:
+
+@@@code
+$ myapp connect
+@@@
+
+## myapp create
+
+Create a resource.
+
+Usage:
+
+@@@code
+$ myapp create
+@@@
+
+## myapp help
+
+Show help.
+
+Usage:
+
+@@@code
+$ myapp help [<command>...]
+@@@
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Show help on command.|
+
+## myapp validate
+
+Validate the config.
+
+Usage:
+
+@@@code
+$ myapp validate
+@@@
+
+`,
+		},
+		{
+			name: "level-3 command order",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				mfa := app.Command("mfa", "Manage MFA resources.")
+				mfa.Command("add", "Add an MFA device.")
+				app.Command("create", "Create a resource")
+				return app
+			},
+			expectSubstring: `## myapp create
+
+Create a resource
+
+Usage:
+
+@@@code
+$ myapp create
+@@@
+
+## myapp help
+
+Show help.
+
+Usage:
+
+@@@code
+$ myapp help [<command>...]
+@@@
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Show help on command.|
+
+## myapp mfa add
+
+Add an MFA device.
+
+Usage:
+
+@@@code
+$ myapp mfa add
+@@@
+
+`,
+		},
+		{
+			name: "empty arg",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				app.Command("kubectl", "Proxy kubectl commands.")
+				kubectl := app.Command("kubectl", "Proxy kubectl commands.").Interspersed(false)
+				// This hack is required in order to accept any args for tsh kubectl.
+				kubectl.Arg("", "").StringsVar(new([]string))
+
+				return app
+			},
+			expectSubstring: `## myapp kubectl
+
+Proxy kubectl commands.
+
+Usage:
+
+@@@code
+$ myapp kubectl [args...]
+@@@
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|args|none (optional)|Arbitrary arguments|
+
+`,
+		},
+		{
+			name: "hidden flag",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				app.Command("kubectl", "Proxy kubectl commands.")
+				kubectl := app.Command("kubectl", "Proxy kubectl commands.").Interspersed(false)
+				kubectl.Flag("diag", "Run diagnostics").Hidden().Bool()
+				app.Command("log", "Print logs")
+
+				return app
+			},
+			expectSubstring: `## myapp kubectl
+
+Proxy kubectl commands.
+
+Usage:
+
+@@@code
+$ myapp kubectl
+@@@
+
+## myapp log
+`,
+		},
+		{
+			name: "main command env vars",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("verbosity", "Verbosity level.").Default("3").Envar("MYAPP_VERBOSITY").Int()
+				return app
+			},
+			expectSubstring: `Global flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--verbosity@|@3@|Verbosity level.|
+
+Global environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|@MYAPP_VERBOSITY@|@3@|Verbosity level.|
+
+`,
+		},
+		{
+			name: "subcommand env vars",
+			makeApp: func() *kingpin.Application {
+				app := InitCLIParser("myapp", "This is the main CLI tool.")
+				app.Flag("config", "The location of the config file").Default("config.yaml").String()
+				create := app.Command("create", "Create a resource.")
+				create.Flag("name", "The name of the resource").Envar("CREATE_NAME").Default("myresource").String()
+				create.Arg("type", "The type of the resource").Envar("CREATE_TYPE").String()
+
+				return app
+			},
+			expectSubstring: `## myapp create
+
+Create a resource.
+
+Usage:
+
+@@@code
+$ myapp create [<flags>] [<type>]
+@@@
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|@CREATE_TYPE@|none (optional)|The type of the resource|
+|@CREATE_NAME@|@myresource@|The name of the resource|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|@--name@|@myresource@|The name of the resource|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|type|none (optional)|The type of the resource|
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := tt.makeApp()
+			var buffer bytes.Buffer
+			app.UsageWriter(&buffer)
+			args := []string{"help"}
+			app.Terminate(func(int) {})
+
+			docsUsageTemplatePath := "docs-usage.md.tmpl"
+			f, err := os.Open(docsUsageTemplatePath)
+			require.NoError(t, err)
+			updateAppUsageTemplate(f, app)
+
+			// kingpin only adds a help command if there is at least
+			// one subcommand. Make sure that all test cases
+			// introduce a help command.
+			app.HelpCommand = app.Command("help", "Print help for the application.")
+			// HelpCommand is triggered on PreAction during Parse.
+			// See kingpin.Application.init for more details.
+			_, err = app.Parse(args)
+			require.NoError(t, err)
+			expected := strings.ReplaceAll(tt.expectSubstring, "@", "`")
+			require.Contains(t, buffer.String(), expected)
+		})
+	}
+}

--- a/lib/utils/usage_test.go
+++ b/lib/utils/usage_test.go
@@ -1,0 +1,107 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !docs
+
+package utils
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAppUsageTemplate(t *testing.T) {
+	makeApp := func(usageWriter io.Writer) *kingpin.Application {
+		app := InitCLIParser("TestUpdateAppUsageTemplate", "some help message")
+		app.UsageWriter(usageWriter)
+		app.Terminate(func(int) {})
+
+		app.Command("hello", "Hello.")
+
+		create := app.Command("create", "Create.")
+		create.Command("box", "Box.")
+		create.Command("rocket", "Rocket.")
+		return app
+	}
+
+	tests := []struct {
+		name           string
+		inputArgs      []string
+		outputContains string
+	}{
+		{
+			name:      "command width aligned for app help",
+			inputArgs: []string{},
+			outputContains: `
+Commands:
+  help          Show help.
+  hello         Hello.
+  create box    Box.
+  create rocket Rocket.
+`,
+		},
+		{
+			name:      "command width aligned for command help",
+			inputArgs: []string{"create"},
+			outputContains: `
+Commands:
+  create box    Box.
+  create rocket Rocket.
+`,
+		},
+		{
+			name:      "command width aligned for unknown command error",
+			inputArgs: []string{"unknown"},
+			outputContains: `
+Commands:
+  help          Show help.
+  hello         Hello.
+  create box    Box.
+  create rocket Rocket.
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("help flag", func(t *testing.T) {
+				var buffer bytes.Buffer
+				app := makeApp(&buffer)
+				args := append(tt.inputArgs, "--help")
+				UpdateAppUsageTemplate(app, args)
+
+				app.Usage(args)
+				require.Contains(t, buffer.String(), tt.outputContains)
+			})
+
+			t.Run("help command", func(t *testing.T) {
+				var buffer bytes.Buffer
+				app := makeApp(&buffer)
+				args := append([]string{"help"}, tt.inputArgs...)
+				UpdateAppUsageTemplate(app, args)
+
+				// HelpCommand is triggered on PreAction during Parse.
+				// See kingpin.Application.init for more details.
+				_, err := app.Parse(args)
+				require.NoError(t, err)
+				require.Contains(t, buffer.String(), tt.outputContains)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Backports #54394

* Add a CLI reference generator

See #3568

Add a function to update the kingpin usage template for a CLI application and print a docs page. As a starting point, includes a `docs` subcommand in `tsh` to call the function for that tool. By generating CLI documentation, we can ensure that commmand, argument, and flag usage information is consistent with the terminal help text for a given CLI. We can also ensure that all changes to a CLI application are reflected in the documentation.

As an alternative, we could edit `UpdateAppUsageTemplate` in `lib/utils` to update the usage template to print an MDX page, e.g., using build tags to print a docs template instead of the default usage template. This approach would update all CLI tools at once and use a consistent approach with minimal changes to each CLI tool. However, using a separate function to take a `*kingpin.Application` and print a docs page is more straightforward and explicit, even though it does require editing each CLI tool to call the function.

One shortcoming of generating the CLI reference docs versus our current manual approach is that it is non-trivial (and potentially impossible) to use `kingpin`'s usage API to obtain the value types of the subcommands, flags, and arguments registered against a `*kingpin.Application`. We can use flag and argument descriptions and default values to achieve the same purpose.

Another shortcoming is that `kingpin`'s usage API does not print usage information for arguments, environment variable, etc. that a CLI looks up directly from the OS, such as the `TELEPORT_CLUSTER` environment variable for `tsh`.

* Respond to zmb3 and atburke feedback

**Separate docs generation code from production code.**

Add a separate implementation of `UpdateAppUsageTemplate` that requires the `docs` build tag. Since all Go-based Teleport CLI tools call `UpdateAppUsageTemplate`, the `docs` build of the function ensure that the `help` command for Teleport CLI tools prints a docs page.

This change also adds a `cli-docs-tsh` make target to generate a docs page for `tsh`.

**Escape pipes in `formatHelp`** to avoid breaking table cells.

* Respond to atburke feedback

- Make the main help description more visible. Assume that the main help description is not necessarily a complete sentence, adding the text to the end of the introductory sentence using a colon.

- Add a make rule for running CLI docs generator tests. Use the `-run` flag since the tests are in a package we already run tests for in another make rule.

* Respond to zmb3 feedback

- Use Fprintf instead of Buffer.WriteString.
- Use the zero value of bytes.Buffer instead of NewBuffer.
- Rename `.*ToColumns` functions to `.*ToRows` for clarity.
- Use slices.ContainsFunc in anyVisibleFlags.
- Use slices.ContainsFunc in anyEnvVarsForCmd.
- Clean up argsToRows.
- Minor cleanup in TestUpdateAppUsageTemplate.
- Clean up sortCommandsByName (no need to implement sort.Interface).
- Read the docs usage template from disk in UpdateAppUsageTemplate. For this to work, add the function updateAppUsageTemplate, which takes an io.Reader, and use separate file paths to pass the io.Reader to the function in the tests and in UpdateAppUsageTemplate.
- Inline formatFlagForTable and remove unnecessary branching.
- Add an ADDTAGS environment variable to the `test-go-unit` make target so it's possible to pass arbitrary build tags, e.g., "docs".