### PR TITLE
Add Support For Plugin Object in Teleport Cache

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -375,6 +375,11 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 		out.Resource = &proto.Event_PluginStaticCredentials{
 			PluginStaticCredentials: r,
 		}
+	case *types.PluginV1:
+		out.Resource = &proto.Event_Plugin{
+			Plugin: r,
+		}
+
 	default:
 		return nil, trace.BadParameter("resource type %T is not supported", in.Resource)
 	}
@@ -667,6 +672,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		return &out, nil
 	} else if r := in.GetRecordingEncryption(); r != nil {
 		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetPlugin(); r != nil {
+		out.Resource = r
 		return &out, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", in.Resource)

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -198,6 +198,7 @@ type Event struct {
 	//	*Event_ScopedRoleAssignment
 	//	*Event_RelayServer
 	//	*Event_RecordingEncryption
+	//	*Event_Plugin
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -949,6 +950,15 @@ func (x *Event) GetRecordingEncryption() *v119.RecordingEncryption {
 	return nil
 }
 
+func (x *Event) GetPlugin() *types.PluginV1 {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_Plugin); ok {
+			return x.Plugin
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1348,6 +1358,11 @@ type Event_RecordingEncryption struct {
 	RecordingEncryption *v119.RecordingEncryption `protobuf:"bytes,83,opt,name=RecordingEncryption,proto3,oneof"`
 }
 
+type Event_Plugin struct {
+	// PluginV1 is a resource for Teleport plugins.
+	Plugin *types.PluginV1 `protobuf:"bytes,84,opt,name=plugin,proto3,oneof"`
+}
+
 func (*Event_ResourceHeader) isEvent_Resource() {}
 
 func (*Event_CertAuthority) isEvent_Resource() {}
@@ -1504,11 +1519,13 @@ func (*Event_RelayServer) isEvent_Resource() {}
 
 func (*Event_RecordingEncryption) isEvent_Resource() {}
 
+func (*Event_Plugin) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xbf/\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xea/\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1601,7 +1618,8 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"ScopedRole\x12e\n" +
 	"\x14ScopedRoleAssignment\x18Q \x01(\v2/.teleport.scopes.access.v1.ScopedRoleAssignmentH\x00R\x14ScopedRoleAssignment\x12F\n" +
 	"\frelay_server\x18R \x01(\v2!.teleport.presence.v1.RelayServerH\x00R\vrelayServer\x12h\n" +
-	"\x13RecordingEncryption\x18S \x01(\v24.teleport.recordingencryption.v1.RecordingEncryptionH\x00R\x13RecordingEncryptionB\n" +
+	"\x13RecordingEncryption\x18S \x01(\v24.teleport.recordingencryption.v1.RecordingEncryptionH\x00R\x13RecordingEncryption\x12)\n" +
+	"\x06plugin\x18T \x01(\v2\x0f.types.PluginV1H\x00R\x06pluginB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1702,6 +1720,7 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v117.ScopedRoleAssignment)(nil),           // 74: teleport.scopes.access.v1.ScopedRoleAssignment
 	(*v118.RelayServer)(nil),                    // 75: teleport.presence.v1.RelayServer
 	(*v119.RecordingEncryption)(nil),            // 76: teleport.recordingencryption.v1.RecordingEncryption
+	(*types.PluginV1)(nil),                      // 77: types.PluginV1
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1783,11 +1802,12 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	74, // 76: proto.Event.ScopedRoleAssignment:type_name -> teleport.scopes.access.v1.ScopedRoleAssignment
 	75, // 77: proto.Event.relay_server:type_name -> teleport.presence.v1.RelayServer
 	76, // 78: proto.Event.RecordingEncryption:type_name -> teleport.recordingencryption.v1.RecordingEncryption
-	79, // [79:79] is the sub-list for method output_type
-	79, // [79:79] is the sub-list for method input_type
-	79, // [79:79] is the sub-list for extension type_name
-	79, // [79:79] is the sub-list for extension extendee
-	0,  // [0:79] is the sub-list for field type_name
+	77, // 79: proto.Event.plugin:type_name -> types.PluginV1
+	80, // [80:80] is the sub-list for method output_type
+	80, // [80:80] is the sub-list for method input_type
+	80, // [80:80] is the sub-list for extension type_name
+	80, // [80:80] is the sub-list for extension extendee
+	0,  // [0:80] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -1874,6 +1894,7 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_ScopedRoleAssignment)(nil),
 		(*Event_RelayServer)(nil),
 		(*Event_RecordingEncryption)(nil),
+		(*Event_Plugin)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -230,5 +230,7 @@ message Event {
     teleport.presence.v1.RelayServer relay_server = 82;
     // RecordingEncryption is a resource for controlling session recording encryption.
     teleport.recordingencryption.v1.RecordingEncryption RecordingEncryption = 83;
+    // PluginV1 is a resource for Teleport plugins.
+    types.PluginV1 plugin = 84;
   }
 }

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -120,6 +120,7 @@ type Plugin interface {
 	SetCredentials(PluginCredentials) error
 	SetStatus(PluginStatus) error
 	GetGeneration() string
+	CloneWithoutSecrets() Plugin
 }
 
 // PluginCredentials are the credentials embedded in Plugin
@@ -418,7 +419,8 @@ func (p *PluginV1) CheckAndSetDefaults() error {
 	return nil
 }
 
-// WithoutSecrets returns an instance of resource without secrets.
+// WithoutSecrets returns the Plugin as a Resource, with secrets removed.
+// If you want to have a copy of the Plugin without secrets use CloneWithoutSecrets instead.
 func (p *PluginV1) WithoutSecrets() Resource {
 	if p.Credentials == nil {
 		return p
@@ -427,6 +429,15 @@ func (p *PluginV1) WithoutSecrets() Resource {
 	p2 := p.Clone().(*PluginV1)
 	p2.SetCredentials(nil)
 	return p2
+}
+
+// CloneWithoutSecrets returns a deep copy of the Plugin instance with secrets removed.
+// Use this when you need a separate Plugin object without secrets,
+// rather than a Resource interface value as returned by WithoutSecrets.
+func (p *PluginV1) CloneWithoutSecrets() Plugin {
+	out := p.Clone().(*PluginV1)
+	out.SetCredentials(nil)
+	return out
 }
 
 func (p *PluginV1) setStaticFields() {

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -113,6 +113,7 @@ type Config struct {
 	GitServers              services.GitServers
 	HealthCheckConfig       services.HealthCheckConfigReader
 	RecordingEncryption     services.RecordingEncryption
+	Plugin                  services.Plugins
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -198,6 +199,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		HealthCheckConfig:       cfg.HealthCheckConfig,
 		BotInstanceService:      cfg.BotInstance,
 		RecordingEncryption:     cfg.RecordingEncryption,
+		Plugin:                  cfg.Plugin,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -554,6 +554,7 @@ func InitTestAuthCache(p TestAuthCacheParams) error {
 		HealthCheckConfig:       p.AuthServer.Services.HealthCheckConfig,
 		BotInstance:             p.AuthServer.Services.BotInstance,
 		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
+		Plugin:                  p.AuthServer.Services.Plugins,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -206,6 +206,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindIdentityCenterAccount},
 		{Kind: types.KindIdentityCenterPrincipalAssignment},
 		{Kind: types.KindIdentityCenterAccountAssignment},
+		{Kind: types.KindPlugin, LoadSecrets: true},
 		{Kind: types.KindPluginStaticCredentials},
 		{Kind: types.KindGitServer},
 		{Kind: types.KindWorkloadIdentity},
@@ -751,6 +752,8 @@ type Config struct {
 	BotInstanceService services.BotInstance
 	// RecordingEncryption manages state surrounding session recording encryption
 	RecordingEncryption services.RecordingEncryption
+	// Plugins is the plugin service used to retrieve plugin information.
+	Plugin services.Plugins
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -142,6 +142,7 @@ type collections struct {
 	relayServers                       *collection[*presencev1.RelayServer, relayServerIndex]
 	botInstances                       *collection[*machineidv1.BotInstance, botInstanceIndex]
 	recordingEncryption                *collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]
+	plugins                            *collection[types.Plugin, pluginIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in
@@ -750,6 +751,13 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.recordingEncryption = collect
 			out.byKind[resourceKind] = out.recordingEncryption
+		case types.KindPlugin:
+			collect, err := newPluginsCollection(c.Plugin, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			out.plugins = collect
+			out.byKind[resourceKind] = out.plugins
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/plugins.go
+++ b/lib/cache/plugins.go
@@ -1,0 +1,175 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type pluginIndex string
+
+const pluginNameIndex pluginIndex = "name"
+
+func newPluginsCollection(service services.Plugins, watch types.WatchKind) (*collection[types.Plugin, pluginIndex], error) {
+	if service == nil {
+		return nil, trace.BadParameter("missing parameter Plugin Service")
+	}
+
+	return &collection[types.Plugin, pluginIndex]{
+		store: newStore(
+			types.KindPlugin,
+			types.Plugin.Clone,
+			map[pluginIndex]func(types.Plugin) string{
+				pluginNameIndex: types.Plugin.GetName,
+			},
+		),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Plugin, error) {
+			fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+				return service.ListPlugins(ctx, pageSize, token, loadSecrets)
+			}
+			out, err := stream.Collect(clientutils.Resources(ctx, fn))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Plugin {
+			return &types.PluginV1{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: watch,
+	}, nil
+}
+
+// GetPlugin retrieves a plugin by name from the cache.
+// If the cache is not healthy, it falls back to fetching the plugin from the upstream.
+// The `withSecrets` flag controls whether secrets should be included in the result.
+func (c *Cache) GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error) {
+	_, span := c.Tracer.Start(ctx, "cache/GetPlugin")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.plugins)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		// Secrets will be included or excluded based on the withSecrets flag.
+		item, err := c.Config.Plugin.GetPlugin(ctx, name, withSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return item, nil
+	}
+
+	// Depending on the watcher configuration, the cached plugin may or may not contain secrets.
+	// The returned plugin will be stripped of secrets if requested.
+	plugin, err := rg.store.get(pluginNameIndex, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return stripAndClonePluginSecrets(plugin, withSecrets), nil
+}
+
+// GetPlugins returns a full list of plugins from the cache.
+// If the cache is not healthy, it falls back to fetching the plugin from the upstream.
+// The `withSecrets` flag controls whether secrets are included in the response.
+func (c *Cache) GetPlugins(ctx context.Context, withSecrets bool) ([]types.Plugin, error) {
+	_, span := c.Tracer.Start(ctx, "cache/GetPlugins")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.plugins)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		// Cache is currently not available; fetch all plugins from the upstream.
+		// The backend will honor the withSecrets flag.
+		plugins, err := c.Config.Plugin.GetPlugins(ctx, withSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return plugins, nil
+	}
+
+	// Strip secrets if requested.
+	plugins := make([]types.Plugin, 0, rg.store.len())
+	for item := range rg.store.resources(pluginNameIndex, "", "") {
+		plugins = append(plugins, stripAndClonePluginSecrets(item, withSecrets))
+	}
+	return plugins, nil
+}
+
+// ListPlugins returns a paginated list of plugins from the cache or backend.
+// If the cache is not healthy, it fetches directly from the backend.
+// The `withSecrets` flag controls inclusion of secrets in the result.
+func (c *Cache) ListPlugins(ctx context.Context, limit int, startKey string, withSecrets bool) ([]types.Plugin, string, error) {
+	_, span := c.Tracer.Start(ctx, "cache/ListPlugins")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.plugins)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		// The backend honors withSecrets when populating the results.
+		items, nextKey, err := c.Config.Plugin.ListPlugins(ctx, limit, startKey, withSecrets)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		return items, nextKey, nil
+	}
+
+	// Limit the number of items returned to the page size.
+	if limit <= 0 || limit > apidefaults.DefaultChunkSize {
+		limit = apidefaults.DefaultChunkSize
+	}
+
+	var plugins []types.Plugin
+	var nextKey string
+	for item := range rg.store.resources(pluginNameIndex, startKey, "") {
+		if len(plugins) == limit {
+			return plugins, item.GetName(), nil
+		}
+		plugins = append(plugins, stripAndClonePluginSecrets(item, withSecrets))
+	}
+	return plugins, nextKey, nil
+}
+
+// stripPluginSecrets returns a cloned plugin, optionally removing secrets.
+// This allows conditional filtering based on the `withSecrets` flag.
+func stripAndClonePluginSecrets(in types.Plugin, withSecrets bool) types.Plugin {
+	if withSecrets {
+		return in.Clone()
+	}
+	return in.CloneWithoutSecrets()
+}

--- a/lib/cache/plugins_test.go
+++ b/lib/cache/plugins_test.go
@@ -1,0 +1,166 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+)
+
+func newPlugin(name string) types.Plugin {
+	return &types.PluginV1{
+		Metadata: types.Metadata{Name: name},
+		Spec: types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_Scim{
+				Scim: &types.PluginSCIMSettings{
+					SamlConnectorName: "example-saml-connector",
+				},
+			},
+		},
+	}
+}
+
+func newPluginWithCreds(name string) types.Plugin {
+	item := newPlugin(name)
+	creds := types.PluginCredentialsV1{
+		Credentials: &types.PluginCredentialsV1_StaticCredentialsRef{
+			StaticCredentialsRef: &types.PluginStaticCredentialsRef{
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+		},
+	}
+	item.SetCredentials(&creds)
+	return item
+}
+
+// TestPlugin tests caching of plugins
+func TestPlugin(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	t.Run("GetPlugins", func(t *testing.T) {
+		testResources(t, p, testFuncs[types.Plugin]{
+			newResource: func(name string) (types.Plugin, error) {
+				return newPlugin(name), nil
+			},
+			create: func(ctx context.Context, item types.Plugin) error {
+				err := p.plugin.CreatePlugin(ctx, item)
+				return err
+			},
+			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
+				return p.cache.GetPlugin(ctx, name, false)
+			},
+			list: func(ctx context.Context) ([]types.Plugin, error) {
+				fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+					return p.plugin.ListPlugins(ctx, pageSize, token, false)
+				}
+				out, err := stream.Collect(clientutils.Resources(ctx, fn))
+				return out, trace.Wrap(err)
+			},
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Plugin, error) {
+				return p.cache.GetPlugins(ctx, false)
+			},
+			update: func(ctx context.Context, item types.Plugin) error {
+				_, err := p.plugin.UpdatePlugin(ctx, item)
+				return err
+			},
+			deleteAll: func(ctx context.Context) error {
+				return p.plugin.DeleteAllPlugins(ctx)
+			},
+		})
+	})
+
+	t.Run("ListPlugins", func(t *testing.T) {
+		testResources(t, p, testFuncs[types.Plugin]{
+			newResource: func(name string) (types.Plugin, error) {
+				return newPlugin(name), nil
+			},
+			create: func(ctx context.Context, item types.Plugin) error {
+				return trace.Wrap(p.plugin.CreatePlugin(ctx, item))
+			},
+			list: func(ctx context.Context) ([]types.Plugin, error) {
+				fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+					return p.plugin.ListPlugins(ctx, pageSize, token, false)
+				}
+				out, err := stream.Collect(clientutils.Resources(ctx, fn))
+				return out, trace.Wrap(err)
+			},
+			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
+				return p.cache.GetPlugin(ctx, name, false)
+			},
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Plugin, error) {
+				fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+					return p.cache.ListPlugins(ctx, pageSize, token, false)
+				}
+				out, err := stream.Collect(clientutils.Resources(ctx, fn))
+				return out, trace.Wrap(err)
+			},
+			update: func(ctx context.Context, item types.Plugin) error {
+				_, err := p.plugin.UpdatePlugin(ctx, item)
+				return err
+			},
+			deleteAll: func(ctx context.Context) error {
+				return p.plugin.DeleteAllPlugins(ctx)
+			},
+		})
+	})
+	t.Run("GetPluginsWithSecrets", func(t *testing.T) {
+		testResources(t, p, testFuncs[types.Plugin]{
+			newResource: func(name string) (types.Plugin, error) {
+				return newPluginWithCreds(name), nil
+			},
+			create: func(ctx context.Context, item types.Plugin) error {
+				err := p.plugin.CreatePlugin(ctx, item)
+				return err
+			},
+			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
+				return p.cache.GetPlugin(ctx, name, true)
+			},
+			list: func(ctx context.Context) ([]types.Plugin, error) {
+				fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+					return p.plugin.ListPlugins(ctx, pageSize, token, true)
+				}
+				out, err := stream.Collect(clientutils.Resources(ctx, fn))
+				return out, trace.Wrap(err)
+			},
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Plugin, error) {
+				fn := func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+					return p.cache.ListPlugins(ctx, pageSize, token, true)
+				}
+				out, err := stream.Collect(clientutils.Resources(ctx, fn))
+				return out, trace.Wrap(err)
+			},
+			update: func(ctx context.Context, item types.Plugin) error {
+				_, err := p.plugin.UpdatePlugin(ctx, item)
+				return err
+			},
+			deleteAll: func(ctx context.Context) error {
+				return p.plugin.DeleteAllPlugins(ctx)
+			},
+		})
+	})
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2875,6 +2875,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.HealthCheckConfig = services.HealthCheckConfig
 	cfg.BotInstance = services.BotInstance
 	cfg.RecordingEncryption = services.RecordingEncryptionManager
+	cfg.Plugin = services.Plugins
 
 	return accesspoint.NewCache(cfg)
 }

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -56,7 +56,6 @@ func (s *PluginsService) CreatePlugin(ctx context.Context, plugin types.Plugin) 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### What

Add support for cache Plugin object in ForAuth flow.  

TODO as follow up PR:
- [ ] Align implementation flow to use plugin cache