### PR TITLE
[v18] Fix directory re-sharing in desktop session

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -26,8 +26,8 @@ import {
 } from 'shared/hooks/useAsync';
 import {
   BitmapFrame,
-  BrowserFileSystem,
   ClientScreenSpec,
+  selectDirectoryInBrowser,
   TdpClient,
   TdpClientEvent,
 } from 'shared/libs/tdp';
@@ -55,7 +55,7 @@ const meta: Meta = {
 export default meta;
 
 const fakeClient = () => {
-  const client = new TdpClient(() => null, new BrowserFileSystem());
+  const client = new TdpClient(() => null, selectDirectoryInBrowser);
   // Don't try to connect to a websocket.
   client.connect = async options => {
     emitFrame(client, options.screenSpec);

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -185,3 +185,63 @@ test('ensure sharing remains enabled if the initial desktop connection attempt f
   await userEvent.click(screen.getByTitle('More actions'));
   expect(await screen.findByText('Share Directory')).toBeVisible();
 });
+
+test('re-sharing directory is possible after a reconnect', async () => {
+  const transport = getMockTransport();
+  const mockFsSpy = jest.fn(async () => mockDirectoryAccess());
+  const tpdClient = new TdpClient(transport.getTransport, mockFsSpy);
+  render(
+    <DesktopSession
+      client={tpdClient}
+      username="admin"
+      desktop="win-lab"
+      aclAttempt={aclAttempt}
+      hasAnotherSession={hasNoOtherSession}
+      browserSupportsSharing
+    />
+  );
+
+  // The session is initializing.
+  expect(await screen.findByTestId('indicator')).toBeInTheDocument();
+
+  // Successfully initialize the connection.
+  await act(() => transport.emitPngFrameMessage());
+
+  // Share a directory.
+  await testSharingDirectory();
+
+  // An error occurred, the connection has been closed.
+  transport.emitTransportError();
+  expect(
+    await screen.findByText('The desktop session is offline.')
+  ).toBeInTheDocument();
+
+  // Reconnect.
+  const reconnect = await screen.findByRole('button', { name: 'Reconnect' });
+  await userEvent.click(reconnect);
+  await act(() => transport.emitPngFrameMessage());
+
+  // Share the directory again.
+  await testSharingDirectory();
+  expect(mockFsSpy).toHaveBeenCalledTimes(2);
+});
+
+async function testSharingDirectory() {
+  expect(await screen.findByTitle('More actions')).toBeVisible();
+  await userEvent.click(screen.getByTitle('More actions'));
+  await userEvent.click(await screen.findByText('Share Directory'));
+  expect(await screen.findByTitle('Alerts')).toHaveTextContent('0');
+}
+
+function mockDirectoryAccess(): SharedDirectoryAccess {
+  return {
+    getDirectoryName: () => '',
+    create: () => undefined,
+    read: () => undefined,
+    stat: () => undefined,
+    delete: () => undefined,
+    readDir: () => undefined,
+    truncate: () => undefined,
+    write: () => undefined,
+  };
+}

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -23,7 +23,12 @@ import { act } from 'react';
 
 import { render } from 'design/utils/testing';
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';
-import { BrowserFileSystem, MessageType, TdpClient } from 'shared/libs/tdp';
+import {
+  MessageType,
+  selectDirectoryInBrowser,
+  SharedDirectoryAccess,
+  TdpClient,
+} from 'shared/libs/tdp';
 
 import { DesktopSession } from './DesktopSession';
 
@@ -102,7 +107,7 @@ test('reconnect button reinitializes the connection', async () => {
   const transport = getMockTransport();
   const tpdClient = new TdpClient(
     transport.getTransport,
-    new BrowserFileSystem()
+    selectDirectoryInBrowser
   );
   jest.spyOn(tpdClient, 'connect');
   jest.spyOn(tpdClient, 'shutdown');
@@ -148,7 +153,7 @@ test('ensure sharing remains enabled if the initial desktop connection attempt f
   const transport = getMockTransport();
   const tpdClient = new TdpClient(
     transport.getTransport,
-    new BrowserFileSystem()
+    selectDirectoryInBrowser
   );
   render(
     <DesktopSession

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -143,19 +143,20 @@ export function DesktopSession({
 
   useListener(client.onClipboardData, onClipboardData);
 
-  const handleFatalError = useCallback(
-    (error: Error) => {
+  const handleConnectionClose = useCallback(
+    (error?: Error) => {
       clearSharing();
       setTdpConnectionStatus({
         status: 'disconnected',
         fromTdpError: error instanceof TdpError,
-        message: error.message,
+        message: error?.message || '',
       });
       initialTdpConnectionSucceeded.current = false;
     },
     [clearSharing]
   );
-  useListener(client.onError, handleFatalError);
+  useListener(client.onError, handleConnectionClose);
+  useListener(client.onTransportClose, handleConnectionClose);
 
   const addWarning = useCallback(
     (warning: string) => {
@@ -182,19 +183,6 @@ export function DesktopSession({
     )
   );
 
-  useListener(
-    client.onTransportClose,
-    useCallback(
-      error => {
-        setTdpConnectionStatus({
-          status: 'disconnected',
-          message: error?.message,
-        });
-        initialTdpConnectionSucceeded.current = false;
-      },
-      [setTdpConnectionStatus]
-    )
-  );
   useListener(
     client.onTransportOpen,
     useCallback(() => {
@@ -361,7 +349,6 @@ export function DesktopSession({
       <TopBar
         isConnected={screenState.state === 'canvas-visible'}
         onDisconnect={() => {
-          clearSharing();
           client.shutdown();
         }}
         userHost={`${username} on ${desktop}`}

--- a/web/packages/shared/components/DesktopSession/Withholder.test.ts
+++ b/web/packages/shared/components/DesktopSession/Withholder.test.ts
@@ -16,7 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { BrowserFileSystem, ButtonState, TdpClient } from 'shared/libs/tdp';
+import {
+  ButtonState,
+  selectDirectoryInBrowser,
+  TdpClient,
+} from 'shared/libs/tdp';
 
 import { Withholder } from './Withholder';
 
@@ -53,7 +57,7 @@ describe('withholder', () => {
     const params = {
       e: { key: 'Enter' } as KeyboardEvent as KeyboardEvent,
       state: ButtonState.DOWN,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
     withholder.handleKeyboardEvent(params, mockHandleKeyboardEvent);
     expect(mockHandleKeyboardEvent).toHaveBeenCalledWith(params);
@@ -63,19 +67,19 @@ describe('withholder', () => {
     const metaDown = {
       e: { key: 'Meta' } as KeyboardEvent,
       state: ButtonState.DOWN,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
     const metaUp = {
       e: { key: 'Meta' } as KeyboardEvent,
       state: ButtonState.UP,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
     const enterDown = {
       e: { key: 'Enter' } as KeyboardEvent as KeyboardEvent,
       state: ButtonState.DOWN,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
     withholder.handleKeyboardEvent(metaDown, mockHandleKeyboardEvent);
@@ -95,12 +99,12 @@ describe('withholder', () => {
     const metaParams = {
       e: { key: 'Meta' } as KeyboardEvent,
       state: ButtonState.UP,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
     const altParams = {
       e: { key: 'Alt' } as KeyboardEvent,
       state: ButtonState.UP,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
     withholder.handleKeyboardEvent(metaParams, mockHandleKeyboardEvent);
@@ -119,7 +123,7 @@ describe('withholder', () => {
     const metaParams = {
       e: { key: 'Meta' } as KeyboardEvent,
       state: ButtonState.UP,
-      cli: new TdpClient(() => null, new BrowserFileSystem()),
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
     withholder.handleKeyboardEvent(metaParams, mockHandleKeyboardEvent);
     expect((withholder as any).withheldKeys).toHaveLength(1);

--- a/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/useDesktopSession.tsx
@@ -28,6 +28,7 @@ import {
 import type { NotificationItem } from 'shared/components/Notification';
 import { Attempt } from 'shared/hooks/useAsync';
 import { ClipboardData, TdpClient } from 'shared/libs/tdp';
+import { isAbortError } from 'shared/utils/error';
 
 declare global {
   interface Window {
@@ -132,6 +133,9 @@ export default function useDesktopSession(
         directorySelected: true,
       });
     } catch (e) {
+      if (isAbortError(e)) {
+        return;
+      }
       setDirectorySharingState({
         directorySelected: false,
       });

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -138,12 +138,13 @@ export class TdpClient extends EventEmitter<EventMap> {
   protected transport: TdpTransport | undefined;
   private transportAbortController: AbortController | undefined;
   private fastPathProcessor: FastPathProcessor | undefined;
+  private sharedDirectory: SharedDirectoryAccess | undefined;
 
   private logger = Logger.create('TDPClient');
 
   constructor(
     private getTransport: (signal: AbortSignal) => Promise<TdpTransport>,
-    private sharedDirectoryAccess: SharedDirectoryAccess
+    private selectSharedDirectory: () => Promise<SharedDirectoryAccess>
   ) {
     super();
     this.codec = new Codec();
@@ -231,6 +232,7 @@ export class TdpClient extends EventEmitter<EventMap> {
 
     this.logger.info('Transport is closed');
 
+    this.sharedDirectory = undefined;
     this.transport = undefined;
   }
 
@@ -525,28 +527,32 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   handleSharedDirectoryAcknowledge(buffer: ArrayBufferLike) {
     const ack = this.codec.decodeSharedDirectoryAcknowledge(buffer);
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
+
     if (ack.errCode !== SharedDirectoryErrCode.Nil) {
       // A failure in the acknowledge message means the directory
       // share operation failed (likely due to server side configuration).
       // Since this is not a fatal error, we emit a warning but otherwise
       // keep the sesion alive.
       this.handleWarning(
-        `Failed to share directory '${this.sharedDirectoryAccess.getDirectoryName()}', drive redirection may be disabled on the RDP server.`,
+        `Failed to share directory '${sharedDirectory.getDirectoryName()}', drive redirection may be disabled on the RDP server.`,
         TdpClientEvent.TDP_WARNING
       );
       return;
     }
 
     this.logger.info(
-      `Started sharing directory: ${this.sharedDirectoryAccess.getDirectoryName()}`
+      `Started sharing directory: ${sharedDirectory.getDirectoryName()}`
     );
   }
 
   async handleSharedDirectoryInfoRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryInfoRequest(buffer);
     const path = req.path;
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
+
     try {
-      const info = await this.sharedDirectoryAccess.stat(path);
+      const info = await sharedDirectory.stat(path);
       this.sendSharedDirectoryInfoResponse({
         completionId: req.completionId,
         errCode: SharedDirectoryErrCode.Nil,
@@ -573,10 +579,11 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   async handleSharedDirectoryCreateRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryCreateRequest(buffer);
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
 
     try {
-      await this.sharedDirectoryAccess.create(req.path, req.fileType);
-      const info = await this.sharedDirectoryAccess.stat(req.path);
+      await sharedDirectory.create(req.path, req.fileType);
+      const info = await sharedDirectory.stat(req.path);
       this.sendSharedDirectoryCreateResponse({
         completionId: req.completionId,
         errCode: SharedDirectoryErrCode.Nil,
@@ -600,9 +607,10 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   async handleSharedDirectoryDeleteRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryDeleteRequest(buffer);
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
 
     try {
-      await this.sharedDirectoryAccess.delete(req.path);
+      await sharedDirectory.delete(req.path);
       this.sendSharedDirectoryDeleteResponse({
         completionId: req.completionId,
         errCode: SharedDirectoryErrCode.Nil,
@@ -618,7 +626,9 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   async handleSharedDirectoryReadRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryReadRequest(buffer);
-    const readData = await this.sharedDirectoryAccess.read(
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
+
+    const readData = await sharedDirectory.read(
       req.path,
       req.offset,
       req.length
@@ -633,7 +643,9 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   async handleSharedDirectoryWriteRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryWriteRequest(buffer);
-    const bytesWritten = await this.sharedDirectoryAccess.write(
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
+
+    const bytesWritten = await sharedDirectory.write(
       req.path,
       req.offset,
       req.writeData
@@ -663,10 +675,10 @@ export class TdpClient extends EventEmitter<EventMap> {
   async handleSharedDirectoryListRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryListRequest(buffer);
     const path = req.path;
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
 
-    const infoList: FileOrDirInfo[] =
-      await this.sharedDirectoryAccess.readDir(path);
-    const fsoList: FileSystemObject[] = infoList.map(info => this.toFso(info));
+    const infoList = await sharedDirectory.readDir(path);
+    const fsoList = infoList.map(info => this.toFso(info));
 
     this.sendSharedDirectoryListResponse({
       completionId: req.completionId,
@@ -677,7 +689,9 @@ export class TdpClient extends EventEmitter<EventMap> {
 
   async handleSharedDirectoryTruncateRequest(buffer: ArrayBufferLike) {
     const req = this.codec.decodeSharedDirectoryTruncateRequest(buffer);
-    await this.sharedDirectoryAccess.truncate(req.path, req.endOfFile);
+    const sharedDirectory = this.getSharedDirectoryOrThrow();
+
+    await sharedDirectory.truncate(req.path, req.endOfFile);
     this.sendSharedDirectoryTruncateResponse({
       completionId: req.completionId,
       errCode: SharedDirectoryErrCode.Nil,
@@ -766,12 +780,15 @@ export class TdpClient extends EventEmitter<EventMap> {
   }
 
   async shareDirectory() {
-    await this.sharedDirectoryAccess.selectDirectory();
+    if (this.sharedDirectory) {
+      throw new Error('Only one shared directory is allowed at a time.');
+    }
+    this.sharedDirectory = await this.selectSharedDirectory();
     this.sendSharedDirectoryAnnounce();
   }
 
   sendSharedDirectoryAnnounce() {
-    const name = this.sharedDirectoryAccess.getDirectoryName();
+    const name = this.sharedDirectory.getDirectoryName();
     this.send(
       this.codec.encodeSharedDirectoryAnnounce({
         discard: 0, // This is always the first request.
@@ -837,6 +854,13 @@ export class TdpClient extends EventEmitter<EventMap> {
   private handleInfo(info: string) {
     this.logger.info(info);
     this.emit(TdpClientEvent.TDP_INFO, info);
+  }
+
+  private getSharedDirectoryOrThrow() {
+    if (!this.sharedDirectory) {
+      throw new Error('No shared directory has been initialized.');
+    }
+    return this.sharedDirectory;
   }
 
   // It's safe to call this multiple times, calls subsequent to the first call

--- a/web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
+++ b/web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
@@ -19,8 +19,6 @@
 import { FileType } from './codec';
 
 export interface SharedDirectoryAccess {
-  /** Prompts the user to select a directory to share. */
-  selectDirectory(): Promise<void>;
   /** Returns the name of the currently shared directory. */
   getDirectoryName(): string;
   /** Retrieves metadata about a file or directory at the given path. */
@@ -40,58 +38,45 @@ export interface SharedDirectoryAccess {
 }
 
 /**
+ * Opens a directory picker and returns an interface for interacting with the selected directory.
+ */
+export async function selectDirectoryInBrowser(): Promise<BrowserFileSystem> {
+  if (typeof window.showDirectoryPicker !== 'function') {
+    // This is a gross error message, but should be infrequent enough that its worth just telling
+    // the user the likely problem, while also displaying the error message just in case that's not it.
+    // In a perfect world, we could check for which error message this is and display
+    // context appropriate directions.
+    throw new Error(
+      'Your user role supports directory sharing over desktop access, \
+however this feature is only available by default on some Chromium \
+based browsers like Google Chrome or Microsoft Edge. Brave users can \
+use the feature by navigating to brave://flags/#file-system-access-api \
+and selecting "Enable". If you\'re not already, please switch to a supported browser.'
+    );
+  }
+
+  const sharedDirectory = await window.showDirectoryPicker();
+  return new BrowserFileSystem(sharedDirectory);
+}
+
+/**
  * Enables directory sharing using FileSystem API.
  * Most of the methods can potentially throw errors and so should be wrapped in try/catch blocks.
  * Should be kept in sync with lib/teleterm/services/desktop/directorysharing.go
  * where file system events are handled for Connect.
  */
-export class BrowserFileSystem implements SharedDirectoryAccess {
-  private dir: FileSystemDirectoryHandle | undefined;
+class BrowserFileSystem implements SharedDirectoryAccess {
+  constructor(private dir: FileSystemDirectoryHandle) {}
 
-  /**
-   * Opens a directory.
-   * @throws Will throw an error if a directory is already being shared.
-   */
-  async selectDirectory() {
-    if (typeof window.showDirectoryPicker !== 'function') {
-      // This is a gross error message, but should be infrequent enough that its worth just telling
-      // the user the likely problem, while also displaying the error message just in case that's not it.
-      // In a perfect world, we could check for which error message this is and display
-      // context appropriate directions.
-      throw new Error(
-        'Your user role supports directory sharing over desktop access, \
-  however this feature is only available by default on some Chromium \
-  based browsers like Google Chrome or Microsoft Edge. Brave users can \
-  use the feature by navigating to brave://flags/#file-system-access-api \
-  and selecting "Enable". If you\'re not already, please switch to a supported browser.'
-      );
-    }
-
-    const sharedDirectory = await window.showDirectoryPicker();
-    if (this.dir) {
-      throw new Error(
-        'SharedDirectoryManager currently only supports sharing a single directory'
-      );
-    }
-    this.dir = sharedDirectory;
-  }
-
-  /**
-   * @throws Will throw an error if a directory has not already been initialized.
-   */
   getDirectoryName(): string {
-    this.checkReady();
     return this.dir.name;
   }
 
   /**
    * Gets the information for the file or directory at path where path is the relative path from the root directory.
-   * @throws Will throw an error if a directory has not already been initialized.
-   * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
+   * @throws {PathDoesNotExistError} if the path isn't a valid path in the shared directory
    */
   async stat(path: string): Promise<FileOrDirInfo> {
-    this.checkReady();
-
     const fileOrDir = await this.walkPath(path);
 
     let isEmpty = true;
@@ -129,12 +114,9 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
 
   /**
    * Gets the FileOrDirInfo for all the children of the directory at path.
-   * @throws Will throw an error if a directory has not already been initialized.
-   * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
+   * @throws {PathDoesNotExistError} if the path isn't a valid path in the shared directory
    */
   async readDir(path: string): Promise<FileOrDirInfo[]> {
-    this.checkReady();
-
     // Get the directory whose contents we want to list.
     const dir = await this.walkPath(path);
     if (dir.kind !== 'directory') {
@@ -158,15 +140,13 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
 
   /**
    * Reads length bytes starting at offset from a file at path.
-   * @throws Will throw an error if a directory has not already been initialized.
-   * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
+   * @throws {PathDoesNotExistError} if the path isn't a valid path in the shared directory
    */
   async read(
     path: string,
     offset: bigint,
     length: number
   ): Promise<Uint8Array> {
-    this.checkReady();
     const fileHandle = await this.getFileHandle(path);
     const file = await fileHandle.getFile();
     return new Uint8Array(
@@ -176,12 +156,9 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
 
   /**
    * Writes the bytes in writeData to the file at path starting at offset.
-   * @throws Will throw an error if a directory has not already been initialized.
    * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
    */
   async write(path: string, offset: bigint, data: Uint8Array): Promise<number> {
-    this.checkReady();
-
     const fileHandle = await this.getFileHandle(path);
     const file = await fileHandle.createWritable({ keepExistingData: true });
     await file.write({ type: 'write', position: Number(offset), data });
@@ -192,11 +169,9 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
 
   /**
    * Truncates the file at path to size bytes.
-   * @throws Will throw an error if a directory has not already been initialized.
-   * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
+   * @throws {PathDoesNotExistError} if the path isn't a valid path in the shared directory
    */
   async truncate(path: string, size: number): Promise<void> {
-    this.checkReady();
     const fileHandle = await this.getFileHandle(path);
     const file = await fileHandle.createWritable({ keepExistingData: true });
     await file.truncate(size);
@@ -238,8 +213,8 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
 
   /**
    * Returns the FileSystemFileHandle for the file at path.
-   * @throws {PathDoesNotExistError} if the pathstr isn't a valid path in the shared directory
-   * @throws {Error} if the pathstr points to a directory
+   * @throws {PathDoesNotExistError} if the path isn't a valid path in the shared directory
+   * @throws {Error} if the path points to a directory
    */
   private async getFileHandle(pathstr: string): Promise<FileSystemFileHandle> {
     const fileHandle = await this.walkPath(pathstr);
@@ -309,17 +284,6 @@ export class BrowserFileSystem implements SharedDirectoryAccess {
     };
 
     return walkIt(this.dir, path);
-  }
-
-  /**
-   * @throws Will throw an error if a directory has not already been initialized.
-   */
-  private checkReady() {
-    if (!this.dir) {
-      throw new Error(
-        'attempted to use a shared directory before one was initialized'
-      );
-    }
   }
 }
 

--- a/web/packages/shared/utils/error.ts
+++ b/web/packages/shared/utils/error.ts
@@ -69,6 +69,17 @@ export function isAbortError(err: any): boolean {
     return true;
   }
 
-  // handles Connect abort error (specifically gRPC cancel error), see TshdRpcError
+  // handles error that went through Electron IPC (it contains only a message)
+  if (getErrorMessage(err).includes('AbortError:')) {
+    return true;
+  }
+
+  // handles gRPC cancel error (see TshdRpcError)
   return err?.code === 'CANCELLED';
+}
+
+export class AbortError extends DOMException {
+  constructor(message = 'The operation was aborted.') {
+    super(message, 'AbortError');
+  }
 }

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -24,7 +24,7 @@ import {
   DesktopSession as SharedDesktopSession,
 } from 'shared/components/DesktopSession';
 import { useAsync } from 'shared/hooks/useAsync';
-import { BrowserFileSystem, TdpClient } from 'shared/libs/tdp';
+import { selectDirectoryInBrowser, TdpClient } from 'shared/libs/tdp';
 
 import { useTeleport } from 'teleport';
 import AuthnDialog from 'teleport/components/AuthnDialog';
@@ -59,7 +59,7 @@ export function DesktopSession() {
             ),
             abortSignal
           ),
-        new BrowserFileSystem()
+        selectDirectoryInBrowser
       )
   );
   const mfa = useMfaEmitter(client, undefined, {

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -16,7 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { BrowserFileSystem, TdpClient, TdpClientEvent } from 'shared/libs/tdp';
+import {
+  selectDirectoryInBrowser,
+  TdpClient,
+  TdpClientEvent,
+} from 'shared/libs/tdp';
 import { base64ToArrayBuffer } from 'shared/utils/base64';
 import { throttle } from 'shared/utils/highbar';
 
@@ -57,7 +61,7 @@ export class PlayerClient extends TdpClient {
     super(
       signal =>
         adaptWebSocketToTdpTransport(new AuthenticatedWebSocket(url), signal),
-      new BrowserFileSystem()
+      selectDirectoryInBrowser
     );
     this.setPlayerStatus = setPlayerStatus;
     this.setStatusText = setStatusText;

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -33,6 +33,8 @@ import {
   shell,
 } from 'electron';
 
+import { AbortError } from 'shared/utils/error';
+
 import Logger from 'teleterm/logger';
 import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import {
@@ -576,7 +578,7 @@ export default class MainProcess {
           properties: ['openDirectory'],
         });
         if (value.canceled) {
-          throw new Error('Selecting directory canceled.');
+          throw new AbortError();
         }
         if (value.filePaths.length !== 1) {
           throw new Error('No directory selected.');

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -83,10 +83,11 @@ export function DocumentDesktopSession(props: {
             logger
           );
         },
-        makeTshdFileSystem(appCtx.mainProcessClient, {
-          desktopUri,
-          login,
-        })
+        () =>
+          shareDirectoryInTshd(appCtx.mainProcessClient, {
+            desktopUri,
+            login,
+          })
       )
   );
 
@@ -177,7 +178,7 @@ async function adaptGRPCStreamToTdpTransport(
 }
 
 /**
- * The tshd daemon is responsible for handling directory sharing.
+ * Opens a directory picker and then shares the selected directory using tsh daemon.
  *
  * The process begins when the Electron main process opens a directory picker.
  * Once a path is selected, it is passed to tshd via the SetSharedDirectoryForDesktopSession API.
@@ -189,19 +190,16 @@ async function adaptGRPCStreamToTdpTransport(
  * This message is safe to send from the renderer because it only provides
  * a display name for the mounted drive on the remote machine and has no effect on local file system operations.
  */
-function makeTshdFileSystem(
+async function shareDirectoryInTshd(
   mainProcessClient: MainProcessClient,
   target: {
     desktopUri: string;
     login: string;
   }
-): SharedDirectoryAccess {
-  let directoryName = '';
+): Promise<SharedDirectoryAccess> {
+  const directoryName =
+    await mainProcessClient.selectDirectoryForDesktopSession(target);
   return {
-    selectDirectory: async () => {
-      directoryName =
-        await mainProcessClient.selectDirectoryForDesktopSession(target);
-    },
     getDirectoryName: () => directoryName,
     // These functions are unimplemented because all file system operations
     // are handled exclusively by the tsh daemon.


### PR DESCRIPTION
Backport #56116 to branch/v18

changelog: Resolved an issue where directory sharing could become unavailable after sharing a directory, disconnecting the desktop session, and reconnecting again
