### PR TITLE
[v18] Set AuthServerAddressMode in terraform provider

### DIFF
--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -514,7 +514,8 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 		return nil, trace.Wrap(err, "Invalid Join Method")
 	}
 	botConfig := &embeddedtbot.BotConfig{
-		AuthServer: addr,
+		AuthServer:            addr,
+		AuthServerAddressMode: tbotconfig.AllowProxyAsAuthServer,
 		Onboarding: tbotconfig.OnboardingConfig{
 			TokenValue: joinToken,
 			CAPath:     caPath,


### PR DESCRIPTION
Backport #56341 to branch/v18

Depends on https://github.com/gravitational/teleport/pull/55818 merging first.

changelog: Fixes broken `tbot` joining in the Terraform provider.
