### PR TITLE
[v17] Bump electron from 36.1.0 to 37.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,8 +492,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       electron:
-        specifier: 36.1.0
-        version: 36.1.0
+        specifier: 37.1.0
+        version: 37.1.0
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12
@@ -3983,8 +3983,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@36.1.0:
-    resolution: {integrity: sha512-gnp3BnbKdGsVc7cm1qlEaZc8pJsR08mIs8H/yTo8gHEtFkGGJbDTVZOYNAfbQlL0aXh+ozv+CnyiNeDNkT1Upg==}
+  electron@37.1.0:
+    resolution: {integrity: sha512-Fcr3yfAw4oU392waVZSlrFUQx4P+h/k31+PRgkBY9tFx9E/zxzdPQQj0achZlG1HRDusw3ooQB+OXb9PvufdzA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -11303,7 +11303,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@36.1.0:
+  electron@37.1.0:
     dependencies:
       '@electron/get': 2.0.2
       '@types/node': 22.14.1

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/whatwg-url": "^11.0.5",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
-    "electron": "36.1.0",
+    "electron": "37.1.0",
     "electron-builder": "^26.0.12",
     "electron-vite": "^3.1.0",
     "events": "3.3.0",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/56287 to branch/v17