### PR TITLE
Deflake database access test suite setup helper

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -44,6 +45,7 @@ import (
 	mssql "github.com/microsoft/go-mssqldb"
 	opensearchclt "github.com/opensearch-project/opensearch-go/v2"
 	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -53,6 +55,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/entitlements"
@@ -2623,20 +2626,16 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t testing.TB, p a
 
 	if !p.NoStart {
 		require.NoError(t, server.Start(ctx))
-
-		// Explicitly send a heartbeat for any statically defined dbs.
-		for _, db := range p.Databases {
-			select {
-			case sender := <-inventoryHandle.Sender():
-				dbServer, err := server.getServerInfo(ctx, db)
-				require.NoError(t, err)
-				require.NoError(t, sender.Send(ctx, &proto.InventoryHeartbeat{
-					DatabaseServer: dbServer,
-				}))
-			case <-time.After(20 * time.Second):
-				t.Fatal("timed out waiting for inventory handle sender")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			dbServers, err := c.proxyServer.cfg.AccessPoint.GetDatabaseServers(ctx, apidefaults.Namespace)
+			if !assert.NoError(t, err) {
+				return
 			}
-		}
+			assert.Subset(t,
+				slices.Collect(types.ResourceNames(dbServers)),
+				slices.Collect(types.ResourceNames(p.Databases)),
+			)
+		}, 20*time.Second, 100*time.Millisecond, "waiting for database servers to become available")
 	}
 
 	return server

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/dynamodb"
 	"github.com/gravitational/teleport/lib/srv/db/endpoints"
@@ -754,35 +753,13 @@ func TestHealthCheck(t *testing.T) {
 	for _, db := range databases {
 		t.Run(db.GetName(), func(t *testing.T) {
 			t.Parallel()
-			waitForHealthStatus(t, ctx, db.GetName(), testCtx.authServer, types.TargetHealthStatusHealthy)
+			dbServer, err := testCtx.server.getServerInfo(ctx, db)
+			require.NoError(t, err)
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				assert.Equal(t, types.TargetHealthStatusHealthy, dbServer.GetTargetHealthStatus())
+			}, 30*time.Second, time.Millisecond*250, "waiting for database %s to become healthy", db.GetName())
 		})
 	}
-}
-
-func waitForHealthStatus(t *testing.T, ctx context.Context, name string, serverGetter services.DatabaseServersGetter, want types.TargetHealthStatus) {
-	t.Helper()
-	timeout := 15 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		servers, err := serverGetter.GetDatabaseServers(ctx, apidefaults.Namespace)
-		if !assert.NoError(t, err) {
-			return
-		}
-		var server types.DatabaseServer
-		for _, s := range servers {
-			if s.GetName() == name {
-				server = s
-				break
-			}
-		}
-		if server == nil {
-			assert.FailNowf(t, "failed to find db_server", "db_server=%s", name)
-			return
-		}
-		assert.Equal(t, want, server.GetTargetHealthStatus())
-	}, timeout, time.Millisecond*250, "waiting for database %s to become healthy", name)
 }
 
 func newHealthCheckConfig(t *testing.T, name string) *healthcheckconfigv1.HealthCheckConfig {


### PR DESCRIPTION
Closes #56304
-  #56304

Wait for database heartbeats to become available to the proxy's access point.

I actually couldn't reproduce the failure from that flaky test run even with `-race -cover -count=1000`.

The root cause of the failure seems to be that the proxy hasn't observed database heartbeats yet, so it fails the connection.
If that's the case, then we just need to make sure the proxy has observed the database heartbeats before we start testing connections through the proxy.