### PR TITLE
[docs] Update auto user provisioning guides

### DIFF
--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -25,8 +25,8 @@ The admin user must have privileges within the database to create users and
 grant them privileges. The admin user must also have privileges to monitor user
 processes and role assignments:
 ```
-CREATE USER "teleport-admin" WITH PASSWORD DISABLE;
-GRANT ROLE "sys:superuser" TO "teleport-admin";
+CREATE USER "<Var name="teleport-admin"/>" WITH PASSWORD DISABLE;
+GRANT ROLE "sys:superuser" TO "<Var name="teleport-admin"/>";
 ```
 
 Users created by Teleport will be assigned the `teleport-auto-user` role in the

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -38,14 +38,14 @@ This database is also used to store custom user attributes and stored procedures
 The RDS MariaDB admin user must use `AWSAuthenticationPlugin` to allow IAM
 authentication:
 ```sql
-CREATE USER 'teleport-admin' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
-GRANT PROCESS, CREATE USER ON *.* TO 'teleport-admin';
-GRANT SELECT ON mysql.roles_mapping TO 'teleport-admin';
-GRANT UPDATE ON mysql.* TO 'teleport-admin'; -- For SET DEFAULT ROLE FOR
-GRANT SELECT ON *.* TO 'teleport-admin'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
+CREATE USER '<Var name="teleport-admin"/>' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+GRANT PROCESS, CREATE USER ON *.* TO '<Var name="teleport-admin"/>';
+GRANT SELECT ON mysql.roles_mapping TO '<Var name="teleport-admin"/>';
+GRANT UPDATE ON mysql.* TO '<Var name="teleport-admin"/>'; -- For SET DEFAULT ROLE FOR
+GRANT SELECT ON *.* TO '<Var name="teleport-admin"/>'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
-GRANT ALL ON `teleport`.* TO 'teleport-admin' WITH GRANT OPTION;
+GRANT ALL ON `teleport`.* TO '<Var name="teleport-admin"/>' WITH GRANT OPTION;
 ```
 
 (!docs/pages/includes/database-access/auto-user-provisioning/mysql-default-database-note.mdx!)
@@ -59,7 +59,7 @@ automatically designates the admin user as "Admin" of those roles.
 
 Alternatively, you can assign the admin user as the "Admin" of existing roles:
 ```sql
-UPDATE mysql.roles_mapping SET User ='teleport-admin' WHERE Admin_option='Y' AND Role='role1';
+UPDATE mysql.roles_mapping SET User ='<Var name="teleport-admin"/>' WHERE Admin_option='Y' AND Role='role1';
 FLUSH PRIVILEGES;
 ```
 
@@ -72,14 +72,14 @@ auto-provisioned users.
 <TabItem label="Self-hosted MariaDB">
 The self-hosted MariaDB admin user must have X.509 authentication configured:
 ```sql
-CREATE USER 'teleport-admin' REQUIRE SUBJECT '/CN=teleport-admin';
-GRANT PROCESS, CREATE USER ON *.* TO 'teleport-admin';
-GRANT SELECT ON mysql.roles_mapping TO 'teleport-admin';
-GRANT UPDATE ON mysql.* TO 'teleport-admin'; -- For SET DEFAULT ROLE FOR
-GRANT SELECT ON *.* TO 'teleport-admin'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
+CREATE USER '<Var name="teleport-admin"/>' REQUIRE SUBJECT '/CN=<Var name="teleport-admin"/>';
+GRANT PROCESS, CREATE USER ON *.* TO '<Var name="teleport-admin"/>';
+GRANT SELECT ON mysql.roles_mapping TO '<Var name="teleport-admin"/>';
+GRANT UPDATE ON mysql.* TO '<Var name="teleport-admin"/>'; -- For SET DEFAULT ROLE FOR
+GRANT SELECT ON *.* TO '<Var name="teleport-admin"/>'; -- Required when using best_effort_drop mode for checking if users own resources before dropping them.
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
-GRANT ALL ON `teleport`.* TO 'teleport-admin' WITH GRANT OPTION;
+GRANT ALL ON `teleport`.* TO '<Var name="teleport-admin"/>' WITH GRANT OPTION;
 ```
 
 (!docs/pages/includes/database-access/auto-user-provisioning/mysql-default-database-note.mdx!)
@@ -90,12 +90,12 @@ the "Admin" of the role.
 
 One way to achieve this is to use the `WITH ADMIN` option when creating roles:
 ```sql
-CREATE ROLE role1 WITH ADMIN 'teleport-admin';
+CREATE ROLE role1 WITH ADMIN '<Var name="teleport-admin"/>';
 ```
 
 Alternatively, you can assign the admin user as the "Admin" of existing roles:
 ```sql
-UPDATE mysql.roles_mapping SET User ='teleport-admin' WHERE Admin_option='Y' AND Role='role1';
+UPDATE mysql.roles_mapping SET User ='<Var name="teleport-admin"/>' WHERE Admin_option='Y' AND Role='role1';
 FLUSH PRIVILEGES;
 ```
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -24,6 +24,8 @@ Automatic user provisioning is not compatible with MongoDB Atlas.
 
 ## Step 1/3. Configure database admin
 
