### PR TITLE
[v18] Fix missing permissions in operator role

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -42,6 +42,10 @@ rules:
       - teleportbotsv1/status
       - teleportworkloadidentitiesv1
       - teleportworkloadidentitiesv1/status
+      - teleportautoupdateconfigsv1
+      - teleportautoupdateconfigsv1/status
+      - teleportautoupdateversionsv1
+      - teleportautoupdateversionsv1/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/55566 to `branch/v18`, the automated backport failed due to a minor conflict.

Fixes: https://github.com/gravitational/teleport/issues/56459

Changelog: fix missing Teleport Kube Operator permission in v18.0.0 causing the operator to fail.