### PR TITLE
MWI: Fix flaky tests for automatic bot lockouts

### DIFF
--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -579,7 +579,7 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err = renewedClient.Ping(ctx)
 		return err != nil && strings.Contains(err.Error(), "access denied")
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 // TestRegisterBotCertificateExtensions ensures bot cert extensions are present.

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -575,9 +575,11 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, locks)
 
-	// The original client should now be locked out.
-	_, err = renewedClient.Ping(ctx)
-	require.ErrorContains(t, err, "access denied")
+	// The original client should be locked out.
+	require.Eventually(t, func() bool {
+		_, err = renewedClient.Ping(ctx)
+		return err != nil && strings.Contains(err.Error(), "access denied")
+	}, 3*time.Second, 100*time.Millisecond)
 }
 
 // TestRegisterBotCertificateExtensions ensures bot cert extensions are present.

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
+	"strings"
 	"testing"
 	"time"
 
@@ -1242,7 +1243,9 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	require.Len(t, locks, 1)
 	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 
-	// The previously working client should now be locked.
-	_, err = client.Ping(ctx)
-	require.ErrorContains(t, err, "access denied")
+	// The previously working client should be locked.
+	require.Eventually(t, func() bool {
+		_, err = client.Ping(ctx)
+		return err != nil && strings.Contains(err.Error(), "access denied")
+	}, 3*time.Second, 100*time.Millisecond)
 }

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1247,5 +1247,5 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err = client.Ping(ctx)
 		return err != nil && strings.Contains(err.Error(), "access denied")
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
This fixes a flaky test, `TestRegisterBotCertificateGenerationStolen`, which assumed authenticated clients would immediately lose access if locked. It also fixes another test introduced at the same time that contains a similar check.

Fixes #56303