### PR TITLE
Fixing Tile Links

### DIFF
--- a/docs/pages/installation/installation.mdx
+++ b/docs/pages/installation/installation.mdx
@@ -20,37 +20,37 @@ These use cases will be addressed in each platform page.
   tiles={[
     {
       icon: <Icon name="linux" size="xl" />,
-      to: "/installation/linux",
+      to: "./linux",
       name: "Linux",
     },
     {
       icon: <Icon name="docker" size="xl" />,
-      to: "/installation/docker",
+      to: "./docker",
       name: "Docker",
     },
     {
       icon: <Icon name="ec2" size="xl" />,
-      to: "/installation/amazon-ec2",
+      to: "./amazon-ec2",
       name: "Amazon EC2",
     },
     {
       icon: <Icon name="kubernetes2" size="xl" />,
-      to: "/installation/helm",
+      to: "./helm",
       name: "Helm",
     },
     {
       icon: <Icon name="apple" size="xl" />,
-      to: "/installation/macos",
+      to: "./macos",
       name: "macOS",
     },
     {
       icon: <Icon name="windows" size="xl" />,
-      to: "/installation/windows",
+      to: "./windows",
       name: "Windows",
     },
     {
       icon: <Icon name="laptop" size="xl" />,
-      to: "/installation/source",
+      to: "./source",
       name: "From Source",
     }
   ]}


### PR DESCRIPTION
The tile links on the Installations page were not relative but where hardcoded. This fixes that. 