### PR TITLE
[docs] Add database service error troubleshooting

### DIFF
--- a/docs/pages/admin-guides/management/admin/troubleshooting.mdx
+++ b/docs/pages/admin-guides/management/admin/troubleshooting.mdx
@@ -18,56 +18,7 @@ services such as the Application Service and Database Service.
 
 ## Step 1/3. Enable verbose logging
 
-To change log levels in Teleport, you can use either of the following methods:
-
-- Debug Service: Allows on-the-fly log level adjustments without restarting the
-  instance, which is ideal for troubleshooting sessions.
-- Updating configuration: Involves updating the Teleport configuration file and
-  restarting the instance.
-
-<Tabs>
-<TabItem label="Debug Service">
-The Teleport Debug Service allows administrators to dynamically manage log levels
-without restarting the instance. The service, enabled by default, ensures
-local-only access and must be consumed from inside the same instance.
-
-To change the instance log level use the `teleport debug set-log-level` command:
-
-```code
-$ teleport debug set-log-level DEBUG
-Changed log level from "INFO" to "DEBUG".
-
-$ kubectl -n teleport exec my-pod -- teleport debug set-log-level DEBUG
-Changed log level from "INFO" to "DEBUG".
-```
-
-If you're unsure what is the current level you can retrieve it using
-`teleport debug get-log-level`.
-
-After troubleshooting, remember to turn the log level back to avoid generating
-unnecessary logs.
-
-(!docs/pages/includes/diagnostics/teleport-debug-config.mdx!)
-</TabItem>
-
-<TabItem label="Updating configuration">
-To diagnose problems, you can configure the `teleport` process to run with
-verbose logging enabled by passing it the `-d` flag. `teleport` will write logs
-to stderr.
-
-Alternatively, you can set the log level from the Teleport configuration file:
-
-```yaml
-teleport:
-  log:
-    severity: DEBUG
-```
-
-Restart the `teleport` process to apply the modified log level. Logs will resemble
-the following (these logs were printed while joining a server to a cluster, then
-terminating the `teleport` process on the server):
-</TabItem>
-</Tabs>
+(!docs/pages/includes/diagnostics/enable-debug-logs.mdx!)
 
 Debug logs include the file and line number of the code that emitted the log, so
 you can investigate (or report) what a `teleport` process was doing before it ran into

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -164,3 +164,37 @@ Service even if TLS Routing was not enabled on the Teleport cluster.
 proxy_service:
   mysql_server_version: "8.0.4"
 ```
+
+## Database Service error logs
+
+<Admonition type="note">
+You may need to enable DEBUG level logs on the Teleport Database Service to diagnose the underlying issue.
+</Admonition>
+
+<details>
+<summary>Enabling DEBUG logs</summary>
+
+(!docs/pages/includes/diagnostics/enable-debug-logs.mdx!)
+
+</details>
+
+### Failed to create db i/o timeout
+
+The Teleport Database Service shows an error message similar to **"failed to create db ... i/o timeout"**.
+
+**Solution:** Check for network restrictions to cloud services. This error is typically caused by restrictions that prevent the Teleport Database Service from reaching cloud services.
+
+[VPC interface endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/interface-endpoints.html) are a common source of this error in AWS deployments.
+If you have created VPC interface endpoints for AWS services such as RDS, then those endpoints will have a security group. 
+- Check each VPC endpoint's security group inbound rules and ensure that the rules allow traffic from the Teleport Database Service.
+- Check the outbound rules for the Teleport Database Service and ensure traffic is allowed to the VPC endpoints.
+
+<Admonition type="tip">
+It may be helpful to use [AWS Reachability Analyzer](https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html) to analyze the network path between the Teleport Database Service and a VPC interface endpoint.
+
+1. Identify the Elastic Network Interface (ENI) associated with the Teleport Database Service host. This can be found in the [EC2 console](https://console.aws.amazon.com/ec2/home?region=ca-central-1#NIC).
+2. Create and analyze a network path:
+    - Set the path source to the ENI associated with the Teleport Database Service host.
+    - Set the path destination to the VPC interface endpoint.
+3. Check the analysis results to identify reachability issues.
+</Admonition>

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -194,7 +194,7 @@ It may be helpful to use [AWS Reachability Analyzer](https://docs.aws.amazon.com
 
 1. Identify the Elastic Network Interface (ENI) associated with the Teleport Database Service host. This can be found in the [EC2 console](https://console.aws.amazon.com/ec2/home?region=ca-central-1#NIC).
 2. Create and analyze a network path:
-    - Set the path source to the ENI associated with the Teleport Database Service host.
-    - Set the path destination to the VPC interface endpoint.
+   - Set the path source to the ENI associated with the Teleport Database Service host.
+   - Set the path destination to the VPC interface endpoint.
 3. Check the analysis results to identify reachability issues.
 </Admonition>

--- a/docs/pages/includes/diagnostics/enable-debug-logs.mdx
+++ b/docs/pages/includes/diagnostics/enable-debug-logs.mdx
@@ -1,0 +1,49 @@
+To change log levels in Teleport, you can use either of the following methods:
+
+- Debug Service: Allows on-the-fly log level adjustments without restarting the
+  instance, which is ideal for troubleshooting sessions.
+- Updating configuration: Involves updating the Teleport configuration file and
+  restarting the instance.
+
+<Tabs>
+<TabItem label="Debug Service">
+The Teleport Debug Service allows administrators to dynamically manage log levels
+without restarting the instance. The service, enabled by default, ensures
+local-only access and must be consumed from inside the same instance.
+
+To change the instance log level use the `teleport debug set-log-level` command:
+
+```code
+$ teleport debug set-log-level DEBUG
+Changed log level from "INFO" to "DEBUG".
+
+$ kubectl -n teleport exec my-pod -- teleport debug set-log-level DEBUG
+Changed log level from "INFO" to "DEBUG".
+```
+
+If you're unsure what is the current level you can retrieve it using
+`teleport debug get-log-level`.
+
+(!docs/pages/includes/diagnostics/teleport-debug-config.mdx!)
+</TabItem>
+<TabItem label="Updating configuration">
+To diagnose problems, you can configure the `teleport` process to run with
+verbose logging enabled by passing it the `-d` flag. `teleport` will write logs
+to stderr.
+
+Alternatively, you can set the log level from the Teleport configuration file:
+
+```yaml
+teleport:
+  log:
+    severity: DEBUG
+```
+
+Restart the `teleport` process to apply the modified log level. Logs will resemble
+the following (these logs were printed while joining a server to a cluster, then
+terminating the `teleport` process on the server):
+</TabItem>
+</Tabs>
+
+After troubleshooting, remember to turn the log level back to avoid generating
+unnecessary logs.


### PR DESCRIPTION
Create a partial for enabling DEBUG log on Teleport.

Update the troubleshooting doc to include error log debugging for i/o timeouts when registering a database. This commonly occurs due to VPC interface endpoints in AWS.