### PR TITLE
Edit the GUI clients guide

### DIFF
--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -6,9 +6,7 @@ description: How to configure graphical database clients for Teleport database a
 This guide describes how to configure popular graphical database clients to
 work with Teleport.
 
-## Setting up your Teleport environment
-
-### Prerequisites
+## Prerequisites
 
 - A running Teleport cluster. If you want to get started with Teleport, [sign
   up](https://goteleport.com/signup) for a free trial or [set up a demo
@@ -28,27 +26,85 @@ work with Teleport.
   [guides](../enroll-resources/database-access/guides/guides.mdx) for how to set up the Teleport
   Database Service for your database.
 
-### Get connection information
+## How GUI clients access Teleport-protected databases
 
-Get information about the host and port where your database is available so you
-can configure your GUI client to access the database.
+In a typical setup, clients accessing a database protected by Teleport send
+traffic to the Teleport Proxy Service in the database's native protocol, and the
+Proxy Service forwards the traffic to and from the protected database. End users
+use TLS certificates to authenticate with Teleport-protected databases. 
 
-#### Using a local proxy server
+GUI clients need to present a certificate to the Teleport Database Service and
+check the database server certificate issued by a Teleport-protected database.
+There are three ways to do this:
+
+- **Authenticated tunnel (recommended):** The local proxy handles loading the
+  Teleport user's client certificate and checking the certificate issued by the
+  Teleport-protected database. The connection remains authenticated, and clients
+  only need to forward database protocol messages to it.
+- **Unauthenticated local proxy:** The local GUI client needs to load the
+  Teleport user's certificate and check database certificates. This requires
+  configuring the client to access TLS credentials, including the user
+  certificate and private key, and a certificate issued by the database's
+  certificate authority. 
+- **Using a remote host and port:** For self-hosted clusters with TLS
+  multiplexing disabled on the Teleport Proxy Service, you can configure GUI
+  clients to communicate with a port on the Proxy Service reserved for
+  traffic in the protected database's protocol. We recommend TLS multiplexing
+  for a typical Teleport cluster, and it is enabled by default on Teleport
+  Cloud.
+
+To access a Teleport-protected database with a GUI client, you will need to
+retrieve connection information to pass to your client.
+
+Determine the database to access by listing databases you can connect to:
+
+```code
+$ tsh db ls
+# Name
+# -------------------
+# database-name
+```
+
+Replace <Var name="database-name" /> with the name of the database you want to
+connect to.
+
+### Authenticated tunnel
+
+To start the local authenticated tunnel, run the following command, 
+
+```code
+$ tsh proxy db --tunnel <Var name="database-name" />
+Started authenticated tunnel for the <engine> database "<Var name="database-name" />" in cluster "<cluster-name>" on 127.0.0.1:62652.
+```
+
+Starting the local database proxy with the `--tunnel` flag will create an
+authenticated tunnel that you can use to connect to your database instances.
+
+You can optionally specify the database name and the user to use by default
+when connecting to the database:
+
+```code
+$ tsh proxy db --db-user=my-database-user --db-name=my-schema --tunnel <Var name="database-name" />
+```
+
+Now, you can connect to the address the proxy command returns. In our example it
+is `127.0.0.1:62652`.
+
+
+### Local proxy server
 
 Use the `tsh proxy db` command to start a local TLS proxy your GUI database
-client will be connecting to. This command requires that you use Teleport
-Enterprise (Cloud) or, if self-hosting Teleport, have enabled [TLS
-routing](../admin-guides/management/operations/tls-routing.mdx) mode.
+client will be connecting to.
 
 Run a command similar to the following::
 
 ```code
-$ tsh proxy db <database-name>
+$ tsh proxy db <Var name="database-name" />
 Started DB proxy on 127.0.0.1:61740
 
-Use following credentials to connect to the <database-name> proxy:
+Use following credentials to connect to the <Var name="database-name" /> proxy:
   ca_file=/Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
-  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<database-name>-x509.pem
+  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<Var name="database-name" />-x509.pem
   key_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice
 ```
 
@@ -56,29 +112,7 @@ Use the displayed local proxy host/port and credentials paths when configuring
 your GUI client below. When entering the hostname, use `localhost` rather than
 `127.0.0.1`.
 
-Starting the local database proxy with the `--tunnel` flag will create an
-authenticated tunnel that you can use to connect to your database instances.
-You won't need to configure any credentials when connecting to this tunnel.
-
-Here is an example on how to start the proxy:
-
-```code
-# Start the local proxy.
-$ tsh proxy db --tunnel <database-name>
-Started authenticated tunnel for the <engine> database "<database-name>" in cluster "<cluster-name>" on 127.0.0.1:62652.
-```
-
-You can optionally specify the database name and the user to use by default
-when connecting to the database:
-
-```code
-$ tsh proxy db --db-user=my-database-user --db-name=my-schema --tunnel <database-name>
-```
-
-Now, you can connect to the address the proxy command returns. In our example it
-is `127.0.0.1:62652`.
-
-#### Using a remote host and port
+### Remote host and port
 
 If you are self-hosting Teleport and not using [TLS
 routing](../admin-guides/management/operations/tls-routing.mdx), run the
@@ -119,7 +153,7 @@ On the "New Connection" panel, click on "Fill in connection fields individually"
 
 On the "Hostname" tab, enter the hostname and port of the proxy you will use to
 access the database (see
-[Get connection information](./gui-clients.mdx#get-connection-information)).
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)).
 Leave "Authentication" as None.
 
 ![MongoDB Compass hostname](../../img/database-access/compass-hostname@2x.png)
@@ -184,7 +218,7 @@ Parameters](../../img/database-access/workbench-parameters@2x.png)
 
 In the "SSL" tab, set "Use SSL" to `Require and Verify Identity` and enter the
 paths to your CA, certificate, and private key files (see
-[Get connection information](./gui-clients.mdx#get-connection-information)):
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)):
 
 ![MySQL Workbench SSL](../../img/database-access/workbench-ssl@2x.png)
 
