### PR TITLE
Relax access_list_member validation

### DIFF
--- a/api/types/accesslist/convert/v1/member_test.go
+++ b/api/types/accesslist/convert/v1/member_test.go
@@ -76,7 +76,7 @@ func TestMemberFromProtoNils(t *testing.T) {
 		{
 			name:     "joined",
 			mutate:   func(m *accesslistv1.Member) { m.Spec.Joined = nil },
-			checkErr: require.Error,
+			checkErr: require.NoError,
 		},
 		{
 			name:     "expires",
@@ -91,7 +91,7 @@ func TestMemberFromProtoNils(t *testing.T) {
 		{
 			name:     "added by",
 			mutate:   func(m *accesslistv1.Member) { m.Spec.AddedBy = "" },
-			checkErr: require.Error,
+			checkErr: require.NoError,
 		},
 	}
 

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -99,15 +99,7 @@ func (a *AccessListMember) CheckAndSetDefaults() error {
 	}
 
 	if a.Spec.Name == "" {
-		return trace.BadParameter("member name is missing")
-	}
-
-	if a.Spec.Joined.IsZero() || a.Spec.Joined.Unix() == 0 {
-		return trace.BadParameter("member %s: joined field empty or missing", a.Spec.Name)
-	}
-
-	if a.Spec.AddedBy == "" {
-		return trace.BadParameter("member %s: added_by field is empty", a.Spec.Name)
+		a.Spec.Name = a.GetName()
 	}
 
 	return nil

--- a/api/types/accesslist/member_test.go
+++ b/api/types/accesslist/member_test.go
@@ -50,19 +50,30 @@ func TestAccessListMemberDefaults(t *testing.T) {
 		}
 	}
 
-	t.Run("join date required for member", func(t *testing.T) {
+	// Joined is set by the UpsertAccessListMember and UpsertAccessListWithMembers
+	t.Run("join date not required", func(t *testing.T) {
 		uut := newValidAccessListMember()
 		uut.Spec.Joined = time.Time{}
 
 		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
+		require.NoError(t, err)
 	})
 
-	t.Run("added-by required", func(t *testing.T) {
+	// AddedBy is set by the UpsertAccessListMember and UpsertAccessListWithMembers
+	t.Run("added-by not required", func(t *testing.T) {
 		uut := newValidAccessListMember()
 		uut.Spec.AddedBy = ""
 
 		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
+		require.NoError(t, err)
+	})
+
+	t.Run("name defaulted to metadata.name", func(t *testing.T) {
+		uut := newValidAccessListMember()
+		uut.Spec.Name = ""
+
+		err := uut.CheckAndSetDefaults()
+		require.NoError(t, err)
+		require.Equal(t, uut.GetMetadata().Name, uut.Spec.Name)
 	})
 }


### PR DESCRIPTION
This PR removes requirement of `spec.joined` and `spec.added_by` and defaults `spec.name` to `metadata.name`.

This is because:

- we don't want to set it Terraform resource
- [those fields are overwritten during the creation/update](https://github.com/gravitational/teleport.e/blob/dc8b64cfa77f06ff6a49835b8bc11ccf1953f27d/lib/accesslist/service.go#L1011-L1031)