### PR TITLE
Add LatencyStats decoder

### DIFF
--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -186,6 +186,8 @@ func decodeMessage(firstByte byte, in byteReader) (Message, error) {
 		return decodeSharedDirectoryTruncateRequest(in)
 	case TypeSharedDirectoryTruncateResponse:
 		return decodeSharedDirectoryTruncateResponse(in)
+	case TypeLatencyStats:
+		return decodeLatencyStats(in)
 	case TypePing:
 		return decodePing(in)
 	case TypeClientKeyboardLayout:
@@ -1651,6 +1653,17 @@ func (l LatencyStats) Encode() ([]byte, error) {
 	writeUint32(buf, l.ClientLatency)
 	writeUint32(buf, l.ServerLatency)
 	return buf.Bytes(), nil
+}
+
+func decodeLatencyStats(in io.Reader) (LatencyStats, error) {
+	var latencyStats LatencyStats
+	if err := binary.Read(in, binary.BigEndian, &latencyStats.ClientLatency); err != nil {
+		return latencyStats, trace.Wrap(err)
+	}
+	if err := binary.Read(in, binary.BigEndian, &latencyStats.ServerLatency); err != nil {
+		return latencyStats, trace.Wrap(err)
+	}
+	return latencyStats, nil
 }
 
 // Ping is used to measure the latency of the connection(s) between proxy and desktop (includes

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2432,6 +2432,12 @@ func TestDesktopAccessMFA(t *testing.T) {
 
 			msg, err := tdpClient.ReadMessage()
 			require.NoError(t, err)
+
+			// sometimes LatencyStats will be sent before we get Alert, in such case just skip it and get next one
+			if _, ok := msg.(tdp.LatencyStats); ok {
+				msg, err = tdpClient.ReadMessage()
+				require.NoError(t, err)
+			}
 			require.IsType(t, tdp.Alert{}, msg)
 		})
 	}


### PR DESCRIPTION
This change adds decoder for `LatencyStats` TDP message.
It also fixes flaky test where we sometimes get `LatencyStats` message before we get expected `Alert`.

Closes #56376