### PR TITLE
[v17] Clean up backend metrics

### DIFF
--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -643,6 +643,3 @@ func (r *ReporterWatcher) watch(ctx context.Context) {
 		return
 	}
 }
-
-// TODO(tross): Remove once crdb is converted to use backendmetrics directly.
-var AtomicWriteContention = backendmetrics.AtomicWriteContention


### PR DESCRIPTION
Updates e to include https://github.com/gravitational/teleport.e/pull/6768 which allows removal of the aliased AtomicWriteContention counter.

Backport https://github.com/gravitational/teleport/pull/56354 to branch/v17