### PR TITLE
Generate the tsh CLI reference

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -1146,6 +1146,7 @@
     "**/reference/infrastructure-as-code/operator-resources/**",
     "**/reference/infrastructure-as-code/teleport-resources/**",
     "**/reference/infrastructure-as-code/terraform-provider/**",
+    "pages/reference/cli/**",
     "../CHANGELOG.md"
   ]
 }

--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -694,7 +694,7 @@ Available key codes:
 ### `tsh ssh` environment variables
 
 Under the hood, Teleport Connect uses `tsh ssh` to connect to SSH servers. As a result,
-Teleport Connect will respect many [tsh environment variables](../../reference/cli/tsh.mdx#tsh-environment-variables)
+Teleport Connect will respect many [tsh environment variables](../../reference/cli/tsh.mdx)
 related to `tsh ssh`. This can make it easier to share common settings between `tsh` and Teleport Connect.
 
 Below is a list of environment variables supported by Teleport Connect for SSH connections:

--- a/docs/pages/connect-your-client/third-party/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/third-party/putty-winscp.mdx
@@ -368,7 +368,3 @@ If this error appears during normal day-to-day operation, this is a bug and shou
 To remove `tsh` and associated user data see
 [Uninstalling Teleport](../../installation/uninstall-teleport.mdx).
 
-## Further reading
-- [CLI Reference](../../reference/cli/tsh.mdx#tsh-puttyconfig).
-
-

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -1,390 +1,856 @@
 ---
-title: tsh CLI reference
+title: tsh Reference
+description: Provides a comprehensive list of commands, arguments, and flags for tsh.
 sidebar_label: tsh
-description: Comprehensive reference of subcommands, flags, and arguments for the tsh CLI tool.
 tags:
- - reference
- - platform-wide
+  - reference
+  - platform-wide
 ---
+{/*vale messaging = NO*/}
 
-`tsh` is a CLI client used by Teleport users. It allows users to interact with
-current and past sessions on the cluster, copy files to and from nodes, and list
-information about the cluster.
+This guide provides a comprehensive list of commands, arguments, and flags for
+tsh: Teleport Command Line Client.
 
-## tsh environment variables
+```code
+$ tsh [<flags>] <command> [<args> ...]
+```
 
-Environment variables configure your tsh client and can help you avoid using flags repetitively.
+Global flags:
 
-| Environment Variable | Description | Example Value |
-| - | - | - |
-| TELEPORT_AUTH | Any defined [authentication connector](../access-controls/authentication.mdx), including `passwordless` and `local` (i.e., no authentication connector) | okta |
-| TELEPORT_CLUSTER | Name of a Teleport root or leaf cluster | cluster.example.com |
-| TELEPORT_LOGIN | Login name to be used by default on the remote host | root |
-| TELEPORT_LOGIN_BIND_ADDR | Address in the form of host:port to bind to for login command webhook | host:port |
-| TELEPORT_LOGIN_BROWSER | Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser. | none |
-| TELEPORT_PROXY | Address of the Teleport proxy server | cluster.example.com:3080 |
-| TELEPORT_RELAY | Address of the Teleport relay server to use, "none" to disable the use of a relay, or "default" to use the default address specified by the control plane at login time. Defaults to port 443. | relay.example.com |
-| TELEPORT_HEADLESS | Use headless authentication | true, false, 1, 0 |
-| TELEPORT_HOME | Home location for tsh configuration and data | /directory |
-| TELEPORT_USER | A Teleport user name | alice |
-| TELEPORT_ADD_KEYS_TO_AGENT | Specifies if the user certificate should be stored on the running SSH agent | yes, no, auto, only |
-| TELEPORT_USE_LOCAL_SSH_AGENT | Disable or enable local SSH agent integration | true, false |
-| TELEPORT_GLOBAL_TSH_CONFIG | Override location of global `tsh` config file from default `/etc/tsh.yaml` | /opt/teleport/tsh.yaml |
-| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | auto, cross-platform, platform, otp, sso |
-| TELEPORT_IDENTITY_FILE | File path to identity file | /opt/identity |
+|Flag|Default|Description|
+|---|---|---|
+|`--auth`|none|Specify the name of authentication connector to use.|
+|`--bind-addr`|none|Override host:port used when opening a browser for cluster logins.|
+|`--callback`|none|Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.|
+|`--cert-format`|none|SSH certificate format.|
+|`-d`, `--[no-]debug`|`false`|Verbose logging to stdout.|
+|`-i`, `--identity`|none|Identity file.|
+|`-J`, `--jumphost`|none|SSH jumphost.|
+|`-k`, `--add-keys-to-agent`|`auto`|Controls how keys are handled. Valid values are \[auto no yes only\].|
+|`-l`, `--login`|none|Remote host login.|
+|`--mfa-mode`|`auto`|Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso).|
+|`--mlock`|`auto`|Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).|
+|`--[no-]enable-escape-sequences`|`true`|Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.|
+|`--[no-]headless`|`false`|Use headless login. Shorthand for --auth=headless.|
+|`--[no-]insecure`|`false`|Do not verify server's certificate and host name. Use only in test environments.|
+|`--[no-]os-log`|`false`|Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. More details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.|
+|`--[no-]skip-version-check`|`false`|Skip version checking between server and client.|
+|`--piv-slot`|none|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d".|
+|`--proxy`|none|Teleport proxy address.|
+|`--relay`|none|Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a different address was specified at login time.|
+|`--ttl`|none|Minutes to live for a session.|
+|`--user`|none|Teleport user, defaults to current local user.|
 
-## tsh global flags
+Global environment variables:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-l, --login` | none | an identity name | The login identity that the Teleport user will use |
-| `--proxy` | none | `host:https_port[,ssh_proxy_port]` | Teleport Proxy Service address |
-| `--relay` | none | `host[:port]|none|default` | Address of the Teleport relay server to use, "none" to disable the use of a relay, or "default" to use the default address specified by the control plane at login time. Defaults to port 443. |
-| `--user` | `$USER` | none | The Teleport username |
-| `--ttl` | `720` (12 hours) | integer | Number of minutes a certificate issued for the `tsh` user will be valid for |
-| `-i, --identity` | none | **string** filepath | Identity file |
-| `--cert-format` | `standard` | `standard` or `oldssh` | SSH certificate format. `oldssh` supports older versions of OpenSSH servers that do not allow for custom metadata, which is how Teleport encodes a user's roles in their SSH certificate. |
-| `--insecure` | none | none | Do not verify the server's certificate and host name. Use only in test environments. |
-| `--auth` | `local` | Any defined [authentication connector](../access-controls/authentication.mdx), including `passwordless` and `local` (i.e., no authentication connector) | Specify the type of authentication connector to use. |
-| `--mfa-mode` | auto | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
-| `--skip-version-check` | none | none | Skip version checking between server and client. |
-| `-d, --debug` | none | none | Verbose logging to stdout |
-| `-J, --jumphost` | none | A jump host | SSH jumphost |
-| `--headless` | none | none | Use Headless Authentication |
-| `--mlock` | `auto` | `auto`, `off`, `best_effort`, `strict` | Lock process memory to protect client secrets stored in memory from being swapped to disk. |
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_ADD_KEYS_TO_AGENT`|`auto`|Controls how keys are handled. Valid values are [auto no yes only].|
+|`TELEPORT_AUTH`|none|Specify the name of authentication connector to use.|
+|`TELEPORT_CLUSTER`|`none`|Name of a Teleport root or leaf cluster|
+|`TELEPORT_GLOBAL_TSH_CONFIG`|`none`|Override location of global `tsh` config file from default `/etc/tsh.yaml`|
+|`TELEPORT_HEADLESS`|`false`|Use headless login. Shorthand for --auth=headless.|
+|`TELEPORT_HOME`|`none`|Home location for tsh configuration and data|
+|`TELEPORT_IDENTITY_FILE`|none|Identity file.|
+|`TELEPORT_LOGIN`|none|Remote host login.|
+|`TELEPORT_LOGIN_BIND_ADDR`|none|Override host:port used when opening a browser for cluster logins.|
+|`TELEPORT_MFA_MODE`|`auto`|Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso).|
+|`TELEPORT_MLOCK_MODE`|`auto`|Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).|
+|`TELEPORT_PIV_SLOT`|none|Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d".|
+|`TELEPORT_PROXY`|none|Teleport proxy address.|
+|`TELEPORT_RELAY`|none|Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a different address was specified at login time.|
+|`TELEPORT_USER`|none|Teleport user, defaults to current local user.|
+
+## tsh apps config
+
+Print app connection information.
+
+Usage:
+
+```code
+$ tsh apps config [<flags>] [<app>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|none|Optional print format, one of: "uri" to print app address, "ca" to print CA cert path, "cert" to print cert path, "key" print key path, "curl" to print example curl command, "json" or "yaml" to print everything as JSON or YAML.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|app|none (optional)|App to print information for. Required when logged into multiple apps.|
+
+## tsh apps login
+
+Retrieve short-lived certificate for an app.
+
+Usage:
+
+```code
+$ tsh apps login [<flags>] <app>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--aws-role`|none|(For AWS CLI access only) Amazon IAM role ARN or role name.|
+|`--azure-identity`|none|(For Azure CLI access only) Azure managed identity name.|
+|`--gcp-service-account`|none|(For GCP CLI access only) GCP service account name.|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`--target-port`|none|Port to which connections made using this cert should be routed to. Valid only for multi-port TCP apps.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|app|none (required)|App name to retrieve credentials for. Can be obtained from `tsh apps ls` output.|
+
+## tsh apps logout
+
+Remove app certificate.
+
+Usage:
+
+```code
+$ tsh apps logout [<app>]
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|app|none (optional)|App to remove credentials for.|
 
 ## tsh apps ls
 