@@ -209,7 +243,7 @@ From the NoSQL Workbench launch screen, click **Launch** next to **Amazon Dynamo
 From the left-side menu select **Operation builder**, then **+ Add connection**.
 Choose the **DynamoDB local** tab, and point to your proxy's endpoint. This is
 `localhost:62652` in the example above. (See
-[Get connection information](./gui-clients.mdx#get-connection-information) for
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases) for
 more information.)
 
 ![DynamoDB local connection in NoSQL Workbench](../../img/database-access/nosql-workbench-connection.png)
@@ -219,7 +253,7 @@ more information.)
 In Azure Data Studio create a connection using your proxy's endpoint. This is
 `localhost,62652` in the example above. On a Windows machine, using an address in
  the format `127.0.0.1,62652` could be required instead of `localhost`. (See
-[Get connection information](./gui-clients.mdx#get-connection-information) for
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases) for
 more information.)
 
 Create a connection with Microsoft SQL Server with these settings:
@@ -240,7 +274,7 @@ Click **Connect** to connect.
 
 To connect to your PostgreSQL instance, use the authenticated proxy address.
 This is `127.0.0.1:62652` in the example above (see the “Authenticated Proxy”
-section on [Get connection information](./gui-clients.mdx#get-connection-information)
+section on [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases)
 for more information).
 
 Use the "Database native" authentication with an empty password:
@@ -292,7 +326,7 @@ for password, leave the password field empty and click OK.
 In Microsoft SQL Server Management Studio connect to a database engine using
 your proxy's endpoint. This is `localhost,62652` in the example above. Using
 the IP `127.0.0.1,62652` connection could be required on a Windows machine
-instead of `localhost`. (See [Get connection information](./gui-clients.mdx#get-connection-information) for
+instead of `localhost`. (See [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases) for
 more information.)
 
 Create a connection with Microsoft SQL Server with these settings:
@@ -325,7 +359,7 @@ Now start a local proxy to your Redis instance:
 `tsh proxy db --db-user=alice redis-db-name`.
 
 Click `Add Database Manually`. Use `127.0.0.1` as the `Host`. Use the port printed by
-the `tsh` command you ran in [Get connection information](#get-connection-information).
+the `tsh` command you ran in [Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases).
 
 Provide your Redis username as `Username` and password as `Password`.
 
@@ -421,7 +455,7 @@ Congratulations! You have just connected to your Snowflake instance.
 
 In the DataGrip connection configuration menu, use your proxy's endpoint. This
 is `localhost:4242` in the example below. (See
-[Get connection information](./gui-clients.mdx#get-connection-information) for
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases) for
 more information.)
 
 Select the "User & Password" authentication option and keep the "Password" field
@@ -435,7 +469,7 @@ Click "OK" to connect.
 
 In the DBeaver connection configuration menu, use your proxy's endpoint. This is
 `localhost:62652` in the example above. (See
-[Get connection information](./gui-clients.mdx#get-connection-information) for
+[Get connection information](./gui-clients.mdx#how-gui-clients-access-teleport-protected-databases) for
 more information.)
 
 Use the SQL Server Authentication option and keep the Password field empty:

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -6,6 +6,10 @@ description: How to configure graphical database clients for Teleport database a
 This guide describes how to configure popular graphical database clients to
 work with Teleport.
 
+If you are using Teleport Connect to access your database, you can follow the
+instructions in the app to connect your GUI client. See [Using Teleport
+Connect](./teleport-connect.mdx#connecting-to-a-database).
+
 ## Prerequisites
 
 - A running Teleport cluster. If you want to get started with Teleport, [sign
@@ -37,21 +41,22 @@ GUI clients need to present a certificate to the Teleport Database Service and
 check the database server certificate issued by a Teleport-protected database.
 There are three ways to do this:
 
-- **Authenticated tunnel (recommended):** The local proxy handles loading the
-  Teleport user's client certificate and checking the certificate issued by the
-  Teleport-protected database. The connection remains authenticated, and clients
-  only need to forward database protocol messages to it.
-- **Unauthenticated local proxy:** The local GUI client needs to load the
-  Teleport user's certificate and check database certificates. This requires
-  configuring the client to access TLS credentials, including the user
-  certificate and private key, and a certificate issued by the database's
-  certificate authority. 
+- **Authenticated tunnel (recommended):** `tsh` or Teleport Connect starts a
+  local proxy, which handles loading the Teleport user's client certificate and
+  checking the certificate issued by the Teleport-protected database. The
+  connection remains authenticated, and clients only need to forward database
+  protocol messages to it.
+- **Unauthenticated local proxy:** `tsh` or Teleport Connect starts a local
+  proxy for database traffic, including authentication from clients. The GUI
+  client needs to load the Teleport user's certificate and check database
+  certificates. This requires configuring the client to access TLS credentials,
+  including the user certificate and private key, and a certificate issued by
+  the database's certificate authority. 
 - **Using a remote host and port:** For self-hosted clusters with TLS
   multiplexing disabled on the Teleport Proxy Service, you can configure GUI
-  clients to communicate with a port on the Proxy Service reserved for
-  traffic in the protected database's protocol. We recommend TLS multiplexing
-  for a typical Teleport cluster, and it is enabled by default on Teleport
-  Cloud.
+  clients to communicate with a port on the Proxy Service reserved for traffic
+  in the protected database's protocol. We recommend TLS multiplexing for a
+  typical Teleport cluster, and it is enabled by default on Teleport Cloud.
 
 To access a Teleport-protected database with a GUI client, you will need to
 retrieve connection information to pass to your client.

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -42,16 +42,16 @@ check the database server certificate issued by a Teleport-protected database.
 There are three ways to do this:
 
 - **Authenticated tunnel (recommended):** `tsh` or Teleport Connect starts a
-  local proxy, which handles loading the Teleport user's client certificate and
-  checking the certificate issued by the Teleport-protected database. The
-  connection remains authenticated, and clients only need to forward database
-  protocol messages to it.
-- **Unauthenticated local proxy:** `tsh` or Teleport Connect starts a local
-  proxy for database traffic, including authentication from clients. The GUI
-  client needs to load the Teleport user's certificate and check database
-  certificates. This requires configuring the client to access TLS credentials,
-  including the user certificate and private key, and a certificate issued by
-  the database's certificate authority. 
+  local proxy. A database GUI client establishes an unauthenticated connection
+  with the local proxy. Before forwarding the connection to the
+  Teleport-protected database, the local proxy automatically secures the
+  connection with the Teleport user's client certificate.
+- **Unauthenticated local proxy:** `tsh` starts a local proxy that routes
+  connections to the Teleport-protected database, but the proxy itself doesn't
+  handle authentication. The user configures a database GUI client to provide
+  the user certificate, private key, and CA certificate at paths printed by
+  `tsh`. (Teleport Connect can start an authenticated tunnel but not an
+  unauthenticated local proxy.)
 - **Using a remote host and port:** For self-hosted clusters with TLS
   multiplexing disabled on the Teleport Proxy Service, you can configure GUI
   clients to communicate with a port on the Proxy Service reserved for traffic

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -162,7 +162,7 @@ Service propagates the correct MySQL server version via TLS Routing extensions.
 
 If migration to TLS Routing is not possible, another way to bypass this error is
 to use the [Teleport local proxy
-command](../../connect-your-client/gui-clients.mdx#get-connection-information),
+command](../../connect-your-client/gui-clients.mdx#how-gui-clients-access-teleport-protected-databases),
 which allows you to establish a TLS Routing connection to the Teleport Proxy
 Service even if TLS Routing was not enabled on the Teleport cluster.
 


### PR DESCRIPTION
Closes #52850

Recommend the authenticated local tunnel approach. To do so:
- Add an introductory paragraph that briefly compares three approaches to configuring a GUI client to access a database: the authenticated tunnel, local proxy, and remote host/port.
- Indicate that we recommend that authenticated tunnel.
- Separate the H3 section that describes `tsh proxy db` into two H3s, one related to the local tunnel and one the standard `tsh proxy db` command.
- Put the section related to the authenticated tunnel first to emphasize it.