### PR TITLE
Remove test code from lib/auth/keystore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,8 @@ linters:
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/utils/mcptest
               desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/auth/keystoretest
+              desc: testing packages should not be imported outside of _test.go files
         logging:
           deny:
             - pkg: github.com/sirupsen/logrus
@@ -206,6 +208,7 @@ linters:
             - '!**/e/tests/**'
             - '!**/lib/auth/helpers.go'
             - '!**/lib/auth/keystore/testhelpers.go'
+            - '!**/lib/auth/keystore/keystoretest/**'
             - '!**/lib/backend/test/**'
             - '!**/lib/events/athena/test.go'
             - '!**/lib/events/test/**'
@@ -261,6 +264,7 @@ linters:
             - '!**/integrations/operator/controllers/resources/testlib/**'
             - '!**/lib/auth/helpers.go'
             - '!**/lib/auth/keystore/testhelpers.go'
+            - '!**/lib/auth/keystore/keystoretest/**'
             - '!**/lib/backend/test/**'
             - '!**/lib/cryptosuites/precompute.go'
             - '!**/lib/cryptosuites/internal/rsa/rsa.go'

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/keystore/keystoretest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/backend"
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 func newHSMAuthConfig(t *testing.T, storageConfig *backend.Config, log *slog.Logger, clock clockwork.Clock) *servicecfg.Config {
 	config := newAuthConfig(t, log, clock)
 	config.Auth.StorageConfig = *storageConfig
-	config.Auth.KeyStore = keystore.HSMTestConfig(t)
+	config.Auth.KeyStore = keystoretest.HSMTestConfig(t)
 	authPref, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 		SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1,
 	})
@@ -423,7 +423,7 @@ func TestHSMMigrate(t *testing.T) {
 	// Phase 1: migrate auth1 to HSM
 	auth1.process.Close()
 	require.NoError(t, auth1.waitForShutdown(ctx))
-	auth1Config.Auth.KeyStore = keystore.HSMTestConfig(t)
+	auth1Config.Auth.KeyStore = keystoretest.HSMTestConfig(t)
 	auth1, err = newTeleportService(ctx, auth1Config, "auth1")
 	require.NoError(t, err)
 
@@ -499,7 +499,7 @@ func TestHSMMigrate(t *testing.T) {
 	// Phase 2: migrate auth2 to HSM
 	auth2.process.Close()
 	require.NoError(t, auth2.waitForShutdown(ctx))
-	auth2Config.Auth.KeyStore = keystore.HSMTestConfig(t)
+	auth2Config.Auth.KeyStore = keystoretest.HSMTestConfig(t)
 	auth2, err = newTeleportService(ctx, auth2Config, "auth2")
 	require.NoError(t, err)
 	authServices = teleportServices{auth1, auth2}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7797,9 +7797,15 @@ func (a *Server) addAdditionalTrustedKeysAtomic(ctx context.Context, ca types.Ce
 	return trace.Errorf("too many conflicts attempting to set additional trusted keys for ca %q of type %q", ca.GetClusterName(), ca.GetType())
 }
 
+type Keystore interface {
+	NewSSHKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.SSHKeyPair, error)
+	NewTLSKeyPair(ctx context.Context, clusterName string, purpose cryptosuites.KeyPurpose) (*types.TLSKeyPair, error)
+	NewJWTKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.JWTKeyPair, error)
+}
+
 // newKeySet generates a new sets of keys for a given CA type.
 // Keep this function in sync with lib/services/suite/suite.go:NewTestCAWithConfig().