-List all available applications:
+List available applications.
+
+Usage:
 
 ```code
-$ tsh apps ls
+$ tsh apps ls [<flags>] [<labels>]
 ```
 
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-R`, `--[no-]all`|`false`|List apps from all clusters and proxies.|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Show extra application fields.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+
+## tsh aws
+
+Access AWS API.
+
+Usage:
+
+```code
+$ tsh aws [<flags>] [<command>...]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional Name of the AWS application to use if logged into multiple.|
+|`--aws-role`|none|(For AWS CLI access only) Amazon IAM role ARN or role name.|
+|`--exec`|none|Execute different commands (e.g. terraform) under Teleport credentials.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|AWS command and subcommands arguments that are going to be forwarded to AWS CLI.|
+
+## tsh az
+
+Access Azure API.
+
+Usage:
+
+```code
+$ tsh az [<flags>] [<command>...]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional name of the Azure application to use if logged into multiple.|
+|`--azure-identity`|none|(For Azure CLI access only) Azure managed identity name.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|`az` command and subcommands arguments that are going to be forwarded to Azure CLI.|
+
 ## tsh clusters
+
+List available Teleport clusters.
+
+Usage:
 
 ```code
 $ tsh clusters [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-q, --quiet` | none | none | no headers in output |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh clusters
-
-# Cluster Name Status
-# ------------ ------
-# staging          online
-# production       offline
-
-$ tsh clusters --quiet
-
-# staging online
-# production offline
-```
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output.|
 
 ## tsh config
 
-Print OpenSSH configuration details to allow using an SSH
-client with credentials managed by Teleport to connect to
-hosts in your cluster.
+Print OpenSSH configuration details.
+
+Usage:
 
 ```code
-$ tsh config
+$ tsh config [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-l, --login` | none | Linux username | Default Linux username to use. Will translate to SSH config's `User` option. |
-| `-p`, `--port` | 3022 | port | Default SSH port to use. Will translate to SSH config's `Port` option. |
+|Flag|Default|Description|
+|---|---|---|
+|`-p`, `--port`|none|SSH port on a remote host.|
 
+## tsh db config
 
-### Examples
+Print database connection information. Useful when configuring GUI clients.
+
+Usage:
 
 ```code
-# Print OpenSSH config file to console
-$ tsh config
-
-# Append Teleport configuration to ssh config
-$ tsh config >> ~/.ssh/config
+$ tsh db config [<flags>] [<db>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|none|Print format: "text" to print in table format (default), "cmd" to print connect command, "json" or "yaml" to print in JSON or YAML.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|Print information for the specified database.|
+
+## tsh db connect
+
+Connect to a database.
+
+Usage:
+
+```code
+$ tsh db connect [<flags>] [<db>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`-n`, `--db-name`|none|Database name to log in to.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource Access Requests.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-r`, `--db-roles`|none|List of comma separate database roles to use for auto-provisioned user.|
+|`--request-reason`|none|Reason for requesting access.|
+|`-u`, `--db-user`|none|Database user to log in as.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|Database service name to connect to.|
+
+## tsh db env
+
+Print environment variables for the configured database.
+
+Usage:
+
+```code
+$ tsh db env [<flags>] [<db>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|Print environment for the specified database.|
+
+## tsh db exec
+
+Execute database commands on target database services.
+
+Usage:
+
+```code
+$ tsh db exec [<flags>] <command>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--dbs`|none|List of comma separated target database services. Mutually exclusive with --search or --labels.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`-n`, `--db-name`|none|Database name to log in to.|
+|`--[no-]confirm`|`true`|Confirm selected database services before executing command.|
+|`--output-dir`|none|Directory to store command output per target database service. A summary is saved as "summary.json".|
+|`--parallel`|`1`|Run commands on target databases in parallel. Defaults to 1, and maximum allowed is 10.|
+|`-r`, `--db-roles`|none|List of comma separate database roles to use for auto-provisioned user.|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-u`, `--db-user`|none|Database user to log in as.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (required)|Execute this command on target database services.|
+
+## tsh db login
+
+Retrieve credentials for a database.
+
+Usage:
+
+```code
+$ tsh db login [<flags>] [<db>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`-n`, `--db-name`|none|Database name to configure as default.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource Access Requests.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-r`, `--db-roles`|none|List of comma separate database roles to use for auto-provisioned user.|
+|`--request-reason`|none|Reason for requesting access.|
+|`-u`, `--db-user`|none|Database user to configure as default.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|Database to retrieve credentials for. Can be obtained from 'tsh db ls' output.|
+
+## tsh db logout
+
+Remove database credentials.
+
+Usage:
+
+```code
+$ tsh db logout [<flags>] [<db>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|Database to remove credentials for.|
+
+## tsh db ls
+
+List all available databases.
+
+Usage:
+
+```code
+$ tsh db ls [<flags>] [<labels>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-R`, `--[no-]all`|`false`|List databases from all clusters and proxies.|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Show extra database fields.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh device enroll
 
-Enroll the current device as a trusted device.
+Enroll this device as a trusted device. Requires Teleport Enterprise.
 
-Requires a device enrollment token created via `tctl devices enroll`.
-
-```code
-$ tsh device enroll --token=TOKEN
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--token` | none | String | Device enrollment token |
-
-### Examples
+Usage:
 
 ```code
-$ tsh device enroll --token=(=devicetrust.enroll_token=)
-Device "(=devicetrust.asset_tag=)"/macOS enrolled
+$ tsh device enroll [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]current-device`|`false`|Attempts to register and enroll the current device. Requires device admin privileges.|
+|`--token`|none|Device enrollment token.|
+
+## tsh env
+
+Print commands to set Teleport session environment variables.
+
+Usage:
+
+```code
+$ tsh env [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]unset`|`false`|Print commands to clear Teleport session environment variables.|
 
 ## tsh gcloud
 
-Proxy `gcloud` CLI commands through the Teleport Application Service. `gcloud`
-is a tool for interacting with Google Cloud. A user must already be
-authenticated to a Google Cloud application in Teleport before they can execute
-`tsh gcloud` commands.
+Access GCP API with the gcloud command.
+
+Usage:
 
 ```code
-$ tsh gcloud [--app] [<command>]
+$ tsh gcloud [<flags>] [<command>...]
 ```
 
-### Arguments
+Flags:
 
-`command`: A `gcloud` command to run, including arguments and flags.
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional name of the GCP application to use if logged into multiple.|
+|`--gcp-service-account`|none|(For GCP CLI access only) GCP service account name.|
 
-### Flags
+Arguments:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|`gcloud` command and subcommands arguments.|
 
-### Global flags
+## tsh git clone
 
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+Clone a Git repository.
 
-### Examples
+Usage:
 
 ```code
-$ tsh gcloud compute instances list
+$ tsh git clone <repository> [<directory>]
 ```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|directory|none (optional)|The name of a new directory to clone into.|
+|repository|none (required)|Git URL of the repository to clone.|
+
+## tsh git config
+
+Check Teleport config on the working Git directory. Or provide an action
+('update' or 'reset') to configure the Git repo.
+
+Usage:
+
+```code
+$ tsh git config [<action>]
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|action|none (optional)|Optional action to perform. 'update' to configure the Git repo to proxy Git commands through Teleport. 'reset' to clear Teleport configuration from the Git repo.|
+
+## tsh git login
+
+Opens a browser and retrieves your login from GitHub.
+
+Usage:
+
+```code
+$ tsh git login --github-org=GITHUB-ORG [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--github-org`|none|GitHub organization.|
+|`--[no-]force`|`false`|Force a login.|
+
+## tsh git ls
+
+List Git servers.
+
+Usage:
+
+```code
+$ tsh git ls [<flags>] [<labels>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh gsutil
 
-Proxy `gsutil` CLI commands through the Teleport Application Service. `gsutil`
-is a tool for interacting with Google Cloud Storage. A user must already be
-authenticated to a Google Cloud application in Teleport before they can execute
-`tsh gsutil` commands.
+Access Google Cloud Storage with the gsutil command.
+
+Usage:
 
 ```code
-$ tsh gsutil [--app] [<command>]
+$ tsh gsutil [<flags>] [<command>...]
 ```
 
-### Arguments
+Flags:
 
-`command`: A `gsutil` command to run, including arguments and flags.
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional name of the GCP application to use if logged into multiple.|
+|`--gcp-service-account`|none|(For GCP CLI access only) GCP service account name.|
 
-### Flags
+Arguments:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|`gsutil` command and subcommands arguments.|
 
-### Global flags
+## tsh headless approve
 
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+Approve a headless authentication request.
 
-### Examples
+Usage:
 
 ```code
-$ tsh gsutil ls
+$ tsh headless approve [<flags>] [<request id>]
 ```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_HEADLESS_SKIP_CONFIRM`|`false`|Skip confirmation and prompt for MFA immediately.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]skip-confirm`|`false`|Skip confirmation and prompt for MFA immediately.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|request id|none (optional)|Headless authentication request ID.|
 
 ## tsh help
 
-Prints help:
+Show help.
+
+Usage:
 
 ```code
-$ tsh help
+$ tsh help [<command>...]
 ```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Show help on command.|
 
 ## tsh join
 
-Joins an active session:
+Join the active SSH or Kubernetes session.
+
+Usage:
 
 ```code
 $ tsh join [<flags>] <session-id>
 ```
 
-### Arguments
+Flags:
 
-`<session-id>`
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-m`, `--mode`|`observer`|Mode of joining the session, valid modes are observer, moderator and peer.|
 
-- `session-id` The UUID of an active Teleport Session obtained by `teleport status` within
-  the session.
+Arguments:
 
-### Flags
+|Argument|Default|Description|
+|---|---|---|
+|session-id|none (required)|ID of the session to join.|
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | a cluster_name | Specify the cluster to connect |
+## tsh kube exec
 
-### Global flags
+Execute a command in a Kubernetes pod.
 
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
+Usage:
 
 ```code
-# join session using teleport user joe as ec2-user
-$ tsh --user=joe --login=ec2-user join <session-id>
+$ tsh kube exec [<flags>] <target> <command>...
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--container`|none|Container name. If omitted, use the kubectl.kubernetes.io/default-container annotation for selecting the container to be attached or the first container in the pod will be chosen.|
+|`-f`, `--filename`|none|To use to exec into the resource.|
+|`--invite`|none|A comma separated list of people to mark as invited for the session.|
+|`-n`, `--namespace`|none|Configure the default Kubernetes namespace.|
+|`--[no-]participant-req`|`false`|Displays a verbose list of required participants in a moderated session.|
+|`-q`, `--[no-]quiet`|`false`|Only print output from the remote session.|
+|`--reason`|none|The purpose of the session.|
+|`-s`, `--[no-]stdin`|`false`|Pass stdin to the container.|
+|`-t`, `--[no-]tty`|`false`|Stdin is a TTY.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (required)|Command to execute in the container.|
+|target|none (required)|Pod or deployment name.|
+
+## tsh kube join
+
+Join an active Kubernetes session.
+
+Usage:
+
+```code
+$ tsh kube join [<flags>] <session>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-m`, `--mode`|`observer`|Mode of joining the session, valid modes are observer, moderator and peer.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|session|none (required)|The ID of the target session.|
 
 ## tsh kube login
 
-Log into a Kubernetes cluster. Discover connected clusters by using [`tsh kube ls`](#tsh-kube-ls).
+Login to a Kubernetes cluster.
+
+Usage:
 
 ```code
-$ tsh kube login <kube-cluster>
+$ tsh kube login [<flags>] [<kube-cluster>]
 ```
 
-```code
-# tsh kube login to k8s cluster (gke_bens-demos_us-central1-c_gks-demo)
-$ tsh kube login gke_bens-demos_us-central1-c_gks-demo
-# Logged into kubernetes cluster "gke_bens-demos_us-central1-c_gks-demo". Try 'kubectl version' to test the connection.
+Flags:
 
-# On login, kubeconfig is pointed at the first cluster (alphabetically)
-$ kubectl config current-context
-# aws-gke_bens-demos_us-central1-c_gks-demo
+|Flag|Default|Description|
+|---|---|---|
+|`--as`|none|Configure custom Kubernetes user impersonation.|
+|`--as-groups`|none|Configure custom Kubernetes group impersonation.|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`-n`, `--namespace`|none|Configure the default Kubernetes namespace.|
+|`--[no-]all`|`false`|Generate a kubeconfig with every cluster the user has access to. Mutually exclusive with --labels or --query.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource Access Requests.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--request-reason`|none|Reason for requesting access.|
+|`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name. To use it with --all include "\{\{.KubeName\}\}".|
 
-# But all clusters are populated as contexts
-$ kubectl config get-contexts
+Arguments:
 
-# CURRENT   NAME                                        CLUSTER                       AUTHINFO                                    NAMESPACE
-# *         aws-gke_bens-demos_us-central1-c_gks-demo   aws                           aws-gke_bens-demos_us-central1-c_gks-demo
-#          aws-microk8s                                aws                           aws-microk8s
-```
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--all` | false | Boolean | Whether to generate a kubeconfig for every Kubernetes cluster the current Teleport user has access to. If this is false, `tsh` will only generate a kubeconfig for the cluster specified in the `tsh kube login` command.|
-| `--as` | none | string | The Kubernetes user that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target user. |
-| `--as-groups` | none | string | A Kubernetes group that the current Teleport user will log in as when they authenticate to the specified Kubernetes cluster. <br/><br/>This uses [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation), so the Teleport user's Kubernetes user must have permissions to impersonate the target group. <br /><br/>You can include this flag multiple times to enable impersonation of multiple Kubernetes groups. |
-| `--cluster` | none | string | Name of the Teleport cluster to log into in order to connect to the given Kubernetes cluster. |
-| `-n`, `--kube-namespace` | none | string | The name of the Kubernetes namespace to configure as the default within the cluster the user is logging into. |
+|Argument|Default|Description|
+|---|---|---|
+|kube-cluster|none (optional)|Name of the Kubernetes cluster to login to. Check 'tsh kube ls' for a list of available clusters.|
 
 ## tsh kube ls
 
-List Kubernetes clusters:
+Get a list of Kubernetes clusters.
+
+Usage:
 
 ```code
-$ tsh kube ls
+$ tsh kube ls [<flags>] [<labels>]
 ```
 
-### Examples
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-R`, `--[no-]all`|`false`|List Kubernetes clusters from all clusters and proxies.|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Show an untruncated list of labels.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+
+## tsh kube sessions
+
+Get a list of active Kubernetes sessions. (DEPRECATED: use tsh sessions ls
+--kind=kube instead.)
+
+Usage:
 
 ```code
-$ tsh kube ls
-
-# Kube Cluster Name                     Selected
-# ------------------------------------- --------
-# gke_bens-demos_us-central1-c_gks-demo *
-# microk8s
+$ tsh kube sessions [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+
+## tsh kubectl
+
+Runs a kubectl command on a Kubernetes cluster.
+
+Usage:
+
+```code
+$ tsh kubectl [args...]
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|args|none (optional)|Arbitrary arguments|
+
+## tsh latency ssh
+
+Measure latency to a particular SSH host.
+
+Usage:
+
+```code
+$ tsh latency ssh [<flags>] <[user@]host>
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|[user@]host|none (required)|Remote hostname and the login to use.|
 
 ## tsh login
 
-Logs in to the cluster. When `tsh` logs in, the auto-expiring key is stored in
-`~/.tsh` and is valid for 12 hours by default unless you specify another
-interval via `--ttl` flag (capped by the server-side configuration).
+Log in to a cluster and retrieve the session certificate.
+
+Usage:
 
 ```code
 $ tsh login [<flags>] [<cluster>]
 ```
 
-### Arguments
+Flags:
 
-- `<cluster>` - the name of the cluster,  see [Trusted Cluster](../../zero-trust-access/deploy-a-cluster/trustedclusters.mdx) for more information.
+|Flag|Default|Description|
+|---|---|---|
+|`--browser`|none|Set to 'none' to suppress browser opening on login.|
+|`-f`, `--format`|`file`|Identity format: file, openssh (for OpenSSH compatibility) or kubernetes (for kubeconfig).|
+|`--kube-cluster`|none|Name of the Kubernetes cluster to login to.|
+|`--[no-]overwrite`|`false`|Whether to overwrite the existing identity file.|
+|`--[no-]request-nowait`|`false`|Finish without waiting for request resolution.|
+|`-o`, `--out`|none|Identity output.|
+|`--request-id`|none|Login with the roles requested in the given request.|
+|`--request-reason`|none|Reason for requesting additional roles.|
+|`--request-reviewers`|none|Suggested reviewers for role request.|
+|`--request-roles`|none|Request one or more extra roles.|
+|`--scope`|none|Scope pins credentials to a given scope.|
+|`-v`, `--[no-]verbose`|`false`|Show extra status information.|
 
-### Flags
+Arguments:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--bind-addr` | none | host:port | Address in the form of host:port to bind to for login command webhook |
-| `--callback` | none | host:port | Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.
-| `-o, --out` | none | filepath | Identity output filepath |
-| `--format` | `file` | `file`, `openssh` or `kubernetes` | Identity format: file, openssh (for OpenSSH compatibility) or kubernetes (for kubeconfig) |
-| `--browser` | none | `none` | Set to 'none' to suppress opening system default browser for `tsh login` commands |
-| `--request-roles` | none | | Request one or more extra roles |
-| `--request-reason` | none | | Reason for requesting additional roles |
-| `--request-nowait` | none | | Finish without waiting for request resolution |
-| `--request-id` | none | | Login with the roles requested in the given request |
-| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`) |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-A relay address specified (or explicitly disabled with the "none" value) at login time will be stored in the `tsh` configuration directory for the specified proxy; if unspecified, the relay address may fall back to a default value specified by the Teleport control plane. Use of a Relay requires `tsh` v18.3.0 or later.
-
-### Examples
-
-*The proxy endpoint can take a https and ssh port in this format `host:https_port[,ssh_proxy_port]`*
-
-```code
-# Try both ports 443 and 3080 for https
-$ tsh --proxy=proxy.example.com login
-
-# Use ports 8080 and 8023 for https and SSH proxy:
-$ tsh --proxy=proxy.example.com:8080,8023 login
-
-# Use port 8080 and 3023 (default) for SSH proxy:
-$ tsh --proxy=proxy.example.com:8080 login
-
-# Use port 23 as custom SSH port, keep HTTPS proxy port as default
-$ tsh --proxy=work.example.com:,23 login
-
-# Login and select cluster "two":
-$ tsh --proxy=proxy.example.com login two
-
-# Select cluster "two" using existing credentials and proxy:
-$ tsh login two
-
-# Login to the  cluster with a very short-lived certificate
-$ tsh --ttl=1 login
-
-# Login using the local Teleport 'admin' user:
-$ tsh --proxy=proxy.example.com --auth=local --user=admin login
-
-# Login using GitHub as an SSO provider, assuming the GitHub connector is called "github"
-$ tsh --proxy=proxy.example.com --auth=github login
-
-# Suppress the opening of the system default browser for external provider logins
-$ tsh --proxy=proxy.example.com --browser=none
-
-# Login to cluster and output a local kubeconfig
-$ tsh login --proxy=proxy.example.com --format=kubernetes -o kubeconfig
-
-# Request access to a cluster.
-$ tsh login --proxy=proxy.example.com --request-reason="I need to run a debug script on production"
-```
+|Argument|Default|Description|
+|---|---|---|
+|cluster|none (optional)|Specify the Teleport cluster to connect.|
 
 ## tsh logout
 
-Deletes the client's cluster certificate:
+Delete a cluster certificate.
+
+Usage:
 
 ```code
 $ tsh logout
@@ -392,918 +858,831 @@ $ tsh logout
 
 ## tsh ls
 
-List cluster nodes:
+List remote SSH nodes.
+
+Usage:
 
 ```code
-$ tsh ls [<flags>] [<label>]
+$ tsh ls [<flags>] [<labels>]
 ```
 
-<details>
-<summary>Not seeing Nodes?</summary>
+Flags:
 
-(!docs/pages/includes/node-logins.mdx!)
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`text`|Format output (text, json, yaml, names).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-R`, `--[no-]all`|`false`|List nodes from all clusters and proxies.|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|One-line output (for text format), including node UUIDs.|
 
-</details>
+Arguments:
 
-### Arguments
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
-- `<labels>` - comma-separated list of `key=value` labels to filter nodes by,
-  e.g., `env=dev,host=foo`.
+## tsh mcp config
 
-### Flags
+Print client configuration details.
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-v, --verbose` | none | none | also print Node ID |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
+Usage:
 
 ```code
-$ tsh ls
-
-# Node Name Address            Labels
-# --------- ------------------ ------
-# grav-00   10.164.0.0:3022    os:linux
-# grav-01   10.156.0.2:3022    os:linux
-# grav-02   10.156.0.7:3022    os:osx
-
-$ tsh ls -v
-
-# Node Name Node ID                              Address            Labels
-# --------- ------------------------------------ ------------------ ------
-# grav-00   52e3e46a-372f-494b-bdd9-a1d25b9d6dec 10.164.0.0:3022    os:linux
-# grav-01   73d86fc7-7c4b-42e3-9a5f-c46e177a29e8 10.156.0.2:3022    os:linux
-# grav-02  24503590-e8ae-4a0a-ad7a-dd1865c04e30 10.156.0.7:3022     os:osx
-
-# Only show nodes with os label set to 'osx':
-$ tsh ls os=osx
-
-# Node Name Address            Labels
-# --------- ------------------ ------
-# grav-02   10.156.0.7:3022    os:osx
+$ tsh mcp config [<flags>] [<name>]
 ```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_MCP_CLIENT_CONFIG`|none|If specified, update the specified client config, assuming its format. "claude" for default Claude Desktop config, "cursor" for global Cursor MCP servers config, or specify a JSON file path. Can also be set with environment variable TELEPORT_MCP_CLIENT_CONFIG.|
+|`TELEPORT_MCP_CONFIG_JSON_FORMAT`|`auto`|Format the JSON file (pretty, compact, auto, none). auto saves in compact if the file is already compact, otherwise pretty. Can also be set with environment variable TELEPORT_MCP_CONFIG_JSON_FORMAT. Default is auto.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--client-config`|none|If specified, update the specified client config, assuming its format. "claude" for default Claude Desktop config, "cursor" for global Cursor MCP servers config, or specify a JSON file path. Can also be set with environment variable TELEPORT_MCP_CLIENT_CONFIG.|
+|`--format`|none|Format specifies the configuration format (claude, vscode, cursor). If not provided it will assume format from the configuration file, When no configuration file is provided it defaults to "claude".|
+|`-H`, `--header`|none|Extra custom headers used for streamable HTTP MCP servers.|
+|`--json-format`|`auto`|Format the JSON file (pretty, compact, auto, none). auto saves in compact if the file is already compact, otherwise pretty. Can also be set with environment variable TELEPORT_MCP_CONFIG_JSON_FORMAT. Default is auto.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--[no-]auto-reconnect`|`false`|Automatically starts a new remote MCP session when the previous remote session is interrupted by network issues or tsh session expirations. Recommended for stateless MCP sessions. Defaults to true.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-R`, `--[no-]all`|`false`|Select all MCP servers. Mutually exclusive with --labels or --query.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (optional)|Name of the MCP server.|
+
+## tsh mcp db config
+
+Print client configuration details.
+
+Usage:
+
+```code
+$ tsh mcp db config [<flags>] [<name>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_MCP_CLIENT_CONFIG`|none|If specified, update the specified client config, assuming its format. "claude" for default Claude Desktop config, "cursor" for global Cursor MCP servers config, or specify a JSON file path. Can also be set with environment variable TELEPORT_MCP_CLIENT_CONFIG.|
+|`TELEPORT_MCP_CONFIG_JSON_FORMAT`|`auto`|Format the JSON file (pretty, compact, auto, none). auto saves in compact if the file is already compact, otherwise pretty. Can also be set with environment variable TELEPORT_MCP_CONFIG_JSON_FORMAT. Default is auto.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--client-config`|none|If specified, update the specified client config, assuming its format. "claude" for default Claude Desktop config, "cursor" for global Cursor MCP servers config, or specify a JSON file path. Can also be set with environment variable TELEPORT_MCP_CLIENT_CONFIG.|
+|`--format`|none|Format specifies the configuration format (claude, vscode, cursor). If not provided it will assume format from the configuration file, When no configuration file is provided it defaults to "claude".|
+|`--json-format`|`auto`|Format the JSON file (pretty, compact, auto, none). auto saves in compact if the file is already compact, otherwise pretty. Can also be set with environment variable TELEPORT_MCP_CONFIG_JSON_FORMAT. Default is auto.|
+|`-n`, `--db-name`|none|Database name to log in to.|
+|`--[no-]overwrite`|`false`|Overwrites command and environment variable from the config file.|
+|`-u`, `--db-user`|none|Database user to log in as.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (optional)|Database service name.|
+
+## tsh mcp ls
+
+List available MCP server applications.
+
+Usage:
+
+```code
+$ tsh mcp ls [<flags>] [<labels>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Show extra MCP server fields.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|labels|none (optional)|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
 
 ## tsh mfa add
 
-Register a new Multi-Factor Authentication (MFA) device:
+Add a new MFA device.
+
+Usage:
 
 ```code
-$ tsh mfa add
+$ tsh mfa add [<flags>]
 ```
 
-### Examples
+Flags:
 
-```code
-$ tsh mfa add
-
-# Choose device type [TOTP, WEBAUTHN]: webauthn
-# Enter device name: desktop yubikey
-# Tap any *registered* security key
-# Tap your *new* security key
-# MFA device "desktop yubikey" added.
-```
-
-```code
-$ tsh mfa add
-
-# Choose device type [TOTP, WEBAUTHN]: totp
-# Enter device name: android
-# Tap any *registered* security key
-# Open your TOTP app and create a new manual entry with these fields:
-# Name: awly@example.com:3080
-# Issuer: Teleport
-# Algorithm: SHA1
-# Number of digits: 6
-# Period: 30s
-# Secret: 6DHDR7GWA7ZKLLWEWRIF55WXJKZ52UVJ
-
-# Once created, enter an OTP code generated by the app: 123456
-# MFA device "android" added.
-```
+|Flag|Default|Description|
+|---|---|---|
+|`--name`|none|Name of the new MFA device.|
+|`--type`|none|Type of the new MFA device (TOTP, WEBAUTHN).|
 
 ## tsh mfa ls
 
-List all registered Multi-Factor Authentication (MFA) devices:
+Get a list of registered MFA devices.
+
+Usage:
 
 ```code
-$ tsh mfa ls
+$ tsh mfa ls [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-v`, `--[no-]verbose`|`false`|Print more information about MFA devices.|
 
 ## tsh mfa rm
 
-Remove a registered Multi-Factor Authentication (MFA) device. You can view your
-registered devices using [`tsh mfa ls`](#tsh-mfa-ls).
+Remove a MFA device.
+
+Usage:
 
 ```code
-$ tsh mfa rm <device-name>
+$ tsh mfa rm <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name or ID of the MFA device to remove.|
+
+## tsh piv agent
+
+Start PIV key agent.
+
+Usage:
+
+```code
+$ tsh piv agent
 ```
 
 ## tsh play
 
-Plays back a prior session:
+Replay the recorded session (SSH, Kubernetes, App, DB).
+
+Usage:
 
 ```code
-$ tsh play [<flags>] <id-or-file>
+$ tsh play [<flags>] <session-id>
 ```
 
-### Arguments
+Flags:
 
-`<id-or-file>`
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`pty`|Format output (pty, json, yaml, text).|
+|`--[no-]skip-idle-time`|`false`|Quickly skip over idle time, applicable when streaming SSH or Kubernetes sessions.|
+|`--speed`|`1x`|Playback speed, applicable when streaming SSH or Kubernetes sessions.|
 
-- `id-or-file` The UUID of a past Teleport session, or the path to a local recording file. If the session is encrypted, it must be streamed from the Teleport Auth Service and local file playback is not possible.
+Arguments:
 
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none   | a cluster_name                 | Specify the cluster to connect |
-| `--format`  | `pty`  | `json`, `yaml`, `pty`, `text`  | Format for playback |
-| `--speed`   | `1x`   | `0.5x`, `1x`, `2x`, `4x`, `8x` | Playback speed |
-| `--skip-idle-time` | `false` | `true, `false` | Skip idle time during playback |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh --proxy proxy.example.com play <session-id>
-
-# Playing back a session streamed from the server.
-$ tsh play 1fe153d1-ce8b-4ef4-9908-6539457ba4ad
-
-# Playing back a local session in JSON format using jq to filter on events
-$ tsh play --format=json ~/play/0c0b81ed-91a9-4a2a-8d7c-7495891a6ca0.tar | jq '.event
-
-# Playing back a session at 2x speed while also skipping idle time
-$ tsh play --speed=2x --skip-idle-time 1fe153d1-ce8b-4ef4-9908-6539457ba4ad
-
-# Dump an SSH session recording to standard out, without respecting timing data.
-$ tsh play --format=text 1fe153d1-ce8b-4ef4-9908-6539457ba4ad
-```
+|Argument|Default|Description|
+|---|---|---|
+|session-id|none (required)|ID or path to session file to play.|
 
 ## tsh proxy app
 
-Starts a local TLS proxy for Application Service connections.
-You can use this proxy to connect to an application repeatedly after a single login to your Teleport cluster,
-which is especially useful for interacting with an application via a CLI.
+Start local TLS proxy for app connection when using Teleport in single-port
+mode.
+
+Usage:
 
 ```code
 $ tsh proxy app [<flags>] <app>
 ```
 
-### Arguments
-`<app>`
+Flags:
 
-- `app` The name of the application to start the local proxy for. To see a list of available applications, run `tsh apps ls`.
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-p`, `--port`|none|Specifies the listening port used by by the proxy app listener. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678".|
 
-### Flags
+Arguments:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-p, --port` | none | port number, port pair | Specify the listening port for the local proxy. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678". |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-```code
-$ tsh proxy app <app>
-
-# Proxy a connection to grafana on local port 10700
-$ tsh proxy --port 10700 app grafana &
-# Proxying connections to grafana on 127.0.0.1:10700
-$ curl http://127.0.0.1:10700/api/users
-```
+|Argument|Default|Description|
+|---|---|---|
+|app|none (required)|The name of the application to start local proxy for.|
 
 ## tsh proxy aws
 
-Start a local proxy for AWS access. The user must already be logged in to at
-least one AWS application via Teleport before the proxy can start.
+Start local proxy for AWS access.
+
+Usage:
 
 ```code
 $ tsh proxy aws [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in AWS app | string | Optional name of the AWS application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
-| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-# Proxy a connection to AWS with the default settings
-$ tsh apps login awsapp
-$ tsh proxy aws
-# Set env variables from output
-$ aws s3 ls
-
-# Proxying connections to AWS on 127.0.0.1:10700 to app awsapp2
-$ tsh apps logins awsapp2
-$ tsh proxy aws --port=10700 --app=awsapp2
-# Set env variables from output
-$ aws s3 ls
-```
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional Name of the AWS application to use if logged into multiple.|
+|`-f`, `--format`|`unix`|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix. Or specify a service format, one of: athena-odbc, athena-jdbc.|
+|`-p`, `--port`|none|Specifies the source port used by the proxy listener.|
 
 ## tsh proxy azure
 
-Starts a local proxy server that provides secure access to an Azure managed
-service identity endpoint. This is useful for managing access to Azure from
-custom client applications. The local proxy forwards traffic to the Teleport
-Application Service, which uses an Azure managed identity to fetch an
-authentication token from Azure.
+Start local proxy for Azure access.
+
+Usage:
 
 ```code
 $ tsh proxy azure [<flags>]
 ```
 
-The command will print the address of the local proxy server along with `export`
-commands for environment variables required to connect:
+Flags:
 
-(!docs/pages/includes/application-access/azure-tsh-proxy-azure-sample.mdx!)
-
-<Admonition type="tip">
-
-`tsh proxy azure` runs the local proxy in the foreground, so don't interrupt
-the process or exit the terminal where you ran the command until you're ready
-to close the local proxy.
-
-</Admonition>
-
-Copy the `export` commands and paste them into a second terminal.
-
-To run the local proxy server, one of the user's roles must include the
-`spec.allow.azure_identities` field with one of the identities used by the
-Application Service. To learn how to set up secure access to Azure via
-Teleport, read [Protect the Azure CLI with Teleport Application
-Access](../../enroll-resources/application-access/cloud-apis/azure.mdx).
-
-### Arguments
-
-This command does not accept any arguments.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. |
-| `--port` | none | port number | The port on `localhost` where the local proxy will listen for connections. |
-| `--format` | `powershell` if on Windows, `unix` otherwise | `text`, `unix`, `command-prompt`, or `powershell` | The format to use for listing environment variables for Azure client applications connecting to the local proxy. |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional Name of the Azure application to use if logged into multiple.|
+|`-f`, `--format`|`unix`|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
+|`-p`, `--port`|none|Specifies the source port used by the proxy listener.|
 
 ## tsh proxy db
 
-Start a local TLS proxy for database connections when using Teleport with TLS
-Routing enabled. Clients can connect to a Teleport-registered database through
-the local proxy.
+Start local TLS proxy for database connections when using Teleport in
+single-port mode.
+
+Usage:
 
 ```code
-$ tsh proxy db [<flags>] <db>
+$ tsh proxy db [<flags>] [<db>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | string | The name of the Teleport cluster to connect to. |
-| `--db-name` | see below | string | The database name to log in to. |
-| `--db-user` | see below | string | The database user to log in as. |
-| `--port` | none | string | Source port used by the local proxy.|
-| `--tunnel` | none | Boolean | Open an authenticated tunnel using a database's client certificate so clients don't need to authenticate. |
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--listen`|none|Specifies the source address used by proxy db listener. Mutually exclusive with --port.|
+|`-n`, `--db-name`|none|Database name to log in to.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource Access Requests.|
+|`--[no-]insecure-listen-anywhere`|`false`|Allows the local proxy to listen on any address without restrictions. WARNING: this will expose unsecured listener to anyone in the network. Only use when network access is otherwise restricted.|
+|`--[no-]tunnel`|`false`|Open authenticated tunnel using database's client certificate so clients don't need to authenticate.|
+|`-p`, `--port`|none|Specifies the source port used by proxy db listener.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`-r`, `--db-roles`|none|List of comma separate database roles to use for auto-provisioned user.|
+|`--request-reason`|none|Reason for requesting access.|
+|`-u`, `--db-user`|none|Database user to log in as.|
 
-(!docs/pages/includes/db-user-name-flags.mdx!)
+Arguments:
 
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-Proxy a DB connection to a named database
-```code
-$ tsh proxy db <db>
-```
-
-Proxy a connection to mysql db on local port 10700:
-```code
-$ tsh proxy db --port 10700  mysql-db
-# Started DB proxy on 127.0.0.1:10700
-
-# Use following credentials to connect to the mysql-db proxy:
-#  ca_file=/Users/jeff/.tsh/keys/teleport.example.com/cas/teleport.example.com.pem
-#  cert_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff-db/tele1c/mysql-db-x509.pem
-#  key_file=/Users/jeff/.tsh/keys/teleport.example.com/jeff
-```
-
-Proxy a connection to mysql db with no credentials required:
-```code
-$ tsh proxy db --tunnel mysql-db
-Started authenticated tunnel for the MySQL database "mysql-db" in cluster "teleport.example.com" on 127.0.0.1:49415.
-
-Use the following command to connect to the database:
-  $ mysql --port 49415 --host localhost --protocol TCP
-```
+|Argument|Default|Description|
+|---|---|---|
+|db|none (optional)|The name of the database to start local proxy for.|
 
 ## tsh proxy gcloud
 
-Start a local proxy for Google Cloud API access. The user must already be logged
-in to at least one Google Cloud application via Teleport before the proxy can
-start.
+Start local proxy for GCP access.
+
+Usage:
 
 ```code
 $ tsh proxy gcloud [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--app` | Currently logged in Google Cloud app | string | Optional name of the Google Cloud application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
-| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as a Google Cloud endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
-| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the Google Cloud proxy |
-
-### [Global Flags](#tsh-global-flags)
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh apps login google-cloud-app
-$ tsh proxy gcloud
-# Set env variables from output
-$ gcloud compute instances list
-$ gsutil ls
-```
+|Flag|Default|Description|
+|---|---|---|
+|`--app`|none|Optional Name of the GCP application to use if logged into multiple.|
+|`-f`, `--format`|`unix`|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
+|`-p`, `--port`|none|Specifies the source port used by the proxy listener.|
 
 ## tsh proxy kube
 
-Start a local TLS proxy for Kubernetes requests when using Teleport with TLS
-Routing enabled. Clients can interact with a Teleport-registered Kubernetes cluster through
-the local proxy.
+Start local proxy for Kubernetes access.
+
+Usage:
 
 ```code
-$ tsh proxy kube [<flags>] <kube-cluster>
+$ tsh proxy kube [<flags>] [<kube-cluster>...]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | string | The name of the Teleport cluster to connect to. |
-| `--kube-cluster` | none | string | The name of the Kubernetes cluster to proxy. |
-| `--as` | none | string | The Kubernetes user to impersonate. |
-| `--as-groups` | none | string | The Kubernetes group to impersonate. |
-| `--namespace` | none | string | The Kubernetes namespace to use. |
-| `--set-context-name` | none | string | A custom Kubernetes context name or template to use. |
-| `--exec` | none | boolean | Runs the proxy in the background and spawns a new shell with the $KUBECONFIG automatically set. |
-| `--port` | none | string | Source port used by the local proxy.|
+|Flag|Default|Description|
+|---|---|---|
+|`--as`|none|Configure custom Kubernetes user impersonation.|
+|`--as-groups`|none|Configure custom Kubernetes group impersonation.|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-f`, `--format`|`unix`|Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`-n`, `--namespace`|none|Configure the default Kubernetes namespace.|
+|`--[no-]exec`|`false`|Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.|
+|`-p`, `--port`|none|Specifies the source port used by the proxy listener.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--set-context-name`|`{{.ClusterName}}-{{.KubeName}}`|Define a custom context name or template.|
 
-### [Global Flags](#tsh-global-flags)
+Arguments:
 
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+|Argument|Default|Description|
+|---|---|---|
+|kube-cluster|none (optional)|Name of the Kubernetes cluster to proxy. Check 'tsh kube ls' for a list of available clusters. If not specified, all clusters previously logged in through `tsh kube login` will be used.|
 
-### Examples
+## tsh proxy mcp
 
-Proxy requests to a Kubernetes cluster
+Start local proxy for MCP access.
+
+Usage:
+
 ```code
-$ tsh proxy kube test-cluster
-Preparing the following Teleport Kubernetes clusters:
-Teleport Cluster Name Kube Cluster Name Context Name
---------------------- ----------------- -----------------
-teleport-test             test-cluster           teleport-test-test-cluster
-
-Started local proxy for Kubernetes on 127.0.0.1:49487
-To avoid port randomization, you can choose the listening port using the --port flag.
-
-Use the following config for your Kubernetes applications. For example:
-export KUBECONFIG="/home/alice/.tsh/keys/proxy.example.com/alice-kube/teleport-test/localproxy-49487-kubeconfig"
-kubectl version
+$ tsh proxy mcp [<flags>] <app>
 ```
 
-Spawn a new shell with the Kubernetes proxy running in the background and the Kubernetes config
-automatically applied.
-```code
-$ tsh proxy kube test-cluster --exec
-Preparing the following Teleport Kubernetes clusters:
-Teleport Cluster Name Kube Cluster Name Context Name
---------------------- ----------------- -----------------
-teleport-test             test-cluster           teleport-test-test-cluster
+Flags:
 
-Started local proxy for Kubernetes Access in the background.
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-p`, `--port`|none|Specifies the listening port used by by the proxy app listener.|
 
-Warning! Teleport will initiate a new shell configured with kubectl for local proxy access.
-To conclude the session, simply use the "exit" command. Upon exiting, your original shell will be restored,
-the local proxy will be closed, and future access through this headless session won't be possible.
+Arguments:
 
-
-Try issuing a command, for example "kubectl version".
-```
+|Argument|Default|Description|
+|---|---|---|
+|app|none (required)|The name of the MCP application to start local proxy for.|
 
 ## tsh proxy ssh
 
-Start a local TLS proxy for `ssh` connections when using Teleport in TLS Routing mode.
-This is typically used as part of the SSH client configuration to use `ssh` as a client
-through Teleport.  See the [OpenSSH Guide](../../enroll-resources/server-access/openssh/openssh-agentless.mdx) guide
-on configuring OpenSSH servers and clients.  The `tsh config` output will include `tsh proxy ssh`
-within a `ProxyCommand` directive.
+Start local TLS proxy for ssh connections when using Teleport in single-port
+mode.
+
+Usage:
 
 ```code
 $ tsh proxy ssh [<flags>] <[user@]host>
 ```
 
-### Arguments
-- `<[user@]host>` Remote hostname and the login to use
+Environment variables:
 
-### Flags
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | Teleport Cluster | The name of the Teleport cluster to connect to.|
+Flags:
 
-### [Global Flags](#tsh-global-flags)
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
 
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
+Arguments:
 
-### Examples
+|Argument|Default|Description|
+|---|---|---|
+|[user@]host|none (required)|Remote hostname and the login to use.|
 
-Run the following command to generate an OpenSSH client configuration:
+## tsh recordings export
 
-```code
-$ tsh config
-```
+Export recorded desktop sessions to video.
 
-This command produces the following configuration:
-
-```
-# Common flags for all example.com hosts
-Host *.example.com example.com
-    UserKnownHostsFile "/Users/jeff/.tsh/known_hosts"
-    IdentityFile "/Users/jeff/.tsh/keys/enterprise.teleportdemo.com/jeff"
-    CertificateFile "/Users/jeff/.tsh/keys/example.com/jeff-ssh/example.com-cert.pub"
-    PubkeyAcceptedKeyTypes +ssh-rsa-cert-v01@openssh.com
-    HostKeyAlgorithms ssh-rsa-cert-v01@openssh.com
-
-# Flags for all example.com hosts except the proxy
-Host *.example.com !example.com
-    Port 3022
-    ProxyCommand "/usr/local/bin/tsh" proxy ssh --cluster=example.com --proxy=example.com %r@%h:%p
-```
-
-This output should be placed into the default SSH Config for environment, `~/.ssh/config` for Mac/Linux or
-`.ssh\config` in the Windows User home directory. You can use this as a standalone SSH config file too.
-
-When you run an `ssh` command against a host with a subdomain of your Proxy
-Service's domain, this SSH configuration will use the `ProxyCommand` to run `tsh
-proxy ssh`:
+Usage:
 
 ```code
-$ ssh myuser@node1.example.com
+$ tsh recordings export [<flags>] <session-id>
 ```
 
-## tsh puttyconfig
+Flags:
 
-Adds a PuTTY saved session to the Windows registry for the currently logged in Windows user.
+|Flag|Default|Description|
+|---|---|---|
+|`--out`|none|Override output file name.|
 
-```
-$ tsh puttyconfig [--leaf <leaf-cluster-name>] [login@]hostname
-```
+Arguments:
 
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-l, --login` | none | Linux username | Default Linux username to use. Will translate to SSH config's `User` option. |
-| `-p`, `--port` | 3022 | port | Default SSH port to use. Will translate to SSH config's `Port` option. |
-| `--leaf` | none | Leaf cluster name | Leaf cluster name to add to the saved session. |
-
-### Examples
-
-```code
-# Add a saved PuTTY session on 'node' for the user 'ec2-user'
-$ tsh puttyconfig ec2-user@node
-
-# Add a saved PuTTY session for the Teleport-registered OpenSSH node 'openssh' for the user 'ubuntu'
-$ tsh puttyconfig --port 22 ubuntu@openssh
-
-# Add a saved PuTTY session on leaf-node for the user 'ec2-user' on the leaf cluster 'example.teleport.sh'
-$ tsh puttyconfig --leaf example.teleport.sh ec2-user@leaf-node
-```
-
-See [full docs on `tsh puttyconfig` here](../../connect-your-client/third-party/putty-winscp.mdx).
+|Argument|Default|Description|
+|---|---|---|
+|session-id|none (required)|ID of the session to export.|
 
 ## tsh recordings ls
 
 List recorded sessions.
 
+Usage:
+
 ```code
 $ tsh recordings ls [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--from-utc` | 24 hours ago | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
-| `--to-utc` | current | date | Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago. |
-| `--limit` | 50 | number | Maximum number of recordings to show. |
-| `--last` | none | duration | Duration into the past from which session recordings should be listed. Format 5h30m40s |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-# get the recorded sessions from the last 24 hours
-$ tsh --proxy proxy.example.com recordings ls
-ID                                   Type Participants Hostname Timestamp
------------------------------------- ---- ------------ -------- -------------------
-b0a04442-70dc-4be8-9308-7b7901d2d600 ssh  jeff         dev       Nov 26 16:36:16 UTC
-c0a02222-70dc-4be8-9308-7b7901d2d600 kube alice                  Nov 26 20:36:16 UTC
-d0a04442-70dc-4be8-9308-7b7901d2d600 ssh  navin        test      Nov 26 16:36:16 UTC
-
-# The session can be played with tsh play
-$ tsh play c0a02222-70dc-4be8-9308-7b7901d2d60
-
-# List recorded sessions that occurred between Nov 1, 2022 to Nov 3, 2022
-$ tsh recordings ls --from-utc=2022-11-01 --to-utc=2022-11-3
-
-# Retrieve recorded sessions in the last 6 hours
-$ tsh recordings ls --last=6h0m0s
-```
-
-<Admonition
-  title="Recorded Sessions Availability"
-  scope={["oss", "enterprise"]} type="tip" scopeOnly
->
-
-Recorded sessions are linked from the audit events to session recordings files
-in their [storage backend](../deployment/backends.mdx).
-The following error can occur if a session recording file is not available or
-when employing multiple auth servers with directory storage backend for recorded
-sessions. When using a directory storage backend for audit logs and recorded sessions,
-only the Auth Service with that recorded session can retrieve it.
-
-```code
-$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b
-ERROR: Recording for session c8e1b2c5-322a-4095-89e3-391edfd2da9b not found.
-```
-
-Using a Security Information and Event Management (SIEM) service that combines
-the audit logs will help consolidate the list of available recordings.
-
-Downloaded recorded session are directly playable as a file.
-
-```code
-$ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b.tar
-```
-
-</Admonition>
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).. Defaults to 'text'.|
+|`--from-utc`|none|Start of time range in which recordings are listed. Format 2006-01-02. Defaults to 24 hours ago.|
+|`--last`|none|Duration into the past from which session recordings should be listed. Format "5h30m40s".|
+|`--limit`|`50`|Maximum number of recordings to show. Default 50.|
+|`--to-utc`|none|End of time range in which recordings are listed. Format 2006-01-02. Defaults to current time.|
 
 ## tsh request create
 
 Create a new Access Request.
 
+Usage:
+
 ```code
 $ tsh request create [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--roles` | none | Comma-separated strings | List of Teleport roles to request |
-| `--resource` | none | String (flag can be repeated to request multiple resources) | Resource ID to be requested |
-| `--reason` | none | String | Reason for making the request (optional) |
-| `--reviewers` | none | Comma-separated strings | Suggested reviewers for the request (optional) |
-| `--nowait` | `false` | `true` or `false` | Finish without waiting for request resolution |
-| `--request-ttl` | 1 hour | Relative duration like `5s`, `2m`, or `3h`, | Defines how long the Access Request will be in a `PENDING` state before becoming invalid |
-| `--session-ttl` | Time left on current session | Relative duration like `5s`, `2m`, or `3h` | Defines how long the elevated session will be valid for |
-| `--max-duration` | none | Relative duration like `5s`, `2m`, `3h`, or `7d` | Defines the maximum duration of the elevated session up to 7 days. The assigned role also must have `max_duration` option specified (optional) |
-| `--assume-start-time` | none | String | Sets time roles can be assumed by requestor (RFC3339) |
-
-<Admonition type="tip" title="Note">
-The `--request-ttl` and `--session-ttl` values can not be greater than the
-following:
-
-- Maximum certificate lifetime.
-- Time left on an existing session (certificate).
-- Maximum session duration defined by the user's roles.
-
-Use `--max-duration` to request access for longer than the maximum certificate
-lifetime.
-</Admonition>
+|Flag|Default|Description|
+|---|---|---|
+|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
+|`--max-duration`|none|How long the access should be granted for.|
+|`--[no-]nowait`|`false`|Finish without waiting for request resolution.|
+|`--reason`|none|Reason for requesting.|
+|`--request-ttl`|none|Expiration time for the Access Request.|
+|`--resource`|none|Resource ID to be requested.|
+|`--reviewers`|none|Suggested reviewers.|
+|`--roles`|none|Roles to be requested.|
+|`--session-ttl`|none|Expiration time for the elevated certificate.|
 
 ## tsh request drop
 
-Drop one or more Access Requests from current identity
+Drop one more Access Requests from current identity.
+
+Usage:
 
 ```code
 $ tsh request drop [<request-id>...]
 ```
 
-### Arguments
+Arguments:
 
-- `<request-id>` - IDs of requests to "drop" from the current identity so that
-  your certificate will lose elevated roles and/or resource restrictions.
-  If no request ID is given, the default is to drop all Access Requests.
+|Argument|Default|Description|
+|---|---|---|
+|request-id|`*` (optional)|IDs of requests to drop (default drops all requests).|
 
 ## tsh request ls
 
-List Access Requests
+List Access Requests.
+
+Usage:
 
 ```code
-$ tsh request ls
+$ tsh request ls [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--format` | `text` | `text`, `json`, or `yaml` | Format output |
-| `--reviewable` | `false` | `true` or `false` | Only show requests reviewable by current user |
-| `--suggested` | `false` | `true` or `false` | Only show requests that suggest current user as reviewer |
-| `--my-requests` | `false` | `true` or `false` | Only show requests created by current user |
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]my-requests`|`false`|Only show requests created by current user.|
+|`--[no-]reviewable`|`false`|Only show requests reviewable by current user.|
+|`--[no-]suggested`|`false`|Only show requests that suggest current user as reviewer.|
 
 ## tsh request review
 
-Review an Access Request
+Review an Access Request.
+
+Usage:
 
 ```code
 $ tsh request review [<flags>] <request-id>
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--approve` | `false` | `true` or `false` | Review proposes approval |
-| `--deny` | `false` | `true` or `false` | Review proposes denial |
-| `--reason` | none | String | Review reason message |
-| `--assume-start-time` | none | String | Sets time roles can be assumed by requestor (RFC3339) |
+|Flag|Default|Description|
+|---|---|---|
+|`--assume-start-time`|none|Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).|
+|`--[no-]approve`|`false`|Review proposes approval.|
+|`--[no-]deny`|`false`|Review proposes denial.|
+|`--reason`|none|Review reason message.|
 
-### Arguments
+Arguments:
 
-- `<request-id>` - ID of the target request
+|Argument|Default|Description|
+|---|---|---|
+|request-id|none (required)|ID of target request.|
 
 ## tsh request search
 
-Search for resources to request access to, or list requestable roles.
+Search for resources to request access to.
+
+Usage:
 
 ```code
 $ tsh request search [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--roles` | false | boolean | List requestable roles instead of searching for resources. Mutually exclusive with --kind. |
-| `--kind` | none | `node`, `kube_cluster`, `kube_resource`, `db`, `app`, `windows_desktop` | Resource kind to search for. Mutually exclusive with --roles. |
-| `--kube-kind` | none | string | Plural name of the kube resource (required when --kind is `kube_resource`) |
-| `--kube-api-group` | none | string | API group of the kube resource (required when --kind is `kube_resource` depending on the resource) |
-| `--search` | none | Comma-separated strings | List of comma-separated search keywords or phrases enclosed in single quotes |
-| `--query` | none | String | Query by [predicate language](../access-controls/predicate-language.mdx#resource-filtering) enclosed in single quotes |
-| `--labels` | none | Comma-separated strings | List of comma-separated labels to filter by labels (e.g. `key=value1,key2=value2`) |
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--kind`|none|Resource kind to search for (node, kube_cluster, kube_resource, db, app, windows_desktop, user_group, saml_idp_service_provider, aws_ic_account, aws_ic_account_assignment, git_server).  Mutually exclusive with --roles.|
+|`--kube-api-group`|none|Kubernetes API group to search for resources.|
+|`--kube-cluster`|none|Kubernetes Cluster to search for Pods.|
+|`--kube-kind`|none|Kubernetes resource kind name (plural) to search for. Required with --kind="kube_resource" Ex: pods, deployments, namespaces, etc.|
+|`--labels`|none|List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2).|
+|`--namespace`|`default`|Kubernetes Namespace to search for Pods.|
+|`--[no-]all-kube-namespaces`|`false`|Search Pods in every namespace.|
+|`--[no-]roles`|`false`|List requestable roles instead of searching for resources. Mutually exclusive with --kind.|
+|`--query`|none|Query by predicate language enclosed in single quotes. Supports ==, !=, &&, and \|\| (e.g. --query='labels\["key1"\] == "value1" && labels\["key2"\] != "value2"').|
+|`--search`|none|List of comma separated search keywords or phrases enclosed in quotations (e.g. --search=foo,bar,"some phrase").|
+|`-v`, `--[no-]verbose`|`false`|Verbose table output, shows full label output.|
 
 ## tsh request show
 
-Show Access Request details
+Show request details.
+
+Usage:
 
 ```code
-$ tsh request show <request-id>
+$ tsh request show [<flags>] <request-id>
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--format` | text | `text`, `json`, or `yaml` | Format output |
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
 
-### Arguments
+Arguments:
 
-- `<request-id>` - ID of the target request
+|Argument|Default|Description|
+|---|---|---|
+|request-id|none (required)|ID of the target request.|
+
+## tsh resolve
+
+Resolves an SSH host.
+
+Usage:
+
+```code
+$ tsh resolve [<flags>] <host>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|host|none (required)|Remote hostname to resolve.|
+
+## tsh scan keys
+
+Scan the local machine for SSH private keys and report findings to Teleport.
+
+Usage:
+
+```code
+$ tsh scan keys [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--dirs`|`/Users/`|Directories to scan.|
+|`--skip-paths`|none|Paths to directories or files to skip. Supports for matching patterns.|
+
+## tsh scopes ls
+
+List scopes at which user has assigned privileges.
+
+Usage:
+
+```code
+$ tsh scopes ls [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-v`, `--[no-]verbose`|`false`|Show table with details of per-scope privileges.|
 
 ## tsh scp
 
-Copies files from source to dest:
+Transfer files to a remote SSH node.
+
+Usage:
 
 ```code
-$ tsh scp [<flags>] <source>... <dest>
+$ tsh scp [<flags>] <from, to>...
 ```
 
-{/* TODO Confirm which flags are supported and whether supports multiple sources */}
+Environment variables:
 
-### Arguments
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
 
-- `<source>` - filepath to copy
-- `<dest>` - target destination
+Flags:
 
-### Flags
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
+|`-p`, `--[no-]preserve`|`false`|Preserves access and modification times from the original file.|
+|`-P`, `--port`|none|Port to connect to on the remote host.|
+|`-q`, `--[no-]quiet`|`false`|Quiet mode.|
+|`-r`, `--[no-]recursive`|`false`|Recursive copy of subdirectories.|
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `--cluster` | none | a cluster_name | Specify the cluster to connect |
-| `-r, --recursive` | none | none | Recursive copy of subdirectories |
-| `-P, --port` | none | port number | Port to connect to on the remote host |
-| `-q, --quiet` | none | none | Quiet mode |
+Arguments:
 
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-### Examples
-
-```code
-$ tsh --proxy=proxy.example.com scp example.txt user@host:/destination/dir
-```
-
-<Admonition type="note">
-  `tsh scp` will not work from the CLI if the user requires session moderation. You can transfer files in a moderated session by joining the SSH session from the Web UI and requesting the file transfer there. Both the session initiator and moderators must be present in the Web UI in order to approve the file transfer request.
-</Admonition>
-
-## tsh ssh
-
-Run shell or execute a command on a remote SSH node:
-
-```code
-$ tsh ssh [<flags>] <[user@]host> [<command>...]
-```
-
-### Arguments
-
-`<[user@]host> [<command>...]`
-
-- `user` The login identity to use on the remote host. If `[user]` is not specified the user defaults to `$USER` or can be set with `--user`. If the flag `--user` and positional argument `[user]` are specified the arg `[user]` takes precedence.
-- `host` The `nodename` of a cluster Node or a label specification like `env=aws` to run on all matching hosts.
-- `command` The command to execute on a remote host.
-
-### Flags
-
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-p, --port` | none | port | SSH port on a remote host |
-| `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
-| `-L, --forward` | none | none | Forward localhost connections to remote server |
-| `-D, --dynamic-forward` | none | none | Forward localhost connections to remote server using SOCKS5 |
-| `-R, --remote-forward` | none | none | Forward remote connections to localhost |
-| `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
-| `--local` | none | | Execute command on localhost after connecting to SSH node |
-| `-t, --tty` | `file` | | Allocate TTY |
-| `--cluster` | none | | Specify the cluster to connect |
-| `-o, --option` | `local` | | OpenSSH options in the format used in the configuration file |
-| `--enable-escape-sequences` | | | Enable support for SSH escape sequences. Type `~?` during an SSH session to list supported sequences. |
-| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`) |
-| `-X, --x11-untrusted` | none | none | Requests untrusted (secure) X11 forwarding for this session. |
-| `-Y, --x11-trusted` | none | none | Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution. |
-| `--x11-untrusted-timeout` | 10m | duration | Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server. |
-
-### Global flags
-
-These flags are available for all commands `--login`, `--proxy`, `--relay`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
-Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
-
-Use of a relay (as specified at `tsh login` time or through the `--relay` flag) requires `tsh` v18.3.0 or later.
-
-### Examples
-
-```code
-# Log in to node `grav-00` as OS User `root` with Teleport User `teleport`
-$ tsh ssh --proxy proxy.example.com --user teleport -d root@grav-00
-# `tsh ssh` takes the same arguments as OpenSSH client:
-$ tsh ssh -o ForwardAgent=yes root@grav-00
-$ tsh ssh -o AddKeysToAgent=yes root@grav-00
-# Run `hostname` on all nodes with the `env: aws` label
-$ tsh ssh root@env=aws hostname
-```
+|Argument|Default|Description|
+|---|---|---|
+|from, to|none (required)|Source and destination to copy, one must be a local path and one must be a remote path.|
 
 ## tsh sessions ls
 
-List active sessions. The resulting list includes only the sessions that the
-caller has permission to join, unless they have a role with explicit `list`
-access on the `session_tracker` resource.
+List active sessions.
+
+Usage:
 
 ```code
-$ tsh sessions ls
+$ tsh sessions ls [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Name | Default Value(s) | Allowed Value(s) | Description |
-| - | - | - | - |
-| `-f, --format` | text | text, json, yaml | Format for output |
-| `--kind` | none | ssh, k8s, db, app, desktop | Optionally filter by session kind(s) |
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--kind`|`ssh`,`k8s`,`db`,`app`,`desktop`|Filter by session kind(s).|
 
-### Examples
+## tsh ssh
+
+Run shell or execute a command on a remote SSH node.
+
+Usage:
 
 ```code
-# list all active sessions
-$ tsh sessions ls
-
-# list all SSH and desktop sessions
-$ tsh sessions ls --kind=ssh --kind=desktop
-
-# list all Kubernetes sessions in JSON format
-$ tsh sessions ls --kind=k8s --format=json
+$ tsh ssh [<flags>] [<[user@]host>] [<command>...]
 ```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_NO_RESUME`|`false`|Disable SSH connection resumption.|
+|`TELEPORT_REQUEST_MODE`|`resource`|Type of automatic Access Request to make (off, resource, role).|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-A`, `--[no-]forward-agent`|`false`|Forward agent to target node.|
+|`-c`, `--cluster`|none|Specify the Teleport cluster to connect.|
+|`-D`, `--dynamic-forward`|none|Forward localhost connections to remote server using SOCKS5.|
+|`-f`, `--[no-]fork-after-authentication`|`false`|Run in background after authentication is complete.|
+|`--invite`|none|A comma separated list of people to mark as invited for the session.|
+|`-L`, `--forward`|none|Forward localhost connections to remote server.|
+|`--log-dir`|none|Directory to log separated command output, when executing on multiple nodes. If set, output from each node will also be labeled in the terminal.|
+|`-N`, `--[no-]no-remote-exec`|`false`|Don't execute remote command, useful for port forwarding.|
+|`--[no-]disable-access-request`|`false`|Disable automatic resource Access Requests (DEPRECATED: use --request-mode=off).|
+|`--[no-]local`|`false`|Execute command on localhost after connecting to SSH node.|
+|`--[no-]no-resume`|`false`|Disable SSH connection resumption.|
+|`--[no-]participant-req`|`false`|Displays a verbose list of required participants in a moderated session.|
+|`--[no-]relogin`|`true`|Permit performing an authentication attempt on a failed command.|
+|`-o`, `--option`|none|OpenSSH options in the format used in the configuration file.|
+|`-p`, `--port`|none|SSH port on a remote host.|
+|`--reason`|none|The purpose of the session.|
+|`--request-mode`|`resource`|Type of automatic Access Request to make (off, resource, role).|
+|`--request-reason`|none|Reason for requesting access.|
+|`-R`, `--remote-forward`|none|Forward remote connections to localhost.|
+|`-t`, `--[no-]tty`|`false`|Allocate TTY.|
+|`--x11-untrusted-timeout`|`10m`|Sets a timeout for untrusted X11 forwarding, after which the client will reject any forwarding requests from the server.|
+|`-X`, `--[no-]x11-untrusted`|`false`|Requests untrusted (secure) X11 forwarding for this session.|
+|`-Y`, `--[no-]x11-trusted`|`false`|Requests trusted (insecure) X11 forwarding for this session. This can make your local machine vulnerable to attacks, use with caution.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Command to execute on a remote host.|
+|[user@]host|none (optional)|Remote hostname and the login to use, this argument is required.|
 
 ## tsh status
 
-Display the list of proxy servers and retrieved certificates:
+Display the list of proxy servers and retrieved certificates.
+
+Usage:
 
 ```code
-$ tsh status
+$ tsh status [<flags>]
 ```
 
-### Examples
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`-v`, `--[no-]verbose`|`false`|Show extra status information after successful login.|
+
+## tsh update
+
+Update client tools (tsh, tctl) to the latest version defined by the cluster
+configuration.
+
+Usage:
 
 ```code
-$ tsh status
-
-# > Profile URL:  https://proxy.example.com:3080
-#   Logged in as:       benarent
-#   Cluster:            aws
-#   Roles:              access, editor, auditor
-#   Logins:             benarent, root, ec2-user, ubunutu
-#   Kubernetes:         enabled
-#   Kubernetes cluster: "gke_bens-demos_us-central1-c_gks-demo"
-#   Kubernetes groups:  system:masters
-#  Valid until:        2020-11-21 01:50:23 -0800 PST [valid for 11h52m0s]
-#  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+$ tsh update [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]clear`|`false`|Removes locally installed client tools updates from the Teleport home directory.|
 
 ## tsh version
 
-Prints the version of your `tsh` binary and the Teleport Proxy Service in the current `tsh` profile
+Print the tsh client and Proxy server versions for the current context.
+
+Usage:
 
 ```code
 $ tsh version [<flags>]
 ```
 
-| Name           | Default Value(s) | Allowed Value(s) | Description                                        |
-|----------------|------------------|------------------|----------------------------------------------------|
-| `-f, --format` | `text`           | text, json, yaml | Format for version output                          |
-| `--client`     | none             | none             | Show the client version only (no server required). |
+Flags:
 
-### Examples
+|Flag|Default|Description|
+|---|---|---|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+|`--[no-]client`|`false`|Show the client version only (no server required).|
 
-```code
-$ tsh version
-Teleport v(=teleport.version=) git: go(=teleport.golang=)
-Proxy version: (=teleport.version=)
-Proxy: teleport.example.com:443
-```
+## tsh vnet
 
-Display in JSON format:
+Start Teleport VNet, a virtual network for TCP application access.
+
+Usage:
 
 ```code
-$ tsh version --format=json
+$ tsh vnet
 ```
 
-```json
-{
-  "version": "(=teleport.version=)",
-  "gitref": "",
-  "runtime": "go(=teleport.golang=)",
-  "proxyVersion": "(=teleport.version=)",
-  "proxyPublicAddress": "teleport.example.com:443"
-}
-```
+## tsh vnet-ssh-autoconfig
 
-Only display the `tsh` binary version:
+Automatically include VNet's generated OpenSSH-compatible config file in
+~/.ssh/config.
+
+Usage:
 
 ```code
-$ tsh version --client
-Teleport v(=teleport.version=) git: go(=teleport.golang=)
+$ tsh vnet-ssh-autoconfig
 ```
+
+## tsh workload-identity issue-x509
+
+Use Teleport Workload Identity to issue an X509 credential write it to a local
+directory.
+
+Usage:
+
+```code
+$ tsh workload-identity issue-x509 --output=OUTPUT [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--credential-ttl`|`1h`|Sets the time to live for the credential.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue.|
+|`--output`|none|Path to the directory to write the SVID into.|
+

--- a/lib/utils/docenvdefaults/tsh.yaml
+++ b/lib/utils/docenvdefaults/tsh.yaml
@@ -18,11 +18,6 @@ TELEPORT_LOGIN_BIND_ADDR:
   default: "none"
   type: "string"
 
-TELEPORT_LOGIN_BROWSER:
-  description: "Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser."
-  default: "none"
-  type: "string"
-
 TELEPORT_PROXY:
   description: "Address of the Teleport proxy server"
   default: "none"

--- a/lib/utils/docs-usage.md.tmpl
+++ b/lib/utils/docs-usage.md.tmpl
@@ -59,6 +59,7 @@ tags:
   - reference
   - {{if eq .App.Name "tbot"}}mwi{{else}}platform-wide{{end}}
 ---
+{/*vale messaging = NO*/}
 
 This guide provides a comprehensive list of commands, arguments, and flags for
 {{.App.Name}}: {{ if .App.Help -}}

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1228,7 +1228,7 @@ func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
 		Default(kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}")).
 		StringVar(&c.overrideContextName)
 	c.Flag("request-reason", "Reason for requesting access.").StringVar(&c.requestReason)
-	c.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&c.disableAccessRequest)
+	c.Flag("disable-access-request", "Disable automatic resource Access Requests.").BoolVar(&c.disableAccessRequest)
 
 	return c
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -971,8 +971,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	ssh.Flag("reason", "The purpose of the session.").StringVar(&cf.Reason)
 	ssh.Flag("participant-req", "Displays a verbose list of required participants in a moderated session.").BoolVar(&cf.displayParticipantRequirements)
 	ssh.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
-	ssh.Flag("request-mode", fmt.Sprintf("Type of automatic access request to make (%s).", strings.Join(accessRequestModes, ", "))).Envar(requestModeEnvVar).Default(accessRequestModeResource).EnumVar(&cf.RequestMode, accessRequestModes...)
-	ssh.Flag("disable-access-request", "Disable automatic resource access requests (DEPRECATED: use --request-mode=off).").BoolVar(&cf.disableAccessRequest)
+	ssh.Flag("request-mode", fmt.Sprintf("Type of automatic Access Request to make (%s).", strings.Join(accessRequestModes, ", "))).Envar(requestModeEnvVar).Default(accessRequestModeResource).EnumVar(&cf.RequestMode, accessRequestModes...)
+	ssh.Flag("disable-access-request", "Disable automatic resource Access Requests (DEPRECATED: use --request-mode=off).").BoolVar(&cf.disableAccessRequest)
 	ssh.Flag("log-dir", "Directory to log separated command output, when executing on multiple nodes. If set, output from each node will also be labeled in the terminal.").StringVar(&cf.SSHLogDir)
 	ssh.Flag("no-resume", "Disable SSH connection resumption.").Envar(noResumeEnvVar).BoolVar(&cf.DisableSSHResumption)
 	ssh.Flag("relogin", "Permit performing an authentication attempt on a failed command.").Default("true").BoolVar(&cf.Relogin)
@@ -1089,7 +1089,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxyDB.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	proxyDB.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	proxyDB.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
-	proxyDB.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
+	proxyDB.Flag("disable-access-request", "Disable automatic resource Access Requests.").BoolVar(&cf.disableAccessRequest)
 
 	proxyApp := proxy.Command("app", "Start local TLS proxy for app connection when using Teleport in single-port mode.")
 	proxyApp.Arg("app", "The name of the application to start local proxy for.").Required().StringVar(&cf.AppName)
@@ -1141,7 +1141,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbLogin.Flag("db-name", "Database name to configure as default.").Short('n').StringVar(&cf.DatabaseName)
 	dbLogin.Flag("db-roles", "List of comma separate database roles to use for auto-provisioned user.").Short('r').StringVar(&cf.DatabaseRoles)
 	dbLogin.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
-	dbLogin.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
+	dbLogin.Flag("disable-access-request", "Disable automatic resource Access Requests.").BoolVar(&cf.disableAccessRequest)
 	dbLogout := db.Command("logout", "Remove database credentials.")
 	dbLogout.Arg("db", "Database to remove credentials for.").StringVar(&cf.DatabaseService)
 	dbLogout.Flag("labels", labelHelp).StringVar(&cf.Labels)
@@ -1169,7 +1169,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbConnect.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	dbConnect.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	dbConnect.Flag("request-reason", "Reason for requesting access.").StringVar(&cf.RequestReason)
-	dbConnect.Flag("disable-access-request", "Disable automatic resource access requests.").BoolVar(&cf.disableAccessRequest)
+	dbConnect.Flag("disable-access-request", "Disable automatic resource Access Requests.").BoolVar(&cf.disableAccessRequest)
 	dbConnect.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").Hidden().BoolVar(&cf.LocalProxyTunnel)
 	dbExec := db.Command("exec", "Execute database commands on target database services.")
 	dbExec.Flag("db-user", "Database user to log in as.").Short('u').StringVar(&cf.DatabaseUser)
@@ -1336,9 +1336,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	environment.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	environment.Flag("unset", "Print commands to clear Teleport session environment variables.").BoolVar(&cf.unsetEnvironment)
 
-	req := app.Command("request", "Manage access requests.").Alias("requests")
+	req := app.Command("request", "Manage Access Requests.").Alias("requests")
 
-	reqList := req.Command("ls", "List access requests.").Alias("list")
+	reqList := req.Command("ls", "List Access Requests.").Alias("list")
 	reqList.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 	reqList.Flag("reviewable", "Only show requests reviewable by current user.").BoolVar(&cf.ReviewableRequests)
 	reqList.Flag("suggested", "Only show requests that suggest current user as reviewer.").BoolVar(&cf.SuggestedRequests)
@@ -1351,18 +1351,18 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// Note: The "tsh request new" subcommand should not be used anymore. It
 	// will be kept around for users that built automation around it, but all
 	// public facing documentation should now refer to "tsh request create".
-	reqCreate := req.Command("create", "Create a new access request.").Alias("new")
+	reqCreate := req.Command("create", "Create a new Access Request.").Alias("new")
 	reqCreate.Flag("roles", "Roles to be requested.").StringVar(&cf.DesiredRoles)
 	reqCreate.Flag("reason", "Reason for requesting.").StringVar(&cf.RequestReason)
 	reqCreate.Flag("reviewers", "Suggested reviewers.").StringVar(&cf.SuggestedReviewers)
 	reqCreate.Flag("nowait", "Finish without waiting for request resolution.").BoolVar(&cf.NoWait)
 	reqCreate.Flag("resource", "Resource ID to be requested.").StringsVar(&cf.RequestedResourceIDs)
-	reqCreate.Flag("request-ttl", "Expiration time for the access request.").DurationVar(&cf.RequestTTL)
+	reqCreate.Flag("request-ttl", "Expiration time for the Access Request.").DurationVar(&cf.RequestTTL)
 	reqCreate.Flag("session-ttl", "Expiration time for the elevated certificate.").DurationVar(&cf.SessionTTL)
 	reqCreate.Flag("max-duration", "How long the access should be granted for.").DurationVar(&cf.MaxDuration)
 	reqCreate.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).").StringVar(&cf.AssumeStartTimeRaw)
 
-	reqReview := req.Command("review", "Review an access request.")
+	reqReview := req.Command("review", "Review an Access Request.")
 	reqReview.Arg("request-id", "ID of target request.").Required().StringVar(&cf.RequestID)
 	reqReview.Flag("approve", "Review proposes approval.").BoolVar(&cf.Approve)
 	reqReview.Flag("deny", "Review proposes denial.").BoolVar(&cf.Deny)
@@ -1440,7 +1440,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	headlessApprove.Arg("request id", "Headless authentication request ID.").StringVar(&cf.HeadlessAuthenticationID)
 	headlessApprove.Flag("skip-confirm", "Skip confirmation and prompt for MFA immediately.").Envar(headlessSkipConfirmEnvVar).BoolVar(&cf.headlessSkipConfirm)
 
-	reqDrop := req.Command("drop", "Drop one more access requests from current identity.")
+	reqDrop := req.Command("drop", "Drop one more Access Requests from current identity.")
 	reqDrop.Arg("request-id", "IDs of requests to drop (default drops all requests).").Default("*").StringsVar(&cf.RequestIDs)
 	kubectl := app.Command("kubectl", "Runs a kubectl command on a Kubernetes cluster.").Interspersed(false)
 	// This hack is required in order to accept any args for tsh kubectl.


### PR DESCRIPTION
Closes #47358

Run the docs generator introduced in #54394 for the `tsh` CLI reference.

Also remove the environment variable override for
`TELEPORT_LOGIN_BROWSER`, which is a hidden flag.

Note that the following hidden global environment variables are present
in the manually maintained guide but, because they are hidden, absent in
the generated guide:

- TELEPORT_LOGIN_BROWSER
- TELEPORT_USE_LOCAL_SSH_AGENT

The guide is also missing the `tsh puttyconfig` command, which is only
present when we build `tsh` for Windows. However, since VNET for SSH
fulfills much of the use case for `tsh puttyconfig`, and generating the
docs adds entries for around 33 more `tsh` commands, this is an
acceptable tradeoff.