### PR TITLE
autoupdate canary support: inventory and auth primitives

### DIFF
--- a/api/types/autoupdate/constants.go
+++ b/api/types/autoupdate/constants.go
@@ -43,4 +43,9 @@ const (
 	// maintenance window. There is no dependency between groups. Agents won't be instructed to update
 	// if the window is over.
 	AgentsStrategyTimeBased = "time-based"
+
+	// MaxCanaryCount is the maximum number of canaries allowed for a single group.
+	// This value is arbitrarily low to avoid XXL rollouts to grow over the max backend
+	// item size.
+	MaxCanaryCount = 10
 )

--- a/api/types/autoupdate/rollout.go
+++ b/api/types/autoupdate/rollout.go
@@ -93,6 +93,12 @@ func ValidateAutoUpdateAgentRollout(v *autoupdate.AutoUpdateAgentRollout) error 
 		if v.Spec.Strategy == AgentsStrategyHaltOnError && i == 0 && group.ConfigWaitHours != 0 {
 			return trace.BadParameter("status.schedules.groups[0].config_wait_hours must be zero as it's the first group")
 		}
+		if group.CanaryCount > MaxCanaryCount {
+			return trace.BadParameter("status.schedules.groups[%d].canary_count must be less than %d", i, MaxCanaryCount)
+		}
+		if len(group.Canaries) > MaxCanaryCount {
+			return trace.BadParameter("status.schedules.groups[%d].canaries must be contain less than %d elements", i, MaxCanaryCount)
+		}
 		if conflictingGroup, ok := seenGroups[group.Name]; ok {
 			return trace.BadParameter("spec.agents.schedules.regular contains groups with the same name %q at indices %d and %d", group.Name, conflictingGroup, i)
 		}

--- a/api/types/autoupdate/rollout_test.go
+++ b/api/types/autoupdate/rollout_test.go
@@ -349,6 +349,23 @@ func TestValidateAutoUpdateAgentRollout(t *testing.T) {
 			},
 			assertErr: require.Error,
 		},
+		{
+			name: "group with too high canary count",
+			rollout: &autoupdate.AutoUpdateAgentRollout{
+				Kind:    types.KindAutoUpdateAgentRollout,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: types.MetaNameAutoUpdateAgentRollout,
+				},
+				Spec: &haltOnErrorRolloutSpec,
+				Status: &autoupdate.AutoUpdateAgentRolloutStatus{
+					Groups: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+						{Name: "g1", ConfigDays: []string{"*"}, CanaryCount: 15},
+					},
+				},
+			},
+			assertErr: require.Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/auth/autoupdate_agent_version_report_test.go
+++ b/lib/auth/autoupdate_agent_version_report_test.go
@@ -70,6 +70,10 @@ func (f fakeControlStream) Done() <-chan struct{} {
 	return f.doneChan
 }
 
+func (f fakeControlStream) Send(ctx context.Context, msg proto.DownstreamInventoryMessage) error {
+	return nil
+}
+
 func (f fakeControlStream) fakeMsg(msg proto.UpstreamInventoryMessage) {
 	f.msgChan <- msg
 }
@@ -237,10 +241,21 @@ func TestServer_generateAgentVersionReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clock := clockwork.NewFakeClockAt(twoMinutesAgo)
+			bk, err := memory.New(memory.Config{})
+			require.NoError(t, err)
 			auth := &Server{
-				logger:   utils.NewSlogLoggerForTests(),
-				ServerID: uuid.NewString(),
+				cancelFunc: func() {},
+				logger:     utils.NewSlogLoggerForTests(),
+				ServerID:   uuid.NewString(),
+				Services: &Services{
+					// The inventory is running heartbeats on the background.
+					// If we don't create a presence service this will cause panics.
+					PresenceInternal: local.NewPresenceService(bk),
+				},
 			}