-func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
+func newKeySet(ctx context.Context, keyStore Keystore, caID types.CertAuthID) (types.CAKeySet, error) {
 	var keySet types.CAKeySet
 
 	// Add SSH keys if necessary.

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -67,7 +67,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/keystore/keystoretest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/authz"
@@ -4019,8 +4019,8 @@ func TestCAGeneration(t *testing.T) {
 	privKey, pubKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	keyStore := keystore.NewSoftwareKeystoreForTests(t,
-		keystore.WithRSAKeyPairSource(func() (priv []byte, pub []byte, err error) {
+	keyStore := keystoretest.NewTestKeystore(
+		keystoretest.WithRSAKeyPairSource(func() (priv []byte, pub []byte, err error) {
 			return privKey, pubKey, nil
 		}),
 	)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -58,7 +58,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
-	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/keystore/keystoretest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -216,7 +216,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 		cfg := setupConfig(t)
 		cfg.FIPS = fips
 		if hsm {
-			cfg.KeyStoreConfig = keystore.HSMTestConfig(t)
+			cfg.KeyStoreConfig = keystoretest.HSMTestConfig(t)
 		}
 		cfg.AuthPreference.SetOrigin(capOrigin)
 		if capOrigin != types.OriginDefaults {
@@ -387,7 +387,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 					},
 				}
 				if tc.hsm {
-					cfg.KeystoreConfig = keystore.HSMTestConfig(t)
+					cfg.KeystoreConfig = keystoretest.HSMTestConfig(t)
 				}
 				testAuthServer, err := NewTestAuthServer(cfg)
 				require.NoError(t, err)

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/lib/auth/integration/credentials"
-	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/keystore/keystoretest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -893,7 +893,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 		Backend:         backendSvc,
 		Authorizer:      authorizer,
 		Cache:           cache,
-		KeyStoreManager: keystore.NewSoftwareKeystoreForTests(t),
+		KeyStoreManager: keystoretest.NewTestKeystore(),
 		Emitter:         events.NewDiscardEmitter(),
 		awsRolesAnywhereCreateSessionFn: func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
 			return &createsession.CreateSessionResponse{

--- a/lib/auth/keystore/internal/backend.go
+++ b/lib/auth/keystore/internal/backend.go
@@ -1,0 +1,68 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package internal
+
+import (
+	"context"
+	"crypto"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
+
+// backend is an interface that holds private keys and provides signing and decryption
+// operations.
+type Backend interface {
+	// generateSigner creates a new key pair and returns its identifier and a crypto.Signer. The returned
+	// identifier can be passed to getSigner later to get an equivalent crypto.Signer.
+	GenerateSigner(context.Context, cryptosuites.Algorithm) (keyID []byte, signer crypto.Signer, err error)
+
+	// generateDecrypter creates a new key pair and returns its identifier and a crypto.Decrypter. The returned
+	// identifier can be passed to getDecrypter later to get an equivalent crypto.Decrypter.
+	GenerateDecrypter(context.Context, cryptosuites.Algorithm) (keyID []byte, decrypter crypto.Decrypter, hash crypto.Hash, err error)
+
+	// getSigner returns a crypto.Signer for the given key identifier, if it is found.
+	// The public key is passed as well so that it does not need to be fetched
+	// from the underlying backend, and it is always stored in the CA anyway.
+	GetSigner(ctx context.Context, keyID []byte, pub crypto.PublicKey) (crypto.Signer, error)
+
+	// getDecrypter returns a crypto.Decrypter for the given key identifier, if it is found.
+	// The public key is passed as well so that it does not need to be fetched
+	// from the underlying backend.
+	GetDecrypter(ctx context.Context, keyID []byte, pub crypto.PublicKey, hash crypto.Hash) (crypto.Decrypter, error)
+
+	// canUseKey returns true if this backend is able to sign or decrypt with the
+	// given key.
+	CanUseKey(ctx context.Context, raw []byte, keyType types.PrivateKeyType) (bool, error)
+
+	// deleteKey deletes the given key from the backend.
+	DeleteKey(ctx context.Context, keyID []byte) error
+
+	// deleteUnusedKeys deletes all keys from the backend if they are:
+	// 1. Not included in the argument activeKeys which is meant to contain all
+	//    active keys currently referenced in the backend CA.
+	// 2. Created in the backend by this Teleport cluster.
+	// 3. Each backend may apply extra restrictions to which keys may be deleted.
+	DeleteUnusedKeys(ctx context.Context, activeKeys [][]byte) error
+
+	// keyTypeDescription returns a human-readable description of the types of
+	// keys this backend uses.
+	KeyTypeDescription() string
+
+	// name returns the name of the backend.
+	Name() string
+}

--- a/lib/auth/keystore/internal/key.go
+++ b/lib/auth/keystore/internal/key.go
@@ -1,0 +1,87 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package internal
+
+import (
+	"bytes"
+
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// keyUsage marks a given key to be used either with signing or decryption
+type keyUsage string
+
+const (
+	keyUsageNone    keyUsage = ""
+	keyUsageSign    keyUsage = "sign"
+	keyUsageDecrypt keyUsage = "decrypt"
+)
+
+func (u keyUsage) toAWS() kmstypes.KeyUsageType {
+	switch u {
+	case keyUsageDecrypt:
+		return kmstypes.KeyUsageTypeEncryptDecrypt
+	default:
+		return kmstypes.KeyUsageTypeSignVerify
+	}
+}
+
+// KeyType returns the type of the given private key.
+func KeyType(key []byte) types.PrivateKeyType {
+	if bytes.HasPrefix(key, pkcs11Prefix) {
+		return types.PrivateKeyType_PKCS11
+	}
+	if bytes.HasPrefix(key, []byte(gcpkmsPrefix)) {
+		return types.PrivateKeyType_GCP_KMS
+	}
+	if bytes.HasPrefix(key, []byte(awskmsPrefix)) {
+		return types.PrivateKeyType_AWS_KMS
+	}
+	return types.PrivateKeyType_RAW
+}
+
+func KeyDescription(key []byte) (string, error) {
+	switch KeyType(key) {
+	case types.PrivateKeyType_PKCS11:
+		keyID, err := parsePKCS11KeyID(key)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return "PKCS#11 HSM keys created by " + keyID.HostID, nil
+	case types.PrivateKeyType_GCP_KMS:
+		keyID, err := ParseGCPKMSKeyID(key)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		keyring, err := keyID.keyring()
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return "GCP KMS keys in keyring " + keyring, nil
+	case types.PrivateKeyType_AWS_KMS:
+		keyID, err := ParseAWSKMSKeyID(key)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return "AWS KMS keys in account " + keyID.Account + " and region " + keyID.Region, nil
+	default:
+		return "raw software keys", nil
+	}
+}

--- a/lib/auth/keystore/internal/ssh_signer.go
+++ b/lib/auth/keystore/internal/ssh_signer.go
@@ -1,0 +1,98 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package internal
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+)
+
+func SSHSignerFromCryptoSigner(cryptoSigner crypto.Signer) (ssh.Signer, error) {
+	sshSigner, err := ssh.NewSignerFromSigner(cryptoSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// [ssh.NewSignerFromSigner] currently always returns an [ssh.AlgorithmSigner].
+	algorithmSigner, ok := sshSigner.(ssh.AlgorithmSigner)
+	if !ok {
+		return nil, trace.BadParameter("SSH CA: unsupported key type: %s", sshSigner.PublicKey().Type())
+	}
+	// Note: we don't actually create keys with all the algorithms supported
+	// below, but customers have been known to import their own existing keys.
+	switch pub := cryptoSigner.Public().(type) {
+	case *rsa.PublicKey:
+		// The current default hash used in ssh.(*Certificate).SignCert for an
+		// RSA signer created via ssh.NewSignerFromSigner is always SHA256,
+		// irrespective of the key size.
+		// This was a change in golang.org/x/crypto 0.14.0, prior to that the
+		// default was always SHA512.
+		//
+		// Due to the historical SHA512 default that existed at a time when
+		// hash algorithm selection was much more difficult, there are many
+		// existing GCP KMS keys that were created as 4096-bit keys using a
+		// SHA512 hash. GCP KMS is very particular about RSA hash algorithms:
+		// - 2048-bit or 3072-bit keys *must* use SHA256
+		// - 4096-bit keys *must* use SHA256 or SHA512
+		// - the hash length must be set *when the key is created* and can't be
+		//   changed.
+		//
+		// The chosen signature algorithms below are necessary to support
+		// existing GCP KMS keys, but they are also reasonable defaults for keys
+		// outside of GCP KMS.
+		//
+		// [rsa.PublicKey.Size()] returns 256 for a 2048-bit key; more generally
+		// it always returns the bit length divided by 8.
+		keySize := pub.Size()
+		switch {
+		case keySize < 256:
+			return nil, trace.BadParameter("SSH CA: RSA key size (%d) is too small", keySize)
+		case keySize < 512:
+			// This case matches 2048 and 3072 bit GCP KMS keys which *must* use SHA256.
+			return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoRSASHA256})
+		default:
+			// This case matches existing 4096 bit GCP KMS keys which *must* use SHA512
+			return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoRSASHA512})
+		}
+	case *ecdsa.PublicKey:
+		// These are all the current defaults, but let's set them explicitly so
+		// golang.org/x/crypto/ssh can't change them in an update and break some
+		// HSM or KMS that wouldn't support the new default.
+		switch pub.Curve {
+		case elliptic.P256():
+			return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoECDSA256})
+		case elliptic.P384():
+			return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoECDSA384})
+		case elliptic.P521():
+			return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoECDSA521})
+		default:
+			return nil, trace.BadParameter("SSH CA: ECDSA curve: %s", pub.Curve.Params().Name)
+		}
+	case ed25519.PublicKey:
+		// This is the current default, but let's set it explicitly so
+		// golang.org/x/crypto/ssh can't change it in an update and break some
+		// HSM or KMS that wouldn't support the new default.
+		return ssh.NewSignerWithAlgorithms(algorithmSigner, []string{ssh.KeyAlgoED25519})
+	default:
+		return nil, trace.BadParameter("SSH CA: unsupported key type: %s", sshSigner.PublicKey().Type())
+	}
+}

