### PR TITLE
Kubernetes RABC simplification - MVP

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -846,6 +846,12 @@ const (
 	// KubeConfigFile is a default filename where k8s stores its user local config
 	KubeConfigFile = "config"
 
+	// KubernetesGroupsWildcardMapping is the name of the default group
+	// that will be assigned to users when using the special `*` wildcard
+	// in `kubernetes_groups` field in roles. This value only applies if
+	// the value from configuration is not set.
+	KubernetesGroupsWildcardMapping = "system:masters"
+
 	// KubeRunTests turns on kubernetes tests
 	KubeRunTests = "TEST_KUBE"
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1744,6 +1744,9 @@ func applyKubeConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	if fc.Kube.KubeClusterName != "" {
 		cfg.Kube.KubeClusterName = fc.Kube.KubeClusterName
 	}
+	if fc.Kube.GroupsWildcardMapping != "" {
+		cfg.Kube.GroupWildcardMapping = fc.Kube.GroupsWildcardMapping
+	}
 	if fc.Kube.StaticLabels != nil {
 		cfg.Kube.StaticLabels = maps.Clone(fc.Kube.StaticLabels)
 	}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2432,6 +2432,9 @@ type Kube struct {
 	DynamicLabels []CommandLabel `yaml:"commands,omitempty"`
 	// ResourceMatchers match cluster kube_cluster resources.
 	ResourceMatchers []ResourceMatcher `yaml:"resources,omitempty"`
+	// GroupsWildcardMapping is the name of the Kubernetes group that
+	// will be used for impersonation when using the special `*` wildcard value.
+	GroupsWildcardMapping string `yaml:"groups_wildcard_mapping,omitempty"`
 }
 
 // ReverseTunnel is a SSH reverse tunnel maintained by one cluster's

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,7 +34,6 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
-
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,6 +34,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//
@@ -174,7 +175,10 @@ func extractKubeCreds(ctx context.Context, component string, cluster string, cli
 	// For each loaded cluster, check impersonation permissions. This
 	// check only logs when permissions are not configured, but does not fail startup.
 	if err := checkPermissions(ctx, cluster, client.AuthorizationV1().SelfSubjectAccessReviews()); err != nil {
-		log.WarnContext(ctx, "Failed to test the necessary Kubernetes permissions. The target Kubernetes cluster may be down or have misconfigured RBAC. This teleport instance will still handle Kubernetes requests towards this Kubernetes cluster.",
+		log.WarnContext(ctx,
+			"Failed to test the necessary Kubernetes permissions. "+
+				"The target Kubernetes cluster may be down or have misconfigured RBAC. "+
+				"This teleport instance will still handle Kubernetes requests towards this Kubernetes cluster.",
 			"error", err,
 		)
 	} else {

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -243,7 +243,13 @@ func (k *kubeDetails) startUpdateClusterLoop(ctx context.Context, cfg clusterDet
 }
 
 func (k *kubeDetails) startResourceWatcher(ctx context.Context, cfg clusterDetailsConfig, creds kubeCreds) error {
-	aecs, err := apiextensionsclientset.NewForConfig(creds.getKubeRestConfig())
+	restConfig := creds.getKubeRestConfig()
+	if restConfig == nil {
+		// Expected in tests.
+		cfg.log.WarnContext(ctx, "Missing Kubernetes REST config, not starting resource watcher")
+		return nil
+	}
+	aecs, err := apiextensionsclientset.NewForConfig(restConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -30,6 +30,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/version"
@@ -167,10 +169,29 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 		gvkSupportedResources: gvkSupportedRes,
 	}
 
+	if err := k.startUpdateClusterLoop(ctx, cfg, creds); err != nil {
+		// If we failed to start the update loop, we close the kubeDetails and return.
+		// NOTE: Can't happen, but just to be safe if we add logic in the future.
+		k.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	if err := k.startResourceWatcher(ctx, cfg, creds); err != nil {
+		// Before v19, we didn't have a watcher and therefore didn't have the permission set in the provisionned clusterrole.
+		// Upgrading from an older version requires updating the role.
+		// If we fail to start the watcher, we still have the periodic update loop as a fallback.
+		// TODO(@creack): Attempt to work around this by impersonating system:masters and cluster-admin.
+		cfg.log.WarnContext(ctx, "Failed to start resource watcher, the cluster may be offline or the Teleport clusterrole may be misconfigured", "error", err)
+	}
+
+	return k, nil
+}
+
+func (k *kubeDetails) startUpdateClusterLoop(ctx context.Context, cfg clusterDetailsConfig, creds kubeCreds) error {
 	// If cluster is online and there's no errors, we refresh details seldom (every 5 minutes),
 	// but if the cluster is offline, we try to refresh details more often to catch it getting back online earlier.
 	firstPeriod := defaultRefreshPeriod
-	if isClusterOffline {
+	if k.isClusterOffline {
 		firstPeriod = backoffRefreshStep
 	}
 	refreshDelay, err := retryutils.NewLinear(retryutils.LinearConfig{
@@ -181,8 +202,22 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 		Clock:  cfg.clock,
 	})
 	if err != nil {
-		k.Close()
-		return nil, trace.Wrap(err)
+		// NOTE: Can't happen as we hard-code the step and max values.
+		//       Here in case the lib's logic changes in the future.
+		return trace.Wrap(err)
+	}
+	refreshFail := func() {
+		// If this is first time we get an error, we reset retry mechanism so it will start trying to refresh details quicker, with linear backoff.
+		if refreshDelay.First == defaultRefreshPeriod {
+			refreshDelay.First = backoffRefreshStep
+			refreshDelay.Reset()
+		} else {
+			refreshDelay.Inc()
+		}
+	}
+	refreshSucess := func() {
+		// Restore details refresh delay to the default value, in case previously cluster was offline.
+		refreshDelay.First = defaultRefreshPeriod
 	}
 
 	k.wg.Add(1)
@@ -195,38 +230,81 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 			case <-ctx.Done():
 				return
 			case <-refreshDelay.After():
-				codecFactory, rbacSupportedTypes, gvkSupportedResources, err := newClusterSchemaBuilder(cfg.log, creds.getKubeClient())
-				if err != nil {
-					// If this is first time we get an error, we reset retry mechanism so it will start trying to refresh details quicker, with linear backoff.
-					if refreshDelay.First == defaultRefreshPeriod {
-						refreshDelay.First = backoffRefreshStep
-						refreshDelay.Reset()
-					} else {
-						refreshDelay.Inc()
-					}
-					cfg.log.ErrorContext(ctx, "Failed to update cluster schema", "error", err)
-					continue
+				if err := k.updateClusterSchema(ctx, cfg, creds); err != nil {
+					refreshFail()
+				} else {
+					refreshSucess()
 				}
-
-				kubeVersion, err := creds.getKubeClient().Discovery().ServerVersion()
-				if err != nil {
-					cfg.log.WarnContext(ctx, "Failed to get Kubernetes cluster version, the cluster may be offline", "error", err)
-				}
-
-				// Restore details refresh delay to the default value, in case previously cluster was offline.
-				refreshDelay.First = defaultRefreshPeriod
-
-				k.rwMu.Lock()
-				k.kubeCodecs = codecFactory
-				k.rbacSupportedTypes = rbacSupportedTypes
-				k.gvkSupportedResources = gvkSupportedResources
-				k.isClusterOffline = false
-				k.kubeClusterVersion = kubeVersion
-				k.rwMu.Unlock()
 			}
 		}
 	}()
-	return k, nil
+
+	return nil
+}
+
+func (k *kubeDetails) startResourceWatcher(ctx context.Context, cfg clusterDetailsConfig, creds kubeCreds) error {
+	aecs, err := apiextensionsclientset.NewForConfig(creds.getKubeRestConfig())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	watcher, err := aecs.ApiextensionsV1().CustomResourceDefinitions().Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		// TODO(@creack): Handle auto-retrying the watcher. It may be that the cluster is offline.
+		return trace.Wrap(err)
+	}
+
+	k.wg.Add(1)
+	// Start the watcher for custom resources.
+	go func() {
+		defer k.wg.Done()
+		defer watcher.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-watcher.ResultChan():
+				if !ok {
+					// TODO(@creack): Consider auto-restarting the watcher.
+					cfg.log.WarnContext(ctx, "Custom resource watcher channel closed, stopping watcher")
+					return
+				}
+				// NOTE: We refresh on every event, even though multiple ones get emitted for the same CRD.
+				//       This is because the Add event is emitted before the CRD is fully registered,
+				//       and the Modified event is emitted before the CRD is fully deleted.
+				if err := k.updateClusterSchema(ctx, cfg, creds); err == nil {
+					cfg.log.DebugContext(ctx, "Cluster schema updated")
+				}
+				// NOTE: The error gets logged in updateClusterSchema, don't do any more with it, the
+				//       periodic update loop will handle retrying.
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (k *kubeDetails) updateClusterSchema(ctx context.Context, cfg clusterDetailsConfig, creds kubeCreds) error {
+	codecFactory, rbacSupportedTypes, gvkSupportedResources, err := newClusterSchemaBuilder(cfg.log, creds.getKubeClient())
+	if err != nil {
+		cfg.log.ErrorContext(ctx, "Failed to update cluster schema", "error", err)
+		return trace.Wrap(err)
+	}
+
+	kubeVersion, err := creds.getKubeClient().Discovery().ServerVersion()
+	if err != nil {
+		cfg.log.WarnContext(ctx, "Failed to get Kubernetes cluster version, the cluster may be offline", "error", err)
+	}
+
+	k.rwMu.Lock()
+	k.kubeCodecs = codecFactory
+	k.rbacSupportedTypes = rbacSupportedTypes
+	k.gvkSupportedResources = gvkSupportedResources
+	k.isClusterOffline = false
+	k.kubeClusterVersion = kubeVersion
+	k.rwMu.Unlock()
+	return nil
 }
 
 func (k *kubeDetails) Close() {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -141,6 +141,9 @@ type ForwarderConfig struct {
 	// KubeClusterName is the name of the kubernetes cluster that this
 	// forwarder handles.
 	KubeClusterName string
+	// KubeGroupsWildcardMapping is the name of the group that will be used
+	// for impersonation when using the special `*` wildcard value in `kubernetes_groups`.
+	KubeGroupsWildcardMapping string
 	// Clock is a server clock, could be overridden in tests
 	Clock clockwork.Clock
 	// ConnPingPeriod is a period for sending ping messages on the incoming
@@ -447,6 +450,9 @@ type authContext struct {
 	// kubeCluster is the Kubernetes cluster the request is targeted to.
 	// It's only available after authorization layer.
 	kubeCluster types.KubeCluster
+	// kubeGroupsWildcardMapping is the name of the group that will be used
+	// for impersonation when using the special `*` wildcard value in `kubernetes_groups`.
+	kubeGroupsWildcardMapping string
 
 	// metaResource holds the resource data:
 	// - the requested resource
@@ -938,13 +944,21 @@ func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, stat
 // a builtin group that allows any user to access common API methods,
 // e.g. discovery methods required for initial client usage, without it,
 // restricted user's kubectl clients will not work.
-func fillDefaultKubePrincipalDetails(kubeUsers []string, kubeGroups []string, username string) ([]string, []string) {
+// If we have a wildcard in the groups, we replace it with
+// kubeGroupsWildcardMapping, which comes from the configuration.
+func fillDefaultKubePrincipalDetails(kubeUsers, kubeGroups []string, username, kubeGroupsWildcardMapping string) ([]string, []string) {
 	if len(kubeUsers) == 0 {
 		kubeUsers = append(kubeUsers, username)
 	}
 
 	if !slices.Contains(kubeGroups, teleport.KubeSystemAuthenticated) {
 		kubeGroups = append(kubeGroups, teleport.KubeSystemAuthenticated)
+	}
+	if idx := slices.Index(kubeGroups, types.Wildcard); idx != -1 {
+		if kubeGroupsWildcardMapping == "" {
+			kubeGroupsWildcardMapping = teleport.KubernetesGroupsWildcardMapping
+		}
+		kubeGroups[idx] = kubeGroupsWildcardMapping
 	}
 	return kubeUsers, kubeGroups
 }
@@ -1112,9 +1126,10 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 
 	// fillDefaultKubePrincipalDetails fills the default details in order to keep
 	// the correct behavior when forwarding the request to the Kubernetes API.
-	kubeUsers, kubeGroups = fillDefaultKubePrincipalDetails(kubeUsers, kubeGroups, actx.User.GetName())
+	kubeUsers, kubeGroups = fillDefaultKubePrincipalDetails(kubeUsers, kubeGroups, actx.User.GetName(), f.cfg.KubeGroupsWildcardMapping)
 	actx.kubeUsers = utils.StringsSet(kubeUsers)
 	actx.kubeGroups = utils.StringsSet(kubeGroups)
+	actx.kubeGroupsWildcardMapping = f.cfg.KubeGroupsWildcardMapping
 
 	// Check authz against the first match.
 	//

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -356,7 +356,12 @@ func deleteResources[T kubeObjectInterface](
 		if err != nil {
 			continue
 		}
-		allowedKubeUsers, allowedKubeGroups = fillDefaultKubePrincipalDetails(allowedKubeUsers, allowedKubeGroups, params.authCtx.User.GetName())
+		allowedKubeUsers, allowedKubeGroups = fillDefaultKubePrincipalDetails(
+			allowedKubeUsers,
+			allowedKubeGroups,
+			params.authCtx.User.GetName(),
+			params.authCtx.kubeGroupsWildcardMapping,
+		)
 
 		impersonatedUsers, impersonatedGroups, err := computeImpersonatedPrincipals(
 			utils.StringsSet(allowedKubeUsers), utils.StringsSet(allowedKubeGroups),

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -223,6 +223,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			KubeconfigPath:                cfg.Kube.KubeconfigPath,
 			KubeClusterName:               cfg.Kube.KubeClusterName,
 			KubeServiceType:               kubeproxy.KubeService,
+			KubeGroupsWildcardMapping:     cfg.Kube.GroupWildcardMapping,
 			Component:                     teleport.ComponentKube,
 			LockWatcher:                   lockWatcher,
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5546,6 +5546,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				HostID:                        cfg.HostUUID,
 				ClusterOverride:               cfg.Proxy.Kube.ClusterOverride,
 				KubeconfigPath:                cfg.Proxy.Kube.KubeconfigPath,
+				KubeGroupsWildcardMapping:     cfg.Kube.GroupWildcardMapping,
 				Component:                     component,
 				KubeServiceType:               kubeServiceType,
 				LockWatcher:                   lockWatcher,

--- a/lib/service/servicecfg/kube.go
+++ b/lib/service/servicecfg/kube.go
@@ -48,6 +48,10 @@ type KubeConfig struct {
 	// KubeconfigPath is a path to kubeconfig
 	KubeconfigPath string
 
+	// GroupWildcardMapping is the name of the Kubernetes group
+	// will be used for impersonation when using the special `*` wildcard value.
+	GroupWildcardMapping string
+
 	// Labels are used for RBAC on clusters.
 	StaticLabels  map[string]string
 	DynamicLabels services.CommandLabels

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -82,7 +82,7 @@ type AccessChecker interface {
 
 	// CheckKubeGroupsAndUsers check if role can login into kubernetes
 	// and returns two lists of combined allowed groups and users
-	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) (groups []string, users []string, err error)
+	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) (groups, users []string, err error)
 
 	// CheckAWSRoleARNs returns a list of AWS role ARNs role is allowed to assume.
 	CheckAWSRoleARNs(ttl time.Duration, overrideTTL bool) ([]string, error)

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -7881,7 +7881,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels, userTraits)
 			// TODO(@creack): Add more test cases with the new config field.
-			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, "", true, matcher)
+			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
 			if tc.errorFunc == nil {
 				require.NoError(t, err)
 			} else {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -7880,7 +7880,8 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			matcher := NewKubernetesClusterLabelMatcher(tc.kubeResLabels, userTraits)
-			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, true, matcher)
+			// TODO(@creack): Add more test cases with the new config field.
+			gotGroups, gotUsers, err := tc.roles.CheckKubeGroupsAndUsers(time.Hour, "", true, matcher)
 			if tc.errorFunc == nil {
 				require.NoError(t, err)
 			} else {

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -226,15 +226,16 @@ func MakeKubeResources(resources []*types.KubernetesResourceV1, cluster string) 
 // This function ignores any verification of the TTL associated with
 // each Role, and focuses only on listing all users and groups that the user may
 // have access to.
-func getAllowedKubeUsersAndGroupsForCluster(accessChecker services.AccessChecker, kube types.KubeCluster) (kubeUsers []string, kubeGroups []string) {
+func getAllowedKubeUsersAndGroupsForCluster(accessChecker services.AccessChecker, kube types.KubeCluster) (kubeUsers, kubeGroups []string) {
 	matcher := services.NewKubernetesClusterLabelMatcher(kube.GetAllLabels(), accessChecker.Traits())
 	// We ignore the TTL verification because we want to include every possibility.
 	// Later, if the user certificate expiration is longer than the maximum allowed TTL
 	// for the role that defines the `kubernetes_*` principals the request will be
 	// denied by Kubernetes Service.
 	// We ignore the returning error since we are only interested in allowed users and groups.
+	// TODO(@creack): Investigate this, we may need to pass the `AdminClusterRoleName` from the configu here.
 	kubeGroups, kubeUsers, _ = accessChecker.CheckKubeGroupsAndUsers(0, true /* force ttl override*/, matcher)
-	return
+	return kubeUsers, kubeGroups
 }
 
 // ConnectionDiagnostic describes a connection diagnostic.


### PR DESCRIPTION
MVP/PoC for #56214

## Making Teleport authoritative
- [x] Create a CRD watcher to instantly register new resources (a38ae3e21dfdcb3f8bcc9a6d2a4caec05352d224)
- [ ] Improve robustness of the CRD watcher
  - [ ] Auto restart
  - [ ] Attempt to impersonate admin role if missing permissions
- [ ] Deny requests on unknown resources

## Create new preset roles
- [ ] Editor
- [ ] Auditor
- [ ] Access

## Update web UI
- [x] Guided resource enrolling (#56972)

## Misc 
- [ ] Improve errors to make sure the user knows what to do to
- [ ] Update docs
- [ ] Update / Add tests
