### PR TITLE
Make minor edits to SSO guides

### DIFF
--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -68,10 +68,13 @@ help guide you through the Wizard.
 - Set the display name to something along the lines of `Teleport`.
 - Skip the token encryption certificate.
 - Select *"Enable support for SAML 2.0 Web SSO protocol"* and set the URL to
-  `https://teleport.example.com/v1/webapi/saml/acs`, replacing the domain name
-  with your Teleport proxy URL.
+  `https://<Var name="teleport.example.com" />/v1/webapi/saml/acs`, replacing the domain name
+  with your Teleport Proxy Service URL. If you have a self-hosted cluster with
+  multiple public addresses for the Teleport Proxy Service (the value of
+  `proxy_service.public_addr` in the Teleport configuration file), ensure that this
+  address points to the first one listed.
 - Set the relying party trust identifier to
-  `https://teleport.example.com/v1/webapi/saml/acs` as well.
+  `https://<Var name="teleport.example.com" />/v1/webapi/saml/acs` as well.
 - For access control policy select *"Permit everyone"*.
 
 Once the Relying Party Trust has been created, update the Claim Issuance Policy
@@ -147,7 +150,7 @@ the attribute.
 Create a SAML connector resource using `tctl`:
 
 ```code
-$ tctl sso configure saml --acs https://teleport.example.com/v1/webapi/saml/acs \
+$ tctl sso configure saml --acs https://<Var name="teleport.example.com" />/v1/webapi/saml/acs \
   --preset adfs \
   --entity-descriptor https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml \
   --attributes-to-roles http://schemas.xmlsoap.org/claims/Group,teleadmins,editor \

--- a/docs/pages/zero-trust-access/sso/azuread.mdx
+++ b/docs/pages/zero-trust-access/sso/azuread.mdx
@@ -80,6 +80,11 @@ Before you get started, you’ll need:
    https://mytenant.teleport.sh:443/v1/webapi/saml/acs/ad
    ```
 
+   If you have a self-hosted cluster with multiple public addresses for the
+   Teleport Proxy Service (the value of `proxy_service.public_addr` in the
+   Teleport configuration file), ensure that this address points to the first
+   one listed.
+
    ![Put in Entity ID and Reply URL](../../../img/azuread/azuread-7-entityandreplyurl.png)
 
    Click **Save** before proceeding to the next step.

--- a/docs/pages/zero-trust-access/sso/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/github-sso.mdx
@@ -66,7 +66,10 @@ https://PROXY_ADDRESS/v1/webapi/github/
 ```
 
 Replace `PROXY_ADDRESS` with be the public address of the Teleport Proxy Service
-or your Teleport Cloud workspace URL (e.g., `example.teleport.sh`).
+or your Teleport Cloud workspace URL (e.g., `example.teleport.sh`). If you have
+a self-hosted cluster with multiple public addresses for the Teleport Proxy
+Service (the value of `proxy_service.public_addr` in the Teleport configuration
+file), ensure that this address points to the first one listed.
 
 The app must have the `read:org` scope in order to be able to read org and team
 membership details.

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -39,11 +39,17 @@ to each of these groups.
 
 1. Create an application in one of your groups (**Group overview** ->
    **Settings** -> **Applications**) that will allow using GitLab as an OAuth
-   provider to Teleport.
+   provider to Teleport. 
+
+   Assign <Var name="teleport.example.com" /> to your Teleport Proxy Service's
+   public address. If you have a self-hosted cluster with multiple public
+   addresses for the Teleport Proxy Service (the value of
+   `proxy_service.public_addr` in the Teleport configuration file), ensure that
+   this address points to the first one listed.
 
    Settings:
 
-   - Redirect URL: `https://<proxy url>/v1/webapi/oidc/callback`.
+   - Redirect URL: `https://<Var name="teleport.example.com" />/v1/webapi/oidc/callback`.
    - Check `Confidential`, `openid`, `profile`, and `email`.
 
    ![Create App](../../../img/sso/gitlab/gitlab-oidc-0.png)
@@ -178,7 +184,7 @@ spec:
   display: GitLab
   issuer_url: https://gitlab.com
   prompt: none
-  redirect_url: https://teleport.example.com:443/v1/webapi/oidc/callback
+  redirect_url: https://<Var name="teleport.example.com" />:443/v1/webapi/oidc/callback
 version: v3
 
 ```
@@ -207,7 +213,7 @@ The Web UI will now contain a new button: "Login with GitLab". The CLI is
 the same as before:
 
 ```code
