### PR TITLE
Unify resource pagination

### DIFF
--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -26,6 +26,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/sortcache"
 )
@@ -49,23 +51,8 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
-			var resources []*accesslist.AccessList
-			var nextToken string
-			for {
-				var page []*accesslist.AccessList
-				var err error
-				page, nextToken, err = upstream.ListAccessLists(ctx, 0 /* page size */, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resources = append(resources, page...)
-
-				if nextToken == "" {
-					break
-				}
-			}
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAccessLists))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessList {
 			return &accesslist.AccessList{
@@ -175,23 +162,8 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
-			var resources []*accesslist.AccessListMember
-			var nextToken string
-			for {
-				var page []*accesslist.AccessListMember
-				var err error
-				page, nextToken, err = upstream.ListAllAccessListMembers(ctx, 0 /* page size */, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resources = append(resources, page...)
-
-				if nextToken == "" {
-					break
-				}
-			}
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListMembers))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.AccessListMember {
 			return &accesslist.AccessListMember{
@@ -340,23 +312,8 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.Review, error) {
-			var resources []*accesslist.Review
-			var nextToken string
-			for {
-				var page []*accesslist.Review
-				var err error
-				page, nextToken, err = upstream.ListAllAccessListReviews(ctx, 0 /* page size */, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resources = append(resources, page...)
-
-				if nextToken == "" {
-					break
-				}
-			}
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAllAccessListReviews))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *accesslist.Review {
 			return &accesslist.Review{

--- a/lib/cache/crown_jewel.go
+++ b/lib/cache/crown_jewel.go
@@ -25,6 +25,8 @@ import (
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -47,23 +49,10 @@ func newCrownJewelCollection(upstream services.CrownJewels, w types.WatchKind) (
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*crownjewelv1.CrownJewel, error) {
-			var out []*crownjewelv1.CrownJewel
-			var nextToken string
-			for {
-				var page []*crownjewelv1.CrownJewel
-				var err error
-
-				const defaultPageSize = 0
-				page, nextToken, err = upstream.ListCrownJewels(ctx, defaultPageSize, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				out = append(out, page...)
-				if nextToken == "" {
-					break
-				}
-			}
-			return out, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, i int, nextToken string) ([]*crownjewelv1.CrownJewel, string, error) {
+				return upstream.ListCrownJewels(ctx, int64(i), nextToken)
+			}))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *crownjewelv1.CrownJewel {
 			return &crownjewelv1.CrownJewel{

--- a/lib/cache/generic_operations.go
+++ b/lib/cache/generic_operations.go
@@ -138,26 +138,3 @@ func (l genericLister[T, I]) list(ctx context.Context, pageSize int, startToken 
 	out, next, err := l.listRange(ctx, pageSize, startToken, "")
 	return out, next, trace.Wrap(err)
 }
-
-// fetchAll fetches all items from a paginated getter that's appropriately
-// shaped. Useful to implement [collection.fetcher].
-func fetchAll[T any](
-	ctx context.Context,
-	getPage func(ctx context.Context, pageSize int, pageToken string) (_ []T, nextPageToken string, _ error),
-) ([]T, error) {
-	var out []T
-	var pageToken string
-	for {
-		const defaultPageSize = 0
-		page, nextPageToken, err := getPage(ctx, defaultPageSize, pageToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out = append(out, page...)
-		if nextPageToken == "" {
-			break
-		}
-		pageToken = nextPageToken
-	}
-	return out, nil
-}

--- a/lib/cache/git_server.go
+++ b/lib/cache/git_server.go
@@ -24,8 +24,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/gitserver"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -46,21 +47,8 @@ func newGitServerCollection(upstream services.GitServerGetter, w types.WatchKind
 				gitServerNameIndex: types.Server.GetName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
-			var all []types.Server
-			var nextToken string
-			for {
-				var page []types.Server
-				var err error
-				page, nextToken, err = upstream.ListGitServers(ctx, apidefaults.DefaultChunkSize, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				all = append(all, page...)
-				if nextToken == "" {
-					break
-				}
-			}
-			return all, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListGitServers))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.Server {
 			return &types.ServerV2{

--- a/lib/cache/okta.go
+++ b/lib/cache/okta.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -42,24 +44,8 @@ func newOktaImportRuleCollection(upstream services.Okta, w types.WatchKind) (*co
 				oktaImportRuleNameIndex: types.OktaImportRule.GetName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.OktaImportRule, error) {
-			var startKey string
-			var resources []types.OktaImportRule
-			for {
-				var importRules []types.OktaImportRule
-				var err error
-				importRules, startKey, err = upstream.ListOktaImportRules(ctx, 0, startKey)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resources = append(resources, importRules...)
-
-				if startKey == "" {
-					break
-				}
-			}
-
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListOktaImportRules))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.OktaImportRule {
 			return &types.OktaImportRuleV1{
@@ -126,24 +112,8 @@ func newOktaImportAssignmentCollection(upstream services.Okta, w types.WatchKind
 				oktaAssignmentNameIndex: types.OktaAssignment.GetName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.OktaAssignment, error) {
-			var startKey string
-			var resources []types.OktaAssignment
-			for {
-				var importRules []types.OktaAssignment
-				var err error
-				importRules, startKey, err = upstream.ListOktaAssignments(ctx, 0, startKey)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				resources = append(resources, importRules...)
-
-				if startKey == "" {
-					break
-				}
-			}
-
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListOktaAssignments))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.OktaAssignment {
 			return &types.OktaAssignmentV1{

--- a/lib/cache/relay_server.go
+++ b/lib/cache/relay_server.go
@@ -24,6 +24,8 @@ import (
 
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -46,7 +48,8 @@ func newRelayServerCollection(upstream services.Presence, w types.WatchKind) (*c
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*presencev1.RelayServer, error) {
-			return fetchAll(ctx, upstream.ListRelayServers)
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListRelayServers))
+			return out, trace.Wrap(err)
 		},
 		watch: w,
 	}, nil

--- a/lib/cache/saml_idp.go
+++ b/lib/cache/saml_idp.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -42,24 +44,8 @@ func newSAMLIdPServiceProviderCollection(upstream services.SAMLIdPServiceProvide
 				samlIdPServiceProviderNameIndex: types.SAMLIdPServiceProvider.GetName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.SAMLIdPServiceProvider, error) {
-			var startKey string
-			var sps []types.SAMLIdPServiceProvider
-			for {
-				var samlProviders []types.SAMLIdPServiceProvider
-				var err error
-				samlProviders, startKey, err = upstream.ListSAMLIdPServiceProviders(ctx, 0, startKey)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				sps = append(sps, samlProviders...)
-
-				if startKey == "" {
-					break
-				}
-			}
-
-			return sps, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListSAMLIdPServiceProviders))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.SAMLIdPServiceProvider {
 			return &types.SAMLIdPServiceProviderV1{

--- a/lib/cache/static_host_user.go
+++ b/lib/cache/static_host_user.go
@@ -25,6 +25,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -47,23 +49,8 @@ func newStaticHostUserCollection(upstream services.StaticHostUser, w types.Watch
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*userprovisioningv2.StaticHostUser, error) {
-			var startKey string
-			var allUsers []*userprovisioningv2.StaticHostUser
-
-			for {
-				users, nextKey, err := upstream.ListStaticHostUsers(ctx, 0, startKey)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				allUsers = append(allUsers, users...)
-
-				if nextKey == "" {
-					break
-				}
-				startKey = nextKey
-			}
-			return allUsers, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListStaticHostUsers))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *userprovisioningv2.StaticHostUser {
 			return &userprovisioningv2.StaticHostUser{

--- a/lib/cache/user_task.go
+++ b/lib/cache/user_task.go
@@ -25,6 +25,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -47,22 +49,10 @@ func newUserTaskCollection(upstream services.UserTasks, w types.WatchKind) (*col
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*usertasksv1.UserTask, error) {
-			var resources []*usertasksv1.UserTask
-			var nextToken string
-			for {
-				var page []*usertasksv1.UserTask
-				var err error
-				page, nextToken, err = upstream.ListUserTasks(ctx, 0 /* page size */, nextToken, &usertasksv1.ListUserTasksFilters{})
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				resources = append(resources, page...)
-
-				if nextToken == "" {
-					break
-				}
-			}
-			return resources, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, size int, nextToken string) ([]*usertasksv1.UserTask, string, error) {
+				return upstream.ListUserTasks(ctx, int64(size), nextToken, &usertasksv1.ListUserTasksFilters{})
+			}))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *usertasksv1.UserTask {
 			return &usertasksv1.UserTask{

--- a/lib/cache/workload_identity.go
+++ b/lib/cache/workload_identity.go
@@ -26,6 +26,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -48,23 +50,8 @@ func newWorkloadIdentityCollection(upstream services.WorkloadIdentities, w types
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
-			var out []*workloadidentityv1pb.WorkloadIdentity
-			var nextToken string
-			for {
-				var page []*workloadidentityv1pb.WorkloadIdentity
-				var err error
-
-				const defaultPageSize = 0
-				page, nextToken, err = upstream.ListWorkloadIdentities(ctx, defaultPageSize, nextToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				out = append(out, page...)
-				if nextToken == "" {
-					break
-				}
-			}
-			return out, nil
+			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListWorkloadIdentities))
+			return out, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *workloadidentityv1pb.WorkloadIdentity {
 			return &workloadidentityv1pb.WorkloadIdentity{

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -58,7 +58,7 @@ import (
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/internalutils/stream"
+	apistream "github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
@@ -67,10 +67,12 @@ import (
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/secreports"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -2436,22 +2438,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		if rc.ref.Name != "" {
 			return nil, trace.BadParameter("reverse tunnel cannot be searched by name")
 		}
-		var tunnels []types.ReverseTunnel
-		var nextToken string
-		for {
-			var page []types.ReverseTunnel
-			var err error
 
-			const defaultPageSize = 0
-			page, nextToken, err = client.ListReverseTunnels(ctx, defaultPageSize, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			tunnels = append(tunnels, page...)
-			if nextToken == "" {
-				break
-			}
+		tunnels, err := stream.Collect(clientutils.Resources(ctx, client.ListReverseTunnels))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &reverseTunnelCollection{tunnels: tunnels}, nil
 	case types.KindCertAuthority:
 		getAll := rc.ref.SubKind == "" && rc.ref.Name == ""
@@ -2755,23 +2747,14 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 		return &kubeClusterCollection{clusters: clusters}, nil
 	case types.KindCrownJewel:
-		cjClient := client.CrownJewelsClient()
-		var rules []*crownjewelv1.CrownJewel
-		nextToken := ""
-		for {
-			resp, token, err := cjClient.ListCrownJewels(ctx, 0 /* default size */, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			rules = append(rules, resp...)
-
-			if token == "" {
-				break
-			}
-			nextToken = token
+		jewels, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, startKey string) ([]*crownjewelv1.CrownJewel, string, error) {
+			return client.CrownJewelsClient().ListCrownJewels(ctx, int64(limit), startKey)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return &crownJewelCollection{items: rules}, nil
+
+		return &crownJewelCollection{items: jewels}, nil
 	case types.KindWindowsDesktopService:
 		if rc.ref.Name != "" {
 			service, err := client.GetWindowsDesktopService(ctx, rc.ref.Name)
@@ -2841,26 +2824,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}, nil
 		}
 
-		pageToken := ""
-		desktops := make([]types.DynamicWindowsDesktop, 0, 100)
-		for {
-			d, next, err := dynamicDesktopClient.ListDynamicWindowsDesktops(ctx, 100, pageToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if rc.ref.Name == "" {
-				desktops = append(desktops, d...)
-			} else {
-				for _, desktop := range desktops {
-					if desktop.GetName() == rc.ref.Name {
-						desktops = append(desktops, desktop)
-					}
-				}
-			}
-			pageToken = next
-			if next == "" {
-				break
-			}
+		desktops, err := stream.Collect(clientutils.Resources(ctx, dynamicDesktopClient.ListDynamicWindowsDesktops))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		return &dynamicWindowsDesktopCollection{desktops}, nil
@@ -2926,20 +2892,17 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	case types.KindLoginRule:
 		loginRuleClient := client.LoginRuleClient()
 		if rc.ref.Name == "" {
-			fetch := func(token string) (*loginrulepb.ListLoginRulesResponse, error) {
+			rules, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*loginrulepb.LoginRule, string, error) {
 				resp, err := loginRuleClient.ListLoginRules(ctx, &loginrulepb.ListLoginRulesRequest{
+					PageSize:  int32(limit),
 					PageToken: token,
 				})
-				return resp, trail.FromGRPC(err)
+				return resp.GetLoginRules(), resp.GetNextPageToken(), trace.Wrap(err)
+			}))
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
-			var rules []*loginrulepb.LoginRule
-			resp, err := fetch("")
-			for ; err == nil; resp, err = fetch(resp.NextPageToken) {
-				rules = append(rules, resp.LoginRules...)
-				if resp.NextPageToken == "" {
-					break
-				}
-			}
+
 			return &loginRuleCollection{rules}, trace.Wrap(err)
 		}
 		rule, err := loginRuleClient.GetLoginRule(ctx, &loginrulepb.GetLoginRuleRequest{
@@ -2954,20 +2917,10 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &samlIdPServiceProviderCollection{serviceProviders: []types.SAMLIdPServiceProvider{serviceProvider}}, nil
 		}
-		var resources []types.SAMLIdPServiceProvider
-		nextKey := ""
-		for {
-			var sps []types.SAMLIdPServiceProvider
-			var err error
-			sps, nextKey, err = client.ListSAMLIdPServiceProviders(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			resources = append(resources, sps...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, client.ListSAMLIdPServiceProviders))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 		return &samlIdPServiceProviderCollection{serviceProviders: resources}, nil
 	case types.KindDevice:
@@ -3026,21 +2979,18 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &botCollection{bots: []*machineidv1pb.Bot{bot}}, nil
 		}
 
-		req := &machineidv1pb.ListBotsRequest{}
-		var bots []*machineidv1pb.Bot
-		for {
-			resp, err := remote.ListBots(ctx, req)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
+		bots, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*machineidv1pb.Bot, string, error) {
+			resp, err := remote.ListBots(ctx, &machineidv1pb.ListBotsRequest{
+				PageSize:  int32(limit),
+				PageToken: token,
+			})
 
-			bots = append(bots, resp.Bots...)
-
-			if resp.NextPageToken == "" {
-				break
-			}
-			req.PageToken = resp.NextPageToken
+			return resp.GetBots(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &botCollection{bots: bots}, nil
 	case types.KindDatabaseObjectImportRule:
 		remote := client.DatabaseObjectImportRuleClient()
@@ -3052,21 +3002,18 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &databaseObjectImportRuleCollection{rules: []*dbobjectimportrulev1.DatabaseObjectImportRule{rule}}, nil
 		}
 
-		req := &dbobjectimportrulev1.ListDatabaseObjectImportRulesRequest{}
-		var rules []*dbobjectimportrulev1.DatabaseObjectImportRule
-		for {
-			resp, err := remote.ListDatabaseObjectImportRules(ctx, req)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
+		rules, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*dbobjectimportrulev1.DatabaseObjectImportRule, string, error) {
+			resp, err := remote.ListDatabaseObjectImportRules(ctx, &dbobjectimportrulev1.ListDatabaseObjectImportRulesRequest{
+				PageSize:  int32(limit),
+				PageToken: token,
+			})
 
-			rules = append(rules, resp.Rules...)
-
-			if resp.NextPageToken == "" {
-				break
-			}
-			req.PageToken = resp.NextPageToken
+			return resp.GetRules(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &databaseObjectImportRuleCollection{rules: rules}, nil
 	case types.KindDatabaseObject:
 		remote := client.DatabaseObjectsClient()
@@ -3078,21 +3025,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &databaseObjectCollection{objects: []*dbobjectv1.DatabaseObject{object}}, nil
 		}
 
-		token := ""
-		var objects []*dbobjectv1.DatabaseObject
-		for {
-			resp, nextToken, err := remote.ListDatabaseObjects(ctx, 0, token)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			objects = append(objects, resp...)
-
-			if nextToken == "" {
-				break
-			}
-			token = nextToken
+		objects, err := stream.Collect(clientutils.Resources(ctx, remote.ListDatabaseObjects))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &databaseObjectCollection{objects: objects}, nil
 	case types.KindOktaImportRule:
 		if rc.ref.Name != "" {
@@ -3102,21 +3039,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &oktaImportRuleCollection{importRules: []types.OktaImportRule{importRule}}, nil
 		}
-		var resources []types.OktaImportRule
-		nextKey := ""
-		for {
-			var importRules []types.OktaImportRule
-			var err error
-			importRules, nextKey, err = client.OktaClient().ListOktaImportRules(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			resources = append(resources, importRules...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, client.OktaClient().ListOktaImportRules))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &oktaImportRuleCollection{importRules: resources}, nil
 	case types.KindOktaAssignment:
 		if rc.ref.Name != "" {
@@ -3126,21 +3054,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &oktaAssignmentCollection{assignments: []types.OktaAssignment{assignment}}, nil
 		}
-		var resources []types.OktaAssignment
-		nextKey := ""
-		for {
-			var assignments []types.OktaAssignment
-			var err error
-			assignments, nextKey, err = client.OktaClient().ListOktaAssignments(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			resources = append(resources, assignments...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, client.OktaClient().ListOktaAssignments))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &oktaAssignmentCollection{assignments: resources}, nil
 	case types.KindUserGroup:
 		if rc.ref.Name != "" {
@@ -3150,21 +3069,12 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &userGroupCollection{userGroups: []types.UserGroup{userGroup}}, nil
 		}
-		var resources []types.UserGroup
-		nextKey := ""
-		for {
-			var userGroups []types.UserGroup
-			var err error
-			userGroups, nextKey, err = client.ListUserGroups(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			resources = append(resources, userGroups...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, client.ListUserGroups))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &userGroupCollection{userGroups: resources}, nil
 	case types.KindExternalAuditStorage:
 		out := []*externalauditstorage.ExternalAuditStorage{}
@@ -3212,20 +3122,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &integrationCollection{integrations: []types.Integration{ig}}, nil
 		}
 
-		var resources []types.Integration
-		var igs []types.Integration
-		var err error
-		var nextKey string
-		for {
-			igs, nextKey, err = client.ListIntegrations(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			resources = append(resources, igs...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, client.ListIntegrations))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		return &integrationCollection{integrations: resources}, nil
 	case types.KindUserTask:
 		userTasksClient := client.UserTasksClient()
@@ -3237,19 +3138,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &userTaskCollection{items: []*usertasksv1.UserTask{uit}}, nil
 		}
 
-		var tasks []*usertasksv1.UserTask
-		nextToken := ""
-		for {
-			resp, token, err := userTasksClient.ListUserTasks(ctx, 0 /* default size */, nextToken, &usertasksv1.ListUserTasksFilters{})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			tasks = append(tasks, resp...)
-
-			if token == "" {
-				break
-			}
-			nextToken = token
+		tasks, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*usertasksv1.UserTask, string, error) {
+			return userTasksClient.ListUserTasks(ctx, int64(limit), token, &usertasksv1.ListUserTasksFilters{})
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 		return &userTaskCollection{items: tasks}, nil
 	case types.KindDiscoveryConfig:
@@ -3262,19 +3155,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &discoveryConfigCollection{discoveryConfigs: []*discoveryconfig.DiscoveryConfig{dc}}, nil
 		}
 
-		var resources []*discoveryconfig.DiscoveryConfig
-		var dcs []*discoveryconfig.DiscoveryConfig
-		var err error
-		var nextKey string
-		for {
-			dcs, nextKey, err = remote.ListDiscoveryConfigs(ctx, 0, nextKey)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			resources = append(resources, dcs...)
-			if nextKey == "" {
-				break
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, remote.ListDiscoveryConfigs))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		return &discoveryConfigCollection{discoveryConfigs: resources}, nil
@@ -3315,7 +3198,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return &serverInfoCollection{serverInfos: []types.ServerInfo{si}}, nil
 		}
-		serverInfos, err := stream.Collect(client.GetServerInfos(ctx))
+		serverInfos, err := apistream.Collect(client.GetServerInfos(ctx))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3419,22 +3302,16 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &workloadIdentityCollection{items: []*workloadidentityv1pb.WorkloadIdentity{resource}}, nil
 		}
 
-		var resources []*workloadidentityv1pb.WorkloadIdentity
-		pageToken := ""
-		for {
+		resources, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
 			resp, err := client.WorkloadIdentityResourceServiceClient().ListWorkloadIdentities(ctx, &workloadidentityv1pb.ListWorkloadIdentitiesRequest{
+				PageSize:  int32(limit),
 				PageToken: pageToken,
 			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			resources = append(resources, resp.WorkloadIdentities...)
-
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.GetWorkloadIdentities(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		return &workloadIdentityCollection{items: resources}, nil
@@ -3451,24 +3328,16 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &workloadIdentityX509RevocationCollection{items: []*workloadidentityv1pb.WorkloadIdentityX509Revocation{resource}}, nil
 		}
 
-		var resources []*workloadidentityv1pb.WorkloadIdentityX509Revocation
-		pageToken := ""
-		for {
-			resp, err := client.
-				WorkloadIdentityRevocationServiceClient().
-				ListWorkloadIdentityX509Revocations(ctx, &workloadidentityv1pb.ListWorkloadIdentityX509RevocationsRequest{
-					PageToken: pageToken,
-				})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
+		resources, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentityX509Revocation, string, error) {
+			resp, err := client.WorkloadIdentityRevocationServiceClient().ListWorkloadIdentityX509Revocations(ctx, &workloadidentityv1pb.ListWorkloadIdentityX509RevocationsRequest{
+				PageSize:  int32(limit),
+				PageToken: pageToken,
+			})
 
-			resources = append(resources, resp.WorkloadIdentityX509Revocations...)
-
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return resp.GetWorkloadIdentityX509Revocations(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		return &workloadIdentityX509RevocationCollection{items: resources}, nil
@@ -3486,28 +3355,19 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &botInstanceCollection{items: []*machineidv1pb.BotInstance{bi}}, nil
 		}
 
-		var instances []*machineidv1pb.BotInstance
-		startKey := ""
-
-		for {
+		instances, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
 			resp, err := client.BotInstanceServiceClient().ListBotInstances(ctx, &machineidv1pb.ListBotInstancesRequest{
-				PageSize:  100,
-				PageToken: startKey,
+				PageSize:  int32(limit),
+				PageToken: pageToken,
 
 				// Note: empty filter lists all bot instances
 				FilterBotName: rc.ref.Name,
 			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 
-			instances = append(instances, resp.BotInstances...)
-
-			if resp.NextPageToken == "" {
-				break
-			}
-
-			startKey = resp.NextPageToken
+			return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		return &botInstanceCollection{items: instances}, nil
@@ -3522,20 +3382,11 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &staticHostUserCollection{items: []*userprovisioningpb.StaticHostUser{hostUser}}, nil
 		}
 
-		var hostUsers []*userprovisioningpb.StaticHostUser
-		var nextToken string
-		for {
-			resp, token, err := hostUserClient.ListStaticHostUsers(ctx, 0, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			hostUsers = append(hostUsers, resp...)
-			if token == "" {
-				break
-			}
-			nextToken = token
+		resources, err := stream.Collect(clientutils.Resources(ctx, hostUserClient.ListStaticHostUsers))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return &staticHostUserCollection{items: hostUsers}, nil
+		return &staticHostUserCollection{items: resources}, nil
 	case types.KindAutoUpdateConfig:
 		config, err := client.GetAutoUpdateConfig(ctx)
 		if err != nil {
@@ -3563,18 +3414,9 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &autoUpdateAgentReportCollection{reports: []*autoupdatev1pb.AutoUpdateAgentReport{report}}, nil
 		}
 
-		var reports []*autoupdatev1pb.AutoUpdateAgentReport
-		var nextToken string
-		for {
-			resp, token, err := client.ListAutoUpdateAgentReports(ctx, 0, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			reports = append(reports, resp...)
-			if token == "" {
-				break
-			}
-			nextToken = token
+		reports, err := stream.Collect(clientutils.Resources(ctx, client.ListAutoUpdateAgentReports))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 		return &autoUpdateAgentReportCollection{reports: reports}, nil
 	case types.KindAccessMonitoringRule:
@@ -3586,43 +3428,25 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return &accessMonitoringRuleCollection{items: []*accessmonitoringrulesv1pb.AccessMonitoringRule{rule}}, nil
 		}
 
-		var rules []*accessmonitoringrulesv1pb.AccessMonitoringRule
-		nextToken := ""
-		for {
-			resp, token, err := client.AccessMonitoringRuleClient().ListAccessMonitoringRules(ctx, 0, nextToken)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			rules = append(rules, resp...)
-			if token == "" {
-				break
-			}
-			nextToken = token
+		rules, err := stream.Collect(clientutils.Resources(ctx, client.AccessMonitoringRuleClient().ListAccessMonitoringRules))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 		return &accessMonitoringRuleCollection{items: rules}, nil
 	case types.KindGitServer:
-		var page, servers []types.Server
-
-		// TODO(greedy52) use unified resource request once available.
 		if rc.ref.Name != "" {
 			server, err := client.GitServerClient().GetGitServer(ctx, rc.ref.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			return &serverCollection{servers: append(servers, server)}, nil
+			return &serverCollection{servers: []types.Server{server}}, nil
 		}
-		var err error
-		var token string
-		for {
-			page, token, err = client.GitServerClient().ListGitServers(ctx, 0, token)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			servers = append(servers, page...)
-			if token == "" {
-				break
-			}
+
+		servers, err := stream.Collect(clientutils.Resources(ctx, client.GitServerClient().ListGitServers))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+
 		// TODO(greedy52) consider making dedicated git server collection.
 		return &serverCollection{servers: servers}, nil
 
@@ -3640,28 +3464,31 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return namedResourceCollection{types.ProtoResource153ToLegacy(r)}, nil
 		}
-		var collection namedResourceCollection
-		var pageToken string
-		for {
-			resp, err := c.ListX509IssuerOverrides(
-				ctx,
-				&workloadidentityv1pb.ListX509IssuerOverridesRequest{
-					PageToken: pageToken,
+
+		resources, err := stream.Collect(
+			stream.FilterMap(
+				clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*workloadidentityv1pb.X509IssuerOverride, string, error) {
+					resp, err := c.ListX509IssuerOverrides(
+						ctx,
+						&workloadidentityv1pb.ListX509IssuerOverridesRequest{
+							PageSize:  int32(limit),
+							PageToken: pageToken,
+						},
+					)
+
+					return resp.GetX509IssuerOverrides(), resp.GetNextPageToken(), trace.Wrap(err)
+				}),
+
+				func(r *workloadidentityv1pb.X509IssuerOverride) (types.Resource, bool) {
+					return types.ProtoResource153ToLegacy(r), true
 				},
-			)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			collection = slices.Grow(collection, len(resp.GetX509IssuerOverrides()))
-			for _, r := range resp.GetX509IssuerOverrides() {
-				collection = append(collection, types.ProtoResource153ToLegacy(r))
-			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return collection, nil
+
+		return namedResourceCollection(resources), nil
 	case types.KindSigstorePolicy:
 		c := client.SigstorePolicyResourceServiceClient()
 		if rc.ref.Name != "" {
@@ -3676,28 +3503,31 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 			return namedResourceCollection{types.ProtoResource153ToLegacy(r)}, nil
 		}
-		var collection namedResourceCollection
-		var pageToken string
-		for {
-			resp, err := c.ListSigstorePolicies(
-				ctx,
-				&workloadidentityv1pb.ListSigstorePoliciesRequest{
-					PageToken: pageToken,
+
+		resources, err := stream.Collect(
+			stream.FilterMap(
+				clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*workloadidentityv1pb.SigstorePolicy, string, error) {
+					resp, err := c.ListSigstorePolicies(
+						ctx,
+						&workloadidentityv1pb.ListSigstorePoliciesRequest{
+							PageSize:  int32(limit),
+							PageToken: pageToken,
+						},
+					)
+
+					return resp.GetSigstorePolicies(), resp.GetNextPageToken(), trace.Wrap(err)
+				}),
+
+				func(r *workloadidentityv1pb.SigstorePolicy) (types.Resource, bool) {
+					return types.ProtoResource153ToLegacy(r), true
 				},
-			)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			collection = slices.Grow(collection, len(resp.GetSigstorePolicies()))
-			for _, r := range resp.GetSigstorePolicies() {
-				collection = append(collection, types.ProtoResource153ToLegacy(r))
-			}
-			pageToken = resp.GetNextPageToken()
-			if pageToken == "" {
-				break
-			}
+			),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return collection, nil
+
+		return namedResourceCollection(resources), nil
 	case types.KindHealthCheckConfig:
 		if rc.ref.Name != "" {
 			cfg, err := client.GetHealthCheckConfig(ctx, rc.ref.Name)
@@ -3708,22 +3538,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 				items: []*healthcheckconfigv1.HealthCheckConfig{cfg},
 			}, nil
 		}
-		var items []*healthcheckconfigv1.HealthCheckConfig
-		var token string
-		for {
-			page, nextToken, err := client.ListHealthCheckConfigs(ctx, 0, token)
-			token = nextToken
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			items = append(items, page...)
-			if token == "" {
-				break
-			}
+
+		items, err := stream.Collect(clientutils.Resources(ctx, client.ListHealthCheckConfigs))
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		return &healthCheckConfigCollection{
-			items: items,
-		}, nil
+
+		return &healthCheckConfigCollection{items: items}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
This converts hand rolled collections of resources via ListFoo RPCs in tctl and the cache to make use of clientutils.Resources. The main driver for the change is consistency and simplifcation. Having a single place that pagination logic exists should help reduce the chances of any pagination bugs in the future. The helper also reduces the amount of code needed at a call site to aggregate resources.

The guts of clientutils.IterateResources have been moved to clientutils.Resources which returns an iter.Seq2[T, error] instead of the callback based approach. This makes the api simpler and allows making use of the itertools/stream helpers. Additionally, the page size used within clientutils.Resources was made to dynamically adjust based on receiving any errors indicating that the max message size was exceeding.