### PR TITLE
Extract SetDefaults and Validate for AccessList{,Member} + ResourceHeader

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -216,35 +215,6 @@ func (t Type) IsReviewable() bool {
 	return false
 }
 
-// Owner is an owner of an access list.
-type Owner struct {
-	// Name is the username of the owner.
-	Name string `json:"name" yaml:"name"`
-
-	// Description is the plaintext description of the owner and why they are an owner.
-	Description string `json:"description" yaml:"description"`
-
-	// IneligibleStatus describes the reason why this owner is not eligible.
-	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
-
-	// MembershipKind describes the kind of ownership,
-	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
-	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
-}
-
-// Audit describes the audit configuration for an access list.
-type Audit struct {
-	// NextAuditDate is the date that the next audit should be performed.
-	NextAuditDate time.Time `json:"next_audit_date" yaml:"next_audit_date"`
-
-	// Recurrence is the recurrence definition for auditing. Valid values are
-	// 1, first, 15, and last.
-	Recurrence Recurrence `json:"recurrence" yaml:"recurrence"`
-
-	// Notifications is the configuration for notifying users.
-	Notifications Notifications `json:"notifications" yaml:"notifications"`
-}
-
 // Recurrence defines when access list reviews should occur.
 type Recurrence struct {
 	// Frequency is the frequency between access list reviews.
@@ -334,10 +304,45 @@ func NewAccessList(metadata header.Metadata, spec Spec) (*AccessList, error) {
 
 // CheckAndSetDefaults validates fields and populates empty fields with default values.
 func (a *AccessList) CheckAndSetDefaults() error {
+	if err := a.SetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// SetDefaults sets the default values for the resource.
+func (a *AccessList) SetDefaults() error {
 	a.SetKind(types.KindAccessList)
 	a.SetVersion(types.V1)
+	if err := a.ResourceHeader.SetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
 
-	if err := a.ResourceHeader.CheckAndSetDefaults(); err != nil {
+	// Deduplicate owners. The backend will currently prevent this, but it's possible that access lists
+	// were created with duplicated owners before the backend checked for duplicate owners. In order to
+	// ensure that these access lists are backwards compatible, we'll deduplicate them here.
+	a.Spec.Owners = deduplicateOwners(a.Spec.Owners)
+	for i := range a.Spec.Owners {
+		// Reference directly from the slice, because we don't want to modify the copy.
+		a.Spec.Owners[i].SetDefaults()
+	}
+
+	if a.IsReviewable() {
+		if err := a.Spec.Audit.SetDefaults(); err != nil {
+			return trace.Wrap(err, "setting audit defaults")
+		}
+	}
+
+	return nil
+}
+
+// Validate performs client-side resource validation which should be performed before sending
+// create/update request.
+func (a *AccessList) Validate() error {
+	if err := a.ResourceHeader.Validate(); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -359,34 +364,8 @@ func (a *AccessList) CheckAndSetDefaults() error {
 	}
 
 	if a.IsReviewable() {
-		if a.Spec.Audit.Recurrence.Frequency == 0 {
-			a.Spec.Audit.Recurrence.Frequency = SixMonths
-		}
-
-		switch a.Spec.Audit.Recurrence.Frequency {
-		case OneMonth, ThreeMonths, SixMonths, OneYear:
-		default:
-			return trace.BadParameter("recurrence frequency is an invalid value")
-		}
-
-		if a.Spec.Audit.Recurrence.DayOfMonth == 0 {
-			a.Spec.Audit.Recurrence.DayOfMonth = FirstDayOfMonth
-		}
-
-		switch a.Spec.Audit.Recurrence.DayOfMonth {
-		case FirstDayOfMonth, FifteenthDayOfMonth, LastDayOfMonth:
-		default:
-			return trace.BadParameter("recurrence day of month is an invalid value")
-		}
-
-		if a.Spec.Audit.NextAuditDate.IsZero() {
-			if err := a.setInitialAuditDate(clockwork.NewRealClock()); err != nil {
-				return trace.Wrap(err, "setting initial audit date")
-			}
-		}
-
-		if a.Spec.Audit.Notifications.Start == 0 {
-			a.Spec.Audit.Notifications.Start = twoWeeks
+		if err := a.Spec.Audit.Validate(); err != nil {
+			return trace.Wrap(err, "invalid audit")
 		}
 	} else {
 		if !isZero(a.Spec.Audit) {
@@ -394,27 +373,11 @@ func (a *AccessList) CheckAndSetDefaults() error {
 		}
 	}
 
-	// Deduplicate owners. The backend will currently prevent this, but it's possible that access lists
-	// were created with duplicated owners before the backend checked for duplicate owners. In order to
-	// ensure that these access lists are backwards compatible, we'll deduplicate them here.
-	ownerMap := make(map[string]struct{}, len(a.Spec.Owners))
-	deduplicatedOwners := []Owner{}
 	for _, owner := range a.Spec.Owners {
-		if owner.Name == "" {
-			return trace.BadParameter("owner name is missing")
+		if err := owner.Validate(); err != nil {
+			return trace.Wrap(err, "invalid owner")
 		}
-		if owner.MembershipKind == "" {
-			owner.MembershipKind = MembershipKindUser
-		}
-
-		if _, ok := ownerMap[owner.Name]; ok {
-			continue
-		}
-
-		ownerMap[owner.Name] = struct{}{}
-		deduplicatedOwners = append(deduplicatedOwners, owner)
 	}
-	a.Spec.Owners = deduplicatedOwners
 
 	return nil
 }
@@ -581,31 +544,5 @@ func (a *AccessList) SelectNextReviewDate() (time.Time, error) {
 	if !a.IsReviewable() {
 		return time.Time{}, trace.BadParameter("access_list %q is not reviewable", a.GetName())
 	}
-
-	numMonths := int(a.Spec.Audit.Recurrence.Frequency)
-	dayOfMonth := int(a.Spec.Audit.Recurrence.DayOfMonth)
-
-	// If the last day of the month has been specified, use the 0 day of the
-	// next month, which will result in the last day of the target month.
-	if dayOfMonth == int(LastDayOfMonth) {
-		numMonths += 1
-		dayOfMonth = 0
-	}
-
-	currentReviewDate := a.Spec.Audit.NextAuditDate
-	nextDate := time.Date(currentReviewDate.Year(), currentReviewDate.Month()+time.Month(numMonths), dayOfMonth,
-		0, 0, 0, 0, time.UTC)
-
-	return nextDate, nil
-}
-
-// setInitialAuditDate sets the NextAuditDate for a newly created AccessList.
-// The function is extracted from CheckAndSetDefaults for the sake of testing
-// (we need to pass a fake clock).
-func (a *AccessList) setInitialAuditDate(clock clockwork.Clock) (err error) {
-	// We act as if the AccessList just got reviewed (we just created it, so
-	// we're pretty sure of what it does) and pick the next review date.
-	a.Spec.Audit.NextAuditDate = clock.Now()
-	a.Spec.Audit.NextAuditDate, err = a.SelectNextReviewDate()
-	return trace.Wrap(err)
+	return selectNextReviewDate(a.Spec.Audit), nil
 }

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/header"
@@ -393,61 +392,6 @@ func TestSelectNextReviewDate(t *testing.T) {
 					}
 				})
 			}
-		})
-	}
-}
-
-func TestAccessList_setInitialReviewDate(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name              string
-		frequency         ReviewFrequency
-		dayOfMonth        ReviewDayOfMonth
-		currentReviewDate time.Time
-		expected          time.Time
-	}{
-		{
-			name:              "one month, first day",
-			frequency:         OneMonth,
-			dayOfMonth:        FirstDayOfMonth,
-			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expected:          time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:              "one month, fifteenth day",
-			frequency:         OneMonth,
-			dayOfMonth:        FifteenthDayOfMonth,
-			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expected:          time.Date(2023, 2, 15, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:              "one month, last day",
-			frequency:         OneMonth,
-			dayOfMonth:        LastDayOfMonth,
-			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expected:          time.Date(2023, 2, 28, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			name:              "six months, last day",
-			frequency:         SixMonths,
-			dayOfMonth:        LastDayOfMonth,
-			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-			expected:          time.Date(2023, 7, 31, 0, 0, 0, 0, time.UTC),
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			accessList := AccessList{}
-			accessList.Spec.Audit.Recurrence = Recurrence{
-				Frequency:  test.frequency,
-				DayOfMonth: test.dayOfMonth,
-			}
-			accessList.setInitialAuditDate(clockwork.NewFakeClockAt(test.currentReviewDate))
-			require.Equal(t, test.expected, accessList.Spec.Audit.NextAuditDate)
 		})
 	}
 }

