### PR TITLE
Cleanup kube proxy.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1581,7 +1581,6 @@ var KubernetesVerbs = []string{
 // KubernetesClusterWideResourceKinds is the list of supported Kubernetes cluster resource kinds
 // that are not namespaced.
 // Needed to maintain backward compatibility.
-// TODO(@creack): Make this a map[string]struct{} to simplify lookups.
 var KubernetesClusterWideResourceKinds = []string{
 	KindKubeNamespace,
 	KindKubeNode,
@@ -1591,49 +1590,48 @@ var KubernetesClusterWideResourceKinds = []string{
 	KindKubeCertificateSigningRequest,
 }
 
-type groupKind = struct{ apiGroup, kind string }
-
 // KubernetesNamespacedResourceKinds is the list of known Kubernetes resource kinds
 // that are namespaced.
+//
 // Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name` (kind k8s v1.32.2).
-// (added .core to core resources.)
 // The format is "<plural>.<apigroup>".
 //
 // Only used in role >=v8 to attempt to validate the api_group field.
 // If we have a match, we know we need a namespaced value, if we don't
 // have a match, we don't know we don't. Best effort basis.
-var kubernetesNamespacedResourceKinds = map[groupKind]struct{}{
-	{"", "bindings"}:                                      {},
-	{"", "configmaps"}:                                    {},
-	{"apps", "controllerrevisions"}:                       {},
-	{"batch", "cronjobs"}:                                 {},
-	{"storage.k8s.io", "csistoragecapacities"}:            {},
-	{"apps", "daemonsets"}:                                {},
-	{"apps", "deployments"}:                               {},
-	{"", "endpoints"}:                                     {},
-	{"discovery.k8s.io", "endpointslices"}:                {},
-	{"events.k8s.io", "events"}:                           {},
-	{"", "events"}:                                        {},
-	{"autoscaling", "horizontalpodautoscalers"}:           {},
-	{"networking.k8s.io", "ingresses"}:                    {},
-	{"batch", "jobs"}:                                     {},
-	{"coordination.k8s.io", "leases"}:                     {},
-	{"", "limitranges"}:                                   {},
-	{"authorization.k8s.io", "localsubjectaccessreviews"}: {},
-	{"networking.k8s.io", "networkpolicies"}:              {},
-	{"", "persistentvolumeclaims"}:                        {},
-	{"policy", "poddisruptionbudgets"}:                    {},
-	{"", "pods"}:                                          {},
-	{"", "podtemplates"}:                                  {},
-	{"apps", "replicasets"}:                               {},
-	{"", "replicationcontrollers"}:                        {},
-	{"", "resourcequotas"}:                                {},
-	{"rbac.authorization.k8s.io", "rolebindings"}:         {},
-	{"rbac.authorization.k8s.io", "roles"}:                {},
-	{"", "secrets"}:                                       {},
-	{"", "serviceaccounts"}:                               {},
-	{"", "services"}:                                      {},
-	{"apps", "statefulsets"}:                              {},
+//
+// Key: resource kind, value: api group.
+var kubernetesNamespacedResourceKinds = map[string]string{
+	"bindings":                  "",
+	"configmaps":                "",
+	"controllerrevisions":       "apps",
+	"cronjobs":                  "batch",
+	"csistoragecapacities":      "storage.k8s.io",
+	"daemonsets":                "apps",
+	"deployments":               "apps",
+	"endpoints":                 "",
+	"endpointslices":            "discovery.k8s.io",
+	"events":                    "events.k8s.io",
+	"horizontalpodautoscalers":  "autoscaling",
+	"ingresses":                 "networking.k8s.io",
+	"jobs":                      "batch",
+	"leases":                    "coordination.k8s.io",
+	"limitranges":               "",
+	"localsubjectaccessreviews": "authorization.k8s.io",
+	"networkpolicies":           "networking.k8s.io",
+	"persistentvolumeclaims":    "",
+	"poddisruptionbudgets":      "policy",
+	"pods":                      "",
+	"podtemplates":              "",
+	"replicasets":               "apps",
+	"replicationcontrollers":    "",
+	"resourcequotas":            "",
+	"rolebindings":              "rbac.authorization.k8s.io",
+	"roles":                     "rbac.authorization.k8s.io",
+	"secrets":                   "",
+	"serviceaccounts":           "",
+	"services":                  "",
+	"statefulsets":              "apps",
 }
 
 // List of "" (core / legacy) resources.

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2091,7 +2091,7 @@ func validateKubeResources(roleVersion string, kubeResources []KubernetesResourc
 			}
 			// Best effort attempt to validate if the namespace field is needed.
 			if kubeResource.Namespace == "" {
-				if _, ok := kubernetesNamespacedResourceKinds[groupKind{kubeResource.APIGroup, kubeResource.Kind}]; ok {
+				if apiGroup, ok := kubernetesNamespacedResourceKinds[kubeResource.Kind]; ok && apiGroup == kubeResource.APIGroup {
 					return trace.BadParameter("KubernetesResource %q must include Namespace", kubeResource.Kind)
 				}
 			}

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -277,8 +277,7 @@ func getItemsUsingReflection(obj runtime.Object) (getItemsUsingReflectionOutput,
 func setItemsUsingReflection(itemsR reflect.Value, underlyingType reflect.Type, items []kubeObjectInterface) {
 	// make a new slice of the same type as the original one.
 	slice := reflect.MakeSlice(itemsR.Type(), len(items), len(items))
-	for i := range items {
-		item := items[i]
+	for i, item := range items {
 		// convert the item to the underlying type of the slice.
 		// this is needed because items is a slice of pointers that
 		// satisfy the kubeObjectInterface interface.
@@ -294,16 +293,15 @@ func setItemsUsingReflection(itemsR reflect.Value, underlyingType reflect.Type, 
 // newImpersonatedKubeClient creates a new Kubernetes Client that impersonates
 // a username and the groups.
 func newImpersonatedKubeClient(creds kubeCreds, username string, groups []string) (*dynamic.DynamicClient, error) {
-	c := &rest.Config{}
 	// clone cluster's rest config.
-	*c = *creds.getKubeRestConfig()
+	c := *creds.getKubeRestConfig()
 	// change the impersonated headers.
 	c.Impersonate = rest.ImpersonationConfig{
 		UserName: username,
 		Groups:   groups,
 	}
 	// TODO(tigrato): reuse the http client.
-	client, err := dynamic.NewForConfig(c)
+	client, err := dynamic.NewForConfig(&c)
 	return client, trace.Wrap(err)
 }
 

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -176,7 +176,17 @@ func Test_filterBuffer(t *testing.T) {
 
 				buf, decompress := newMemoryResponseWriter(t, data.Bytes(), tt.args.contentEncoding)
 
-				err = filterBuffer(newResourceFilterer(r, "", types.KubeVerbList, false, &globalKubeCodecs, allowedResources, nil, utils.NewSlogLoggerForTests()), buf)
+				mr := metaResource{
+					requestedResource: apiResource{
+						resourceKind: r,
+						apiGroup:     "",
+					},
+					resourceDefinition: &metav1.APIResource{
+						Namespaced: true,
+					},
+					verb: types.KubeVerbList,
+				}
+				err = filterBuffer(newResourceFilterer(mr, &globalKubeCodecs, allowedResources, nil, utils.NewSlogLoggerForTests()), buf)
 				require.NoError(t, err)
 
 				// Decompress the buffer to compare the result.

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -679,7 +679,17 @@ func TestWatcherResponseWriter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			userReader, userWriter := io.Pipe()
 			negotiator := newClientNegotiator(&globalKubeCodecs)
-			filterWrapper := newResourceFilterer("pods", "", types.KubeVerbWatch, false, &globalKubeCodecs, tt.args.allowed, tt.args.denied, utils.NewSlogLoggerForTests())
+			mr := metaResource{
+				requestedResource: apiResource{
+					resourceKind: "pods",
+					apiGroup:     "",
+				},
+				resourceDefinition: &metav1.APIResource{
+					Namespaced: true,
+				},
+				verb: types.KubeVerbWatch,
+			}
+			filterWrapper := newResourceFilterer(mr, &globalKubeCodecs, tt.args.allowed, tt.args.denied, utils.NewSlogLoggerForTests())
 			// watcher parses the data written into itself and if the user is allowed to
 			// receive the update, it writes the event into target.
 			watcher, err := responsewriters.NewWatcherResponseWriter(newFakeResponseWriter(userWriter) /*target*/, negotiator, filterWrapper)

--- a/lib/kube/proxy/response_rewriter.go
+++ b/lib/kube/proxy/response_rewriter.go
@@ -148,7 +148,7 @@ func collectSystemMastersTeleportRoles(s *clusterSession) []string {
 	// results in the intersection of roles that match the "kubernetes_labels" and
 	// roles that allow access to the desired "kubernetes_resource".
 	// If from the intersection results an empty set, the request is denied.
-	if rbacRes := s.metaResource.rbacResource(); rbacRes != nil {
+	if rbacRes := s.metaResource.rbacResource(); rbacRes != nil && !s.metaResource.isList {
 		matchers = append(
 			matchers,
 			services.NewKubernetesResourceMatcher(*rbacRes, s.metaResource.isClusterWideResource()),

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -40,14 +40,14 @@ type metaResource struct {
 	resourceDefinition *metav1.APIResource // Resource definition data from the schema.
 	requestedResource  apiResource         // User input, based on URL.
 	verb               string              // Verb of the user request.
-	isClusterWide      bool                // TODO(@creack): Remove this in favor of resourceDefinition.Namespaced.
+	isList             bool
 }
 
 func (mr *metaResource) isClusterWideResource() bool {
 	if mr == nil {
 		return false
 	}
-	return mr.isClusterWide || (mr.resourceDefinition != nil && !mr.resourceDefinition.Namespaced)
+	return mr.resourceDefinition != nil && !mr.resourceDefinition.Namespaced
 }
 
 func (mr *metaResource) rbacResource() *types.KubernetesResource {
@@ -237,11 +237,12 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 		// If the resource is not supported, return nil.
 		return out, nil
 	}
-	out.isClusterWide = !resource.Namespaced
+	out.resourceDefinition = &resource
 
 	if apiResource.resourceName == "" && out.verb != types.KubeVerbCreate {
 		// if the resource is supported but the resource name is not present and not a create request,
 		// return nil because it's a list request.
+		out.isList = true
 		return out, nil
 	}
 
@@ -254,7 +255,6 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (metaRe
 		apiResource.resourceName = resourceName
 		out.requestedResource = apiResource
 	}
-	out.resourceDefinition = &resource
 
 	return out, nil
 }

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -133,20 +133,20 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/apis/apps/", want: nil},
 		{path: "/apis/apps/v1", want: nil},
 		{path: "/apis/apps/v1/", want: nil},
-		{path: "/api/v1/pods", want: nil},
-		{path: "/api/v1/watch/pods", want: nil},
+		{path: "/api/v1/pods", want: &types.KubernetesResource{Kind: "pods", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/watch/pods", want: &types.KubernetesResource{Kind: "pods", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/kube-system", want: &types.KubernetesResource{Kind: "namespaces", Name: "kube-system", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/kube-system", want: &types.KubernetesResource{Kind: "namespaces", Name: "kube-system", Verbs: []string{"watch"}, APIGroup: ""}},
-		{path: "/api/v1/namespaces/kube-system/pods", want: nil},
-		{path: "/api/v1/watch/namespaces/kube-system/pods", want: nil},
+		{path: "/api/v1/namespaces/kube-system/pods", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/watch/namespaces/kube-system/pods", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/kube-system/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/apis/apiregistration.k8s.io/v1/apiservices/foo/status", want: nil},
 
 		// core
 		// Pods
-		{path: "/api/v1/pods", want: nil},
-		{path: "/api/v1/namespaces/default/pods", want: nil},
+		{path: "/api/v1/pods", want: &types.KubernetesResource{Kind: "pods", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/pods", want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/kube-system/pods/foo/exec", want: &types.KubernetesResource{Kind: "pods", Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}, APIGroup: ""}},
@@ -156,58 +156,58 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/api/v1/namespaces/default/pods", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "pods", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Secrets
-		{path: "/api/v1/secrets", want: nil},
-		{path: "/api/v1/namespaces/default/secrets", want: nil},
+		{path: "/api/v1/secrets", want: &types.KubernetesResource{Kind: "secrets", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/secrets", want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/secrets/foo", want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/secrets", body: bodyFunc("Secret", "v1"), want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/secrets", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "secrets", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Configmaps
-		{path: "/api/v1/configmaps", want: nil},
-		{path: "/api/v1/namespaces/default/configmaps", want: nil},
+		{path: "/api/v1/configmaps", want: &types.KubernetesResource{Kind: "configmaps", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/configmaps", want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/configmaps/foo", want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/configmaps", body: bodyFunc("ConfigMap", "v1"), want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/configmaps", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "configmaps", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Namespaces
-		{path: "/api/v1/namespaces", want: nil},
+		{path: "/api/v1/namespaces", want: &types.KubernetesResource{Kind: "namespaces", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default", want: &types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default", want: &types.KubernetesResource{Kind: "namespaces", Name: "default", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces", body: bodyFunc("Namespace", "v1"), want: &types.KubernetesResource{Kind: "namespaces", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "namespaces", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// Nodes
-		{path: "/api/v1/nodes", want: nil},
+		{path: "/api/v1/nodes", want: &types.KubernetesResource{Kind: "nodes", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/nodes/foo/proxy/bar", want: &types.KubernetesResource{Kind: "nodes", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		// Services
-		{path: "/api/v1/services", want: nil},
-		{path: "/api/v1/namespaces/default/services", want: nil},
+		{path: "/api/v1/services", want: &types.KubernetesResource{Kind: "services", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/services", want: &types.KubernetesResource{Kind: "services", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/services/foo", want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/services", body: bodyFunc("Service", "v1"), want: &types.KubernetesResource{Kind: "services", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: ""}},
 
 		// ServiceAccounts
-		{path: "/api/v1/serviceaccounts", want: nil},
-		{path: "/api/v1/namespaces/default/serviceaccounts", want: nil},
+		{path: "/api/v1/serviceaccounts", want: &types.KubernetesResource{Kind: "serviceaccounts", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/serviceaccounts", want: &types.KubernetesResource{Kind: "serviceaccounts", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: "serviceaccounts", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/serviceaccounts/foo", want: &types.KubernetesResource{Kind: "serviceaccounts", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		// PersistentVolumes
-		{path: "/api/v1/persistentvolumes", want: nil},
-		{path: "/api/v1/namespaces/default/persistentvolumes", want: nil},
+		{path: "/api/v1/persistentvolumes", want: &types.KubernetesResource{Kind: "persistentvolumes", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/persistentvolumes", want: &types.KubernetesResource{Kind: "persistentvolumes", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: "persistentvolumes", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/persistentvolumes/foo", want: &types.KubernetesResource{Kind: "persistentvolumes", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 		// PersistentVolumeClaims
-		{path: "/api/v1/persistentvolumeclaims", want: nil},
-		{path: "/api/v1/namespaces/default/persistentvolumeclaims", want: nil},
+		{path: "/api/v1/persistentvolumeclaims", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Verbs: []string{"list"}, APIGroup: ""}},
+		{path: "/api/v1/namespaces/default/persistentvolumeclaims", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Namespace: "default", Verbs: []string{"list"}, APIGroup: ""}},
 		{path: "/api/v1/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: ""}},
 		{path: "/api/v1/watch/namespaces/default/persistentvolumeclaims/foo", want: &types.KubernetesResource{Kind: "persistentvolumeclaims", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: ""}},
 
 		// apis/apps
 		// Deployments
-		{path: "/apis/apps/v1/deployments", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/deployments", want: nil},
+		{path: "/apis/apps/v1/deployments", want: &types.KubernetesResource{Kind: "deployments", Verbs: []string{"list"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/deployments", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Verbs: []string{"list"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/watch/namespaces/default/deployments/foo", want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFunc("Deployment", "apps/v1"), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
@@ -215,39 +215,39 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/apis/apps/v1/namespaces/default/deployments", body: bodyFuncWithoutGVK(), want: &types.KubernetesResource{Kind: "deployments", Namespace: "default", Name: "foo-create", Verbs: []string{"create"}, APIGroup: "apps"}},
 
 		// Statefulsets
-		{path: "/apis/apps/v1/statefulsets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/statefulsets", want: nil},
+		{path: "/apis/apps/v1/statefulsets", want: &types.KubernetesResource{Kind: "statefulsets", Verbs: []string{"list"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/statefulsets", want: &types.KubernetesResource{Kind: "statefulsets", Namespace: "default", Verbs: []string{"list"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: "statefulsets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/watch/namespaces/default/statefulsets/foo", want: &types.KubernetesResource{Kind: "statefulsets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 		// Replicasets
-		{path: "/apis/apps/v1/replicasets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/replicasets", want: nil},
+		{path: "/apis/apps/v1/replicasets", want: &types.KubernetesResource{Kind: "replicasets", Verbs: []string{"list"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/replicasets", want: &types.KubernetesResource{Kind: "replicasets", Namespace: "default", Verbs: []string{"list"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: "replicasets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/watch/namespaces/default/replicasets/foo", want: &types.KubernetesResource{Kind: "replicasets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 		// Daemonsets
-		{path: "/apis/apps/v1/daemonsets", want: nil},
-		{path: "/apis/apps/v1/namespaces/default/daemonsets", want: nil},
+		{path: "/apis/apps/v1/daemonsets", want: &types.KubernetesResource{Kind: "daemonsets", Verbs: []string{"list"}, APIGroup: "apps"}},
+		{path: "/apis/apps/v1/namespaces/default/daemonsets", want: &types.KubernetesResource{Kind: "daemonsets", Namespace: "default", Verbs: []string{"list"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: "daemonsets", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "apps"}},
 		{path: "/apis/apps/v1/watch/namespaces/default/daemonsets/foo", want: &types.KubernetesResource{Kind: "daemonsets", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "apps"}},
 
 		// apis/batch
 		// Job
-		{path: "/apis/batch/v1/jobs", want: nil},
-		{path: "/apis/batch/v1/namespaces/default/jobs", want: nil},
+		{path: "/apis/batch/v1/jobs", want: &types.KubernetesResource{Kind: "jobs", Verbs: []string{"list"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/namespaces/default/jobs", want: &types.KubernetesResource{Kind: "jobs", Namespace: "default", Verbs: []string{"list"}, APIGroup: "batch"}},
 		{path: "/apis/batch/v1/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: "jobs", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
 		{path: "/apis/batch/v1/watch/namespaces/default/jobs/foo", want: &types.KubernetesResource{Kind: "jobs", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
 		// CronJob
-		{path: "/apis/batch/v1/cronjobs", want: nil},
-		{path: "/apis/batch/v1/namespaces/default/cronjobs", want: nil},
+		{path: "/apis/batch/v1/cronjobs", want: &types.KubernetesResource{Kind: "cronjobs", Verbs: []string{"list"}, APIGroup: "batch"}},
+		{path: "/apis/batch/v1/namespaces/default/cronjobs", want: &types.KubernetesResource{Kind: "cronjobs", Namespace: "default", Verbs: []string{"list"}, APIGroup: "batch"}},
 		{path: "/apis/batch/v1/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: "cronjobs", Namespace: "default", Name: "foo", Verbs: []string{"get"}, APIGroup: "batch"}},
 		{path: "/apis/batch/v1/watch/namespaces/default/cronjobs/foo", want: &types.KubernetesResource{Kind: "cronjobs", Namespace: "default", Name: "foo", Verbs: []string{"watch"}, APIGroup: "batch"}},
 
 		// apis/certificates.k8s.io
-		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests", want: nil},
+		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests", want: &types.KubernetesResource{Kind: "certificatesigningrequests", Verbs: []string{"list"}, APIGroup: "certificates.k8s.io"}},
 		{path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/foo", want: &types.KubernetesResource{Kind: "certificatesigningrequests", Name: "foo", Verbs: []string{"get"}, APIGroup: "certificates.k8s.io"}},
 
 		// apis/networking.k8s.io
-		{path: "/apis/networking.k8s.io/v1/ingresses", want: nil},
+		{path: "/apis/networking.k8s.io/v1/ingresses", want: &types.KubernetesResource{Kind: "ingresses", Verbs: []string{"list"}, APIGroup: "networking.k8s.io"}},
 		{path: "/apis/networking.k8s.io/v1/ingresses/foo", want: &types.KubernetesResource{Kind: "ingresses", Name: "foo", Verbs: []string{"get"}, APIGroup: "networking.k8s.io"}},
 	}
 


### PR DESCRIPTION
Based off #54891

Minor cleanup addressing pending TODOs in kube proxy.

- Leverage the `metaResource` struct instead of passing kind/group/verb/isClusterwide everywhere.
- Keep the resourceDefinition even when dealing with list. Use a flag instead.
- minor housekeeping