### PR TITLE
test: stop setting TELEPORT_UNSTABLE_REJECT_OLD_CLIENTS

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -81,8 +81,7 @@ import (
 )
 
 func TestRejectedClients(t *testing.T) {
-	t.Setenv("TELEPORT_UNSTABLE_REJECT_OLD_CLIENTS", "yes")
-
+	t.Parallel()
 	server, err := NewTestAuthServer(TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "cluster",


### PR DESCRIPTION
Teleport no longer uses this environment variable, so setting it in the test does not nothing other than make the test unsafe for parallelization.