+(!docs/pages/includes/database-access/auto-user-provisioning/configure-admin.mdx!)
+
 Teleport uses the same authentication mechanism (X.509) when connecting as an
 admin user as for regular user connections.
 
@@ -75,7 +77,7 @@ Now create the admin user with this role:
 
 ```code
 db.getSiblingDB("$external").runCommand({
-  createUser: "CN=teleport-admin",
+  createUser: "CN=<Var name="teleport-admin"/>",
   roles: [ { role: 'teleport-admin-role', db: 'admin' } ],
 })
 ```

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -58,12 +58,12 @@ Stored procedures are also created and executed from this database.
 The RDS MySQL admin user must use `AWSAuthenticationPlugin` to allow IAM
 authentication:
 ```sql
-CREATE USER 'teleport-admin' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
-GRANT SELECT ON mysql.role_edges TO 'teleport-admin' ;
-GRANT PROCESS, ROLE_ADMIN, CREATE USER ON *.* TO 'teleport-admin' ;
+CREATE USER '<Var name="teleport-admin"/>' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+GRANT SELECT ON mysql.role_edges TO '<Var name="teleport-admin"/>' ;
+GRANT PROCESS, ROLE_ADMIN, CREATE USER ON *.* TO '<Var name="teleport-admin"/>' ;
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
-GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO 'teleport-admin' ;
+GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO '<Var name="teleport-admin"/>' ;
 ```
 
 (!docs/pages/includes/database-access/auto-user-provisioning/mysql-default-database-note.mdx!)
@@ -73,12 +73,12 @@ GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO 'teleport-admin'
 <TabItem label="Self-hosted MySQL">
 The self-hosted MySQL admin user must have X.509 authentication configured:
 ```sql
-CREATE USER "teleport-admin" REQUIRE SUBJECT "/CN=teleport-admin";
-GRANT SELECT ON mysql.role_edges TO 'teleport-admin' ;
-GRANT PROCESS, ROLE_ADMIN, CREATE USER ON *.* TO 'teleport-admin' ;
+CREATE USER "<Var name="teleport-admin"/>" REQUIRE SUBJECT "/CN=<Var name="teleport-admin"/>";
+GRANT SELECT ON mysql.role_edges TO '<Var name="teleport-admin"/>' ;
+GRANT PROCESS, ROLE_ADMIN, CREATE USER ON *.* TO '<Var name="teleport-admin"/>' ;
 
 CREATE DATABASE IF NOT EXISTS `teleport`;
-GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO 'teleport-admin' ;
+GRANT ALTER ROUTINE, CREATE ROUTINE, EXECUTE ON `teleport`.* TO '<Var name="teleport-admin"/>' ;
 ```
 
 (!docs/pages/includes/database-access/auto-user-provisioning/mysql-default-database-note.mdx!)

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -34,8 +34,8 @@ The RDS PostgreSQL admin user must have the `rds_iam` role attached to allow IAM
 authentication:
 
 ```sql
-CREATE USER "teleport-admin" login createrole;
-GRANT rds_iam TO "teleport-admin" WITH ADMIN OPTION;
+CREATE USER "<Var name="teleport-admin"/>" login createrole;
+GRANT rds_iam TO "<Var name="teleport-admin"/>" WITH ADMIN OPTION;
 ```
 
 Note that the RDS database must have IAM authentication enabled.
@@ -46,28 +46,28 @@ for more information.
 If the admin user needs to grant the `rds_superuser` role to auto-provisioned
 users, the admin user must also be a `rds_superuser`:
 ```sql
-GRANT rds_superuser TO "teleport-admin";
+GRANT rds_superuser TO "<Var name="teleport-admin"/>";
 ```
 
 For PostgreSQL 16+, you must grant the `ADMIN` option to the admin user for each
 PostgreSQL role that Teleport will assign to your Teleport user. For example, to
 allow the admin user to grant and revoke role `reader`:
 ```sql
-GRANT reader TO "teleport-admin" WITH ADMIN OPTION;
+GRANT reader TO "<Var name="teleport-admin"/>" WITH ADMIN OPTION;
 ```
 </TabItem>
 <TabItem label="Self-hosted PostgreSQL">
 The self-hosted PostgreSQL admin user must have X.509 authentication configured.
 
 ```sql
-CREATE USER "teleport-admin" login createrole;
+CREATE USER "<Var name="teleport-admin"/>" login createrole;
 ```
 
 For PostgreSQL 16+, you must grant the `ADMIN` option to the admin user for each
 PostgreSQL role that Teleport will assign to your Teleport user. For example, to
 allow the admin user to grant and revoke role `reader`:
 ```sql
-GRANT reader TO "teleport-admin" WITH ADMIN OPTION;
+GRANT reader TO "<Var name="teleport-admin"/>" WITH ADMIN OPTION;
 ```
 
 Note that the database must be configured to accept client certificate auth