+			t.Cleanup(func() {
+				auth.Close()
+			})
 			controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
 			for _, fixture := range tt.fixtures {
 				clock.Advance(fixture.delay)
@@ -297,13 +312,23 @@ func TestServer_reportAgentVersions(t *testing.T) {
 	// Test setup: load fixtures.
 	const testNodeCount = 10
 	auth := &Server{
-		clock:    clock,
-		ServerID: uuid.NewString(),
-		Services: &Services{AutoUpdateService: svc},
-		logger:   utils.NewSlogLoggerForTests(),
+		cancelFunc: func() {},
+		clock:      clock,
+		ServerID:   uuid.NewString(),
+		Services: &Services{
+			AutoUpdateService: svc,
+			// The inventory is running heartbeats on the background.
+			// If we don't create a presence service this will cause panics.
+			PresenceInternal: local.NewPresenceService(bk),
+		},
+		logger: utils.NewSlogLoggerForTests(),
 	}
+	t.Cleanup(func() {
+		auth.Close()
+	})
 	auth.Cache = auth.Services
-	controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
+	controller := inventory.NewController(auth, nil,
+		inventory.WithClock(clock))
 	auth.inventory = controller
 
 	for range testNodeCount {

--- a/lib/auth/autoupdate_rollout.go
+++ b/lib/auth/autoupdate_rollout.go
@@ -1,0 +1,168 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"math/rand/v2"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/lib/inventory"
+)
+
+// SampleAgentsFromAutoUpdateGroup iterates over every handle in the inventory to
+// build a random sample of agents belonging to a given group.
+// The main use-case for this function is to pick canaries that can be updated.
+func (a *Server) SampleAgentsFromAutoUpdateGroup(ctx context.Context, groupName string, sampleSize int, groups []string) ([]*autoupdatev1pb.Canary, error) {
+	if len(groups) == 0 {
+		return nil, trace.BadParameter("no groups specified")
+	}
+	isCatchAll := groupName == groups[len(groups)-1]
+	var groupSet map[string]struct{}
+
+	// Small optimization, we only need to build the groupSet if we are sampling the catch-all group
+	if isCatchAll {
+		groupSet = make(map[string]struct{})
+		for _, group := range groups {
+			groupSet[group] = struct{}{}
+		}
+	}
+
+	filter := func(handle inventory.UpstreamHandle) bool {
+		if result := filterHandler(handle, a.clock.Now()); result != autoUpdateFilterResultMatching {
+			return false
+		}
+
+		// If this is not the catch-all group, we can only check if the agent group is the right one.
+		if !isCatchAll {
+			// No need to check for UpdaterInfo being nil, it would have been filtered
+			// out by filterHandler().
+			return handle.Hello().UpdaterInfo.UpdateGroup == groupName
+		}
+		// This is the catch-call group, it matches agents from every group not in groups.
+		_, ok := groupSet[groupName]
+		// If the agent group is not in the group list, it falls into the catch-all.
+		return !ok
+	}
+
+	sampler := newHandlerSampler(sampleSize, filter)
+
+	a.inventory.UniqueHandles(sampler.visit)
+
+	sampled := sampler.Sampled()
+	canaries := make([]*autoupdatev1pb.Canary, 0, len(sampled))
+	for _, h := range sampled {
+		hello := h.Hello()
+		updaterID, err := uuid.FromBytes(hello.UpdaterInfo.UpdateUUID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		canaries = append(canaries, &autoupdatev1pb.Canary{
+			UpdaterId: updaterID.String(),
+			HostId:    hello.ServerID,
+			Hostname:  hello.Hostname,
+			Success:   false,
+		})
+	}
+	return canaries, nil
+}
+
+// handleSampler randomly samples handles from the inventory.
+// It implements Alan Waterman's Reservoir Sampling Algorithm R
+// (The Art of Computer Programming Volume 2).
+// See https://en.wikipedia.org/wiki/Reservoir_sampling for more details.
+type handleSampler struct {
+	sampleSize int
+	seenCount  int
+	filter     func(handle inventory.UpstreamHandle) bool
+	sample     []inventory.UpstreamHandle
+}
+
+func newHandlerSampler(sampleSize int, filter func(handle inventory.UpstreamHandle) bool) *handleSampler {
+	return &handleSampler{
+		sampleSize: sampleSize,
+		seenCount:  sampleSize,
+		filter:     filter,
+		sample:     make([]inventory.UpstreamHandle, 0, sampleSize),
+	}
+}
+
+// pass this function to inventory.AllHandles()
+func (h *handleSampler) visit(handle inventory.UpstreamHandle) {
+	// filter out everything we don't want
+	if !h.filter(handle) {
+		return
+	}
+
+	// Fill the reservoir
+	if len(h.sample) < h.sampleSize {
+		h.sample = append(h.sample, handle)
+		h.seenCount++
+		return
+	}
+
+	// Reservoir is already filled, replace existing elements.
+	if j := rand.N(h.seenCount); j < h.sampleSize {
+		h.sample[j] = handle
+	}
+	h.seenCount++
+}
+
+func (h *handleSampler) Sampled() []inventory.UpstreamHandle {
+	return h.sample
+}
+
+// LookupAgentInInventory looks for a specific hostID in the local inventory
+// and returns all the Hello messages associated to those agents.
+// Agents that joined less than a minute ago or that are terminating/restarting
+// are ignored.
+func (a *Server) LookupAgentInInventory(ctx context.Context, hostID string) ([]*proto.UpstreamInventoryHello, error) {
+	handles := a.inventory.Handles(hostID)
+	now := a.clock.Now()
+
+	var qualifiedHellos []*proto.UpstreamInventoryHello
+
+	for handle := range handles {
+		// If the instance is being soft-reloaded or shut down, we ignore it.
+		if goodbye := handle.Goodbye(); goodbye.GetSoftReload() || goodbye.GetDeleteResources() {
+			continue
+		}
+
+		// We skip servers that joined less than a minute ago as they might have been
+		// connected to another auth instance a few seconds ago, which would lead to double-counting.
+		if now.Sub(handle.RegistrationTime()) < constants.AutoUpdateAgentReportPeriod {
+			continue
+		}
+		// Do don't apply other filtering logic like filterHandle() does because the instance already
+		// got selected with strict constraints earlier during sampling. We don't want a filtering rule change, or an instance change, to make the lookup fail and block the rollout.
+		qualifiedHellos = append(qualifiedHellos, handle.Hello())
+	}
+
+	if len(qualifiedHellos) == 0 {
+		return nil, trace.NotFound("no control streams meet requirements for host %v", hostID)
+	}
+
+	return qualifiedHellos, nil
+
+}

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -1,0 +1,312 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/inventory"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestSampleAgentsFromGroup(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	auth := &Server{
+		cancelFunc: func() {},
+		clock:      clock,
+		ServerID:   uuid.NewString(),
+		logger:     utils.NewSlogLoggerForTests(),
+		Services: &Services{
+			// The inventory is running heartbeats on the background.
+			// If we don't create a presence service this will cause panics.
+			PresenceInternal: local.NewPresenceService(bk),
+		},
+	}
+	controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
+	auth.inventory = controller
+	t.Cleanup(func() {
+		auth.Close()
+	})
+
+	const (
+		testNodeCount         = 1000
+		testGroupName         = "my-group"
+		testCatchAllGroupName = "catch-all-group"
+	)
+
+	testGroups := []string{testGroupName, testCatchAllGroupName}
+
+	for range testNodeCount {
+		updaterID := uuid.New()
+		stream := newFakeControlStream()
+		controller.RegisterControlStream(stream, &proto.UpstreamInventoryHello{
+			Services:         types.SystemRoles{types.RoleNode}.StringSlice(),
+			Version:          "1.2.3",
+			ServerID:         uuid.NewString(),
+			ExternalUpgrader: types.UpgraderKindTeleportUpdate,
+			UpdaterInfo: &types.UpdaterV2Info{
+				UpdateUUID:    updaterID[:],
+				UpdaterStatus: types.UpdaterStatus_UPDATER_STATUS_OK,
+				UpdateGroup:   testGroupName,
+			},
+		})
+		t.Cleanup(stream.close)
+	}
+
+	// Nodes that just registered are ignored, we advance the clock so our fixtures are not filtered out by filterHandler().
+	clock.Advance(2 * time.Minute)
+
+	// Text execution: check that we sample the correct amount of canaries
+	const sampleSize = 10
+	canaries, err := auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testGroupName, sampleSize, testGroups)
+	require.NoError(t, err)
+	require.Len(t, canaries, sampleSize)
+
+	// Test execution: check that there were no duplicates in the samples
+	canarySet := make(map[string]*autoupdatev1pb.Canary)
+	for _, canary := range canaries {
+		canarySet[canary.UpdaterId] = canary
+	}
+	require.Len(t, canarySet, sampleSize, "some canary got duplicated")
+
+	canaries2, err := auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testGroupName, sampleSize, testGroups)
+	require.NoError(t, err)
+	require.Len(t, canaries2, sampleSize)
+	canarySet = make(map[string]*autoupdatev1pb.Canary)
+	for _, canary := range canaries2 {
+		canarySet[canary.UpdaterId] = canary
+	}
+	require.Len(t, canarySet, sampleSize, "some canary got duplicated")
+
+	// Text execution: check that the random looks sane
+	var conflicts int
+	for i := range sampleSize {
+		if canaries[i].UpdaterId == canaries2[i].UpdaterId {
+			conflicts++
+		}
+	}
+	// The probability of having 4 nodes sampled at the same position twice in
+	// a row is 2e-10.
+	require.Less(t, conflicts, 4)
+
+	// Test execution: check that agents not belonging to any group are sampled whe requesting the catch-all group.
+	canariesCatchAll, err := auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testGroupName, sampleSize, []string{"group-a", testCatchAllGroupName})
+	require.NoError(t, err)
+	require.Len(t, canariesCatchAll, sampleSize)
+	canarySet = make(map[string]*autoupdatev1pb.Canary)
+	for _, canary := range canariesCatchAll {
+		canarySet[canary.UpdaterId] = canary
+	}
+	require.Len(t, canarySet, sampleSize, "some canary got duplicated")
+
+}
+
+func TestLookupAgentInInventory(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	auth := &Server{
+		cancelFunc: func() {},
+		clock:      clock,
+		ServerID:   uuid.NewString(),
+		logger:     utils.NewSlogLoggerForTests(),
+		Services: &Services{
+			// The inventory is running heartbeats on the background.
+			// If we don't create a presence service this will cause panics.
+			PresenceInternal: local.NewPresenceService(bk),
+		},
+	}
+	controller := inventory.NewController(auth, nil, inventory.WithClock(clock))
+	auth.inventory = controller
+	t.Cleanup(func() {
+		auth.Close()
+	})
+
+	const testNodeCount = 5
+	const testGroupName = "my-group"
+
+	hosts := make(map[string][]*proto.UpstreamInventoryHello, testNodeCount)
+
+	// Test setup:
+	// We register X nodes, node number 1 has 1 handler, node 2 has 2, ...
+	for i := range testNodeCount {
+		hostID := uuid.New().String()
+		updaterID := uuid.New()
+		hellos := make([]*proto.UpstreamInventoryHello, i+1)
+		for j := range i + 1 {
+			hello := &proto.UpstreamInventoryHello{
+				Services:         types.SystemRoles{types.RoleNode}.StringSlice(),
+				Version:          fmt.Sprintf("1.2.%d", j),
+				ServerID:         hostID,
+				ExternalUpgrader: types.UpgraderKindTeleportUpdate,
+				UpdaterInfo: &types.UpdaterV2Info{
+					UpdateUUID:    updaterID[:],
+					UpdaterStatus: types.UpdaterStatus_UPDATER_STATUS_OK,
+					UpdateGroup:   testGroupName,
+				},
+			}
+			hellos[j] = hello
+
+			stream := newFakeControlStream()
+			controller.RegisterControlStream(stream, hello)
+			t.Cleanup(stream.close)
+		}
+		hosts[hostID] = hellos
+	}
+
+	clock.Advance(2 * time.Minute)
+
+	// Test execution: for each hostID registered, we get the handles and make sure we have the right length
+	// and content matches.
+
+	opts := cmp.Options{
+		cmpopts.SortSlices(func(a, b *proto.UpstreamInventoryHello) bool { return a.Version > b.Version }),
+		protocmp.Transform(),
+	}
+	for hostID, handles := range hosts {
+		result, err := auth.LookupAgentInInventory(t.Context(), hostID)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(handles, result, opts))
+	}
+}
+
+type fakeHandle struct {
+	inventory.UpstreamHandle
+	id int
+}
+
+func (f *fakeHandle) Hello() *proto.UpstreamInventoryHello {
+	return &proto.UpstreamInventoryHello{
+		Hostname: fmt.Sprintf("hostname-%d", f.id),
+	}
+}
+
+func TestHandlerSampler(t *testing.T) {
+	filterOK := func(handle inventory.UpstreamHandle) bool {
+		return true
+	}
+	filterKO := func(handle inventory.UpstreamHandle) bool {
+		return false
+	}
+
+	generateHandles := func(i int) iter.Seq[inventory.UpstreamHandle] {
+		return func(yield func(inventory.UpstreamHandle) bool) {
+			for j := range i {
+				yield(&fakeHandle{id: j})
+			}
+		}
+	}
+
+	const testSampleSize = 10
+	// no agents to sample
+	// reservoir not filled yet
+	// reservoir filled
+	// filter always rejecting
+	tests := []struct {
+		name              string
+		filter            func(handle inventory.UpstreamHandle) bool
+		initialSeenCount  int
+		handleFixtures    iter.Seq[inventory.UpstreamHandle]
+		expectedSeenCount int
+		assertSample      func(t *testing.T, reservoir []inventory.UpstreamHandle)
+	}{
+		{
+			name:              "filter rejects all",
+			filter:            filterKO,
+			initialSeenCount:  0,
+			handleFixtures:    generateHandles(100),
+			expectedSeenCount: 0,
+			assertSample: func(t *testing.T, reservoir []inventory.UpstreamHandle) {
+				require.Empty(t, reservoir)
+			},
+		},
+		{
+			name:              "no agent to sample",
+			filter:            filterOK,
+			initialSeenCount:  0,
+			handleFixtures:    generateHandles(0),
+			expectedSeenCount: 0,
+			assertSample: func(t *testing.T, reservoir []inventory.UpstreamHandle) {
+				require.Empty(t, reservoir)
+			},
+		},
+		{
+			name:              "reservoir not filled entirely",
+			filter:            filterOK,
+			initialSeenCount:  0,
+			handleFixtures:    generateHandles(5),
+			expectedSeenCount: 5,
+			assertSample: func(t *testing.T, reservoir []inventory.UpstreamHandle) {
+				require.Len(t, reservoir, 5)
+				for i, h := range reservoir {
+					expectedHostname := fmt.Sprintf("hostname-%d", i)
+					require.Equal(t, expectedHostname, h.Hello().Hostname)
+				}
+			},
+		},
+		{
+			name:              "overflowing reservoir",
+			filter:            filterOK,
+			initialSeenCount:  0,
+			handleFixtures:    generateHandles(110),
+			expectedSeenCount: 110,
+			assertSample: func(t *testing.T, reservoir []inventory.UpstreamHandle) {
+				require.Len(t, reservoir, testSampleSize)
+				// the probability of no elements being sampled in the last 100 elements is 10e-200
+				require.NotElementsMatch(t, slices.Collect(generateHandles(testSampleSize)), reservoir)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sampler := handleSampler{
+				sampleSize: testSampleSize,
+				seenCount:  test.initialSeenCount,
+				filter:     test.filter,
+				sample:     make([]inventory.UpstreamHandle, 0, testSampleSize),
+			}
+			for handle := range test.handleFixtures {
+				sampler.visit(handle)
+			}
+
+			require.Equal(t, test.expectedSeenCount, sampler.seenCount)
+			test.assertSample(t, sampler.sample)
+		})
+	}
+}

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -20,6 +20,7 @@ package inventory
 
 import (
 	"context"
+	"iter"
 	"log/slog"
 	"math/rand/v2"
 	"os"
@@ -379,6 +380,11 @@ func (c *Controller) RegisterControlStream(stream client.UpstreamInventoryContro
 func (c *Controller) GetControlStream(serverID string) (handle UpstreamHandle, ok bool) {
 	handle, ok = c.store.Get(serverID)
 	return
+}
+
+// Handles gets the handles for the given server ID if they exist.
+func (c *Controller) Handles(serverID string) iter.Seq[UpstreamHandle] {
+	return c.store.Handles(serverID)
 }
 
 // UniqueHandles iterates across unique handles registered with this controller.

--- a/lib/inventory/store.go
+++ b/lib/inventory/store.go
@@ -20,6 +20,7 @@ package inventory
 
 import (
 	"hash/maphash"
+	"iter"
 	"sync"
 	"sync/atomic"
 )
@@ -61,6 +62,12 @@ func NewStore() *Store {
 // is selected pseudorandomly from the available set.
 func (s *Store) Get(serverID string) (handle UpstreamHandle, ok bool) {
 	return s.getShard(serverID).get(serverID)
+}
+
+// Handles attempts to load all known handlers for the given server ID.
+// If you only need one handler, use Get instead.
+func (s *Store) Handles(serverID string) iter.Seq[UpstreamHandle] {
+	return s.getShard(serverID).handles(serverID)
 }
 
 // Insert adds a new handle to the store.
@@ -142,6 +149,26 @@ func (s *shard) get(serverID string) (handle UpstreamHandle, ok bool) {
 	idx := entry.ct.Add(1) % uint64(len(entry.handles))
 	handle = entry.handles[int(idx)]
 	return handle, true
+}
+
+// handles gets all handles registered for a given hostID.
+// To get a random handle, use get() instead.
+func (s *shard) handles(serverID string) iter.Seq[UpstreamHandle] {
+	return func(yield func(UpstreamHandle) bool) {
+		s.rw.RLock()
+		defer s.rw.RUnlock()
+
+		entry, ok := s.m[serverID]
+		if !ok {
+			return
+		}
+
+		for _, handle := range entry.handles {
+			if !yield(handle) {
+				return
+			}
+		}
+	}
 }
 
 func (s *shard) iter(fn func(UpstreamHandle)) {


### PR DESCRIPTION
Part 2 of the canary support as described in [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

This PR adds the auth primitives to:
- sample canaries
- lookup a single host in the inventory

The PR also adds a `Handles(hostID string)` function to get all handles for a host in the inventory.

You can find the [meta canary PR here](https://github.com/gravitational/teleport/pull/56128), I'm upstreaming it bit by bit to make the review more palatable.

Goal (internal): https://github.com/gravitational/cloud/issues/13207
Depends on: https://github.com/gravitational/teleport/pull/56259