### PR TITLE
Bump clickhouse-go to v2.37.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,7 +113,7 @@ linters:
           deny:
             - pkg: github.com/gravitational/teleport/integration
               desc: integration test should not be imported outside of intergation tests
-            - pkg: github.com/gravitational/teleport/lib/srv/db/cassandra/testing
+            - pkg: github.com/gravitational/teleport/lib/srv/db/cassandra/protocoltest
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/utils/mcptest
               desc: testing packages should not be imported outside of _test.go files
@@ -189,9 +189,11 @@ linters:
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/tool/teleport/testenv
               desc: testing packages should not be imported outside of _test.go files
-            - pkg: github.com/gravitational/teleport/lib/srv/db/redis/testing
+            - pkg: github.com/gravitational/teleport/lib/srv/db/redis/protocoltest
               desc: testing packages should not be imported outside of _test.go files
-            - pkg: github.com/gravitational/teleport/lib/srv/db/spanner/testing
+            - pkg: github.com/gravitational/teleport/lib/srv/db/spanner/protocoltest
+              desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/srv/db/clickhouse/protocoltest
               desc: testing packages should not be imported outside of _test.go files
         testify:
           files:

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
 	github.com/ClickHouse/ch-go v0.66.1
-	github.com/ClickHouse/clickhouse-go/v2 v2.35.0
+	github.com/ClickHouse/clickhouse-go/v2 v2.37.2
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,8 @@ github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/ch-go v0.66.1 h1:LQHFslfVYZsISOY0dnOYOXGkOUvpv376CCm8g7W74A4=
 github.com/ClickHouse/ch-go v0.66.1/go.mod h1:NEYcg3aOFv2EmTJfo4m2WF7sHB/YFbLUuIWv9iq76xY=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0 h1:ZMLZqxu+NiW55f4JS32kzyEbMb7CthGn3ziCcULOvSE=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0/go.mod h1:O2FFT/rugdpGEW2VKyEGyMUWyQU0ahmenY9/emxLPxs=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2 h1:wRLNKoynvHQEN4znnVHNLaYnrqVc9sGJmGYg+GGCfto=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2/go.mod h1:pH2zrBGp5Y438DMwAxXMm1neSXPPjSI7tD4MURVULw8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -168,7 +168,6 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/dmarkham/enumer v1.5.11 // indirect
 	github.com/docker/cli v28.3.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v28.3.0+incompatible // indirect
@@ -371,7 +370,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/oracle/oci-go-sdk/v65 v65.95.0 // indirect
 	github.com/parquet-go/parquet-go v0.25.1 // indirect
-	github.com/pascaldekloe/name v1.0.1 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 // indirect

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/ClickHouse/ch-go v0.66.1 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.35.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.37.2 // indirect
 	github.com/DanielTitkov/go-adaptive-cards v0.2.2 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -118,8 +118,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.66.1 h1:LQHFslfVYZsISOY0dnOYOXGkOUvpv376CCm8g7W74A4=
 github.com/ClickHouse/ch-go v0.66.1/go.mod h1:NEYcg3aOFv2EmTJfo4m2WF7sHB/YFbLUuIWv9iq76xY=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0 h1:ZMLZqxu+NiW55f4JS32kzyEbMb7CthGn3ziCcULOvSE=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0/go.mod h1:O2FFT/rugdpGEW2VKyEGyMUWyQU0ahmenY9/emxLPxs=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2 h1:wRLNKoynvHQEN4znnVHNLaYnrqVc9sGJmGYg+GGCfto=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2/go.mod h1:pH2zrBGp5Y438DMwAxXMm1neSXPPjSI7tD4MURVULw8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -138,8 +138,8 @@ github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/ch-go v0.66.1 h1:LQHFslfVYZsISOY0dnOYOXGkOUvpv376CCm8g7W74A4=
 github.com/ClickHouse/ch-go v0.66.1/go.mod h1:NEYcg3aOFv2EmTJfo4m2WF7sHB/YFbLUuIWv9iq76xY=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0 h1:ZMLZqxu+NiW55f4JS32kzyEbMb7CthGn3ziCcULOvSE=
