### PR TITLE
AWS Roles Anywhere: list profiles endpoint

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5601,6 +5601,16 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	integrationv1pb.RegisterAWSOIDCServiceServer(server, integrationAWSOIDCServiceServer)
 
+	integrationAWSRolesAnywhereServiceServer, err := integrationv1.NewAWSRolesAnywhereService(&integrationv1.AWSRolesAnywhereServiceConfig{
+		Authorizer:         cfg.Authorizer,
+		IntegrationService: integrationServiceServer,
+		Clock:              cfg.AuthServer.clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	integrationv1pb.RegisterAWSRolesAnywhereServiceServer(server, integrationAWSRolesAnywhereServiceServer)
+
 	userTask, err := usertasksv1.NewService(usertasksv1.ServiceConfig{
 		Authorizer: cfg.Authorizer,
 		Backend:    cfg.AuthServer.Services,

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -20,10 +20,14 @@ package integrationv1
 
 import (
 	"context"
+	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
@@ -39,7 +43,7 @@ func (s *Service) GenerateAWSRACredentials(ctx context.Context, req *integration
 
 	for _, allowedRole := range []types.SystemRole{types.RoleAuth, types.RoleProxy} {
 		if authz.HasBuiltinRole(*authCtx, string(allowedRole)) {
-			return s.generateAWSRACredentialsWithoutAuthZ(ctx, req)
+			return s.generateAWSRACredentialsWithoutAuthZ(ctx, req, "" /* trustAnchor */)
 		}
 	}
 
@@ -48,14 +52,14 @@ func (s *Service) GenerateAWSRACredentials(ctx context.Context, req *integration
 
 // generateAWSRACredentialsWithoutAuthZ generates a set of AWS credentials which uses the AWS Roles Anywhere integration.
 // Bypasses authz and should only be used by other methods that validate AuthZ.
-func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req *integrationpb.GenerateAWSRACredentialsRequest) (*integrationpb.GenerateAWSRACredentialsResponse, error) {
-	integration, err := s.cache.GetIntegration(ctx, req.GetIntegration())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	spec := integration.GetAWSRolesAnywhereIntegrationSpec()
-	if spec == nil {
-		return nil, trace.BadParameter("integration %q is not an AWSRA integration", req.Integration)
+func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req *integrationpb.GenerateAWSRACredentialsRequest, trustAnchor string) (*integrationpb.GenerateAWSRACredentialsResponse, error) {
+	if trustAnchor == "" {
+		spec, err := s.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		trustAnchor = spec.TrustAnchorARN
 	}
 
 	var durationSeconds *int
@@ -66,7 +70,7 @@ func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req 
 
 	awsCredentials, err := awsra.GenerateCredentials(ctx, awsra.GenerateCredentialsRequest{
 		Clock:                 s.clock,
-		TrustAnchorARN:        spec.TrustAnchorARN,
+		TrustAnchorARN:        trustAnchor,
 		ProfileARN:            req.GetProfileArn(),
 		RoleARN:               req.GetRoleArn(),
 		SubjectCommonName:     req.GetSubjectName(),
@@ -85,5 +89,138 @@ func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req 
 		SecretAccessKey: awsCredentials.SecretAccessKey,
 		SessionToken:    awsCredentials.SessionToken,
 		Expiration:      timestamppb.New(awsCredentials.Expiration),
+	}, nil
+}
+
+func (s *Service) getAWSRolesAnywhereIntegrationSpec(ctx context.Context, integrationName string) (*types.AWSRAIntegrationSpecV1, error) {
+	integration, err := s.cache.GetIntegration(ctx, integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	spec := integration.GetAWSRolesAnywhereIntegrationSpec()
+	if spec == nil {
+		return nil, trace.BadParameter("integration %q is not an AWSRA integration", integrationName)
+	}
+
+	return spec, nil
+}
+
+// AWSRolesAnywhereServiceConfig holds configuration options for the AWSRolesAnywhere Integration gRPC service.
+type AWSRolesAnywhereServiceConfig struct {
+	// IntegrationService is the service that provides access to integration credentials.
+	IntegrationService *Service
+	// Authorizer is the authorizer used to check access to the integration.
+	Authorizer authz.Authorizer
+
+	Clock  clockwork.Clock
+	Logger *slog.Logger
+}
+
+// CheckAndSetDefaults checks the AWSRolesAnywhereServiceConfig fields and returns an error if a required param is not provided.
+// Authorizer and IntegrationService are required params.
+func (s *AWSRolesAnywhereServiceConfig) CheckAndSetDefaults() error {
+	if s.Authorizer == nil {
+		return trace.BadParameter("authorizer is required")
+	}
+
+	if s.IntegrationService == nil {
+		return trace.BadParameter("integration service is required")
+	}
+
+	if s.Clock == nil {
+		s.Clock = clockwork.NewRealClock()
+	}
+
+	if s.Logger == nil {
+		s.Logger = slog.With(teleport.ComponentKey, "integrations.awsra.service")
+	}
+
+	return nil
+}
+
+// AWSRolesAnywhereService implements the teleport.integration.v1.AWSRolesAnywhereService RPC service.
+type AWSRolesAnywhereService struct {
+	integrationpb.UnimplementedAWSRolesAnywhereServiceServer
+
+	integrationService *Service
+	authorizer         authz.Authorizer
+	logger             *slog.Logger
+	clock              clockwork.Clock
+}
+
+// NewAWSRolesAnywhereService returns a new AWSRolesAnywhereService.
+func NewAWSRolesAnywhereService(cfg *AWSRolesAnywhereServiceConfig) (*AWSRolesAnywhereService, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &AWSRolesAnywhereService{
+		integrationService: cfg.IntegrationService,
+		logger:             cfg.Logger,
+		authorizer:         cfg.Authorizer,
+		clock:              cfg.Clock,
+	}, nil
+}
+
+var _ integrationpb.AWSRolesAnywhereServiceServer = (*AWSRolesAnywhereService)(nil)
+
+// ListRolesAnywhereProfiles returns a paginated list of Roles Anywhere Profiles.
+func (s *AWSRolesAnywhereService) ListRolesAnywhereProfiles(ctx context.Context, req *integrationpb.ListRolesAnywhereProfilesRequest) (*integrationpb.ListRolesAnywhereProfilesResponse, error) {
+	authCtx, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authCtx.CheckAccessToKind(types.KindIntegration, types.VerbUse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// ListRolesAnywhereProfiles uses the ProfileSync config's Profile and Role.
+	spec, err := s.integrationService.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	trustAnchor := spec.TrustAnchorARN
+
+	credentials, err := s.integrationService.generateAWSRACredentialsWithoutAuthZ(ctx, &integrationpb.GenerateAWSRACredentialsRequest{
+		ProfileArn:                    spec.ProfileSyncConfig.ProfileARN,
+		RoleArn:                       spec.ProfileSyncConfig.RoleARN,
+		ProfileAcceptsRoleSessionName: spec.ProfileSyncConfig.ProfileAcceptsRoleSessionName,
+		SubjectName:                   authCtx.Identity.GetIdentity().Username,
+	}, trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	trustAnchorARNParsed, err := arn.Parse(trustAnchor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	trustAnchorRegion := trustAnchorARNParsed.Region
+
+	listRolesAnywhereClient, err := awsra.NewListRolesAnywhereProfilesClient(ctx, &awsra.AWSClientConfig{
+		Credentials: awsra.Credentials{
+			AccessKeyID:     credentials.AccessKeyId,
+			SecretAccessKey: credentials.SecretAccessKey,
+			SessionToken:    credentials.SessionToken,
+			Expiration:      credentials.Expiration.AsTime(),
+			Version:         1,
+		},
+		Region: trustAnchorRegion,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	profileList, err := awsra.ListRolesAnywhereProfiles(ctx, listRolesAnywhereClient, awsra.ListRolesAnywhereProfilesRequest{
+		NextToken: req.GetNextPageToken(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &integrationpb.ListRolesAnywhereProfilesResponse{
+		Profiles:      profileList.Profiles,
+		NextPageToken: profileList.NextToken,
 	}, nil
 }

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -118,7 +118,6 @@ type AWSRolesAnywhereServiceConfig struct {
 }
 
 // CheckAndSetDefaults checks the AWSRolesAnywhereServiceConfig fields and returns an error if a required param is not provided.
-// Authorizer and IntegrationService are required params.
 func (s *AWSRolesAnywhereServiceConfig) CheckAndSetDefaults() error {
 	if s.Authorizer == nil {
 		return trace.BadParameter("authorizer is required")

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -52,11 +52,12 @@ func (s *Service) GenerateAWSRACredentials(ctx context.Context, req *integration
 
 // generateAWSRACredentialsWithoutAuthZ generates a set of AWS credentials which uses the AWS Roles Anywhere integration.
 // Bypasses authz and should only be used by other methods that validate AuthZ.
+// If trustAnchor is unset, it will use the trust anchor from the integration spec.
 func (s *Service) generateAWSRACredentialsWithoutAuthZ(ctx context.Context, req *integrationpb.GenerateAWSRACredentialsRequest, trustAnchor string) (*integrationpb.GenerateAWSRACredentialsResponse, error) {
 	if trustAnchor == "" {
 		spec, err := s.getAWSRolesAnywhereIntegrationSpec(ctx, req.GetIntegration())
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.BadParameter("trust anchor not provided and could not be fetched from the integration: %v", err)
 		}
 
 		trustAnchor = spec.TrustAnchorARN

--- a/lib/integrations/awsra/client.go
+++ b/lib/integrations/awsra/client.go
@@ -56,7 +56,7 @@ func (req *AWSClientConfig) checkAndSetDefaults() error {
 	return nil
 }
 
-// newAWSConfig creates a new [aws.Config] using the [AWSClientRequest] fields.
+// newAWSConfig creates a new [aws.Config] using the [AWSClientConfig] fields.
 func newAWSConfig(ctx context.Context, req *AWSClientConfig) (aws.Config, error) {
 	if err := req.checkAndSetDefaults(); err != nil {
 		return aws.Config{}, trace.Wrap(err)

--- a/lib/integrations/awsra/client.go
+++ b/lib/integrations/awsra/client.go
@@ -1,0 +1,81 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/gravitational/trace"
+
+	awsutils "github.com/gravitational/teleport/api/utils/aws"
+)
+
+// AWSClientConfig contains the required fields to set up an AWS SDK Clients.
+type AWSClientConfig struct {
+	// Credentials contains the AWS credentials to use.
+	Credentials Credentials
+
+	// Region where the API call should be made.
+	Region string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *AWSClientConfig) checkAndSetDefaults() error {
+	if req.Credentials.AccessKeyID == "" ||
+		req.Credentials.SecretAccessKey == "" ||
+		req.Credentials.SessionToken == "" {
+
+		return trace.BadParameter("credentials are missing")
+	}
+
+	if req.Region != "" {
+		if err := awsutils.IsValidRegion(req.Region); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// newAWSConfig creates a new [aws.Config] using the [AWSClientRequest] fields.
+func newAWSConfig(ctx context.Context, req *AWSClientConfig) (aws.Config, error) {
+	if err := req.checkAndSetDefaults(); err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(req.Region),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				req.Credentials.AccessKeyID,
+				req.Credentials.SecretAccessKey,
+				req.Credentials.SessionToken,
+			),
+		),
+	)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	return awsConfig, nil
+}

--- a/lib/integrations/awsra/list_rolesanywhere_profiles.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles.go
@@ -1,0 +1,132 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	"github.com/gravitational/trace"
+
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+)
+
+// ListRolesAnywhereProfilesRequest contains the required fields to list the Roles Anywhere Profiles in Amazon IAM.
+type ListRolesAnywhereProfilesRequest struct {
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string
+}
+
+// ListRolesAnywhereProfilesResponse contains a page of Roles Anywhere Profiles.
+type ListRolesAnywhereProfilesResponse struct {
+	// Profiles contains the page of Roles Anywhere Profiles.
+	Profiles []*integrationv1.RolesAnywhereProfile `json:"profiles"`
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string `json:"nextToken"`
+}
+
+// RolesAnywhereProfilesLister is an interface that defines methods to interact with the AWS IAM Roles Anywhere service.
+type RolesAnywhereProfilesLister interface {
+	// Lists all profiles in the authenticated account and Amazon Web Services Region.
+	ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error)
+
+	// Lists the tags attached to the resource.
+	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
+}
+
+// ListRolesAnywhereProfilesClient describes the required methods to list AWS VPCs.
+type ListRolesAnywhereProfilesClient interface {
+	RolesAnywhereProfilesLister
+}
+
+type defaultListRolesAnywhereProfilesClient struct {
+	RolesAnywhereProfilesLister
+}
+
+// NewListRolesAnywhereProfilesClient creates a new ListRolesAnywhereProfilesClient using an AWSClientRequest.
+func NewListRolesAnywhereProfilesClient(ctx context.Context, req *AWSClientConfig) (ListRolesAnywhereProfilesClient, error) {
+	awsConfig, err := newAWSConfig(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListRolesAnywhereProfilesClient{
+		RolesAnywhereProfilesLister: rolesanywhere.NewFromConfig(awsConfig),
+	}, nil
+}
+
+// ListRolesAnywhereProfiles calls the following AWS API:
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+// It returns a list of Roles Anywhere Profiles and an optional NextToken that can be used to fetch the next page.
+func ListRolesAnywhereProfiles(ctx context.Context, clt ListRolesAnywhereProfilesClient, req ListRolesAnywhereProfilesRequest) (*ListRolesAnywhereProfilesResponse, error) {
+	var nextToken *string
+	if req.NextToken != "" {
+		nextToken = aws.String(req.NextToken)
+	}
+	profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, nextToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ListRolesAnywhereProfilesResponse{
+		Profiles:  profiles,
+		NextToken: aws.ToString(nextPageToken),
+	}, nil
+}
+
+func listRolesAnywhereProfilesPage(ctx context.Context, raClient RolesAnywhereProfilesLister, nextPage *string) ([]*integrationv1.RolesAnywhereProfile, *string, error) {
+	var ret []*integrationv1.RolesAnywhereProfile
+
+	profilesListResp, err := raClient.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
+		NextToken: nextPage,
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	for _, profile := range profilesListResp.Profiles {
+		profileTags, err := raClient.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
+			ResourceArn: profile.ProfileArn,
+		})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		labels := make(map[string]string, len(profileTags.Tags))
+		for _, tag := range profileTags.Tags {
+			labels[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+		}
+
+		ret = append(ret, &integrationv1.RolesAnywhereProfile{
+			Arn:                   aws.ToString(profile.ProfileArn),
+			Name:                  aws.ToString(profile.Name),
+			Enabled:               aws.ToBool(profile.Enabled),
+			AcceptRoleSessionName: aws.ToBool(profile.AcceptRoleSessionName),
+			Roles:                 profile.RoleArns,
+			Tags:                  labels,
+		})
+	}
+
+	return ret, profilesListResp.NextToken, nil
+}

--- a/lib/integrations/awsra/list_rolesanywhere_profiles.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles.go
@@ -54,17 +54,12 @@ type RolesAnywhereProfilesLister interface {
 	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
 }
 
-// ListRolesAnywhereProfilesClient describes the required methods to list AWS VPCs.
-type ListRolesAnywhereProfilesClient interface {
-	RolesAnywhereProfilesLister
-}
-
 type defaultListRolesAnywhereProfilesClient struct {
 	RolesAnywhereProfilesLister
 }
 
 // NewListRolesAnywhereProfilesClient creates a new ListRolesAnywhereProfilesClient using an AWSClientRequest.
-func NewListRolesAnywhereProfilesClient(ctx context.Context, req *AWSClientConfig) (ListRolesAnywhereProfilesClient, error) {
+func NewListRolesAnywhereProfilesClient(ctx context.Context, req *AWSClientConfig) (RolesAnywhereProfilesLister, error) {
 	awsConfig, err := newAWSConfig(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -79,7 +74,7 @@ func NewListRolesAnywhereProfilesClient(ctx context.Context, req *AWSClientConfi
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
 // It returns a list of Roles Anywhere Profiles and an optional NextToken that can be used to fetch the next page.
-func ListRolesAnywhereProfiles(ctx context.Context, clt ListRolesAnywhereProfilesClient, req ListRolesAnywhereProfilesRequest) (*ListRolesAnywhereProfilesResponse, error) {
+func ListRolesAnywhereProfiles(ctx context.Context, clt RolesAnywhereProfilesLister, req ListRolesAnywhereProfilesRequest) (*ListRolesAnywhereProfilesResponse, error) {
 	var nextToken *string
 	if req.NextToken != "" {
 		nextToken = aws.String(req.NextToken)

--- a/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRolesAnywhereProfiles(t *testing.T) {
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	syncProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	disabledProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3"),
+		Enabled:               aws.Bool(false),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	t.Run("listing returns 3 profiles", func(t *testing.T) {
+		client := &mockListRolesAnywhereProfiles{
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+				syncProfile,
+				disabledProfile,
+			},
+		}
+		resp, err := ListRolesAnywhereProfiles(t.Context(), client, ListRolesAnywhereProfilesRequest{})
+		require.NoError(t, err)
+
+		require.Len(t, resp.Profiles, 3)
+	})
+}
+
+type mockListRolesAnywhereProfiles struct {
+	profiles []ratypes.ProfileDetail
+}
+
+func (m *mockListRolesAnywhereProfiles) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles:  m.profiles,
+		NextToken: nil,
+	}, nil
+}
+
+func (m *mockListRolesAnywhereProfiles) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: []ratypes.Tag{
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}, nil
+}

--- a/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
@@ -50,19 +50,17 @@ func TestListRolesAnywhereProfiles(t *testing.T) {
 		AcceptRoleSessionName: aws.Bool(true),
 	}
 
-	t.Run("listing returns 3 profiles", func(t *testing.T) {
-		client := &mockListRolesAnywhereProfiles{
-			profiles: []ratypes.ProfileDetail{
-				exampleProfile,
-				syncProfile,
-				disabledProfile,
-			},
-		}
-		resp, err := ListRolesAnywhereProfiles(t.Context(), client, ListRolesAnywhereProfilesRequest{})
-		require.NoError(t, err)
+	client := &mockListRolesAnywhereProfiles{
+		profiles: []ratypes.ProfileDetail{
+			exampleProfile,
+			syncProfile,
+			disabledProfile,
+		},
+	}
+	resp, err := ListRolesAnywhereProfiles(t.Context(), client, ListRolesAnywhereProfilesRequest{})
+	require.NoError(t, err)
 
-		require.Len(t, resp.Profiles, 3)
-	})
+	require.Len(t, resp.Profiles, 3)
 }
 
 type mockListRolesAnywhereProfiles struct {

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -30,12 +30,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
-	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/constants"
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/utils"
@@ -279,14 +279,12 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 
 	var nextPage *string
 	for {
-		profilesListResp, err := raClient.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
-			NextToken: nextPage,
-		})
+		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, nextPage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		for _, profile := range profilesListResp.Profiles {
+		for _, profile := range profilesListResp {
 			err := processProfile(ctx, processProfileRequest{
 				Params:          params,
 				Profile:         profile,
@@ -296,18 +294,18 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 			})
 			if err != nil {
 				if errors.Is(err, errDisabledProfile) || errors.Is(err, errProfileIsUsedForSync) {
-					logger.DebugContext(ctx, "Skipping profile", "profile_name", aws.ToString(profile.Name), "error", err.Error())
+					logger.DebugContext(ctx, "Skipping profile", "profile_name", profile.Name, "error", err.Error())
 					continue
 				}
 
-				logger.WarnContext(ctx, "Failed to process profile", "profile_name", aws.ToString(profile.Name), "error", err)
+				logger.WarnContext(ctx, "Failed to process profile", "profile_name", profile.Name, "error", err)
 			}
 		}
 
-		if aws.ToString(profilesListResp.NextToken) == "" {
+		if aws.ToString(respNextToken) == "" {
 			break
 		}
-		nextPage = profilesListResp.NextToken
+		nextPage = respNextToken
 	}
 
 	return nil
@@ -320,7 +318,7 @@ var (
 
 type processProfileRequest struct {
 	Params          AWSRolesAnywherProfileSyncerParams
-	Profile         ratypes.ProfileDetail
+	Profile         *integrationv1.RolesAnywhereProfile
 	RAClient        RolesAnywhereClient
 	Integration     types.Integration
 	ProxyPublicAddr string
@@ -329,22 +327,15 @@ type processProfileRequest struct {
 func processProfile(ctx context.Context, req processProfileRequest) error {
 	profileSyncProfileARN := req.Integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
 
-	if aws.ToString(req.Profile.ProfileArn) == profileSyncProfileARN {
+	if req.Profile.Arn == profileSyncProfileARN {
 		return errProfileIsUsedForSync
 	}
 
-	if !aws.ToBool(req.Profile.Enabled) {
+	if !req.Profile.Enabled {
 		return errDisabledProfile
 	}
 
-	profileTags, err := req.RAClient.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
-		ResourceArn: req.Profile.ProfileArn,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), profileTags.Tags, req.ProxyPublicAddr)
+	appServer, err := convertProfile(req.Params, req.Profile, req.Integration.GetName(), req.ProxyPublicAddr)
 	if err != nil {
 		return trace.BadParameter("failed to convert Profile to AppServer: %v", err)
 	}
@@ -356,22 +347,20 @@ func processProfile(ctx context.Context, req processProfileRequest) error {
 	return nil
 }
 
-func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.ProfileDetail, integrationName string, profileTags []ratypes.Tag, proxyPublicAddr string) (types.AppServer, error) {
-	profileName := aws.ToString(profile.Name)
-	profileARN := aws.ToString(profile.ProfileArn)
-	parsedProfileARN, err := arn.Parse(profileARN)
+func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile *integrationv1.RolesAnywhereProfile, integrationName string, proxyPublicAddr string) (types.AppServer, error) {
+	parsedProfileARN, err := arn.Parse(profile.Arn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	applicationName := profileName + "-" + integrationName
+	applicationName := profile.Name + "-" + integrationName
 
-	labels := make(map[string]string, len(profileTags))
-	for _, tag := range profileTags {
-		labels["aws/"+aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	labels := make(map[string]string, len(profile.Tags))
+	for tagKey, tagValue := range profile.Tags {
+		labels["aws/"+tagKey] = tagValue
 
-		if aws.ToString(tag.Key) == types.AWSRolesAnywhereProfileNameOverrideLabel {
-			applicationName = aws.ToString(tag.Value)
+		if tagKey == types.AWSRolesAnywhereProfileNameOverrideLabel {
+			applicationName = tagValue
 		}
 	}
 
@@ -380,7 +369,7 @@ func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.P
 	labels[types.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[constants.AWSAccountIDLabel] = parsedProfileARN.AccountID
 	labels[types.IntegrationLabel] = integrationName
-	labels[types.AWSRolesAnywhereProfileARNLabel] = profileARN
+	labels[types.AWSRolesAnywhereProfileARNLabel] = profile.Arn
 
 	// TODO(marco): add origin label in v19: teleport.dev/origin: integration_awsrolesanywhere
 	// types.Metadata.CheckAndSetDefaults in v17 returns an error if the origin label is set to AWS Roles Anywhere.
@@ -405,8 +394,8 @@ func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile ratypes.P
 				PublicAddr:  appURL,
 				AWS: &types.AppAWS{
 					RolesAnywhereProfile: &types.AppAWSRolesAnywhereProfile{
-						ProfileARN:            aws.ToString(profile.ProfileArn),
-						AcceptRoleSessionName: aws.ToBool(profile.AcceptRoleSessionName),
+						ProfileARN:            profile.Arn,
+						AcceptRoleSessionName: profile.AcceptRoleSessionName,
 					},
 				},
 			},

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -279,7 +279,8 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 
 	var nextPage *string
 	for {
-		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, nextPage)
+		const useAPIDefaultPageSize = 0
+		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, nextPage, useAPIDefaultPageSize)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1063,6 +1063,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// AWS IAM Roles Anywhere Integration Actions
 	h.GET("/webapi/scripts/integrations/configure/awsra-trust-anchor.sh", h.WithLimiter(h.awsRolesAnywhereConfigureTrustAnchor))
+	h.POST("/webapi/sites/:site/integrations/aws-ra/:name/listprofiles", h.WithClusterAuth(h.awsRolesAnywhereListProfiles))
 
 	// SAML IDP integration endpoints
 	h.GET("/webapi/scripts/integrations/configure/gcp-workforce-saml.sh", h.WithLimiter(h.gcpWorkforceConfigScript))

--- a/lib/web/integrations_awsra.go
+++ b/lib/web/integrations_awsra.go
@@ -145,7 +145,7 @@ func (h *Handler) awsRolesAnywhereConfigureTrustAnchor(w http.ResponseWriter, r 
 	return nil, trace.Wrap(err)
 }
 
-// awsRolesAnywhereListProfiles lists profiles Roles Anywhere Profiles accessible by the integration.
+// awsRolesAnywhereListProfiles lists Roles Anywhere Profiles accessible by the integration.
 func (h *Handler) awsRolesAnywhereListProfiles(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	ctx := r.Context()
 

--- a/lib/web/integrations_awsra.go
+++ b/lib/web/integrations_awsra.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
-	libui "github.com/gravitational/teleport/lib/ui"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -166,34 +165,11 @@ func (h *Handler) awsRolesAnywhereListProfiles(w http.ResponseWriter, r *http.Re
 
 	listResp, err := clt.IntegrationAWSRolesAnywhereClient().ListRolesAnywhereProfiles(ctx, &integrationv1.ListRolesAnywhereProfilesRequest{
 		Integration:   integrationName,
-		NextPageToken: req.NextToken,
+		NextPageToken: req.StartKey,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	ret := &ui.AWSRolesAnywhereListProfilesResponse{
-		Profiles:  make([]ui.AWSRolesAnywhereListProfile, 0, len(listResp.GetProfiles())),
-		NextToken: listResp.GetNextPageToken(),
-	}
-
-	for _, profile := range listResp.GetProfiles() {
-		uiTags := make([]libui.Label, 0, len(profile.GetTags()))
-		for tagKey, tagValue := range profile.GetTags() {
-			uiTags = append(uiTags, libui.Label{
-				Name:  tagKey,
-				Value: tagValue,
-			})
-		}
-		ret.Profiles = append(ret.Profiles, ui.AWSRolesAnywhereListProfile{
-			ARN:                   profile.GetArn(),
-			Name:                  profile.GetName(),
-			Enabled:               profile.GetEnabled(),
-			AcceptRoleSessionName: profile.GetAcceptRoleSessionName(),
-			Roles:                 profile.GetRoles(),
-			Tags:                  uiTags,
-		})
-	}
-
-	return ret, nil
+	return listResp, nil
 }

--- a/lib/web/integrations_awsra.go
+++ b/lib/web/integrations_awsra.go
@@ -29,11 +29,15 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	libui "github.com/gravitational/teleport/lib/ui"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
+	"github.com/gravitational/teleport/lib/web/ui"
 )
 
 // awsRolesAnywhereConfigureTrustAnchor returns a script that configures AWS IAM Roles Anywhere Integration
@@ -139,4 +143,57 @@ func (h *Handler) awsRolesAnywhereConfigureTrustAnchor(w http.ResponseWriter, r 
 	_, err = w.Write([]byte(script))
 
 	return nil, trace.Wrap(err)
+}
+
+// awsRolesAnywhereListProfiles lists profiles Roles Anywhere Profiles accessible by the integration.
+func (h *Handler) awsRolesAnywhereListProfiles(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	integrationName := p.ByName("name")
+	if integrationName == "" {
+		return nil, trace.BadParameter("an integration name is required")
+	}
+
+	var req ui.AWSRolesAnywhereListProfilesRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clt, err := sctx.GetUserClient(ctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	listResp, err := clt.IntegrationAWSRolesAnywhereClient().ListRolesAnywhereProfiles(ctx, &integrationv1.ListRolesAnywhereProfilesRequest{
+		Integration:   integrationName,
+		NextPageToken: req.NextToken,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ret := &ui.AWSRolesAnywhereListProfilesResponse{
+		Profiles:  make([]ui.AWSRolesAnywhereListProfile, 0, len(listResp.GetProfiles())),
+		NextToken: listResp.GetNextPageToken(),
+	}
+
+	for _, profile := range listResp.GetProfiles() {
+		uiTags := make([]libui.Label, 0, len(profile.GetTags()))
+		for tagKey, tagValue := range profile.GetTags() {
+			uiTags = append(uiTags, libui.Label{
+				Name:  tagKey,
+				Value: tagValue,
+			})
+		}
+		ret.Profiles = append(ret.Profiles, ui.AWSRolesAnywhereListProfile{
+			ARN:                   profile.GetArn(),
+			Name:                  profile.GetName(),
+			Enabled:               profile.GetEnabled(),
+			AcceptRoleSessionName: profile.GetAcceptRoleSessionName(),
+			Roles:                 profile.GetRoles(),
+			Tags:                  uiTags,
+		})
+	}
+
+	return ret, nil
 }

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -672,32 +672,7 @@ type AWSOIDCCreateAWSAppAccessRequest struct {
 
 // AWSRolesAnywhereListProfilesRequest contains the list of Roles Anywhere Profiles.
 type AWSRolesAnywhereListProfilesRequest struct {
-	// NextToken is the token to be used to fetch the next page.
+	// StartKey is the token to be used to fetch the next page.
 	// If empty, the first page is fetched.
-	NextToken string `json:"nextToken"`
-}
-
-// AWSRolesAnywhereListProfilesResponse contains the result of the ListProfiles request.
-type AWSRolesAnywhereListProfilesResponse struct {
-	// Profiles contains the list of Roles Anywhere Profiles.
-	Profiles []AWSRolesAnywhereListProfile `json:"profiles"`
-	// NextToken is the token to be used to fetch the next page.
-	// If empty, the first page is fetched.
-	NextToken string `json:"nextToken,omitempty"`
-}
-
-// AWSRolesAnywhereListProfile represents a single IAM Roles Anywhere Profile.
-type AWSRolesAnywhereListProfile struct {
-	// The AWS Roles Anywhere Profile ARN.
-	ARN string `json:"arn,omitempty"`
-	// Whether the AWS Roles Anywhere Profile is enabled.
-	Enabled bool `json:"enabled,omitempty"`
-	// The name of the AWS Roles Anywhere Profile.
-	Name string `json:"name,omitempty"`
-	// Whether the profile accepts role session names.
-	AcceptRoleSessionName bool `json:"acceptRoleSessionName,omitempty"`
-	// The tags associated with the AWS Roles Anywhere Profile.
-	Tags []ui.Label `json:"tags,omitempty"`
-	// The roles accessible from this AWS Roles Anywhere Profile.
-	Roles []string `json:"roles,omitempty"`
+	StartKey string `json:"startKey"`
 }

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -669,3 +669,35 @@ type AWSOIDCCreateAWSAppAccessRequest struct {
 	// Labels added to the app server resource that will be created.
 	Labels map[string]string `json:"labels"`
 }
+
+// AWSRolesAnywhereListProfilesRequest contains the list of Roles Anywhere Profiles.
+type AWSRolesAnywhereListProfilesRequest struct {
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken"`
+}
+
+// AWSRolesAnywhereListProfilesResponse contains the result of the ListProfiles request.
+type AWSRolesAnywhereListProfilesResponse struct {
+	// Profiles contains the list of Roles Anywhere Profiles.
+	Profiles []AWSRolesAnywhereListProfile `json:"profiles"`
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken,omitempty"`
+}
+
+// AWSRolesAnywhereListProfile represents a single IAM Roles Anywhere Profile.
+type AWSRolesAnywhereListProfile struct {
+	// The AWS Roles Anywhere Profile ARN.
+	ARN string `json:"arn,omitempty"`
+	// Whether the AWS Roles Anywhere Profile is enabled.
+	Enabled bool `json:"enabled,omitempty"`
+	// The name of the AWS Roles Anywhere Profile.
+	Name string `json:"name,omitempty"`
+	// Whether the profile accepts role session names.
+	AcceptRoleSessionName bool `json:"acceptRoleSessionName,omitempty"`
+	// The tags associated with the AWS Roles Anywhere Profile.
+	Tags []ui.Label `json:"tags,omitempty"`
+	// The roles accessible from this AWS Roles Anywhere Profile.
+	Roles []string `json:"roles,omitempty"`
+}


### PR DESCRIPTION
AWS IAM Roles Anywhere allows users to access their AWS Account/Role using Roles Anywhere.

The discover wizard will guide the user for the whole process.
The last step includes setting up the profile synchronization.
For this, the user will be presented with a list of Profiles that are part of their account.
This endpoint will allow the WebUI to list those profiles.

demo:
```bash
$ curl 'https://proxy.example.com/v1/webapi/sites/my-cluster/integrations/aws-ra/raa/listprofiles' --data-raw '{}'

{
  "profiles": [
    {
      "arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
      "enabled": true,
      "name": "MarcoRA-RO-S3",
      "accept_role_session_name": true,
      "roles": [
        "arn:aws:iam::123456789012:role/MarcoRA-RO-S3-Role"
      ]
    },
    {
      "arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2",
      "enabled": true,
      "name": "MarcoRA-RO-EC2",
      "accept_role_session_name": true,
      "tags": {
        "MyTag1": "MyTagValue1"
      }
      ],
      "roles": [
        "arn:aws:iam::123456789012:role/MarcoRA-RO-EC2-Role"
      ]
    }
  ]
}
```
