### PR TITLE
autoupdate canary support: rollout controller

### DIFF
--- a/lib/autoupdate/rollout/client.go
+++ b/lib/autoupdate/rollout/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -55,6 +56,13 @@ type Client interface {
 	// ListAutoUpdateAgentReports lists the autoupdate_agent_report resources
 	// so the controller can measure the rollout progress.
 	ListAutoUpdateAgentReports(ctx context.Context, pageSize int, nextKey string) ([]*autoupdatepb.AutoUpdateAgentReport, string, error)
+
+	// SampleAgentsFromAutoUpdateGroup samples agents belonging to a specific autoupdate group.
+	// This is used to pick canaries.
+	SampleAgentsFromAutoUpdateGroup(ctx context.Context, groupName string, sampleSize int, groups []string) ([]*autoupdatepb.Canary, error)
+
+	// LookupAgentInInventory looks up a specific HostID in the auth local inventory and returns its Hello message.
+	LookupAgentInInventory(ctx context.Context, hostID string) ([]*proto.UpstreamInventoryHello, error)
 }
 
 func getAllReports(ctx context.Context, clt Client) ([]*autoupdatepb.AutoUpdateAgentReport, error) {

--- a/lib/autoupdate/rollout/controller.go
+++ b/lib/autoupdate/rollout/controller.go
@@ -41,7 +41,6 @@ const (
 // We currently wake up every minute, in the future we might decide to also watch for events
 // (from autoupdate_config and autoupdate_version changefeed) to react faster.
 type Controller struct {
-	// TODO(hugoShaka) add prometheus metrics describing the reconciliation status
 	reconciler reconciler
 	clock      clockwork.Clock
 	log        *slog.Logger

--- a/lib/autoupdate/rollout/strategy.go
+++ b/lib/autoupdate/rollout/strategy.go
@@ -98,7 +98,8 @@ func setGroupState(group *autoupdate.AutoUpdateAgentRolloutStatusGroup, newState
 		group.State = newState
 		changed = true
 		// If we just started the group, also update the start time
-		if newState == autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE {
+		if newState == autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE ||
+			newState == autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY {
 			group.StartTime = timestamppb.New(now)
 		}
 	}

--- a/lib/autoupdate/rollout/strategy_haltonerror.go
+++ b/lib/autoupdate/rollout/strategy_haltonerror.go
@@ -134,7 +134,7 @@ func (h *haltOnErrorStrategy) progressRollout(ctx context.Context, spec *autoupd
 				// All previous groups are DONE and time-related criteria are met.
 				// We can start.
 
-				// We pass the list of groups to the sampler because it must compute the
+				// We pass the list of groups to the sampler because it must compute the catch-call group
 				groups := make([]string, len(status.Groups))
 				for j, g := range status.Groups {
 					groups[j] = g.GetName()
@@ -226,7 +226,7 @@ func (h *haltOnErrorStrategy) sampleCanaries(ctx context.Context, group *autoupd
 		previousLength := len(group.Canaries)
 		h.log.DebugContext(ctx, "Group is missing canaries, sampling some more", "group", group, "got", previousLength, "want", int(group.CanaryCount))
 
-		// We pass the list of groups to the sampler because it must compute the
+		// We pass the list of groups to the sampler because it must compute the catch-all group.
 		groups := make([]string, len(status.Groups))
 		for j, g := range status.Groups {
 			groups[j] = g.GetName()
@@ -252,6 +252,7 @@ func injectCanaries(group *autoupdate.AutoUpdateAgentRolloutStatusGroup, additio
 		for _, existingCanary := range group.Canaries {
 			if existingCanary.UpdaterId == canary.UpdaterId {
 				alreadySampled = true
+				break
 			}
 		}
 

--- a/lib/autoupdate/rollout/strategy_haltonerror.go
+++ b/lib/autoupdate/rollout/strategy_haltonerror.go
@@ -24,10 +24,13 @@ import (
 	"slices"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	update "github.com/gravitational/teleport/api/types/autoupdate"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
 const (
@@ -36,6 +39,8 @@ const (
 	updateReasonPreviousGroupsNotDone = "previous_groups_not_done"
 	updateReasonUpdateComplete        = "update_complete"
 	updateReasonUpdateInProgress      = "update_in_progress"
+	updateReasonCanariesAlive         = "canaries_are_alive"
+	updateReasonWaitingForCanaries    = "waiting_for_canaries"
 	haltOnErrorWindowDuration         = time.Hour
 )
 
@@ -128,8 +133,35 @@ func (h *haltOnErrorStrategy) progressRollout(ctx context.Context, spec *autoupd
 			default:
 				// All previous groups are DONE and time-related criteria are met.
 				// We can start.
-				setGroupState(group, autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE, updateReasonCanStart, now)
-				group.InitialCount = uint64(agentCount)
+
+				// We pass the list of groups to the sampler because it must compute the
+				groups := make([]string, len(status.Groups))
+				for j, g := range status.Groups {
+					groups[j] = g.GetName()
+				}
+				h.startGroup(ctx, group, now, agentCount, status)
+			}
+			previousGroupsAreDone = false
+		case autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY:
+			// Sample the canaries if they were not sampled yet.
+			if err := h.sampleCanaries(ctx, group, status); err != nil {
+				return trace.Wrap(err, "failed to sample canaries")
+			}
+			// Check if the canaries are back online and running the right version
+			targetVersion, err := version.EnsureSemver(spec.GetTargetVersion())
+			if err != nil {
+				return trace.Wrap(err, "failed to parse target version, rollout is malformed")
+			}
+			successfulCanaries := h.updateCanariesStatus(ctx, group, *targetVersion)
+
+			// If all canaries are OK, we can transition to the active state
+			if successfulCanaries == int(group.CanaryCount) {
+				h.log.DebugContext(ctx, "All canaries came back alive, transitioning to the active state", "group", group, "got", successfulCanaries, "want", int(group.CanaryCount))
+				setGroupState(group, autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE, updateReasonCanariesAlive, now)
+			} else {
+				h.log.DebugContext(ctx, "Not all canaries came back yet, staying into canary state", "group", group, "got", successfulCanaries, "want", int(group.CanaryCount))
+				setGroupState(group, group.State, updateReasonWaitingForCanaries, now)
+
 			}
 			previousGroupsAreDone = false
 		case autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK:
@@ -155,6 +187,138 @@ func (h *haltOnErrorStrategy) progressRollout(ctx context.Context, spec *autoupd
 		}
 	}
 	return nil
+}
+
+const (
+	canaryCount     = 5
+	canaryThreshold = 20
+)
+
+func shouldUseCanaries(currentCount int) bool {
+	// in the future we might change this logic to be a multiple of the required canary count
+	// and make the canary count dynamic
+	return currentCount >= canaryThreshold
+}
+
+func (h *haltOnErrorStrategy) startGroup(ctx context.Context, group *autoupdate.AutoUpdateAgentRolloutStatusGroup, now time.Time, agentCount int, status *autoupdate.AutoUpdateAgentRolloutStatus) {
+	group.InitialCount = uint64(agentCount)
+
+	if !shouldUseCanaries(agentCount) {
+		h.log.DebugContext(ctx, "Skipping canary rollout, transitioning directly to the active state", "group", group.Name)
+		setGroupState(group, autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE, updateReasonCanStart, now)
+		return
+	}
+
+	setGroupState(group, autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY, updateReasonCanStart, now)
+	// This is a small optimization, as we just transitioned into the canary state we can sample canaries.
+	// This will allow us to start updating without having to wait for the next reconciliation cycle.
+	if err := h.sampleCanaries(ctx, group, status); err != nil {
+		h.log.WarnContext(ctx, "Failed to sample canaries", "group", group.Name)
+	}
+}
+
+func (h *haltOnErrorStrategy) sampleCanaries(ctx context.Context, group *autoupdate.AutoUpdateAgentRolloutStatusGroup, status *autoupdate.AutoUpdateAgentRolloutStatus) error {
+	if group.CanaryCount == 0 {
+		group.CanaryCount = canaryCount
+	}
+	// Check if we need to pick more canaries
+	if len(group.Canaries) < int(group.CanaryCount) {
+		previousLength := len(group.Canaries)
+		h.log.DebugContext(ctx, "Group is missing canaries, sampling some more", "group", group, "got", previousLength, "want", int(group.CanaryCount))
+
+		// We pass the list of groups to the sampler because it must compute the
+		groups := make([]string, len(status.Groups))
+		for j, g := range status.Groups {
+			groups[j] = g.GetName()
+		}
+		// We sample as many canaries as possible instead of just the missing ones
+		// Because we might sample an already sampled canary.
+		additionalCanaries, err := h.clt.SampleAgentsFromAutoUpdateGroup(ctx, group.Name, int(group.CanaryCount), groups)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		injectCanaries(group, additionalCanaries)
+		h.log.DebugContext(ctx, "Additional canaries sampled", "group", group, "before", previousLength, "after", len(group.Canaries))
+	} else {
+		h.log.DebugContext(ctx, "Canaries already sampled", "group", group.Name, "got", len(group.Canaries))
+	}
+	return nil
+}
+
+func injectCanaries(group *autoupdate.AutoUpdateAgentRolloutStatusGroup, additionalCanaries []*autoupdate.Canary) {
+	for _, canary := range additionalCanaries {
+		// We first check if the canary has already been sampled
+		alreadySampled := false
+		for _, existingCanary := range group.Canaries {
+			if existingCanary.UpdaterId == canary.UpdaterId {
+				alreadySampled = true
+			}
+		}
+
+		// If it was not, great, we have a new canary.
+		if !alreadySampled {
+			group.Canaries = append(group.Canaries, canary)
+		}
+
+		// Stop adding canaries once we have the right amount
+		if len(group.Canaries) == int(group.CanaryCount) {
+			return
+		}
+	}
+}
+
+func (h *haltOnErrorStrategy) updateCanariesStatus(ctx context.Context, group *autoupdate.AutoUpdateAgentRolloutStatusGroup, targetVersion semver.Version) int {
+	h.log.DebugContext(ctx, "Checking canaries", "group", group.Name)
+	var successfulCanaries int
+	for _, canary := range group.Canaries {
+		// If the canary already came back healthy, nothing to do
+		if canary.Success {
+			successfulCanaries++
+			continue
+		}
+
+		canaryLogInfo := slog.Group("canary", "host_id", canary.HostId, "updater_id", canary.UpdaterId, "hostname", canary.Hostname)
+		log := h.log.With(canaryLogInfo).With("group", group.Name)
+
+		// Check if the canary is connected to our auth
+		hellos, err := h.clt.LookupAgentInInventory(ctx, canary.HostId)
+		if err != nil {
+			if trace.IsNotFound(err) {
+				// Canary is not registered to our Auth Service.
+				// Note: One old canary instance might still be connected to the auth,
+				// be we are ignoring terminating instances.
+				log.DebugContext(ctx, "Node not connected")
+			} else {
+				h.log.WarnContext(ctx, "Failed to lookup agent")
+			}
+			continue
+		}
+
+		if canaryIsRunningTargetVersion(ctx, hellos, targetVersion, log) {
+			canary.Success = true
+			successfulCanaries++
+		}
+	}
+	return successfulCanaries
+}
+
+// canaryIsRunningTargetVersion returns true if at least one of the Hellos indicates
+// the canary is running the target version.
+func canaryIsRunningTargetVersion(ctx context.Context, hellos []*proto.UpstreamInventoryHello, targetVersion semver.Version, log *slog.Logger) bool {
+	for _, hello := range hellos {
+		canaryVersion, err := version.EnsureSemver(hello.Version)
+		if err != nil {
+			log.WarnContext(ctx, "Failed to parse canary version", "err", err, "current_version", hello.Version)
+			continue
+		}
+		if !targetVersion.Equal(*canaryVersion) {
+			log.DebugContext(ctx, "Canary is not running the target version", "current_version", canaryVersion, "expected_version", targetVersion)
+			continue
+		}
+		log.DebugContext(ctx, "Canary is running the target version, marking it healthy", "current_version", canaryVersion, "expected_version", targetVersion)
+		return true
+	}
+	return false
 }
 
 func canStartHaltOnError(group, previousGroup *autoupdate.AutoUpdateAgentRolloutStatusGroup, now time.Time) (bool, error) {

--- a/lib/autoupdate/rollout/strategy_haltonerror_test.go
+++ b/lib/autoupdate/rollout/strategy_haltonerror_test.go
@@ -20,16 +20,22 @@ package rollout
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -167,7 +173,7 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					},
 					group2Name: {
 						Versions: map[string]*autoupdate.AutoUpdateAgentReportSpecGroupVersion{
-							startVersion:  {Count: 5},
+							startVersion:  {Count: 3},
 							targetVersion: {Count: 5},
 						},
 					},
@@ -198,12 +204,121 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 		},
 	}
 
+	// canaryTestReports contain more agents, so it triggers the canary logic
+	canaryTestReports := []*autoupdate.AutoUpdateAgentReport{
+		{
+			Metadata: &headerv1.Metadata{Name: "auth1"},
+			Spec: &autoupdate.AutoUpdateAgentReportSpec{
+				Timestamp: timestamppb.New(fewSecondsAgo),
+				Groups: map[string]*autoupdate.AutoUpdateAgentReportSpecGroup{
+					group1Name: {
+						Versions: map[string]*autoupdate.AutoUpdateAgentReportSpecGroupVersion{
+							startVersion:  {Count: 20},
+							targetVersion: {Count: 5},
+							otherVersion:  {Count: 1},
+						},
+					},
+					group2Name: {
+						Versions: map[string]*autoupdate.AutoUpdateAgentReportSpecGroupVersion{
+							startVersion:  {Count: 3},
+							targetVersion: {Count: 5},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var (
+		testCanaries        []*autoupdate.Canary
+		healthyTestCanaries []*autoupdate.Canary
+	)
+	for i := range 10 {
+		updaterId := uuid.NewString()
+		hostID := uuid.NewString()
+		hostName := fmt.Sprintf("canary-%d", i)
+		testCanaries = append(testCanaries, &autoupdate.Canary{
+			UpdaterId: updaterId,
+			HostId:    hostID,
+			Hostname:  hostName,
+			Success:   false,
+		})
+		healthyTestCanaries = append(healthyTestCanaries, &autoupdate.Canary{
+			UpdaterId: updaterId,
+			HostId:    hostID,
+			Hostname:  hostName,
+			Success:   true,
+		})
+	}
+
+	testCanariesLookupNotFound := make(map[string][]callAnswer[[]*proto.UpstreamInventoryHello])
+	testCanariesLookupStartVersion := make(map[string][]callAnswer[[]*proto.UpstreamInventoryHello])
+	testCanariesLookupTargetVersion := make(map[string][]callAnswer[[]*proto.UpstreamInventoryHello])
+	testCanariesLookupTargetVersionDualHandles := make(map[string][]callAnswer[[]*proto.UpstreamInventoryHello])
+
+	for _, canary := range testCanaries {
+		testCanariesLookupNotFound[canary.HostId] = []callAnswer[[]*proto.UpstreamInventoryHello]{
+			{err: trace.NotFound("handle not found")},
+		}
+		testCanariesLookupStartVersion[canary.HostId] = []callAnswer[[]*proto.UpstreamInventoryHello]{
+			{
+				result: []*proto.UpstreamInventoryHello{
+					{
+						Version:                 startVersion,
+						ServerID:                canary.HostId,
+						Hostname:                canary.Hostname,
+						ExternalUpgrader:        types.UpgraderKindTeleportUpdate,
+						ExternalUpgraderVersion: startVersion,
+					},
+				},
+				err: nil,
+			},
+		}
+		testCanariesLookupTargetVersion[canary.HostId] = []callAnswer[[]*proto.UpstreamInventoryHello]{
+			{
+				result: []*proto.UpstreamInventoryHello{
+					{
+						Version:                 targetVersion,
+						ServerID:                canary.HostId,
+						Hostname:                canary.Hostname,
+						ExternalUpgrader:        types.UpgraderKindTeleportUpdate,
+						ExternalUpgraderVersion: targetVersion,
+					},
+				},
+				err: nil,
+			},
+		}
+		testCanariesLookupTargetVersionDualHandles[canary.HostId] = []callAnswer[[]*proto.UpstreamInventoryHello]{
+			{
+				result: []*proto.UpstreamInventoryHello{
+					{
+						Version:                 startVersion,
+						ServerID:                canary.HostId,
+						Hostname:                canary.Hostname,
+						ExternalUpgrader:        types.UpgraderKindTeleportUpdate,
+						ExternalUpgraderVersion: startVersion,
+					},
+					{
+						Version:                 targetVersion,
+						ServerID:                canary.HostId,
+						Hostname:                canary.Hostname,
+						ExternalUpgrader:        types.UpgraderKindTeleportUpdate,
+						ExternalUpgraderVersion: targetVersion,
+					},
+				},
+				err: nil,
+			},
+		}
+	}
+
 	tests := []struct {
 		name             string
 		initialState     []*autoupdate.AutoUpdateAgentRolloutStatusGroup
 		reports          []*autoupdate.AutoUpdateAgentReport
 		rolloutStartTime *timestamppb.Timestamp
 		expectedState    []*autoupdate.AutoUpdateAgentRolloutStatusGroup
+		canarySamples    []callAnswer[[]*autoupdate.Canary]
+		agentLookups     map[string][]callAnswer[[]*proto.UpstreamInventoryHello]
 	}{
 		{
 			name: "single group unstarted -> unstarted",
@@ -566,7 +681,7 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					ConfigDays:       cannotStartToday,
 					ConfigStartHour:  matchingStartHour,
 					// Group1 is the catch-all group, so it should count group2 agents
-					PresentCount:  20,
+					PresentCount:  18,
 					UpToDateCount: 10,
 				},
 			},
@@ -598,7 +713,7 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					ConfigDays:       canStartToday,
 					ConfigStartHour:  matchingStartHour,
 					// Group1 is the catch-all group, so it should count group2 agents
-					PresentCount:  20,
+					PresentCount:  18,
 					UpToDateCount: 10,
 					// InitialCount must not be changed during active -> active transitions
 					InitialCount: 25,
@@ -606,7 +721,7 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 			},
 		},
 		{
-			name: "single group unstarted -> active",
+			name: "single group unstarted -> active with reports",
 			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
 				{
 					Name:             group1Name,
@@ -630,8 +745,8 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					ConfigDays:       canStartToday,
 					ConfigStartHour:  matchingStartHour,
 					// InitialCount must be set during unstarted -> active transition
-					InitialCount:  20,
-					PresentCount:  20,
+					InitialCount:  18,
+					PresentCount:  18,
 					UpToDateCount: 10,
 				},
 			},
@@ -695,8 +810,8 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					ConfigDays:       canStartToday,
 					ConfigStartHour:  matchingStartHour,
 					ConfigWaitHours:  24,
-					InitialCount:     10,
-					PresentCount:     10,
+					InitialCount:     8,
+					PresentCount:     8,
 					UpToDateCount:    5,
 				},
 				{
@@ -707,6 +822,271 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					ConfigDays:       canStartToday,
 					ConfigStartHour:  matchingStartHour,
 					ConfigWaitHours:  0,
+				},
+			},
+		},
+		{
+			name: "single group unstarted -> canary, no canaries sampled",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+					LastUpdateTime:   timestamppb.New(yesterday),
+					LastUpdateReason: updateReasonCreated,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					PresentCount:     12,
+					UpToDateCount:    3,
+				},
+			},
+			reports:       canaryTestReports,
+			canarySamples: []callAnswer[[]*autoupdate.Canary]{{}},
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					StartTime:        timestamppb.New(clock.Now()),
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+				},
+			},
+		},
+		{
+			name: "single group canary -> canary, sampling agents, agents not found",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					// Checking that if CanaryCount is not set/null (e.g. we came from a manual transition)
+					// We still set it instead of jumping to the active state.
+					CanaryCount: 0,
+				},
+			},
+			reports:       canaryTestReports,
+			canarySamples: mockResponseForCanaries(testCanaries[:5]),
+			agentLookups:  testCanariesLookupNotFound,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonWaitingForCanaries,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      testCanaries[:5],
+				},
+			},
+		},
+		{
+			name: "single group canary -> canary, sampling agents, agents running old version",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+				},
+			},
+			reports:       canaryTestReports,
+			canarySamples: mockResponseForCanaries(testCanaries[:5]),
+			agentLookups:  testCanariesLookupStartVersion,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonWaitingForCanaries,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      testCanaries[:5],
+				},
+			},
+		},
+		{
+			name: "single group canary -> active, sampling agents, agents running target version",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+				},
+			},
+			reports:       canaryTestReports,
+			canarySamples: mockResponseForCanaries(testCanaries[:5]),
+			agentLookups:  testCanariesLookupTargetVersion,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					StartTime:        timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanariesAlive,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      healthyTestCanaries[:5],
+				},
+			},
+		},
+		{
+			name: "single group canary -> active, already sampled agents, agents running target version",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      testCanaries[:5],
+				},
+			},
+			reports: canaryTestReports,
+			// no canarySamples set, we don't expect a sampling call
+			agentLookups: testCanariesLookupTargetVersion,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					StartTime:        timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanariesAlive,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      healthyTestCanaries[:5],
+				},
+			},
+		},
+		{
+			name: "single group canary -> canary, incomplete sampled agents, agents running start version",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					// Only 2 canaries
+					Canaries: testCanaries[8:10],
+				},
+			},
+			reports:       canaryTestReports,
+			canarySamples: mockResponseForCanaries(testCanaries[:5]),
+			agentLookups:  testCanariesLookupStartVersion,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonWaitingForCanaries,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					// We expect the 2 initial agents to stay here, and 3 additional agents
+					Canaries: append(testCanaries[8:10], testCanaries[0:3]...),
+				},
+			},
+		},
+		{
+			name: "single group canary -> active, already sampled agents, agents running target version, several handles",
+			initialState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanStart,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      testCanaries[:5],
+				},
+			},
+			reports: canaryTestReports,
+			// no canarySamples set, we don't expect a sampling call
+			agentLookups: testCanariesLookupTargetVersionDualHandles,
+			expectedState: []*autoupdate.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:             group1Name,
+					State:            autoupdate.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+					LastUpdateTime:   timestamppb.New(clock.Now()),
+					StartTime:        timestamppb.New(clock.Now()),
+					LastUpdateReason: updateReasonCanariesAlive,
+					ConfigDays:       canStartToday,
+					ConfigStartHour:  matchingStartHour,
+					// InitialCount must be set during unstarted -> active transition
+					InitialCount:  34,
+					PresentCount:  34,
+					UpToDateCount: 10,
+					CanaryCount:   5,
+					Canaries:      healthyTestCanaries[:5],
 				},
 			},
 		},