-github.com/ClickHouse/clickhouse-go/v2 v2.35.0/go.mod h1:O2FFT/rugdpGEW2VKyEGyMUWyQU0ahmenY9/emxLPxs=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2 h1:wRLNKoynvHQEN4znnVHNLaYnrqVc9sGJmGYg+GGCfto=
+github.com/ClickHouse/clickhouse-go/v2 v2.37.2/go.mod h1:pH2zrBGp5Y438DMwAxXMm1neSXPPjSI7tD4MURVULw8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DanielTitkov/go-adaptive-cards v0.2.2 h1:tBFExyvsbCcrBJEvPaV3FW4gcAkwQjXFKiKEBrE7Yuw=

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -410,8 +410,6 @@ github.com/distribution/distribution/v3 v3.0.0 h1:q4R8wemdRQDClzoNNStftB2ZAfqOiN
 github.com/distribution/distribution/v3 v3.0.0/go.mod h1:tRNuFoZsUdyRVegq8xGNeds4KLjwLCRin/tTo6i1DhU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/dmarkham/enumer v1.5.11 h1:quorLCaEfzjJ23Pf7PB9lyyaHseh91YfTM/sAD/4Mbo=
-github.com/dmarkham/enumer v1.5.11/go.mod h1:yixql+kDDQRYqcuBM2n9Vlt7NoT9ixgXhaXry8vmRg8=
 github.com/docker/cli v28.3.0+incompatible h1:s+ttruVLhB5ayeuf2BciwDVxYdKi+RoUlxmwNHV3Vfo=
 github.com/docker/cli v28.3.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
@@ -1073,8 +1071,6 @@ github.com/oracle/oci-go-sdk/v65 v65.95.0 h1:fI+/mfJOS2DkQ+/AFSyJAfn1XFR4TTGm2Ah
 github.com/oracle/oci-go-sdk/v65 v65.95.0/go.mod h1:u6XRPsw9tPziBh76K7GrrRXPa8P8W3BQeqJ6ZZt9VLA=
 github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po3KG8Xgo=
 github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
-github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=
-github.com/pascaldekloe/name v1.0.1/go.mod h1:Z//MfYJnH4jVpQ9wkclwu2I2MkHmXTlT9wR5UZScttM=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible h1:IWzUvJ72xMjmrjR9q3H1PF+jwdN0uNQiR2t1BLNalyo=
 github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -78,7 +78,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	cassandra "github.com/gravitational/teleport/lib/srv/db/cassandra/protocoltest"
-	"github.com/gravitational/teleport/lib/srv/db/clickhouse"
+	clickhouse "github.com/gravitational/teleport/lib/srv/db/clickhouse/protocoltest"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	dbconnect "github.com/gravitational/teleport/lib/srv/db/common/connect"

--- a/lib/srv/db/audit_test.go
+++ b/lib/srv/db/audit_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/srv/db/clickhouse"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	redis "github.com/gravitational/teleport/lib/srv/db/redis/protocoltest"
@@ -335,12 +336,11 @@ func TestAuditClickHouseHTTP(t *testing.T) {
 		})
 
 		requireEvent(t, testCtx, libevents.DatabaseSessionStartCode)
-		// Select timezone.
 		event := waitForEvent(t, testCtx, libevents.DatabaseSessionQueryCode)
-		assertDatabaseQueryFromAuditEvent(t, event, "SELECT timezone()")
+		assertDatabaseQueryFromAuditEvent(t, event, clickhouse.HelloQuery)
 
 		event = waitForEvent(t, testCtx, libevents.DatabaseSessionQueryCode)
-		assertDatabaseQueryFromAuditEvent(t, event, "SELECT 1")
+		assertDatabaseQueryFromAuditEvent(t, event, clickhouse.PingQuery)
 
 		require.NoError(t, conn.Close())
 		requireEvent(t, testCtx, libevents.DatabaseSessionEndCode)

--- a/lib/srv/db/audit_test.go
+++ b/lib/srv/db/audit_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/srv/db/clickhouse"
+	clickhouse "github.com/gravitational/teleport/lib/srv/db/clickhouse/protocoltest"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	redis "github.com/gravitational/teleport/lib/srv/db/redis/protocoltest"

