### PR TITLE
MWI: Add joining URIs for tbot

### DIFF
--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -133,7 +133,6 @@ func newSharedStartArgs(cmd *kingpin.CmdClause) *sharedStartArgs {
 		"(%s)",
 		strings.Join(config.SupportedJoinMethods, ", "),
 	)
-	cmd.Arg("joining-uri", "An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.").StringVar(&args.JoiningURI)
 	cmd.Flag("token", "A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.").Envar(TokenEnvVar).StringVar(&args.Token)
 	cmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&args.CAPins)
 	cmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").DurationVar(&args.CertificateTTL)
@@ -143,6 +142,7 @@ func newSharedStartArgs(cmd *kingpin.CmdClause) *sharedStartArgs {
 	cmd.Flag("diag-addr", "If set and the bot is in debug mode, a diagnostics service will listen on specified address.").StringVar(&args.DiagAddr)
 	cmd.Flag("storage", "A destination URI for tbot's internal storage, e.g. file:///foo/bar").StringVar(&args.Storage)
 	cmd.Flag("registration-secret", "For bound keypair joining, specifies a registration secret for use at first join.").StringVar(&args.RegistrationSecret)
+	cmd.Flag("join-uri", "An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.").StringVar(&args.JoiningURI)
 
 	return args
 }
