### PR TITLE
Disable notifications for non-dynamic Access Lists

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -180,10 +180,18 @@ type Spec struct {
 type Type string
 
 const (
+	// ImplicitDynamic type is for backward compatibility. It has the same semantics as
+	// [Dynamic].
 	ImplicitDynamic Type = ""
-	Dynamic         Type = "dynamic"
-	Static          Type = "static"
-	SCIM            Type = "scim"
+	// Dynamic Access Lists are the default type supposed to be managed with the web UI. They
+	// require periodic audit reviews.
+	Dynamic Type = "dynamic"
+	// Static Access Lists are supposed to be managed with the IaC tools like Terraform. Audit
+	// reviews are not supported for them and the ownership is optional.
+	Static Type = "static"
+	// SCIM Access Lists are created with the SCIM integration. Audit reviews are not supported
+	// for them and the ownership is optional.
+	SCIM Type = "scim"
 )
 
 func NewTypeFromString(s string) (Type, error) {
@@ -544,6 +552,15 @@ func (n Notifications) MarshalJSON() ([]byte, error) {
 		Alias: (Alias)(n),
 		Start: n.Start.String(),
 	})
+}
+
+// IsReviewable returns true if the AccessList type supports the audit reviews in the web UI.
+func (a *AccessList) IsReviewable() bool {
+	switch a.Spec.Type {
+	case ImplicitDynamic, Dynamic:
+		return true
+	}
+	return false
 }
 
 // SelectNextReviewDate will select the next review date for the access list.

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -180,14 +180,15 @@ type Spec struct {
 type Type string
 
 const (
-	Dynamic Type = "dynamic"
-	Static  Type = "static"
-	SCIM    Type = "scim"
+	ImplicitDynamic Type = ""
+	Dynamic         Type = "dynamic"
+	Static          Type = "static"
+	SCIM            Type = "scim"
 )
 
 func NewTypeFromString(s string) (Type, error) {
 	switch s {
-	case "", string(Dynamic):
+	case string(ImplicitDynamic), string(Dynamic):
 		return Dynamic, nil
 	case string(Static):
 		return Static, nil

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,6 +170,12 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		}
 
 		for _, accessList := range accessLists {
+			switch accessList.Spec.Type {
+			case accesslist.ImplicitDynamic, accesslist.Dynamic:
+				// ok, we want reviews for those
+			default:
+				continue
+			}
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)
 			if err != nil {
 				log.WarnContext(ctx, "Error getting recipients to notify for review due for access list",
@@ -225,7 +231,7 @@ func (a *App) getRecipientsRequiringReminders(ctx context.Context, accessList *a
 		return nil, nil
 	}
 
-	allRecipients := a.fetchRecipients(ctx, accessList, now, notificationStart)
+	allRecipients := a.fetchRecipients(ctx, accessList)
 	if len(allRecipients) == 0 {
 		return nil, trace.NotFound("no recipients could be fetched for access list %s", accessList.GetName())
 	}
@@ -254,7 +260,7 @@ func (a *App) getRecipientsRequiringReminders(ctx context.Context, accessList *a
 }
 
 // fetchRecipients will return all recipients.
-func (a *App) fetchRecipients(ctx context.Context, accessList *accesslist.AccessList, now, notificationStart time.Time) map[string]common.Recipient {
+func (a *App) fetchRecipients(ctx context.Context, accessList *accesslist.AccessList) map[string]common.Recipient {
 	log := logger.Get(ctx)
 
 	var allOwners []*accesslist.Owner

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -267,7 +267,6 @@ func TestAccessListReminders_NoneForNonDynamic(t *testing.T) {
 			advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists)
 		})
 	}
-
 }
 
 func TestAccessListReminders_Batched(t *testing.T) {

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -206,6 +206,70 @@ func TestAccessListReminders_Single(t *testing.T) {
 	}
 }
 
+func TestAccessListReminders_NoneForNonDynamic(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	server := newTestAuth(t)
+
+	as := server.Auth()
+	t.Cleanup(func() {
+		require.NoError(t, as.Close())
+	})
+
+	bot := &mockMessagingBot{
+		recipients: map[string]*common.Recipient{
+			"static-owner": {Name: "static-owner", ID: "static-owner"},
+		},
+	}
+	app := common.NewApp(&mockPluginConfig{client: as, bot: bot}, "test-plugin")
+	app.Clock = clock
+	ctx := context.Background()
+	go func() {
+		app.Run(ctx)
+	}()
+
+	ready, err := app.WaitReady(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	t.Cleanup(func() {
+		app.Terminate()
+		<-app.Done()
+		require.NoError(t, app.Err())
+	})
+
+	for _, typ := range []accesslist.Type{
+		accesslist.SCIM,
+		accesslist.Static,
+	} {
+		t.Run(string(typ), func(t *testing.T) {
+			nonDynamicAccessList, err := accesslist.NewAccessList(header.Metadata{
+				Name: "test-non-dynamnic-access-list",
+			}, accesslist.Spec{
+				Type:   typ,
+				Title:  "test static access list",
+				Owners: []accesslist.Owner{{Name: "static-owner"}},
+				Grants: accesslist.Grants{
+					Roles: []string{"role"},
+				},
+				Audit: accesslist.Audit{},
+			})
+			require.NoError(t, err)
+
+			accessLists := []*accesslist.AccessList{nonDynamicAccessList}
+
+			// No notifications for today
+			advanceAndLookForRecipients(t, bot, as, clock, 0, accessLists)
+
+			// Advance by one week, expect no notifications.
+			advanceAndLookForRecipients(t, bot, as, clock, oneDay*7, accessLists)
+		})
+	}
+
+}
+
 func TestAccessListReminders_Batched(t *testing.T) {
 	modules.SetTestModules(t, &modules.TestModules{
 		TestFeatures: modules.Features{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6464,6 +6464,12 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 		}
 
 		for _, al := range response {
+			switch al.Spec.Type {
+			case accesslist.ImplicitDynamic, accesslist.Dynamic:
+				// ok, we want notifications for those
+			default:
+				continue
+			}
 			daysDiff := int(al.Spec.Audit.NextAuditDate.Sub(now).Hours() / 24)
 			// Only keep access lists that fall within our thresholds in memory
 			if daysDiff <= 15 {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6464,10 +6464,7 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 		}
 
 		for _, al := range response {
-			switch al.Spec.Type {
-			case accesslist.ImplicitDynamic, accesslist.Dynamic:
-				// ok, we want notifications for those
-			default:
+			if !al.IsReviewable() {
 				continue
 			}
 			daysDiff := int(al.Spec.Audit.NextAuditDate.Sub(now).Hours() / 24)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4749,10 +4749,10 @@ func createAccessList(t *testing.T, authServer *Server, name string, opts ...cre
 			Roles: []string{"grant"},
 		},
 	})
-	require.NoError(t, err, "accesslist.NewAccessList")
+	require.NoError(t, err)
 
 	_, err = authServer.UpsertAccessList(ctx, al)
-	require.NoError(t, err, "authServer.UpsertAccessList")
+	require.NoError(t, err)
 }
 
 func TestServer_GetAnonymizationKey(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4646,33 +4646,6 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	client, err := testServer.NewClient(TestUser(testUsername))
 	require.NoError(t, err)
 
-	// Helper to create access lists with specific next audit dates
-	createAccessList := func(t *testing.T, name string, nextAuditDate time.Time) {
-		al, err := accesslist.NewAccessList(header.Metadata{
-			Name: name,
-		}, accesslist.Spec{
-			Title:       fmt.Sprintf("Access List %s", name),
-			Description: fmt.Sprintf("Test access list %s", name),
-			Owners: []accesslist.Owner{{
-				Name:           testUsername,
-				Description:    "",
-				MembershipKind: "",
-			}},
-			Audit: accesslist.Audit{
-				NextAuditDate: nextAuditDate,
-				Recurrence:    accesslist.Recurrence{},
-				Notifications: accesslist.Notifications{},
-			},
-			Grants: accesslist.Grants{
-				Roles: []string{"grant"},
-			},
-		})
-		require.NoError(t, err)
-
-		_, err = authServer.UpsertAccessList(ctx, al)
-		require.NoError(t, err)
-	}
-
 	// Create access lists with different expiry times
 	accessLists := []struct {
 		name      string
@@ -4696,7 +4669,12 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	}
 
 	for _, al := range accessLists {
-		createAccessList(t, al.name, authServer.clock.Now().Add(time.Duration(al.dueInDays)*24*time.Hour))
+		createAccessList(t, authServer, al.name+"-static", withType(accesslist.Static))
+		createAccessList(t, authServer, al.name+"-scim", withType(accesslist.SCIM))
+		createAccessList(t, authServer, al.name,
+			withOwners([]accesslist.Owner{{Name: testUsername}}),
+			withNextAuditDate(authServer.clock.Now().Add(time.Duration(al.dueInDays)*24*time.Hour)),
+		)
 	}
 
 	// Run CreateAccessListReminderNotifications()
@@ -4718,6 +4696,63 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.Notifications, 6)
+}
+
+type createAccessListOptions struct {
+	typ           accesslist.Type
+	nextAuditDate time.Time
+	owners        []accesslist.Owner
+}
+
+type createAccessListOpt func(*createAccessListOptions)
+
+func withType(typ accesslist.Type) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.typ = typ
+	}
+}
+
+func withNextAuditDate(nextAuditDate time.Time) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.nextAuditDate = nextAuditDate
+	}
+}
+
+func withOwners(owners []accesslist.Owner) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.owners = owners
+	}
+}
+
+func createAccessList(t *testing.T, authServer *Server, name string, opts ...createAccessListOpt) {
+	t.Helper()
+	ctx := t.Context()
+
+	options := createAccessListOptions{}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	al, err := accesslist.NewAccessList(header.Metadata{
+		Name: name,
+	}, accesslist.Spec{
+		Type:        options.typ,
+		Title:       fmt.Sprintf("Test Access List %s", name),
+		Description: fmt.Sprintf("Test Access List %s description", name),
+		Owners:      options.owners,
+		Audit: accesslist.Audit{
+			NextAuditDate: options.nextAuditDate,
+			Recurrence:    accesslist.Recurrence{},
+			Notifications: accesslist.Notifications{},
+		},
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+	})
+	require.NoError(t, err, "accesslist.NewAccessList")
+
+	_, err = authServer.UpsertAccessList(ctx, al)
+	require.NoError(t, err, "authServer.UpsertAccessList")
 }
 
 func TestServer_GetAnonymizationKey(t *testing.T) {


### PR DESCRIPTION
Backports:

- [ ] v18
  - [ ] [#55969](https://github.com/gravitational/teleport/pull/55969) needs to be backported first - `type Type string` from accesslist package is missing
- [ ] https://github.com/gravitational/teleport/pull/56447