### PR TITLE
[v16] Support traits in `workload_identity_labels` (#56249)

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -293,6 +293,14 @@ spec:
     cluster_labels:
       'env': 'prod'
 
+    # workload_identity_labels: a user/bot with this role will be allowed to
+    # issue Workload Identities with labels matching below.
+    #
+    # Supports role templating with traits.
+    workload_identity_labels:
+      'env': 'prod'
+      'team': '{{external.team}}'
+
     # node_labels_expression has the same purpose as node_labels but
     # supports predicate expressions to configure custom logic.
     # A user with this role will be allowed to access nodes if they are in the

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -497,6 +497,7 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 			types.KindDatabaseService,
 			types.KindWindowsDesktop,
 			types.KindUserGroup,
+			types.KindWorkloadIdentity,
 		} {
 			labelMatchers, err := r.GetLabelMatchers(condition, kind)
 			if err != nil {


### PR DESCRIPTION
Backports #56249

changelog: Trait role templating is now supported in the workload_identity_labels field