--- a/api/types/accesslist/audit.go
+++ b/api/types/accesslist/audit.go
@@ -1,0 +1,108 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// Audit describes the audit configuration for an access list.
+type Audit struct {
+	// NextAuditDate is the date that the next audit should be performed.
+	NextAuditDate time.Time `json:"next_audit_date" yaml:"next_audit_date"`
+
+	// Recurrence is the recurrence definition for auditing. Valid values are
+	// 1, first, 15, and last.
+	Recurrence Recurrence `json:"recurrence" yaml:"recurrence"`
+
+	// Notifications is the configuration for notifying users.
+	Notifications Notifications `json:"notifications" yaml:"notifications"`
+}
+
+// Validate performs client-side resource validation which should be performed before sending
+// create/update request.
+func (a *Audit) SetDefaults() error {
+	if a.Recurrence.Frequency == 0 {
+		a.Recurrence.Frequency = SixMonths
+	}
+
+	if a.Recurrence.DayOfMonth == 0 {
+		a.Recurrence.DayOfMonth = FirstDayOfMonth
+	}
+
+	if a.NextAuditDate.IsZero() {
+		a.setInitialAuditDate(clockwork.NewRealClock())
+	}
+
+	if a.Notifications.Start == 0 {
+		a.Notifications.Start = twoWeeks
+	}
+
+	return nil
+}
+
+// setInitialAuditDate sets the NextAuditDate for a newly created AccessList.
+// The function is extracted from CheckAndSetDefaults for the sake of testing
+// (we need to pass a fake clock).
+func (a *Audit) setInitialAuditDate(clock clockwork.Clock) {
+	// We act as if the AccessList just got reviewed (we just created it, so
+	// we're pretty sure of what it does) and pick the next review date.
+	a.NextAuditDate = clock.Now()
+	a.NextAuditDate = selectNextReviewDate(*a)
+}
+
+// Validate performs client-side resource validation which should be performed before sending
+// create/update request.
+func (a *Audit) Validate() error {
+	switch a.Recurrence.Frequency {
+	case OneMonth, ThreeMonths, SixMonths, OneYear:
+	default:
+		return trace.BadParameter("recurrence frequency is an invalid value")
+	}
+
+	switch a.Recurrence.DayOfMonth {
+	case FirstDayOfMonth, FifteenthDayOfMonth, LastDayOfMonth:
+	default:
+		return trace.BadParameter("recurrence day of month is an invalid value")
+	}
+
+	return nil
+}
+
+// selectNextReviewDate will select the next review date for the access list.
+func selectNextReviewDate(a Audit) time.Time {
+	numMonths := int(a.Recurrence.Frequency)
+	dayOfMonth := int(a.Recurrence.DayOfMonth)
+
+	// If the last day of the month has been specified, use the 0 day of the
+	// next month, which will result in the last day of the target month.
+	if dayOfMonth == int(LastDayOfMonth) {
+		numMonths += 1
+		dayOfMonth = 0
+	}
+
+	currentReviewDate := a.NextAuditDate
+	nextDate := time.Date(currentReviewDate.Year(), currentReviewDate.Month()+time.Month(numMonths), dayOfMonth,
+		0, 0, 0, 0, time.UTC)
+
+	return nextDate
+}

