### PR TITLE
Clean up backend metrics

### DIFF
--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -677,6 +677,3 @@ func (r *ReporterWatcher) watch(ctx context.Context) {
 		return
 	}
 }
-
-// TODO(tross): Remove once crdb is converted to use backendmetrics directly.
-var AtomicWriteContention = backendmetrics.AtomicWriteContention


### PR DESCRIPTION
Updates e to include https://github.com/gravitational/teleport.e/pull/6765 which allows removal of the aliased AtomicWriteContention counter.