### PR TITLE
[v17] Set AuthServerAddressMode in terraform provider

### DIFF
--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -513,7 +513,8 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 		return nil, trace.Wrap(err, "Invalid Join Method")
 	}
 	botConfig := &embeddedtbot.BotConfig{
-		AuthServer: addr,
+		AuthServer:            addr,
+		AuthServerAddressMode: tbotconfig.AllowProxyAsAuthServer,
 		Onboarding: tbotconfig.OnboardingConfig{
 			TokenValue: joinToken,
 			CAPath:     caPath,


### PR DESCRIPTION
Backport #56341 to branch/v17

changelog: Fixes broken `tbot` joining in the Terraform provider.