--- a/api/types/accesslist/audit_test.go
+++ b/api/types/accesslist/audit_test.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAudit_setInitialReviewDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		frequency         ReviewFrequency
+		dayOfMonth        ReviewDayOfMonth
+		currentReviewDate time.Time
+		expected          time.Time
+	}{
+		{
+			name:              "one month, first day",
+			frequency:         OneMonth,
+			dayOfMonth:        FirstDayOfMonth,
+			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected:          time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:              "one month, fifteenth day",
+			frequency:         OneMonth,
+			dayOfMonth:        FifteenthDayOfMonth,
+			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected:          time.Date(2023, 2, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:              "one month, last day",
+			frequency:         OneMonth,
+			dayOfMonth:        LastDayOfMonth,
+			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected:          time.Date(2023, 2, 28, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:              "six months, last day",
+			frequency:         SixMonths,
+			dayOfMonth:        LastDayOfMonth,
+			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected:          time.Date(2023, 7, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			audit := Audit{
+				Recurrence: Recurrence{
+					Frequency:  test.frequency,
+					DayOfMonth: test.dayOfMonth,
+				},
+			}
+			audit.setInitialAuditDate(clockwork.NewFakeClockAt(test.currentReviewDate))
+			require.Equal(t, test.expected, audit.NextAuditDate)
+		})
+	}
+}

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -83,33 +83,46 @@ func NewAccessListMember(metadata header.Metadata, spec AccessListMemberSpec) (*
 
 // CheckAndSetDefaults validates fields and populates empty fields with default values.
 func (a *AccessListMember) CheckAndSetDefaults() error {
-	a.SetKind(types.KindAccessListMember)
-	a.SetVersion(types.V1)
-
-	if err := a.ResourceHeader.CheckAndSetDefaults(); err != nil {
+	if err := a.SetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := a.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
 
+// SetDefaults sets the default values for the resource.
+func (a *AccessListMember) SetDefaults() error {
+	a.SetKind(types.KindAccessListMember)
+	a.SetVersion(types.V1)
+	if err := a.ResourceHeader.SetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
 	if a.Spec.MembershipKind == "" {
 		a.Spec.MembershipKind = MembershipKindUser
 	}
+	return nil
+}
 
+// Validate performs client-side resource validation which should be performed before sending
+// create/update request.
+func (a *AccessListMember) Validate() error {
+	if err := a.ResourceHeader.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
 	if a.Spec.AccessList == "" {
 		return trace.BadParameter("access list is missing")
 	}
-
 	if a.Spec.Name == "" {
 		return trace.BadParameter("member name is missing")
 	}
-
 	if a.Spec.Joined.IsZero() || a.Spec.Joined.Unix() == 0 {
 		return trace.BadParameter("member %s: joined field empty or missing", a.Spec.Name)
 	}
-
 	if a.Spec.AddedBy == "" {
 		return trace.BadParameter("member %s: added_by field is empty", a.Spec.Name)
 	}
-
 	return nil
 }
 

--- a/api/types/accesslist/owner.go
+++ b/api/types/accesslist/owner.go
@@ -1,0 +1,67 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslist
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Owner is an owner of an access list.
+type Owner struct {
+	// Name is the username of the owner.
+	Name string `json:"name" yaml:"name"`
+
+	// Description is the plaintext description of the owner and why they are an owner.
+	Description string `json:"description" yaml:"description"`
+
+	// IneligibleStatus describes the reason why this owner is not eligible.
+	IneligibleStatus string `json:"ineligible_status" yaml:"ineligible_status"`
+
+	// MembershipKind describes the kind of ownership,
+	// either "MEMBERSHIP_KIND_USER" or "MEMBERSHIP_KIND_LIST".
+	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
+}
+
+// SetDefaults sets the default values for the resource.
+func (o *Owner) SetDefaults() error {
+	if o.MembershipKind == "" {
+		o.MembershipKind = MembershipKindUser
+	}
+	return nil
+}
+
+// Validate performs client-side resource validation which should be performed before sending
+// create/update request.
+func (o *Owner) Validate() error {
+	if o.Name == "" {
+		return trace.BadParameter("name is missing")
+	}
+	return nil
+}
+
+// deduplicateOwners returns a new slice with owners with the same name removed. The order is not
+// guaranteed. deduplicateOwners zeroes the elements between the new length and the original
+// length.
+func deduplicateOwners(owners []Owner) []Owner {
+	slices.SortFunc(owners, func(x, y Owner) int { return strings.Compare(x.Name, y.Name) })
+	return slices.CompactFunc(owners, func(x, y Owner) bool { return x.Name == y.Name })
+}

--- a/api/types/header/header.go
+++ b/api/types/header/header.go
@@ -163,13 +163,36 @@ func (h *ResourceHeader) GetAllLabels() map[string]string {
 // CheckAndSetDefaults will verify that the resource header is valid. This will additionally
 // verify that the metadata is valid.
 func (h *ResourceHeader) CheckAndSetDefaults() error {
+	if err := h.SetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := h.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// SetDefaults sets the default values for the header.
+func (h *ResourceHeader) SetDefaults() error {
+	if err := h.Metadata.SetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Validate performs client-side header which should be performed before sending create/update
+// request.
+func (h *ResourceHeader) Validate() error {
+	if err := h.Metadata.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
 	if h.Kind == "" {
 		return trace.BadParameter("resource has an empty Kind field")
 	}
 	if h.Version == "" {
 		return trace.BadParameter("resource has an empty Version field")
 	}
-	return trace.Wrap(h.Metadata.CheckAndSetDefaults())
+	return nil
 }
 
 // IsEqual determines if two resource headers are equivalent to one another.
@@ -255,13 +278,29 @@ func (m *Metadata) SetOrigin(origin string) {
 
 // CheckAndSetDefaults verifies that the metadata object is valid.
 func (m *Metadata) CheckAndSetDefaults() error {
-	if m.Name == "" {
-		return trace.BadParameter("missing parameter Name")
+	if err := m.SetDefaults(); err != nil {
+		return trace.Wrap(err)
 	}
+	if err := m.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
 
+// SetDefaults sets the default values for the Metadata.
+func (m *Metadata) SetDefaults() error {
 	// adjust expires time to UTC if it's set
 	if !m.Expires.IsZero() {
 		utils.UTC(&m.Expires)
+	}
+	return nil
+}
+
+// Validate performs client-side metadata validation which should be performed before sending
+// create/update request.
+func (m *Metadata) Validate() error {
+	if m.Name == "" {
+		return trace.BadParameter("missing parameter Name")
 	}
 
 	for key := range m.Labels {


### PR DESCRIPTION
Related https://github.com/gravitational/teleport/pull/56470

Based on https://github.com/gravitational/teleport/pull/56465 (no direct relationship, but it will make it easier for the PR train)

Extract SetDefaults + Validate (which are now called from CheckAndSetDefaults) for:

- Metadata
- ResourceHeader
- AccessList (and children types)
- AccessListMember

There are no semantic changes. Only the code is shuffled.