### PR TITLE
Forbid setting audit in non-dynamic Access Lists

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -180,10 +180,18 @@ type Spec struct {
 type Type string
 
 const (
+	// ImplicitDynamic type is for backward compatibility. It has the same semantics as
+	// [Dynamic].
 	ImplicitDynamic Type = ""
-	Dynamic         Type = "dynamic"
-	Static          Type = "static"
-	SCIM            Type = "scim"
+	// Dynamic Access Lists are the default type supposed to be managed with the web UI. They
+	// require periodic audit reviews.
+	Dynamic Type = "dynamic"
+	// Static Access Lists are supposed to be managed with the IaC tools like Terraform. Audit
+	// reviews are not supported for them and the ownership is optional.
+	Static Type = "static"
+	// SCIM Access Lists are created with the SCIM integration. Audit reviews are not supported
+	// for them and the ownership is optional.
+	SCIM Type = "scim"
 )
 
 func NewTypeFromString(s string) (Type, error) {
@@ -554,6 +562,7 @@ func (n Notifications) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// IsReviewable returns true if the AccessList type supports the audit reviews in the web UI.
 func (a *AccessList) IsReviewable() bool {
 	switch a.Spec.Type {
 	case ImplicitDynamic, Dynamic:

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -314,6 +314,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 		dayOfMonth        ReviewDayOfMonth
 		currentReviewDate time.Time
 		expected          time.Time
+		expectedErr       bool
 	}{
 		{
 			name:              "one month, first day",
@@ -322,46 +323,52 @@ func TestSelectNextReviewDate(t *testing.T) {
 			dayOfMonth:        FirstDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:          time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			expectedErr:       false,
 		},
 		{
 			name:              "one month, fifteenth day",
-			accessListTypes:   []Type{"", Dynamic},
+			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
 			frequency:         OneMonth,
 			dayOfMonth:        FifteenthDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:          time.Date(2023, 2, 15, 0, 0, 0, 0, time.UTC),
+			expectedErr:       false,
 		},
 		{
 			name:              "one month, last day",
-			accessListTypes:   []Type{"", Dynamic},
+			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
 			frequency:         OneMonth,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:          time.Date(2023, 2, 28, 0, 0, 0, 0, time.UTC),
+			expectedErr:       false,
 		},
 		{
 			name:              "six months, last day",
-			accessListTypes:   []Type{"", Dynamic},
+			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
 			frequency:         SixMonths,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:          time.Date(2023, 7, 31, 0, 0, 0, 0, time.UTC),
+			expectedErr:       false,
 		},
 		{
 			name:              "six months, last day",
-			accessListTypes:   []Type{Static, SCIM},
+			accessListTypes:   []Type{Static, SCIM, "__test_unknown__"},
 			frequency:         SixMonths,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Time{},
 			expected:          time.Time{},
+			expectedErr:       true,
 		},
 		{
 			name:              "six months, last day",
-			accessListTypes:   []Type{Static, SCIM},
+			accessListTypes:   []Type{Static, SCIM, "__test_unknown__"},
 			frequency:         SixMonths,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			expected:          time.Time{},
+			expectedErr:       true,
 		},
 	}
 
@@ -377,7 +384,13 @@ func TestSelectNextReviewDate(t *testing.T) {
 						Frequency:  test.frequency,
 						DayOfMonth: test.dayOfMonth,
 					}
-					require.Equal(t, test.expected, accessList.SelectNextReviewDate())
+					nextReviewDate, err := accessList.SelectNextReviewDate()
+					if test.expectedErr {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, test.expected, nextReviewDate)
+					}
 				})
 			}
 		})

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestWithOwnersIneligibleStatusField(t *testing.T) {
+	t.Parallel()
+
 	proto := []*accesslistv1.AccessListOwner{
 		{
 			Name:             "expired",
@@ -89,26 +91,54 @@ func TestWithOwnersIneligibleStatusField(t *testing.T) {
 }
 
 func TestRoundtrip(t *testing.T) {
-	t.Run("with custom subkind", func(t *testing.T) {
-		accessList := newAccessList(t, "access-list")
-		accessList.ResourceHeader.SetSubKind("access-list-subkind")
+	t.Parallel()
 
-		converted, err := FromProto(ToProto(accessList))
-		require.NoError(t, err)
+	type testCase struct {
+		name           string
+		modificationFn func(*accesslist.AccessList)
+	}
 
-		require.Empty(t, cmp.Diff(accessList, converted))
-	})
+	for _, tc := range []testCase{
+		{
+			name:           "no-modifications",
+			modificationFn: func(accessList *accesslist.AccessList) {},
+		},
+		{
+			name: "with-subkind",
+			modificationFn: func(accessList *accesslist.AccessList) {
+				accessList.ResourceHeader.SetSubKind("access-list-subkind")
+			},
+		},
+		{
+			name: "dynamic-type",
+			modificationFn: func(accessList *accesslist.AccessList) {
+				accessList.Spec.Type = accesslist.Dynamic
+			},
+		},
+		{
+			name: "implicit-dynamic-type",
+			modificationFn: func(accessList *accesslist.AccessList) {
+				accessList.Spec.Type = ""
+			},
+		},
+		{
+			name: "static-type",
+			modificationFn: func(accessList *accesslist.AccessList) {
+				accessList.Spec.Type = accesslist.Static
+				accessList.Spec.Audit = accesslist.Audit{}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			accessList := newAccessList(t, "access-list")
+			tc.modificationFn(accessList)
 
-	t.Run("with non-default type", func(t *testing.T) {
-		accessList := newAccessList(t, "access-list")
-		accessList.Spec.Type = accesslist.Static
+			converted, err := FromProto(ToProto(accessList))
+			require.NoError(t, err)
 
-		converted, err := FromProto(ToProto(accessList))
-		require.NoError(t, err)
-
-		require.Empty(t, cmp.Diff(accessList, converted))
-		require.Equal(t, accesslist.Static, converted.Spec.Type)
-	})
+			require.Empty(t, cmp.Diff(accessList, converted))
+		})
+	}
 }
 
 func Test_FromProto_withBadType(t *testing.T) {
@@ -122,6 +152,8 @@ func Test_FromProto_withBadType(t *testing.T) {
 
 // Make sure that we don't panic if any of the message fields are missing.
 func TestFromProtoNils(t *testing.T) {
+	t.Parallel()
+
 	t.Run("spec", func(t *testing.T) {
 		accessList := ToProto(newAccessList(t, "access-list"))
 		accessList.Spec = nil
@@ -275,6 +307,8 @@ func TestNextAuditDateZeroTime(t *testing.T) {
 }
 
 func TestConvAccessList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input *accesslistv1.AccessList
@@ -372,21 +406,6 @@ func TestConvAccessList(t *testing.T) {
 					Title:       "test access list",
 					Description: "test description",
 					Owners:      []*accesslistv1.AccessListOwner{},
-					Audit: &accesslistv1.AccessListAudit{
-						Recurrence: &accesslistv1.Recurrence{
-							Frequency:  1,
-							DayOfMonth: 1,
-						},
-						NextAuditDate: &timestamppb.Timestamp{
-							Seconds: 6,
-							Nanos:   1,
-						},
-						Notifications: &accesslistv1.Notifications{
-							Start: &durationpb.Duration{
-								Seconds: 1209600,
-							},
-						},
-					},
 					Grants: &accesslistv1.AccessListGrants{
 						Roles: []string{"role1"},
 					},

--- a/api/types/accesslist/funcs.go
+++ b/api/types/accesslist/funcs.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package accesslist
 
 func isZero[T comparable](t T) bool {

--- a/api/types/accesslist/funcs.go
+++ b/api/types/accesslist/funcs.go
@@ -1,0 +1,6 @@
+package accesslist
+
+func isZero[T comparable](t T) bool {
+	var zero T
+	return t == zero
+}

--- a/api/types/accesslist/review.go
+++ b/api/types/accesslist/review.go
@@ -1,18 +1,20 @@
 /*
-Copyright 2023 Gravitational, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package accesslist
 

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -916,7 +916,10 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 			return trace.Wrap(err)
 		}
 
-		nextAuditDate = accessList.SelectNextReviewDate()
+		nextAuditDate, err = accessList.SelectNextReviewDate()
+		if err != nil {
+			return trace.Wrap(err, "selecting next review date")
+		}
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
 		for _, removedMember := range review.Spec.Changes.RemovedMembers {


### PR DESCRIPTION
Backports:

- [ ] v18
  - [x] needs [#56120](https://github.com/gravitational/teleport/pull/56120) for the `TestConvAccessList`
  - [ ] [#6797](https://github.com/gravitational/teleport.e/pull/6797) should be backported first
- [ ] https://github.com/gravitational/teleport/pull/56445
  - [ ] [#6797](https://github.com/gravitational/teleport.e/pull/6797) should be backported first