### PR TITLE
docs: update minimum Linux kernel version

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -34,7 +34,7 @@ running Teleport on UNIX variants other than Linux \[1].
 
 | Operating System | `teleport` Daemon | `tctl` Admin Tool | `tsh` and Teleport Connect User Clients [2] | Web UI (via the browser) | `tbot` Daemon |
 | - | - | - | - | - | - |
-| Linux v2.6.23+ (RHEL/CentOS 7+, Rocky Linux 8+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
+| Linux 3.2+ (RHEL/CentOS 7+, Rocky Linux 8+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
 | macOS 11+  (Big Sur)| yes | yes | yes | yes | yes |
 | Windows 10+ (rev. 1607) \[4] | no | yes | yes | yes | yes |
 

--- a/lib/utils/uds/socketpair_impl_atomic.go
+++ b/lib/utils/uds/socketpair_impl_atomic.go
@@ -31,8 +31,7 @@ import (
 // socketpair directly in close-on-exec mode.
 func cloexecSocketpair(t SocketType) (uintptr, uintptr, error) {
 	// SOCK_CLOEXEC on socketpair is supported since Linux 2.6.27 and go's
-	// minimum requirement is 2.6.32 (FreeBSD supports it since FreeBSD 10 and
-	// go 1.20+ requires FreeBSD 12)
+	// minimum requirement is 3.2
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, t.proto()|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return 0, 0, trace.Wrap(err)


### PR DESCRIPTION
Teleport 18 is built with Go 1.24, which requires Linux kernel 3.2 or later.