@@ -83,17 +83,17 @@ to ensure that your configuration is correct.
 </TabItem>
 </Tabs>
 
-<Admonition type="note" title="Database Access Controls for `teleport-admin`">
+<Admonition type="note" title="Database Access Controls for the admin user">
 When [Database Access Controls](../rbac.mdx) feature is in use, the
-`teleport-admin` should have permissions to relevant database objects. You can
-grant `teleport-admin` the `SUPERUSER` option for self-hosted databases, or the
+admin user should have permissions to relevant database objects. You can
+give the admin user the `SUPERUSER` attribute for self-hosted databases, or grant it the
 `rds_superuser` role for RDS databases.
 
 For improved security through the principle of least privilege, you can also
 assign permissions directly to specific database objects. For example:
 
 ```sql
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA schema1, schema2, schema3 TO "teleport-admin";
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA schema1, schema2, schema3 TO "<Var name="teleport-admin"/>";
 ```
 </Admonition>
 
@@ -207,7 +207,7 @@ DETAIL: User does not have CONNECT privilege.
 
 Make sure `CONNECT` is granted to the admin user and the respective roles:
 ```sql
-GRANT CONNECT ON DATABASE <database> to "teleport-admin";
+GRANT CONNECT ON DATABASE <database> to "<Var name="teleport-admin"/>";
 GRANT CONNECT ON DATABASE <database> to "reader";
 ```
 
@@ -239,8 +239,8 @@ ERROR: no schema has been selected to create in (SQLSTATE 3F000)
 To fix this, make sure that the admin user is granted `USAGE` and `CREATE` on
 schema `public` in the target database:
 ```sql
-GRANT USAGE ON SCHEMA public TO "teleport-admin";
-GRANT CREATE ON SCHEMA public TO "teleport-admin";
+GRANT USAGE ON SCHEMA public TO "<Var name="teleport-admin"/>";
+GRANT CREATE ON SCHEMA public TO "<Var name="teleport-admin"/>";
 ```
 
 ### Permission denied to grant role "rds_iam"
@@ -257,7 +257,7 @@ This happens when the admin user does not have permission to grant the
 "rds_iam" role to other users. To fix this, grant the "rds_iam" role with the
 `ADMIN` option to the admin user:
 ```sql
-GRANT rds_iam TO "teleport-admin" WITH ADMIN OPTION;
+GRANT rds_iam TO "<Var name="teleport-admin"/>" WITH ADMIN OPTION;
 ```
 
 ### Use your mapped remote username error

--- a/docs/pages/includes/database-access/auto-user-provisioning/configure-admin.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/configure-admin.mdx
@@ -1,4 +1,9 @@
 Teleport should be able to connect to the database as a user that can create
-other users and assign them roles. We recommend creating a separate user
-designated specifically for Teleport automatic user provisioning. Let's call it
-`teleport-admin`.
+other users and assign them roles.
+
+Choose a name for the Teleport automatic user provisioning admin: <Var name="teleport-admin"/>
+
+<Admonition type="tip">
+We recommend creating a separate user
+designated specifically for Teleport automatic user provisioning.
+</Admonition>

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition-default-dbname.mdx
@@ -10,7 +10,7 @@ spec:
   protocol: "{{ protocol }}"
   uri: "{{ uri }}"
   admin_user:
-    name: "teleport-admin"
+    name: "<Var name="teleport-admin"/>"
     # Optional default database the admin user logs into. Default is
     # {{ default }}, if not specified.
     # default_database: teleport

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition-self-hosted.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition-self-hosted.mdx
@@ -9,7 +9,7 @@ spec:
   protocol: "{{ protocol }}"
   uri: "{{ uri }}"
   admin_user:
-    name: "teleport-admin"
+    name: "<Var name="teleport-admin"/>"
 ```
 
 This example assumes that you have configured the database as a dynamic

--- a/docs/pages/includes/database-access/auto-user-provisioning/db-definition.mdx
+++ b/docs/pages/includes/database-access/auto-user-provisioning/db-definition.mdx
@@ -9,7 +9,7 @@ spec:
   protocol: "{{ protocol }}"
   uri: "{{ uri }}"
   admin_user:
-    name: "teleport-admin"
+    name: "<Var name="teleport-admin"/>"
 ```
 
 This example assumes that you have configured the database as a dynamic


### PR DESCRIPTION
Use a Var component so that the admin user name can be customized for the guides.