### PR TITLE
AWS Roles Anywhere: ping endpoint

### DIFF
--- a/lib/auth/integration/integrationv1/awsra_test.go
+++ b/lib/auth/integration/integrationv1/awsra_test.go
@@ -19,14 +19,20 @@
 package integrationv1
 
 import (
+	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -92,4 +98,118 @@ func TestGenerateAWSRACredentials(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+}
+
+func TestAWSRolesAnywherePing(t *testing.T) {
+	t.Parallel()
+	clusterName := "test-cluster"
+	integrationName := "my-integration"
+	proxyPublicAddr := "example.com:443"
+
+	ca := newCertAuthority(t, types.AWSRACA, clusterName)
+	ctx, localClient, resourceSvc := initSvc(t, ca, clusterName, proxyPublicAddr)
+
+	ig, err := types.NewIntegrationAWSRA(
+		types.Metadata{Name: integrationName},
+		&types.AWSRAIntegrationSpecV1{
+			TrustAnchorARN: "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012",
+			ProfileSyncConfig: &types.AWSRolesAnywhereProfileSyncConfig{
+				Enabled:    false,
+				ProfileARN: "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/12345678-1234-1234-1234-123456789012",
+				RoleARN:    "arn:aws:iam::123456789012:role/SyncRole",
+			},
+		},
+	)
+	require.NoError(t, err)
+	_, err = localClient.CreateIntegration(ctx, ig)
+	require.NoError(t, err)
+
+	ctx = authorizerForDummyUser(t, ctx, types.RoleSpecV6{
+		Allow: types.RoleConditions{Rules: []types.Rule{
+			{Resources: []string{types.KindIntegration}, Verbs: []string{types.VerbUse}},
+		}},
+	}, localClient)
+
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+		RoleArns: []string{
+			"arn:aws:iam::123456789012:role/ExampleRole",
+			"arn:aws:iam::123456789012:role/SyncRole",
+		},
+	}
+
+	awsRolesAnywhereService, err := NewAWSRolesAnywhereService(&AWSRolesAnywhereServiceConfig{
+		IntegrationService: resourceSvc,
+		Authorizer:         resourceSvc.authorizer,
+		Clock:              resourceSvc.clock,
+		Logger:             resourceSvc.logger,
+		newPingClient: func(ctx context.Context, req *awsra.AWSClientConfig) (awsra.PingClient, error) {
+			return &mockPingClient{
+				accountID: "123456789012",
+				profiles: []ratypes.ProfileDetail{
+					exampleProfile,
+				},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("test connection using an integration", func(t *testing.T) {
+		pingResp, err := awsRolesAnywhereService.AWSRolesAnywherePing(ctx, &integrationv1.AWSRolesAnywherePingRequest{
+			Mode: &integrationv1.AWSRolesAnywherePingRequest_Integration{
+				Integration: integrationName,
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, pingResp)
+		require.Equal(t, "123456789012", pingResp.AccountId)
+		require.Equal(t, int32(1), pingResp.ProfileCount)
+	})
+
+	t.Run("test connection using provided trust anchor", func(t *testing.T) {
+		pingResp, err := awsRolesAnywhereService.AWSRolesAnywherePing(ctx, &integrationv1.AWSRolesAnywherePingRequest{
+			Mode: &integrationv1.AWSRolesAnywherePingRequest_Custom{
+				Custom: &integrationv1.AWSRolesAnywherePingRequestWithoutIntegration{
+					TrustAnchorArn: "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012",
+					RoleArn:        "arn:aws:iam::123456789012:role/SyncRole",
+					ProfileArn:     "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/12345678-1234-1234-1234-123456789012",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, pingResp)
+		require.Equal(t, "123456789012", pingResp.AccountId)
+		require.Equal(t, int32(1), pingResp.ProfileCount)
+	})
+}
+
+type mockPingClient struct {
+	accountID string
+	profiles  []ratypes.ProfileDetail
+}
+
+func (m *mockPingClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles:  m.profiles,
+		NextToken: nil,
+	}, nil
+}
+
+func (m *mockPingClient) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: []ratypes.Tag{
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}, nil
+}
+
+func (m *mockPingClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String(m.accountID),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test-user"),
+		UserId:  aws.String("USERID1234567890"),
+	}, nil
 }

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -1,0 +1,115 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+)
+
+// PingResponse contains the identity information and how many Roles Anywhere Profiles are active and have at least one Role.
+type PingResponse struct {
+	// AccountID is the AWS account ID of the caller.
+	AccountID string
+	// ARN is the ARN of the caller.
+	ARN string
+	// UserID is the user ID of the caller.
+	UserID string
+	// EnabledProfileCounter is the number of Roles Anywhere Profiles that are enabled and have at least one Role.
+	EnabledProfileCounter int
+}
+
+// PingClient describes the required methods to list AWS VPCs.
+type PingClient interface {
+	RolesAnywhereProfilesLister
+	CallerIdentityGetter
+}
+
+type defaultPingClient struct {
+	RolesAnywhereProfilesLister
+	stsClient CallerIdentityGetter
+}
+
+// GetCallerIdentity returns information about the caller identity.
+func (c *defaultPingClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return c.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+// NewPingClient creates a new PingClient using an AWSClientCredentials.
+func NewPingClient(ctx context.Context, req *AWSClientConfig) (PingClient, error) {
+	awsConfig, err := newAWSConfig(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultPingClient{
+		RolesAnywhereProfilesLister: rolesanywhere.NewFromConfig(awsConfig),
+		stsClient:                   stsutils.NewFromConfig(awsConfig),
+	}, nil
+}
+
+// Ping calls the following AWS API:
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
+// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+// It returns a list of Roles Anywhere Profiles that are enabled.
+func Ping(ctx context.Context, clt PingClient) (*PingResponse, error) {
+	var errs []error
+
+	profileCounter := 0
+	var nextToken *string
+	for {
+		const useAPIDefaultPageSize = 0
+		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, nextToken, useAPIDefaultPageSize)
+		if err != nil {
+			errs = append(errs, err)
+			break
+		}
+		for _, profile := range profiles {
+			if profile.Enabled && len(profile.Roles) > 0 {
+				profileCounter++
+			}
+		}
+		if aws.ToString(nextPageToken) == "" {
+			break
+		}
+		nextToken = nextPageToken
+	}
+
+	callerIdentity, err := clt.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return nil, trace.NewAggregate(errs...)
+	}
+
+	return &PingResponse{
+		EnabledProfileCounter: profileCounter,
+		AccountID:             aws.ToString(callerIdentity.Account),
+		ARN:                   aws.ToString(callerIdentity.Arn),
+		UserID:                aws.ToString(callerIdentity.UserId),
+	}, nil
+}

--- a/lib/integrations/awsra/ping_test.go
+++ b/lib/integrations/awsra/ping_test.go
@@ -1,0 +1,113 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPing(t *testing.T) {
+	exampleProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("ExampleProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+		RoleArns: []string{
+			"arn:aws:iam::123456789012:role/ExampleRole",
+			"arn:aws:iam::123456789012:role/SyncRole",
+		},
+	}
+
+	syncProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid2"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+		RoleArns: []string{
+			"arn:aws:iam::123456789012:role/ExampleRole",
+			"arn:aws:iam::123456789012:role/SyncRole",
+		},
+	}
+
+	disabledProfile := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3"),
+		Enabled:               aws.Bool(false),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	profileWithoutRoles := ratypes.ProfileDetail{
+		Name:                  aws.String("SyncProfile"),
+		ProfileArn:            aws.String("arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid4"),
+		Enabled:               aws.Bool(true),
+		AcceptRoleSessionName: aws.Bool(true),
+	}
+
+	t.Run("ping returns the caller identity and 2 enabled profiles", func(t *testing.T) {
+		resp, err := Ping(t.Context(), &mockPingClient{
+			accountID: "123456789012",
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+				syncProfile,
+				disabledProfile,
+				profileWithoutRoles,
+			},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "123456789012", resp.AccountID)
+		require.Equal(t, 2, resp.EnabledProfileCounter)
+	})
+
+}
+
+type mockPingClient struct {
+	accountID string
+	profiles  []ratypes.ProfileDetail
+}
+
+func (m *mockPingClient) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles:  m.profiles,
+		NextToken: nil,
+	}, nil
+}
+
+func (m *mockPingClient) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: []ratypes.Tag{
+			{Key: aws.String("MyTagKey"), Value: aws.String("my-tag-value")},
+		},
+	}, nil
+}
+
+func (m *mockPingClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String(m.accountID),
+		Arn:     aws.String("arn:aws:iam::123456789012:user/test-user"),
+		UserId:  aws.String("USERID1234567890"),
+	}, nil
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1063,6 +1063,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// AWS IAM Roles Anywhere Integration Actions
 	h.GET("/webapi/scripts/integrations/configure/awsra-trust-anchor.sh", h.WithLimiter(h.awsRolesAnywhereConfigureTrustAnchor))