-$ tsh --proxy=teleport.example.com login
+$ tsh --proxy=<Var name="teleport.example.com" /> login
 ```
 
 This command will print the SSO login URL (and will try to open it

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -194,8 +194,11 @@ To create an OAuth client identifier:
 
 1. Under Authorized redirect URIs, click **Add URI**.
 
-1. Set the redirect URI to the address of your Teleport cluster, then add 
-`/v1/webapi/oidc/callback` to the URI.
+1. Set the redirect URI to the address of your Teleport cluster, then add
+   `/v1/webapi/oidc/callback` to the URI. If you have a self-hosted cluster with
+   multiple public addresses for the Teleport Proxy Service (the value of
+   `proxy_service.public_addr` in the Teleport configuration file), ensure that
+   this address points to the first one listed:
    
    ![OAuth client ID creation](../../../img/sso/googleoidc/redirect-uri.png)
 

--- a/docs/pages/zero-trust-access/sso/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/keycloak.mdx
@@ -55,7 +55,11 @@ Before you get started, you’ll need:
    ```
    ![SAML](../../../img/sso/keycloak/saml.png)
 
-1. Set the **Valid Redirect URIs** field  to the URL for your Teleport Proxy Service host and Save
+1. Set the **Valid Redirect URIs** field  to the URL for your Teleport Proxy
+   Service host. If you have a self-hosted cluster with multiple public
+   addresses for the Teleport Proxy Service (the value of
+   `proxy_service.public_addr` in the Teleport configuration file), ensure that
+   this address points to the first one listed:
 
    ```code
    https://<Var name="mytenant.teleport.sh" />/v1/webapi/saml/acs/keycloak

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -56,11 +56,14 @@ OIDC relies on HTTP redirects to return control back to Teleport after
 authentication is complete. The redirect URL must be selected by a Teleport
 administrator in advance.
 
-The redirect URL for OIDC authentication in Teleport is <nobr>
-<Var name="mytenant.teleport.sh:443" description="Your Teleport Cloud tenant or Proxy
-Service address"/>`/v1/webapi/oidc/callback`</nobr>. 
-Replace <Var name="mytenant.teleport.sh:443" /> with your Teleport Cloud tenant or
-Proxy Service address.
+The redirect URL for OIDC authentication in Teleport is <nobr> <Var
+name="mytenant.teleport.sh:443" description="Your Teleport Cloud tenant or Proxy
+Service address"/>`/v1/webapi/oidc/callback`</nobr>.  Replace <Var
+name="mytenant.teleport.sh:443" /> with your Teleport Cloud tenant or Proxy
+Service address. If you have a self-hosted cluster with multiple public
+addresses for the Teleport Proxy Service (the value of
+`proxy_service.public_addr` in the Teleport configuration file), ensure that
+this address points to the first one listed.
 
 ## OIDC connector configuration
 

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -92,8 +92,11 @@ Provide the following values to their respective fields:
 
 #### General
 
-Replace <Var name="example.teleport.sh:443" /> with your Teleport Proxy Service or Enterprise
-Cloud account domain and port (`443` by default).
+Replace <Var name="example.teleport.sh:443" /> with your Teleport Proxy Service
+or Enterprise Cloud account domain and port (`443` by default). If you have a
+self-hosted cluster with multiple public addresses for the Teleport Proxy
+Service (the value of `proxy_service.public_addr` in the Teleport configuration
+file), ensure that this address points to the first one listed.
 
 - Single sign on URL:
 

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -50,13 +50,16 @@ to define policies like:
    - <a href={SquareIcon} download>Square Icon</a>
    - <a href={RectangleIcon} download>Rectangular Icon</a>
 
-1. From the application's **Configuration** page, set the following values:
+1. From the application's **Configuration** page, set the following values. Set
+   <Var name="teleport.example.com:443" description="Your Teleport Proxy Service
+   address and port, or cloud tenant." /> here with your Teleport Proxy Service
+   address and port, or Teleport Enterprise Cloud tenant (e.g.
+   `company.teleport.sh:443`) to fill out the values below.
 
-   <Admonition type="tip">
-   Set <Var name="teleport.example.com:443" description="Your Teleport Proxy Service address and port, or cloud tenant." />
-   here with your Teleport Proxy Service address and port, or Teleport Enterprise
-   Cloud tenant (e.g. `company.teleport.sh:443`) to fill out the values below.
-   </Admonition>
+   If you have a self-hosted cluster with multiple public addresses for the
+   Teleport Proxy Service (the value of `proxy_service.public_addr` in the
+   Teleport configuration file), ensure that this address points to the first
+   one listed.
    
    - **Login URL**:
      - `https://`<Var name="teleport.example.com:443"/>`/web/login`


### PR DESCRIPTION
Closes #16046

In each SSO guide that instructs the user to provide a redirect URL with the Proxy Service address, indicate that, if there is more than one Proxy Service address configured in `public_addr`, the user must use the first address listed.