@@ -151,7 +151,7 @@ func (s *sharedStartArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 	// Note: Debug, FIPS, and Insecure are included from globals.
 
 	if s.JoiningURI != "" {
-		cfg.JoiningURI = s.JoiningURI
+		cfg.JoinURI = s.JoiningURI
 	}
 
 	if s.AuthProxyArgs != nil {

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -124,8 +124,6 @@ type sharedStartArgs struct {
 
 // newSharedStartArgs initializes shared arguments on the given parent command.
 func newSharedStartArgs(cmd *kingpin.CmdClause) *sharedStartArgs {
-	cmd.Interspersed(true)
-
 	args := &sharedStartArgs{}
 	args.AuthProxyArgs = newAuthProxyArgs(cmd)
 

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -219,6 +219,11 @@ type BotConfig struct {
 	// such as tctl or the Kubernetes operator.
 	AuthServerAddressMode AuthServerAddressMode `yaml:"-"`
 
+	// JoiningURI is a joining URI, used to supply connection and authentication
+	// parameters in a single bundle. If set, the value is parsed and merged on
+	// top of the existing configuration during `CheckAndSetDefaults()`.
+	JoiningURI string `yaml:"uri"`
+
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
 	Oneshot            bool               `yaml:"oneshot"`
 	// FIPS instructs `tbot` to run in a mode designed to comply with FIPS

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -219,10 +219,10 @@ type BotConfig struct {
 	// such as tctl or the Kubernetes operator.
 	AuthServerAddressMode AuthServerAddressMode `yaml:"-"`
 
-	// JoiningURI is a joining URI, used to supply connection and authentication
+	// JoinURI is a joining URI, used to supply connection and authentication
 	// parameters in a single bundle. If set, the value is parsed and merged on
 	// top of the existing configuration during `CheckAndSetDefaults()`.
-	JoiningURI string `yaml:"uri,omitempty"`
+	JoinURI string `yaml:"join_uri,omitempty"`
 
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
 	Oneshot            bool               `yaml:"oneshot"`

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -222,7 +222,7 @@ type BotConfig struct {
 	// JoiningURI is a joining URI, used to supply connection and authentication
 	// parameters in a single bundle. If set, the value is parsed and merged on
 	// top of the existing configuration during `CheckAndSetDefaults()`.
-	JoiningURI string `yaml:"uri"`
+	JoiningURI string `yaml:"uri,omitempty"`
 
 	CredentialLifetime CredentialLifetime `yaml:",inline"`
 	Oneshot            bool               `yaml:"oneshot"`

--- a/lib/tbot/config/uri.go
+++ b/lib/tbot/config/uri.go
@@ -123,7 +123,7 @@ func (p *JoinURIParams) ApplyToConfig(cfg *BotConfig) error {
 				"URI join method parameter %q conflicts with configured field: onboarding.gitlab.token_env_var_name", param))
 		case types.JoinMethodBoundKeypair:
 			errors = append(errors, applyValueOrError(
-				&cfg.Onboarding.BoundKeypair.InitialJoinSecret, param,
+				&cfg.Onboarding.BoundKeypair.RegistrationSecret, param,
 				"URI join method parameter %q conflicts with configured field: onboarding.bound_keypair.initial_join_secret", param))
 		default:
 			slog.WarnContext(

--- a/lib/tbot/config/uri.go
+++ b/lib/tbot/config/uri.go
@@ -1,0 +1,195 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+const (
+	// URISchemePrefix is the prefix for
+	URISchemePrefix = "tbot"
+)
+
+type JoinURIParams struct {
+	// AddressKind is the type of joining address, i.e. proxy or auth.
+	AddressKind AddressKind
+
+	// JoinMethod is the join method to use when joining, in combination with
+	// the token name.
+	JoinMethod types.JoinMethod
+
+	// Token is the token name to use when joining
+	Token string
+
+	// JoinMethodParameter is an optional parameter to pass to the join method.
+	// Its specific meaning depends on the join method in use.
+	JoinMethodParameter string
+
+	// Address is either an auth or proxy address, depending on the configured
+	// AddressKind. It includes the port.
+	Address string
+}
+
+func applyValueOrError[T comparable](target *T, value T, errMsg string, errArgs ...any) error {
+	var zero T
+	if *target == zero {
+		*target = value
+		return nil
+	} else if *target == value {
+		return nil
+	}
+
+	return trace.BadParameter(errMsg, errArgs...)
+}
+
+// ApplyToConfig applies parameters from a parsed joining URI to the given bot
+// config. This is designed to be applied to a configuration that has already
+// been loaded - but not yet validated - and returns an error if any fields in
+// the URI will conflict with those already set in the existing configuration.
+func (p *JoinURIParams) ApplyToConfig(cfg *BotConfig) error {
+	var errors []error
+
+	switch p.AddressKind {
+	case AddressKindAuth:
+		errors = append(errors, applyValueOrError(
+			&cfg.AuthServer, p.Address,
+			"URI host %q conflicts with configured field: auth_server", p.Address))
+	default:
+		// this parameter should not be unspecified due to checks in
+		// ParseJoinURI, so we'll assume proxy.
+		errors = append(errors, applyValueOrError(
+			&cfg.ProxyServer, p.Address,
+			"URI host %q conflicts with configured field: proxy_server", p.Address))
+	}
+
+	errors = append(errors, applyValueOrError(
+		&cfg.Onboarding.JoinMethod, p.JoinMethod,
+		"URI joining method %q conflicts with configured field: onboarding.join_method", p.JoinMethod))
+	cfg.Onboarding.SetToken(p.Token)
+
+	// The join method parameter maps to a method-specific field when set.
+	if param := p.JoinMethodParameter; param != "" {
+		switch p.JoinMethod {
+		case types.JoinMethodAzure:
+			errors = append(errors, applyValueOrError(
+				&cfg.Onboarding.Azure.ClientID, param,
+				"URI join method parameter %q conflicts with configured field: onboarding.azure.client_id",
+				param))
+		case types.JoinMethodTerraformCloud:
+			errors = append(errors, applyValueOrError(
+				&cfg.Onboarding.Terraform.AudienceTag, param,
+				"URI join method parameter %q conflicts with configured field: onboarding.terraform.audience_tag", param))
+		case types.JoinMethodGitLab:
+			errors = append(errors, applyValueOrError(
+				&cfg.Onboarding.Gitlab.TokenEnvVarName, param,
+				"URI join method parameter %q conflicts with configured field: onboarding.gitlab.token_env_var_name", param))
+		case types.JoinMethodBoundKeypair:
+			errors = append(errors, applyValueOrError(
+				&cfg.Onboarding.BoundKeypair.InitialJoinSecret, param,
+				"URI join method parameter %q conflicts with configured field: onboarding.bound_keypair.initial_join_secret", param))
+		default:
+			slog.WarnContext(
+				context.Background(),
+				"ignoring join method parameter for unsupported join method",
+				"join_method", p.JoinMethod,
+			)
+		}
+	}
+
+	return trace.NewAggregate(errors...)
+}
+
+// MapURLSafeJoinMethod converts a URL safe join method name to a defined join
+// method constant.
+func MapURLSafeJoinMethod(name string) (types.JoinMethod, error) {
+	// When given a join method name that is already URL safe, just return it.
+	if slices.Contains(SupportedJoinMethods, name) {
+		return types.JoinMethod(name), nil
+	}
+
+	switch name {
+	case "bound-keypair", "boundkeypair":
+		return types.JoinMethodBoundKeypair, nil
+	case "azure-devops", "azuredevops":
+		return types.JoinMethodAzureDevops, nil
+	case "terraform-cloud", "terraformcloud":
+		return types.JoinMethodTerraformCloud, nil
+	default:
+		return types.JoinMethodUnspecified, trace.BadParameter("unsupported join method %q", name)
+	}
+}
+
+// ParseJoinURI parses a joining URI from its string form. It returns an error
+// if the input URI is malformed, missing parameters, or references an unknown
+// or invalid join method or connection type.
+func ParseJoinURI(s string) (*JoinURIParams, error) {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing joining URI")
+	}
+
+	schemeParts := strings.SplitN(uri.Scheme, "+", 3)
+	if len(schemeParts) != 3 {
+		return nil, trace.BadParameter("unsupported joining URI scheme: %q", uri.Scheme)
+	}
+
+	if schemeParts[0] != URISchemePrefix {
+		return nil, trace.BadParameter(
+			"unsupported joining URI scheme %q: scheme prefix must be %q",
+			uri.Scheme, URISchemePrefix)
+	}
+
+	var kind AddressKind
+	switch schemeParts[1] {
+	case string(AddressKindProxy):
+		kind = AddressKindProxy
+	case string(AddressKindAuth):
+		kind = AddressKindAuth
+	default:
+		return nil, trace.BadParameter(
+			"unsupported joining URI scheme %q: address kind must be one of [%q, %q], got: %q",
+			uri.Scheme, AddressKindProxy, AddressKindAuth, schemeParts[1])
+	}
+
+	joinMethod, err := MapURLSafeJoinMethod(schemeParts[2])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if uri.User == nil {
+		return nil, trace.BadParameter("invalid joining URI: must contain join token in user field")
+	}
+
+	param, _ := uri.User.Password()
+	return &JoinURIParams{
+		AddressKind:         kind,
+		JoinMethod:          joinMethod,
+		Token:               uri.User.Username(),
+		JoinMethodParameter: param,
+		Address:             uri.Host,
+	}, nil
+}

--- a/lib/tbot/config/uri.go
+++ b/lib/tbot/config/uri.go
@@ -25,8 +25,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 const (
@@ -54,12 +55,18 @@ type JoinURIParams struct {
 	Address string
 }
 
+// applyValueOrError sets the target `target` to the value `value`, but only if
+// the current value is that type's zero value, or if the current value is equal
+// to the desired value. If not, an error is returned per the error message
+// string and arguments. This can be used to ensure existing values will not be
+// overwritten.
 func applyValueOrError[T comparable](target *T, value T, errMsg string, errArgs ...any) error {
 	var zero T
-	if *target == zero {
+	switch *target {
+	case zero:
 		*target = value
 		return nil
-	} else if *target == value {
+	case value:
 		return nil
 	}
 

--- a/lib/tbot/config/uri_test.go
+++ b/lib/tbot/config/uri_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestParseJoinURI(t *testing.T) {

--- a/lib/tbot/config/uri_test.go
+++ b/lib/tbot/config/uri_test.go
@@ -119,7 +119,7 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodBoundKeypair,
 					BoundKeypair: BoundKeypairOnboardingConfig{
-						InitialJoinSecret: "secret",
+						RegistrationSecret: "secret",
 					},
 				},
 				ProxyServer: "example.com:1234",
@@ -204,7 +204,7 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 					TokenValue: "token",
 					JoinMethod: types.JoinMethodBoundKeypair,
 					BoundKeypair: BoundKeypairOnboardingConfig{
-						InitialJoinSecret: "secret2",
+						RegistrationSecret: "secret2",
 					},
 				},
 			},

--- a/lib/tbot/config/uri_test.go
+++ b/lib/tbot/config/uri_test.go
@@ -1,0 +1,94 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJoinURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		expect      *JoinURIParams
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			uri: "tbot+proxy+token://asdf@example.com:1234",
+			expect: &JoinURIParams{
+				AddressKind:         AddressKindProxy,
+				Token:               "asdf",
+				JoinMethod:          types.JoinMethodToken,
+				Address:             "example.com:1234",
+				JoinMethodParameter: "",
+			},
+		},
+		{
+			uri: "tbot+auth+bound-keypair://token:param@example.com",
+			expect: &JoinURIParams{
+				AddressKind:         AddressKindAuth,
+				Token:               "token",
+				JoinMethod:          types.JoinMethodBoundKeypair,
+				Address:             "example.com",
+				JoinMethodParameter: "param",
+			},
+		},
+		{
+			uri: "",
+			expectError: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "unsupported joining URI scheme")
+			},
+		},
+		{
+			uri: "tbot+foo+token://example.com",
+			expectError: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "address kind must be one of")
+			},
+		},
+		{
+			uri: "tbot+proxy+bar://example.com",
+			expectError: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "unsupported join method")
+			},
+		},
+		{
+			uri: "https://example.com",
+			expectError: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "unsupported joining URI scheme")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			parsed, err := ParseJoinURI(tt.uri)
+			if tt.expectError == nil {
+				require.NoError(t, err)
+			} else {
+				tt.expectError(t, err)
+			}
+
+			require.Empty(t, cmp.Diff(parsed, tt.expect))
+		})
+	}
+}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -782,6 +782,17 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	ctx, span := tracer.Start(ctx, "Bot/preRunChecks")
 	defer func() { apitracing.EndSpan(span, err) }()
 
