### PR TITLE
docs: include bitbucket in machine-id ci/cd faq entry

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/faq.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/faq.mdx
@@ -14,6 +14,7 @@ no persistent state exists between individual workflow runs), Machine ID works
 best where a supported join method exists. These are:
 
 - GitHub Actions
+- Bitbucket
 - CircleCI
 - GitLab
 - AWS


### PR DESCRIPTION
Bitbucket is a supported token type that can be used in CI/CD Bitbucket pipelines.