### PR TITLE
Fix misleading error in Terraform Provider

### DIFF
--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -493,7 +493,7 @@ func (CredentialsFromNativeMachineID) Credentials(ctx context.Context, config pr
 		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
 	}
 	if joinToken == "" {
-		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
+		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinToken, constants.EnvVarTerraformJoinToken)
 	}
 	if addr == "" {
 		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformAddress, constants.EnvVarTerraformAddress)


### PR DESCRIPTION
Previously, error states that the `join_method` has not been provided, but the logic is actually checking for `join_token`. This is confusing for end-users.