+	if b.cfg.JoiningURI != "" {
+		parsed, err := config.ParseJoinURI(b.cfg.JoiningURI)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing joining URI")
+		}
+
+		if err := parsed.ApplyToConfig(b.cfg); err != nil {
+			return nil, trace.Wrap(err, "applying joining URI to bot config")
+		}
+	}
+
 	_, addrKind := b.cfg.Address()
 	switch addrKind {
 	case config.AddressKindUnspecified:

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -782,8 +782,8 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	ctx, span := tracer.Start(ctx, "Bot/preRunChecks")
 	defer func() { apitracing.EndSpan(span, err) }()
 
-	if b.cfg.JoiningURI != "" {
-		parsed, err := config.ParseJoinURI(b.cfg.JoiningURI)
+	if b.cfg.JoinURI != "" {
+		parsed, err := config.ParseJoinURI(b.cfg.JoinURI)
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing joining URI")
 		}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1237,3 +1237,61 @@ func TestBotSSHMultiplexer(t *testing.T) {
 		})
 	}
 }
+
+// TestBotJoiningURI ensures configured joining URIs work in place of
+// traditional YAML onboarding config.
+func TestBotJoiningURI(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := utils.NewSlogLoggerForTests()
+
+	process := testenv.MakeTestServer(
+		t,
+		defaultTestServerOpts(t, log),
+		testenv.WithProxyKube(t),
+	)
+	rootClient := testenv.MakeDefaultAuthClient(t, process)
+
+	role, err := types.NewRole("role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"*": apiutils.Strings{"*"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = rootClient.UpsertRole(ctx, role)
+
+	botParams, _ := makeBot(t, rootClient, "test", "role")
+	cfg := &config.BotConfig{
+		JoiningURI: fmt.Sprintf(
+			"tbot+proxy+%s://%s@%s",
+			botParams.JoinMethod,
+			botParams.TokenValue,
+			process.Config.Proxy.WebAddr.String(),
+		),
+		Storage: &config.StorageConfig{
+			Destination: &config.DestinationMemory{},
+		},
+		Services: config.ServiceConfigs{
+			&config.IdentityOutput{
+				Destination: &config.DestinationMemory{},
+			},
+		},
+		Oneshot:  true,
+		Insecure: true,
+	}
+	require.NoError(t, cfg.CheckAndSetDefaults())
+
+	bot := New(cfg, log)
+	require.NoError(t, bot.Run(ctx))
+
+	// Perform some cursory checks on the identity to make sure a cert bundle
+	// was actually produced.
+	id := bot.BotIdentity()
+	tlsIdent, err := tlsca.FromSubject(
+		id.X509Cert.Subject, id.X509Cert.NotAfter,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "test", tlsIdent.BotName)
+}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1261,6 +1261,7 @@ func TestBotJoiningURI(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = rootClient.UpsertRole(ctx, role)
+	require.NoError(t, err)
 
 	botParams, _ := makeBot(t, rootClient, "test", "role")
 	cfg := &config.BotConfig{

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1265,7 +1265,7 @@ func TestBotJoiningURI(t *testing.T) {
 
 	botParams, _ := makeBot(t, rootClient, "test", "role")
 	cfg := &config.BotConfig{
-		JoiningURI: fmt.Sprintf(
+		JoinURI: fmt.Sprintf(
 			"tbot+proxy+%s://%s@%s",
 			botParams.JoinMethod,
 			botParams.TokenValue,

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -357,8 +357,8 @@ func onConfigure(
 
 	// Ensure they have provided either a valid joining URI, or a
 	// join method to use in the configuration.
-	if cfg.JoiningURI != "" {
-		if _, err := config.ParseJoinURI(cfg.JoiningURI); err != nil {
+	if cfg.JoinURI != "" {
+		if _, err := config.ParseJoinURI(cfg.JoinURI); err != nil {
 			return trace.Wrap(err, "invalid joining URI")
 		}
 	} else if cfg.Onboarding.JoinMethod == types.JoinMethodUnspecified {

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -355,8 +355,13 @@ func onConfigure(
 		out = f
 	}
 
-	// Ensure they have provided a join method to use in the configuration.
-	if cfg.Onboarding.JoinMethod == types.JoinMethodUnspecified {
+	// Ensure they have provided either a valid joining URI, or a
+	// join method to use in the configuration.
+	if cfg.JoiningURI != "" {
+		if _, err := config.ParseJoinURI(cfg.JoiningURI); err != nil {
+			return trace.Wrap(err, "invalid joining URI")
+		}
+	} else if cfg.Onboarding.JoinMethod == types.JoinMethodUnspecified {
 		return trace.BadParameter("join method must be provided")
 	}
 


### PR DESCRIPTION
This adds support for joining URIs to tbot. Joining URIs are intended to condense tbot's growing list of required server-side config options or CLI parameters into a single string that can be provided to the `tbot` client.

For example, consider these two equivalent CLI commands:

```
$ tbot start identity \
    --proxy-server example.teleport.sh:443 \
    --join-method bound_keypair \
    --token my-token \
    --registration-secret abc123 \
    --storage ./tbot-data
    --destination ./tbot-user

$ tbot start identity \
    --join-uri tbot+proxy+bound-keypair://my-token:abc123@example.teleport.sh:443 \
    --storage ./tbot-data \
    --destination ./tbot-user
```

As shown, all parameters necessary for bots to actually connect to and authenticate with the remote Teleport instance are included in a single parameter. This parameter can be generated by existing tooling, like the example command printed via `tctl bots add`, or the web UI.

End users will only need to paste a single "token", provide their own client-side parameters (if any), and run. Similarly, we now have a new minimally viable YAML config:

```yaml
version: v2
join_uri: tbot+proxy+bound-keypair://my-token:abc123@example.teleport.sh:443
storage:
  type: directory
  path: ./tbot-data
services:
  - type: identity
    destination:
      type: directory
      path: ./tbot-user
```

This implementation is designed to be only additive, and should not interfere with existing config files or CLI strings. Parsed URI parameters are merged on top of the traditional config fields during the bot's pre-run check, and raise an error if any field conflicts.

changelog: Machine and Workload ID: Add support for new bot joining URIs to simplify bot configuration and onboarding

RFD: #52546