### PR TITLE
MWI: Add build/release steps to MWI Terraform Provider Makefile

### DIFF
--- a/integrations/terraform-mwi/CONTRIBUTING.md
+++ b/integrations/terraform-mwi/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+## Contributing
+
+### Testing local builds 
+
+Configure `dev_overrides` in `~/.terraformrc`, e.g:
+
+```hcl
+provider_installation {
+
+  dev_overrides {
+      "terraform.releases.teleport.dev/gravitational/teleport-mwi" = "/Users/noah/code/teleport/integrations/terraform-mwi/build"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+and then run `make build`.
+
+See https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers
+for more information.

--- a/integrations/terraform-mwi/CONTRIBUTING.md
+++ b/integrations/terraform-mwi/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Configure `dev_overrides` in `~/.terraformrc`, e.g:
 provider_installation {
 
   dev_overrides {
-      "terraform.releases.teleport.dev/gravitational/teleport-mwi" = "/Users/noah/code/teleport/integrations/terraform-mwi/build"
+      "terraform.releases.teleport.dev/gravitational/teleportmwi" = "/Users/noah/code/teleport/integrations/terraform-mwi/build"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/integrations/terraform-mwi/Makefile
+++ b/integrations/terraform-mwi/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell go run ../hack/get-version/get-version.go)
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
-RELEASE = terraform-provider-teleport-mwi-v$(VERSION)-$(OS)-$(ARCH)-bin
+RELEASE = terraform-provider-teleportmwi-v$(VERSION)-$(OS)-$(ARCH)-bin
 
 BUILDDIR ?= build
 
@@ -20,25 +20,25 @@ clean:
 .PHONY: build
 build: clean
 # Turning off GOWORK to prevent missing package errors.
-	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleport-mwi $(BUILDFLAGS)
+	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleportmwi $(BUILDFLAGS)
 
-build-darwin-universal: $(addprefix $(BUILDDIR)/terraform-provider-teleport-mwi_,arm64 amd64)
-	lipo -create -output $(BUILDDIR)/terraform-provider-teleport-mwi $^
+build-darwin-universal: $(addprefix $(BUILDDIR)/terraform-provider-teleportmwi_,arm64 amd64)
+	lipo -create -output $(BUILDDIR)/terraform-provider-teleportmwi $^
 	rm -r $^ $(BUILDDIR)/$(OS)
 
 # Architecture-specific binaries for the universal binary are extracted from
 # the release tarball. make will not automatically build this; you will need
 # to run "make ARCH=amd64 release" and "make ARCH=arm64 release" first as is
 # done in the build workflow.
-$(BUILDDIR)/terraform-provider-teleport-mwi_%: terraform-provider-teleport-mwi-v$(VERSION)-$(OS)-%-bin.tar.gz
+$(BUILDDIR)/terraform-provider-teleportmwi_%: terraform-provider-teleportmwi-v$(VERSION)-$(OS)-%-bin.tar.gz
 	mkdir -p $(BUILDDIR)/$(OS)/$*
 	tar -xzf $< -C $(BUILDDIR)/$(OS)/$*
-	mv $(BUILDDIR)/$(OS)/$*/terraform-provider-teleport-mwi $@
+	mv $(BUILDDIR)/$(OS)/$*/terraform-provider-teleportmwi $@
 
 # darwin-signed-build is a wrapper around the build target that ensures it is codesigned
 include ../../darwin-signing.mk
 .PHONY: darwin-signed-build
-darwin-signed-build: BINARIES=$(BUILDDIR)/terraform-provider-teleport-mwi
+darwin-signed-build: BINARIES=$(BUILDDIR)/terraform-provider-teleportmwi
 ifeq ($(OS)-$(ARCH),darwin-universal)
 darwin-signed-build: build-darwin-universal
 else

--- a/integrations/terraform-mwi/Makefile
+++ b/integrations/terraform-mwi/Makefile
@@ -1,3 +1,59 @@
+VERSION ?= $(shell go run ../hack/get-version/get-version.go)
+
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+RELEASE = terraform-provider-teleport-mwi-v$(VERSION)-$(OS)-$(ARCH)-bin
+
+BUILDDIR ?= build
+
+ADDFLAGS ?=
+BUILDFLAGS ?= $(ADDFLAGS) -trimpath -ldflags '-w -s'
+# CGO must NOT be enabled as hashicorp cloud does not support running providers using on CGO.
+CGOFLAG ?= CGO_ENABLED=0
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf $(RELEASE).tar.gz
+	go clean
+
+.PHONY: build
+build: clean
+# Turning off GOWORK to prevent missing package errors.
+	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleport-mwi $(BUILDFLAGS)
+
+build-darwin-universal: $(addprefix $(BUILDDIR)/terraform-provider-teleport-mwi_,arm64 amd64)
+	lipo -create -output $(BUILDDIR)/terraform-provider-teleport-mwi $^
+	rm -r $^ $(BUILDDIR)/$(OS)
+
+# Architecture-specific binaries for the universal binary are extracted from
+# the release tarball. make will not automatically build this; you will need
+# to run "make ARCH=amd64 release" and "make ARCH=arm64 release" first as is
+# done in the build workflow.
+$(BUILDDIR)/terraform-provider-teleport-mwi_%: terraform-provider-teleport-mwi-v$(VERSION)-$(OS)-%-bin.tar.gz
+	mkdir -p $(BUILDDIR)/$(OS)/$*
+	tar -xzf $< -C $(BUILDDIR)/$(OS)/$*
+	mv $(BUILDDIR)/$(OS)/$*/terraform-provider-teleport-mwi $@
+
+# darwin-signed-build is a wrapper around the build target that ensures it is codesigned
+include ../../darwin-signing.mk
+.PHONY: darwin-signed-build
+darwin-signed-build: BINARIES=$(BUILDDIR)/terraform-provider-teleport-mwi
+ifeq ($(OS)-$(ARCH),darwin-universal)
+darwin-signed-build: build-darwin-universal
+else
+darwin-signed-build: build
+endif
+	$(NOTARIZE_BINARIES)
+
+.PHONY: release
+ifeq ($(OS),darwin)
+release: darwin-signed-build
+else
+release: build
+endif
+	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
+
 PHONY: test
 test:
 	go test -v -cover -timeout=120s -parallel=10 ./...

--- a/integrations/terraform-mwi/main.go
+++ b/integrations/terraform-mwi/main.go
@@ -37,7 +37,7 @@ func main() {
 		ctx,
 		provider.New(),
 		providerserver.ServeOpts{
-			Address: "terraform.releases.teleport.dev/gravitational/teleport-mwi",
+			Address: "terraform.releases.teleport.dev/gravitational/teleportmwi",
 			Debug:   debug,
 		},
 	)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/55204

As per https://github.com/gravitational/teleport/issues/54829 and RFD: https://github.com/gravitational/teleport/pull/54949

This is largely based on the prior art for `integrations/terraform`. Running the builds locally seems to yield sensible results and the built binary can be used with a local terraform plan/apply.