### PR TITLE
bug: fixes improper termination of websocket connections

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -297,7 +297,7 @@ const (
 	// ProxyPingInterval is the interval ping messages are going to be sent.
 	// This is only applicable for TLS routing protocols that support ping
 	// wrapping.
-	ProxyPingInterval = 30 * time.Second
+	ProxyPingInterval = 15 * time.Second
 )
 
 const (

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -355,8 +355,11 @@ func mustReadClientConnString(t *testing.T, clientConn net.Conn, expectedPayload
 func mustReadClientWebSocketClosed(t *testing.T, clientConn net.Conn, expectedPayload string) {
 	t.Helper()
 
-	_, err := ws.ReadFrame(clientConn)
-	require.True(t, utils.IsOKNetworkError(err))
+	frame, err := ws.ReadFrame(clientConn)
+	require.NoError(t, err)
+	code, reason := ws.ParseCloseFrameData(frame.Payload)
+	require.Equal(t, ws.StatusUnsupportedData, code)
+	require.Equal(t, "unknown or empty subprotocol", reason)
 }
 
 // responseWriterHijacker is a mock http.ResponseWriter that also serves a


### PR DESCRIPTION
This PR fixes a bug where clients never receives a proper close message from the websocket because the server automatically closed the connection instead of sending the close signal followed by closing the connection.

It also adjust the ping interval to be smaller than most LB default values - 30s.

Fixes https://github.com/gravitational/teleport/issues/56344

Changelog: Fixed a bug that could cause abrupt WebSocket disconnects for clusters operating behind L7 load balancers.