@@ -723,7 +1103,10 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 				TargetVersion: targetVersion,
 			}
 
-			stubs := mockClientStubs{}
+			stubs := mockClientStubs{
+				agentSamples:          tt.canarySamples,
+				inventoryAgentLookups: tt.agentLookups,
+			}
 			if tt.reports == nil {
 				stubs.reportsAnswers = []callAnswer[[]*autoupdate.AutoUpdateAgentReport]{
 					{
@@ -739,16 +1122,17 @@ func Test_progressGroupsHaltOnError(t *testing.T) {
 					},
 				}
 			}
+
 			clt := newMockClient(t, stubs)
 			strategy, err := newHaltOnErrorStrategy(log, clt)
 			require.NoError(t, err)
 			err = strategy.progressRollout(ctx, spec, status, clock.Now())
 			require.NoError(t, err)
-			// We use require.Equal instead of Elements match because group order matters.
+			// Group order matters.
 			// It's not super important for time-based, but is crucial for halt-on-error.
 			// So it's better to be more conservative and validate order never changes for
 			// both strategies.
-			require.Equal(t, tt.expectedState, tt.initialState)
+			require.Empty(t, cmp.Diff(tt.expectedState, tt.initialState, protocmp.Transform()))
 		})
 	}
 }
@@ -821,5 +1205,13 @@ func TestCountCatchAll(t *testing.T) {
 			require.Equal(t, tt.expectedCount, count)
 			require.Equal(t, tt.expectedUpToDate, upToDate)
 		})
