### PR TITLE
iac: fix incorrect `s3:GetObject` permission

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -452,19 +452,28 @@ func StatementAccessGraphAWSSyncSQS(sqsQueueARN string) *Statement {
 	}
 }
 
-// StatementAccessGraphAWSSyncS3BucketDownload returns the statement that allows downloading
+// StatementsAccessGraphAWSSyncS3BucketDownload returns the statements that allows downloading
 // objects from the specified S3 bucket. This is used for downloading AWS cloud trail logs.
-func StatementAccessGraphAWSSyncS3BucketDownload(s3BucketARN string) *Statement {
-	return &Statement{
-		Effect: EffectAllow,
-		Actions: []string{
-			"s3:GetObject",
-			"s3:GetObjectVersion",
-			"s3:ListBucket",
-			"s3:ListBucketVersions",
-			"s3:GetBucketLocation",
+func StatementsAccessGraphAWSSyncS3BucketDownload(s3BucketARN string) []*Statement {
+	return []*Statement{
+		{
+			Effect: EffectAllow,
+			Actions: []string{
+				"s3:GetObject",
+				"s3:GetObjectVersion",
+			},
+			Resources: []string{s3BucketARN + "/*"},
 		},
-		Resources: []string{s3BucketARN},
+		{
+			Effect: EffectAllow,
+			Actions: []string{
+				"s3:ListBucket",
+				"s3:ListBucketVersions",
+				"s3:GetBucketLocation",
+				"s3:GetBucketVersioning",
+			},
+			Resources: []string{s3BucketARN},
+		},
 	}
 }
 

--- a/lib/integrations/awsoidc/accessgraph_sync.go
+++ b/lib/integrations/awsoidc/accessgraph_sync.go
@@ -174,7 +174,7 @@ func ConfigureAccessGraphSyncIAM(ctx context.Context, clt AccessGraphIAMConfigur
 		statements = append(statements, awslib.StatementAccessGraphAWSSyncSQS(arnString))
 	}
 	if req.CloudTrailBucketARN != "" {
-		statements = append(statements, awslib.StatementAccessGraphAWSSyncS3BucketDownload(req.CloudTrailBucketARN))
+		statements = append(statements, awslib.StatementsAccessGraphAWSSyncS3BucketDownload(req.CloudTrailBucketARN)...)
 	}
 
 	if len(req.KMSKeyARNs) > 0 {

--- a/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
+++ b/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
@@ -71,10 +71,17 @@ PutRolePolicy: {
                 "Effect": "Allow",
                 "Action": [
                     "s3:GetObject",
-                    "s3:GetObjectVersion",
+                    "s3:GetObjectVersion"
+                ],
+                "Resource": "arn:aws:s3:::my-cloudtrail-bucket/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
                     "s3:ListBucket",
                     "s3:ListBucketVersions",
-                    "s3:GetBucketLocation"
+                    "s3:GetBucketLocation",
+                    "s3:GetBucketVersioning"
                 ],
                 "Resource": "arn:aws:s3:::my-cloudtrail-bucket"
             },


### PR DESCRIPTION
This PR fixes an incorrect AWS IAM permission that didn't set the wildcard for the `s3:GetObject` permission. This caused the download to fail because AWS requires the file wildcard to be present.