### PR TITLE
Add access requests (requester and reviewer) MCP server

### DIFF
--- a/lib/client/db/mcp/errors.go
+++ b/lib/client/db/mcp/errors.go
@@ -23,17 +23,15 @@ import (
 
 	"github.com/gravitational/trace"
 
-	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/lib/client/mcp"
-	"github.com/gravitational/teleport/lib/utils"
+	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
 )
 
 // FormatErrorMessage formats the database MCP error messages.
 // format.
 func FormatErrorMessage(err error) error {
 	switch {
-	case errors.Is(err, apiclient.ErrClientCredentialsHaveExpired) || utils.IsCertExpiredError(err):
-		return trace.BadParameter(ReloginRequiredErrorMessage)
+	case clientmcp.IsSessionExpiredError(err):
+		return trace.BadParameter(clientmcp.ReloginRequiredErrorMessage)
 	case strings.Contains(err.Error(), "connection reset by peer") || errors.Is(err, io.ErrClosedPipe):
 		return trace.BadParameter(LocalProxyConnectionErrorMessage)
 	}
@@ -42,12 +40,6 @@ func FormatErrorMessage(err error) error {
 }
 
 const (
-	// ReloginRequiredErrorMessage is the message returned to the MCP client
-	// when the tsh session expired.
-	ReloginRequiredErrorMessage = `It looks like your Teleport session expired,
-you must relogin (using "tsh login" on a terminal) before continue using this
-tool. After that, there is no need to update or relaunch the MCP client - just
-try using it again.`
 	// LocalProxyConnectionErrorMessage is the message returned to the MCP client when
 	// the database client cannot connect to the local proxy.
 	LocalProxyConnectionErrorMessage = `Teleport MCP server is having issue while
@@ -65,7 +57,7 @@ of databases on the MCP command is correct.`
 var (
 	// WrongDatabaseURIFormatError is the message returned to the MCP client
 	// when it sends a malformed database resource URI.
-	WrongDatabaseURIFormatError = trace.BadParameter("Malformed database resource URI. Database resources must follow the format: %q", mcp.SampleDatabaseResource)
+	WrongDatabaseURIFormatError = trace.BadParameter("Malformed database resource URI. Database resources must follow the format: %q", clientmcp.SampleDatabaseResource)
 	// DatabaseNotFoundError is the message returned to the MCP client when the
 	// requested database is not available as MCP resource.
 	DatabaseNotFoundError = trace.NotFound(`Database not found. Only registered databases

--- a/lib/client/db/mcp/mcp.go
+++ b/lib/client/db/mcp/mcp.go
@@ -94,8 +94,5 @@ type DatabaseResource struct {
 
 // ToolName generates a database access tool name.
 func ToolName(protocol, name string) string {
-	return ToolPrefix + protocol + "_" + name
+	return mcp.ToolName(protocol + "_" + name)
 }
-
-// ToolPrefix is the default tool prefix for every MCP tool.
-const ToolPrefix = "teleport_"

--- a/lib/client/db/mcp/server.go
+++ b/lib/client/db/mcp/server.go
@@ -29,12 +29,18 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/gravitational/teleport"
+	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
 )
 
-// listDatabasesTool is the MCP tool that list all databases being served
-// (from all protocols).
-var listDatabasesTool = mcp.NewTool(listDatabasesToolName,
-	mcp.WithDescription("List database resources available to be used with Teleport tools."),
+var (
+	// listDatabasesTool is the MCP tool that list all databases being served
+	// (from all protocols).
+	listDatabasesTool = mcp.NewTool(listDatabasesToolName,
+		mcp.WithDescription("List database resources available to be used with Teleport tools."),
+	)
+
+	// listDatabasesTool is the list databases tool name.
+	listDatabasesToolName = clientmcp.ToolName("list_databases")
 )
 
 // RootServer database access root MCP server. It includes common MCP tools and
@@ -51,7 +57,7 @@ type RootServer struct {
 // NewRootServer initializes a new root MCP server.
 func NewRootServer(logger *slog.Logger) *RootServer {
 	server := &RootServer{
-		MCPServer:          mcpserver.NewMCPServer(serverName, teleport.Version),
+		MCPServer:          mcpserver.NewMCPServer(clientmcp.ServerName("databases"), teleport.Version),
 		logger:             logger,
 		availableDatabases: make(map[string]*Database),
 	}
@@ -145,10 +151,6 @@ func encodeDatabaseResource(db *Database) (mcp.ResourceContents, error) {
 }
 
 const (
-	// serverName is the database MCP server name.
-	serverName = "teleport_databases"
-	// listDatabasesTool is the list databases tool name.
-	listDatabasesToolName = ToolPrefix + "list_databases"
 	// databaseResourceMIMEType is the MIME type of the database resources.
 	databaseResourceMIMEType = "application/yaml"
 )

--- a/lib/client/db/postgres/mcp/mcp_test.go
+++ b/lib/client/db/postgres/mcp/mcp_test.go
@@ -140,7 +140,7 @@ func TestFormatErrors(t *testing.T) {
 				},
 			},
 			expectErrorMessage: func(tt require.TestingT, i1 any, i2 ...any) {
-				require.Equal(t, dbmcp.ReloginRequiredErrorMessage, i1)
+				require.Equal(t, clientmcp.ReloginRequiredErrorMessage, i1)
 			},
 		},
 	} {

--- a/lib/client/mcp/errors.go
+++ b/lib/client/mcp/errors.go
@@ -1,0 +1,37 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"errors"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// IsSessionExpiredError returns if the MCP error is related to the `tsh`
+// session being expired.
+func IsSessionExpiredError(err error) bool {
+	return errors.Is(err, apiclient.ErrClientCredentialsHaveExpired) || utils.IsCertExpiredError(err)
+}
+
+// ReloginRequiredErrorMessage is the message returned to the MCP client
+// when the tsh session expired.
+const ReloginRequiredErrorMessage = `It looks like your Teleport session expired,
+you must relogin (using "tsh login" on a terminal) before continue using this
+tool. After that, there is no need to update or relaunch the MCP client - just
+try using it again.`

--- a/lib/client/mcp/naming.go
+++ b/lib/client/mcp/naming.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mcp
+
+// ToolName generates a MCP tool name.
+func ToolName(name string) string {
+	return ToolPrefix + name
+}
+
+// ServerName generates a MCP server name.
+func ServerName(name string) string {
+	return ServerPrefix + name
+}
+
+// ToolPrefix is the default tool prefix for Teleport MCP tools.
+const ToolPrefix = "teleport_"
+
+// ServerPrefix is the default MCP server prefix for Teleport MCP servers.
+const ServerPrefix = "teleport_"

--- a/lib/client/mcp/platform/access_requests.go
+++ b/lib/client/mcp/platform/access_requests.go
@@ -1,0 +1,489 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+var (
+	// listUserAccessRequestsTool is the current user list access requests tool
+	// defintion.
+	listUserAccessRequestsTool = mcp.NewTool(
+		clientmcp.ToolName("list_access_requests"),
+		mcp.WithDescription("Lists current user access requests using the provided filters."),
+		mcp.WithString(
+			"state",
+			mcp.Required(),
+			mcp.Description(fmt.Sprintf(
+				"State of the request. Can be any of: %s.",
+				strings.Join(validStateValues, ","),
+			)),
+		),
+	)
+
+	// listRequestableRoles is the current user list requestable roles tool
+	// definition.
+	listRequestableRoles = mcp.NewTool(
+		clientmcp.ToolName("list_requestable_roles"),
+		mcp.WithDescription("Lists Teleport roles the current user can request access to."),
+	)
+
+	// createAccessRequestTool is the create access request tool definition.
+	createAccessRequestTool = mcp.NewTool(
+		clientmcp.ToolName("create_access_request"),
+		mcp.WithDescription("Requests access to a Teleport resource."),
+		mcp.WithArray(
+			"roles",
+			mcp.Items(map[string]any{"type": "string"}),
+			mcp.Required(),
+			mcp.Description("Is the list of Teleport roles to request access to."),
+		),
+		mcp.WithString(
+			"request_ttl",
+			mcp.Required(),
+			mcp.Description("Is the expiration time of the access request (how long it will await for approval). "+durationExamples),
+		),
+		mcp.WithString(
+			"session_ttl",
+			mcp.Required(),
+			mcp.Description("Is the expiration time for the session that will be used if the access request is approved. "+durationExamples),
+		),
+		mcp.WithString("reason", mcp.Description("Indicates the reason for an access request.")),
+	)
+
+	// listRequestsToBeReviewedTool is the list access requests to be reviwed by
+	// current user tool definition.
+	listRequestsToBeReviewedTool = mcp.NewTool(
+		clientmcp.ToolName("list_access_requests_to_be_reviewed"),
+		mcp.WithDescription("Lists access requests that can be reviewed by the current user."),
+	)
+
+	// approveAccessRequestTool is the approve access requests tool definition.
+	approveAccessRequestTool = mcp.NewTool(
+		clientmcp.ToolName("approve_access_request"),
+		mcp.WithDescription("Approves the access request."),
+		mcp.WithString(
+			"access_request_uri",
+			mcp.Required(),
+			mcp.Description("Teleport access request resource URI that will be approved."),
+		),
+		mcp.WithString(
+			"reason",
+			mcp.Required(),
+			mcp.Description("Reason for the approval."),
+		),
+	)
+
+	// denyAccessRequestTool is the deny access requests tool definition.
+	denyAccessRequestTool = mcp.NewTool(
+		clientmcp.ToolName("deny_access_request"),
+		mcp.WithDescription("Denies the access request."),
+		mcp.WithString(
+			"access_request_uri",
+			mcp.Required(),
+			mcp.Description("Teleport access request resource URI that will be denied."),
+		),
+		mcp.WithString(
+			"reason",
+			mcp.Required(),
+			mcp.Description("Reason for the denial."),
+		),
+	)
+
+	// validStateValues is the list of supported access requests state
+	// values.
+	validStateValues = slices.Collect(maps.Values(types.RequestState_name))
+)
+
+const (
+	// durationExamples includes a short description of the time duration
+	// format and some examples.
+	durationExamples = "It must follow Golang's duration format, for example '10m' for 10 minutes, '1d20h30s' for 1 day, 20 hours and 30 seconds."
+)
+
+// AccessRequestResource is the access request MCP resource.
+type AccessRequestResource struct {
+	types.Metadata
+	// URI is the MCP URI resource.
+	URI string `json:"uri"`
+	// ClusterName is the cluster the access request is from.
+	ClusterName string `json:"cluster_name"`
+	// State is the access request state.
+	State string `json:"state"`
+	// Requester is the user requesting access.
+	Requester string `json:"requester"`
+	// RequestReason is the request reason.
+	RequestReason string `json:"request_reason,omitempty"`
+	// ResolveReason is the resolve reason.
+	ResolveReason string `json:"resolve_reason,omitempty"`
+	// Roles is the list of roles being requested.
+	Roles []string `json:"roles,omitempty"`
+	// Resources is the list of resources being requested.
+	Resources []AccessRequestResourceItem `json:"resources,omitempty"`
+}
+
+// AccessRequestResourceItem is the requested resources MCP resource.
+type AccessRequestResourceItem struct {
+	// Kind is the resource kind.
+	Kind string `json:"kind"`
+	// Name is the resource name.
+	Name string `json:"name"`
+}
+
+// AccessRequestStateArg represents the access request state argument.
+type AccessRequestStateArg struct {
+	// State used to only return access requests with specified state.
+	State string `json:"state"`
+}
+
+// ParseState parses the access request state into protobuf type.
+func (a AccessRequestStateArg) ParseState() (types.RequestState, error) {
+	if a.State == "" {
+		return types.RequestState_NONE, trace.BadParameter("an access request state must be provided")
+	}
+
+	// Some models are not consistent with upper/lower case, so here we enforce
+	// uppercase to cover both scenarios.
+	state, ok := types.RequestState_value[strings.ToUpper(a.State)]
+	if !ok {
+		return types.RequestState_NONE, trace.BadParameter("%q is not a valid access request state. Value must be one of the following: %s", state, strings.Join(validStateValues, ", "))
+	}
+
+	return types.RequestState(state), nil
+}
+
+// ListUserAccessRequestsToolArgs is list access requests MCP tool arguments
+// definition.
+// 
+// The JSON field names must match the arguments on the `listUserAccessRequestsTool`
+// tool definition.
+type ListUserAccessRequestsToolArgs struct {
+	AccessRequestStateArg
+}
+
+// AccessRequestsServer exposes Access Requests as MCP resources and tools.
+type AccessRequestsServer struct {
+	config PlatformServerConfig
+	server *mcpserver.MCPServer
+	logger *slog.Logger
+}
+
+// NewAccessRequestsServer initializes the access request MCP server.
+func NewAccessRequestsServer(rootServer *PlatformServer) *AccessRequestsServer {
+	srv := &AccessRequestsServer{
+		config: rootServer.config,
+		logger: rootServer.config.Logger.With("server", "access_requests"),
+	}
+
+	if rootServer.config.AccessRequesterServerEnabled {
+		rootServer.AddTool(listRequestableRoles, srv.ListUserRequestableRoles)
+		rootServer.AddTool(listUserAccessRequestsTool, mcp.NewTypedToolHandler(srv.ListUserRequests))
+		rootServer.AddTool(createAccessRequestTool, mcp.NewTypedToolHandler(srv.Create))
+	}
+
+	if rootServer.config.AccessRequestsReviwerServerEnabled {
+		rootServer.AddTool(listRequestsToBeReviewedTool, srv.ListRequestsToBeReviewed)
+		rootServer.AddTool(approveAccessRequestTool, mcp.NewTypedToolHandler(srv.Approve))
+		rootServer.AddTool(denyAccessRequestTool, mcp.NewTypedToolHandler(srv.Deny))
+	}
+
+	return srv
+}
+
+// Close closes the MCP server, cleaning up resources.
+func (a *AccessRequestsServer) Close() error {
+	return nil
+}
+
+// ListUserRequestableRolesResponse is the response object of the
+// ListUserRequestableRoles tool call.
+type ListUserRequestableRolesResponse struct {
+	Roles []string `json:"roles"`
+}
+
+// ListUserRequestableRoles lists the current user requestable roles.
+func (a *AccessRequestsServer) ListUserRequestableRoles(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// fetch requestable roles.
+	caps, err := a.config.Client.GetAccessCapabilities(ctx, types.AccessCapabilitiesRequest{
+		User:             a.config.Username,
+		RequestableRoles: true,
+	})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	resp, err := utils.FastMarshal(ListUserRequestableRolesResponse{
+		Roles: caps.RequestableRoles,
+	})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText(string(resp)), nil
+}
+
+// ListUserRequestsResponse is the response object of the ListUserRequests tool
+// call.
+type ListUserRequestsResponse struct {
+	// Requests list of requests made by the user.
+	Requests []AccessRequestResource `json:"requests"`
+}
+
+// ListUserRequests lists the current user access requests.
+//
+// TODO(gabrielcorado): add support for pagination.
+func (a *AccessRequestsServer) ListUserRequests(ctx context.Context, _ mcp.CallToolRequest, args ListUserAccessRequestsToolArgs) (*mcp.CallToolResult, error) {
+	state, err := args.ParseState()
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	resp, err := a.config.Client.GetAccessRequests(ctx, types.AccessRequestFilter{
+		Requester: a.config.Username,
+		State:     state,
+	})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	resources := make([]AccessRequestResource, len(resp))
+	for i, req := range resp {
+		resources[i] = a.buildAccessRequestResource(req)
+	}
+
+	out, err := utils.FastMarshal(ListUserRequestsResponse{Requests: resources})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// AccessRequestsCreateArgs is the arguments used by create access request MCP
+// tool.
+//
+// The JSON field names must match the arguments on the `createAccessRequestTool`
+// tool definition.
+type AccessRequestsCreateArgs struct {
+	// Roles are the requested roles.
+	Roles []string `json:"roles"`
+	// RequestTTL is the expiration time of the access requestis.
+	RequestTTL types.Duration `json:"request_ttl"`
+	// SessionTTL is the expiration time of the session.
+	SessionTTL types.Duration `json:"session_ttl"`
+	// Reason is the reason for an access request.
+	Reason string `json:"reason"`
+}
+
+// CheckAndSetDefaults checks and set defaults.
+func (a AccessRequestsCreateArgs) CheckAndSetDefaults() error {
+	if len(a.Roles) == 0 {
+		return trace.BadParameter("must request access to at least one role")
+	}
+	if a.RequestTTL == 0 {
+		return trace.BadParameter("request_ttl duration must be greater than zero")
+	}
+	if a.SessionTTL == 0 {
+		return trace.BadParameter("session_ttl duration must be greater than zero")
+	}
+	return nil
+}
+
+// AccessRequestsCreateResponse is the create access request response.
+type AccessRequestsCreateResponse struct {
+	// Request is the resulting access request.
+	Request AccessRequestResource `json:"request"`
+}
+
+// Create creates a new access request.
+//
+// TODO(gabrielcorado): support requesting access to resources.
+func (a *AccessRequestsServer) Create(ctx context.Context, _ mcp.CallToolRequest, args AccessRequestsCreateArgs) (*mcp.CallToolResult, error) {
+	if err := args.CheckAndSetDefaults(); err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	accessReq, err := services.NewAccessRequestWithResources(a.config.Username, args.Roles, nil /* resourceIDs */)
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	accessReq.SetRequestReason(args.Reason)
+	accessReq.SetExpiry(time.Now().UTC().Add(args.RequestTTL.Value()))
+	accessReq.SetAccessExpiry(time.Now().UTC().Add(args.SessionTTL.Value()))
+
+	req, err := a.config.Client.CreateAccessRequestV2(ctx, accessReq)
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	out, err := utils.FastMarshal(AccessRequestsCreateResponse{
+		Request: a.buildAccessRequestResource(req),
+	})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// ListRequestsToBeReviewedResponse is the list requests to be reviewed
+// response.
+type ListRequestsToBeReviewedResponse struct {
+	// Requests list of requests that are still peding review.
+	Requests []AccessRequestResource `json:"requests"`
+}
+
+// ListRequestsToBeReviewed lists access requests that can be reviewed by the
+// current user.
+//
+// TODO(gabrielcorado): add support for pagination.
+func (a *AccessRequestsServer) ListRequestsToBeReviewed(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	reqs, err := a.config.Client.GetAccessRequests(ctx, types.AccessRequestFilter{
+		State: types.RequestState_PENDING,
+	})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	var filtered []AccessRequestResource
+reqs:
+	for _, req := range reqs {
+		// Do not include requests made by the user.
+		if req.GetUser() == a.config.Username {
+			continue
+		}
+
+		// Also skip requests already reviewed by the user.
+		for _, rev := range req.GetReviews() {
+			if rev.Author == a.config.Username {
+				continue reqs
+			}
+		}
+
+		filtered = append(filtered, a.buildAccessRequestResource(req))
+	}
+
+	out, err := utils.FastMarshal(ListRequestsToBeReviewedResponse{Requests: filtered})
+	if err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// AccessRequestReviewArgs is the args used by Approve and Deny MCP tools.
+//
+// The JSON field names must match the arguments on the `approveAccessRequestTool`
+// and `denyAccessRequestTool` tool definitions.
+type AccessRequestReviewArgs struct {
+	// AccessRequestURI is the access request MCP resource URI.
+	AccessRequestURI string `json:"access_request_uri"`
+	// Reason is the reason to Approve or Deny the request.
+	Reason string `json:"reason"`
+}
+
+// Approve approves an access request.
+func (a *AccessRequestsServer) Approve(ctx context.Context, _ mcp.CallToolRequest, args AccessRequestReviewArgs) (*mcp.CallToolResult, error) {
+	if err := a.reviewRequest(ctx, types.RequestState_APPROVED, args); err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText("Approved with success"), nil
+}
+
+// Deny denies an access request.
+func (a *AccessRequestsServer) Deny(ctx context.Context, _ mcp.CallToolRequest, args AccessRequestReviewArgs) (*mcp.CallToolResult, error) {
+	if err := a.reviewRequest(ctx, types.RequestState_DENIED, args); err != nil {
+		return a.formatError(trace.Wrap(err))
+	}
+
+	return mcp.NewToolResultText("Denied with success"), nil
+}
+
+func (a *AccessRequestsServer) reviewRequest(ctx context.Context, propsedState types.RequestState, args AccessRequestReviewArgs) error {
+	parsedURI, err := clientmcp.ParseResourceURI(args.AccessRequestURI)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !parsedURI.IsAccessRequest() {
+		return trace.BadParameter("must provide a valid access request resource URI")
+	}
+
+	_, err = a.config.Client.SubmitAccessReview(ctx, types.AccessReviewSubmission{
+		RequestID: parsedURI.GetAccessRequestID(),
+		Review: types.AccessReview{
+			Author:        a.config.Username,
+			ProposedState: propsedState,
+			Reason:        args.Reason,
+			// TODO(gabrielcorado): support AssumeStartTime
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (a *AccessRequestsServer) buildAccessRequestResource(req types.AccessRequest) AccessRequestResource {
+	var resources []AccessRequestResourceItem
+	for _, res := range req.GetRequestedResourceIDs() {
+		resources = append(resources, AccessRequestResourceItem{
+			Kind: res.Kind,
+			Name: res.Name,
+		})
+	}
+
+	return AccessRequestResource{
+		Metadata:      req.GetMetadata(),
+		URI:           clientmcp.NewAccessRequestResourceURI(a.config.ClusterName, req.GetName()).String(),
+		ClusterName:   a.config.ClusterName,
+		State:         types.RequestState_name[int32(req.GetState())],
+		Requester:     req.GetUser(),
+		RequestReason: req.GetRequestReason(),
+		ResolveReason: req.GetResolveReason(),
+		Roles:         req.GetRoles(),
+		Resources:     resources,
+	}
+}
+
+func (a *AccessRequestsServer) formatError(err error) (*mcp.CallToolResult, error) {
+	message := err.Error()
+	if clientmcp.IsSessionExpiredError(err) {
+		message = clientmcp.ReloginRequiredErrorMessage
+	}
+
+	return mcp.NewToolResultError(message), nil
+}

--- a/lib/client/mcp/platform/access_requests_test.go
+++ b/lib/client/mcp/platform/access_requests_test.go
@@ -1,0 +1,628 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package platform
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gravitational/trace"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/types"
+	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/mcptest"
+)
+
+func TestAccessRequesterServer(t *testing.T) {
+	t.Run("Tools", func(t *testing.T) {
+		clt := setupPlatformMCPClient(t, PlatformServerConfig{
+			Client:                       &mockPlatformClient{},
+			Username:                     "alice",
+			ClusterName:                  "root",
+			AccessRequesterServerEnabled: true,
+		})
+
+		// Expect only requester tools to be available.
+		expectMCPTools(t, clt, []string{
+			listRequestableRoles.GetName(),
+			listUserAccessRequestsTool.GetName(),
+			createAccessRequestTool.GetName(),
+		})
+	})
+
+	t.Run("ListRequestableRoles", func(t *testing.T) {
+		requestableRoles := []string{"read", "other", "everything"}
+		clt := setupPlatformMCPClient(t, PlatformServerConfig{
+			Client: &mockPlatformClient{
+				getAccessCapabilitiesResponse: &types.AccessCapabilities{
+					RequestableRoles: requestableRoles,
+				},
+			},
+			Username:                     "alice",
+			ClusterName:                  "root",
+			AccessRequesterServerEnabled: true,
+		})
+
+		res, err := clt.CallTool(t.Context(), mcp.CallToolRequest{Params: mcp.CallToolParams{Name: listRequestableRoles.GetName()}})
+		require.NoError(t, err)
+		require.False(t, res.IsError)
+
+		var l ListUserRequestableRolesResponse
+		require.NoError(t, utils.FastUnmarshal([]byte(toolCallResultText(t, res)), &l))
+		require.ElementsMatch(t, requestableRoles, l.Roles)
+	})
+
+	t.Run("ListUserAccessRequests", func(t *testing.T) {
+		// RawListArgs is a simplified structure that contains all values as
+		// primitive types acting like a regular MCP client building the tool
+		// arguments. We use this to avoid any pre-validation from our Golang
+		// definition like.
+		type RawListArgs struct {
+			State string `json:"state"`
+		}
+
+		for name, tc := range map[string]struct {
+			platformClient      PlatformAPIClient
+			accessRequestState  string
+			expectError         bool
+			expectedRequestsIDs []string
+		}{
+			"pending access requests": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsResponse: []types.AccessRequest{
+						&types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+						&types.AccessRequestV3{Metadata: types.Metadata{Name: "req-2"}},
+						&types.AccessRequestV3{Metadata: types.Metadata{Name: "req-3"}},
+					},
+				},
+				accessRequestState:  "PENDING",
+				expectedRequestsIDs: []string{"req-1", "req-2", "req-3"},
+			},
+			"wrong access requests state": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsResponse: []types.AccessRequest{
+						&types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+					},
+				},
+				accessRequestState: "RANDOM",
+				expectError:        true,
+			},
+			"empty": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsResponse: []types.AccessRequest{},
+				},
+				accessRequestState:  "PENDING",
+				expectedRequestsIDs: []string{},
+			},
+			"get error": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsErr: trace.AccessDenied("unabled to retrieve requests"),
+				},
+				accessRequestState: "PENDING",
+				expectError:        true,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				clt := setupPlatformMCPClient(t, PlatformServerConfig{
+					Client:                       tc.platformClient,
+					Username:                     "alice",
+					ClusterName:                  "root",
+					AccessRequesterServerEnabled: true,
+				})
+
+				res, err := clt.CallTool(t.Context(), mcp.CallToolRequest{Params: mcp.CallToolParams{
+					Name:      listUserAccessRequestsTool.GetName(),
+					Arguments: RawListArgs{State: tc.accessRequestState},
+				}})
+				require.NoError(t, err)
+				require.Equal(t, tc.expectError, res.IsError)
+				if tc.expectError {
+					return
+				}
+
+				var l ListUserRequestsResponse
+				require.NoError(t, utils.FastUnmarshal([]byte(toolCallResultText(t, res)), &l))
+
+				currentIDs := make([]string, len(l.Requests))
+				for i, req := range l.Requests {
+					uri, err := clientmcp.ParseResourceURI(req.URI)
+					require.NoError(t, err, "expected %q to be a MCP resource URI", req.URI)
+					currentIDs[i] = uri.GetAccessRequestID()
+				}
+				require.ElementsMatch(t, tc.expectedRequestsIDs, currentIDs)
+			})
+		}
+	})
+
+	t.Run("CreateAccessRequest", func(t *testing.T) {
+		// RawCreateArgs is a simplified structure that contains all values as
+		// primitive types acting like a regular MCP client building the tool
+		// arguments. We use this to avoid any pre-validation from our Golang
+		// definition like types.Duration parsing.
+		type RawCreateArgs struct {
+			Roles      []string `json:"roles"`
+			RequestTTL string   `json:"request_ttl"`
+			SessionTTL string   `json:"session_ttl"`
+			Reason     string   `json:"reason"`
+		}
+
+		for name, tc := range map[string]struct {
+			platformClient    PlatformAPIClient
+			createArgs        any
+			expectError       bool
+			expectedRequestID string
+		}{
+			"success": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "10m",
+					SessionTTL: "10m",
+					Reason:     "Requesting access...",
+				},
+				expectedRequestID: "req-1",
+			},
+			"malformatted request_ttl": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "xxx",
+					SessionTTL: "10m",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+			"malformatted session_ttl": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "10m",
+					SessionTTL: "xxx",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+			"zero request_ttl": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "0s",
+					SessionTTL: "10m",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+			"zero session_ttl": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "10m",
+					SessionTTL: "0s",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+			"empty requested roles": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{},
+					RequestTTL: "10m",
+					SessionTTL: "10m",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+			"empty args": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestResponse: &types.AccessRequestV3{Metadata: types.Metadata{Name: "req-1"}},
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{""},
+					RequestTTL: "",
+					SessionTTL: "",
+					Reason:     "",
+				},
+				expectError: true,
+			},
+			"create error": {
+				platformClient: &mockPlatformClient{
+					createAccessRequestErr: trace.AccessDenied("failed to create access request"),
+				},
+				createArgs: RawCreateArgs{
+					Roles:      []string{"role-1"},
+					RequestTTL: "10m",
+					SessionTTL: "10m",
+					Reason:     "Requesting access...",
+				},
+				expectError: true,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				clt := setupPlatformMCPClient(t, PlatformServerConfig{
+					Client:                       tc.platformClient,
+					Username:                     "alice",
+					ClusterName:                  "root",
+					AccessRequesterServerEnabled: true,
+				})
+
+				res, err := clt.CallTool(t.Context(), mcp.CallToolRequest{Params: mcp.CallToolParams{
+					Name:      createAccessRequestTool.GetName(),
+					Arguments: tc.createArgs,
+				}})
+				require.NoError(t, err)
+				txt := toolCallResultText(t, res)
+				require.Equal(t, tc.expectError, res.IsError, txt)
+				if tc.expectError {
+					return
+				}
+
+				var l AccessRequestsCreateResponse
+				require.NoError(t, utils.FastUnmarshal([]byte(txt), &l))
+				uri, err := clientmcp.ParseResourceURI(l.Request.URI)
+				require.NoError(t, err, "expected %q to be a MCP resource URI", l.Request.URI)
+				require.Equal(t, tc.expectedRequestID, uri.GetAccessRequestID())
+			})
+		}
+	})
+}
+
+func TestAccessRequestsReviewerServer(t *testing.T) {
+	t.Run("Tools", func(t *testing.T) {
+		clt := setupPlatformMCPClient(t, PlatformServerConfig{
+			Client:                             &mockPlatformClient{},
+			Username:                           "alice",
+			ClusterName:                        "root",
+			AccessRequestsReviwerServerEnabled: true,
+		})
+
+		// Expect only requester tools to be available.
+		expectMCPTools(t, clt, []string{
+			listRequestsToBeReviewedTool.GetName(),
+			approveAccessRequestTool.GetName(),
+			denyAccessRequestTool.GetName(),
+		})
+	})
+
+	t.Run("ListRequestsToBeReviwed", func(t *testing.T) {
+		user := "alice"
+		for name, tc := range map[string]struct {
+			platformClient      PlatformAPIClient
+			expectError         bool
+			expectedRequestsIDs []string
+		}{
+			"reviwable requests": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsResponse: []types.AccessRequest{
+						// Other user requested and not reviews yet, should be included.
+						&types.AccessRequestV3{
+							Metadata: types.Metadata{Name: "req-1"},
+							Spec:     types.AccessRequestSpecV3{User: "bob"},
+						},
+						// User is the requester, shouldn't be included.
+						&types.AccessRequestV3{
+							Metadata: types.Metadata{Name: "req-2"},
+							Spec:     types.AccessRequestSpecV3{User: user},
+						},
+						// Other user requested, and user didn't review yet, should be included.
+						&types.AccessRequestV3{
+							Metadata: types.Metadata{Name: "req-3"},
+							Spec: types.AccessRequestSpecV3{
+								User: "bob",
+								Reviews: []types.AccessReview{
+									{Author: "jeff"},
+								},
+							},
+						},
+						// Other user requested, and user already reviewed it, shouldn't be included.
+						&types.AccessRequestV3{
+							Metadata: types.Metadata{Name: "req-4"},
+							Spec: types.AccessRequestSpecV3{
+								User: "bob",
+								Reviews: []types.AccessReview{
+									{Author: user},
+								},
+							},
+						},
+					},
+				},
+				expectedRequestsIDs: []string{"req-1", "req-3"},
+			},
+			"empty": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsResponse: []types.AccessRequest{},
+				},
+				expectedRequestsIDs: []string{},
+			},
+			"get error": {
+				platformClient: &mockPlatformClient{
+					getAccessRequestsErr: trace.AccessDenied("unabled to retrieve requests"),
+				},
+				expectError: true,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				clt := setupPlatformMCPClient(t, PlatformServerConfig{
+					Client:                             tc.platformClient,
+					Username:                           user,
+					ClusterName:                        "root",
+					AccessRequestsReviwerServerEnabled: true,
+				})
+
+				res, err := clt.CallTool(t.Context(), mcp.CallToolRequest{Params: mcp.CallToolParams{Name: listRequestsToBeReviewedTool.GetName()}})
+				require.NoError(t, err)
+				require.Equal(t, tc.expectError, res.IsError)
+				if tc.expectError {
+					return
+				}
+
+				var l ListRequestsToBeReviewedResponse
+				require.NoError(t, utils.FastUnmarshal([]byte(toolCallResultText(t, res)), &l))
+
+				currentIDs := make([]string, len(l.Requests))
+				for i, req := range l.Requests {
+					uri, err := clientmcp.ParseResourceURI(req.URI)
+					require.NoError(t, err, "expected %q to be a MCP resource URI", req.URI)
+					currentIDs[i] = uri.GetAccessRequestID()
+				}
+				require.ElementsMatch(t, tc.expectedRequestsIDs, currentIDs)
+			})
+		}
+	})
+
+	// RawReviewArgs is a simplified structure that contains all values as
+	// primitive types acting like a regular MCP client building the tool
+	// arguments. We use this to avoid any pre-validation from our Golang
+	// definition.
+	type RawReviewArgs struct {
+		URI    string `json:"access_request_uri"`
+		Reason string `json:"reason"`
+	}
+
+	t.Run("Review", func(t *testing.T) {
+		clusterName := "root"
+
+		for name, tc := range map[string]struct {
+			platformClient PlatformAPIClient
+			reviewArgs     RawReviewArgs
+			expectError    bool
+		}{
+			"success": {
+				platformClient: &mockPlatformClient{
+					submitAccessReviewResponse: &types.AccessRequestV3{},
+				},
+				reviewArgs: RawReviewArgs{
+					URI:    clientmcp.NewAccessRequestResourceURI(clusterName, "req-1").String(),
+					Reason: "Hello",
+				},
+			},
+			"error": {
+				platformClient: &mockPlatformClient{
+					submitAccessReviewErr: trace.AccessDenied("failed to submit review"),
+				},
+				reviewArgs: RawReviewArgs{
+					URI:    clientmcp.NewAccessRequestResourceURI(clusterName, "req-1").String(),
+					Reason: "Hello",
+				},
+				expectError: true,
+			},
+			"malformed URI": {
+				platformClient: &mockPlatformClient{
+					submitAccessReviewResponse: &types.AccessRequestV3{},
+				},
+				reviewArgs: RawReviewArgs{
+					URI:    "xxx",
+					Reason: "Hello",
+				},
+				expectError: true,
+			},
+			"wrong resource URI": {
+				platformClient: &mockPlatformClient{
+					submitAccessReviewResponse: &types.AccessRequestV3{},
+				},
+				reviewArgs: RawReviewArgs{
+					URI:    clientmcp.NewDatabaseResourceURI(clusterName, "db-1").String(),
+					Reason: "Hello",
+				},
+				expectError: true,
+			},
+		} {
+			for _, toolName := range []string{approveAccessRequestTool.GetName(), denyAccessRequestTool.GetName()} {
+				t.Run(toolName+"_"+name, func(t *testing.T) {
+					clt := setupPlatformMCPClient(t, PlatformServerConfig{
+						Client:                             tc.platformClient,
+						Username:                           "alice",
+						ClusterName:                        clusterName,
+						AccessRequestsReviwerServerEnabled: true,
+					})
+
+					res, err := clt.CallTool(t.Context(), mcp.CallToolRequest{Params: mcp.CallToolParams{
+						Name:      toolName,
+						Arguments: tc.reviewArgs,
+					}})
+					require.NoError(t, err)
+					txt := toolCallResultText(t, res)
+					require.Equal(t, tc.expectError, res.IsError, txt)
+					if tc.expectError {
+						return
+					}
+				})
+			}
+		}
+	})
+}
+
+func TestFormatAccessRequestResource(t *testing.T) {
+	user := "alice"
+	clusterName := "root"
+	rootSrv, err := NewPlaformServer(PlatformServerConfig{
+		Client:      &mockPlatformClient{},
+		Username:    user,
+		ClusterName: clusterName,
+	})
+	require.NoError(t, err)
+	srv := NewAccessRequestsServer(rootSrv)
+
+	req, err := types.NewAccessRequest("req-1", user, "role-1", "role-2")
+	require.NoError(t, err)
+	req.SetState(types.RequestState_APPROVED)
+
+	resource := srv.buildAccessRequestResource(req)
+	require.Equal(t, clusterName, resource.ClusterName)
+	require.Equal(t, "APPROVED", resource.State)
+
+	uri, err := clientmcp.ParseResourceURI(resource.URI)
+	require.NoError(t, err)
+	require.True(t, uri.IsAccessRequest())
+	require.Equal(t, req.GetName(), uri.GetAccessRequestID())
+	require.Equal(t, clusterName, uri.GetClusterName())
+}
+
+func TestAccessRequestErrors(t *testing.T) {
+	rootSrv, err := NewPlaformServer(PlatformServerConfig{
+		Client:      &mockPlatformClient{},
+		Username:    "alice",
+		ClusterName: "root",
+	})
+	require.NoError(t, err)
+
+	srv := NewAccessRequestsServer(rootSrv)
+	for name, tc := range map[string]struct {
+		err             error
+		expectedMessage string
+	}{
+		"expired session error": {
+			err:             apiclient.ErrClientCredentialsHaveExpired,
+			expectedMessage: clientmcp.ReloginRequiredErrorMessage,
+		},
+		"API errors": {
+			err:             trace.AccessDenied("failed to fetch access requests"),
+			expectedMessage: "failed to fetch access requests",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res, err := srv.formatError(tc.err)
+			require.NoError(t, err)
+			require.True(t, res.IsError)
+
+			require.Len(t, res.Content, 1)
+			content := res.Content[0]
+			require.IsType(t, mcp.TextContent{}, content)
+			require.Contains(t, content.(mcp.TextContent).Text, tc.expectedMessage)
+		})
+	}
+}
+
+// setupPlatformMCPClient starts serving the platform MCP server and initializes
+// the MCP client.
+func setupPlatformMCPClient(t *testing.T, cfg PlatformServerConfig) *mcpclient.Client {
+	clientIn, serverOut := io.Pipe()
+	serverIn, clientOut := io.Pipe()
+	t.Cleanup(func() {
+		require.NoError(t, trace.NewAggregate(
+			clientIn.Close(), serverOut.Close(),
+			serverIn.Close(), clientOut.Close(),
+		))
+	})
+
+	srv, err := NewPlaformServer(cfg)
+	require.NoError(t, err)
+
+	go func() {
+		_ = srv.ServeStdio(t.Context(), serverIn, serverOut)
+	}()
+
+	clt := mcptest.NewStdioClient(t, clientIn, clientOut)
+	_, err = mcptest.InitializeClient(t.Context(), clt)
+	require.NoError(t, err)
+
+	return clt
+}
+
+func expectMCPTools(t *testing.T, clt *mcpclient.Client, expectedTools []string) {
+	toolsResp, err := clt.ListTools(t.Context(), mcp.ListToolsRequest{})
+	require.NoError(t, err)
+
+	tools := make([]string, len(toolsResp.Tools))
+	for i, tool := range toolsResp.Tools {
+		tools[i] = tool.GetName()
+	}
+
+	require.ElementsMatch(t, expectedTools, tools)
+}
+
+// toolCallResultText extracts the text result from a tool call, assuming the
+// tool returns a single text result.
+func toolCallResultText(t *testing.T, res *mcp.CallToolResult) string {
+	require.Len(t, res.Content, 1)
+	content := res.Content[0]
+	require.IsType(t, mcp.TextContent{}, content)
+	return content.(mcp.TextContent).Text
+}
+
+type mockPlatformClient struct {
+	createAccessRequestErr      error
+	createAccessRequestResponse types.AccessRequest
+
+	getAccessCapabilitiesResponse *types.AccessCapabilities
+	getAccessCapabilitiesErr      error
+
+	getAccessRequestsResponse []types.AccessRequest
+	getAccessRequestsErr      error
+
+	submitAccessReviewResponse types.AccessRequest
+	submitAccessReviewErr      error
+}
+
+// CreateAccessRequestV2 implements PlatformAPIClient.
+func (m *mockPlatformClient) CreateAccessRequestV2(ctx context.Context, req types.AccessRequest) (types.AccessRequest, error) {
+	return m.createAccessRequestResponse, m.createAccessRequestErr
+}
+
+// GetAccessCapabilities implements PlatformAPIClient.
+func (m *mockPlatformClient) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
+	return m.getAccessCapabilitiesResponse, m.getAccessCapabilitiesErr
+}
+
+// GetAccessRequests implements PlatformAPIClient.
+func (m *mockPlatformClient) GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error) {
+	return m.getAccessRequestsResponse, m.getAccessRequestsErr
+}
+
+// SubmitAccessReview implements PlatformAPIClient.
+func (m *mockPlatformClient) SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error) {
+	return m.submitAccessReviewResponse, m.submitAccessReviewErr
+}
+
+var _ PlatformAPIClient = (*mockPlatformClient)(nil)

--- a/lib/client/mcp/platform/platform.go
+++ b/lib/client/mcp/platform/platform.go
@@ -1,0 +1,125 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package platform
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
+
+	"github.com/gravitational/trace"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// PlatformAPIClient defines the API client used by platform MCP servers.
+type PlatformAPIClient interface {
+	// GetAccessRequests retrieves a list of all access requests matching the provided filter.
+	GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error)
+	// CreateAccessRequestV2 registers a new access request with the auth server.
+	CreateAccessRequestV2(ctx context.Context, req types.AccessRequest) (types.AccessRequest, error)
+	// SubmitAccessReview applies a review to a request and returns the post-application state.
+	SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error)
+	// GetAccessCapabilities requests the access capabilities of a user.
+	GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error)
+}
+
+// PlatformServerConfig is the general platform MCPs configuration.
+type PlatformServerConfig struct {
+	// Logger is the slog logger.
+	Logger *slog.Logger
+	// Client is the Teleport API client.
+	Client PlatformAPIClient
+	// Username is the current user username.
+	Username string
+	// ClusterName is the current cluster name.
+	ClusterName string
+	// AccessRequesterServerEnabled defines if the access requester is enabled.
+	AccessRequesterServerEnabled bool
+	// AccessRequestsReviwerServerEnabled defines if the access requests reviwer
+	// is enabled.
+	AccessRequestsReviwerServerEnabled bool
+}
+
+// CheckAndSetDefaults checks and set defaults.
+func (c *PlatformServerConfig) CheckAndSetDefaults() error {
+	if c.Logger == nil {
+		c.Logger = slog.Default()
+	}
+	if c.Client == nil {
+		return trace.BadParameter("API client is required")
+	}
+	if c.Username == "" {
+		return trace.BadParameter("username is required")
+	}
+	if c.ClusterName == "" {
+		return trace.BadParameter("cluster name is required")
+	}
+	return nil
+}
+
+// Server defines a platform MCP server.
+type Server interface {
+	// Close closes the MCP server, cleaning up resources.
+	Close() error
+}
+
+// PlatformServer is the MCP server for platform resources/tools.
+//
+// This server serves as a root/base server where other servers register their
+// tools and resources.
+type PlatformServer struct {
+	*mcpserver.MCPServer
+	config  PlatformServerConfig
+	servers []Server
+}
+
+// NewPlaformServer initializes the platform MCP server.
+func NewPlaformServer(config PlatformServerConfig) (*PlatformServer, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv := &PlatformServer{
+		// TODO apply naming convetion here
+		MCPServer: mcpserver.NewMCPServer(clientmcp.ServerName("platform"), teleport.Version),
+		config:    config,
+	}
+
+	if config.AccessRequesterServerEnabled || config.AccessRequestsReviwerServerEnabled {
+		srv.servers = append(srv.servers, NewAccessRequestsServer(srv))
+	}
+
+	return srv, nil
+}
+
+// ServeStdio starts serving the MCP server using STDIO transport.
+func (p *PlatformServer) ServeStdio(ctx context.Context, in io.Reader, out io.Writer) error {
+	return trace.Wrap(mcpserver.NewStdioServer(p.MCPServer).Listen(ctx, in, out))
+}
+
+// Close closes all running MCP servers.
+func (p *PlatformServer) Close() error {
+	var errs []error
+	for _, srv := range p.servers {
+		errs = append(errs, srv.Close())
+	}
+	return trace.NewAggregate(errs...)
+}

--- a/lib/client/mcp/uri.go
+++ b/lib/client/mcp/uri.go
@@ -29,6 +29,9 @@ var (
 	clusterURITemplate = urlpath.New("/clusters/:cluster/*")
 	// databaseURITemplate template used to parse database resource URIs.
 	databaseURITemplate = urlpath.New("/clusters/:cluster/databases/:dbName")
+	// accessRequestURITemplate templated used to parse access request resource
+	// URIs.
+	accessRequestURITemplate = urlpath.New("/clusters/:cluster/access-requests/:accessRequestID")
 )
 
 const (
@@ -126,6 +129,23 @@ func NewDatabaseResourceURI(cluster string, databaseName string, opts ...databas
 	}
 }
 
+// NewAccessRequestResourceURI creates a new access request resource URI.
+func NewAccessRequestResourceURI(cluster string, id string) ResourceURI {
+	pathWithHost, _ := accessRequestURITemplate.Build(urlpath.Match{
+		Params: map[string]string{
+			"cluster":         cluster,
+			"accessRequestID": id,
+		},
+	})
+
+	return ResourceURI{
+		url: url.URL{
+			Scheme: resourceScheme,
+			Path:   strings.TrimPrefix(pathWithHost, "/"),
+		},
+	}
+}
+
 // GetDatabaseServiceName returns the Teleport cluster name.
 func (u ResourceURI) GetClusterName() string {
 	if match, ok := clusterURITemplate.Match(u.path()); ok {
@@ -157,9 +177,24 @@ func (u ResourceURI) GetDatabaseName() string {
 	return u.url.Query().Get(databaseNameQueryParamName)
 }
 
+// GetAccessRequestID returns the access request ID param of the resource.
+// Returns empty if the resource is not an access request.
+func (u ResourceURI) GetAccessRequestID() string {
+	if match, ok := accessRequestURITemplate.Match(u.path()); ok {
+		return match.Params["accessRequestID"]
+	}
+
+	return ""
+}
+
 // IsDatabase returns true if the resource is a database.
 func (u ResourceURI) IsDatabase() bool {
 	return u.GetDatabaseServiceName() != ""
+}
+
+// IsAccessRequest returns true if the resource is an access request.
+func (u ResourceURI) IsAccessRequest() bool {
+	return u.GetAccessRequestID() != ""
 }
 
 // String returns the string representation of the resource URI.

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -36,11 +36,14 @@ type mcpCommands struct {
 	config  *mcpConfigCommand
 	list    *mcpListCommand
 	connect *mcpConnectCommand
+
+	platformStart *mcpPlatformStartCommand
 }
 
 func newMCPCommands(app *kingpin.Application, cf *CLIConf) *mcpCommands {
 	mcp := app.Command("mcp", "View and control proxied MCP servers.")
 	db := mcp.Command("db", "Database access for MCP servers.")
+	platform := mcp.Command("platform", "MCP servers for Teleport APIs")
 	return &mcpCommands{
 		dbStart:  newMCPDBCommand(db, cf),
 		dbConfig: newMCPDBconfigCommand(db, cf),
@@ -48,6 +51,8 @@ func newMCPCommands(app *kingpin.Application, cf *CLIConf) *mcpCommands {
 		list:    newMCPListCommand(mcp, cf),
 		config:  newMCPConfigCommand(mcp, cf),
 		connect: newMCPConnectCommand(mcp, cf),
+
+		platformStart: newMCPPlatformStartCommand(platform, cf),
 	}
 }
 

--- a/tool/tsh/common/mcp_platform.go
+++ b/tool/tsh/common/mcp_platform.go
@@ -1,0 +1,80 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"github.com/gravitational/teleport/lib/client/mcp/platform"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+// mcpDBStartCommand implements `tsh mcp platform start` command.
+type mcpPlatformStartCommand struct {
+	*kingpin.CmdClause
+
+	cf                           *CLIConf
+	accessRequesterEnabled       bool
+	accessRequestReviewerEnabled bool
+}
+
+func newMCPPlatformStartCommand(parent *kingpin.CmdClause, cf *CLIConf) *mcpPlatformStartCommand {
+	cmd := &mcpPlatformStartCommand{
+		CmdClause: parent.Command("start", "Start a local MCP server for Teleport APIs."),
+		cf:        cf,
+	}
+
+	cmd.Flag("access-requester", "Enables tools and resources used to request access to resources.").BoolVar(&cmd.accessRequesterEnabled)
+	cmd.Flag("access-requests-reviewer", "Enables tools and resources used to review access requests.").BoolVar(&cmd.accessRequestReviewerEnabled)
+	return cmd
+}
+
+func (c *mcpPlatformStartCommand) run() error {
+	logger, err := initLogger(c.cf, utils.LoggingForMCP, getLoggingOptsForMCPServer(c.cf))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	tc, err := makeClient(c.cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Avoid any input request on the command execution. This is required,
+	// otherwise the MCP clients will be stuck waiting for a response.
+	tc.NonInteractive = false
+
+	clt, err := tc.ConnectToCluster(c.cf.Context)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	srv, err := platform.NewPlaformServer(platform.PlatformServerConfig{
+		Logger:                             logger,
+		Client:                             clt.AuthClient,
+		Username:                           tc.Username,
+		ClusterName:                        tc.SiteName,
+		AccessRequesterServerEnabled:       c.accessRequesterEnabled,
+		AccessRequestsReviwerServerEnabled: c.accessRequestReviewerEnabled,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(srv.ServeStdio(c.cf.Context, c.cf.Stdin(), c.cf.Stdout()))
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1816,6 +1816,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = mcpCmd.list.run()
 	case mcpCmd.config.FullCommand():
 		err = mcpCmd.config.run()
+	case mcpCmd.platformStart.FullCommand():
+		err = mcpCmd.platformStart.run()
 	default:
 		// Handle commands that might not be available.
 		switch {


### PR DESCRIPTION
This PR introduces a new command for Teleport-related MCP servers (`tsh mcp platform start`), and adds MCP tools for requesting and reviewing access requests. The access requests are now limited only to roles. Requesting access to resources will be added later.

Both sets of tools work independently, and users to choose whether they want by setting flags on the start command:
- `tsh mcp platform start --access-requester`: Only tools for requesting access will be available.
- `tsh mcp platform start --access-requests-reviewer`: Only tools for reviewing access requests will be available.
- Both flags can be used on the same start command.

Note: For now, no tools are available for assuming the approved access requests. This will be done in a separate PR. The same goes for config commands.

<details>
<summary>Claude desktop config example</summary>

```json
{
  "mcpServers": {
    "teleport-access-requests": {
      "command": "tsh",
      "args": [
        "mcp",
        "platform",
        "start",
        "--access-requester",
        "--access-requests-reviewer"
      ]
    }
  }
}
```
</details>

<details>
<summary>Demo requesting access</summary>


https://github.com/user-attachments/assets/569dfd98-9697-4689-8798-60d692744aec
</details>

<details>
<summary>Demo reviewing requests</summary>


https://github.com/user-attachments/assets/74003f58-2357-4850-9f33-040a0a302ab9
</details>