--- a/lib/srv/db/clickhouse/protocoltest/test.go
+++ b/lib/srv/db/clickhouse/protocoltest/test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package clickhouse
+package protocoltest
 
 import (
 	"context"

--- a/lib/srv/db/clickhouse/test.go
+++ b/lib/srv/db/clickhouse/test.go
@@ -121,32 +121,32 @@ func encodeHello() ([]byte, error) {
 	var block proto.Block
 
 	type columnWithValue struct {
-		name string
+		name       string
 		columnType column.Type
-		value any
+		value      any
 	}
-	columns := []columnWithValue {
+	columns := []columnWithValue{
 		{
-			name: "displayName()",
+			name:       "displayName()",
 			columnType: "String",
-			value: "ClickHouse",
+			value:      "ClickHouse",
 		},
 		{
-			name: "version()",
+			name:       "version()",
 			columnType: "String",
 			// x509 HTTP auth is support from ClickHouse 22.4.x.x
 			// Report a random version to a ClickHouse HTTP client.
 			value: "23.4.2.11",
 		},
 		{
-			name: "revision()",
+			name:       "revision()",
 			columnType: "UInt32",
-			value: uint32(12345),
+			value:      uint32(12345),
 		},
 		{
-			name: "timezone()",
+			name:       "timezone()",
 			columnType: "String",
-			value: "UTC",
+			value:      "UTC",
 		},
 	}
 
@@ -187,17 +187,19 @@ func encodePing() ([]byte, error) {
 
 }
 
-func (s *TestServer) serveHTTP() error {
-	const (
-		// The HTTP client does a "hello" by selecting a few common metadata.
-		// https://github.com/ClickHouse/clickhouse-go/blob/10732d7bb20224020e7099e9675f4c47ae5f5e7f/conn_http.go#L321-L324
-		helloQuery = "SELECT displayName(), version(), revision(), timezone()"
-		pingQuery     = "SELECT 1"
-	)
+const (
+	// HelloQuery is the "hello" query sent by the HTTP client to select a few
+	// common metadata.
+	// https://github.com/ClickHouse/clickhouse-go/blob/10732d7bb20224020e7099e9675f4c47ae5f5e7f/conn_http.go#L321-L324
+	HelloQuery = "SELECT displayName(), version(), revision(), timezone()"
+	// PingQuery is the basic query to ping.
+	PingQuery = "SELECT 1"
+)
 
+func (s *TestServer) serveHTTP() error {
 	encHandler := map[string]func() ([]byte, error){
-		helloQuery: encodeHello,
-		pingQuery:     encodePing,
+		HelloQuery: encodeHello,
+		PingQuery:  encodePing,
 	}
 
 	mux := http.NewServeMux()

--- a/lib/srv/db/clickhouse/test.go
+++ b/lib/srv/db/clickhouse/test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ClickHouse/ch-go"
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/gravitational/trace"
 
@@ -38,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/utils"
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // TestServerOption allows setting test server options.
@@ -115,17 +117,52 @@ func (s *TestServer) Serve() error {
 	}
 }
 
-func encodeVersion() ([]byte, error) {
+func encodeHello() ([]byte, error) {
 	var block proto.Block
-	if err := block.AddColumn("versions()", "String"); err != nil {
+
+	type columnWithValue struct {
+		name string
+		columnType column.Type
+		value any
+	}
+	columns := []columnWithValue {
+		{
+			name: "displayName()",
+			columnType: "String",
+			value: "ClickHouse",
+		},
+		{
+			name: "version()",
+			columnType: "String",
+			// x509 HTTP auth is support from ClickHouse 22.4.x.x
+			// Report a random version to a ClickHouse HTTP client.
+			value: "23.4.2.11",
+		},
+		{
+			name: "revision()",
+			columnType: "UInt32",
+			value: uint32(12345),
+		},
+		{
+			name: "timezone()",
+			columnType: "String",
+			value: "UTC",
+		},
+	}
+
+	for _, c := range columns {
+		if err := block.AddColumn(c.name, c.columnType); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	values := sliceutils.Map(columns, func(c columnWithValue) any {
+		return c.value
+	})
+	if err := block.Append(values...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// x509 HTTP auth is support from ClickHouse 22.4.x.x
-	// Report random version to a ClickHouse HTTP client.
-	if err := block.Append("23.4.2.11"); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	var chb chproto.Buffer
 	if err := block.Encode(&chb, 0); err != nil {
 		return nil, trace.Wrap(err)
@@ -150,32 +187,16 @@ func encodePing() ([]byte, error) {
 
 }
 
-func encodeTimezone() ([]byte, error) {
-	block := proto.Block{}
-	if err := block.AddColumn("timezone()", "String"); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := block.Append("UTC"); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var chb chproto.Buffer
-	if err := block.Encode(&chb, 0); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return chb.Buf, nil
-
-}
-
 func (s *TestServer) serveHTTP() error {
 	const (
-		timeZoneQuery = "SELECT timezone()"
-		versionQuery  = "SELECT version()"
+		// The HTTP client does a "hello" by selecting a few common metadata.
+		// https://github.com/ClickHouse/clickhouse-go/blob/10732d7bb20224020e7099e9675f4c47ae5f5e7f/conn_http.go#L321-L324
+		helloQuery = "SELECT displayName(), version(), revision(), timezone()"
 		pingQuery     = "SELECT 1"
 	)
 
 	encHandler := map[string]func() ([]byte, error){
-		timeZoneQuery: encodeTimezone,
-		versionQuery:  encodeVersion,
+		helloQuery: encodeHello,
 		pingQuery:     encodePing,
 	}
 


### PR DESCRIPTION
related:
- #56289 

The clickhouse HTTP client changed its "hello" message so we had to update our mock test server.