### PR TITLE
chore: remove `host_uuid` kube storage compatibility layer

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6834,18 +6834,6 @@ func readOrGenerateHostID(ctx context.Context, cfg *servicecfg.Config, kubeBacke
 		if err := persistHostIDToStorages(ctx, cfg, kubeBackend); err != nil {
 			return trace.Wrap(err)
 		}
-	} else if kubeBackend != nil && hostid.ExistsLocally(cfg.DataDir) {
-		// This case is used when loading a Teleport pre-11 agent with storage attached.
-		// In this case, we have to copy the "host_uuid" from the agent to the secret
-		// in case storage is removed later.
-		// loadHostIDFromKubeSecret will check if the `host_uuid` is already in the secret.
-		if id, err := loadHostIDFromKubeSecret(ctx, kubeBackend); err != nil || len(id) == 0 {
-			// Forces the copy of the host_uuid into the Kubernetes Secret if PV storage is enabled.
-			// This is only required if PV storage is removed later.
-			if err := writeHostIDToKubeSecret(ctx, kubeBackend, cfg.HostUUID); err != nil {
-				return trace.Wrap(err)
-			}
-		}
 	}
 	return nil
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1098,25 +1098,6 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 		},
 		{
-			name: "Kube Backend is available but key is missing. Load from local storage and store in kube",
-			args: args{
-				kubeBackend: &fakeKubeBackend{
-					getData: nil,
-					getErr:  fmt.Errorf("key not found"),
-				},
-				hostIDContent: id,
-			},
-			wantFunc: func(receivedID string) bool {
-				return receivedID == id
-			},
-			wantKubeItemFunc: func(i *backend.Item) bool {
-				return cmp.Diff(&backend.Item{
-					Key:   backend.KeyFromString(hostUUIDKey),
-					Value: []byte(id),
-				}, i, cmp.AllowUnexported(backend.Key{})) == ""
-			},
-		},
-		{
 			name: "Kube Backend is available with key. Load from kube storage",
 			args: args{
 				kubeBackend: &fakeKubeBackend{

--- a/lib/utils/hostid/hostid.go
+++ b/lib/utils/hostid/hostid.go
@@ -37,18 +37,12 @@ func GetPath(dataDir string) string {
 	return filepath.Join(dataDir, FileName)
 }
 
-// ExistsLocally checks if dataDir/host_uuid file exists in local storage.
-func ExistsLocally(dataDir string) bool {
-	_, err := ReadFile(dataDir)
-	return err == nil
-}
-
 // ReadFile reads host UUID from the file in the data dir
 func ReadFile(dataDir string) (string, error) {
 	out, err := utils.ReadPath(GetPath(dataDir))
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
-			//do not convert to system error as this loses the ability to compare that it is a permission error
+			// do not convert to system error as this loses the ability to compare that it is a permission error
 			return "", trace.Wrap(err)
 		}
 		return "", trace.ConvertSystemError(err)


### PR DESCRIPTION
This PR removes the compatibility layer introduced in Teleport 11 to support converting existing deployments that used storage to a the Kubernetes Secret storage used after Teleport 11.

This logic reads the data from the local file and re-stores it in Kubernetes secret if the secret doesn't have the `host_uuid` entry set. This behaviour should be sane because we re-get the secret to ensure it's not stored there but in reality this is no longer needed since Teleport 11 and should be removed to ensure this isn't the cause of racy behaviour.