### PR TITLE
[v17] Unset AWS_PROFILE in TestCreateSignedSTSIdentityRequest

### DIFF
--- a/lib/auth/join/iam/iam_test.go
+++ b/lib/auth/join/iam/iam_test.go
@@ -41,6 +41,8 @@ func TestCreateSignedSTSIdentityRequest(t *testing.T) {
 	// If the user has an AWS config file that sets a region, it conflicts with
 	// the test cases. Disable loading a config file by setting a nonexistent path.
 	t.Setenv("AWS_CONFIG_FILE", "fake-file-this-must-not-exist")
+	// Ensure we don't try to use the user's profile.
+	t.Setenv("AWS_PROFILE", "")
 
 	const challenge = "asdf12345"
 


### PR DESCRIPTION
Backport #56393 to branch/v17