### PR TITLE
[v18][vnet] feat: serve DNS on IPv4

### DIFF
--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -75,12 +75,13 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 		return trace.Wrap(err, "reporting network stack info to client application")
 	}
 
-	osConfigProvider, err := newRemoteOSConfigProvider(
-		clt,
-		tunName,
-		networkStackConfig.ipv6Prefix.String(),
-		networkStackConfig.dnsIPv6.String(),
-	)
+	osConfigProvider, err := newRemoteOSConfigProvider(remoteOSConfigProviderConfig{
+		clt:           clt,
+		tunName:       tunName,
+		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
+		addDNSAddress: networkStack.addDNSAddress,
+	})
 	if err != nil {
 		return trace.Wrap(err, "creating OS config provider")
 	}

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -116,12 +116,13 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		return trace.Wrap(err, "reporting network stack info to client application")
 	}
 
-	osConfigProvider, err := newRemoteOSConfigProvider(
-		clt,
-		tunName,
-		networkStackConfig.ipv6Prefix.String(),
-		networkStackConfig.dnsIPv6.String(),
-	)
+	osConfigProvider, err := newRemoteOSConfigProvider(remoteOSConfigProviderConfig{
+		clt:           clt,
+		tunName:       tunName,
+		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
+		addDNSAddress: networkStack.addDNSAddress,
+	})
 	if err != nil {
 		return trace.Wrap(err, "creating OS config provider")
 	}

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"os/exec"
 	"strings"
@@ -32,7 +31,7 @@ type osConfig struct {
 	tunIPv4    string
 	tunIPv6    string
 	cidrRanges []string
-	dnsAddr    string
+	dnsAddrs   []string
 	dnsZones   []string
 }
 
@@ -123,20 +122,6 @@ func tunIPv6ForPrefix(ipv6Prefix string) (string, error) {
 		return "", trace.BadParameter("IPv6 prefix %s is not an IPv6 address", ipv6Prefix)
 	}
 	return addr.Next().String(), nil
