### PR TITLE
Update pnpm to 10.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "engines": {
     "node": "^22"
   }


### PR DESCRIPTION
I usually do this in the PR with dep updates, but dep updates are not backported to release branches. I feel like it'd be good to have pnpm on the same version across all three release branches if possible, otherwise we risk some slight differences in how packages are managed.