--- a/lib/auth/keystore/keystoretest/testhelpers.go
+++ b/lib/auth/keystore/keystoretest/testhelpers.go
@@ -1,0 +1,397 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package keystoretest
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/keystore/internal"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func HSMTestConfig(t *testing.T) servicecfg.KeystoreConfig {
+	if cfg, ok := YubiHSMTestConfig(t); ok {
+		t.Log("Running test with YubiHSM")
+		return cfg
+	}
+	if cfg, ok := CloudHSMTestConfig(t); ok {
+		t.Log("Running test with AWS CloudHSM")
+		return cfg
+	}
+	if cfg, ok := AWSKMSTestConfig(t); ok {
+		t.Log("Running test with AWS KMS")
+		return cfg
+	}
+	if cfg, ok := GCPKMSTestConfig(t); ok {
+		t.Log("Running test with GCP KMS")
+		return cfg
+	}
+	if cfg, ok := SoftHSMTestConfig(t); ok {
+		t.Log("Running test with SoftHSM")
+		return cfg
+	}
+	t.Skip("No HSM available for test")
+	return servicecfg.KeystoreConfig{}
+}
+
+func YubiHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
+	yubiHSMPath := os.Getenv("TELEPORT_TEST_YUBIHSM_PKCS11_PATH")
+	yubiHSMPin := os.Getenv("TELEPORT_TEST_YUBIHSM_PIN")
+	if yubiHSMPath == "" || yubiHSMPin == "" {
+		return servicecfg.KeystoreConfig{}, false
+	}
+
+	slotNumber := 0
+	return servicecfg.KeystoreConfig{
+		PKCS11: servicecfg.PKCS11Config{
+			Path:       yubiHSMPath,
+			SlotNumber: &slotNumber,
+			PIN:        yubiHSMPin,
+		},
+	}, true
+}
+
+func CloudHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
+	cloudHSMPin := os.Getenv("TELEPORT_TEST_CLOUDHSM_PIN")
+	if cloudHSMPin == "" {
+		return servicecfg.KeystoreConfig{}, false
+	}
+	return servicecfg.KeystoreConfig{
+		PKCS11: servicecfg.PKCS11Config{
+			Path:       "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
+			TokenLabel: "cavium",
+			PIN:        cloudHSMPin,
+		},
+	}, true
+}
+
+func AWSKMSTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
+	awsKMSAccount := os.Getenv("TELEPORT_TEST_AWS_KMS_ACCOUNT")
+	awsKMSRegion := os.Getenv("TELEPORT_TEST_AWS_KMS_REGION")
+	if awsKMSAccount == "" || awsKMSRegion == "" {
+		return servicecfg.KeystoreConfig{}, false
+	}
+	return servicecfg.KeystoreConfig{
+		AWSKMS: &servicecfg.AWSKMSConfig{
+			AWSAccount: awsKMSAccount,
+			AWSRegion:  awsKMSRegion,
+		},
+	}, true
+}
+
+func GCPKMSTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
+	gcpKeyring := os.Getenv("TELEPORT_TEST_GCP_KMS_KEYRING")
+	if gcpKeyring == "" {
+		return servicecfg.KeystoreConfig{}, false
+	}
+	return servicecfg.KeystoreConfig{
+		GCPKMS: servicecfg.GCPKMSConfig{
+			KeyRing:         gcpKeyring,
+			ProtectionLevel: "SOFTWARE",
+		},
+	}, true
+}
+
+var (
+	cachedSoftHSMConfig      *servicecfg.KeystoreConfig
+	cachedSoftHSMConfigMutex sync.Mutex
+)
+
+// softHSMTestConfig is for use in tests only and creates a test SOFTHSM2 token.
+// This should be used for all tests which need to use SoftHSM because the
+// library can only be initialized once and SOFTHSM2_PATH and SOFTHSM2_CONF
+// cannot be changed. New tokens added after the library has been initialized
+// will not be found by the library.
+//
+// A new token will be used for each `go test` invocation, but it's difficult
+// to create a separate token for each test because because new tokens
+// added after the library has been initialized will not be found by the
+// library. It's also difficult to clean up the token because tests for all
+// packages are run in parallel there is not a good time to safely
+// delete the token or the entire token directory. Each test should clean up
+// all keys that it creates because SoftHSM2 gets really slow when there are
+// many keys for a given token.
+func SoftHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
+	path := os.Getenv("SOFTHSM2_PATH")
+	if path == "" {
+		return servicecfg.KeystoreConfig{}, false
+	}
+
+	cachedSoftHSMConfigMutex.Lock()
+	defer cachedSoftHSMConfigMutex.Unlock()
+
+	if cachedSoftHSMConfig != nil {
+		return *cachedSoftHSMConfig, true
+	}
+
+	if os.Getenv("SOFTHSM2_CONF") == "" {
+		// create tokendir
+		tokenDir, err := os.MkdirTemp("", "tokens")
+		require.NoError(t, err)
+
+		// create config file
+		configFile, err := os.CreateTemp("", "softhsm2.conf")
+		require.NoError(t, err)
+
+		// write config file
+		_, err = fmt.Fprintf(configFile, "directories.tokendir = %s\nobjectstore.backend = file\nlog.level = DEBUG\n", tokenDir)
+		require.NoError(t, err)
+		require.NoError(t, configFile.Close())
+
+		// set env
+		os.Setenv("SOFTHSM2_CONF", configFile.Name())
+	}
+
+	// create test token (max length is 32 chars)
+	tokenLabel := strings.ReplaceAll(uuid.NewString(), "-", "")
+	cmd := exec.Command("softhsm2-util", "--init-token", "--free", "--label", tokenLabel, "--so-pin", "password", "--pin", "password")
+	t.Logf("Running command: %q", cmd)
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			require.NoError(t, exitErr, "error creating test softhsm token: %s", string(exitErr.Stderr))
+		}
+		require.NoError(t, err, "error attempting to run softhsm2-util")
+	}
+
+	cachedSoftHSMConfig = &servicecfg.KeystoreConfig{
+		PKCS11: servicecfg.PKCS11Config{
+			Path:       path,
+			TokenLabel: tokenLabel,
+			PIN:        "password",
+		},
+	}
+	return *cachedSoftHSMConfig, true
+}
+
+type testKeystoreOptions struct {
+	rsaKeyPairSource internal.RSAKeyPairSource
+}
+
+type TestKeystoreOption func(*testKeystoreOptions)
+
+func WithRSAKeyPairSource(rsaKeyPairSource internal.RSAKeyPairSource) TestKeystoreOption {
+	return func(opts *testKeystoreOptions) {
+		opts.rsaKeyPairSource = rsaKeyPairSource
+	}
+}
+
+// NewTestKeystore returns a new TestKeystore that is valid for tests and
+// not specifically testing the keystore functionality.
+func NewTestKeystore(opts ...TestKeystoreOption) *TestKeystore {
+	var options testKeystoreOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	softwareBackend := internal.NewSoftwareKeyStore(options.rsaKeyPairSource)
+	return &TestKeystore{
+		backend: softwareBackend,
+	}
+}
+
+type TestKeystore struct {
+	backend internal.Backend
+}
+
+func (t *TestKeystore) NewSSHKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.SSHKeyPair, error) {
+	alg, err := cryptosuites.AlgorithmForKey(ctx,
+		func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
+		},
+		purpose)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshKey, signer, err := t.backend.GenerateSigner(ctx, alg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sshPub, err := ssh.NewPublicKey(signer.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &types.SSHKeyPair{
+		PublicKey:      ssh.MarshalAuthorizedKey(sshPub),
+		PrivateKey:     sshKey,
+		PrivateKeyType: internal.KeyType(sshKey),
+	}, nil
+}
+
+func (t *TestKeystore) NewJWTKeyPair(ctx context.Context, purpose cryptosuites.KeyPurpose) (*types.JWTKeyPair, error) {
+	alg, err := cryptosuites.AlgorithmForKey(ctx,
+		func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
+		},
+		purpose)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	jwtKey, signer, err := t.backend.GenerateSigner(ctx, alg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	publicKey, err := keys.MarshalPublicKey(signer.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &types.JWTKeyPair{
+		PublicKey:      publicKey,
+		PrivateKey:     jwtKey,
+		PrivateKeyType: internal.KeyType(jwtKey),
+	}, nil
+}
+
+func (t *TestKeystore) NewTLSKeyPair(ctx context.Context, clusterName string, purpose cryptosuites.KeyPurpose) (*types.TLSKeyPair, error) {
+	alg, err := cryptosuites.AlgorithmForKey(ctx,
+		func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
+		},
+		purpose)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsKey, signer, err := t.backend.GenerateSigner(ctx, alg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsCert, err := tlsca.GenerateSelfSignedCAWithSigner(
+		signer,
+		pkix.Name{
+			CommonName:   clusterName,
+			Organization: []string{clusterName},
+		},
+		nil,
+		defaults.CATTL,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &types.TLSKeyPair{
+		Cert:    tlsCert,
+		Key:     tlsKey,
+		KeyType: internal.KeyType(tlsKey),
+	}, nil
+}
+
+func (t *TestKeystore) GetTLSCertAndSigner(ctx context.Context, ca types.CertAuthority) ([]byte, crypto.Signer, error) {
+	for _, keyPair := range ca.GetActiveKeys().TLS {
+		canUse, err := t.backend.CanUseKey(ctx, keyPair.Key, keyPair.KeyType)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		if !canUse {
+			continue
+		}
+
+		block, _ := pem.Decode(keyPair.Cert)
+		if block == nil {
+			return nil, nil, trace.BadParameter("failed to parse PEM block")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, trace.Wrap(err, "failed to parse x509 certificate")
+		}
+
+		signer, err := t.backend.GetSigner(ctx, keyPair.Key, cert.PublicKey)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return keyPair.Cert, signer, nil
+	}
+
+	return nil, nil, trace.NotFound("no usable TLS key pairs found")
+}
+
+func (t *TestKeystore) GetJWTSigner(ctx context.Context, ca types.CertAuthority) (crypto.Signer, error) {
+	for _, keyPair := range ca.GetActiveKeys().JWT {
+		canUse, err := t.backend.CanUseKey(ctx, keyPair.PrivateKey, keyPair.PrivateKeyType)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !canUse {
+			continue
+		}
+		pub, err := keys.ParsePublicKey(keyPair.PublicKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		signer, err := t.backend.GetSigner(ctx, keyPair.PrivateKey, pub)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return signer, nil
+	}
+
+	return nil, trace.NotFound("no usable JWT key pairs found")
+}
+
+func (t *TestKeystore) GetSSHSignerFromKeySet(ctx context.Context, keySet types.CAKeySet) (ssh.Signer, error) {
+	for _, keyPair := range keySet.SSH {
+		canUse, err := t.backend.CanUseKey(ctx, keyPair.PrivateKey, keyPair.PrivateKeyType)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !canUse {
+			continue
+		}
+
+		sshPublicKey, _, _, _, err := ssh.ParseAuthorizedKey(keyPair.PublicKey)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse SSH public key")
+		}
+		cryptoPublicKey, ok := sshPublicKey.(ssh.CryptoPublicKey)
+		if !ok {
+			return nil, trace.BadParameter("unsupported SSH public key type %q", sshPublicKey.Type())
+		}
+
+		signer, err := t.backend.GetSigner(ctx, keyPair.PrivateKey, cryptoPublicKey.CryptoPublicKey())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		sshSigner, err := internal.SSHSignerFromCryptoSigner(signer)
+		return sshSigner, trace.Wrap(err)
+	}
+
+	return nil, trace.NotFound("no usable SSH key pairs found")
+}

--- a/lib/auth/keystore/ssh_signature_test.go
+++ b/lib/auth/keystore/ssh_signature_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/keystore/internal"
 )
 
 // TestSSHSignatureAlgorithm asserts that [ssh.(*Certificate).SignCert] honors
@@ -79,7 +80,7 @@ func TestSSHSignatureAlgorithm(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			sshSigner, err := sshSignerFromCryptoSigner(tc.signer)
+			sshSigner, err := internal.SSHSignerFromCryptoSigner(tc.signer)
 			require.NoError(t, err)
 			cert := ssh.Certificate{
 				Key:         subjectPubKey,

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -20,213 +20,24 @@ package keystore
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-	"sync"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
-
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/keystore/internal"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
-
-func HSMTestConfig(t *testing.T) servicecfg.KeystoreConfig {
-	if cfg, ok := yubiHSMTestConfig(t); ok {
-		t.Log("Running test with YubiHSM")
-		return cfg
-	}
-	if cfg, ok := cloudHSMTestConfig(t); ok {
-		t.Log("Running test with AWS CloudHSM")
-		return cfg
-	}
-	if cfg, ok := awsKMSTestConfig(t); ok {
-		t.Log("Running test with AWS KMS")
-		return cfg
-	}
-	if cfg, ok := gcpKMSTestConfig(t); ok {
-		t.Log("Running test with GCP KMS")
-		return cfg
-	}
-	if cfg, ok := softHSMTestConfig(t); ok {
-		t.Log("Running test with SoftHSM")
-		return cfg
-	}
-	t.Skip("No HSM available for test")
-	return servicecfg.KeystoreConfig{}
-}
-
-func yubiHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
-	yubiHSMPath := os.Getenv("TELEPORT_TEST_YUBIHSM_PKCS11_PATH")
-	yubiHSMPin := os.Getenv("TELEPORT_TEST_YUBIHSM_PIN")
-	if yubiHSMPath == "" || yubiHSMPin == "" {
-		return servicecfg.KeystoreConfig{}, false
-	}
-	slotNumber := 0
-	return servicecfg.KeystoreConfig{
-		PKCS11: servicecfg.PKCS11Config{
-			Path:       yubiHSMPath,
-			SlotNumber: &slotNumber,
-			PIN:        yubiHSMPin,
-		},
-	}, true
-}
-
-func cloudHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
-	cloudHSMPin := os.Getenv("TELEPORT_TEST_CLOUDHSM_PIN")
-	if cloudHSMPin == "" {
-		return servicecfg.KeystoreConfig{}, false
-	}
-	return servicecfg.KeystoreConfig{
-		PKCS11: servicecfg.PKCS11Config{
-			Path:       "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
-			TokenLabel: "cavium",
-			PIN:        cloudHSMPin,
-		},
-	}, true
-}
-
-func awsKMSTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
-	awsKMSAccount := os.Getenv("TELEPORT_TEST_AWS_KMS_ACCOUNT")
-	awsKMSRegion := os.Getenv("TELEPORT_TEST_AWS_KMS_REGION")
-	if awsKMSAccount == "" || awsKMSRegion == "" {
-		return servicecfg.KeystoreConfig{}, false
-	}
-	return servicecfg.KeystoreConfig{
-		AWSKMS: &servicecfg.AWSKMSConfig{
-			AWSAccount: awsKMSAccount,
-			AWSRegion:  awsKMSRegion,
-		},
-	}, true
-}
-
-func gcpKMSTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
-	gcpKeyring := os.Getenv("TELEPORT_TEST_GCP_KMS_KEYRING")
-	if gcpKeyring == "" {
-		return servicecfg.KeystoreConfig{}, false
-	}
-	return servicecfg.KeystoreConfig{
-		GCPKMS: servicecfg.GCPKMSConfig{
-			KeyRing:         gcpKeyring,
-			ProtectionLevel: "SOFTWARE",
-		},
-	}, true
-}
-
-var (
-	cachedSoftHSMConfig      *servicecfg.KeystoreConfig
-	cachedSoftHSMConfigMutex sync.Mutex
-)
-
-// softHSMTestConfig is for use in tests only and creates a test SOFTHSM2 token.
-// This should be used for all tests which need to use SoftHSM because the
-// library can only be initialized once and SOFTHSM2_PATH and SOFTHSM2_CONF
-// cannot be changed. New tokens added after the library has been initialized
-// will not be found by the library.
-//
-// A new token will be used for each `go test` invocation, but it's difficult
-// to create a separate token for each test because because new tokens
-// added after the library has been initialized will not be found by the
-// library. It's also difficult to clean up the token because tests for all
-// packages are run in parallel there is not a good time to safely
-// delete the token or the entire token directory. Each test should clean up
-// all keys that it creates because SoftHSM2 gets really slow when there are
-// many keys for a given token.
-func softHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
-	path := os.Getenv("SOFTHSM2_PATH")
-	if path == "" {
-		return servicecfg.KeystoreConfig{}, false
-	}
-
-	cachedSoftHSMConfigMutex.Lock()
-	defer cachedSoftHSMConfigMutex.Unlock()
-
-	if cachedSoftHSMConfig != nil {
-		return *cachedSoftHSMConfig, true
-	}
-
-	if os.Getenv("SOFTHSM2_CONF") == "" {
-		// create tokendir
-		tokenDir, err := os.MkdirTemp("", "tokens")
-		require.NoError(t, err)
-
-		// create config file
-		configFile, err := os.CreateTemp("", "softhsm2.conf")
-		require.NoError(t, err)
-
-		// write config file
-		_, err = fmt.Fprintf(configFile, "directories.tokendir = %s\nobjectstore.backend = file\nlog.level = DEBUG\n", tokenDir)
-		require.NoError(t, err)
-		require.NoError(t, configFile.Close())
-
-		// set env
-		os.Setenv("SOFTHSM2_CONF", configFile.Name())
-	}
-
-	// create test token (max length is 32 chars)
-	tokenLabel := strings.ReplaceAll(uuid.NewString(), "-", "")
-	cmd := exec.Command("softhsm2-util", "--init-token", "--free", "--label", tokenLabel, "--so-pin", "password", "--pin", "password")
-	t.Logf("Running command: %q", cmd)
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			require.NoError(t, exitErr, "error creating test softhsm token: %s", string(exitErr.Stderr))
-		}
-		require.NoError(t, err, "error attempting to run softhsm2-util")
-	}
-
-	cachedSoftHSMConfig = &servicecfg.KeystoreConfig{
-		PKCS11: servicecfg.PKCS11Config{
-			Path:       path,
-			TokenLabel: tokenLabel,
-			PIN:        "password",
-		},
-	}
-	return *cachedSoftHSMConfig, true
-}
-
-type testKeystoreOptions struct {
-	rsaKeyPairSource RSAKeyPairSource
-}
-
-type TestKeystoreOption func(*testKeystoreOptions)
-
-func WithRSAKeyPairSource(rsaKeyPairSource RSAKeyPairSource) TestKeystoreOption {
-	return func(opts *testKeystoreOptions) {
-		opts.rsaKeyPairSource = rsaKeyPairSource
-	}
-}
 
 // NewSoftwareKeystoreForTests returns a new *Manager that is valid for tests not specifically testing the
 // keystore functionality.