-}
-
-// tunIPv4ForCIDR returns the IPv4 address to use for the TUN interface in
-// cidrRange. It always returns the second address in the range.
-func tunIPv4ForCIDR(cidrRange string) (string, error) {
-	_, ipnet, err := net.ParseCIDR(cidrRange)
-	if err != nil {
-		return "", trace.Wrap(err, "parsing CIDR %q", cidrRange)
-	}
-	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
-	// Add 1 to assign the TUN address, like 100.64.0.1
-	tunAddress := ipnet.IP
-	tunAddress[len(tunAddress)-1]++
-	return tunAddress.String(), nil
 }
 
 func runCommand(ctx context.Context, path string, args ...string) error {

--- a/lib/vnet/remote_osconfig_provider.go
+++ b/lib/vnet/remote_osconfig_provider.go
@@ -18,6 +18,8 @@ package vnet
 
 import (
 	"context"
+	"net"
+	"slices"
 
 	"github.com/gravitational/trace"
 
@@ -27,60 +29,93 @@ import (
 // remoteOSConfigProvider fetches a target OS configuration based on cluster
 // configuration fetched via the client application process available over gRPC.
 type remoteOSConfigProvider struct {
-	clt     targetOSConfigGetter
-	tunName string
-	dnsAddr string
-	tunIPv6 string
-	tunIPv4 string
+	cfg      remoteOSConfigProviderConfig
+	dnsAddrs []string
+	tunIPv6  string
+	tunIPv4  string
+}
+
+// remoteOSConfigProviderConfig holds configuration parameters for a remoteOSConfigProvider.
+type remoteOSConfigProviderConfig struct {
+	clt           targetOSConfigGetter
+	tunName       string
+	ipv6Prefix    string
+	dnsIPv6       string
+	addDNSAddress func(net.IP) error
 }
 
 type targetOSConfigGetter interface {
 	GetTargetOSConfiguration(context.Context) (*vnetv1.TargetOSConfiguration, error)
 }
 
-func newRemoteOSConfigProvider(clt targetOSConfigGetter, tunName, ipv6Prefix, dnsAddr string) (*remoteOSConfigProvider, error) {
-	tunIPv6, err := tunIPv6ForPrefix(ipv6Prefix)
+func newRemoteOSConfigProvider(cfg remoteOSConfigProviderConfig) (*remoteOSConfigProvider, error) {
+	tunIPv6, err := tunIPv6ForPrefix(cfg.ipv6Prefix)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &remoteOSConfigProvider{
-		clt:     clt,
-		tunName: tunName,
-		dnsAddr: dnsAddr,
-		tunIPv6: tunIPv6,
+		cfg:      cfg,
+		dnsAddrs: []string{cfg.dnsIPv6},
+		tunIPv6:  tunIPv6,
 	}, nil
 }
 
 func (p *remoteOSConfigProvider) targetOSConfig(ctx context.Context) (*osConfig, error) {
-	targetOSConfig, err := p.clt.GetTargetOSConfiguration(ctx)
+	targetOSConfig, err := p.cfg.clt.GetTargetOSConfiguration(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting target OS configuration from client application")
 	}
 	if p.tunIPv4 == "" && len(targetOSConfig.Ipv4CidrRanges) > 0 {
-		// Choose an IPv4 address for the TUN interface from the CIDR range of one arbitrary currently
-		// logged-in cluster. Only one IPv4 address is needed.
-		if err := p.setTunIPv4FromCIDR(targetOSConfig.Ipv4CidrRanges[0]); err != nil {
+		// Choose an IPv4 address for the TUN interface and the IPv4 DNS server
+		// from the CIDR range of one arbitrary currently logged-in cluster.
+		// We currently only assign one V4 address to the interface and only
+		// advertise DNS on one V4 address.
+		if err := p.setV4IPsFromFirstCIDR(targetOSConfig.Ipv4CidrRanges[0]); err != nil {
 			return nil, trace.Wrap(err, "setting TUN IPv4 address")
 		}
 	}
 	return &osConfig{
-		tunName:    p.tunName,
+		tunName:    p.cfg.tunName,
 		tunIPv6:    p.tunIPv6,
 		tunIPv4:    p.tunIPv4,
-		dnsAddr:    p.dnsAddr,
+		dnsAddrs:   p.dnsAddrs,
 		dnsZones:   targetOSConfig.GetDnsZones(),
 		cidrRanges: targetOSConfig.GetIpv4CidrRanges(),
 	}, nil
 }
 
-func (p *remoteOSConfigProvider) setTunIPv4FromCIDR(cidrRange string) error {
+func (p *remoteOSConfigProvider) setV4IPsFromFirstCIDR(cidrRange string) error {
 	if p.tunIPv4 != "" {
+		// Only set these once.
 		return nil
 	}
-	ip, err := tunIPv4ForCIDR(cidrRange)
+	tunIPv4, dnsIPv4, err := ipsForCIDR(cidrRange)
 	if err != nil {
 		return trace.Wrap(err, "setting TUN IPv4 address for range %s", cidrRange)
 	}
-	p.tunIPv4 = ip
+	if err := p.cfg.addDNSAddress(dnsIPv4); err != nil {
+		return trace.Wrap(err, "adding IPv4 DNS server at %s", dnsIPv4.String())
+	}
+	p.tunIPv4 = tunIPv4.String()
+	p.dnsAddrs = append(p.dnsAddrs, dnsIPv4.String())
 	return nil
+}
+
+// ipsForCIDR returns the V4 IPs to assign to the interface and use for DNS in
+// cidrRange.
+func ipsForCIDR(cidrRange string) (tunIP net.IP, dnsIP net.IP, err error) {
+	_, ipnet, err := net.ParseCIDR(cidrRange)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "parsing CIDR %q", cidrRange)
+	}
+	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
+	// Add 1 to assign the TUN address, like 100.64.0.1
+	tunIP = ipnet.IP
+	tunIP[len(tunIP)-1]++
+
+	// Add 1 again to assign the DNS address, like 100.64.0.2
+	dnsIP = slices.Clone(tunIP)
+	dnsIP[len(dnsIP)-1]++
+
+	return tunIP, dnsIP, nil
 }

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -44,4 +44,5 @@ var (
 	_ = (*osConfigurator).runOSConfigurationLoop
 	_ = runCommand
 	_ = newNetworkStackConfig
+	_ = (*networkStack).addDNSAddress
 )


### PR DESCRIPTION
Backport #55539 to branch/v18

This backport was delayed because I was originally planning to include it in the v18 backport of VNet SSH but we're going to hold that one for a while.

changelog: Made VNet DNS available over IPv4