### PR TITLE
[v16] chore: remove `host_uuid` kube storage compatibility layer

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6418,18 +6418,6 @@ func readOrGenerateHostID(ctx context.Context, cfg *servicecfg.Config, kubeBacke
 		if err := persistHostIDToStorages(ctx, cfg, kubeBackend); err != nil {
 			return trace.Wrap(err)
 		}
-	} else if kubeBackend != nil && hostid.ExistsLocally(cfg.DataDir) {
-		// This case is used when loading a Teleport pre-11 agent with storage attached.
-		// In this case, we have to copy the "host_uuid" from the agent to the secret
-		// in case storage is removed later.
-		// loadHostIDFromKubeSecret will check if the `host_uuid` is already in the secret.
-		if id, err := loadHostIDFromKubeSecret(ctx, kubeBackend); err != nil || len(id) == 0 {
-			// Forces the copy of the host_uuid into the Kubernetes Secret if PV storage is enabled.
-			// This is only required if PV storage is removed later.
-			if err := writeHostIDToKubeSecret(ctx, kubeBackend, cfg.HostUUID); err != nil {
-				return trace.Wrap(err)
-			}
-		}
 	}
 	return nil
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1107,25 +1107,6 @@ func Test_readOrGenerateHostID(t *testing.T) {
 			},
 		},
 		{
-			name: "Kube Backend is available but key is missing. Load from local storage and store in lube",
-			args: args{
-				kubeBackend: &fakeKubeBackend{
-					getData: nil,
-					getErr:  fmt.Errorf("key not found"),
-				},
-				hostIDContent: id,
-			},
-			wantFunc: func(receivedID string) bool {
-				return receivedID == id
-			},
-			wantKubeItemFunc: func(i *backend.Item) bool {
-				return cmp.Diff(&backend.Item{
-					Key:   []byte(hostUUIDKey),
-					Value: []byte(id),
-				}, i) == ""
-			},
-		},
-		{
 			name: "Kube Backend is available with key. Load from kube storage",
 			args: args{
 				kubeBackend: &fakeKubeBackend{

--- a/lib/utils/hostid/hostid.go
+++ b/lib/utils/hostid/hostid.go
@@ -37,18 +37,12 @@ func GetPath(dataDir string) string {
 	return filepath.Join(dataDir, FileName)
 }
 
-// ExistsLocally checks if dataDir/host_uuid file exists in local storage.
-func ExistsLocally(dataDir string) bool {
-	_, err := ReadFile(dataDir)
-	return err == nil
-}
-
 // ReadFile reads host UUID from the file in the data dir
 func ReadFile(dataDir string) (string, error) {
 	out, err := utils.ReadPath(GetPath(dataDir))
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
-			//do not convert to system error as this loses the ability to compare that it is a permission error
+			// do not convert to system error as this loses the ability to compare that it is a permission error
 			return "", trace.Wrap(err)
 		}
 		return "", trace.ConvertSystemError(err)


### PR DESCRIPTION
Backport #56210 to branch/v16