### PR TITLE
Align SCIM Plugin tctl plugin install flow

### DIFF
--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -25,11 +25,9 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
-	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	"github.com/gravitational/teleport/api/mfa"
@@ -37,12 +35,6 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
-)
-
-const (
-	logFieldPlugin        = "plugin"
-	logFieldSAMLConnector = "saml_connector"
-	logFieldRole          = "role"
 )
 
 func logErrorMessage(err error) slog.Attr {
@@ -64,9 +56,6 @@ type pluginInstallArgs struct {
 type scimArgs struct {
 	cmd           *kingpin.CmdClause
 	samlConnector string
-	token         string
-	role          string
-	force         bool
 }
 
 type pluginDeleteArgs struct {
@@ -108,34 +97,6 @@ func (p *PluginsCommand) initInstall(parent *kingpin.CmdClause, config *servicec
 	p.initInstallNetIQ(p.install.cmd)
 	p.initInstallAWSIC(p.install.cmd)
 	p.initInstallGithub(p.install.cmd)
-}
-
-func (p *PluginsCommand) initInstallSCIM(parent *kingpin.CmdClause) {
-	p.install.scim.cmd = p.install.cmd.Command("scim", "Install a new SCIM integration.")
-	p.install.scim.cmd.
-		Flag("name", "The name of the SCIM plugin resource to create").
-		Default("scim").
-		StringVar(&p.install.name)
-	p.install.scim.cmd.
-		Flag("saml-connector", "The name of the Teleport SAML connector users will log in with.").
-		Required().
-		StringVar(&p.install.scim.samlConnector)
-	p.install.scim.cmd.
-		Flag("role", "The Teleport role to assign users created by the plugin").
-		Short('r').
-		Default(teleport.PresetRequesterRoleName).
-		StringVar(&p.install.scim.role)
-	p.install.scim.cmd.
-		Flag("token", "The bearer token used by the SCIM client to authenticate").
-		Short('t').
-		Required().
-		Envar("TELEPORT_SCIM_BEARER_TOKEN").
-		StringVar(&p.install.scim.token)
-	p.install.scim.cmd.
-		Flag("force", "Proceed with installation even if validation fails").
-		Short('f').
-		Default("false").
-		BoolVar(&p.install.scim.force)
 }
 
 func (p *PluginsCommand) initDelete(parent *kingpin.CmdClause) {
@@ -230,94 +191,6 @@ type pluginsClient interface {
 type installPluginArgs struct {
 	authClient authClient
 	plugins    pluginsClient
-}
-
-// InstallSCIM implements `tctl plugins install scim`, installing a SCIM integration
-// plugin into the teleport cluster
-func (p *PluginsCommand) InstallSCIM(ctx context.Context, args installPluginArgs) error {
-	log := p.config.Logger.With(logFieldPlugin, p.install.name)
-
-	log.DebugContext(ctx, "Fetching cluster info...")
-	info, err := args.authClient.Ping(ctx)
-	if err != nil {
-		return trace.Wrap(err, "failed fetching cluster info")
-	}
-
-	scimBaseURL := fmt.Sprintf("https://%s/v1/webapi/scim/%s", info.ProxyPublicAddr, p.install.name)
-
-	scimTokenHash, err := bcrypt.GenerateFromPassword([]byte(p.install.scim.token), bcrypt.DefaultCost)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	connectorID := p.install.scim.samlConnector
-	log.DebugContext(ctx, "Validating SAML Connector...", logFieldSAMLConnector, connectorID)
-	connector, err := args.authClient.GetSAMLConnector(ctx, p.install.scim.samlConnector, false)
-	if err != nil {
-		if !p.install.scim.force {
-			return trace.Wrap(err, "failed validating SAML connector")
-		}
-	}
-
-	role := p.install.scim.role
-	log.DebugContext(ctx, "Validating Default Role...", logFieldRole, role)
-	if _, err := args.authClient.GetRole(ctx, role); err != nil {
-		if !p.install.scim.force {
-			return trace.Wrap(err, "failed validating role")
-		}
-	}
-
-	request := &pluginsv1.CreatePluginRequest{
-		Plugin: &types.PluginV1{
-			SubKind: types.PluginSubkindProvisioning,
-			Metadata: types.Metadata{
-				Labels: map[string]string{
-					types.HostedPluginLabel: "true",
-					types.SCIMBaseURLLabel:  scimBaseURL,
-				},
-				Name: p.install.name,
-			},
-			Spec: types.PluginSpecV1{
-				Settings: &types.PluginSpecV1_Scim{
-					Scim: &types.PluginSCIMSettings{
-						SamlConnectorName: p.install.scim.samlConnector,
-						DefaultRole:       p.install.scim.role,
-					},
-				},
-			},
-		},
-		StaticCredentials: &types.PluginStaticCredentialsV1{
-			ResourceHeader: types.ResourceHeader{
-				Metadata: types.Metadata{
-					Name: p.install.name,
-				},
-			},
-			Spec: &types.PluginStaticCredentialsSpecV1{
-				Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
-					APIToken: string(scimTokenHash),
-				},
-			},
-		},
-	}
-
-	log.DebugContext(ctx, "Creating SCIM Plugin...")
-	if _, err := args.plugins.CreatePlugin(ctx, request); err != nil {
-		log.ErrorContext(ctx, "Failed to create SCIM integration", logErrorMessage(err))
-		return trace.Wrap(err)
-	}
-
-	fmt.Printf("Successfully created SCIM plugin %q\n", p.install.name)
-	fmt.Printf("SCIM base URL: %s\n", scimBaseURL)
-
-	if connector == nil {
-		return nil
-	}
-
-	switch connector.Origin() {
-	case types.OriginOkta:
-		fmt.Println("Follow this guide to configure SCIM provisioning on Okta side: https://goteleport.com/docs/application-access/okta/hosted-guide/#configuring-scim-provisioning")
-	}
-	return nil
 }
 
 // TryRun runs the plugins command

--- a/tool/tctl/common/plugin/scim.go
+++ b/tool/tctl/common/plugin/scim.go
@@ -1,0 +1,114 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func (p *PluginsCommand) initInstallSCIM(parent *kingpin.CmdClause) {
+	p.install.scim.cmd = parent.Command("scim", "Install a Teleport SCIM plugin.")
+	cmd := p.install.scim.cmd
+
+	cmd.Flag("connector", "Name of the Teleport SAML connector to use.").
+		Required().
+		StringVar(&p.install.scim.samlConnector)
+}
+
+// InstallSCIM implements `tctl plugins install scim`, installing a SCIM integration
+// plugin into the teleport cluster
+func (p *PluginsCommand) InstallSCIM(ctx context.Context, args installPluginArgs) error {
+	scimArgs := p.install.scim
+
+	pluginName := types.PluginTypeSCIM
+	plugin := &types.PluginV1{
+		SubKind: types.PluginSubkindAccess,
+		Metadata: types.Metadata{
+			Labels: map[string]string{
+				"teleport.dev/hosted-plugin": "true",
+			},
+			Name: pluginName,
+		},
+		Spec: types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_Scim{
+				Scim: &types.PluginSCIMSettings{
+					SamlConnectorName: scimArgs.samlConnector,
+				},
+			},
+		},
+	}
+
+	clientID, err := utils.CryptoRandomHex(16)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	clientSecret, err := utils.CryptoRandomHex(32)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	req := &pluginspb.CreatePluginRequest{
+		Plugin: plugin,
+		StaticCredentialsList: []*types.PluginStaticCredentialsV1{
+			buildOauthCreds(clientID, clientSecret),
+		},
+	}
+	if _, err := args.plugins.CreatePlugin(ctx, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	pingResp, err := args.authClient.Ping(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	scimBaseURL := fmt.Sprintf("https://%s/v1/webapi/scim/%s", pingResp.GetProxyPublicAddr(), pluginName)
+	scimTokenURL := fmt.Sprintf("https://%s/v1/webapi/plugin/%s/token", pingResp.GetProxyPublicAddr(), pluginName)
+
+	fmt.Printf("\nSCIM Plugin Installed Successfully\n")
+	fmt.Println(" Base URL:        ", scimBaseURL)
+	fmt.Println(" OAuth Client ID:       ", clientID)
+	fmt.Println(" OAuth Client Secret:   ", clientSecret)
+	fmt.Println(" OAuth Token URL:       ", scimTokenURL)
+	return nil
+}
+
+func buildOauthCreds(clientID, clientSecret string) *types.PluginStaticCredentialsV1 {
+	return &types.PluginStaticCredentialsV1{
+		ResourceHeader: types.ResourceHeader{
+			Metadata: types.Metadata{
+				Name: fmt.Sprintf("%s-%s", types.PluginTypeSCIM, uuid.NewString()),
+			},
+		},
+		Spec: &types.PluginStaticCredentialsSpecV1{Credentials: &types.PluginStaticCredentialsSpecV1_OAuthClientSecret{
+			OAuthClientSecret: &types.PluginStaticCredentialsOAuthClientSecret{
+				ClientId:     clientID,
+				ClientSecret: clientSecret,
+			},
+		}},
+	}
+}


### PR DESCRIPTION
### What

Align The `tctl plugins install scim` tctl flow. 

Note that the old SCIM flow was never used and the SCIM flow was never implemented so this is not consider as breaking change because we have never supported SCIM plugin logic in backend. 


#### UX:


```
tctl plugins install scim  --connector=okta  --name=sailpoint

SCIM Plugin Installed Successfully
 Base URL:               https://teleport.example.com:443/v1/webapi/scim/sailpoint
 OAuth Client ID:        123481234a1541e7cb4326118c1234
 OAuth Client Secret:    c20181234123418da4f4a52492b8635efc8028255ef02d0c551fce212341234
 OAuth Token URL:        https://teleport.example.com:443/v1/webapi/plugin/sailpoint/token
 ```