-func NewSoftwareKeystoreForTests(_ *testing.T, opts ...TestKeystoreOption) *Manager {
-	var options testKeystoreOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
-	softwareBackend := newSoftwareKeyStore(&softwareConfig{rsaKeyPairSource: options.rsaKeyPairSource})
+// Deprecated: Prefer using keystoretest.NewTestKeystore instead.
+// TODO(tross): delete after e reference is updated.
+func NewSoftwareKeystoreForTests(_ *testing.T) *Manager {
+	softwareBackend := internal.NewSoftwareKeyStore(nil)
 	return &Manager{
 		backendForNewKeys: softwareBackend,
-		usableBackends:    []backend{softwareBackend},
+		usableBackends:    []internal.Backend{softwareBackend},
 		currentSuiteGetter: cryptosuites.GetSuiteFunc(func(context.Context) (types.SignatureAlgorithmSuite, error) {
 			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
 		}),
 	}
-}
-
-type fakeAuthPreferenceGetter struct {
-	suite types.SignatureAlgorithmSuite
-}
-
-func (f *fakeAuthPreferenceGetter) GetAuthPreference(context.Context) (types.AuthPreference, error) {
-	return &types.AuthPreferenceV2{
-		Spec: types.AuthPreferenceSpecV2{
-			SignatureAlgorithmSuite: f.suite,
-		},
-	}, nil
 }

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/keystore/keystoretest"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -57,7 +57,7 @@ func TestGenerateCredentials(t *testing.T) {
 		SubjectCommonName:     "test-common-name",
 		DurationSeconds:       nil,
 		AcceptRoleSessionName: true,
-		KeyStoreManager:       keystore.NewSoftwareKeystoreForTests(t),
+		KeyStoreManager:       keystoretest.NewTestKeystore(),
 		Cache: &mockCache{
 			domainName: "cluster-name",
 			ca:         ca,


### PR DESCRIPTION
All test helpers have been relocated to lib/auth/keystore/keystoretest to remove testing symbols from from leaking out of the keystore package. To facilitate the refactoring without exposing any unexported items in the from the keystore package common internal code has been moved to lib/keystore/internal. The tight coupling of the tests on the keystore.Manager required leaving the kms specific tests in the kestore package. A new TestKeystore is now being returned from keystoretest.NewTestKeystore for the same reasons.

Updates https://github.com/gravitational/teleport/issues/51023.