### PR TITLE
Replaces deprecated dependabot reviewers with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,25 @@
 # Merge rules are governed by logic in the Workflow Bot. Protect the
 # .github/workflows directory (and the merge logic) using CODEOWNERS.
-/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy
-/build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3
+/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @doggydogworld @rosstimothy
+/.github/actions/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @doggydogworld @rosstimothy
+/build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3 @rosstimothy
 
-# Owners for dependency updates in JS packages.
+# Owners for JS dependency updates.
 /pnpm-lock.yaml @avatus @gzdunek @ravicious
-web/packages/teleterm/package.json @gzdunek @ravicious
+/web/packages/teleterm/package.json @gzdunek @ravicious
+
+# Owners for Go dependency updates.
+/go.mod @russjones @r0mant @zmb3 @rosstimothy
+/api/go.mod @russjones @r0mant @zmb3 @rosstimothy
+/assets/aws/go.mod @russjones @r0mant @zmb3 @rosstimothy
+/assets/backport/go.mod @russjones @r0mant @zmb3 @rosstimothy
+/build.assets/tooling/go.mod @russjones @r0mant @zmb3 @rosstimothy @fheinecke @camscale @doggydogworld
+/integrations/terraform/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato
+/integrations/terraform-mwi/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato @strideynet
+/integrations/event-handler/go.mod @russjones @r0mant @zmb3 @rosstimothy @hugoShaka @tigrato
+
+# Owners for Rust dependency updates.
+/Cargo.toml @russjones @r0mant @zmb3 @rosstimothy @fspmarshall @espadolini
+/tool/fdpass-teleport/Cargo.toml @russjones @r0mant @zmb3 @rosstimothy @fspmarshall @espadolini
+/web/packages/shared/libs/ironrdp/Cargo.toml @russjones @r0mant @zmb3 @rosstimothy @fspmarshall @espadolini @probakowski
+/lib/srv/desktop/rdp/rdpclient/Cargo.toml @russjones @r0mant @zmb3 @rosstimothy @fspmarshall @espadolini @probakowski

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     ignore:
-      # Breaks backwards compatibility
-      - dependency-name: github.com/gravitational/ttlmap
       # Must be kept in-sync with libbpf
       - dependency-name: github.com/aquasecurity/libbpfgo
       # Forked/replaced dependencies
       - dependency-name: github.com/alecthomas/kingpin/v2
-      - dependency-name: github.com/coreos/go-oidc
       - dependency-name: github.com/go-mysql-org/go-mysql
       - dependency-name: github.com/gogo/protobuf
       - dependency-name: github.com/julienschmidt/httprouter
@@ -25,44 +22,36 @@ updates:
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - zmb3
-      - hugoShaka
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/api"
+    directory: '/api'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     open-pull-requests-limit: 20
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - zmb3
-      - hugoShaka
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/assets/aws"
+    directory: '/assets/aws'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     ignore:
       # Forked/replaced dependencies
       - dependency-name: github.com/alecthomas/kingpin/v2
@@ -70,43 +59,36 @@ updates:
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - tcsc
-      - zmb3
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/assets/backport"
+    directory: '/assets/backport'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     open-pull-requests-limit: 20
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - zmb3
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/build.assets/tooling"
+    directory: '/build.assets/tooling'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     ignore:
       # Forked/replaced dependencies
       - dependency-name: github.com/alecthomas/kingpin/v2
@@ -114,23 +96,19 @@ updates:
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - fheinecke
-      - rosstimothy
-      - zmb3
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/integrations/terraform"
+    directory: '/integrations/terraform'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     ignore:
       # breaks compatibility
       - dependency-name: github.com/hashicorp/terraform-plugin-framework
@@ -140,136 +118,156 @@ updates:
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - hugoShaka
-      - tigrato
-      - marcoandredinis
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
   - package-ecosystem: gomod
-    directory: "/integrations/event-handler"
+    directory: '/integrations/terraform-mwi'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     open-pull-requests-limit: 20
     groups:
       go:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - hugoShaka
-      - tigrato
-      - marcoandredinis
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "go"
-      - "no-changelog"
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
 
-
-  - package-ecosystem: cargo
-    directory: "/"
+  - package-ecosystem: gomod
+    directory: '/integrations/event-handler'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
+    open-pull-requests-limit: 20
+    groups:
+      go:
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+      - 'go'
+      - 'no-changelog'
+
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule:
+      interval: monthly
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     open-pull-requests-limit: 20
     groups:
       rust:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - zmb3
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "rust"
-      - "no-changelog"
+      - 'dependencies'
+      - 'rust'
+      - 'no-changelog'
 
   - package-ecosystem: cargo
-    directory: "/lib/srv/desktop/rdp/rdpclient"
+    directory: '/lib/srv/desktop/rdp/rdpclient'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     open-pull-requests-limit: 20
     groups:
       rust:
         update-types:
-          - "minor"
-          - "patch"
-    reviewers:
-      - rosstimothy
-      - zmb3
+          - 'minor'
+          - 'patch'
     labels:
-      - "dependencies"
-      - "rust"
-      - "no-changelog"
+      - 'dependencies'
+      - 'rust'
+      - 'no-changelog'
+
+  - package-ecosystem: cargo
+    directory: '/tool/fdpass-teleport'
+    schedule:
+      interval: monthly
+      day: 'sunday'
+      time: '09:00' # 9am UTC
+    open-pull-requests-limit: 20
+    groups:
+      rust:
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+      - 'rust'
+      - 'no-changelog'
+
+  - package-ecosystem: cargo
+    directory: '/web/packages/shared/libs/ironrdp/Cargo.toml'
+    schedule:
+      interval: monthly
+      day: 'sunday'
+      time: '09:00' # 9am UTC
+    open-pull-requests-limit: 20
+    groups:
+      rust:
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+      - 'rust'
+      - 'no-changelog'
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
-      day: "sunday"
-      time: "09:00" # 9am UTC
+      day: 'sunday'
+      time: '09:00' # 9am UTC
     labels:
-      - "dependencies"
-      - "ui"
-      - "no-changelog"
+      - 'dependencies'
+      - 'ui'
+      - 'no-changelog'
     groups:
       electron:
         patterns:
-        - "electron*"
+          - 'electron*'
       ui:
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
         exclude-patterns:
-          - "electron*"
+          - 'electron*'
     open-pull-requests-limit: 20
-    reviewers:
-      - avatus
-      - kimlisa
-      - rudream
-      - bl-nero
-      - gzdunek
-      - ravicious
-      - ryanclark
   - package-ecosystem: github-actions
-    directory: "/.github/workflows"
+    directory: '/.github/workflows'
     schedule:
       interval: monthly
       day: monday
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    reviewers:
-      - fheinecke
-      - camscale
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     labels:
-      - "dependencies"
-      - "github-actions"
-      - "no-changelog"
+      - 'dependencies'
+      - 'github-actions'
+      - 'no-changelog'
 
   - package-ecosystem: github-actions
-    directory: "/.github/actions"
+    directory: '/.github/actions'
     schedule:
       interval: monthly
       day: monday
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    reviewers:
-      - fheinecke
-      - camscale
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     labels:
-      - "dependencies"
-      - "github-actions"
-      - "no-changelog"
+      - 'dependencies'
+      - 'github-actions'
+      - 'no-changelog'


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Enterprise equivalent: https://github.com/gravitational/teleport.e/pull/6780.