+	h.POST("/webapi/sites/:site/integrations/aws-ra/:name/ping", h.WithClusterAuth(h.awsRolesAnywherePing))
 	h.POST("/webapi/sites/:site/integrations/aws-ra/:name/listprofiles", h.WithClusterAuth(h.awsRolesAnywhereListProfiles))
 
 	// SAML IDP integration endpoints

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -670,6 +670,30 @@ type AWSOIDCCreateAWSAppAccessRequest struct {
 	Labels map[string]string `json:"labels"`
 }
 
+// AWSRolesAnywherePingRequest contains ping request fields.
+type AWSRolesAnywherePingRequest struct {
+	// TrustAnchorARN is the ARN of the IAM Roles Anywhere Trust Anchor.
+	TrustAnchorARN string `json:"trustAnchorArn"`
+	// SyncProfileARN is the ARN of the IAM Roles Anywhere Profile that is used to sync profiles.
+	SyncProfileARN string `json:"syncProfileArn"`
+	// SyncRoleARN is the ARN of the IAM Role that is used to sync profiles.
+	SyncRoleARN string `json:"syncRoleArn"`
+}
+
+// AWSRolesAnywherePingResponse contains the result of the Ping request.
+// This response contains meta information about the current state of the Integration.
+type AWSRolesAnywherePingResponse struct {
+	// ProfileCount is the number of IAM Roles Anywhere Profiles that can be accessed by the Integration.
+	// Profiles that are disabled or don't have any IAM Role associated with them are not counted.
+	ProfileCount int `json:"profileCount"`
+	// AccountID number of the account that owns or contains the calling entity.
+	AccountID string `json:"accountId"`
+	// ARN associated with the calling entity.
+	ARN string `json:"arn"`
+	// UserID is the unique identifier of the calling entity.
+	UserID string `json:"userId"`
+}
+
 // AWSRolesAnywhereListProfilesRequest contains the list of Roles Anywhere Profiles.
 type AWSRolesAnywhereListProfilesRequest struct {
 	// StartKey is the token to be used to fetch the next page.


### PR DESCRIPTION
During the AWS IAM Roles Anywhere integration set up, the WebUI will test the connection.
This ensures the user has immediate feedback about whether the integration set up was a success.

This new endpoint allows for two things:
- prior to integration existence, it will be capable of testing against the provided Trust Anchor, Profile and IAM Role.
- after the integration is created, it can also be tested and it will use the integration's configured config settings (to obtain the Profile and IAM Role, the Trust Anchor is the one stored in the integration's spec).


Demo
```bash
$ curl 'https://proxy.example.com/v1/webapi/sites/my-cluster/integrations/aws-ra/raa/ping' \
  --data '{"trustAnchorArn":"arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/uuid2","syncProfileArn":"arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid3","syncRoleArn":"arn:aws:iam::123456789012:role/MarcoRASyncRole"}'

{
  "profileCount": 5,
  "accountId": "123456789012",
  "arn": "arn:aws:sts::123456789012:assumed-role/MarcoRASyncRole/uuid1",
  "userId": "RANDOMVALUE:uuid1"
}
```