### PR TITLE
Enhances MCP servers usage with Cursor

### DIFF
--- a/lib/client/db/mcp/server.go
+++ b/lib/client/db/mcp/server.go
@@ -61,6 +61,10 @@ func NewRootServer(logger *slog.Logger) *RootServer {
 }
 
 // ListDatabases tool function used to list all available/served databases.
+//
+// Note: Given some MCP clients not fully support resources of any kind (including
+// embedded and references), we must return the databases as plain text result so
+// the tool keeps working on those clients.
 func (s *RootServer) ListDatabases(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/lib/client/mcp/claude/config.go
+++ b/lib/client/mcp/claude/config.go
@@ -57,6 +57,18 @@ func DefaultConfigPath() (string, error) {
 	}
 }
 
+// GlobalCursorPath returns the default path for Cursor global MCP configuration.
+//
+// https://docs.cursor.com/context/mcp#configuration-locations
+func GlobalCursorPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return filepath.Join(homeDir, ".cursor", "mcp.json"), nil
+}
+
 // MCPServer contains details to launch an MCP server.
 //
 // https://modelcontextprotocol.io/quickstart/user
@@ -235,6 +247,17 @@ func LoadConfigFromDefaultPath() (*FileConfig, error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "finding Claude Desktop config path")
 	}
+	config, err := LoadConfigFromFile(configPath)
+	return config, trace.Wrap(err)
+}
+
+// LoadConfigFromGlobalCursor loads the Cursor global MCP server configuration.
+func LoadConfigFromGlobalCursor() (*FileConfig, error) {
+	configPath, err := GlobalCursorPath()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	config, err := LoadConfigFromFile(configPath)
 	return config, trace.Wrap(err)
 }

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -85,6 +85,9 @@ Examples:
   Add all MCP servers to Claude Desktop
   $ tsh mcp config --all --client-config=claude
 
+  Add all MCP servers to Cursor
+  $ tsh mcp config --all --client-config=cursor
+
   Search MCP servers with labels and add to the specified JSON file
   $ tsh mcp config --labels env=dev --client-config=my-config.json`
 
@@ -95,6 +98,9 @@ Examples:
 
   Add the database configuration to Claude Desktop
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=claude my-db-resource
+
+  Add the database configuration to Cursor
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=cursor my-db-resource
 
   Add the database configuration to the specified JSON file
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=my-config.json my-db-resource

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -58,14 +58,16 @@ type mcpClientConfigFlags struct {
 
 const (
 	mcpClientConfigClaude = "claude"
+	mcpClientConfigCursor = "cursor"
 )
 
 func (m *mcpClientConfigFlags) addToCmd(cmd *kingpin.CmdClause) {
 	cmd.Flag(
 		"client-config",
 		fmt.Sprintf(
-			"If specified, update the specified client config. %q for default Claude Desktop config, or specify a JSON file path. Can also be set with environment variable %s.",
+			"If specified, update the specified client config. %q for default Claude Desktop config, %q for global Cursor MCP servers config, or specify a JSON file path. Can also be set with environment variable %s.",
 			mcpClientConfigClaude,
+			mcpClientConfigCursor,
 			mcpClientConfigEnvVar,
 		)).
 		Envar(mcpClientConfigEnvVar).
@@ -92,6 +94,8 @@ func (m *mcpClientConfigFlags) loadConfig() (*claude.FileConfig, error) {
 	switch m.clientConfig {
 	case mcpClientConfigClaude:
 		return claude.LoadConfigFromDefaultPath()
+	case mcpClientConfigCursor:
+		return claude.LoadConfigFromGlobalCursor()
 	default:
 		return claude.LoadConfigFromFile(m.clientConfig)
 	}
@@ -107,9 +111,7 @@ func (m *mcpClientConfigFlags) jsonFormatOptions() []string {
 }
 
 func (m *mcpClientConfigFlags) printHint(w io.Writer) error {
-	_, err := fmt.Fprintln(w, `Tip: use --client-config=claude to update your Claude Desktop configuration.
-You can also specify a custom config path with --client-config=<path> to update
-a config file compatible with the "mcpServer" mapping.`)
+	_, err := fmt.Fprintln(w, mcpConfigHint)
 	return trace.Wrap(err)
 }
 
@@ -149,3 +151,10 @@ func getLoggingOptsForMCPServer(cf *CLIConf) loggingOpts {
 		debug: true,
 	})
 }
+
+// mcpConfigHint is the hint message displayed when the configuration is shown
+// to users.
+const mcpConfigHint = `Tip: You can use this command to update your MCP servers configuration file automatically.
+- For Claude Desktop, use --client-config=claude to update the default configuration, or specify the file path using --client-config=<path>.
+- For Cursor, use --client-config=cursor to update the global MCP servers configuration, or update a project using --client-config=<path-to-project>/.cursor/mcp.json
+In addition, --client-config=<path> can be used to update any config file compatible with the "mcpServers" mapping.`

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -155,6 +155,7 @@ func getLoggingOptsForMCPServer(cf *CLIConf) loggingOpts {
 // mcpConfigHint is the hint message displayed when the configuration is shown
 // to users.
 const mcpConfigHint = `Tip: You can use this command to update your MCP servers configuration file automatically.
-- For Claude Desktop, use --client-config=claude to update the default configuration, or specify the file path using --client-config=<path>.
-- For Cursor, use --client-config=cursor to update the global MCP servers configuration, or update a project using --client-config=<path-to-project>/.cursor/mcp.json
-In addition, --client-config=<path> can be used to update any config file compatible with the "mcpServers" mapping.`
+- For Claude Desktop, use --client-config=claude to update the default configuration.
+- For Cursor, use --client-config=cursor to update the global MCP servers configuration.
+In addition, you can use --client-config=<path> to specify a config file location that is compatible with the "mcpServers" mapping.
+For example, you can update a Cursor project using --client-config=<path-to-project>/.cursor/mcp.json`


### PR DESCRIPTION
This PR consists of two changes:
1. Cursor MCP configuration support: Cursor follows the same format as Claude Desktop. This PR only adds an alias for updating Cursor's global MCP configuration (`--client-config=cursor`), and updates the tip message to include Cursor instructions.
2. Update `teleport_list_databases` function (MCP DB) to return text instead of embedded resources so Cursor can use this function. Cursor completely removed support for MCP resources, and any tool that returns its type is not parsed and returns an error. This change doesn't affect the server functionality, and other clients (like Claude Desktop) should have the same behavior.

For reviewers: Given that Cursor and Claude Desktop use the same configuration format, I've added small helper functions for Cursor (instead of duplicating or moving the implementation to a shared package).

Note: [Cursor MCP deeplinks](https://docs.cursor.com/tools/developers) generation wasn't added as hyperlinks on terminals might not be the best UX. The links would probably be available on WebUI.