+	}
+}
+
+func mockResponseForCanaries(canaries []*autoupdate.Canary) []callAnswer[[]*autoupdate.Canary] {
+	return []callAnswer[[]*autoupdate.Canary]{
+		{
+			result: canaries,
+		},
 	}
 }

--- a/lib/autoupdate/rollout/transitions.go
+++ b/lib/autoupdate/rollout/transitions.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/constants"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types/autoupdate"
 )
@@ -63,20 +64,10 @@ func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, reports []*au
 		return trace.Wrap(err)
 	}
 
-	switch desiredState {
-	case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED:
-		// When unspecified, we default to active
-		desiredState = autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE
-	case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
-	default:
-		return trace.BadParameter("unsupported desired state: %s, supported states are 'unspecified' and 'active'", desiredState)
-	}
-
 	// filter out expired reports
 	validReports := make([]*autoupdatev1pb.AutoUpdateAgentReport, len(reports))
 	for _, report := range reports {
-		// TODO replace time.minute by the auth periodic operation constant
-		if now.Sub(report.GetSpec().GetTimestamp().AsTime()) <= time.Minute {
+		if now.Sub(report.GetSpec().GetTimestamp().AsTime()) <= constants.AutoUpdateAgentReportPeriod {
 			validReports = append(validReports, report)
 		}
 	}
@@ -87,6 +78,15 @@ func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, reports []*au
 	if len(groups) == 0 {
 		return trace.BadParameter("rollout has no groups")
 	}
+	var initialCount, upToDateCount int
+
+	switch desiredState {
+	case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+		autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+		autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+	default:
+		return trace.BadParameter("unsupported desired state: %s, supported states are 'unspecified', 'canary' and 'active'", desiredState)
+	}
 
 	// Part where we do the real work, doing a state transition for every requested group.
 	for groupName := range groupsToTrigger {
@@ -95,10 +95,18 @@ func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, reports []*au
 			return trace.Wrap(err)
 		}
 
+		if groupName == groups[len(groups)-1].GetName() {
+			initialCount, upToDateCount = countCatchAll(rollout.GetStatus(), countByGroup, upToDateByGroup)
+		} else {
+			initialCount = countByGroup[groupName]
+			upToDateCount = upToDateByGroup[groupName]
+		}
+
 		// We check if the group state transition is legal.
 		switch group.GetState() {
 		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
 			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
 			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK:
 		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
 			return trace.AlreadyExists("group %q is already active", groupName)
@@ -108,14 +116,22 @@ func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, reports []*au
 			return trace.BadParameter("group %q in unexpected state %s", groupName, group.GetState())
 		}
 
-		var initialCount, upToDateCount int
-		setGroupState(group, desiredState, updateReasonManualTrigger, now)
-		if groupName == groups[len(groups)-1].GetName() {
-			initialCount, upToDateCount = countCatchAll(rollout.GetStatus(), countByGroup, upToDateByGroup)
-		} else {
-			initialCount = countByGroup[groupName]
-			upToDateCount = upToDateByGroup[groupName]
+		switch desiredState {
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED:
+			if shouldUseCanaries(initialCount) {
+				// We switch to the canary state but we don't sample canaries now.
+				// Canary sampling will happen during the next reconciliation.
+				desiredState = autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY
+			} else {
+				desiredState = autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE
+			}
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+		default:
+			return trace.BadParameter("unsupported desired state: %s, supported states are 'unspecified' and 'active'", desiredState)
 		}
+
+		setGroupState(group, desiredState, updateReasonManualTrigger, now)
 		group.UpToDateCount = uint64(upToDateCount)
 		group.InitialCount = uint64(initialCount)
 		group.PresentCount = uint64(initialCount)
@@ -158,7 +174,8 @@ func ForceGroupsDone(rollout *autoupdatev1pb.AutoUpdateAgentRollout, groupsToFor
 		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
 			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
 			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
-			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY:
 		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
 			return trace.AlreadyExists("group %q is already done", groupName)
 		default:
@@ -179,6 +196,7 @@ func GetStartedGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout) GroupSet {
 	for _, group := range groups {
 		switch group.GetState() {
 		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_CANARY,
 			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
 			startedGroups[group.GetName()] = struct{}{}
 		}


### PR DESCRIPTION
This PR adds canary support to the autoupdate_agent_rollout controller when the strategy is "halt-on-error".

Part 3 of the canary support as described in [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

This PR adds the canary logic to the halt-on-error strategy. Currently, canary has the following hardcoded limitations:
- canary mode kicks in if you have more than 20 agents currently reporting in the group being updated
- canary count is hardcoded to 5

You can find the [meta canary PR here](https://github.com/gravitational/teleport/pull/56128), I'm upstreaming it bit by bit to make the review more palatable.

Goal (internal): https://github.com/gravitational/cloud/issues/13207