### PR TITLE
Refactor auth test helpers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -205,6 +205,8 @@ linters:
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/utils/logtesttest
               desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/auth/authtest
+              desc: testing packages should not be imported outside of _test.go files
         testify:
           files:
             - '!$test'
@@ -267,6 +269,7 @@ linters:
             - '!**/integrations/access/msteams/testlib/**'
             - '!**/integrations/access/slack/testlib/**'
             - '!**/integrations/operator/controllers/resources/testlib/**'
+            - '!**/lib/auth/authtest/**'
             - '!**/lib/auth/helpers.go'
             - '!**/lib/auth/keystore/testhelpers.go'
             - '!**/lib/backend/test/**'

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -207,7 +207,7 @@ func mustCreateUserKeyRingWithKeys(t *testing.T, tc *TeleInstance, username stri
 
 	tlsPub, err := keys.MarshalPublicKey(tlsKey.Public())
 	require.NoError(t, err)
-	sshCert, tlsCert, err := tc.Process.GetAuthServer().GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+	sshCert, tlsCert, err := tc.Process.GetAuthServer().GenerateUserTestCertsWithContext(t.Context(), auth.GenerateUserTestCertsRequest{
 		SSHPubKey:      keyRing.SSHPrivateKey.MarshalSSHPublicKey(),
 		TLSPubKey:      tlsPub,
 		Username:       username,

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -134,7 +134,7 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 		return nil, trace.Wrap(err)
 	}
 	a := req.Process.GetAuthServer()
-	sshCert, x509Cert, err := a.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+	sshCert, x509Cert, err := a.GenerateUserTestCertsWithContext(context.Background(), auth.GenerateUserTestCertsRequest{
 		SSHPubKey:      sshPub,
 		TLSPubKey:      tlsPub,
 		Username:       req.Username,

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1266,7 +1266,7 @@ type userAuthCreds struct {
 	username      string
 	password      []byte
 
-	totpDev, webDev *authtest.TestDevice
+	totpDev, webDev *authtest.Device
 }
 
 func createUserWithSecondFactors(testServer *authtest.TestTLSServer) (*userAuthCreds, error) {

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1269,7 +1269,7 @@ type userAuthCreds struct {
 	totpDev, webDev *authtest.Device
 }
 
-func createUserWithSecondFactors(testServer *authtest.TestTLSServer) (*userAuthCreds, error) {
+func createUserWithSecondFactors(testServer *authtest.TLSServer) (*userAuthCreds, error) {
 	ctx := context.Background()
 	username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
 	password := []byte("abcdef123456")

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -40,7 +40,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -59,9 +61,9 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 	ctx := context.Background()
 
 	user := "fake@fake.com"
-	rc, err := srv.Auth().generateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
-	require.Len(t, rc.Codes, numOfRecoveryCodes)
+	require.Len(t, rc.Codes, auth.NumOfRecoveryCodes)
 	require.NotEmpty(t, rc.Created)
 
 	// Test codes are not marked used.
@@ -80,7 +82,7 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 		require.True(t, strings.HasPrefix(code, "tele-"))
 
 		// Test codes match.
-		err := srv.Auth().verifyRecoveryCode(ctx, user, []byte(code))
+		err := srv.Auth().VerifyRecoveryCode(ctx, user, []byte(code))
 		require.NoError(t, err)
 	}
 
@@ -92,15 +94,15 @@ func TestGenerateAndUpsertRecoveryCodes(t *testing.T) {
 	}
 
 	// Test with a used code returns error.
-	err = srv.Auth().verifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with invalid recovery code returns error.
-	err = srv.Auth().verifyRecoveryCode(ctx, user, []byte("invalidcode"))
+	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte("invalidcode"))
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Test with non-existing user returns error.
-	err = srv.Auth().verifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
+	err = srv.Auth().VerifyRecoveryCode(ctx, "doesnotexist", []byte(rc.Codes[0]))
 	require.True(t, trace.IsAccessDenied(err))
 }
 
@@ -109,26 +111,26 @@ func TestRecoveryCodeEventsEmitted(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	user := "fake@fake.com"
 
 	// Test generated recovery codes event.
-	rc, err := srv.Auth().generateAndUpsertRecoveryCodes(ctx, user)
+	rc, err := srv.Auth().GenerateAndUpsertRecoveryCodes(ctx, user)
 	require.NoError(t, err)
 	event := mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeGeneratedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodesGenerateCode, event.GetCode())
 
 	// Test used recovery code event.
-	err = srv.Auth().verifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.NoError(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
 	require.Equal(t, events.RecoveryCodeUseSuccessCode, event.GetCode())
 
 	// Re-using the same token emits failed event.
-	err = srv.Auth().verifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
+	err = srv.Auth().VerifyRecoveryCode(ctx, user, []byte(rc.Codes[0]))
 	require.Error(t, err)
 	event = mockEmitter.LastEvent()
 	require.Equal(t, events.RecoveryCodeUsedEvent, event.GetType())
@@ -140,7 +142,7 @@ func TestStartAccountRecovery(t *testing.T) {
 	ctx := context.Background()
 	fakeClock := srv.Clock().(*clockwork.FakeClock)
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -251,21 +253,21 @@ func TestStartAccountRecovery_UserErrors(t *testing.T) {
 	}{
 		{
 			desc:      "username not in valid email format",
-			expErrMsg: startRecoveryGenericErrMsg,
+			expErrMsg: auth.StartRecoveryGenericErrMsg,
 			req: &proto.StartAccountRecoveryRequest{
 				Username: "malformed-email",
 			},
 		},
 		{
 			desc:      "user does not exist",
-			expErrMsg: startRecoveryBadAuthnErrMsg,
+			expErrMsg: auth.StartRecoveryBadAuthnErrMsg,
 			req: &proto.StartAccountRecoveryRequest{
 				Username: "dne@test.com",
 			},
 		},
 		{
 			desc:      "invalid recovery code",
-			expErrMsg: startRecoveryBadAuthnErrMsg,
+			expErrMsg: auth.StartRecoveryBadAuthnErrMsg,
 			req: &proto.StartAccountRecoveryRequest{
 				Username:     u.username,
 				RecoveryCode: []byte("invalid-code"),
@@ -273,7 +275,7 @@ func TestStartAccountRecovery_UserErrors(t *testing.T) {
 		},
 		{
 			desc:      "missing recover type in request",
-			expErrMsg: startRecoveryGenericErrMsg,
+			expErrMsg: auth.StartRecoveryGenericErrMsg,
 			req: &proto.StartAccountRecoveryRequest{
 				Username:     u.username,
 				RecoveryCode: []byte(u.recoveryCodes[0]),
@@ -295,7 +297,7 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 	ctx := context.Background()
 	fakeClock := srv.Clock().(*clockwork.FakeClock)
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -369,7 +371,7 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			// Acquire a start token.
-			startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, c.recoverType)
+			startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, c.recoverType)
 			require.NoError(t, err)
 
 			// Try a failed attempt, to test it gets cleared later.
@@ -377,7 +379,7 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 			c.invalidReq.RecoveryStartTokenID = startToken.GetName()
 			_, err = srv.Auth().VerifyAccountRecovery(ctx, c.invalidReq)
 			require.True(t, trace.IsAccessDenied(err))
-			require.Equal(t, verifyRecoveryBadAuthnErrMsg, err.Error())
+			require.Equal(t, auth.VerifyRecoveryBadAuthnErrMsg, err.Error())
 
 			// Get request with authn.
 			mfaChallenge, err := srv.Auth().CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
@@ -418,7 +420,7 @@ func TestVerifyAccountRecovery_WithLock(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -430,7 +432,7 @@ func TestVerifyAccountRecovery_WithLock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Acquire a start token.
-	startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+	startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 	require.NoError(t, err)
 
 	// Trigger login lock.
@@ -449,7 +451,7 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -469,7 +471,7 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 			name: "invalid token type",
 			getRequest: func() *proto.VerifyAccountRecoveryRequest {
 				// Generate an incorrect token type.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.VerifyAccountRecoveryRequest{
@@ -479,7 +481,7 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "token not found",
-			expErrMsg: verifyRecoveryGenericErrMsg,
+			expErrMsg: auth.VerifyRecoveryGenericErrMsg,
 			getRequest: func() *proto.VerifyAccountRecoveryRequest {
 				return &proto.VerifyAccountRecoveryRequest{
 					RecoveryStartTokenID: "non-existent-token-id",
@@ -488,10 +490,10 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "username does not match",
-			expErrMsg: verifyRecoveryBadAuthnErrMsg,
+			expErrMsg: auth.VerifyRecoveryBadAuthnErrMsg,
 			getRequest: func() *proto.VerifyAccountRecoveryRequest {
 				// Acquire a start token.
-				startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.VerifyAccountRecoveryRequest{
@@ -502,10 +504,10 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "provide password when it expects MFA authn response",
-			expErrMsg: verifyRecoveryBadAuthnErrMsg,
+			expErrMsg: auth.VerifyRecoveryBadAuthnErrMsg,
 			getRequest: func() *proto.VerifyAccountRecoveryRequest {
 				// Acquire a start token for recovering second factor.
-				startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.VerifyAccountRecoveryRequest{
@@ -516,10 +518,10 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "provide MFA authn response when it expects password",
-			expErrMsg: verifyRecoveryBadAuthnErrMsg,
+			expErrMsg: auth.VerifyRecoveryBadAuthnErrMsg,
 			getRequest: func() *proto.VerifyAccountRecoveryRequest {
 				// Acquire a start token for recovering password.
-				startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+				startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 				require.NoError(t, err)
 
 				return &proto.VerifyAccountRecoveryRequest{
@@ -548,7 +550,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -563,7 +565,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	triggerLoginLock(t, srv.Auth(), u.username)
 
 	// Acquire an approved token for recovering password.
-	approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+	approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 	require.NoError(t, err)
 
 	err = srv.Auth().CompleteAccountRecovery(ctx, &proto.CompleteAccountRecoveryRequest{
@@ -584,7 +586,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	require.Empty(t, attempts)
 
 	// Test adding MFA devices.
-	approvedToken, err = srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+	approvedToken, err = srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -600,7 +602,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 				})
 				require.NoError(t, err, "CreateRegisterChallenge")
 
-				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal, WithTestDeviceClock(srv.Clock()))
+				_, registerSolved, err := authtest.NewTestDeviceFromChallenge(registerChal, authtest.WithTestDeviceClock(srv.Clock()))
 				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -622,7 +624,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 				})
 				require.NoError(t, err, "CreateRegisterChallenge")
 
-				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+				_, registerSolved, err := authtest.NewTestDeviceFromChallenge(registerChal)
 				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -669,7 +671,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
@@ -692,7 +694,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 			// expectErrMsg not supplied on purpose, there is no const err message for this error.
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Generate an incorrect token type.
-				startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -702,7 +704,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "token not found",
-			expErrMsg: completeRecoveryGenericErrMsg,
+			expErrMsg: auth.CompleteRecoveryGenericErrMsg,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				return &proto.CompleteAccountRecoveryRequest{
 					RecoveryApprovedTokenID: "non-existent-token-id",
@@ -711,10 +713,10 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "provide new password when it expects new MFA register response",
-			expErrMsg: completeRecoveryGenericErrMsg,
+			expErrMsg: auth.CompleteRecoveryGenericErrMsg,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Acquire an approved token for recovering second factor.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -725,10 +727,10 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 		},
 		{
 			name:      "provide new MFA register response when it expects new password",
-			expErrMsg: completeRecoveryGenericErrMsg,
+			expErrMsg: auth.CompleteRecoveryGenericErrMsg,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Acquire an approved token for recovering password.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 				require.NoError(t, err)
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -742,7 +744,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 			isDuplicate: true,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Acquire an approved token for recovering second factor.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				// Retrieve list of devices to get the name of an existing device.
@@ -757,7 +759,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 				})
 				require.NoError(t, err, "CreateRegisterChallenge")
 
-				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+				_, registerSolved, err := authtest.NewTestDeviceFromChallenge(registerChal)
 				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -774,7 +776,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 			isBadParameter: true,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Acquire an approved token for recovering second factor.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -801,7 +803,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 			isBadParameter: true,
 			getRequest: func(t *testing.T) *proto.CompleteAccountRecoveryRequest {
 				// Acquire an approved token for recovering second factor.
-				approvedToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				approvedToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -940,7 +942,7 @@ func TestAccountRecoveryFlow(t *testing.T) {
 				})
 				require.NoError(t, err, "CreateRegisterChallenge")
 
-				_, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+				_, registerSolved, err := authtest.NewTestDeviceFromChallenge(registerChal)
 				require.NoError(t, err, "NewTestDeviceFromChallenge")
 
 				return &proto.CompleteAccountRecoveryRequest{
@@ -1030,7 +1032,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				wrongTokenType, err := srv.Auth().newUserToken(authclient.CreateUserTokenRequest{
+				wrongTokenType, err := srv.Auth().NewUserToken(authclient.CreateUserTokenRequest{
 					Name: "llama",
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,
@@ -1058,7 +1060,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery start token",
 			tokenType: authclient.UserTokenTypeRecoveryStart,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1070,7 +1072,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:      "recovery approve token",
 			tokenType: authclient.UserTokenTypeRecoveryApproved,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().CreateRecoveryToken(ctx, "llama", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.GetAccountRecoveryTokenRequest{
@@ -1118,7 +1120,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	require.NoError(t, err)
 
 	const user = "llama@example.com"
-	_, _, err = CreateUserAndRole(srv.Auth(), user, []string{user}, nil /* allowRules */)
+	_, _, err = authtest.CreateUserAndRole(srv.Auth(), user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	cases := []struct {
@@ -1130,7 +1132,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1151,7 +1153,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 			name:    "invalid user name",
 			wantErr: true,
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().CreateRecoveryToken(ctx, "invalid-username", authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1162,7 +1164,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "recovery approved token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
+				token, err := srv.Auth().CreateRecoveryToken(ctx, user, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_MFA)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1173,7 +1175,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 		{
 			name: "privilege token",
 			getRequest: func() *proto.CreateAccountRecoveryCodesRequest {
-				token, err := srv.Auth().createPrivilegeToken(ctx, user, authclient.UserTokenTypePrivilege)
+				token, err := auth.CreatePrivilegeToken(ctx, srv.Auth(), user, authclient.UserTokenTypePrivilege)
 				require.NoError(t, err)
 
 				return &proto.CreateAccountRecoveryCodesRequest{
@@ -1194,7 +1196,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 
 			default:
 				require.NoError(t, err)
-				require.Len(t, res.GetCodes(), numOfRecoveryCodes)
+				require.Len(t, res.GetCodes(), auth.NumOfRecoveryCodes)
 				require.NotEmpty(t, res.GetCreated())
 
 				// Check token is deleted after success.
@@ -1229,7 +1231,7 @@ func TestGetAccountRecoveryCodes(t *testing.T) {
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
 
-	clt, err := srv.NewClient(TestUser(u.username))
+	clt, err := srv.NewClient(authtest.TestUser(u.username))
 	require.NoError(t, err)
 
 	rc, err := clt.GetAccountRecoveryCodes(ctx, &proto.GetAccountRecoveryCodesRequest{})
@@ -1238,9 +1240,9 @@ func TestGetAccountRecoveryCodes(t *testing.T) {
 	require.NotEmpty(t, rc.Created)
 }
 
-func triggerLoginLock(t *testing.T, srv *Server, username string) {
+func triggerLoginLock(t *testing.T, srv *auth.Server, username string) {
 	for i := 1; i <= defaults.MaxLoginAttempts; i++ {
-		_, _, _, err := srv.authenticateUser(
+		_, _, _, err := srv.AuthenticateUser(
 			context.Background(),
 			authclient.AuthenticateUserRequest{
 				Username: username,
@@ -1252,9 +1254,9 @@ func triggerLoginLock(t *testing.T, srv *Server, username string) {
 
 		// Test last attempt returns locked error.
 		if i == defaults.MaxLoginAttempts {
-			require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
+			require.Equal(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 		} else {
-			require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
+			require.NotEqual(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 		}
 	}
 }
@@ -1264,10 +1266,10 @@ type userAuthCreds struct {
 	username      string
 	password      []byte
 
-	totpDev, webDev *TestDevice
+	totpDev, webDev *authtest.TestDevice
 }
 
-func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, error) {
+func createUserWithSecondFactors(testServer *authtest.TestTLSServer) (*userAuthCreds, error) {
 	ctx := context.Background()
 	username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
 	password := []byte("abcdef123456")
@@ -1289,7 +1291,7 @@ func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, err
 		return nil, trace.Wrap(err)
 	}
 
-	_, _, err = CreateUserAndRole(authServer, username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, []string{username}, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1309,7 +1311,7 @@ func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, err
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	webDev, registerSolved, err := NewTestDeviceFromChallenge(registerChal)
+	webDev, registerSolved, err := authtest.NewTestDeviceFromChallenge(registerChal)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1322,7 +1324,7 @@ func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, err
 		return nil, trace.Wrap(err)
 	}
 
-	userClient, err := testServer.NewClient(TestUser(username))
+	userClient, err := testServer.NewClient(authtest.TestUser(username))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1338,12 +1340,12 @@ func createUserWithSecondFactors(testServer *TestTLSServer) (*userAuthCreds, err
 	webDev.MFA = devicesResp.Devices[0]
 
 	// Register a TOTP device.
-	totpDev, err := RegisterTestDevice(
+	totpDev, err := authtest.RegisterTestDevice(
 		ctx,
 		userClient,
 		"otp-1", proto.DeviceType_DEVICE_TYPE_TOTP,
 		webDev, /* authenticator */
-		WithTestDeviceClock(testServer.Clock()))
+		authtest.WithTestDeviceClock(testServer.Clock()))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1383,7 +1385,7 @@ func TestProquint(t *testing.T) {
 		addr4 := addr.As4()
 
 		hi, lo := binary.BigEndian.Uint16(addr4[:2]), binary.BigEndian.Uint16(addr4[2:])
-		proquint := encodeProquint(hi) + "-" + encodeProquint(lo)
+		proquint := auth.EncodeProquint(hi) + "-" + auth.EncodeProquint(lo)
 		require.Equal(t, tc.proquint, proquint, "wrong encoding for address %v", addr)
 	}
 }

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"bytes"
@@ -33,6 +33,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -114,13 +115,13 @@ func TestUpsertServer(t *testing.T) {
 			// Create a fake HTTP request.
 			inSrv, err := services.MarshalServer(tt.reqServer)
 			require.NoError(t, err)
-			body, err := json.Marshal(upsertServerRawReq{Server: inSrv})
+			body, err := json.Marshal(auth.UpsertServerRawReq{Server: inSrv})
 			require.NoError(t, err)
 			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(body))
 			req.RemoteAddr = remoteAddr
 			req.Header.Add("Content-Type", "application/json")
 
-			_, err = new(APIServer).upsertServer(s, tt.role, req, httprouter.Params{httprouter.Param{Key: "namespace", Value: apidefaults.Namespace}})
+			_, err = auth.UpsertServer(new(auth.APIServer), s, tt.role, req, httprouter.Params{httprouter.Param{Key: "namespace", Value: apidefaults.Namespace}})
 			tt.assertErr(t, err)
 			if err != nil {
 				return

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2151,7 +2151,7 @@ func (a *Server) SetClock(clock clockwork.Clock) {
 	a.clock = clock
 }
 
-// SetClock sets clock, used in tests
+// SetBcryptCost sets bcryptCostOverride, used in tests
 func (a *Server) SetBcryptCost(cost int) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -2610,11 +2610,12 @@ type GenerateUserTestCertsRequest struct {
 	Usage                   []string
 }
 
+// GenerateUserTestCerts is used to generate user certificate, used internally for tests
 func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
 	return a.GenerateUserTestCertsWithContext(context.TODO(), req)
 }
 
-// GenerateUserTestCerts is used to generate user certificate, used internally for tests
+// GenerateUserTestCertsWithContext is used to generate user certificate, used internally for tests
 func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
 	userState, err := a.GetUserOrLoginState(ctx, req.Username)
 	if err != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2610,9 +2610,12 @@ type GenerateUserTestCertsRequest struct {
 	Usage []string
 }
 
-// GenerateUserTestCerts is used to generate user certificate, used internally for tests
 func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
-	ctx := context.Background()
+	return a.GenerateUserTestCertsWithContext(context.TODO(), req)
+}
+
+// GenerateUserTestCerts is used to generate user certificate, used internally for tests
+func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
 	userState, err := a.GetUserOrLoginState(ctx, req.Username)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2589,6 +2589,7 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 }
 
 // GenerateUserTestCertsRequest is a request to generate test certificates.
+// TODO(tross): Figure out how to move this into test only code.
 type GenerateUserTestCertsRequest struct {
 	SSHPubKey               []byte
 	TLSPubKey               []byte
@@ -2611,11 +2612,13 @@ type GenerateUserTestCertsRequest struct {
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
+// TODO(tross): Figure out how to move this into test only code.
 func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
 	return a.GenerateUserTestCertsWithContext(context.TODO(), req)
 }
 
 // GenerateUserTestCertsWithContext is used to generate user certificate, used internally for tests
+// TODO(tross): Figure out how to move this into test only code.
 func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
 	userState, err := a.GetUserOrLoginState(ctx, req.Username)
 	if err != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2607,6 +2607,7 @@ type GenerateUserTestCertsRequest struct {
 	Generation              uint64
 	ActiveRequests          []string
 	KubernetesCluster       string
+	Usage []string
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
@@ -2647,6 +2648,7 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 		renewable:                        req.Renewable,
 		activeRequests:                   req.ActiveRequests,
 		kubernetesCluster:                req.KubernetesCluster,
+		usage: req.Usage,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2607,7 +2607,7 @@ type GenerateUserTestCertsRequest struct {
 	Generation              uint64
 	ActiveRequests          []string
 	KubernetesCluster       string
-	Usage []string
+	Usage                   []string
 }
 
 func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
@@ -2651,7 +2651,7 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 		renewable:                        req.Renewable,
 		activeRequests:                   req.ActiveRequests,
 		kubernetesCluster:                req.KubernetesCluster,
-		usage: req.Usage,
+		usage:                            req.Usage,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2151,6 +2151,13 @@ func (a *Server) SetClock(clock clockwork.Clock) {
 	a.clock = clock
 }
 
+// SetClock sets clock, used in tests
+func (a *Server) SetBcryptCost(cost int) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.bcryptCostOverride = &cost
+}
+
 func (a *Server) SetSCIMService(scim services.SCIM) {
 	a.Services.SCIM = scim
 }
@@ -2595,6 +2602,11 @@ type GenerateUserTestCertsRequest struct {
 	TLSAttestationStatement *hardwarekey.AttestationStatement
 	AppName                 string
 	AppSessionID            string
+	DeviceExtensions        DeviceExtensions
+	Renewable               bool
+	Generation              uint64
+	ActiveRequests          []string
+	KubernetesCluster       string
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
@@ -2630,6 +2642,11 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 		tlsPublicKeyAttestationStatement: req.TLSAttestationStatement,
 		appName:                          req.AppName,
 		appSessionID:                     req.AppSessionID,
+		deviceExtensions:                 req.DeviceExtensions,
+		generation:                       req.Generation,
+		renewable:                        req.Renewable,
+		activeRequests:                   req.ActiveRequests,
+		kubernetesCluster:                req.KubernetesCluster,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1900,7 +1900,7 @@ type configureMFAResp struct {
 	TOTPDev, WebDev *authtest.Device
 }
 
-func configureForMFA(t *testing.T, srv *authtest.TestTLSServer) *configureMFAResp {
+func configureForMFA(t *testing.T, srv *authtest.TLSServer) *configureMFAResp {
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorOptional,

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -1714,7 +1714,7 @@ func TestServer_Authenticate_nonPasswordlessRequiresUsername(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name    string
-		dev     *authtest.TestDevice
+		dev     *authtest.Device
 		wantErr string
 	}{
 		{
@@ -1897,7 +1897,7 @@ func TestServer_Authenticate_headless(t *testing.T) {
 
 type configureMFAResp struct {
 	User, Password  string
-	TOTPDev, WebDev *authtest.TestDevice
+	TOTPDev, WebDev *authtest.Device
 }
 
 func configureForMFA(t *testing.T, srv *authtest.TestTLSServer) *configureMFAResp {

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -35,7 +35,9 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -231,7 +233,7 @@ func TestCreateAuthenticateChallenge_WithAuth(t *testing.T) {
 	u, err := createUserWithSecondFactors(srv)
 	require.NoError(t, err)
 
-	clt, err := srv.NewClient(TestUser(u.username))
+	clt, err := srv.NewClient(authtest.TestUser(u.username))
 	require.NoError(t, err)
 
 	res, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
@@ -326,9 +328,9 @@ func TestCreateAuthenticateChallenge_WithUserCredentials_WithLock(t *testing.T) 
 
 		// Test last attempt returns locked error.
 		if i == defaults.MaxLoginAttempts {
-			require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
+			require.Equal(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 		} else {
-			require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
+			require.NotEqual(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 		}
 	}
 }
@@ -350,7 +352,7 @@ func TestCreateAuthenticateChallenge_WithRecoveryStartToken(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.CreateAuthenticateChallengeRequest {
-				wrongToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+				wrongToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 				require.NoError(t, err)
 
 				return &proto.CreateAuthenticateChallengeRequest{
@@ -370,7 +372,7 @@ func TestCreateAuthenticateChallenge_WithRecoveryStartToken(t *testing.T) {
 		{
 			name: "valid token",
 			getRequest: func() *proto.CreateAuthenticateChallengeRequest {
-				startToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+				startToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 				require.NoError(t, err)
 
 				return &proto.CreateAuthenticateChallengeRequest{
@@ -403,7 +405,7 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 	testServer := newTestTLSServer(t)
 	ctx := context.Background()
 
-	adminClient, err := testServer.NewClient(TestBuiltin(types.RoleAdmin))
+	adminClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err, "NewClient(types.RoleAdmin)")
 
 	// Register a couple of SSH nodes.
@@ -505,7 +507,7 @@ func TestCreateAuthenticateChallenge_mfaVerification(t *testing.T) {
 		_, err = adminClient.UpdateUser(ctx, user.(*types.UserV2))
 		require.NoError(t, err, "UpdateUser(%q)", username)
 
-		userClient, err := testServer.NewClient(TestUser(username))
+		userClient, err := testServer.NewClient(authtest.TestUser(username))
 		require.NoError(t, err, "NewClient(%q)", username)
 
 		return userClient
@@ -634,7 +636,7 @@ func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
 	mfa := configureForMFA(t, testServer)
 
 	// Proxy identity is used during login.
-	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err, "NewClient(RoleProxy) failed")
 
 	t.Run("emits audit event", func(t *testing.T) {
@@ -668,7 +670,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test invalid token type.
-	wrongToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+	wrongToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryStart, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 	require.NoError(t, err)
 	_, err = srv.Auth().CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
 		TokenID:    wrongToken.GetName(),
@@ -677,7 +679,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Create a valid token.
-	validToken, err := srv.Auth().createRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
+	validToken, err := srv.Auth().CreateRecoveryToken(ctx, u.username, authclient.UserTokenTypeRecoveryApproved, types.UserTokenUsage_USER_TOKEN_RECOVER_PASSWORD)
 	require.NoError(t, err)
 
 	// Test unspecified token returns error.
@@ -719,7 +721,7 @@ func TestCreateRegisterChallenge(t *testing.T) {
 	}
 
 	t.Run("register using context user", func(t *testing.T) {
-		authClient, err := srv.NewClient(TestUser(u.username))
+		authClient, err := srv.NewClient(authtest.TestUser(u.username))
 		require.NoError(t, err, "NewClient(%q)", u.username)
 
 		// Attempt without a token or a solved authn challenge should fail.
@@ -808,20 +810,20 @@ func TestCreateRegisterChallenge_unusableDevice(t *testing.T) {
 		},
 	}
 
-	devOpts := []TestDeviceOpt{WithTestDeviceClock(clock)}
+	devOpts := []authtest.TestDeviceOpt{authtest.WithTestDeviceClock(clock)}
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			setAuthPref(t, initialPref) // restore permissive settings.
 
 			// Create user.
 			username := fmt.Sprintf("llama-%d", i)
-			user, _, err := CreateUserAndRole(authServer, username, []string{username} /* logins */, nil /* allowRules */)
+			user, _, err := authtest.CreateUserAndRole(authServer, username, []string{username} /* logins */, nil /* allowRules */)
 			require.NoError(t, err, "CreateUserAndRole")
-			userClient, err := testServer.NewClient(TestUser(user.GetName()))
+			userClient, err := testServer.NewClient(authtest.TestUser(user.GetName()))
 			require.NoError(t, err, "NewClient")
 
 			// Register initial MFA device.
-			_, err = RegisterTestDevice(
+			_, err = authtest.RegisterTestDevice(
 				ctx,
 				userClient,
 				"existing", test.existingType, nil /* authenticator */, devOpts...)
@@ -891,13 +893,13 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 
 	// makeRun is used to test both SSH and Web login by switching the
 	// authenticate function.
-	makeRun := func(authenticate func(*Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
+	makeRun := func(authenticate func(*auth.Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
 		return func(t *testing.T) {
 			require.NoError(t, authenticate(authServer, authclient.AuthenticateUserRequest{
 				Username: "bowman",
@@ -905,7 +907,7 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 			}))
 		}
 	}
-	t.Run("ssh", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+	t.Run("ssh", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 		req.SSHPublicKey = []byte(sshPubKey)
 		req.TLSPublicKey = []byte(tlsPubKey)
 		_, err := s.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
@@ -914,7 +916,7 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 		})
 		return err
 	}))
-	t.Run("web", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+	t.Run("web", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 		_, err := s.AuthenticateWebUser(ctx, req)
 		return err
 	}))
@@ -929,15 +931,15 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 
 	const username = "capybara"
 
-	setPassword := func(pwd string) func(*testing.T, *Server) {
-		return func(t *testing.T, s *Server) {
+	setPassword := func(pwd string) func(*testing.T, *auth.Server) {
+		return func(t *testing.T, s *auth.Server) {
 			require.NoError(t, s.UpsertPassword(username, []byte(pwd)))
 		}
 	}
 
 	tests := []struct {
 		name         string
-		setup        func(*testing.T, *Server)
+		setup        func(*testing.T, *auth.Server)
 		authUser     string
 		authPassword string
 	}{
@@ -955,7 +957,7 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 		},
 		{
 			name:         "password not found",
-			setup:        func(*testing.T, *Server) {},
+			setup:        func(*testing.T, *auth.Server) {},
 			authUser:     username,
 			authPassword: "secure password",
 		},
@@ -964,9 +966,9 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 	for _, test := range tests {
 		// makeRun is used to test both SSH and Web login by switching the
 		// authenticate function.
-		makeRun := func(authenticate func(*Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
+		makeRun := func(authenticate func(*auth.Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
 			return func(t *testing.T) {
-				_, _, err := CreateUserAndRole(authServer, username, nil, nil)
+				_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
 				require.NoError(t, err)
 				t.Cleanup(func() {
 					assert.NoError(t, authServer.DeleteUser(ctx, username), "failed to delete user %s", username)
@@ -981,7 +983,7 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 				assert.True(t, trace.IsAccessDenied(err), "got %T: %v, want AccessDenied", trace.Unwrap(err), err)
 			}
 		}
-		t.Run(test.name+"/ssh", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+		t.Run(test.name+"/ssh", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 			req.SSHPublicKey = []byte(sshPubKey)
 			req.TLSPublicKey = []byte(tlsPubKey)
 			_, err := s.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
@@ -990,7 +992,7 @@ func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {
 			})
 			return err
 		}))
-		t.Run(test.name+"/web", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+		t.Run(test.name+"/web", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 			_, err := s.AuthenticateWebUser(ctx, req)
 			return err
 		}))
@@ -1006,13 +1008,13 @@ func TestServer_AuthenticateUser_setsPasswordState(t *testing.T) {
 
 	const username = "bowman"
 	const password = "it's full of stars!"
-	_, _, err := CreateUserAndRole(authServer, username, nil, nil)
+	_, _, err := authtest.CreateUserAndRole(authServer, username, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 
 	// makeRun is used to test both SSH and Web login by switching the
 	// authenticate function.
-	makeRun := func(authenticate func(*Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
+	makeRun := func(authenticate func(*auth.Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
 		return func(t *testing.T) {
 			// Enforce unspecified password state.
 			u, err := authServer.Identity.UpdateAndSwapUser(ctx, username, false, /* withSecrets */
@@ -1037,7 +1039,7 @@ func TestServer_AuthenticateUser_setsPasswordState(t *testing.T) {
 			assert.Equal(t, types.PasswordState_PASSWORD_STATE_SET, u.GetPasswordState())
 		}
 	}
-	t.Run("ssh", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+	t.Run("ssh", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 		req.SSHPublicKey = []byte(sshPubKey)
 		req.TLSPublicKey = []byte(tlsPubKey)
 		_, err := s.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
@@ -1046,7 +1048,7 @@ func TestServer_AuthenticateUser_setsPasswordState(t *testing.T) {
 		})
 		return err
 	}))
-	t.Run("web", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+	t.Run("web", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 		_, err := s.AuthenticateWebUser(ctx, req)
 		return err
 	}))
@@ -1072,7 +1074,7 @@ func TestServer_AuthenticateUser_mfaDevices(t *testing.T) {
 	for _, test := range tests {
 		// makeRun is used to test both SSH and Web login by switching the
 		// authenticate function.
-		makeRun := func(authenticate func(*Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
+		makeRun := func(authenticate func(*auth.Server, authclient.AuthenticateUserRequest) error) func(t *testing.T) {
 			return func(t *testing.T) {
 				// 1st step: acquire challenge
 				challenge, err := authServer.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
@@ -1108,14 +1110,14 @@ func TestServer_AuthenticateUser_mfaDevices(t *testing.T) {
 				require.NoError(t, authenticate(authServer, authReq))
 			}
 		}
-		t.Run(test.name+"/ssh", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+		t.Run(test.name+"/ssh", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 			_, err := s.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
 				AuthenticateUserRequest: req,
 				TTL:                     24 * time.Hour,
 			})
 			return err
 		}))
-		t.Run(test.name+"/web", makeRun(func(s *Server, req authclient.AuthenticateUserRequest) error {
+		t.Run(test.name+"/web", makeRun(func(s *auth.Server, req authclient.AuthenticateUserRequest) error {
 			_, err := s.AuthenticateWebUser(ctx, req)
 			return err
 		}))
@@ -1144,12 +1146,12 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 	// Create user and initial WebAuthn device (MFA).
 	const user = "llama"
 	const password = "p@ssw0rd1234"
-	_, _, err = CreateUserAndRole(authServer, user, []string{"llama", "root"}, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, user, []string{"llama", "root"}, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(user, []byte(password)))
-	userClient, err := svr.NewClient(TestUser(user))
+	userClient, err := svr.NewClient(authtest.TestUser(user))
 	require.NoError(t, err)
-	webDev, err := RegisterTestDevice(
+	webDev, err := authtest.RegisterTestDevice(
 		ctx, userClient, "web", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 	require.NoError(t, err)
 
@@ -1196,19 +1198,19 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 	require.NoError(t, err, "Failed to register passwordless device")
 
 	// Use a proxy client for now on; the user's identity isn't established yet.
-	proxyClient, err := svr.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := svr.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// used to keep track of calls to login hooks.
 	var loginHookCounter atomic.Int32
-	var loginHook LoginHook = func(_ context.Context, _ types.User) error {
+	var loginHook auth.LoginHook = func(_ context.Context, _ types.User) error {
 		loginHookCounter.Add(1)
 		return nil
 	}
 
 	tests := []struct {
 		name         string
-		loginHooks   []LoginHook
+		loginHooks   []auth.LoginHook
 		authenticate func(t *testing.T, resp *wantypes.CredentialAssertionResponse)
 	}{
 		{
@@ -1230,7 +1232,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 		},
 		{
 			name: "ssh with login hooks",
-			loginHooks: []LoginHook{
+			loginHooks: []auth.LoginHook{
 				loginHook,
 				loginHook,
 			},
@@ -1261,7 +1263,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 		},
 		{
 			name: "web with login hooks",
-			loginHooks: []LoginHook{
+			loginHooks: []auth.LoginHook{
 				loginHook,
 			},
 			authenticate: func(t *testing.T, resp *wantypes.CredentialAssertionResponse) {
@@ -1335,9 +1337,9 @@ func TestPasswordlessProhibitedForSSO(t *testing.T) {
 	ctx := context.Background()
 
 	// Register a passwordless device.
-	userClient, err := testServer.NewClient(TestUser(mfa.User))
+	userClient, err := testServer.NewClient(authtest.TestUser(mfa.User))
 	require.NoError(t, err, "NewClient failed")
-	pwdlessDev, err := RegisterTestDevice(ctx, userClient, "pwdless", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, mfa.WebDev, WithPasswordless())
+	pwdlessDev, err := authtest.RegisterTestDevice(ctx, userClient, "pwdless", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, mfa.WebDev, authtest.WithPasswordless())
 	require.NoError(t, err, "RegisterTestDevice failed")
 
 	// Edit the configured user so it looks like an SSO user attempting local
@@ -1359,7 +1361,7 @@ func TestPasswordlessProhibitedForSSO(t *testing.T) {
 	require.NoError(t, err, "UpdateAndSwapUser failed")
 
 	// Authentication happens through the Proxy identity.
-	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1447,7 +1449,7 @@ func TestSSOPasswordBypass(t *testing.T) {
 	// and proceed from there.
 
 	// Authentication happens through the Proxy identity.
-	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	createAuthenticateChallenge := func(t *testing.T) *proto.MFAAuthenticateChallenge {
@@ -1574,7 +1576,7 @@ func TestSSOPasswordBypass(t *testing.T) {
 		mfaResp, err := mfa.TOTPDev.SolveAuthn(chal)
 		require.NoError(t, err, "SolveAuthn failed")
 
-		userClient, err := testServer.NewClient(TestUser(mfa.User))
+		userClient, err := testServer.NewClient(authtest.TestUser(mfa.User))
 		require.NoError(t, err, "NewClient failed")
 
 		err = userClient.ChangePassword(ctx, &proto.ChangePasswordRequest{
@@ -1589,7 +1591,7 @@ func TestSSOPasswordBypass(t *testing.T) {
 	t.Run("CreateResetPasswordToken", func(t *testing.T) {
 		t.Parallel()
 
-		adminClient, err := testServer.NewClient(TestBuiltin(types.RoleAdmin))
+		adminClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 		require.NoError(t, err, "NewClient failed")
 
 		_, err = adminClient.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
@@ -1633,7 +1635,7 @@ func TestSSOAccountRecoveryProhibited(t *testing.T) {
 	// Create a user that looks like an SSO user. The name must be an e-mail for
 	// account recovery to work.
 	const user = "llama@example.com"
-	_, _, err = CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
+	_, _, err = authtest.CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	_, err = authServer.UpdateAndSwapUser(ctx, user, false /* withSecrets */, func(u types.User) (changed bool, err error) {
 		u.SetCreatedBy(types.CreatedBy{
@@ -1652,9 +1654,9 @@ func TestSSOAccountRecoveryProhibited(t *testing.T) {
 	require.NoError(t, err, "UpdateAndSwapUser failed")
 
 	// Register an MFA device.
-	userClient, err := testServer.NewClient(TestUser(user))
+	userClient, err := testServer.NewClient(authtest.TestUser(user))
 	require.NoError(t, err, "NewClient failed")
-	totpDev, err := RegisterTestDevice(ctx, userClient, "totp", proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, WithTestDeviceClock(clock))
+	totpDev, err := authtest.RegisterTestDevice(ctx, userClient, "totp", proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, authtest.WithTestDeviceClock(clock))
 	require.NoError(t, err, "RegisterTestDevice failed")
 
 	t.Run("CreateAccountRecoveryCodes", func(t *testing.T) {
@@ -1704,15 +1706,15 @@ func TestServer_Authenticate_nonPasswordlessRequiresUsername(t *testing.T) {
 	username := mfa.User
 	password := mfa.Password
 
-	userClient, err := svr.NewClient(TestUser(username))
+	userClient, err := svr.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
-	proxyClient, err := svr.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := svr.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	ctx := context.Background()
 	tests := []struct {
 		name    string
-		dev     *TestDevice
+		dev     *authtest.TestDevice
 		wantErr string
 	}{
 		{
@@ -1827,7 +1829,7 @@ func TestServer_Authenticate_headless(t *testing.T) {
 			t.Parallel()
 
 			srv := newTestTLSServer(t)
-			proxyClient, err := srv.NewClient(TestBuiltin(types.RoleProxy))
+			proxyClient, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 			require.NoError(t, err)
 
 			// We don't mind about the specifics of the configuration, as long as we have
@@ -1895,10 +1897,10 @@ func TestServer_Authenticate_headless(t *testing.T) {
 
 type configureMFAResp struct {
 	User, Password  string
-	TOTPDev, WebDev *TestDevice
+	TOTPDev, WebDev *authtest.TestDevice
 }
 
-func configureForMFA(t *testing.T, srv *TestTLSServer) *configureMFAResp {
+func configureForMFA(t *testing.T, srv *authtest.TestTLSServer) *configureMFAResp {
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
 		SecondFactor: constants.SecondFactorOptional,
@@ -1916,17 +1918,17 @@ func configureForMFA(t *testing.T, srv *TestTLSServer) *configureMFAResp {
 	// Create user with a default password.
 	const username = "llama@goteleport.com"
 	const password = "supersecurepass"
-	_, _, err = CreateUserAndRole(authServer, username, []string{"llama", "root"}, nil)
+	_, _, err = authtest.CreateUserAndRole(authServer, username, []string{"llama", "root"}, nil)
 	require.NoError(t, err)
 	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
 
-	clt, err := srv.NewClient(TestUser(username))
+	clt, err := srv.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
 
-	totpDev, err := RegisterTestDevice(ctx, clt, "totp-1", proto.DeviceType_DEVICE_TYPE_TOTP, nil, WithTestDeviceClock(srv.Clock()))
+	totpDev, err := authtest.RegisterTestDevice(ctx, clt, "totp-1", proto.DeviceType_DEVICE_TYPE_TOTP, nil, authtest.WithTestDeviceClock(srv.Clock()))
 	require.NoError(t, err)
 
-	webDev, err := RegisterTestDevice(ctx, clt, "web-1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, totpDev)
+	webDev, err := authtest.RegisterTestDevice(ctx, clt, "web-1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, totpDev)
 	require.NoError(t, err)
 
 	return &configureMFAResp{

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3079,7 +3079,7 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 			}
 
 			_, _, err = p.a.GenerateUserTestCerts(certReq)
-			require.NoError(t, err)
+			tt.assertErr(t, err)
 		})
 	}
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2345,7 +2345,7 @@ type augmentUserData struct {
 	webSessionID string
 }
 
-func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *authtest.TestTLSServer) *augmentUserData {
+func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *authtest.TLSServer) *augmentUserData {
 	authServer := testServer.Auth()
 	ctx := context.Background()
 
@@ -4183,7 +4183,7 @@ func TestAccessRequestAuditLog(t *testing.T) {
 	require.Equal(t, "APPROVED", arc.RequestState)
 }
 
-func testCreateRole(t *testing.T, server *authtest.TestTLSServer, name string, setup func(*types.RoleSpecV6)) types.Role {
+func testCreateRole(t *testing.T, server *authtest.TLSServer, name string, setup func(*types.RoleSpecV6)) types.Role {
 	t.Helper()
 	ctx := context.Background()
 
@@ -4210,7 +4210,7 @@ func testCreateRole(t *testing.T, server *authtest.TestTLSServer, name string, s
 	return createdRole
 }
 
-func testCreateUserWithRoles(t *testing.T, server *authtest.TestTLSServer, user string, roles ...string) (authtest.TestIdentity, *authclient.Client) {
+func testCreateUserWithRoles(t *testing.T, server *authtest.TLSServer, user string, roles ...string) (authtest.TestIdentity, *authclient.Client) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -4233,7 +4233,7 @@ func TestAccessRequestNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})
@@ -4321,7 +4321,7 @@ func TestAccessRequestDryRunEnrichment(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: clockwork.NewFakeClock(),
 	})
@@ -4475,7 +4475,7 @@ func TestCleanupNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        fakeClock,
 		CacheEnabled: true,
@@ -4786,7 +4786,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+			testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 				Dir:       t.TempDir(),
 				Clock:     clockwork.NewFakeClock(),
 				ClusterID: "cluster-id",
@@ -4858,7 +4858,7 @@ func newGlobalNotificationWithExpiry(t *testing.T, title string, expires *timest
 func TestServerHostnameSanitization(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
 	cases := []struct {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"cmp"
@@ -66,7 +66,9 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -92,14 +94,14 @@ import (
 
 type testPack struct {
 	bk             backend.Backend
-	versionStorage VersionStorage
+	versionStorage auth.VersionStorage
 	clusterName    types.ClusterName
-	a              *Server
+	a              *auth.Server
 	mockEmitter    *eventstest.MockRecorderEmitter
 }
 
 func newTestPack(
-	ctx context.Context, dataDir string, opts ...ServerOption,
+	ctx context.Context, dataDir string, opts ...auth.ServerOption,
 ) (testPack, error) {
 	var (
 		p   testPack
@@ -116,7 +118,7 @@ func newTestPack(
 		return p, trace.Wrap(err)
 	}
 
-	p.versionStorage = NewFakeTeleportVersion()
+	p.versionStorage = authtest.NewFakeTeleportVersion()
 
 	identityService, err := local.NewTestIdentityService(p.bk)
 	if err != nil {
@@ -124,7 +126,7 @@ func newTestPack(
 	}
 
 	p.mockEmitter = &eventstest.MockRecorderEmitter{}
-	authConfig := &InitConfig{
+	authConfig := &auth.InitConfig{
 		DataDir:        dataDir,
 		Backend:        p.bk,
 		VersionStorage: p.versionStorage,
@@ -135,7 +137,7 @@ func newTestPack(
 		Identity:               identityService,
 		SkipPeriodicOperations: true,
 	}
-	p.a, err = NewServer(authConfig, opts...)
+	p.a, err = auth.NewServer(authConfig, opts...)
 	if err != nil {
 		return p, trace.Wrap(err)
 	}
@@ -153,7 +155,7 @@ func newTestPack(
 	p.a.SetLockWatcher(lockWatcher)
 
 	urc, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
-		Clock: p.a.clock,
+		Clock: p.a.GetClock(),
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentAuth,
 			Client:    p.a,
@@ -244,7 +246,7 @@ func TestSessions(t *testing.T) {
 	user := "user1"
 	pass := []byte("abcdef123456")
 
-	_, _, err := CreateUserAndRole(s.a, user, []string{user}, nil)
+	_, _, err := authtest.CreateUserAndRole(s.a, user, []string{user}, nil)
 	require.NoError(t, err)
 
 	err = s.a.UpsertPassword(user, pass)
@@ -353,7 +355,7 @@ func TestAuthenticateWebUser_deviceWebToken(t *testing.T) {
 
 	// Prepare user and password.
 	// 2nd factors are not important for this test.
-	_, _, err := CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
+	_, _, err := authtest.CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(user, []byte(pass)),
@@ -516,7 +518,7 @@ func TestAuthenticateWebUser_trustedDeviceRequirement(t *testing.T) {
 		{user: user1, pass: pass1},
 		{user: user2, pass: pass2, roles: []string{rtdRole.GetName()}},
 	} {
-		user, _, err := CreateUserAndRole(
+		user, _, err := authtest.CreateUserAndRole(
 			authServer,
 			u.user,
 			append(u.roles, u.user),
@@ -637,7 +639,7 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	require.ErrorAs(t, err, &accessDeniedErr)
 
 	// Create the user.
-	_, role, err := CreateUserAndRole(s.a, user, []string{user}, nil)
+	_, role, err := authtest.CreateUserAndRole(s.a, user, []string{user}, nil)
 	require.NoError(t, err)
 	err = s.a.UpsertPassword(user, pass)
 	require.NoError(t, err)
@@ -918,27 +920,27 @@ func TestAuthenticateUser_mfaDeviceLocked(t *testing.T) {
 	require.NoError(t, err, "UpdateAuthPreference")
 
 	// Prepare user, password and MFA device.
-	_, _, err = CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
+	_, _, err = authtest.CreateUserAndRole(authServer, user, []string{user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole")
 	require.NoError(t,
 		authServer.UpsertPassword(user, []byte(pass)),
 		"UpsertPassword")
 
-	userClient, err := testServer.NewClient(TestUser(user))
+	userClient, err := testServer.NewClient(authtest.TestUser(user))
 	require.NoError(t, err, "NewClient")
 
 	// OTP devices would work for this test too.
-	dev1, err := RegisterTestDevice(ctx, userClient, "dev1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
+	dev1, err := authtest.RegisterTestDevice(ctx, userClient, "dev1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 	require.NoError(t, err, "RegisterTestDevice")
-	dev2, err := RegisterTestDevice(ctx, userClient, "dev2", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, dev1 /* authenticator */)
+	dev2, err := authtest.RegisterTestDevice(ctx, userClient, "dev2", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, dev1 /* authenticator */)
 	require.NoError(t, err, "RegisterTestDevice")
 
 	// Users initially authenticate via Proxy, as there isn't a userClient before
 	// authn.
-	proxyClient, err := testServer.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err, "NewClient")
 
-	authenticateSSH := func(dev *TestDevice) (*authclient.SSHLoginResponse, error) {
+	authenticateSSH := func(dev *authtest.TestDevice) (*authclient.SSHLoginResponse, error) {
 		chal, err := proxyClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_UserCredentials{
 				UserCredentials: &proto.UserCredentials{
@@ -1033,7 +1035,7 @@ func TestUserLock(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	_, _, err = CreateUserAndRole(s.a, username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(s.a, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	err = s.a.UpsertPassword(username, pass)
@@ -1172,7 +1174,7 @@ func TestLocalControlStream(t *testing.T) {
 	// wait for control stream to get inserted into the controller (happens after
 	// hello exchange is finished).
 	require.Eventually(t, func() bool {
-		_, ok := s.a.inventory.GetControlStream(serverID)
+		_, ok := s.a.Inventory().GetControlStream(serverID)
 		return ok
 	}, time.Second*5, time.Millisecond*200)
 
@@ -1210,14 +1212,14 @@ func TestUpdateConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// use same backend but start a new auth server with different config.
-	authConfig := &InitConfig{
+	authConfig := &auth.InitConfig{
 		ClusterName:            clusterName,
 		Backend:                s.bk,
 		VersionStorage:         s.versionStorage,
 		Authority:              testauthority.New(),
 		SkipPeriodicOperations: true,
 	}
-	authServer, err := NewServer(authConfig)
+	authServer, err := auth.NewServer(authConfig)
 	require.NoError(t, err)
 
 	err = authServer.SetClusterName(clusterName)
@@ -1262,7 +1264,7 @@ func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
 	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
-	s.a.emitter = s.mockEmitter
+	s.a.SetEmitter(s.mockEmitter)
 
 	// set up existing cluster to bypass switch cases that
 	// makes a network request when creating new clusters
@@ -1280,7 +1282,7 @@ func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
 	require.NoError(t, s.a.UpsertCertAuthority(ctx, suite.NewTestCA(types.UserCA, "test")))
 	require.NoError(t, s.a.UpsertCertAuthority(ctx, suite.NewTestCA(types.HostCA, "test")))
 
-	err = s.a.createReverseTunnel(ctx, tc)
+	err = s.a.CreateReverseTunnel(ctx, tc)
 	require.NoError(t, err)
 
 	// test create event for switch case: when tc exists but enabled is false
@@ -1328,7 +1330,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	})
 	// test github create event
 	require.NoError(t, err)
-	github, err = s.a.createGithubConnector(ctx, github)
+	github, err = s.a.CreateGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
@@ -1338,7 +1340,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 
 	// test github update event
 	github.SetDisplay("llama")
-	github, err = s.a.updateGithubConnector(ctx, github)
+	github, err = s.a.UpdateGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorUpdate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorUpdatedEvent, s.mockEmitter.LastEvent().GetType())
@@ -1348,7 +1350,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 
 	// test github upsert event
 	github.SetDisplay("alpaca")
-	upserted, err := s.a.upsertGithubConnector(ctx, github)
+	upserted, err := s.a.UpsertGithubConnector(ctx, github)
 	require.NoError(t, err)
 	require.NotNil(t, upserted)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
@@ -1358,7 +1360,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	s.mockEmitter.Reset()
 
 	// test github delete event
-	err = s.a.deleteGithubConnector(ctx, "test")
+	err = s.a.DeleteGithubConnector(ctx, "test")
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorDelete{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())
@@ -1491,7 +1493,7 @@ func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
 func TestEmitSSOLoginFailureEvent(t *testing.T) {
 	mockE := &eventstest.MockRecorderEmitter{}
 
-	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), false)
+	auth.EmitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), false)
 
 	expectedLoginFailure := &apievents.UserLogin{
 		Metadata: apievents.Metadata{
@@ -1507,7 +1509,7 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 	}
 	require.Equal(t, expectedLoginFailure, mockE.LastEvent())
 
-	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), true)
+	auth.EmitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"), true)
 
 	expectedTestFailure := &apievents.UserLogin{
 		Metadata: apievents.Metadata{
@@ -1530,7 +1532,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	emitter := &eventstest.MockRecorderEmitter{}
-	authServer.emitter = emitter
+	authServer.SetEmitter(emitter)
 	ctx := context.Background()
 
 	const username = "llama"
@@ -1542,7 +1544,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	principals := []string{"login0", username, "-teleport-internal-join"}
 
 	// Prepare the user to test with.
-	_, _, err := CreateUserAndRole(authServer, username, principals, nil)
+	_, _, err := authtest.CreateUserAndRole(authServer, username, principals, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(username, []byte(pass)),
@@ -1575,7 +1577,7 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 	tests := []struct {
 		name           string
 		x509PEM        []byte
-		opts           *AugmentUserCertificateOpts
+		opts           *auth.AugmentUserCertificateOpts
 		wantSSHCert    bool
 		assertX509Cert func(t *testing.T, c *x509.Certificate)
 		assertSSHCert  func(t *testing.T, c *ssh.Certificate)
@@ -1583,10 +1585,10 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 		{
 			name:    "device extensions",
 			x509PEM: authResp.TLSCert,
-			opts: &AugmentUserCertificateOpts{
+			opts: &auth.AugmentUserCertificateOpts{
 				SSHAuthorizedKey:         authResp.Cert,
 				SSHKeySatisfiedChallenge: true,
-				DeviceExtensions: &DeviceExtensions{
+				DeviceExtensions: &auth.DeviceExtensions{
 					DeviceID:     devID,
 					AssetTag:     devTag,
 					CredentialID: devCred,
@@ -1609,8 +1611,8 @@ func TestServer_AugmentContextUserCertificates(t *testing.T) {
 		{
 			name:    "augment without SSH",
 			x509PEM: authResp.TLSCert,
-			opts: &AugmentUserCertificateOpts{
-				DeviceExtensions: &DeviceExtensions{
+			opts: &auth.AugmentUserCertificateOpts{
+				DeviceExtensions: &auth.DeviceExtensions{
 					DeviceID:     devID,
 					AssetTag:     devTag,
 					CredentialID: devCred,
@@ -1699,19 +1701,19 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	const pass3 = "secret!!3!!!"
 
 	// Prepare a few distinct users.
-	user1, _, err := CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
+	user1, _, err := authtest.CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(user1.GetName(), []byte(pass1)),
 		"UpsertPassword failed")
 
-	user2, _, err := CreateUserAndRole(authServer, "alpaca", []string{"alpaca"}, nil)
+	user2, _, err := authtest.CreateUserAndRole(authServer, "alpaca", []string{"alpaca"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(user2.GetName(), []byte(pass2)),
 		"UpsertPassword failed")
 
-	user3, _, err := CreateUserAndRole(authServer, "camel", []string{"camel"}, nil)
+	user3, _, err := authtest.CreateUserAndRole(authServer, "camel", []string{"camel"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	require.NoError(t,
 		authServer.UpsertPassword(user3.GetName(), []byte(pass3)),
@@ -1799,10 +1801,10 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 	})
 	aaCtx, err := ctxFromAuthorize(aCtx)
 	require.NoError(t, err, "ctxFromAuthorize failed")
-	augResp, err := authServer.AugmentContextUserCertificates(aCtx, aaCtx, &AugmentUserCertificateOpts{
+	augResp, err := authServer.AugmentContextUserCertificates(aCtx, aaCtx, &auth.AugmentUserCertificateOpts{
 		SSHAuthorizedKey:         sshRaw1,
 		SSHKeySatisfiedChallenge: true,
-		DeviceExtensions: &DeviceExtensions{
+		DeviceExtensions: &auth.DeviceExtensions{
 			DeviceID:     "device1",
 			AssetTag:     "tag1",
 			CredentialID: "credential1",
@@ -1824,15 +1826,15 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 		return ssh.MarshalAuthorizedKey(c)
 	}
 
-	baseOpts := &AugmentUserCertificateOpts{
-		DeviceExtensions: &DeviceExtensions{
+	baseOpts := &auth.AugmentUserCertificateOpts{
+		DeviceExtensions: &auth.DeviceExtensions{
 			DeviceID:     "deviceid1",
 			AssetTag:     "devicetag1",
 			CredentialID: "credentialid1",
 		},
 		SSHKeySatisfiedChallenge: true,
 	}
-	optsFromBase := func(_ *testing.T) *AugmentUserCertificateOpts { return baseOpts }
+	optsFromBase := func(_ *testing.T) *auth.AugmentUserCertificateOpts { return baseOpts }
 
 	tests := []struct {
 		name     string
@@ -1841,7 +1843,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 		// createAuthCtx defaults to ctxFromAuthorize.
 		createAuthCtx func(ctx context.Context) (*authz.Context, error)
 		// createOpts defaults to optsFromBase.
-		createOpts func(t *testing.T) *AugmentUserCertificateOpts
+		createOpts func(t *testing.T) *auth.AugmentUserCertificateOpts
 		wantErr    string
 	}{
 		// Simple input validation errors.
@@ -1856,14 +1858,14 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:       "opts nil",
 			x509Cert:   xCert1,
 			identity:   identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts { return nil },
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts { return nil },
 			wantErr:    "opts",
 		},
 		{
 			name:     "opts missing extensions",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
 				cp.DeviceExtensions = nil
 				return &cp
@@ -1876,9 +1878,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "opts.DeviceExtensions.DeviceID empty",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
-				cp.DeviceExtensions = &DeviceExtensions{
+				cp.DeviceExtensions = &auth.DeviceExtensions{
 					DeviceID:     "",
 					AssetTag:     "asset1",
 					CredentialID: "credential1",
@@ -1891,9 +1893,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "opts.DeviceExtensions.AssetTag empty",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
-				cp.DeviceExtensions = &DeviceExtensions{
+				cp.DeviceExtensions = &auth.DeviceExtensions{
 					DeviceID:     "id1",
 					AssetTag:     "",
 					CredentialID: "credential1",
@@ -1906,9 +1908,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "opts.DeviceExtensions.CredentialID empty",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
-				cp.DeviceExtensions = &DeviceExtensions{
+				cp.DeviceExtensions = &auth.DeviceExtensions{
 					DeviceID:     "id1",
 					AssetTag:     "asset1",
 					CredentialID: "",
@@ -1929,7 +1931,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH challenge not satisfied and x509/SSH public key mismatch",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
 				cp.SSHAuthorizedKey = sshRaw11 // should be sshRaw1
 				cp.SSHKeySatisfiedChallenge = false
@@ -1941,7 +1943,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH/identity mismatch",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
 				cp.SSHAuthorizedKey = sshRaw2 // should be sshRaw1
 				return &cp
@@ -1952,7 +1954,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH/identity principals mismatch",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
 				changedPrincipals := *sshCert1
 				changedPrincipals.ValidPrincipals = append(changedPrincipals.ValidPrincipals, "camel")
 				sshRaw := signAndMarshalSSH(t, &changedPrincipals)
@@ -1967,7 +1969,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH cert type mismatch",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
 				changedType := *sshCert1
 				changedType.CertType = ssh.HostCert // shouldn't happen!
 				sshRaw := signAndMarshalSSH(t, &changedType)
@@ -1990,7 +1992,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH cert unknown authority",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
 				cp.SSHAuthorizedKey = wrongSSHRaw1 // signed by a different CA
 				return &cp
@@ -2001,7 +2003,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH cert expired",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
 				// Fake a 1h TTL, expired cert.
 				now := testServer.Clock().Now()
 				after := now.Add(-1 * time.Hour)
@@ -2030,7 +2032,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "SSH cert with device extensions not reissued",
 			x509Cert: xCert1,
 			identity: identity1,
-			createOpts: func(_ *testing.T) *AugmentUserCertificateOpts {
+			createOpts: func(_ *testing.T) *auth.AugmentUserCertificateOpts {
 				cp := *baseOpts
 				cp.SSHAuthorizedKey = augSSHRaw1 // already has extensions.
 				return &cp
@@ -2053,7 +2055,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 				lockTarget := types.LockTarget{
 					User: user3.GetName(),
 				}
-				watcher, err := authServer.lockWatcher.Subscribe(ctx, lockTarget)
+				watcher, err := authServer.SubscribeToLockTarget(ctx, lockTarget)
 				if err != nil {
 					return nil, err
 				}
@@ -2081,9 +2083,9 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 			name:     "locked device",
 			x509Cert: xCert1,
 			identity: identity1, // device locked below.
-			createOpts: func(t *testing.T) *AugmentUserCertificateOpts {
-				opts := &AugmentUserCertificateOpts{
-					DeviceExtensions: &DeviceExtensions{
+			createOpts: func(t *testing.T) *auth.AugmentUserCertificateOpts {
+				opts := &auth.AugmentUserCertificateOpts{
+					DeviceExtensions: &auth.DeviceExtensions{
 						DeviceID:     "bad-device-1",
 						AssetTag:     "bad-device-tag",
 						CredentialID: "bad-device-credential",
@@ -2094,7 +2096,7 @@ func TestServer_AugmentContextUserCertificates_errors(t *testing.T) {
 				lockTarget := types.LockTarget{
 					Device: opts.DeviceExtensions.DeviceID,
 				}
-				watcher, err := authServer.lockWatcher.Subscribe(ctx, lockTarget)
+				watcher, err := authServer.SubscribeToLockTarget(ctx, lockTarget)
 				require.NoError(t, err, "Subscribe failed")
 				defer watcher.Close()
 
@@ -2150,7 +2152,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
 
 	// Safe to reuse, user-independent.
-	deviceExts := &DeviceExtensions{
+	deviceExts := &auth.DeviceExtensions{
 		DeviceID:     "my-device-id",
 		AssetTag:     "my-device-asset-tag",
 		CredentialID: "my-device-credential-id",
@@ -2178,7 +2180,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel() // Get the errors suite going asap.
 
-		opts := &AugmentWebSessionCertificatesOpts{
+		opts := &auth.AugmentWebSessionCertificatesOpts{
 			WebSessionID:     userData.webSessionID,
 			User:             userData.user,
 			DeviceExtensions: deviceExts,
@@ -2205,7 +2207,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	})
 
 	user2Data := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
-	user2Opts := &AugmentWebSessionCertificatesOpts{
+	user2Opts := &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     user2Data.webSessionID,
 		User:             user2Data.user,
 		DeviceExtensions: deviceExts,
@@ -2214,7 +2216,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		tests := []struct {
 			name      string
-			opts      *AugmentWebSessionCertificatesOpts
+			opts      *auth.AugmentWebSessionCertificatesOpts
 			wantErr   string
 			assertErr func(error) bool // defaults to trace.IsBadParameter
 		}{
@@ -2224,7 +2226,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 			},
 			{
 				name: "opts.WebSessionID is empty",
-				opts: func() *AugmentWebSessionCertificatesOpts {
+				opts: func() *auth.AugmentWebSessionCertificatesOpts {
 					opts := *user2Opts
 					opts.WebSessionID = ""
 					return &opts
@@ -2233,7 +2235,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 			},
 			{
 				name: "opts.User is empty",
-				opts: func() *AugmentWebSessionCertificatesOpts {
+				opts: func() *auth.AugmentWebSessionCertificatesOpts {
 					opts := *user2Opts
 					opts.User = ""
 					return &opts
@@ -2242,7 +2244,7 @@ func TestServer_AugmentWebSessionCertificates(t *testing.T) {
 			},
 			{
 				name: "opts.DeviceExtensions nil",
-				opts: func() *AugmentWebSessionCertificatesOpts {
+				opts: func() *auth.AugmentWebSessionCertificatesOpts {
 					opts := *user2Opts
 					opts.DeviceExtensions = nil
 					return &opts
@@ -2278,14 +2280,14 @@ func TestServer_ExtendWebSession_deviceExtensions(t *testing.T) {
 
 	userData := setupUserForAugmentWebSessionCertificatesTest(t, testServer)
 
-	deviceExts := &DeviceExtensions{
+	deviceExts := &auth.DeviceExtensions{
 		DeviceID:     "my-device-id",
 		AssetTag:     "my-device-asset-tag",
 		CredentialID: "my-device-credential-id",
 	}
 
 	// Augment the user's session, then later extend it.
-	err := authServer.AugmentWebSessionCertificates(ctx, &AugmentWebSessionCertificatesOpts{
+	err := authServer.AugmentWebSessionCertificates(ctx, &auth.AugmentWebSessionCertificatesOpts{
 		WebSessionID:     userData.webSessionID,
 		User:             userData.user,
 		DeviceExtensions: deviceExts,
@@ -2343,7 +2345,7 @@ type augmentUserData struct {
 	webSessionID string
 }
 
-func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *TestTLSServer) *augmentUserData {
+func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *authtest.TestTLSServer) *augmentUserData {
 	authServer := testServer.Auth()
 	ctx := context.Background()
 
@@ -2353,7 +2355,7 @@ func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *Tes
 	}
 
 	// Create user and assign a password.
-	_, _, err := CreateUserAndRole(authServer, user.user, []string{user.user}, nil /* allowRules */)
+	_, _, err := authtest.CreateUserAndRole(authServer, user.user, []string{user.user}, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole")
 	require.NoError(t,
 		authServer.UpsertPassword(user.user, user.pass),
@@ -2390,13 +2392,13 @@ func TestGenerateUserCertIPPinning(t *testing.T) {
 	pass := []byte("abcdef123456")
 
 	// Create the user without IP pinning
-	_, _, err := CreateUserAndRole(s.a, unpinnedUser, []string{unpinnedUser}, nil)
+	_, _, err := authtest.CreateUserAndRole(s.a, unpinnedUser, []string{unpinnedUser}, nil)
 	require.NoError(t, err)
 	err = s.a.UpsertPassword(unpinnedUser, pass)
 	require.NoError(t, err)
 
 	// Create the user with IP pinning enabled
-	_, pinnedRole, err := CreateUserAndRole(s.a, pinnedUser, []string{pinnedUser}, nil)
+	_, pinnedRole, err := authtest.CreateUserAndRole(s.a, pinnedUser, []string{pinnedUser}, nil)
 	require.NoError(t, err)
 	err = s.a.UpsertPassword(pinnedUser, pass)
 	require.NoError(t, err)
@@ -2530,7 +2532,7 @@ func TestGenerateUserCertWithCertExtension(t *testing.T) {
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)
 
-	user, role, err := CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	user, role, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
 	require.NoError(t, err)
 
 	extension := types.CertExtension{
@@ -2545,21 +2547,16 @@ func TestGenerateUserCertWithCertExtension(t *testing.T) {
 	_, err = p.a.UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	accessInfo := services.AccessInfoFromUserState(user)
-	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
-
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
-	certReq := certRequest{
-		user:         user,
-		checker:      accessChecker,
-		sshPublicKey: sshPubKey,
-		tlsPublicKey: tlsPubKey,
-	}
-	certs, err := p.a.generateUserCert(ctx, certReq)
+
+	sshCert, _, err := p.a.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		SSHPubKey: sshPubKey,
+		TLSPubKey: tlsPubKey,
+		Username:  user.GetName(),
+	})
 	require.NoError(t, err)
 
-	key, err := sshutils.ParseCertificate(certs.SSH)
+	key, err := sshutils.ParseCertificate(sshCert)
 	require.NoError(t, err)
 
 	val, ok := key.Extensions[extension.Name]
@@ -2606,7 +2603,7 @@ func TestGenerateOpenSSHCert(t *testing.T) {
 
 	// create keypair and sign with OpenSSH CA
 	logins := []string{"login1", "login2"}
-	u, r, err := CreateUserAndRole(p.a, "test-user", logins, nil)
+	u, r, err := authtest.CreateUserAndRole(p.a, "test-user", logins, nil)
 	require.NoError(t, err)
 
 	user, ok := u.(*types.UserV2)
@@ -2658,30 +2655,29 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)
 
-	user, _, err := CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
 	require.NoError(t, err)
-	accessInfo := services.AccessInfoFromUserState(user)
-	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
+
 	const mfaID = "test-mfa-id"
 	const requestID = "test-access-request"
 	const deviceID = "deviceid1"
 
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
-	certReq := certRequest{
-		user:           user,
-		checker:        accessChecker,
-		mfaVerified:    mfaID,
-		sshPublicKey:   sshPubKey,
-		tlsPublicKey:   tlsPubKey,
-		activeRequests: []string{requestID},
-		deviceExtensions: DeviceExtensions{
+
+	certReq := auth.GenerateUserTestCertsRequest{
+		SSHPubKey:      sshPubKey,
+		TLSPubKey:      tlsPubKey,
+		Username:       user.GetName(),
+		ActiveRequests: []string{requestID},
+		MFAVerified:    mfaID,
+		DeviceExtensions: auth.DeviceExtensions{
 			DeviceID:     deviceID,
 			AssetTag:     "assettag1",
 			CredentialID: "credentialid1",
 		},
 	}
-	_, err = p.a.generateUserCert(ctx, certReq)
+
+	_, _, err = p.a.GenerateUserTestCerts(certReq)
 	require.NoError(t, err)
 
 	testTargets := append(
@@ -2695,7 +2691,7 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 	)
 	for _, target := range testTargets {
 		t.Run(fmt.Sprintf("lock targeting %v", target), func(t *testing.T) {
-			lockWatch, err := p.a.lockWatcher.Subscribe(ctx, target)
+			lockWatch, err := p.a.SubscribeToLockTarget(ctx, target)
 			require.NoError(t, err)
 			defer lockWatch.Close()
 			lock, err := types.NewLock("test-lock", types.LockSpecV2{Target: target})
@@ -2711,7 +2707,8 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 			case <-time.After(2 * time.Second):
 				t.Fatal("Timeout waiting for lock update.")
 			}
-			_, err = p.a.generateUserCert(ctx, certReq)
+
+			_, _, err = p.a.GenerateUserTestCerts(certReq)
 			require.Error(t, err)
 			require.EqualError(t, err, services.LockInForceAccessDenied(lock).Error())
 		})
@@ -2733,7 +2730,7 @@ func TestGenerateHostCertWithLocks(t *testing.T) {
 	require.NoError(t, err)
 
 	target := types.LockTarget{ServerID: hostID}
-	lockWatch, err := p.a.lockWatcher.Subscribe(ctx, target)
+	lockWatch, err := p.a.SubscribeToLockTarget(ctx, target)
 	require.NoError(t, err)
 	defer lockWatch.Close()
 	lock, err := types.NewLock("test-lock", types.LockSpecV2{Target: target})
@@ -2764,27 +2761,22 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)
 
-	user, role, err := CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	user, role, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
 	require.NoError(t, err)
-	userState, err := p.a.GetUserOrLoginState(ctx, user.GetName())
-	require.NoError(t, err)
-	accessInfo := services.AccessInfoFromUserState(userState)
-	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
+
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
 
 	// Generate cert with no user login state.
-	certReq := certRequest{
-		user:         user,
-		checker:      accessChecker,
-		sshPublicKey: sshPubKey,
-		tlsPublicKey: tlsPubKey,
-		traits:       accessChecker.Traits(),
+	certReq := auth.GenerateUserTestCertsRequest{
+		SSHPubKey: sshPubKey,
+		TLSPubKey: tlsPubKey,
+		Username:  user.GetName(),
 	}
-	resp, err := p.a.generateUserCert(ctx, certReq)
+
+	rawSSHCert, _, err := p.a.GenerateUserTestCerts(certReq)
 	require.NoError(t, err)
 
-	sshCert, err := sshutils.ParseCertificate(resp.SSH)
+	sshCert, err := sshutils.ParseCertificate(rawSSHCert)
 	require.NoError(t, err)
 
 	sshIdent, err := sshca.DecodeIdentity(sshCert)
@@ -2827,24 +2819,16 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	_, err = p.a.UpsertRole(ctx, ulsRole2)
 	require.NoError(t, err)
 
-	userState, err = p.a.GetUserOrLoginState(ctx, user.GetName())
-	require.NoError(t, err)
-	accessInfo = services.AccessInfoFromUserState(userState)
-	accessChecker, err = services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
-
-	certReq = certRequest{
-		user:         user,
-		checker:      accessChecker,
-		sshPublicKey: sshPubKey,
-		tlsPublicKey: tlsPubKey,
-		traits:       accessChecker.Traits(),
+	certReq = auth.GenerateUserTestCertsRequest{
+		SSHPubKey: sshPubKey,
+		TLSPubKey: tlsPubKey,
+		Username:  user.GetName(),
 	}
 
-	resp, err = p.a.generateUserCert(ctx, certReq)
+	rawSSHCert, _, err = p.a.GenerateUserTestCerts(certReq)
 	require.NoError(t, err)
 
-	sshCert, err = sshutils.ParseCertificate(resp.SSH)
+	sshCert, err = sshutils.ParseCertificate(rawSSHCert)
 	require.NoError(t, err)
 
 	sshIdent, err = sshca.DecodeIdentity(sshCert)
@@ -2865,7 +2849,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)
 
-	user, _, err := CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
 	require.NoError(t, err)
 	user.SetTraits(map[string][]string{
 		// add in other random serial numbers to test comparison logic.
@@ -2876,16 +2860,12 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 	_, err = p.a.UpdateUser(ctx, user)
 	require.NoError(t, err)
 
-	accessInfo := services.AccessInfoFromUserState(user)
-	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
-
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
-	certReq := certRequest{
-		user:         user,
-		checker:      accessChecker,
-		sshPublicKey: sshPubKey,
-		tlsPublicKey: tlsPubKey,
+
+	certReq := auth.GenerateUserTestCertsRequest{
+		SSHPubKey: sshPubKey,
+		TLSPubKey: tlsPubKey,
+		Username:  user.GetName(),
 	}
 
 	for _, tt := range []struct {
@@ -3023,8 +3003,8 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 			_, err = p.a.UpsertAuthPreference(ctx, authPref)
 			require.NoError(t, err)
 
-			_, err = p.a.generateUserCert(ctx, certReq)
-			tt.assertErr(t, err)
+			_, _, err = p.a.GenerateUserTestCerts(certReq)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -3034,7 +3014,7 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 	p, err := newTestPack(ctx, t.TempDir())
 	require.NoError(t, err)
 
-	user, _, err := CreateUserAndRole(p.a, "test-user", []string{}, nil)
+	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{}, nil)
 	require.NoError(t, err)
 
 	rc, err := types.NewRemoteCluster("leaf")
@@ -3061,10 +3041,6 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 		}
 		assert.Contains(t, gotNames, kubeCluster.GetName(), "missing kube cluster")
 	}, 15*time.Second, 100*time.Millisecond)
-
-	accessInfo := services.AccessInfoFromUserState(user)
-	accessChecker, err := services.NewAccessChecker(accessInfo, p.clusterName.GetClusterName(), p.a)
-	require.NoError(t, err)
 
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
 
@@ -3094,17 +3070,16 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			certReq := certRequest{
-				user:              user,
-				checker:           accessChecker,
-				sshPublicKey:      sshPubKey,
-				tlsPublicKey:      tlsPubKey,
-				routeToCluster:    tt.teleportCluster,
-				kubernetesCluster: tt.kubernetesCluster,
+			certReq := auth.GenerateUserTestCertsRequest{
+				SSHPubKey:         sshPubKey,
+				TLSPubKey:         tlsPubKey,
+				Username:          user.GetName(),
+				RouteToCluster:    tt.teleportCluster,
+				KubernetesCluster: tt.kubernetesCluster,
 			}
 
-			_, err = p.a.generateUserCert(ctx, certReq)
-			tt.assertErr(t, err)
+			_, _, err = p.a.GenerateUserTestCerts(certReq)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -3123,20 +3098,20 @@ func TestNewWebSession(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a user.
-	user, _, err := CreateUserAndRole(p.a, "test-user", []string{"test-role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(p.a, "test-user", []string{"test-role"}, nil)
 	require.NoError(t, err)
 
 	// Create a new web session.
-	req := NewWebSessionRequest{
+	req := auth.NewWebSessionRequest{
 		User:       user.GetName(),
 		Roles:      user.GetRoles(),
 		Traits:     user.GetTraits(),
-		LoginTime:  p.a.clock.Now().UTC(),
+		LoginTime:  p.a.GetClock().Now().UTC(),
 		SessionTTL: apidefaults.CertDuration,
 	}
 	bearerTokenTTL := min(req.SessionTTL, defaults.BearerTokenTTL)
 
-	ws, _, err := p.a.newWebSession(ctx, req, nil /* opts */)
+	ws, _, err := p.a.NewWebSession(ctx, req, nil /* opts */)
 	require.NoError(t, err)
 	require.Equal(t, user.GetName(), ws.GetUser())
 	require.Equal(t, duration, ws.GetIdleTimeout())
@@ -3156,12 +3131,12 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 	testServer := newTestTLSServer(t)
 	authServer := testServer.Auth()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	authServer.emitter = mockEmitter
+	authServer.SetEmitter(mockEmitter)
 
 	ctx := context.Background()
 
 	const username = "llama@goteleport.com"
-	_, _, err := CreateUserAndRole(authServer, username, []string{username}, nil /* allowRules */)
+	_, _, err := authtest.CreateUserAndRole(authServer, username, []string{username}, nil /* allowRules */)
 	require.NoError(t, err)
 
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -3175,18 +3150,18 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 	_, err = authServer.UpsertAuthPreference(ctx, authPreference)
 	require.NoError(t, err)
 
-	userClient, err := testServer.NewClient(TestUser(username))
+	userClient, err := testServer.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
 
 	// webDev1 is used as the authenticator for various checks.
-	webDev1, err := RegisterTestDevice(ctx, userClient, "web1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
+	webDev1, err := authtest.RegisterTestDevice(ctx, userClient, "web1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 	require.NoError(t, err, "RegisterTestDevice(web1)")
 
 	// Insert devices for deletion.
-	deviceOpts := []TestDeviceOpt{WithTestDeviceClock(testServer.Clock())}
-	registerDevice := func(t *testing.T, deviceName string, deviceType proto.DeviceType) *TestDevice {
+	deviceOpts := []authtest.TestDeviceOpt{authtest.WithTestDeviceClock(testServer.Clock())}
+	registerDevice := func(t *testing.T, deviceName string, deviceType proto.DeviceType) *authtest.TestDevice {
 		t.Helper()
-		testDev, err := RegisterTestDevice(
+		testDev, err := authtest.RegisterTestDevice(
 			ctx, userClient, deviceName, deviceType, webDev1 /* authenticator */, deviceOpts...)
 		require.NoError(t, err, "RegisterTestDevice(%v)", deviceName)
 		return testDev
@@ -3198,7 +3173,7 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 
 	deleteReqUsingToken := func(tokenReq authclient.CreateUserTokenRequest) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 		return func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
-			token, err := authServer.newUserToken(tokenReq)
+			token, err := authServer.NewUserToken(tokenReq)
 			require.NoError(t, err, "newUserToken")
 
 			_, err = authServer.CreateUserToken(ctx, token)
@@ -3210,7 +3185,7 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 		}
 	}
 
-	deleteReqUsingChallenge := func(authenticator *TestDevice) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
+	deleteReqUsingChallenge := func(authenticator *authtest.TestDevice) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 		return func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 			authnChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 				Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -3306,7 +3281,7 @@ func TestDeleteMFADeviceSync_WithErrors(t *testing.T) {
 	ctx := context.Background()
 
 	const username = "llama@goteleport.com"
-	_, _, err := CreateUserAndRole(authServer, username, []string{username}, nil)
+	_, _, err := authtest.CreateUserAndRole(authServer, username, []string{username}, nil)
 	require.NoError(t, err)
 
 	const origin = "localhost"
@@ -3321,13 +3296,13 @@ func TestDeleteMFADeviceSync_WithErrors(t *testing.T) {
 	_, err = authServer.UpsertAuthPreference(ctx, authPreference)
 	require.NoError(t, err)
 
-	userClient, err := testServer.NewClient(TestUser(username))
+	userClient, err := testServer.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
 
 	// Insert a device.
 	const devName = "otp"
-	_, err = RegisterTestDevice(
-		ctx, userClient, devName, proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, WithTestDeviceClock(clock))
+	_, err = authtest.RegisterTestDevice(
+		ctx, userClient, devName, proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, authtest.WithTestDeviceClock(clock))
 	require.NoError(t, err)
 
 	createReq := func(name string) *proto.DeleteMFADeviceSyncRequest {
@@ -3403,7 +3378,7 @@ func TestDeleteMFADeviceSync_WithErrors(t *testing.T) {
 			deleteReq := test.deleteReq
 
 			if test.tokenRequest != nil {
-				token, err := authServer.newUserToken(*test.tokenRequest)
+				token, err := authServer.NewUserToken(*test.tokenRequest)
 				require.NoError(t, err)
 				_, err = authServer.CreateUserToken(context.Background(), token)
 				require.NoError(t, err)
@@ -3433,7 +3408,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 	userCreds, err := createUserWithSecondFactors(testServer)
 	require.NoError(t, err, "createUserWithSecondFactors")
 
-	userClient, err := testServer.NewClient(TestUser(userCreds.username))
+	userClient, err := testServer.NewClient(authtest.TestUser(userCreds.username))
 	require.NoError(t, err, "NewClient")
 	totpDev := userCreds.totpDev
 	webDev := userCreds.webDev
@@ -3455,7 +3430,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 		require.NoError(t, err, "UpsertAuthPreference")
 	}
 
-	deleteDevice := func(userClient *authclient.Client, testDev *TestDevice) error {
+	deleteDevice := func(userClient *authclient.Client, testDev *authtest.TestDevice) error {
 		// Issue and solve authn challenge.
 		authnChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -3479,7 +3454,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 		})
 	}
 
-	makeTest := func(sf constants.SecondFactorType, deviceToDelete *TestDevice) func(t *testing.T) {
+	makeTest := func(sf constants.SecondFactorType, deviceToDelete *authtest.TestDevice) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
@@ -3518,7 +3493,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 	t.Run("second factor on, otp device", makeTest(constants.SecondFactorOn, totpDev))
 
 	// Same as above, but now delete the last Webauthn device.
-	webDev, err = RegisterTestDevice(ctx, userClient, "web1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, totpDev /* authenticator */)
+	webDev, err = authtest.RegisterTestDevice(ctx, userClient, "web1", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, totpDev /* authenticator */)
 	require.NoError(t, err, "RegisterTestDevice")
 	require.NoError(t,
 		deleteDevice(userClient, totpDev),
@@ -3551,7 +3526,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 	u, err := createUserWithSecondFactors(testServer)
 	require.NoError(t, err)
 
-	userClient, err := testServer.NewClient(TestUser(u.username))
+	userClient, err := testServer.NewClient(authtest.TestUser(u.username))
 	require.NoError(t, err)
 
 	solveChallengeWithToken := func(
@@ -3559,8 +3534,8 @@ func TestAddMFADeviceSync(t *testing.T) {
 		tokenType string,
 		deviceType proto.DeviceType,
 		deviceUsage proto.DeviceUsage,
-	) (token string, testDev *TestDevice, registerSolved *proto.MFARegisterResponse) {
-		privilegeToken, err := authServer.createPrivilegeToken(ctx, u.username, tokenType)
+	) (token string, testDev *authtest.TestDevice, registerSolved *proto.MFARegisterResponse) {
+		privilegeToken, err := auth.CreatePrivilegeToken(ctx, authServer, u.username, tokenType)
 		require.NoError(t, err, "createPrivilegeToken")
 		token = privilegeToken.GetName()
 
@@ -3571,7 +3546,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 		})
 		require.NoError(t, err, "CreateRegisterChallenge")
 
-		testDev, registerSolved, err = NewTestDeviceFromChallenge(registerChal, WithTestDeviceClock(clock))
+		testDev, registerSolved, err = authtest.NewTestDeviceFromChallenge(registerChal, authtest.WithTestDeviceClock(clock))
 		require.NoError(t, err, "NewTestDeviceFromChallenge")
 		return token, testDev, registerSolved
 	}
@@ -3580,7 +3555,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 		t *testing.T,
 		deviceType proto.DeviceType,
 		deviceUsage proto.DeviceUsage,
-	) (*TestDevice, *proto.MFARegisterResponse) {
+	) (*authtest.TestDevice, *proto.MFARegisterResponse) {
 		// Create and solve a registration challenge.
 		authChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -3602,9 +3577,9 @@ func TestAddMFADeviceSync(t *testing.T) {
 		})
 		require.NoError(t, err, "CreateRegisterChallenge")
 
-		testDev, registerSolved, err := NewTestDeviceFromChallenge(
+		testDev, registerSolved, err := authtest.NewTestDeviceFromChallenge(
 			registerChal,
-			WithTestDeviceClock(clock),
+			authtest.WithTestDeviceClock(clock),
 		)
 		require.NoError(t, err, "NewTestDeviceFromChallenge")
 		return testDev, registerSolved
@@ -3621,7 +3596,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 			wantErr: true,
 			getReq: func(t *testing.T, deviceName string) *proto.AddMFADeviceSyncRequest {
 				// Obtain a non privilege token.
-				token, err := authServer.newUserToken(authclient.CreateUserTokenRequest{
+				token, err := authServer.NewUserToken(authclient.CreateUserTokenRequest{
 					Name: u.username,
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,
@@ -3666,7 +3641,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 		},
 		{
 			name:       "invalid device name length",
-			deviceName: strings.Repeat("A", mfaDeviceNameMaxLen+1),
+			deviceName: strings.Repeat("A", auth.MFADeviceNameMaxLen+1),
 			wantErr:    true,
 			getReq: func(t *testing.T, deviceName string) *proto.AddMFADeviceSyncRequest {
 				token, _, registerSolved := solveChallengeWithToken(
@@ -3767,14 +3742,14 @@ func TestGetMFADevices_WithToken(t *testing.T) {
 	require.NoError(t, err)
 
 	username := "llama@goteleport.com"
-	_, _, err = CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
 	require.NoError(t, err)
 
-	clt, err := srv.NewClient(TestUser(username))
+	clt, err := srv.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
-	webDev, err := RegisterTestDevice(ctx, clt, "web", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
+	webDev, err := authtest.RegisterTestDevice(ctx, clt, "web", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 	require.NoError(t, err)
-	totpDev, err := RegisterTestDevice(ctx, clt, "otp", proto.DeviceType_DEVICE_TYPE_TOTP, webDev, WithTestDeviceClock(srv.Clock()))
+	totpDev, err := authtest.RegisterTestDevice(ctx, clt, "otp", proto.DeviceType_DEVICE_TYPE_TOTP, webDev, authtest.WithTestDeviceClock(srv.Clock()))
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -3810,7 +3785,7 @@ func TestGetMFADevices_WithToken(t *testing.T) {
 			tokenID := "test-token-not-found"
 
 			if tc.tokenRequest != nil {
-				token, err := srv.Auth().newUserToken(*tc.tokenRequest)
+				token, err := srv.Auth().NewUserToken(*tc.tokenRequest)
 				require.NoError(t, err)
 				_, err = srv.Auth().CreateUserToken(context.Background(), token)
 				require.NoError(t, err)
@@ -3850,14 +3825,14 @@ func TestGetMFADevices_WithAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	username := "llama@goteleport.com"
-	_, _, err = CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err = authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
 	require.NoError(t, err)
 
-	clt, err := srv.NewClient(TestUser(username))
+	clt, err := srv.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
-	webDev, err := RegisterTestDevice(ctx, clt, "web", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
+	webDev, err := authtest.RegisterTestDevice(ctx, clt, "web", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
 	require.NoError(t, err)
-	totpDev, err := RegisterTestDevice(ctx, clt, "otp", proto.DeviceType_DEVICE_TYPE_TOTP, webDev, WithTestDeviceClock(srv.Clock()))
+	totpDev, err := authtest.RegisterTestDevice(ctx, clt, "otp", proto.DeviceType_DEVICE_TYPE_TOTP, webDev, authtest.WithTestDeviceClock(srv.Clock()))
 	require.NoError(t, err)
 
 	res, err := clt.GetMFADevices(ctx, &proto.GetMFADevicesRequest{})
@@ -3865,7 +3840,7 @@ func TestGetMFADevices_WithAuth(t *testing.T) {
 	compareDevices(t, true /* ignoreUpdateAndCounter */, res.GetDevices(), webDev.MFA, totpDev.MFA)
 }
 
-func newTestServices(t *testing.T) Services {
+func newTestServices(t *testing.T) auth.Services {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 
@@ -3875,7 +3850,7 @@ func newTestServices(t *testing.T) Services {
 	identityService, err := local.NewTestIdentityService(bk)
 	require.NoError(t, err)
 
-	return Services{
+	return auth.Services{
 		TrustInternal:                local.NewCAService(bk),
 		PresenceInternal:             local.NewPresenceService(bk),
 		Provisioner:                  local.NewProvisioningService(bk),
@@ -3977,7 +3952,7 @@ func TestFilterResources(t *testing.T) {
 			cache:          mockCache{resources: nodes},
 			errorAssertion: require.NoError,
 			filterFn: func(labels types.ResourceWithLabels) error {
-				return ErrDone
+				return auth.ErrDone
 			},
 		},
 		{
@@ -4005,7 +3980,7 @@ func TestFilterResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			srv := &Server{Cache: tt.cache}
+			srv := &auth.Server{Cache: tt.cache}
 
 			err := srv.IterateResources(ctx, proto.ListResourcesRequest{
 				ResourceType: types.KindNode,
@@ -4045,8 +4020,7 @@ func TestCAGeneration(t *testing.T) {
 	for _, caType := range types.CertAuthTypes {
 		t.Run(string(caType), func(t *testing.T) {
 			testKeySet := suite.NewTestCA(caType, clusterName, privKey).Spec.ActiveKeys
-
-			keySet, err := newKeySet(ctx, keyStoreManager, types.CertAuthID{Type: caType, DomainName: clusterName})
+			keySet, err := auth.NewKeySet(ctx, keyStoreManager, types.CertAuthID{Type: caType, DomainName: clusterName})
 			require.NoError(t, err)
 
 			// Don't compare values as those are different. Only check if the key is set/not set in both cases.
@@ -4130,7 +4104,7 @@ func TestGetTokens(t *testing.T) {
 	s := newAuthSuite(t)
 	ctx := context.Background()
 
-	_, _, err := CreateUserAndRole(s.a, "username", []string{"username"}, nil)
+	_, _, err := authtest.CreateUserAndRole(s.a, "username", []string{"username"}, nil)
 	require.NoError(t, err)
 	_, err = s.a.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
 		Name: "username",
@@ -4186,7 +4160,7 @@ func TestAccessRequestAuditLog(t *testing.T) {
 
 	accessRequest, err := types.NewAccessRequest(uuid.NewString(), requester, "requestRole")
 	require.NoError(t, err)
-	req, err := p.a.CreateAccessRequestV2(ctx, accessRequest, TestUser(requester).I.GetIdentity())
+	req, err := p.a.CreateAccessRequestV2(ctx, accessRequest, authtest.TestUser(requester).I.GetIdentity())
 	require.NoError(t, err)
 
 	expectedAnnotations, err := apievents.EncodeMapStrings(paymentsRole.GetAccessRequestConditions(types.Allow).Annotations)
@@ -4209,7 +4183,7 @@ func TestAccessRequestAuditLog(t *testing.T) {
 	require.Equal(t, "APPROVED", arc.RequestState)
 }
 
-func testCreateRole(t *testing.T, server *TestTLSServer, name string, setup func(*types.RoleSpecV6)) types.Role {
+func testCreateRole(t *testing.T, server *authtest.TestTLSServer, name string, setup func(*types.RoleSpecV6)) types.Role {
 	t.Helper()
 	ctx := context.Background()
 
@@ -4236,7 +4210,7 @@ func testCreateRole(t *testing.T, server *TestTLSServer, name string, setup func
 	return createdRole
 }
 
-func testCreateUserWithRoles(t *testing.T, server *TestTLSServer, user string, roles ...string) (TestIdentity, *authclient.Client) {
+func testCreateUserWithRoles(t *testing.T, server *authtest.TestTLSServer, user string, roles ...string) (authtest.TestIdentity, *authclient.Client) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -4246,7 +4220,7 @@ func testCreateUserWithRoles(t *testing.T, server *TestTLSServer, user string, r
 	_, err = server.AuthServer.AuthServer.UpsertUser(ctx, u)
 	require.NoError(t, err, "AuthServer.UpsertUser")
 
-	identity := TestUser(user)
+	identity := authtest.TestUser(user)
 	client, err := server.NewClient(identity)
 	require.NoError(t, err, "server.NewClient")
 
@@ -4259,7 +4233,7 @@ func TestAccessRequestNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})
@@ -4318,7 +4292,7 @@ func TestAccessRequestNotifications(t *testing.T) {
 	// Create another access request.
 	accessRequest, err = types.NewAccessRequest(uuid.NewString(), requester.GetUsername(), requestRole.GetName())
 	require.NoError(t, err)
-	req, err = testTLSServer.AuthServer.AuthServer.CreateAccessRequestV2(ctx, accessRequest, TestUser(requester.GetUsername()).I.GetIdentity())
+	req, err = testTLSServer.AuthServer.AuthServer.CreateAccessRequestV2(ctx, accessRequest, authtest.TestUser(requester.GetUsername()).I.GetIdentity())
 	require.NoError(t, err)
 
 	// Deny the request.
@@ -4347,7 +4321,7 @@ func TestAccessRequestDryRunEnrichment(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: clockwork.NewFakeClock(),
 	})
@@ -4501,7 +4475,7 @@ func TestCleanupNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	authServer, err := NewTestAuthServer(TestAuthServerConfig{
+	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        fakeClock,
 		CacheEnabled: true,
@@ -4661,7 +4635,7 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	_, err = authServer.UpsertUser(ctx, user)
 	require.NoError(t, err)
 
-	client, err := testServer.NewClient(TestUser(testUsername))
+	client, err := testServer.NewClient(authtest.TestUser(testUsername))
 	require.NoError(t, err)
 
 	// Create access lists with different expiry times
@@ -4691,7 +4665,7 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 		createAccessList(t, authServer, al.name+"-scim", withType(accesslist.SCIM))
 		createAccessList(t, authServer, al.name,
 			withOwners([]accesslist.Owner{{Name: testUsername}}),
-			withNextAuditDate(authServer.clock.Now().Add(time.Duration(al.dueInDays)*24*time.Hour)),
+			withNextAuditDate(authServer.GetClock().Now().Add(time.Duration(al.dueInDays)*24*time.Hour)),
 		)
 	}
 
@@ -4742,7 +4716,7 @@ func withOwners(owners []accesslist.Owner) createAccessListOpt {
 	}
 }
 
-func createAccessList(t *testing.T, authServer *Server, name string, opts ...createAccessListOpt) {
+func createAccessList(t *testing.T, authServer *auth.Server, name string, opts ...createAccessListOpt) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -4812,7 +4786,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+			testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 				Dir:       t.TempDir(),
 				Clock:     clockwork.NewFakeClock(),
 				ClusterID: "cluster-id",
@@ -4884,7 +4858,7 @@ func newGlobalNotificationWithExpiry(t *testing.T, title string, expires *timest
 func TestServerHostnameSanitization(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -4921,7 +4895,7 @@ func TestServerHostnameSanitization(t *testing.T) {
 		},
 		{
 			name:            "exceptionally long hostname",
-			hostname:        strings.Repeat("a", serverHostnameMaxLen*2),
+			hostname:        strings.Repeat("a", auth.ServerHostnameMaxLen*2),
 			invalidHostname: true,
 		},
 		{
@@ -5038,7 +5012,7 @@ func TestValidServerHostname(t *testing.T) {
 		},
 		{
 			name:     "super long hostname",
-			hostname: strings.Repeat("a", serverHostnameMaxLen*2),
+			hostname: strings.Repeat("a", auth.ServerHostnameMaxLen*2),
 			want:     false,
 		},
 		{
@@ -5059,7 +5033,7 @@ func TestValidServerHostname(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := validServerHostname(tt.hostname)
+			got := auth.ValidServerHostname(tt.hostname)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -5127,11 +5101,11 @@ func TestCreateAuthPreference(t *testing.T) {
 			clusterConfigService, err := local.NewClusterConfigurationService(bk)
 			require.NoError(t, err)
 
-			server, err := NewServer(&InitConfig{
+			server, err := auth.NewServer(&auth.InitConfig{
 				DataDir:                t.TempDir(),
 				Backend:                bk,
 				ClusterName:            clusterName,
-				VersionStorage:         NewFakeTeleportVersion(),
+				VersionStorage:         authtest.NewFakeTeleportVersion(),
 				Authority:              testauthority.New(),
 				Emitter:                &eventstest.MockRecorderEmitter{},
 				ClusterConfiguration:   clusterConfigService,

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -940,7 +940,7 @@ func TestAuthenticateUser_mfaDeviceLocked(t *testing.T) {
 	proxyClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err, "NewClient")
 
-	authenticateSSH := func(dev *authtest.TestDevice) (*authclient.SSHLoginResponse, error) {
+	authenticateSSH := func(dev *authtest.Device) (*authclient.SSHLoginResponse, error) {
 		chal, err := proxyClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_UserCredentials{
 				UserCredentials: &proto.UserCredentials{
@@ -3159,7 +3159,7 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 
 	// Insert devices for deletion.
 	deviceOpts := []authtest.TestDeviceOpt{authtest.WithTestDeviceClock(testServer.Clock())}
-	registerDevice := func(t *testing.T, deviceName string, deviceType proto.DeviceType) *authtest.TestDevice {
+	registerDevice := func(t *testing.T, deviceName string, deviceType proto.DeviceType) *authtest.Device {
 		t.Helper()
 		testDev, err := authtest.RegisterTestDevice(
 			ctx, userClient, deviceName, deviceType, webDev1 /* authenticator */, deviceOpts...)
@@ -3185,7 +3185,7 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 		}
 	}
 
-	deleteReqUsingChallenge := func(authenticator *authtest.TestDevice) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
+	deleteReqUsingChallenge := func(authenticator *authtest.Device) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 		return func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 			authnChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 				Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -3430,7 +3430,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 		require.NoError(t, err, "UpsertAuthPreference")
 	}
 
-	deleteDevice := func(userClient *authclient.Client, testDev *authtest.TestDevice) error {
+	deleteDevice := func(userClient *authclient.Client, testDev *authtest.Device) error {
 		// Issue and solve authn challenge.
 		authnChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{
@@ -3454,7 +3454,7 @@ func TestDeleteMFADeviceSync_lastDevice(t *testing.T) {
 		})
 	}
 
-	makeTest := func(sf constants.SecondFactorType, deviceToDelete *authtest.TestDevice) func(t *testing.T) {
+	makeTest := func(sf constants.SecondFactorType, deviceToDelete *authtest.Device) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
@@ -3534,7 +3534,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 		tokenType string,
 		deviceType proto.DeviceType,
 		deviceUsage proto.DeviceUsage,
-	) (token string, testDev *authtest.TestDevice, registerSolved *proto.MFARegisterResponse) {
+	) (token string, testDev *authtest.Device, registerSolved *proto.MFARegisterResponse) {
 		privilegeToken, err := auth.CreatePrivilegeToken(ctx, authServer, u.username, tokenType)
 		require.NoError(t, err, "createPrivilegeToken")
 		token = privilegeToken.GetName()
@@ -3555,7 +3555,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 		t *testing.T,
 		deviceType proto.DeviceType,
 		deviceUsage proto.DeviceUsage,
-	) (*authtest.TestDevice, *proto.MFARegisterResponse) {
+	) (*authtest.Device, *proto.MFARegisterResponse) {
 		// Create and solve a registration challenge.
 		authChal, err := userClient.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
 			Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1330,7 +1330,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	})
 	// test github create event
 	require.NoError(t, err)
-	github, err = s.a.CreateGithubConnector(ctx, github)
+	github, err = auth.CreateGithubConnector(ctx, s.a, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorCreatedEvent, s.mockEmitter.LastEvent().GetType())
@@ -1340,7 +1340,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 
 	// test github update event
 	github.SetDisplay("llama")
-	github, err = s.a.UpdateGithubConnector(ctx, github)
+	github, err = auth.UpdateGithubConnector(ctx, s.a, github)
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorUpdate{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorUpdatedEvent, s.mockEmitter.LastEvent().GetType())
@@ -1350,7 +1350,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 
 	// test github upsert event
 	github.SetDisplay("alpaca")
-	upserted, err := s.a.UpsertGithubConnector(ctx, github)
+	upserted, err := auth.UpsertGithubConnector(ctx, s.a, github)
 	require.NoError(t, err)
 	require.NotNil(t, upserted)
 	require.IsType(t, &apievents.GithubConnectorCreate{}, s.mockEmitter.LastEvent())
@@ -1360,7 +1360,7 @@ func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
 	s.mockEmitter.Reset()
 
 	// test github delete event
-	err = s.a.DeleteGithubConnector(ctx, "test")
+	err = auth.DeleteGithubConnector(ctx, s.a, "test")
 	require.NoError(t, err)
 	require.IsType(t, &apievents.GithubConnectorDelete{}, s.mockEmitter.LastEvent())
 	require.Equal(t, events.GithubConnectorDeletedEvent, s.mockEmitter.LastEvent().GetType())

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -2549,7 +2549,7 @@ func TestGenerateUserCertWithCertExtension(t *testing.T) {
 
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
 
-	sshCert, _, err := p.a.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+	sshCert, _, err := p.a.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
 		SSHPubKey: sshPubKey,
 		TLSPubKey: tlsPubKey,
 		Username:  user.GetName(),
@@ -2677,7 +2677,7 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 		},
 	}
 
-	_, _, err = p.a.GenerateUserTestCerts(certReq)
+	_, _, err = p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 	require.NoError(t, err)
 
 	testTargets := append(
@@ -2708,7 +2708,7 @@ func TestGenerateUserCertWithLocks(t *testing.T) {
 				t.Fatal("Timeout waiting for lock update.")
 			}
 
-			_, _, err = p.a.GenerateUserTestCerts(certReq)
+			_, _, err = p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 			require.Error(t, err)
 			require.EqualError(t, err, services.LockInForceAccessDenied(lock).Error())
 		})
@@ -2773,7 +2773,7 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 		Username:  user.GetName(),
 	}
 
-	rawSSHCert, _, err := p.a.GenerateUserTestCerts(certReq)
+	rawSSHCert, _, err := p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 	require.NoError(t, err)
 
 	sshCert, err := sshutils.ParseCertificate(rawSSHCert)
@@ -2825,7 +2825,7 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 		Username:  user.GetName(),
 	}
 
-	rawSSHCert, _, err = p.a.GenerateUserTestCerts(certReq)
+	rawSSHCert, _, err = p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 	require.NoError(t, err)
 
 	sshCert, err = sshutils.ParseCertificate(rawSSHCert)
@@ -3003,7 +3003,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 			_, err = p.a.UpsertAuthPreference(ctx, authPref)
 			require.NoError(t, err)
 
-			_, _, err = p.a.GenerateUserTestCerts(certReq)
+			_, _, err = p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 			tt.assertErr(t, err)
 		})
 	}
@@ -3078,7 +3078,7 @@ func TestGenerateKubernetesUserCert(t *testing.T) {
 				KubernetesCluster: tt.kubernetesCluster,
 			}
 
-			_, _, err = p.a.GenerateUserTestCerts(certReq)
+			_, _, err = p.a.GenerateUserTestCertsWithContext(ctx, certReq)
 			tt.assertErr(t, err)
 		})
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3004,7 +3004,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 			require.NoError(t, err)
 
 			_, _, err = p.a.GenerateUserTestCerts(certReq)
-			require.NoError(t, err)
+			tt.assertErr(t, err)
 		})
 	}
 }

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -29,7 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/authz"
 )
 
@@ -51,17 +53,17 @@ func newOktaUser(t *testing.T) types.User {
 
 // newTestServerWithRoles creates a self-cleaning `ServerWithRoles`, configured
 // with a given
-func newTestServerWithRoles(t *testing.T, srv *TestAuthServer, role types.SystemRole) *ServerWithRoles {
+func newTestServerWithRoles(t *testing.T, srv *authtest.TestAuthServer, role types.SystemRole) *auth.ServerWithRoles {
 
-	authzContext := authz.ContextWithUser(context.Background(), TestBuiltin(role).I)
+	authzContext := authz.ContextWithUser(context.Background(), authtest.TestBuiltin(role).I)
 	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
 	require.NoError(t, err)
 
-	authWithRole := &ServerWithRoles{
-		authServer: srv.AuthServer,
-		alog:       srv.AuditLog,
-		context:    *ctxIdentity,
-	}
+	authWithRole := auth.NewServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		*ctxIdentity,
+	)
 
 	t.Cleanup(func() { authWithRole.Close() })
 
@@ -72,7 +74,7 @@ func TestOktaMayNotResetPasswords(t *testing.T) {
 	ctx := context.Background()
 
 	// Given an auth server...
-	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 
@@ -135,7 +137,7 @@ func TestOktaServiceLockCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	// Given an auth server...
-	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 

--- a/lib/auth/auth_with_roles_okta_rbac_test.go
+++ b/lib/auth/auth_with_roles_okta_rbac_test.go
@@ -53,7 +53,7 @@ func newOktaUser(t *testing.T) types.User {
 
 // newTestServerWithRoles creates a self-cleaning `ServerWithRoles`, configured
 // with a given
-func newTestServerWithRoles(t *testing.T, srv *authtest.TestAuthServer, role types.SystemRole) *auth.ServerWithRoles {
+func newTestServerWithRoles(t *testing.T, srv *authtest.AuthServer, role types.SystemRole) *auth.ServerWithRoles {
 
 	authzContext := authz.ContextWithUser(context.Background(), authtest.TestBuiltin(role).I)
 	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
@@ -74,7 +74,7 @@ func TestOktaMayNotResetPasswords(t *testing.T) {
 	ctx := context.Background()
 
 	// Given an auth server...
-	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 
@@ -137,7 +137,7 @@ func TestOktaServiceLockCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	// Given an auth server...
-	srv, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{Dir: t.TempDir()})
+	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -530,7 +530,7 @@ func TestGithubAuthRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	upserted, err := srv.Auth().UpsertGithubConnector(context.Background(), conn)
+	upserted, err := auth.UpsertGithubConnector(context.Background(), srv.Auth(), conn)
 	require.NoError(t, err)
 	require.NotNil(t, upserted)
 
@@ -660,7 +660,7 @@ func TestGithubAuthCompat(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
-	_, err = srv.Auth().UpsertGithubConnector(context.Background(), connector)
+	_, err = auth.UpsertGithubConnector(context.Background(), srv.Auth(), connector)
 	require.NoError(t, err)
 
 	srv.Auth().GithubUserAndTeamsOverride = func() (*auth.GithubUserResponse, []auth.GithubTeamResponse, error) {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -653,6 +653,7 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 			DeviceExtensions: auth.DeviceExtensions(id.Identity.DeviceExtensions),
 			Generation:       id.Identity.Generation,
 			Renewable:        id.Identity.Renewable,
+			Usage:            identity.AcceptedUsage,
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -652,7 +652,7 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 			MFAVerified:      id.Identity.MFAVerified,
 			DeviceExtensions: auth.DeviceExtensions(id.Identity.DeviceExtensions),
 			Generation:       id.Identity.Generation,
-			Renewable:        id.Identity.Renewable,
+			Renewable:        identity.Renewable,
 			Usage:            identity.AcceptedUsage,
 		})
 		if err != nil {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1,0 +1,1534 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package authtest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/accesspoint"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/state"
+	authority "github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TestAuthServerConfig is auth server test config
+type TestAuthServerConfig struct {
+	// ClusterName is cluster name
+	ClusterName string
+	// ClusterID is the cluster ID; optional - sets to random UUID string if not present
+	ClusterID string
+	// Dir is directory for local backend
+	Dir string
+	// AcceptedUsage is an optional list of restricted
+	// server usage
+	AcceptedUsage []string
+	// CipherSuites is the list of ciphers that the server supports.
+	CipherSuites []uint16
+	// Clock is used to control time in tests.
+	Clock clockwork.Clock
+	// ClusterNetworkingConfig allows a test to change the default
+	// networking configuration.
+	ClusterNetworkingConfig types.ClusterNetworkingConfig
+	// Streamer allows a test to set its own session recording streamer.
+	Streamer events.Streamer
+	// AuditLog allows a test to configure its own audit log.
+	AuditLog events.AuditLogSessionStreamer
+	// TraceClient allows a test to configure the trace client
+	TraceClient otlptrace.Client
+	// AuthPreferenceSpec is custom initial AuthPreference spec for the test.
+	AuthPreferenceSpec *types.AuthPreferenceSpecV2
+	// CacheEnabled enables the primary auth server cache.
+	CacheEnabled bool
+	// RunWhileLockedRetryInterval is the interval to retry the run while locked
+	// operation.
+	RunWhileLockedRetryInterval time.Duration
+	// FIPS means the cluster should run in FIPS mode.
+	FIPS bool
+	// KeystoreConfig is configuration for the CA keystore.
+	KeystoreConfig servicecfg.KeystoreConfig
+}
+
+// CheckAndSetDefaults checks and sets defaults
+func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
+	if cfg.ClusterName == "" {
+		cfg.ClusterName = "localhost"
+	}
+	if cfg.Dir == "" {
+		return trace.BadParameter("missing parameter Dir")
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewFakeClock()
+	}
+	if len(cfg.CipherSuites) == 0 {
+		cfg.CipherSuites = utils.DefaultCipherSuites()
+	}
+	if cfg.AuthPreferenceSpec == nil {
+		cfg.AuthPreferenceSpec = &types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOff,
+		}
+	}
+	return nil
+}
+
+// TestServer defines the set of server components for a test
+type TestServer struct {
+	TLS        *TestTLSServer
+	AuthServer *TestAuthServer
+}
+
+// TestServerConfig defines the configuration for all server components
+type TestServerConfig struct {
+	// Auth specifies the auth server configuration
+	Auth TestAuthServerConfig
+	// TLS optionally specifies the configuration for the TLS server.
+	// If unspecified, will be generated automatically
+	TLS *TestTLSServerConfig
+}
+
+// NewTestServer creates a new test server configuration
+func NewTestServer(cfg TestServerConfig) (*TestServer, error) {
+	authServer, err := NewTestAuthServer(cfg.Auth)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Set the (test) auth server in cfg.TLS and set any defaults that
+	// are not set.
+	tlsCfg := cfg.TLS
+	if tlsCfg == nil {
+		tlsCfg = &TestTLSServerConfig{}
+	}
+	if tlsCfg.APIConfig == nil {
+		tlsCfg.APIConfig = &auth.APIConfig{}
+	}
+
+	tlsCfg.AuthServer = authServer
+	tlsCfg.APIConfig.AuthServer = authServer.AuthServer
+
+	if tlsCfg.APIConfig.Authorizer == nil {
+		tlsCfg.APIConfig.Authorizer = authServer.Authorizer
+	}
+	if tlsCfg.APIConfig.AuditLog == nil {
+		tlsCfg.APIConfig.AuditLog = authServer.AuditLog
+	}
+	if tlsCfg.APIConfig.Emitter == nil {
+		tlsCfg.APIConfig.Emitter = authServer.AuthServer
+	}
+	if tlsCfg.AcceptedUsage == nil {
+		tlsCfg.AcceptedUsage = authServer.AcceptedUsage
+	}
+
+	tlsServer, err := NewTestTLSServer(*tlsCfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TestServer{
+		AuthServer: authServer,
+		TLS:        tlsServer,
+	}, nil
+}
+
+// Auth returns the underlying auth server instance
+func (a *TestServer) Auth() *auth.Server {
+	return a.AuthServer.AuthServer
+}
+
+func (a *TestServer) NewClient(identity TestIdentity) (*authclient.Client, error) {
+	return a.TLS.NewClient(identity)
+}
+
+func (a *TestServer) ClusterName() string {
+	return a.TLS.ClusterName()
+}
+
+// Shutdown stops this server instance gracefully
+func (a *TestServer) Shutdown(ctx context.Context) error {
+	return trace.NewAggregate(
+		a.TLS.Shutdown(ctx),
+		a.AuthServer.Close(),
+	)
+}
+
+// WithClock is a functional server option that sets the server's clock
+func WithClock(clock clockwork.Clock) auth.ServerOption {
+	return func(s *auth.Server) error {
+		s.SetClock(clock)
+		return nil
+	}
+}
+
+// WithBcryptCost is a functional server option that sets the server's bcrypt cost.
+func WithBcryptCost(cost int) auth.ServerOption {
+	return func(s *auth.Server) error {
+		s.SetBcryptCost(cost)
+		return nil
+	}
+}
+
+// TestAuthServer is auth server using local filesystem backend
+// and test certificate authority key generation that speeds up
+// keygen by using the same private key
+type TestAuthServer struct {
+	// TestAuthServer config is configuration used for auth server setup
+	TestAuthServerConfig
+	// AuthServer is an auth server
+	AuthServer *auth.Server
+	// AuditLog is an event audit log
+	AuditLog events.AuditLogSessionStreamer
+	// Backend is a backend for auth server
+	Backend backend.Backend
+	// Authorizer is an authorizer used in tests
+	Authorizer authz.Authorizer
+	// LockWatcher is a lock watcher used in tests.
+	LockWatcher *services.LockWatcher
+}
+
+// NewTestAuthServer returns new instances of Auth server
+func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
+	ctx := context.Background()
+
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	srv := &TestAuthServer{
+		TestAuthServerConfig: cfg,
+	}
+	b, err := memory.New(memory.Config{
+		Context:   ctx,
+		Clock:     cfg.Clock,
+		EventsOff: false,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Wrap backend in sanitizer like in production.
+	srv.Backend = backend.NewSanitizer(b)
+
+	if cfg.AuditLog != nil {
+		srv.AuditLog = cfg.AuditLog
+	} else {
+		localLog, err := events.NewAuditLog(events.AuditLogConfig{
+			DataDir:       cfg.Dir,
+			ServerID:      cfg.ClusterName,
+			Clock:         cfg.Clock,
+			UploadHandler: eventstest.NewMemoryUploader(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		srv.AuditLog = localLog
+	}
+
+	access := local.NewAccessService(srv.Backend)
+	identity, err := local.NewTestIdentityService(srv.Backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	emitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
+		Inner: srv.AuditLog,
+		Clock: cfg.Clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	accessLists, err := local.NewAccessListService(srv.Backend, cfg.Clock, local.WithRunWhileLockedRetryInterval(cfg.RunWhileLockedRetryInterval))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
+		ClusterName: cfg.ClusterName,
+		ClusterID:   cfg.ClusterID,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.AuthServer, err = auth.NewServer(&auth.InitConfig{
+		DataDir:                cfg.Dir,
+		Backend:                srv.Backend,
+		VersionStorage:         NewFakeTeleportVersion(),
+		Authority:              authority.NewWithClock(cfg.Clock),
+		Access:                 access,
+		Identity:               identity,
+		AuditLog:               srv.AuditLog,
+		Streamer:               cfg.Streamer,
+		SkipPeriodicOperations: true,
+		Emitter:                emitter,
+		TraceClient:            cfg.TraceClient,
+		Clock:                  cfg.Clock,
+		ClusterName:            clusterName,
+		HostUUID:               uuid.New().String(),
+		AccessLists:            accessLists,
+		FIPS:                   cfg.FIPS,
+		KeyStoreConfig:         cfg.KeystoreConfig,
+	},
+		WithClock(cfg.Clock),
+		// Reduce auth.Server bcrypt costs when testing.
+		WithBcryptCost(bcrypt.MinCost),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if cfg.CacheEnabled {
+		if err := InitTestAuthCache(TestAuthCacheParams{
+			AuthServer: srv.AuthServer,
+			Unstarted:  true,
+		}); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	err = srv.AuthServer.SetClusterAuditConfig(ctx, types.DefaultClusterAuditConfig())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clusterNetworkingCfg := cfg.ClusterNetworkingConfig
+	if clusterNetworkingCfg == nil {
+		clusterNetworkingCfg = types.DefaultClusterNetworkingConfig()
+	}
+
+	_, err = srv.AuthServer.UpsertClusterNetworkingConfig(ctx, clusterNetworkingCfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	_, err = srv.AuthServer.UpsertSessionRecordingConfig(ctx, types.DefaultSessionRecordingConfig())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = srv.AuthServer.SetClusterName(clusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authPreference, err := types.NewAuthPreferenceFromConfigFile(*cfg.AuthPreferenceSpec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if authPreference.GetSignatureAlgorithmSuite() == types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED {
+		authPreference.SetSignatureAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1)
+	}
+	_, err = srv.AuthServer.UpsertAuthPreference(ctx, authPreference)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	token, err := types.NewProvisionTokenFromSpec("static-token", time.Unix(0, 0).UTC(), types.ProvisionTokenSpecV2{
+		Roles: types.SystemRoles{types.RoleNode},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// set static tokens
+	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
+		StaticTokens: []types.ProvisionTokenV1{
+			*token.V1(),
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = srv.AuthServer.SetStaticTokens(staticTokens)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// create the default role
+	if _, err := srv.AuthServer.UpsertRole(ctx, services.NewImplicitRole()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Setup certificate and signing authorities.
+	for _, caType := range types.CertAuthTypes {
+		if err = srv.AuthServer.UpsertCertAuthority(ctx, suite.NewTestCAWithConfig(suite.TestCAConfig{
+			Type:        caType,
+			ClusterName: srv.ClusterName,
+			Clock:       cfg.Clock,
+		})); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	srv.LockWatcher, err = services.NewLockWatcher(ctx, services.LockWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component:      teleport.ComponentAuth,
+			Client:         srv.AuthServer,
+			Clock:          cfg.Clock,
+			MaxRetryPeriod: defaults.HighResPollingPeriod,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	srv.AuthServer.SetLockWatcher(srv.LockWatcher)
+
+	unifiedResourcesCache, err := services.NewUnifiedResourceCache(srv.AuthServer.CloseContext(), services.UnifiedResourceCacheConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			QueueSize:    defaults.UnifiedResourcesQueueSize,
+			Component:    teleport.ComponentUnifiedResource,
+			Client:       srv.AuthServer,
+			MaxStaleness: time.Minute,
+		},
+		ResourceGetter: srv.AuthServer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.AuthServer.SetUnifiedResourcesCache(unifiedResourcesCache)
+
+	accessRequestCache, err := services.NewAccessRequestCache(services.AccessRequestCacheConfig{
+		Events: srv.AuthServer.Services,
+		Getter: srv.AuthServer.Services,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.AuthServer.SetAccessRequestCache(accessRequestCache)
+
+	headlessAuthenticationWatcher, err := local.NewHeadlessAuthenticationWatcher(srv.AuthServer.CloseContext(), local.HeadlessAuthenticationWatcherConfig{
+		Backend: b,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := headlessAuthenticationWatcher.WaitInit(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	srv.AuthServer.SetHeadlessAuthenticationWatcher(headlessAuthenticationWatcher)
+
+	srv.Authorizer, err = authz.NewAuthorizer(authz.AuthorizerOpts{
+		ClusterName:         srv.ClusterName,
+		AccessPoint:         srv.AuthServer,
+		ReadOnlyAccessPoint: srv.AuthServer.ReadOnlyCache,
+		LockWatcher:         srv.LockWatcher,
+		// AuthServer does explicit device authorization checks.
+		DeviceAuthorization: authz.DeviceAuthorizationOpts{
+			DisableGlobalMode: true,
+			DisableRoleMode:   true,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	userNotificationCache, err := services.NewUserNotificationCache(services.NotificationCacheConfig{
+		Events: srv.AuthServer.Services,
+		Getter: srv.AuthServer.Cache,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.AuthServer.SetUserNotificationCache(userNotificationCache)
+
+	globalNotificationCache, err := services.NewGlobalNotificationCache(services.NotificationCacheConfig{
+		Events: srv.AuthServer.Services,
+		Getter: srv.AuthServer.Cache,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.AuthServer.SetGlobalNotificationCache(globalNotificationCache)
+
+	// Auth initialization is done (including creation/updating of all singleton
+	// configuration resources) so now we can start the cache.
+	if c, ok := srv.AuthServer.Cache.(*cache.Cache); ok {
+		if err := c.Start(); err != nil {
+			return nil, trace.NewAggregate(err, c.Close())
+		}
+	}
+	return srv, nil
+}
+
+type TestAuthCacheParams struct {
+	AuthServer *auth.Server
+	Unstarted  bool
+}
+
+func InitTestAuthCache(p TestAuthCacheParams) error {
+	c, err := accesspoint.NewCache(accesspoint.Config{
+		Context:      p.AuthServer.CloseContext(),
+		Setup:        cache.ForAuth,
+		CacheName:    []string{teleport.ComponentAuth},
+		EventsSystem: true,
+		Unstarted:    p.Unstarted,
+
+		Access:                  p.AuthServer.Services.Access,
+		AccessLists:             p.AuthServer.Services.AccessLists,
+		AccessMonitoringRules:   p.AuthServer.Services.AccessMonitoringRules,
+		AppSession:              p.AuthServer.Services.Identity,
+		Apps:                    p.AuthServer.Services.Apps,
+		ClusterConfig:           p.AuthServer.Services.ClusterConfigurationInternal,
+		CrownJewels:             p.AuthServer.Services.CrownJewels,
+		DatabaseObjects:         p.AuthServer.Services.DatabaseObjects,
+		DatabaseServices:        p.AuthServer.Services.DatabaseServices,
+		Databases:               p.AuthServer.Services.Databases,
+		DiscoveryConfigs:        p.AuthServer.Services.DiscoveryConfigs,
+		DynamicAccess:           p.AuthServer.Services.DynamicAccessExt,
+		Events:                  p.AuthServer.Services.Events,
+		Integrations:            p.AuthServer.Services.Integrations,
+		KubeWaitingContainers:   p.AuthServer.Services.KubeWaitingContainer,
+		Kubernetes:              p.AuthServer.Services.Kubernetes,
+		Notifications:           p.AuthServer.Services.Notifications,
+		Okta:                    p.AuthServer.Services.Okta,
+		Presence:                p.AuthServer.Services.PresenceInternal,
+		Provisioner:             p.AuthServer.Services.Provisioner,
+		Restrictions:            p.AuthServer.Services.Restrictions,
+		SAMLIdPServiceProviders: p.AuthServer.Services.SAMLIdPServiceProviders,
+		SecReports:              p.AuthServer.Services.SecReports,
+		SnowflakeSession:        p.AuthServer.Services.Identity,
+		SPIFFEFederations:       p.AuthServer.Services.SPIFFEFederations,
+		StaticHostUsers:         p.AuthServer.Services.StaticHostUser,
+		Trust:                   p.AuthServer.Services.TrustInternal,
+		UserGroups:              p.AuthServer.Services.UserGroups,
+		UserTasks:               p.AuthServer.Services.UserTasks,
+		UserLoginStates:         p.AuthServer.Services.UserLoginStates,
+		Users:                   p.AuthServer.Services.Identity,
+		WebSession:              p.AuthServer.Services.Identity.WebSessions(),
+		WebToken:                p.AuthServer.Services.WebTokens(),
+		WorkloadIdentity:        p.AuthServer.Services.WorkloadIdentities,
+		DynamicWindowsDesktops:  p.AuthServer.Services.DynamicWindowsDesktops,
+		WindowsDesktops:         p.AuthServer.Services.WindowsDesktops,
+		AutoUpdateService:       p.AuthServer.Services.AutoUpdateService,
+		ProvisioningStates:      p.AuthServer.Services.ProvisioningStates,
+		IdentityCenter:          p.AuthServer.Services.IdentityCenter,
+		PluginStaticCredentials: p.AuthServer.Services.PluginStaticCredentials,
+		GitServers:              p.AuthServer.Services.GitServers,
+		HealthCheckConfig:       p.AuthServer.Services.HealthCheckConfig,
+		BotInstance:             p.AuthServer.Services.BotInstance,
+		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.AuthServer.Cache = c
+	return nil
+}
+
+func (a *TestAuthServer) Close() error {
+	defer a.LockWatcher.Close()
+
+	return trace.NewAggregate(
+		a.AuthServer.Close(),
+		a.Backend.Close(),
+		a.AuditLog.Close(),
+	)
+}
+
+// GenerateUserCert takes the public key in the OpenSSH `authorized_keys`
+// plain text format, signs it using User Certificate Authority signing key and returns the
+// resulting certificate.
+func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.Duration, compatibility string) ([]byte, error) {
+	sshCert, _, err := a.AuthServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		SSHPubKey:     key,
+		Username:      username,
+		TTL:           ttl,
+		Compatibility: compatibility,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sshCert, nil
+}
+
+// PrivateKeyToPublicKeyTLS gets the TLS public key from a raw private key.
+func PrivateKeyToPublicKeyTLS(privateKey []byte) (tlsPublicKey []byte, err error) {
+	sshPrivate, err := ssh.ParseRawPrivateKey(privateKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsPublicKey, err = tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivate)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return tlsPublicKey, nil
+}
+
+// generateCertificate generates certificate for identity,
+// returns private public key pair
+func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte, []byte, error) {
+	ctx := context.TODO()
+
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsPublicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	sshPublicKey, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	sshPublicKeyPEM := ssh.MarshalAuthorizedKey(sshPublicKey)
+
+	switch id := identity.I.(type) {
+	case authz.LocalUser:
+		if identity.TTL == 0 {
+			identity.TTL = time.Hour
+		}
+
+		_, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+			SSHPubKey:        sshPublicKeyPEM,
+			TLSPubKey:        tlsPublicKeyPEM,
+			Username:         id.Username,
+			TTL:              identity.TTL,
+			RouteToCluster:   identity.RouteToCluster,
+			PinnedIP:         id.Identity.PinnedIP,
+			MFAVerified:      id.Identity.MFAVerified,
+			DeviceExtensions: auth.DeviceExtensions(id.Identity.DeviceExtensions),
+			Generation:       id.Identity.Generation,
+			Renewable:        id.Identity.Renewable,
+		})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		return tlsCert, privateKeyPEM, nil
+	case authz.BuiltinRole:
+		certs, err := authServer.GenerateHostCerts(ctx,
+			&proto.HostCertsRequest{
+				HostID:       id.Username,
+				NodeName:     id.Username,
+				Role:         id.Role,
+				PublicTLSKey: tlsPublicKeyPEM,
+				PublicSSHKey: sshPublicKeyPEM,
+				SystemRoles:  id.AdditionalSystemRoles,
+			})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return certs.TLS, privateKeyPEM, nil
+	case authz.RemoteBuiltinRole:
+		certs, err := authServer.GenerateHostCerts(ctx,
+			&proto.HostCertsRequest{
+				HostID:       id.Username,
+				NodeName:     id.Username,
+				Role:         id.Role,
+				PublicTLSKey: tlsPublicKeyPEM,
+				PublicSSHKey: sshPublicKeyPEM,
+			})
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return certs.TLS, privateKeyPEM, nil
+	default:
+		return nil, nil, trace.BadParameter("identity of unknown type %T is unsupported", identity)
+	}
+}
+
+// NewCertificate returns new TLS credentials generated by test auth server
+func (a *TestAuthServer) NewCertificate(identity TestIdentity) (*tls.Certificate, error) {
+	cert, key, err := generateCertificate(a.AuthServer, identity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsCert, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &tlsCert, nil
+}
+
+// Clock returns clock used by auth server
+func (a *TestAuthServer) Clock() clockwork.Clock {
+	return a.AuthServer.GetClock()
+}
+
+// Trust adds other server host certificate authority as trusted
+func (a *TestAuthServer) Trust(ctx context.Context, remote *TestAuthServer, roleMap types.RoleMap) error {
+	remoteCA, err := remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: remote.ClusterName,
+	}, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.AuthServer.UpsertCertAuthority(ctx, remoteCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	remoteCA, err = remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.DatabaseCA,
+		DomainName: remote.ClusterName,
+	}, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.AuthServer.UpsertCertAuthority(ctx, remoteCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	remoteCA, err = remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.DatabaseClientCA,
+		DomainName: remote.ClusterName,
+	}, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.AuthServer.UpsertCertAuthority(ctx, remoteCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	remoteCA, err = remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.OpenSSHCA,
+		DomainName: remote.ClusterName,
+	}, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.AuthServer.UpsertCertAuthority(ctx, remoteCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	remoteCA, err = remote.AuthServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.UserCA,
+		DomainName: remote.ClusterName,
+	}, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	remoteCA.SetRoleMap(roleMap)
+	err = a.AuthServer.UpsertCertAuthority(ctx, remoteCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// NewTestTLSServer returns new test TLS server
+func (a *TestAuthServer) NewTestTLSServer(opts ...TestTLSServerOption) (*TestTLSServer, error) {
+	apiConfig := &auth.APIConfig{
+		AuthServer: a.AuthServer,
+		Authorizer: a.Authorizer,
+		AuditLog:   a.AuditLog,
+		Emitter:    a.AuthServer,
+	}
+	cfg := TestTLSServerConfig{
+		APIConfig:     apiConfig,
+		AuthServer:    a,
+		AcceptedUsage: a.AcceptedUsage,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	srv, err := NewTestTLSServer(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return srv, nil
+}
+
+// TestTLSServerOption is a functional option passed to NewTestTLSServer
+type TestTLSServerOption func(*TestTLSServerConfig)
+
+// WithLimiterConfig sets connection and request limiter configuration.
+func WithLimiterConfig(config *limiter.Config) TestTLSServerOption {
+	return func(cfg *TestTLSServerConfig) {
+		cfg.Limiter = config
+	}
+}
+
+// WithAccessGraphConfig sets the access graph configuration.
+func WithAccessGraphConfig(config auth.AccessGraphConfig) TestTLSServerOption {
+	return func(cfg *TestTLSServerConfig) {
+		cfg.APIConfig.AccessGraph = config
+	}
+}
+
+// NewRemoteClient creates new client to the remote server using identity
+// generated for this certificate authority
+func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
+	tlsConfig := utils.TLSConfig(a.CipherSuites)
+	cert, err := a.NewCertificate(identity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{*cert}
+	tlsConfig.RootCAs = pool
+	tlsConfig.ServerName = apiutils.EncodeClusterName(a.ClusterName)
+	tlsConfig.Time = a.AuthServer.GetClock().Now
+
+	return authclient.NewClient(client.Config{
+		Addrs: []string{addr.String()},
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+	})
+}
+
+// TestTLSServerConfig is a configuration for test TLS server
+type TestTLSServerConfig struct {
+	// APIConfig is a configuration of API server
+	APIConfig *auth.APIConfig
+	// AuthServer is a test auth server used to serve requests
+	AuthServer *TestAuthServer
+	// Limiter is a connection and request limiter
+	Limiter *limiter.Config
+	// Listener is a listener to serve requests on
+	Listener net.Listener
+	// AcceptedUsage is a list of accepted usage restrictions
+	AcceptedUsage []string
+}
+
+// Auth returns auth server used by this TLS server
+func (t *TestTLSServer) Auth() *auth.Server {
+	return t.AuthServer.AuthServer
+}
+
+// TestTLSServer is a test TLS server
+type TestTLSServer struct {
+	// TestTLSServerConfig is a configuration for TLS server
+	TestTLSServerConfig
+	// Identity is a generated TLS/SSH identity used to answer in TLS
+	Identity *state.Identity
+	// TLSServer is a configured TLS server
+	TLSServer *auth.TLSServer
+}
+
+// ClusterName returns name of test TLS server cluster
+func (t *TestTLSServer) ClusterName() string {
+	return t.AuthServer.ClusterName
+}
+
+// Clock returns clock used by auth server
+func (t *TestTLSServer) Clock() clockwork.Clock {
+	return t.AuthServer.Clock()
+}
+
+// CheckAndSetDefaults checks and sets limiter defaults
+func (cfg *TestTLSServerConfig) CheckAndSetDefaults() error {
+	if cfg.APIConfig == nil {
+		return trace.BadParameter("missing parameter APIConfig")
+	}
+	if cfg.AuthServer == nil {
+		return trace.BadParameter("missing parameter AuthServer")
+	}
+	// use very permissive limiter configuration by default
+	if cfg.Limiter == nil {
+		cfg.Limiter = &limiter.Config{
+			MaxConnections: 1000,
+		}
+	}
+	return nil
+}
+
+// NewTestTLSServer returns new test TLS server that is started and is listening
+// on 127.0.0.1 loopback on any available port
+func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
+	err := cfg.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	srv := &TestTLSServer{
+		TestTLSServerConfig: cfg,
+	}
+	srv.Identity, err = NewServerIdentity(srv.AuthServer.AuthServer, "test-tls-server", types.RoleAuth)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Register TLS endpoint of the auth service
+	tlsConfig, err := srv.Identity.TLSConfig(srv.AuthServer.CipherSuites)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig.Time = cfg.AuthServer.Clock().Now
+	tlsCert := tlsConfig.Certificates[0]
+
+	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
+		Listener:             srv.Listener,
+		AccessPoint:          srv.AuthServer.AuthServer.Cache,
+		TLS:                  tlsConfig,
+		GetClientCertificate: func() (*tls.Certificate, error) { return &tlsCert, nil },
+		APIConfig:            *srv.APIConfig,
+		LimiterConfig:        *srv.Limiter,
+		AcceptedUsage:        cfg.AcceptedUsage,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := srv.Start(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return srv, nil
+}
+
+// TestIdentity is test identity spec used to generate identities in tests
+type TestIdentity struct {
+	I              authz.IdentityGetter
+	TTL            time.Duration
+	AcceptedUsage  []string
+	RouteToCluster string
+	Renewable      bool
+	Generation     uint64
+}
+
+// TestUser returns TestIdentity for local user
+func TestUser(username string) TestIdentity {
+	return TestIdentity{
+		I: authz.LocalUser{
+			Username: username,
+			Identity: tlsca.Identity{Username: username},
+		},
+	}
+}
+
+// TestUserWithDeviceExtensions returns a TestIdentity for a local user,
+// including the supplied device extensions in the tlsca.Identity.
+func TestUserWithDeviceExtensions(username string, exts tlsca.DeviceExtensions) TestIdentity {
+	return TestIdentity{
+		I: authz.LocalUser{
+			Username: username,
+			Identity: tlsca.Identity{
+				Username:         username,
+				DeviceExtensions: exts,
+			},
+		},
+	}
+}
+
+// TestRenewableUser returns a TestIdentity for a local user
+// with renewable credentials.
+func TestRenewableUser(username string, generation uint64) TestIdentity {
+	return TestIdentity{
+		I: authz.LocalUser{
+			Username: username,
+			Identity: tlsca.Identity{
+				Username: username,
+			},
+		},
+		Renewable:  true,
+		Generation: generation,
+	}
+}
+
+// TestNop returns "Nop" - unauthenticated identity
+func TestNop() TestIdentity {
+	return TestIdentity{
+		I: nil,
+	}
+}
+
+// TestAdmin returns TestIdentity for admin user
+func TestAdmin() TestIdentity {
+	return TestBuiltin(types.RoleAdmin)
+}
+
+// TestBuiltin returns TestIdentity for builtin user
+func TestBuiltin(role types.SystemRole) TestIdentity {
+	return TestIdentity{
+		I: authz.BuiltinRole{
+			Role:     role,
+			Username: string(role),
+		},
+	}
+}
+
+// TestServerID returns a TestIdentity for a node with the passed in serverID.
+func TestServerID(role types.SystemRole, serverID string) TestIdentity {
+	return TestIdentity{
+		I: authz.BuiltinRole{
+			Role:                  types.RoleInstance,
+			Username:              serverID,
+			AdditionalSystemRoles: types.SystemRoles{role},
+			Identity: tlsca.Identity{
+				Username: serverID,
+			},
+		},
+	}
+}
+
+// TestRemoteBuiltin returns TestIdentity for a remote builtin role.
+func TestRemoteBuiltin(role types.SystemRole, remoteCluster string) TestIdentity {
+	return TestIdentity{
+		I: authz.RemoteBuiltinRole{
+			Role:        role,
+			Username:    string(role),
+			ClusterName: remoteCluster,
+		},
+	}
+}
+
+func (i TestIdentity) GetUsername() string {
+	return i.I.GetIdentity().Username
+}
+
+// NewClientFromWebSession returns new authenticated client from web session
+func (t *TestTLSServer) NewClientFromWebSession(sess types.WebSession) (*authclient.Client, error) {
+	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsCert, err := tls.X509KeyPair(sess.GetTLSCert(), sess.GetTLSPriv())
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
+	}
+	tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
+
+	return authclient.NewClient(client.Config{
+		Addrs: []string{t.Addr().String()},
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+	})
+}
+
+// CertPool returns cert pool that auth server represents
+func (t *TestTLSServer) CertPool() (*x509.CertPool, error) {
+	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tlsConfig.RootCAs, nil
+}
+
+// ClientTLSConfig returns client TLS config based on the identity
+func (t *TestTLSServer) ClientTLSConfig(identity TestIdentity) (*tls.Config, error) {
+	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if identity.I != nil {
+		cert, err := t.AuthServer.NewCertificate(identity)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{*cert}
+	} else {
+		// this client is not authenticated, which means that auth
+		// server should apply Nop builtin role
+		tlsConfig.Certificates = nil
+	}
+	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
+	return tlsConfig, nil
+}
+
+// CloneClient uses the same credentials as the passed client
+// but forces the client to be recreated
+func (t *TestTLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *authclient.Client {
+	tlsConfig := clt.Config()
+	// When cloning a client, we want to make sure that we don't reuse
+	// the same session ticket cache. The session ticket cache should not be
+	// shared between all clients that use the same TLS config.
+	// Reusing the cache will skip the TLS handshake and may introduce a weird
+	// behavior in tests.
+	if tlsConfig.ClientSessionCache != nil {
+		tlsConfig = tlsConfig.Clone()
+		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(utils.DefaultLRUCapacity)
+	}
+
+	newClient, err := authclient.NewClient(client.Config{
+		Addrs: []string{t.Addr().String()},
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+	})
+	if err != nil {
+		tt.Fatalf("error creating auth client: %v", err.Error())
+	}
+
+	tt.Cleanup(func() { _ = newClient.Close() })
+	return newClient
+}
+
+// NewClientWithCert creates a new client using given cert and private key
+func (t *TestTLSServer) NewClientWithCert(clientCert tls.Certificate) *authclient.Client {
+	tlsConfig, err := t.Identity.TLSConfig(t.AuthServer.CipherSuites)
+	if err != nil {
+		panic(err)
+	}
+	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
+	tlsConfig.Certificates = []tls.Certificate{clientCert}
+	newClient, err := authclient.NewClient(client.Config{
+		Addrs: []string{t.Addr().String()},
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return newClient
+}
+
+// NewClient returns new client to test server authenticated with identity
+func (t *TestTLSServer) NewClient(identity TestIdentity) (*authclient.Client, error) {
+	tlsConfig, err := t.ClientTLSConfig(identity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	newClient, err := authclient.NewClient(client.Config{
+		DialInBackground: true,
+		Addrs:            []string{t.Addr().String()},
+		Credentials: []client.Credentials{
+			client.LoadTLS(tlsConfig),
+		},
+		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newClient, nil
+}
+
+// Addr returns address of TLS server
+func (t *TestTLSServer) Addr() net.Addr {
+	return t.Listener.Addr()
+}
+
+// Start starts TLS server on loopback address on the first listening socket
+func (t *TestTLSServer) Start() error {
+	go t.TLSServer.Serve()
+	return nil
+}
+
+// Close closes the listener and HTTP server
+func (t *TestTLSServer) Close() error {
+	var errs []error
+	if err := t.Stop(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if t.AuthServer.Backend != nil {
+		if err := t.AuthServer.Backend.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return trace.NewAggregate(errs...)
+}
+
+// Shutdown closes the listener and HTTP server gracefully
+func (t *TestTLSServer) Shutdown(ctx context.Context) error {
+	var errs []error
+	if err := t.TLSServer.Shutdown(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if t.Listener != nil {
+		if err := t.Listener.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
+			errs = append(errs, err)
+		}
+
+	}
+	if t.AuthServer.Backend != nil {
+		if err := t.AuthServer.Backend.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return trace.NewAggregate(errs...)
+}
+
+// Stop stops listening server, but does not close the auth backend
+func (t *TestTLSServer) Stop() error {
+	var errs []error
+	if err := t.TLSServer.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	if t.Listener != nil {
+		if err := t.Listener.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	return trace.NewAggregate(errs...)
+}
+
+// FakeTeleportVersion fake version storage implementation always return current version.
+type FakeTeleportVersion struct{}
+
+// NewFakeTeleportVersion creates fake version storage.
+func NewFakeTeleportVersion() *FakeTeleportVersion {
+	return &FakeTeleportVersion{}
+}
+
+// GetTeleportVersion returns current Teleport version.
+func (s FakeTeleportVersion) GetTeleportVersion(_ context.Context) (semver.Version, error) {
+	return *teleport.SemVer(), nil
+}
+
+// WriteTeleportVersion stub function for writing.
+func (s FakeTeleportVersion) WriteTeleportVersion(_ context.Context, _ semver.Version) error {
+	return nil
+}
+
+// DeleteTeleportVersion error stub function for deleting.
+func (s FakeTeleportVersion) DeleteTeleportVersion(_ context.Context) error {
+	return nil
+}
+
+// NewServerIdentity generates new server identity, used in tests
+func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (*state.Identity, error) {
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKeyPEM, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsPubKey, err := keys.MarshalPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certs, err := clt.GenerateHostCerts(context.Background(),
+		&proto.HostCertsRequest{
+			HostID:       hostID,
+			NodeName:     hostID,
+			Role:         role,
+			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
+			PublicTLSKey: tlsPubKey,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.ReadIdentityFromKeyPair(privateKeyPEM, certs)
+}
+
+// clt limits required interface to the necessary methods
+// used to pass different clients in tests
+type clt interface {
+	UpsertRole(context.Context, types.Role) (types.Role, error)
+	UpsertUser(context.Context, types.User) (types.User, error)
+}
+
+// CreateRole creates a role without assigning any users. Used in tests.
+func CreateRole(ctx context.Context, clt clt, name string, spec types.RoleSpecV6) (types.Role, error) {
+	role, err := types.NewRole(name, spec)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	upserted, err := clt.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return upserted, nil
+}
+
+// CreateUserRoleAndRequestable creates two roles for a user, one base role with allowed login
+// matching username, and another role with a login matching rolename that can be requested.
+func CreateUserRoleAndRequestable(clt clt, username string, rolename string) (types.User, error) {
+	ctx := context.TODO()
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	baseRole := services.RoleForUser(user)
+	baseRole.SetAccessRequestConditions(types.Allow, types.AccessRequestConditions{
+		Roles: []string{rolename},
+	})
+	baseRole.SetLogins(types.Allow, nil)
+	baseRole, err = clt.UpsertRole(ctx, baseRole)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user.AddRole(baseRole.GetName())
+	_, err = clt.UpsertUser(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	requestableRole := services.RoleForUser(user)
+	requestableRole.SetName(rolename)
+	requestableRole.SetLogins(types.Allow, []string{rolename})
+	_, err = clt.UpsertRole(ctx, requestableRole)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return user, nil
+}
+
+// CreateAccessPluginUser creates a user with list/read abilites for access requests, and list/read/update
+// abilities for access plugin data.
+func CreateAccessPluginUser(ctx context.Context, clt clt, username string) (types.User, error) {
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	role := services.RoleForUser(user)
+	rules := role.GetRules(types.Allow)
+	rules = append(rules,
+		types.Rule{
+			Resources: []string{types.KindAccessRequest},
+			Verbs:     []string{types.VerbRead, types.VerbList},
+		},
+		types.Rule{
+			Resources: []string{types.KindAccessPluginData},
+			Verbs:     []string{types.VerbRead, types.VerbList, types.VerbUpdate},
+		},
+	)
+	role.SetRules(types.Allow, rules)
+	role.SetLogins(types.Allow, nil)
+	upsertedRole, err := clt.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user.AddRole(upsertedRole.GetName())
+	if _, err := clt.UpsertUser(ctx, user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return user, nil
+}
+
+// CreateUser creates user and role and assigns role to a user, used in tests
+func CreateUser(ctx context.Context, clt clt, username string, roles ...types.Role) (types.User, error) {
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, role := range roles {
+		upsertedRole, err := clt.UpsertRole(ctx, role)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		user.AddRole(upsertedRole.GetName())
+	}
+
+	created, err := clt.UpsertUser(ctx, user)
+	return created, trace.Wrap(err)
+}
+
+// createUserAndRoleOptions is a set of options for CreateUserAndRole
+type createUserAndRoleOptions struct {
+	mutateUser []func(user types.User)
+	mutateRole []func(role types.Role)
+	version    string
+}
+
+// CreateUserAndRoleOption is a functional option for CreateUserAndRole
+type CreateUserAndRoleOption func(*createUserAndRoleOptions)
+
+// WithRoleVersion sets the version of the role to be created.
+func WithRoleVersion(version string) CreateUserAndRoleOption {
+	return func(o *createUserAndRoleOptions) {
+		o.version = version
+	}
+}
+
+// WithUserMutator sets a function that will be called to mutate the user before it is created
+func WithUserMutator(mutate ...func(user types.User)) CreateUserAndRoleOption {
+	return func(o *createUserAndRoleOptions) {
+		o.mutateUser = append(o.mutateUser, mutate...)
+	}
+}
+
+// WithRoleMutator sets a function that will be called to mutate the role before it is created
+func WithRoleMutator(mutate ...func(role types.Role)) CreateUserAndRoleOption {
+	return func(o *createUserAndRoleOptions) {
+		o.mutateRole = append(o.mutateRole, mutate...)
+	}
+}
+
+// CreateUserAndRole creates user and role and assigns role to a user, used in tests
+// If allowRules is nil, the role has admin privileges.
+// If allowRules is not-nil, then the rules associated with the role will be
+// replaced with those specified.
+func CreateUserAndRole(clt clt, username string, allowedLogins []string, allowRules []types.Rule, opts ...CreateUserAndRoleOption) (types.User, types.Role, error) {
+	o := createUserAndRoleOptions{
+		version: types.DefaultRoleVersion,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	ctx := context.TODO()
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	role := services.RoleWithVersionForUser(user, o.version)
+	role.SetLogins(types.Allow, allowedLogins)
+	if allowRules != nil {
+		role.SetRules(types.Allow, allowRules)
+	}
+	for _, mutate := range o.mutateRole {
+		mutate(role)
+	}
+	upsertedRole, err := clt.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	user.AddRole(upsertedRole.GetName())
+	for _, mutate := range o.mutateUser {
+		mutate(user)
+	}
+	created, err := clt.UpsertUser(ctx, user)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return created, role, nil
+}
+
+// CreateUserAndRoleWithoutRoles creates user and role, but does not assign user to a role, used in tests
+func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []string) (types.User, types.Role, error) {
+	ctx := context.TODO()
+	user, err := types.NewUser(username)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	role := services.RoleForUser(user)
+	set := services.MakeRuleSet(role.GetRules(types.Allow))
+	delete(set, types.KindRole)
+	role.SetRules(types.Allow, set.Slice())
+	role.SetLogins(types.Allow, []string{user.GetName()})
+	upsertedRole, err := clt.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	user.AddRole(upsertedRole.GetName())
+	created, err := clt.UpsertUser(ctx, user)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return created, upsertedRole, nil
+}
+
+// Flusher is the set of methods expected by the FlushCache helper.
+type Flusher interface {
+	// GetRole returns role by name
+	GetRole(ctx context.Context, name string) (types.Role, error)
+	// CreateRole creates a new role.
+	CreateRole(context.Context, types.Role) (types.Role, error)
+	// DeleteRole deletes the role by name.
+	DeleteRole(ctx context.Context, name string) error
+}
+
+// FlushCache is a helper for waiting until preceding changes have propagated to the
+// cache during a test. this is useful for writing tests that may want to update backend
+// state and then perform some operation that depends on the auth server knowing that state.
+// note that this is only intended for use with the memory backend, as this helper relies on the assumption that
+// write events for different keys show up in the order in which the writes were performed, which
+// is not necessarily true for all backends.
+func FlushCache(t *testing.T, clt Flusher) {
+	ctx := context.Background()
+
+	// the pattern of writing a resource and then waiting for it to appear
+	// works for any resource type (when using memory backend).
+	name := strings.ReplaceAll(uuid.NewString(), "-", "")
+	defer clt.DeleteRole(ctx, name)
+
+	role, err := types.NewRole(name, types.RoleSpecV6{})
+	if err != nil {
+		t.Fatalf("Failed to instantiate new role: %v", err)
+	}
+
+	role, err = clt.CreateRole(ctx, role)
+	if err != nil {
+		t.Fatalf("Failed to create new role: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	for {
+		r, err := clt.GetRole(ctx, name)
+		if err == nil && r.GetRevision() == role.GetRevision() {
+			return
+		}
+
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-ctx.Done():
+			t.Fatal("Time out waiting for role to be replicated")
+		}
+	}
+}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -561,6 +561,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		HealthCheckConfig:       p.AuthServer.Services.HealthCheckConfig,
 		BotInstance:             p.AuthServer.Services.BotInstance,
 		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
+		Plugin:                  p.AuthServer.Services.Plugins,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/authtest/helpers_mfa.go
+++ b/lib/auth/authtest/helpers_mfa.go
@@ -1,0 +1,270 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package authtest
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
+	"github.com/gravitational/teleport/lib/utils/clocki"
+)
+
+// TestDevice is a test MFA device.
+type TestDevice struct {
+	MFA        *types.MFADevice
+	TOTPSecret string
+	Key        *mocku2f.Key
+
+	clock        clockwork.Clock
+	origin       string
+	passwordless bool
+}
+
+// TestDeviceOpt is a creation option for TestDevice.
+type TestDeviceOpt func(d *TestDevice)
+
+func WithTestDeviceClock(clock clockwork.Clock) TestDeviceOpt {
+	return func(d *TestDevice) {
+		d.clock = clock
+	}
+}
+
+func WithPasswordless() TestDeviceOpt {
+	return func(d *TestDevice) {
+		d.passwordless = true
+	}
+}
+
+func NewTestDeviceFromChallenge(c *proto.MFARegisterChallenge, opts ...TestDeviceOpt) (*TestDevice, *proto.MFARegisterResponse, error) {
+	dev := &TestDevice{}
+	for _, opt := range opts {
+		opt(dev)
+	}
+
+	registerRes, err := dev.solveRegister(c)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return dev, registerRes, nil
+}
+
+// RegisterTestDevice creates and registers a TestDevice.
+// TOTP devices require a clock option.
+func RegisterTestDevice(
+	ctx context.Context, clt authClientI, devName string, devType proto.DeviceType, authenticator *TestDevice, opts ...TestDeviceOpt,
+) (*TestDevice, error) {
+	dev := &TestDevice{} // Remaining parameters set during registration
+	for _, opt := range opts {
+		opt(dev)
+	}
+	if devType == proto.DeviceType_DEVICE_TYPE_TOTP && dev.clock == nil {
+		return nil, trace.BadParameter("TOTP devices require the WithTestDeviceClock option")
+	}
+	return dev, dev.registerDevice(ctx, clt, devName, devType, authenticator)
+}
+
+func (d *TestDevice) Origin() string {
+	if d.origin == "" {
+		return "https://localhost"
+	}
+	return d.origin
+}
+
+type authClientI interface {
+	CreateAuthenticateChallenge(context.Context, *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error)
+	CreateRegisterChallenge(context.Context, *proto.CreateRegisterChallengeRequest) (*proto.MFARegisterChallenge, error)
+	AddMFADeviceSync(context.Context, *proto.AddMFADeviceSyncRequest) (*proto.AddMFADeviceSyncResponse, error)
+}
+
+func (d *TestDevice) registerDevice(ctx context.Context, authClient authClientI, devName string, devType proto.DeviceType, authenticator *TestDevice) error {
+	mfaCeremony := &mfa.Ceremony{
+		PromptConstructor: func(opts ...mfa.PromptOpt) mfa.Prompt {
+			return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+				return authenticator.SolveAuthn(chal)
+			})
+		},
+		CreateAuthenticateChallenge: authClient.CreateAuthenticateChallenge,
+	}
+
+	authnSolved, err := mfaCeremony.Run(ctx, &proto.CreateAuthenticateChallengeRequest{
+		ChallengeExtensions: &mfav1.ChallengeExtensions{
+			Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_MANAGE_DEVICES,
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Acquire and solve registration challenge.
+	usage := proto.DeviceUsage_DEVICE_USAGE_MFA
+	if d.passwordless {
+		usage = proto.DeviceUsage_DEVICE_USAGE_PASSWORDLESS
+	}
+	registerChal, err := authClient.CreateRegisterChallenge(ctx, &proto.CreateRegisterChallengeRequest{
+		ExistingMFAResponse: authnSolved,
+		DeviceType:          devType,
+		DeviceUsage:         usage,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	registerSolved, err := d.solveRegister(registerChal)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Register.
+	addResp, err := authClient.AddMFADeviceSync(ctx, &proto.AddMFADeviceSyncRequest{
+		NewDeviceName:  devName,
+		NewMFAResponse: registerSolved,
+		DeviceUsage:    usage,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	d.MFA = addResp.Device
+	return nil
+}
+
+func (d *TestDevice) SolveAuthn(c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	switch {
+	case c.TOTP == nil && c.WebauthnChallenge == nil:
+		return &proto.MFAAuthenticateResponse{}, nil // no challenge
+	case d.Key != nil:
+		return d.solveAuthnKey(c)
+	case d.TOTPSecret != "":
+		return d.solveAuthnTOTP(c)
+	default:
+		return nil, trace.BadParameter("TestDevice has neither TOTPSecret or Key")
+	}
+}
+
+func (d *TestDevice) solveAuthnKey(c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if c.WebauthnChallenge == nil {
+		return nil, trace.BadParameter("key-based challenge not present")
+	}
+	resp, err := d.Key.SignAssertion(d.Origin(), wantypes.CredentialAssertionFromProto(c.WebauthnChallenge))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_Webauthn{
+			Webauthn: wantypes.CredentialAssertionResponseToProto(resp),
+		},
+	}, nil
+}
+
+func (d *TestDevice) solveAuthnTOTP(c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+	if c.TOTP == nil {
+		return nil, trace.BadParameter("TOTP challenge not present")
+	}
+
+	if d.clock == nil {
+		return nil, trace.BadParameter("clock not set")
+	}
+	clocki.Advance(d.clock, 30*time.Second)
+
+	code, err := totp.GenerateCode(d.TOTPSecret, d.clock.Now())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_TOTP{
+			TOTP: &proto.TOTPResponse{
+				Code: code,
+			},
+		},
+	}, nil
+}
+
+func (d *TestDevice) solveRegister(c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, error) {
+	switch {
+	case c.GetWebauthn() != nil:
+		return d.solveRegisterWebauthn(c)
+	case c.GetTOTP() != nil:
+		return d.solveRegisterTOTP(c)
+	default:
+		return nil, trace.BadParameter("unexpected challenge type: %T", c.Request)
+	}
+}
+
+func (d *TestDevice) solveRegisterWebauthn(c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, error) {
+	var err error
+	d.Key, err = mocku2f.Create()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	d.Key.PreferRPID = true
+
+	if d.passwordless {
+		d.Key.SetPasswordless()
+	}
+
+	resp, err := d.Key.SignCredentialCreation(d.Origin(), wantypes.CredentialCreationFromProto(c.GetWebauthn()))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.MFARegisterResponse{
+		Response: &proto.MFARegisterResponse_Webauthn{
+			Webauthn: wantypes.CredentialCreationResponseToProto(resp),
+		},
+	}, nil
+}
+
+func (d *TestDevice) solveRegisterTOTP(c *proto.MFARegisterChallenge) (*proto.MFARegisterResponse, error) {
+	if d.clock == nil {
+		return nil, trace.BadParameter("clock not set")
+	}
+	clocki.Advance(d.clock, 30*time.Second)
+
+	if c.GetTOTP().Algorithm != otp.AlgorithmSHA1.String() {
+		return nil, trace.BadParameter("unexpected TOTP challenge algorithm: %s", c.GetTOTP().Algorithm)
+	}
+
+	d.TOTPSecret = c.GetTOTP().Secret
+	code, err := totp.GenerateCodeCustom(d.TOTPSecret, d.clock.Now(), totp.ValidateOpts{
+		Period:    uint(c.GetTOTP().PeriodSeconds),
+		Digits:    otp.Digits(c.GetTOTP().Digits),
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.MFARegisterResponse{
+		Response: &proto.MFARegisterResponse_TOTP{
+			TOTP: &proto.TOTPRegisterResponse{
+				Code: code,
+				ID:   c.GetTOTP().ID,
+			},
+		},
+	}, nil
+}

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -228,7 +228,9 @@ func TestHandlerSampler(t *testing.T) {
 	generateHandles := func(i int) iter.Seq[inventory.UpstreamHandle] {
 		return func(yield func(inventory.UpstreamHandle) bool) {
 			for j := range i {
-				yield(&fakeHandle{id: j})
+				if !yield(&fakeHandle{id: j}) {
+					return
+				}
 			}
 		}
 	}

--- a/lib/auth/azure_certs_test.go
+++ b/lib/auth/azure_certs_test.go
@@ -16,12 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/auth"
 )
 
 func TestIsAllowedDomain(t *testing.T) {
@@ -69,7 +71,7 @@ func TestIsAllowedDomain(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.assert(t, isAllowedDomain(tc.url, allowedDomains))
+			tc.assert(t, auth.IsAllowedDomain(tc.url, allowedDomains))
 		})
 	}
 }

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"bytes"
@@ -55,7 +55,9 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -74,7 +76,7 @@ import (
 
 func renewBotCerts(
 	ctx context.Context,
-	srv *TestTLSServer,
+	srv *authtest.TestTLSServer,
 	tlsCertPEM []byte,
 	botUser string,
 	key crypto.Signer,
@@ -121,11 +123,11 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	ctx := context.Background()
 	fakeClock := srv.Clock().(*clockwork.FakeClock)
 
-	_, err := CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	// Create a new bot.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
@@ -233,11 +235,11 @@ func TestBotJoinAttrs_Kubernetes(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	role, err := CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
+	role, err := authtest.CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	// Create a new bot.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
@@ -372,11 +374,11 @@ func TestRegisterBotInstance(t *testing.T) {
 	srv.Auth().SetEmitter(mockEmitter)
 	ctx := context.Background()
 
-	_, err := CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	// Create a new bot.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
@@ -518,11 +520,11 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	t.Parallel()
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
-	_, err := CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	// Create a new bot.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
@@ -594,11 +596,11 @@ func TestRegisterBotCertificateExtensions(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	_, err := CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, srv.Auth(), "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	// Create a new bot.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
@@ -663,7 +665,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
 
 	roleName := "test-role"
-	_, err = CreateRole(ctx, a, roleName, types.RoleSpecV6{})
+	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	botName := "botty"
@@ -676,19 +678,19 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.clock.Now(), "")
+	}, a.GetClock().Now(), "")
 	require.NoError(t, err)
 
 	remoteAddr := "42.42.42.42:42"
 
 	t.Run("IAM method", func(t *testing.T) {
-		a.httpClientForAWSSTS = &mockClient{
+		a.SetHTTPClientForAWSSTS(&mockClient{
 			respStatusCode: http.StatusOK,
-			respBody: responseFromAWSIdentity(awsIdentity{
+			respBody: responseFromAWSIdentity(auth.AWSIdentity{
 				Account: "1234",
 				Arn:     "arn:aws::1111",
 			}),
-		}
+		})
 
 		// add token to auth server
 		awsTokenName := "aws-test-token"
@@ -737,7 +739,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 		rsID := vmResourceID(subID, resourceGroup, "test-vm")
 		vmID := "vmID"
 
-		accessToken, err := makeToken(rsID, "", a.clock.Now())
+		accessToken, err := makeToken(rsID, "", a.GetClock().Now())
 		require.NoError(t, err)
 
 		// add token to auth server
@@ -777,7 +779,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 		require.NoError(t, err)
 
 		certs, err := a.RegisterUsingAzureMethodWithOpts(context.Background(), func(challenge string) (*proto.RegisterUsingAzureMethodRequest, error) {
-			ad := attestedData{
+			ad := auth.AttestedData{
 				Nonce:          challenge,
 				SubscriptionID: subID,
 				ID:             vmID,
@@ -789,7 +791,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 			require.NoError(t, s.AddSigner(tlsConfig.Certificate, pkey, pkcs7.SignerInfoConfig{}))
 			signature, err := s.Finish()
 			require.NoError(t, err)
-			signedAD := signedAttestedData{
+			signedAD := auth.SignedAttestedData{
 				Encoding:  "pkcs7",
 				Signature: base64.StdEncoding.EncodeToString(signature),
 			}
@@ -809,7 +811,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 				AccessToken:  accessToken,
 			}
 			return req, nil
-		}, withCerts([]*x509.Certificate{tlsConfig.Certificate}), withVerifyFunc(mockVerifyToken(nil)), withVMClientGetter(getVMClient))
+		}, auth.WithAzureCerts([]*x509.Certificate{tlsConfig.Certificate}), auth.WithAzureVerifyFunc(mockVerifyToken(nil)), auth.WithAzureVMClientGetter(getVMClient))
 		require.NoError(t, err)
 		checkCertLoginIP(t, certs.TLS, remoteAddr)
 	})
@@ -933,21 +935,21 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 	k8sReadFileFunc := func(name string) ([]byte, error) {
 		return []byte(k8sTokenName), nil
 	}
-	a.k8sJWKSValidator = func(_ time.Time, _ []byte, _ string, tkn string) (*token.ValidationResult, error) {
+	a.SetJWKSValidator(func(_ time.Time, _ []byte, _ string, tkn string) (*token.ValidationResult, error) {
 		if tkn == k8sTokenName {
 			return &token.ValidationResult{Username: "system:serviceaccount:static-jwks:matching"}, nil
 		}
 
 		return nil, errMockInvalidToken
-	}
+	})
 
-	a.httpClientForAWSSTS = &mockClient{
+	a.SetHTTPClientForAWSSTS(&mockClient{
 		respStatusCode: http.StatusOK,
-		respBody: responseFromAWSIdentity(awsIdentity{
+		respBody: responseFromAWSIdentity(auth.AWSIdentity{
 			Account: "1234",
 			Arn:     "arn:aws::1111",
 		}),
-	}
+	})
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "FAKE_ID")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "FAKE_KEY")
@@ -956,7 +958,7 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 
 	// Create a bot
 	roleName := "test-role"
-	_, err := CreateRole(ctx, a, roleName, types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	botName := "bot"
@@ -969,7 +971,7 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.clock.Now(), "")
+	}, a.GetClock().Now(), "")
 	require.NoError(t, err)
 
 	// Create k8s and IAM join tokens
@@ -1088,13 +1090,13 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 
 	botName := "bot"
 	k8sTokenName := "jwks-matching-service-account"
-	a.k8sJWKSValidator = func(_ time.Time, _ []byte, _ string, tkn string) (*token.ValidationResult, error) {
+	a.SetJWKSValidator(func(_ time.Time, _ []byte, _ string, tkn string) (*token.ValidationResult, error) {
 		if tkn == k8sTokenName {
 			return &token.ValidationResult{Username: "system:serviceaccount:static-jwks:matching"}, nil
 		}
 
 		return nil, errMockInvalidToken
-	}
+	})
 	token, err := types.NewProvisionTokenFromSpec("static-jwks", time.Now().Add(10*time.Minute), types.ProvisionTokenSpecV2{
 		JoinMethod: types.JoinMethodKubernetes,
 		Roles:      []types.SystemRole{types.RoleBot},
@@ -1113,7 +1115,7 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 	require.NoError(t, a.CreateToken(ctx, token))
 
 	roleName := "test-role"
-	_, err = CreateRole(ctx, a, roleName, types.RoleSpecV6{})
+	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
@@ -1125,10 +1127,10 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 		Spec: &machineidv1pb.BotSpec{
 			Roles: []string{roleName},
 		},
-	}, a.clock.Now(), "")
+	}, a.GetClock().Now(), "")
 	require.NoError(t, err)
 
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	privateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
@@ -1192,7 +1194,7 @@ func TestRegisterBotMultipleTokens(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	// Initial setup, create a bot and join token.
-	client, err := srv.NewClient(TestAdmin())
+	client, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -76,7 +76,7 @@ import (
 
 func renewBotCerts(
 	ctx context.Context,
-	srv *authtest.TestTLSServer,
+	srv *authtest.TLSServer,
 	tlsCertPEM []byte,
 	botUser string,
 	key crypto.Signer,
@@ -92,7 +92,11 @@ func renewBotCerts(
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	client := srv.NewClientWithCert(tlsCert)
+
+	client, err := srv.NewClientWithCert(tlsCert)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 
 	sshPub, err := ssh.NewPublicKey(key.Public())
 	if err != nil {
@@ -340,7 +344,8 @@ func TestBotJoinAttrs_Kubernetes(t *testing.T) {
 	require.NoError(t, err)
 	tlsPub, err := keys.MarshalPublicKey(result.PrivateKey.Public())
 	require.NoError(t, err)
-	botClient := srv.NewClientWithCert(tlsCert)
+	botClient, err := srv.NewClientWithCert(tlsCert)
+	require.NoError(t, err)
 	roleCerts, err := botClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
 		SSHPublicKey: ssh.MarshalAuthorizedKey(sshPub),
 		TLSPublicKey: tlsPub,

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -32,6 +32,8 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -92,7 +94,7 @@ func Test_getSnowflakeJWTParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			subject, issuer := getSnowflakeJWTParams(context.Background(), tt.args.accountName, tt.args.userName, tt.args.publicKey)
+			subject, issuer := auth.GetSnowflakeJWTParams(context.Background(), tt.args.accountName, tt.args.userName, tt.args.publicKey)
 
 			require.Equal(t, tt.wantSubject, subject)
 			require.Equal(t, tt.wantIssuer, issuer)
@@ -102,7 +104,7 @@ func Test_getSnowflakeJWTParams(t *testing.T) {
 
 func TestDBCertSigning(t *testing.T) {
 	t.Parallel()
-	authServer, err := NewTestAuthServer(TestAuthServerConfig{
+	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Clock:       clockwork.NewFakeClockAt(time.Now()),
 		ClusterName: "local.me",
 		Dir:         t.TempDir(),
@@ -260,7 +262,7 @@ func TestFilterExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterExtensions(context.Background(), slog.Default(), tt.input, tt.allowedOIDs...)
+			got := auth.FilterExtensions(context.Background(), slog.Default(), tt.input, tt.allowedOIDs...)
 			require.Equal(t, tt.expected, got)
 		})
 	}

--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -104,7 +104,7 @@ func Test_getSnowflakeJWTParams(t *testing.T) {
 
 func TestDBCertSigning(t *testing.T) {
 	t.Parallel()
-	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Clock:       clockwork.NewFakeClockAt(time.Now()),
 		ClusterName: "local.me",
 		Dir:         t.TempDir(),

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -1,0 +1,455 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/jonboulle/clockwork"
+	"github.com/julienschmidt/httprouter"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/join/oracle"
+	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/circleci"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/inventory"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tpm"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// The items exported here exist solely to prevent import cycles and facilitate
+// preexisting tests in lib/auth which relied on unexported items. All new
+// tests in lib/auth should exist in the auth_test package and not rely on
+// internal state.
+
+const (
+	NumOfRecoveryCodes     = numOfRecoveryCodes
+	NumWordsInRecoveryCode = numWordsInRecoveryCode
+
+	StartRecoveryGenericErrMsg  = startRecoveryGenericErrMsg
+	StartRecoveryBadAuthnErrMsg = startRecoveryBadAuthnErrMsg
+
+	VerifyRecoveryGenericErrMsg  = verifyRecoveryGenericErrMsg
+	VerifyRecoveryBadAuthnErrMsg = verifyRecoveryBadAuthnErrMsg
+
+	CompleteRecoveryGenericErrMsg = completeRecoveryGenericErrMsg
+
+	MFADeviceNameMaxLen = mfaDeviceNameMaxLen
+
+	ServerHostnameMaxLen = serverHostnameMaxLen
+
+	MaxUserAgentLen = maxUserAgentLen
+	ForwardedTag    = forwardedTag
+
+	AzureAccessTokenAudience = azureAccessTokenAudience
+)
+
+var (
+	RemoteClusterRefreshLimit   = remoteClusterRefreshLimit
+	RemoteClusterRefreshBuckets = remoteClusterRefreshBuckets
+
+	ErrDeleteRoleUser       = errDeleteRoleUser
+	ErrDeleteRoleCA         = errDeleteRoleCA
+	ErrDeleteRoleAccessList = errDeleteRoleAccessList
+
+	CreateAuditStreamAcceptedTotalMetric = createAuditStreamAcceptedTotalMetric
+
+	AWSRSA2048CertBytes = awsRSA2048CertBytes
+)
+
+func (a *Server) VerifyRecoveryCode(ctx context.Context, username string, recoveryCode []byte) (errResult error) {
+	return a.verifyRecoveryCode(ctx, username, recoveryCode)
+}
+
+func (a *Server) CreateRecoveryToken(ctx context.Context, username, tokenType string, usage types.UserTokenUsage) (types.UserToken, error) {
+	return a.createRecoveryToken(ctx, username, tokenType, usage)
+}
+
+func (a *Server) NewUserToken(req authclient.CreateUserTokenRequest) (types.UserToken, error) {
+	return a.newUserToken(req)
+}
+
+func CreatePrivilegeToken(ctx context.Context, srv *Server, username, tokenKind string) (*types.UserTokenV3, error) {
+	return srv.createPrivilegeToken(ctx, username, tokenKind)
+}
+
+func (a *Server) GenerateAndUpsertRecoveryCodes(ctx context.Context, username string) (*proto.RecoveryCodes, error) {
+	return a.generateAndUpsertRecoveryCodes(ctx, username)
+}
+
+func (p *HostAndUserCAPoolInfo) VerifyPeerCert() func([][]byte, [][]*x509.Certificate) error {
+	return p.verifyPeerCert()
+}
+
+func (a *Server) CheckPassword(ctx context.Context, user string, password []byte, otpToken string) error {
+	_, err := a.checkPassword(ctx, user, password, otpToken)
+	return err
+}
+
+func (a *Server) SetPrivateKey(key []byte) {
+	a.privateKey = key
+}
+
+func (a *Server) SyncUpgradeWindowStartHour(ctx context.Context) error {
+	return a.syncUpgradeWindowStartHour(ctx)
+}
+
+func (a *Server) ValidateTrustedCluster(ctx context.Context, req *authclient.ValidateTrustedClusterRequest) (*authclient.ValidateTrustedClusterResponse, error) {
+	return a.validateTrustedCluster(ctx, req)
+}
+
+func (a *Server) CreateReverseTunnel(ctx context.Context, t types.TrustedCluster) error {
+	return a.createReverseTunnel(ctx, t)
+}
+
+func (a *Server) RefreshRemoteClusters(ctx context.Context) {
+	a.refreshRemoteClusters(ctx)
+}
+
+func CreateGithubConnector(ctx context.Context, srv *Server, connector types.GithubConnector) (types.GithubConnector, error) {
+	return srv.createGithubConnector(ctx, connector)
+}
+
+func UpdateGithubConnector(ctx context.Context, srv *Server, connector types.GithubConnector) (types.GithubConnector, error) {
+	return srv.updateGithubConnector(ctx, connector)
+}
+
+func UpsertGithubConnector(ctx context.Context, srv *Server, connector types.GithubConnector) (types.GithubConnector, error) {
+	return srv.upsertGithubConnector(ctx, connector)
+}
+
+func DeleteGithubConnector(ctx context.Context, srv *Server, name string) error {
+	return srv.deleteGithubConnector(ctx, name)
+}
+
+func (a *Server) CalculateGithubUser(ctx context.Context, diagCtx *SSODiagContext, connector types.GithubConnector, claims *types.GithubClaims, request *types.GithubAuthRequest) (*CreateUserParams, error) {
+	return a.calculateGithubUser(ctx, diagCtx, connector, claims, request)
+}
+
+func (a *Server) SubscribeToLockTarget(ctx context.Context, targets ...types.LockTarget) (types.Watcher, error) {
+	return a.lockWatcher.Subscribe(ctx, targets...)
+}
+
+func (a *Server) NewWebSession(
+	ctx context.Context,
+	req NewWebSessionRequest,
+	opts *newWebSessionOpts,
+) (types.WebSession, services.AccessChecker, error) {
+	return a.newWebSession(ctx, req, opts)
+}
+
+func (a *Server) AuthenticateUser(
+	ctx context.Context,
+	req authclient.AuthenticateUserRequest,
+	requiredExt mfav1.ChallengeExtensions,
+) (verifyLocks func(verifyMFADeviceLocksParams) error, mfaDev *types.MFADevice, user string, err error) {
+	return a.authenticateUser(ctx, req, requiredExt)
+}
+
+func (a *Server) Inventory() *inventory.Controller {
+	return a.inventory
+}
+
+func (a *Server) CheckPasswordWOToken(ctx context.Context, user string, password []byte) error {
+	return a.checkPasswordWOToken(ctx, user, password)
+}
+
+func (a *Server) ResetPassword(ctx context.Context, username string) error {
+	return a.resetPassword(ctx, username)
+}
+
+func (a *Server) SetHTTPClientForAWSSTS(clt utils.HTTPDoClient) {
+	a.httpClientForAWSSTS = clt
+}
+
+func (a *Server) SetJWKSValidator(clt JWKSValidator) {
+	a.k8sJWKSValidator = clt
+}
+
+func (a *Server) SetAzureDevopsIDTokenValidator(validator azureDevopsIDTokenValidator) {
+	a.azureDevopsIDTokenValidator = validator
+}
+
+func (a *Server) SetBitbucketIDTokenValidator(validator bitbucketIDTokenValidator) {
+	a.bitbucketIDTokenValidator = validator
+}
+
+func (a *Server) SetCircleCITokenValidate(validator func(ctx context.Context, organizationID, token string) (*circleci.IDTokenClaims, error)) {
+	a.circleCITokenValidate = validator
+}
+
+func (a *Server) SetGCPIDTokenValidator(validator gcpIDTokenValidator) {
+	a.gcpIDTokenValidator = validator
+}
+
+func (a *Server) SetGitlabIDTokenValidator(validator gitlabIDTokenValidator) {
+	a.gitlabIDTokenValidator = validator
+}
+
+func (a *Server) SetK8sTokenReviewValidator(validator k8sTokenReviewValidator) {
+	a.k8sTokenReviewValidator = validator
+}
+
+func (a *Server) SetSpaceliftIDTokenValidator(validator spaceliftIDTokenValidator) {
+	a.spaceliftIDTokenValidator = validator
+}
+
+func (a *Server) SetTerraformIDTokenValidator(validator terraformCloudIDTokenValidator) {
+	a.terraformIDTokenValidator = validator
+}
+
+func (a *Server) SetTPMValidator(validator func(ctx context.Context, log *slog.Logger, params tpm.ValidateParams) (*tpm.ValidatedTPM, error)) {
+	a.tpmValidator = validator
+}
+
+func (a *Server) SetGHAIDTokenValidator(validator ghaIDTokenValidator) {
+	a.ghaIDTokenValidator = validator
+}
+
+func (a *Server) SetGHAIDTokenJWKSValidator(validator ghaIDTokenJWKSValidator) {
+	a.ghaIDTokenJWKSValidator = validator
+}
+
+type BoundKeypairValidator = boundKeypairValidator
+
+type CreateBoundKeypairValidator func(subject string, clusterName string, publicKey crypto.PublicKey) (BoundKeypairValidator, error)
+
+func (a *Server) SetCreateBoundKeypairValidator(validator CreateBoundKeypairValidator) {
+	a.createBoundKeypairValidator = func(subject, clusterName string, publicKey crypto.PublicKey) (boundKeypairValidator, error) {
+		return validator(subject, clusterName, publicKey)
+	}
+}
+
+func (a *Server) AuthenticateUserLogin(ctx context.Context, req authclient.AuthenticateUserRequest) (services.UserState, services.AccessChecker, error) {
+	return a.authenticateUserLogin(ctx, req)
+}
+
+func (a *Server) RefreshULS(ctx context.Context, user types.User, ulsService services.UserLoginStates) (*userloginstate.UserLoginState, error) {
+	return a.ulsGenerator.Refresh(ctx, user, ulsService)
+}
+
+func (a *Server) CreateGithubUser(ctx context.Context, p *CreateUserParams, dryRun bool) (types.User, error) {
+	return a.createGithubUser(ctx, p, dryRun)
+}
+
+func BuildAPIEndpoint(apiEndpointURLStr string) (string, error) {
+	return buildAPIEndpoint(apiEndpointURLStr)
+}
+
+func FormatGithubURL(host string, path string) string {
+	return formatGithubURL(host, path)
+}
+
+func CheckGithubOrgSSOSupport(ctx context.Context, conn types.GithubConnector, userTeams []GithubTeamResponse, orgCache *utils.FnCache, client httpRequester) error {
+	return checkGithubOrgSSOSupport(ctx, conn, userTeams, orgCache, client)
+}
+
+func ChangeUserAuthentication(ctx context.Context, a *Server, req *proto.ChangeUserAuthenticationRequest) (types.User, error) {
+	return a.changeUserAuthentication(ctx, req)
+}
+
+func ValidateOracleJoinToken(token types.ProvisionToken) error {
+	return validateOracleJoinToken(token)
+}
+
+func CreatePresetUsers(ctx context.Context, um PresetUsers) error {
+	return createPresetUsers(ctx, um)
+}
+
+func CreatePresetRoles(ctx context.Context, um PresetRoleManager) error {
+	return createPresetRoles(ctx, um)
+}
+
+func CreatePresetHealthCheckConfig(ctx context.Context, svc services.HealthCheckConfig) error {
+	return createPresetHealthCheckConfig(ctx, svc)
+}
+
+func GetPresetUsers() []types.User {
+	return getPresetUsers()
+}
+
+func CreatePresetDatabaseObjectImportRule(ctx context.Context, rules services.DatabaseObjectImportRules) error {
+	return createPresetDatabaseObjectImportRule(ctx, rules)
+}
+
+func ValidServerHostname(hostname string) bool {
+	return validServerHostname(hostname)
+}
+
+func FormatAccountName(s proxyDomainGetter, username string, authHostname string) (string, error) {
+	return formatAccountName(s, username, authHostname)
+}
+
+func ConfigureCAsForTrustedCluster(tc types.TrustedCluster, cas []types.CertAuthority) {
+	configureCAsForTrustedCluster(tc, cas)
+}
+
+func UpdateAccessRequestWithAdditionalReviewers(ctx context.Context, req types.AccessRequest, accessLists services.AccessListsGetter, promotions *types.AccessRequestAllowedPromotions) {
+	updateAccessRequestWithAdditionalReviewers(ctx, req, accessLists, promotions)
+}
+
+func EncodeProquint(x uint16) string {
+	return encodeProquint(x)
+}
+
+func EmitSSOLoginFailureEvent(ctx context.Context, emitter apievents.Emitter, method string, err error, testFlow bool) {
+	emitSSOLoginFailureEvent(ctx, emitter, method, err, testFlow)
+}
+
+type UpsertServerRawReq = upsertServerRawReq
+
+func UpsertServer(srv *APIServer, auth presenceForAPIServer, role types.SystemRole, r *http.Request, p httprouter.Params) (any, error) {
+	return srv.upsertServer(auth, role, r, p)
+}
+
+func NewServerWithRoles(srv *Server, alog events.AuditLogSessionStreamer, authzContext authz.Context) *ServerWithRoles {
+	return &ServerWithRoles{
+		authServer: srv,
+		alog:       alog,
+		context:    authzContext,
+	}
+}
+
+func NewKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
+	return newKeySet(ctx, keyStore, caID)
+}
+
+func ValidateIdentity(c *TransportCredentials, conn net.Conn, tlsInfo *credentials.TLSInfo) (net.Conn, IdentityInfo, error) {
+	return c.validateIdentity(conn, tlsInfo)
+}
+
+func (m *Middleware) SetLastRejectedTime(t time.Time) {
+	m.lastRejectedAlertTime.Store(t.UnixNano())
+}
+
+func RegisterUsingOracleMethod(
+	ctx context.Context,
+	srv *Server,
+	tokenReq *types.RegisterUsingTokenRequest,
+	challengeResponse client.RegisterOracleChallengeResponseFunc,
+	fetchClaims oracleClaimsFetcher,
+) (certs *proto.Certs, err error) {
+	return srv.registerUsingOracleMethod(ctx, tokenReq, challengeResponse, fetchClaims)
+}
+
+func TrimUserAgent(userAgent string) string {
+	return trimUserAgent(userAgent)
+}
+
+func IsAllowedDomain(cn string, domains []string) bool {
+	return isAllowedDomain(cn, domains)
+}
+
+func GetSnowflakeJWTParams(ctx context.Context, accountName, userName string, publicKey []byte) (string, string) {
+	return getSnowflakeJWTParams(ctx, accountName, userName, publicKey)
+}
+
+func FilterExtensions(ctx context.Context, logger *slog.Logger, extensions []pkix.Extension, oids ...asn1.ObjectIdentifier) []pkix.Extension {
+	return filterExtensions(ctx, logger, extensions, oids...)
+}
+
+func PopulateGithubClaims(user *GithubUserResponse, teams []GithubTeamResponse) (*types.GithubClaims, error) {
+	return populateGithubClaims(user, teams)
+}
+
+func ValidateGithubAuthCallbackHelper(ctx context.Context, m GitHubManager, diagCtx *SSODiagContext, q url.Values, emitter apievents.Emitter, logger *slog.Logger) (*authclient.GithubAuthResponse, error) {
+	return validateGithubAuthCallbackHelper(ctx, m, diagCtx, q, emitter, logger)
+}
+
+func IsGCPZoneInLocation(rawLocation, rawZone string) bool {
+	return isGCPZoneInLocation(rawLocation, rawZone)
+}
+
+func JoinRuleGlobMatch(want string, got string) (bool, error) {
+	return joinRuleGlobMatch(want, got)
+}
+
+func FormatHeaderFromMap(m map[string]string) http.Header {
+	return formatHeaderFromMap(m)
+}
+
+func CheckHeaders(headers http.Header, challenge string, clock clockwork.Clock) error {
+	return checkHeaders(headers, challenge, clock)
+}
+
+func CheckOracleAllowRules(claims oracle.Claims, token string, allowRules []*types.ProvisionTokenSpecV2Oracle_Rule) error {
+	return checkOracleAllowRules(claims, token, allowRules)
+}
+
+type GitHubManager = githubManager
+type AWSIdentity = awsIdentity
+type AttestedData = attestedData
+type SignedAttestedData = signedAttestedData
+type JWKSValidator = k8sJWKSValidator
+type AzureRegisterOption = azureRegisterOption
+type AzureRegisterConfig = azureRegisterConfig
+type AzureVMClientGetter = vmClientGetter
+type AzureVerifyTokenFunc = azureVerifyTokenFunc
+type AccessTokenClaims = accessTokenClaims
+type EC2Client = ec2Client
+type EC2ClientKey = ec2ClientKey
+type IAMRegisterOption = iamRegisterOption
+
+func WithAzureCerts(certs []*x509.Certificate) AzureRegisterOption {
+	return func(cfg *AzureRegisterConfig) {
+		cfg.certificateAuthorities = certs
+	}
+}
+
+func WithAzureVerifyFunc(verify azureVerifyTokenFunc) AzureRegisterOption {
+	return func(cfg *AzureRegisterConfig) {
+		cfg.verify = verify
+	}
+}
+
+func WithAzureVMClientGetter(getVMClient vmClientGetter) AzureRegisterOption {
+	return func(cfg *AzureRegisterConfig) {
+		cfg.getVMClient = getVMClient
+	}
+}
+
+func WithFIPS(b bool) iamRegisterOption {
+	return withFips(b)
+}
+
+func WithAuthVersion(v *semver.Version) iamRegisterOption {
+	return withAuthVersion(v)
+}
+
+func (s *TLSServer) GRPCServer() *GRPCServer {
+	return s.grpcServer
+}

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -79,9 +79,6 @@ const (
 )
 
 var (
-	RemoteClusterRefreshLimit   = remoteClusterRefreshLimit
-	RemoteClusterRefreshBuckets = remoteClusterRefreshBuckets
-
 	ErrDeleteRoleUser       = errDeleteRoleUser
 	ErrDeleteRoleCA         = errDeleteRoleCA
 	ErrDeleteRoleAccessList = errDeleteRoleAccessList
@@ -90,6 +87,14 @@ var (
 
 	AWSRSA2048CertBytes = awsRSA2048CertBytes
 )
+
+func (a *Server) SetRemoteClusterRefreshLimit(limit int) {
+	remoteClusterRefreshLimit = limit
+}
+
+func (a *Server) RemoteClusterRefreshBuckets(buckets int) {
+	remoteClusterRefreshBuckets = buckets
+}
 
 func (a *Server) VerifyRecoveryCode(ctx context.Context, username string, recoveryCode []byte) (errResult error) {
 	return a.verifyRecoveryCode(ctx, username, recoveryCode)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -427,7 +427,7 @@ func GithubAuthRequestFromProto(req *types.GithubAuthRequest) authclient.GithubA
 }
 
 type githubManager interface {
-	validateGithubAuthCallback(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error)
+	ValidateGithubAuthRedirect(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error)
 }
 
 // ValidateGithubAuthCallback validates Github auth callback redirect
@@ -445,7 +445,7 @@ func validateGithubAuthCallbackHelper(ctx context.Context, m githubManager, diag
 		ConnectionMetadata: authz.ConnectionMetadata(ctx),
 	}
 
-	auth, err := m.validateGithubAuthCallback(ctx, diagCtx, q)
+	auth, err := m.ValidateGithubAuthRedirect(ctx, diagCtx, q)
 	diagCtx.Info.Error = trace.UserMessage(err)
 	event.AppliedLoginRules = diagCtx.Info.AppliedLoginRules
 
@@ -535,8 +535,8 @@ func newGithubOAuth2Config(connector types.GithubConnector) oauth2.Config {
 	}
 }
 
-// ValidateGithubAuthCallback validates Github auth callback redirect
-func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+// ValidateGithubAuthRedirect validates Github auth callback redirect
+func (a *Server) ValidateGithubAuthRedirect(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 	logger := a.logger.With(teleport.ComponentKey, "github")
 
 	if errParam := q.Get("error"); errParam != "" {

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"bytes"
@@ -38,7 +38,9 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -54,7 +56,7 @@ import (
 )
 
 type githubContext struct {
-	a           *Server
+	a           *auth.Server
 	mockEmitter *eventstest.MockRecorderEmitter
 	b           backend.Backend
 	c           *clockwork.FakeClock
@@ -81,18 +83,18 @@ func setupGithubContext(ctx context.Context, t *testing.T) *githubContext {
 		require.NoError(t, tt.b.Close())
 	})
 
-	authConfig := &InitConfig{
+	authConfig := &auth.InitConfig{
 		ClusterName:            clusterName,
 		Backend:                tt.b,
-		VersionStorage:         NewFakeTeleportVersion(),
+		VersionStorage:         authtest.NewFakeTeleportVersion(),
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	tt.a, err = NewServer(authConfig)
+	tt.a, err = auth.NewServer(authConfig)
 	require.NoError(t, err)
 
 	tt.mockEmitter = &eventstest.MockRecorderEmitter{}
-	tt.a.emitter = tt.mockEmitter
+	tt.a.SetEmitter(tt.mockEmitter)
 
 	return &tt
 }
@@ -110,7 +112,7 @@ func TestPopulateClaims(t *testing.T) {
 	teams, err := client.getTeams()
 	require.NoError(t, err)
 
-	claims, err := populateGithubClaims(user, teams)
+	claims, err := auth.PopulateGithubClaims(user, teams)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(claims, &types.GithubClaims{
 		Username: "octocat",
@@ -128,7 +130,7 @@ func TestCreateGithubUser(t *testing.T) {
 	tt := setupGithubContext(ctx, t)
 
 	// Dry-run creation of Github user.
-	user, err := tt.a.createGithubUser(ctx, &CreateUserParams{
+	user, err := tt.a.CreateGithubUser(ctx, &auth.CreateUserParams{
 		ConnectorName: "github",
 		Username:      "foo@example.com",
 		Roles:         []string{"admin"},
@@ -142,7 +144,7 @@ func TestCreateGithubUser(t *testing.T) {
 	require.Error(t, err)
 
 	// Create GitHub user with 1 minute expiry.
-	_, err = tt.a.createGithubUser(ctx, &CreateUserParams{
+	_, err = tt.a.CreateGithubUser(ctx, &auth.CreateUserParams{
 		ConnectorName: "github",
 		Username:      "foo",
 		Roles:         []string{"admin"},
@@ -162,26 +164,26 @@ func TestCreateGithubUser(t *testing.T) {
 
 type testGithubAPIClient struct{}
 
-func (c *testGithubAPIClient) getUser() (*GithubUserResponse, error) {
-	return &GithubUserResponse{Login: "octocat", ID: 1234567}, nil
+func (c *testGithubAPIClient) getUser() (*auth.GithubUserResponse, error) {
+	return &auth.GithubUserResponse{Login: "octocat", ID: 1234567}, nil
 }
 
-func (c *testGithubAPIClient) getTeams() ([]GithubTeamResponse, error) {
-	return []GithubTeamResponse{
+func (c *testGithubAPIClient) getTeams() ([]auth.GithubTeamResponse, error) {
+	return []auth.GithubTeamResponse{
 		{
 			Name: "team1",
 			Slug: "team1",
-			Org:  GithubOrgResponse{Login: "org1"},
+			Org:  auth.GithubOrgResponse{Login: "org1"},
 		},
 		{
 			Name: "team2",
 			Slug: "team2",
-			Org:  GithubOrgResponse{Login: "org1"},
+			Org:  auth.GithubOrgResponse{Login: "org1"},
 		},
 		{
 			Name: "team1",
 			Slug: "team1",
-			Org:  GithubOrgResponse{Login: "org2"},
+			Org:  auth.GithubOrgResponse{Login: "org2"},
 		},
 	}, nil
 }
@@ -192,7 +194,7 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 	tt := setupGithubContext(ctx, t)
 	logger := logtest.NewLogger()
 
-	auth := &authclient.GithubAuthResponse{
+	resp := &authclient.GithubAuthResponse{
 		Username: "test-name",
 	}
 
@@ -208,8 +210,8 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 		return nil
 	}
 
-	ssoDiagContextFixture := func(testFlow bool) *SSODiagContext {
-		diagCtx := NewSSODiagContext(types.KindGithub, SSODiagServiceFunc(createSSODiagnosticInfoStub))
+	ssoDiagContextFixture := func(testFlow bool) *auth.SSODiagContext {
+		diagCtx := auth.NewSSODiagContext(types.KindGithub, auth.SSODiagServiceFunc(createSSODiagnosticInfoStub))
 		diagCtx.RequestID = uuid.New().String()
 		diagCtx.Info.TestFlow = testFlow
 		return diagCtx
@@ -218,12 +220,12 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 
 	// Test success event, non-test-flow.
 	diagCtx := ssoDiagContextFixture(false /* testFlow */)
-	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 		diagCtx.Info.GithubClaims = claims
 		diagCtx.Info.AppliedLoginRules = []string{"login-rule"}
-		return auth, nil
+		return resp, nil
 	}
-	_, _ = validateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.emitter, logger)
+	_, _ = auth.ValidateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.GetEmitter(), logger)
 	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
 	require.Equal(t, events.UserSSOLoginCode, tt.mockEmitter.LastEvent().GetCode())
 	loginEvt := tt.mockEmitter.LastEvent().(*apievents.UserLogin)
@@ -234,11 +236,11 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 
 	// Test failure event, non-test-flow.
 	diagCtx = ssoDiagContextFixture(false /* testFlow */)
-	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 		diagCtx.Info.GithubClaims = claims
-		return auth, trace.BadParameter("")
+		return resp, trace.BadParameter("")
 	}
-	_, _ = validateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.emitter, logger)
+	_, _ = auth.ValidateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.GetEmitter(), logger)
 	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
 	require.Equal(t, events.UserSSOLoginFailureCode, tt.mockEmitter.LastEvent().GetCode())
 	loginEvt = tt.mockEmitter.LastEvent().(*apievents.UserLogin)
@@ -247,11 +249,11 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 
 	// Test success event, test-flow.
 	diagCtx = ssoDiagContextFixture(true /* testFlow */)
-	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 		diagCtx.Info.GithubClaims = claims
-		return auth, nil
+		return resp, nil
 	}
-	_, _ = validateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.emitter, logger)
+	_, _ = auth.ValidateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.GetEmitter(), logger)
 	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
 	require.Equal(t, events.UserSSOTestFlowLoginCode, tt.mockEmitter.LastEvent().GetCode())
 	loginEvt = tt.mockEmitter.LastEvent().(*apievents.UserLogin)
@@ -261,11 +263,11 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 
 	// Test failure event, test-flow.
 	diagCtx = ssoDiagContextFixture(true /* testFlow */)
-	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+	m.mockValidateGithubAuthCallback = func(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 		diagCtx.Info.GithubClaims = claims
-		return auth, trace.BadParameter("")
+		return resp, trace.BadParameter("")
 	}
-	_, _ = validateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.emitter, logger)
+	_, _ = auth.ValidateGithubAuthCallbackHelper(ctx, m, diagCtx, nil, tt.a.GetEmitter(), logger)
 	require.Equal(t, events.UserLoginEvent, tt.mockEmitter.LastEvent().GetType())
 	require.Equal(t, events.UserSSOTestFlowLoginFailureCode, tt.mockEmitter.LastEvent().GetCode())
 	loginEvt = tt.mockEmitter.LastEvent().(*apievents.UserLogin)
@@ -274,10 +276,10 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 }
 
 type mockedGithubManager struct {
-	mockValidateGithubAuthCallback func(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error)
+	mockValidateGithubAuthCallback func(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error)
 }
 
-func (m *mockedGithubManager) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
+func (m *mockedGithubManager) ValidateGithubAuthRedirect(ctx context.Context, diagCtx *auth.SSODiagContext, q url.Values) (*authclient.GithubAuthResponse, error) {
 	if m.mockValidateGithubAuthCallback != nil {
 		return m.mockValidateGithubAuthCallback(ctx, diagCtx, q)
 	}
@@ -287,7 +289,7 @@ func (m *mockedGithubManager) validateGithubAuthCallback(ctx context.Context, di
 
 func TestCalculateGithubUserNoTeams(t *testing.T) {
 	ctx := context.Background()
-	a := &Server{}
+	a := &auth.Server{}
 	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
 		TeamsToRoles: []types.TeamRolesMapping{
 			{
@@ -299,9 +301,9 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	diagCtx := &SSODiagContext{}
+	diagCtx := &auth.SSODiagContext{}
 
-	_, err = a.calculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
+	_, err = a.CalculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
 		Username: "octocat",
 		OrganizationToTeams: map[string][]string{
 			"org1": {"team1", "team2"},
@@ -309,7 +311,7 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 		},
 		Teams: []string{"team1", "team2", "team1"},
 	}, &types.GithubAuthRequest{})
-	require.ErrorIs(t, err, ErrGithubNoTeams)
+	require.ErrorIs(t, err, auth.ErrGithubNoTeams)
 }
 
 // Test that calculateGithubUser calls the login rule evaluator, evaluated
@@ -330,7 +332,7 @@ func TestCalculateGithubUserWithLoginRules(t *testing.T) {
 			},
 		},
 	}
-	a := &Server{
+	a := &auth.Server{
 		Cache: &mockRoleCache{
 			roles: roles,
 		},
@@ -362,9 +364,9 @@ func TestCalculateGithubUserWithLoginRules(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	diagCtx := &SSODiagContext{}
+	diagCtx := &auth.SSODiagContext{}
 
-	userParams, err := a.calculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
+	userParams, err := a.CalculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
 		Username: "octocat",
 		OrganizationToTeams: map[string][]string{
 			"org1": {"team1"},
@@ -373,7 +375,7 @@ func TestCalculateGithubUserWithLoginRules(t *testing.T) {
 	}, &types.GithubAuthRequest{})
 	require.NoError(t, err)
 
-	require.Equal(t, &CreateUserParams{
+	require.Equal(t, &auth.CreateUserParams{
 		ConnectorName: "github",
 		Username:      "octocat",
 		KubeGroups:    evaluatedTraits[constants.TraitKubeGroups],
@@ -537,7 +539,7 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := checkGithubOrgSSOSupport(ctx, tt.connector, nil, orgCache, client)
+			err := auth.CheckGithubOrgSSOSupport(ctx, tt.connector, nil, orgCache, client)
 			if tt.errFunc == nil {
 				require.NoError(t, err)
 			} else {
@@ -572,7 +574,7 @@ func TestGithubURLFormat(t *testing.T) {
 	}
 
 	for _, tt := range tts {
-		require.Equal(t, tt.expect, formatGithubURL(tt.host, tt.path))
+		require.Equal(t, tt.expect, auth.FormatGithubURL(tt.host, tt.path))
 	}
 }
 
@@ -606,7 +608,7 @@ func TestBuildAPIEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildAPIEndpoint(tt.input)
+			got, err := auth.BuildAPIEndpoint(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, got)
 		})

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3030,7 +3030,8 @@ func TestInstanceCertAndControlStream(t *testing.T) {
 	// make an instance client
 	instanceCert, err := tls.X509KeyPair(certs.TLS, priv)
 	require.NoError(t, err)
-	instanceClt := srv.NewClientWithCert(instanceCert)
+	instanceClt, err := srv.NewClientWithCert(instanceCert)
+	require.NoError(t, err)
 
 	// instance cert can self-renew without assertions
 	req.SystemRoleAssertionID = ""
@@ -4651,7 +4652,7 @@ func TestExport(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			as, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+			as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 				Dir:         t.TempDir(),
 				Clock:       clockwork.NewFakeClock(),
 				TraceClient: &tt.mockTraceClient,

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -72,7 +72,9 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
@@ -112,9 +114,9 @@ func TestMFADeviceManagement(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake user.
-	user, _, err := CreateUserAndRole(authServer, "mfa-user", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(authServer, "mfa-user", []string{"role"}, nil)
 	require.NoError(t, err)
-	userClient, err := testServer.NewClient(TestUser(user.GetName()))
+	userClient, err := testServer.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	// No MFA devices should exist for a new user.
@@ -306,7 +308,7 @@ func TestMFADeviceManagement(t *testing.T) {
 	// Register an extra device to test allow deletion of other devices and test that
 	// the last device cannot be deleted.
 	const lastDeviceName = "lastDevice"
-	lastDevice, err := RegisterTestDevice(ctx, userClient, lastDeviceName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, devs.WebDev)
+	lastDevice, err := authtest.RegisterTestDevice(ctx, userClient, lastDeviceName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, devs.WebDev)
 	require.NoError(t, err, "RegisterTestDevice failed")
 
 	// Also add a password so we can testing add last non-passkey MFA device. Testing the
@@ -473,9 +475,9 @@ func TestMFADeviceManagement_SSO(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake user.
-	user, _, err := CreateUserAndRole(authServer, "mfa-user", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(authServer, "mfa-user", []string{"role"}, nil)
 	require.NoError(t, err)
-	userClient, err := testServer.NewClient(TestUser(user.GetName()))
+	userClient, err := testServer.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	// Create an auth connector.
@@ -493,7 +495,7 @@ func TestMFADeviceManagement_SSO(t *testing.T) {
 	require.NoError(t, err)
 
 	// Convert the user to an SSO user for this auth connector.
-	userCreatedAt := authServer.clock.Now()
+	userCreatedAt := authServer.GetClock().Now()
 	user.SetCreatedBy(types.CreatedBy{
 		Time: userCreatedAt,
 		Connector: &types.ConnectorRef{
@@ -511,7 +513,7 @@ func TestMFADeviceManagement_SSO(t *testing.T) {
 
 	// prepare a passwordless device.
 	passkeyName := "passkey"
-	passkey, err := RegisterTestDevice(ctx, userClient, passkeyName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil, WithPasswordless())
+	passkey, err := authtest.RegisterTestDevice(ctx, userClient, passkeyName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil, authtest.WithPasswordless())
 	require.NoError(t, err, "RegisterTestDevice")
 
 	passkeyWebAuthnHandler := func(t *testing.T, challenge *proto.MFAAuthenticateChallenge) *proto.MFAAuthenticateResponse {
@@ -576,12 +578,12 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		setup    func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice)
+		setup    func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice)
 		checkErr require.ErrorAssertionFunc
 	}{
 		{
 			name:  "NOK no other MFA device",
-			setup: func(*testing.T, string, *authclient.Client, *TestDevice) {},
+			setup: func(*testing.T, string, *authclient.Client, *authtest.TestDevice) {},
 			checkErr: func(t require.TestingT, err error, _ ...any) {
 				require.ErrorContains(t,
 					err,
@@ -592,18 +594,18 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK extra passwordless device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
-				_, err := RegisterTestDevice(ctx, userClient, "another-passkey", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, pwdlessDev, WithPasswordless())
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+				_, err := authtest.RegisterTestDevice(ctx, userClient, "another-passkey", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, pwdlessDev, authtest.WithPasswordless())
 				require.NoError(t, err, "RegisterTestDevice failed")
 			},
 			checkErr: require.NoError,
 		},
 		{
 			name: "OK password set with other WebAuthn device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
-				_, err = RegisterTestDevice(
+				_, err = authtest.RegisterTestDevice(
 					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, pwdlessDev)
 				require.NoError(t, err, "RegisterTestDevice")
 			},
@@ -611,18 +613,18 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK password set with other TOTP device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
-				_, err = RegisterTestDevice(
-					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, WithTestDeviceClock(clock))
+				_, err = authtest.RegisterTestDevice(
+					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, authtest.WithTestDeviceClock(clock))
 				require.NoError(t, err, "RegisterTestDevice")
 			},
 			checkErr: require.NoError,
 		},
 		{
 			name: "OK SSO user with other device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
 				user, err := authServer.GetUser(ctx, username, false)
 				require.NoError(t, err, "GetUser")
 				user.SetCreatedBy(types.CreatedBy{
@@ -630,7 +632,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 				})
 				_, err = authServer.UpsertUser(ctx, user)
 				require.NoError(t, err, "UpsertUser")
-				_, err = RegisterTestDevice(
+				_, err = authtest.RegisterTestDevice(
 					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, pwdlessDev)
 				require.NoError(t, err, "RegisterTestDevice")
 			},
@@ -638,7 +640,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK password set but no other MFAs",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
 			},
@@ -652,9 +654,9 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK other MFAs, but no password set",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *TestDevice) {
-				_, err := RegisterTestDevice(
-					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, WithTestDeviceClock(clock))
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+				_, err := authtest.RegisterTestDevice(
+					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, authtest.WithTestDeviceClock(clock))
 				require.NoError(t, err, "RegisterTestDevice")
 			},
 			checkErr: func(t require.TestingT, err error, _ ...any) {
@@ -667,9 +669,9 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK other MFAs, but no password set, passwordless is off",
-			setup: func(t *testing.T, _ string, userClient *authclient.Client, pwdlessDev *TestDevice) {
+			setup: func(t *testing.T, _ string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
 				// Register a non-passwordless device without adding a password.
-				_, err := RegisterTestDevice(ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, WithTestDeviceClock(clock))
+				_, err := authtest.RegisterTestDevice(ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, authtest.WithTestDeviceClock(clock))
 				require.NoError(t, err, "RegisterTestDevice")
 
 				authPref, err := authServer.GetAuthPreference(ctx)
@@ -709,9 +711,9 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 
 			// Create a fake user.
 			username := fmt.Sprintf("mfa-user-%d", i)
-			user, _, err := CreateUserAndRole(authServer, username, []string{"role"}, nil)
+			user, _, err := authtest.CreateUserAndRole(authServer, username, []string{"role"}, nil)
 			require.NoError(t, err)
-			userClient, err := testServer.NewClient(TestUser(user.GetName()))
+			userClient, err := testServer.NewClient(authtest.TestUser(user.GetName()))
 			require.NoError(t, err)
 
 			// No MFA devices should exist for a new user.
@@ -721,8 +723,8 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 
 			// Add the passwordless device to be deleted.
 			pwdlessDevName := "pwdless-dev"
-			pwdlessDev, err := RegisterTestDevice(
-				ctx, userClient, pwdlessDevName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil, WithPasswordless())
+			pwdlessDev, err := authtest.RegisterTestDevice(
+				ctx, userClient, pwdlessDevName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil, authtest.WithPasswordless())
 			require.NoError(t, err)
 
 			// Case-specific setup.
@@ -750,10 +752,10 @@ type mfaDevices struct {
 	webOrigin string
 
 	TOTPName string
-	TOTPDev  *TestDevice
+	TOTPDev  *authtest.TestDevice
 
 	WebName string
-	WebDev  *TestDevice
+	WebDev  *authtest.TestDevice
 }
 
 func (d *mfaDevices) totpAuthHandler(t *testing.T, challenge *proto.MFAAuthenticateChallenge) *proto.MFAAuthenticateResponse {
@@ -784,11 +786,11 @@ func addOneOfEachMFADevice(t *testing.T, userClient *authclient.Client, clock cl
 
 	ctx := context.Background()
 
-	totpDev, err := RegisterTestDevice(
-		ctx, userClient, totpName, proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, WithTestDeviceClock(clock))
+	totpDev, err := authtest.RegisterTestDevice(
+		ctx, userClient, totpName, proto.DeviceType_DEVICE_TYPE_TOTP, nil /* authenticator */, authtest.WithTestDeviceClock(clock))
 	require.NoError(t, err, "RegisterTestDevice(totp)")
 
-	webDev, err := RegisterTestDevice(
+	webDev, err := authtest.RegisterTestDevice(
 		ctx, userClient, webName, proto.DeviceType_DEVICE_TYPE_WEBAUTHN, totpDev /* authenticator */)
 	require.NoError(t, err, "RegisterTestDevice(totp)")
 
@@ -884,7 +886,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 	authServer := testServer.Auth()
 
 	// Create an user for testing.
-	user, _, err := CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
+	user, _, err := authtest.CreateUserAndRole(authServer, "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	// Register an application.
@@ -909,7 +911,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		modifyUser func(u *TestIdentity)
+		modifyUser func(u *authtest.TestIdentity)
 		assertCert func(t *testing.T, cert *x509.Certificate)
 	}{
 		{
@@ -919,7 +921,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 		},
 		{
 			name: "user with device extensions",
-			modifyUser: func(u *TestIdentity) {
+			modifyUser: func(u *authtest.TestIdentity) {
 				lu := u.I.(authz.LocalUser)
 				lu.Identity.DeviceExtensions = *wantExtensions
 				u.I = lu
@@ -936,7 +938,7 @@ func TestCreateAppSession_deviceExtensions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			u := TestUser(user.GetName())
+			u := authtest.TestUser(user.GetName())
 			if test.modifyUser != nil {
 				test.modifyUser(&u)
 			}
@@ -968,7 +970,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 	testServer := newTestTLSServer(t)
 
 	// Create an user for testing.
-	user, _, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	user, _, err := authtest.CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
@@ -984,7 +986,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		modifyUser func(u *TestIdentity)
+		modifyUser func(u *authtest.TestIdentity)
 		assertCert func(t *testing.T, cert *x509.Certificate)
 	}{
 		{
@@ -994,7 +996,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 		},
 		{
 			name: "user with device extensions",
-			modifyUser: func(u *TestIdentity) {
+			modifyUser: func(u *authtest.TestIdentity) {
 				lu := u.I.(authz.LocalUser)
 				lu.Identity.DeviceExtensions = *wantExtensions
 				u.I = lu
@@ -1011,7 +1013,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			u := TestUser(user.GetName())
+			u := authtest.TestUser(user.GetName())
 			if test.modifyUser != nil {
 				test.modifyUser(&u)
 			}
@@ -1056,7 +1058,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	authServer := testServer.Auth()
 
 	// Create a user for testing.
-	user, role, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	user, role, err := authtest.CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	username := user.GetName()
 
@@ -1083,11 +1085,11 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create clients with and without device extensions.
-	clientWithoutDevice, err := testServer.NewClient(TestUser(username))
+	clientWithoutDevice, err := testServer.NewClient(authtest.TestUser(username))
 	require.NoError(t, err, "NewClient failed")
 
 	clientWithDevice, err := testServer.NewClient(
-		TestUserWithDeviceExtensions(username, tlsca.DeviceExtensions{
+		authtest.TestUserWithDeviceExtensions(username, tlsca.DeviceExtensions{
 			DeviceID:     "deviceid1",
 			AssetTag:     "assettag1",
 			CredentialID: "credentialid1",
@@ -1293,16 +1295,16 @@ func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
 	authServer := testServer.Auth()
 
 	// Create a user for testing.
-	user, _, err := CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
+	user, _, err := authtest.CreateUserAndRole(testServer.Auth(), "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole failed")
 	username := user.GetName()
 
 	// Create clients with and without device extensions.
-	clientWithoutDevice, err := testServer.NewClient(TestUser(username))
+	clientWithoutDevice, err := testServer.NewClient(authtest.TestUser(username))
 	require.NoError(t, err, "NewClient failed")
 
 	clientWithDevice, err := testServer.NewClient(
-		TestUserWithDeviceExtensions(username, tlsca.DeviceExtensions{
+		authtest.TestUserWithDeviceExtensions(username, tlsca.DeviceExtensions{
 			DeviceID:     "deviceid1",
 			AssetTag:     "assettag1",
 			CredentialID: "credentialid1",
@@ -1501,7 +1503,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake user.
-	user, role, err := CreateUserAndRole(srv.Auth(), "mfa-user", []string{"role"}, nil)
+	user, role, err := authtest.CreateUserAndRole(srv.Auth(), "mfa-user", []string{"role"}, nil)
 	require.NoError(t, err)
 	// Make sure MFA is required for this user.
 	roleOpt := role.GetOptions()
@@ -1514,7 +1516,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 	role.SetOptions(roleOpt)
 	_, err = srv.Auth().UpsertRole(ctx, role)
 	require.NoError(t, err)
-	testUser := TestUser(user.GetName())
+	testUser := authtest.TestUser(user.GetName())
 	testUser.TTL = userCertTTL
 	cl, err := srv.NewClient(testUser)
 	require.NoError(t, err)
@@ -2036,7 +2038,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 		{
 			desc: "device extensions copied SSH cert",
 			newClient: func() (*authclient.Client, error) {
-				u := TestUser(user.GetName())
+				u := authtest.TestUser(user.GetName())
 				u.TTL = 1 * time.Hour
 
 				// Add device extensions to the fake user's identity.
@@ -2080,7 +2082,7 @@ func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
 		{
 			desc: "device extensions copied TLS cert",
 			newClient: func() (*authclient.Client, error) {
-				u := TestUser(user.GetName())
+				u := authtest.TestUser(user.GetName())
 				u.TTL = 1 * time.Hour
 
 				// Add device extensions to the fake user's identity.
@@ -2500,7 +2502,7 @@ func TestIsMFARequired(t *testing.T) {
 						testModules.MockAttestationData.PrivateKeyPolicy = keys.PrivateKeyPolicyHardwareKey
 					}
 
-					cl, err := srv.NewClient(TestUser(user.GetName()))
+					cl, err := srv.NewClient(authtest.TestUser(user.GetName()))
 					require.NoError(t, err)
 
 					resp, err := cl.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
@@ -2578,7 +2580,7 @@ func TestIsMFARequired_unauthorized(t *testing.T) {
 	_, err = srv.Auth().UpsertNode(ctx, node2)
 	require.NoError(t, err)
 
-	user, role, err := CreateUserAndRole(srv.Auth(), "alice", []string{"alice"}, nil)
+	user, role, err := authtest.CreateUserAndRole(srv.Auth(), "alice", []string{"alice"}, nil)
 	require.NoError(t, err)
 
 	// Require MFA.
@@ -2589,7 +2591,7 @@ func TestIsMFARequired_unauthorized(t *testing.T) {
 	_, err = srv.Auth().UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	cl, err := srv.NewClient(TestUser(user.GetName()))
+	cl, err := srv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	// Call the endpoint for an authorized login. The user is only authorized
@@ -2633,7 +2635,7 @@ func TestIsMFARequired_nodeMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake user with per session mfa required for all nodes.
-	role, err := CreateRole(ctx, srv.Auth(), "mfa-user", types.RoleSpecV6{
+	role, err := authtest.CreateRole(ctx, srv.Auth(), "mfa-user", types.RoleSpecV6{
 		Options: types.RoleOptions{
 			RequireMFAType: types.RequireMFAType_SESSION,
 		},
@@ -2644,10 +2646,10 @@ func TestIsMFARequired_nodeMatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	user, err := CreateUser(ctx, srv.Auth(), "mfa-user", role)
+	user, err := authtest.CreateUser(ctx, srv.Auth(), "mfa-user", role)
 	require.NoError(t, err)
 
-	cl, err := srv.NewClient(TestUser(user.GetName()))
+	cl, err := srv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -2709,7 +2711,7 @@ func TestIsMFARequired_nodeMatch(t *testing.T) {
 			require.NoError(t, err, "IsMFARequired")
 
 			assert.Equal(t, tc.want, resp.MFARequired, "MFARequired mismatch")
-			assert.Equal(t, MFARequiredToBool(tc.want), resp.Required, "Required mismatch")
+			assert.Equal(t, auth.MFARequiredToBool(tc.want), resp.Required, "Required mismatch")
 		})
 	}
 }
@@ -2820,7 +2822,7 @@ func TestIsMFARequired_App(t *testing.T) {
 		user, err = srv.Auth().UpsertUser(ctx, user)
 		require.NoError(t, err)
 
-		cl, err := srv.NewClient(TestUser(user.GetName()))
+		cl, err := srv.NewClient(authtest.TestUser(user.GetName()))
 		require.NoError(t, err)
 
 		resp, err := cl.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
@@ -2837,13 +2839,13 @@ func TestIsMFARequired_App(t *testing.T) {
 
 // testOriginDynamicStored tests setting a ResourceWithOrigin via the server
 // API always results in the resource being stored with OriginDynamic.
-func testOriginDynamicStored(t *testing.T, setWithOrigin func(*authclient.Client, string) error, getStored func(*Server) (types.ResourceWithOrigin, error)) {
+func testOriginDynamicStored(t *testing.T, setWithOrigin func(*authclient.Client, string) error, getStored func(*auth.Server) (types.ResourceWithOrigin, error)) {
 	srv := newTestTLSServer(t)
 
 	// Create a fake user.
-	user, _, err := CreateUserAndRole(srv.Auth(), "configurer", []string{}, nil)
+	user, _, err := authtest.CreateUserAndRole(srv.Auth(), "configurer", []string{}, nil)
 	require.NoError(t, err)
-	cl, err := srv.NewClient(TestUser(user.GetName()))
+	cl, err := srv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	for _, origin := range types.OriginValues {
@@ -2869,7 +2871,7 @@ func TestAuthPreferenceOriginDynamic(t *testing.T) {
 		return err
 	}
 
-	getStored := func(asrv *Server) (types.ResourceWithOrigin, error) {
+	getStored := func(asrv *auth.Server) (types.ResourceWithOrigin, error) {
 		return asrv.GetAuthPreference(ctx)
 	}
 
@@ -2887,7 +2889,7 @@ func TestClusterNetworkingConfigOriginDynamic(t *testing.T) {
 		return trace.Wrap(err)
 	}
 
-	getStored := func(asrv *Server) (types.ResourceWithOrigin, error) {
+	getStored := func(asrv *auth.Server) (types.ResourceWithOrigin, error) {
 		return asrv.GetClusterNetworkingConfig(ctx)
 	}
 
@@ -2905,7 +2907,7 @@ func TestSessionRecordingConfigOriginDynamic(t *testing.T) {
 		return err
 	}
 
-	getStored := func(asrv *Server) (types.ResourceWithOrigin, error) {
+	getStored := func(asrv *auth.Server) (types.ResourceWithOrigin, error) {
 		return asrv.GetSessionRecordingConfig(ctx)
 	}
 
@@ -2917,13 +2919,13 @@ func TestGenerateHostCerts(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	priv, pub, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	pubTLS, err := PrivateKeyToPublicKeyTLS(priv)
+	pubTLS, err := auth.PrivateKeyToPublicKeyTLS(priv)
 	require.NoError(t, err)
 
 	certs, err := clt.GenerateHostCerts(ctx, &proto.HostCertsRequest{
@@ -2944,7 +2946,7 @@ func TestGenerateDatabaseCerts(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Generate CSR once for speed sake.
@@ -2978,14 +2980,14 @@ func TestInstanceCertAndControlStream(t *testing.T) {
 		types.RoleProxy,
 	}
 
-	clt, err := srv.NewClient(TestServerID(types.RoleNode, serverID))
+	clt, err := srv.NewClient(authtest.TestServerID(types.RoleNode, serverID))
 	require.NoError(t, err)
 	defer clt.Close()
 
 	priv, pub, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	pubTLS, err := PrivateKeyToPublicKeyTLS(priv)
+	pubTLS, err := auth.PrivateKeyToPublicKeyTLS(priv)
 	require.NoError(t, err)
 
 	req := proto.HostCertsRequest{
@@ -3005,7 +3007,7 @@ func TestInstanceCertAndControlStream(t *testing.T) {
 	// perform assertions
 	for _, role := range roles {
 		func() {
-			clt, err := srv.NewClient(TestServerID(role, serverID))
+			clt, err := srv.NewClient(authtest.TestServerID(role, serverID))
 			require.NoError(t, err)
 			defer clt.Close()
 
@@ -3059,7 +3061,7 @@ func TestInstanceCertAndControlStream(t *testing.T) {
 	go func() {
 		defer close(pingErr)
 		// get an admin client so that we can test pings
-		clt, err := srv.NewClient(TestAdmin())
+		clt, err := srv.NewClient(authtest.TestAdmin())
 		if err != nil {
 			pingErr <- err
 			return
@@ -3094,7 +3096,7 @@ func TestGetSSHTargets(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	upper, err := types.NewServerWithLabels(uuid.New().String(), types.KindNode, types.ServerSpecV2{
@@ -3147,7 +3149,7 @@ func TestResolveSSHTarget(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	upper, err := types.NewServerWithLabels(uuid.New().String(), types.KindNode, types.ServerSpecV2{
@@ -3210,7 +3212,7 @@ func TestNodesCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// node1 and node2 will be added to default namespace
@@ -3307,7 +3309,7 @@ func TestLocksCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	now := srv.Clock().Now()
@@ -3426,7 +3428,7 @@ func TestApplicationServersCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Create a couple app servers.
@@ -3499,7 +3501,7 @@ func TestAppsCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Create a couple apps.
@@ -3646,7 +3648,7 @@ func TestAppServersCRUD(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	// Create an app server, expected origin dynamic.
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	app1, err := types.NewAppV3(types.Metadata{
@@ -3705,7 +3707,7 @@ func TestAppServersCRUD(t *testing.T) {
 	require.ErrorIs(t, err, trace.BadParameter("only the Okta role can create app servers and apps with an Okta origin"))
 
 	// Create an app server with Okta labels using the Okta role.
-	clt, err = srv.NewClient(TestBuiltin(types.RoleOkta))
+	clt, err = srv.NewClient(authtest.TestBuiltin(types.RoleOkta))
 	require.NoError(t, err)
 
 	app2.SetOrigin(types.OriginOkta)
@@ -3743,7 +3745,7 @@ func TestDatabasesCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Create a couple databases.
@@ -3834,7 +3836,7 @@ func TestDatabaseServicesCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Create two DatabaseServices.
@@ -3960,7 +3962,7 @@ func TestServerInfoCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	serverInfo1, err := types.NewServerInfo(types.Metadata{
@@ -4057,7 +4059,7 @@ func TestSAMLIdPServiceProvidersCRUD(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// Create two SAML IdP service providers.
@@ -4142,7 +4144,7 @@ func TestListResources(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	clt, err := srv.NewClient(TestAdmin())
+	clt, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	testCases := map[string]struct {
@@ -4372,7 +4374,7 @@ func TestCustomRateLimiting(t *testing.T) {
 			// specifically failed, otherwise multiple cases can fail from running
 			// cases in parallel.
 			srv := newTestTLSServer(t)
-			clt, err := srv.NewClient(TestNop())
+			clt, err := srv.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 
 			var attempts int
@@ -4430,7 +4432,7 @@ func TestExport(t *testing.T) {
 	validateResource := func(forwardedFor string, resourceSpan *otlptracev1.ResourceSpans) {
 		var forwarded []string
 		for _, attribute := range resourceSpan.Resource.Attributes {
-			if attribute.Key == forwardedTag {
+			if attribute.Key == auth.ForwardedTag {
 				forwarded = append(forwarded, attribute.Value.GetStringValue())
 			}
 		}
@@ -4440,7 +4442,7 @@ func TestExport(t *testing.T) {
 		for _, scopeSpan := range resourceSpan.ScopeSpans {
 			for _, span := range scopeSpan.Spans {
 				for _, attribute := range span.Attributes {
-					if attribute.Key == forwardedTag {
+					if attribute.Key == auth.ForwardedTag {
 						forwarded = append(forwarded, attribute.Value.GetStringValue())
 					}
 				}
@@ -4469,7 +4471,7 @@ func TestExport(t *testing.T) {
 					for _, span := range scopeSpan.Spans {
 						var foundForwardedTag bool
 						for _, attribute := range span.Attributes {
-							if attribute.Key == forwardedTag {
+							if attribute.Key == auth.ForwardedTag {
 								require.False(t, foundForwardedTag)
 								foundForwardedTag = true
 								require.Equal(t, forwardedFor, attribute.Value.GetStringValue())
@@ -4530,7 +4532,7 @@ func TestExport(t *testing.T) {
 						},
 						{
 							Name:       "with-tag",
-							Attributes: []*otlpcommonv1.KeyValue{{Key: forwardedTag, Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "test"}}}},
+							Attributes: []*otlpcommonv1.KeyValue{{Key: auth.ForwardedTag, Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "test"}}}},
 						},
 						{
 							Name: "no-attributes",
@@ -4568,7 +4570,7 @@ func TestExport(t *testing.T) {
 							Name: "already-tagged",
 							Attributes: []*otlpcommonv1.KeyValue{
 								{
-									Key: forwardedTag,
+									Key: auth.ForwardedTag,
 									Value: &otlpcommonv1.AnyValue{
 										Value: &otlpcommonv1.AnyValue_StringValue{
 											StringValue: user,
@@ -4593,7 +4595,7 @@ func TestExport(t *testing.T) {
 
 	cases := []struct {
 		name              string
-		identity          TestIdentity
+		identity          authtest.TestIdentity
 		errAssertion      require.ErrorAssertionFunc
 		uploadedAssertion require.ValueAssertionFunc
 		spans             []*otlptracev1.ResourceSpans
@@ -4602,7 +4604,7 @@ func TestExport(t *testing.T) {
 	}{
 		{
 			name:              "error when unauthorized",
-			identity:          TestNop(),
+			identity:          authtest.TestNop(),
 			errAssertion:      require.Error,
 			uploadedAssertion: require.Empty,
 			spans:             make([]*otlptracev1.ResourceSpans, 1),
@@ -4610,13 +4612,13 @@ func TestExport(t *testing.T) {
 		},
 		{
 			name:              "nop for empty spans",
-			identity:          TestBuiltin(types.RoleNode),
+			identity:          authtest.TestBuiltin(types.RoleNode),
 			errAssertion:      require.NoError,
 			uploadedAssertion: require.Empty,
 		},
 		{
 			name:     "failure to forward spans",
-			identity: TestBuiltin(types.RoleNode),
+			identity: authtest.TestBuiltin(types.RoleNode),
 			errAssertion: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.ErrorIs(t, trail.FromGRPC(trace.Unwrap(err)), uploadErr)
@@ -4630,14 +4632,14 @@ func TestExport(t *testing.T) {
 		},
 		{
 			name:              "forwarded spans get tagged for system roles",
-			identity:          TestBuiltin(types.RoleProxy),
+			identity:          authtest.TestBuiltin(types.RoleProxy),
 			errAssertion:      require.NoError,
 			spans:             testSpans,
 			uploadedAssertion: validateTaggedSpans(fmt.Sprintf("%s.localhost:%s", types.RoleProxy, types.RoleProxy)),
 		},
 		{
 			name:              "forwarded spans get tagged for users",
-			identity:          TestUser(user),
+			identity:          authtest.TestUser(user),
 			errAssertion:      require.NoError,
 			spans:             testSpans,
 			uploadedAssertion: validateTaggedSpans(user),
@@ -4649,7 +4651,7 @@ func TestExport(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			as, err := NewTestAuthServer(TestAuthServerConfig{
+			as, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 				Dir:         t.TempDir(),
 				Clock:       clockwork.NewFakeClock(),
 				TraceClient: &tt.mockTraceClient,
@@ -4662,12 +4664,12 @@ func TestExport(t *testing.T) {
 			t.Cleanup(func() { require.NoError(t, srv.Close()) })
 
 			// Create a fake user.
-			_, _, err = CreateUserAndRole(srv.Auth(), user, []string{"role"}, nil)
+			_, _, err = authtest.CreateUserAndRole(srv.Auth(), user, []string{"role"}, nil)
 			require.NoError(t, err)
 
 			// Setup the server
 			if tt.authorizer != nil {
-				srv.TLSServer.grpcServer.Authorizer = tt.authorizer
+				srv.TLSServer.GRPCServer().Authorizer = tt.authorizer
 				require.NoError(t, err)
 			}
 
@@ -4755,9 +4757,9 @@ func TestSAMLValidation(t *testing.T) {
 				require.NoError(t, err)
 			}))
 
-			role, err := CreateRole(ctx, server.Auth(), "test_role", types.RoleSpecV6{Allow: tc.allow})
+			role, err := authtest.CreateRole(ctx, server.Auth(), "test_role", types.RoleSpecV6{Allow: tc.allow})
 			require.NoError(t, err)
-			user, err := CreateUser(ctx, server.Auth(), "test_user", role)
+			user, err := authtest.CreateUser(ctx, server.Auth(), "test_user", role)
 			require.NoError(t, err)
 
 			connector, err := types.NewSAMLConnector("test_connector", types.SAMLConnectorSpecV2{
@@ -4770,7 +4772,7 @@ func TestSAMLValidation(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			client, err := server.NewClient(TestUser(user.GetName()))
+			client, err := server.NewClient(authtest.TestUser(user.GetName()))
 			require.NoError(t, err)
 
 			_, err = client.UpsertSAMLConnector(ctx, connector)
@@ -4810,9 +4812,9 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	server := newTestTLSServer(t)
-	grpc := server.TLSServer.grpcServer
+	grpc := server.TLSServer.GRPCServer()
 
-	user := TestAdmin()
+	user := authtest.TestAdmin()
 	ctx = authz.ContextWithUser(ctx, user.I)
 
 	tests := []struct {
@@ -4959,10 +4961,10 @@ func TestRoleVersions(t *testing.T) {
 		},
 	})
 
-	user, err := CreateUser(context.Background(), srv.Auth(), "user", enabledRole, disabledRole, undefinedRole)
+	user, err := authtest.CreateUser(context.Background(), srv.Auth(), "user", enabledRole, disabledRole, undefinedRole)
 	require.NoError(t, err)
 
-	client, err := srv.NewClient(TestUser(user.GetName()))
+	client, err := srv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -5175,7 +5177,7 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 	parentCtx := context.Background()
 	server := newTestTLSServer(t)
 
-	admin := TestAdmin()
+	admin := authtest.TestAdmin()
 
 	client, err := server.NewClient(admin)
 	require.NoError(t, err)
@@ -5206,7 +5208,7 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 	require.ErrorContains(t, err, "only the Okta role can create app servers and apps with an Okta origin")
 
 	// Okta origin should not work with instance and node roles.
-	client, err = server.NewClient(TestIdentity{
+	client, err = server.NewClient(authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role: types.RoleInstance,
 			AdditionalSystemRoles: []types.SystemRole{
@@ -5223,7 +5225,7 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 	require.ErrorContains(t, err, "only the Okta role can create app servers and apps with an Okta origin")
 
 	// Okta origin should work with Okta role in role field.
-	node := TestIdentity{
+	node := authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role: types.RoleOkta,
 			AdditionalSystemRoles: []types.SystemRole{
@@ -5240,7 +5242,7 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 	require.NoError(t, err)
 
 	// Okta origin should work with Okta role in additional system roles.
-	node = TestIdentity{
+	node = authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role: types.RoleInstance,
 			AdditionalSystemRoles: []types.SystemRole{
@@ -5267,13 +5269,13 @@ func TestGetAccessGraphConfig(t *testing.T) {
 		},
 	})
 	server := newTestTLSServer(t,
-		withAccessGraphConfig(AccessGraphConfig{
+		withAccessGraphConfig(auth.AccessGraphConfig{
 			Enabled: true,
 			CA:      []byte("ca"),
 			Address: "addr",
 		}),
 	)
-	user, _, err := CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
 	require.NoError(t, err)
 	positiveResponse := &clusterconfigpb.AccessGraphConfig{
 		Enabled:           true,
@@ -5317,7 +5319,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			client, err := server.NewClient(TestIdentity{
+			client, err := server.NewClient(authtest.TestIdentity{
 				I: test.identity,
 			})
 			require.NoError(t, err)
@@ -5330,7 +5332,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 
 func TestGetVnetConfig(t *testing.T) {
 	server := newTestTLSServer(t)
-	user, _, err := CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(server.Auth(), "test", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	// Create newConfig.
@@ -5346,7 +5348,7 @@ func TestGetVnetConfig(t *testing.T) {
 	identity := authz.LocalUser{
 		Username: user.GetName(),
 	}
-	client, err := server.NewClient(TestIdentity{I: identity})
+	client, err := server.NewClient(authtest.TestIdentity{I: identity})
 	require.NoError(t, err)
 	actualConfig, err := client.GetVnetConfig(t.Context())
 	require.NoError(t, err)
@@ -5360,7 +5362,7 @@ func TestCreateAuditStreamLimit(t *testing.T) {
 	ctx := t.Context()
 
 	server := newTestTLSServer(t)
-	clt, err := server.NewClient(TestServerID(types.RoleNode, uuid.NewString()))
+	clt, err := server.NewClient(authtest.TestServerID(types.RoleNode, uuid.NewString()))
 	require.NoError(t, err)
 
 	// HACK(espadolini): we're piggybacking on the prometheus counter which
@@ -5372,7 +5374,7 @@ func TestCreateAuditStreamLimit(t *testing.T) {
 	// server uses a discard emitter which never ends up sending anything
 	getAcceptedTotal := func() int {
 		var m prom_client_model.Metric
-		require.NoError(t, createAuditStreamAcceptedTotalMetric.Write(&m))
+		require.NoError(t, auth.CreateAuditStreamAcceptedTotalMetric.Write(&m))
 		return int(m.Counter.GetValue())
 	}
 	currentAcceptedTotal := getAcceptedTotal()
@@ -5660,7 +5662,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 		},
 	})
 
-	user, err := CreateUser(context.Background(), srv.Auth(), "user",
+	user, err := authtest.CreateUser(context.Background(), srv.Auth(), "user",
 		testRole1,
 		downgradev7comptibleK8sResourcesRole,
 		downgradev7incompatibleK8sResourcesRole,
@@ -5674,7 +5676,7 @@ func TestRoleVersionV8ToV7Downgrade(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	client, err := srv.NewClient(TestUser(user.GetName()))
+	client, err := srv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	for _, tc := range []struct {

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -578,12 +578,12 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		setup    func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice)
+		setup    func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device)
 		checkErr require.ErrorAssertionFunc
 	}{
 		{
 			name:  "NOK no other MFA device",
-			setup: func(*testing.T, string, *authclient.Client, *authtest.TestDevice) {},
+			setup: func(*testing.T, string, *authclient.Client, *authtest.Device) {},
 			checkErr: func(t require.TestingT, err error, _ ...any) {
 				require.ErrorContains(t,
 					err,
@@ -594,7 +594,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK extra passwordless device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				_, err := authtest.RegisterTestDevice(ctx, userClient, "another-passkey", proto.DeviceType_DEVICE_TYPE_WEBAUTHN, pwdlessDev, authtest.WithPasswordless())
 				require.NoError(t, err, "RegisterTestDevice failed")
 			},
@@ -602,7 +602,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK password set with other WebAuthn device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
 				_, err = authtest.RegisterTestDevice(
@@ -613,7 +613,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK password set with other TOTP device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
 				_, err = authtest.RegisterTestDevice(
@@ -624,7 +624,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "OK SSO user with other device",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				user, err := authServer.GetUser(ctx, username, false)
 				require.NoError(t, err, "GetUser")
 				user.SetCreatedBy(types.CreatedBy{
@@ -640,7 +640,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK password set but no other MFAs",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				err := authServer.UpsertPassword(username, []byte("living on the edge"))
 				require.NoError(t, err, "UpsertPassword")
 			},
@@ -654,7 +654,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK other MFAs, but no password set",
-			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, username string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				_, err := authtest.RegisterTestDevice(
 					ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, authtest.WithTestDeviceClock(clock))
 				require.NoError(t, err, "RegisterTestDevice")
@@ -669,7 +669,7 @@ func TestDeletingLastPasswordlessDevice(t *testing.T) {
 		},
 		{
 			name: "NOK other MFAs, but no password set, passwordless is off",
-			setup: func(t *testing.T, _ string, userClient *authclient.Client, pwdlessDev *authtest.TestDevice) {
+			setup: func(t *testing.T, _ string, userClient *authclient.Client, pwdlessDev *authtest.Device) {
 				// Register a non-passwordless device without adding a password.
 				_, err := authtest.RegisterTestDevice(ctx, userClient, "another-dev", proto.DeviceType_DEVICE_TYPE_TOTP, pwdlessDev, authtest.WithTestDeviceClock(clock))
 				require.NoError(t, err, "RegisterTestDevice")
@@ -752,10 +752,10 @@ type mfaDevices struct {
 	webOrigin string
 
 	TOTPName string
-	TOTPDev  *authtest.TestDevice
+	TOTPDev  *authtest.Device
 
 	WebName string
-	WebDev  *authtest.TestDevice
+	WebDev  *authtest.Device
 }
 
 func (d *mfaDevices) totpAuthHandler(t *testing.T, challenge *proto.MFAAuthenticateChallenge) *proto.MFAAuthenticateResponse {

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -1508,54 +1507,4 @@ func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	}
 
 	return created, upsertedRole, nil
-}
-
-// flushClt is the set of methods expected by the flushCache helper.
-type flushClt interface {
-	// GetRole returns role by name
-	GetRole(ctx context.Context, name string) (types.Role, error)
-	// CreateRole creates a new role.
-	CreateRole(context.Context, types.Role) (types.Role, error)
-	// DeleteRole deletes the role by name.
-	DeleteRole(ctx context.Context, name string) error
-}
-
-// flushCache is a helper for waiting until preceding changes have propagated to the
-// cache during a test. this is useful for writing tests that may want to update backend
-// state and then perform some operation that depends on the auth server knoowing that state.
-// note that this is only intended for use with the memory backend, as this helper relies on the assumption that
-// write events for different keys show up in the order in which the writes were performed, which
-// is not necessarily true for all backends.
-func flushCache(t *testing.T, clt flushClt) {
-	ctx := context.Background()
-
-	// the pattern of writing a resource and then waiting for it to appear
-	// works for any resource type (when using memory backend).
-	name := strings.ReplaceAll(uuid.NewString(), "-", "")
-	defer clt.DeleteRole(ctx, name)
-
-	role, err := types.NewRole(name, types.RoleSpecV6{})
-	if err != nil {
-		t.Fatalf("Failed to instantiate new role: %v", err)
-	}
-
-	role, err = clt.CreateRole(ctx, role)
-	if err != nil {
-		t.Fatalf("Failed to create new role: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-	for {
-		r, err := clt.GetRole(ctx, name)
-		if err == nil && r.GetRevision() == role.GetRevision() {
-			return
-		}
-
-		select {
-		case <-time.After(200 * time.Millisecond):
-		case <-ctx.Done():
-			t.Fatal("Time out waiting for role to be replicated")
-		}
-	}
 }

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -63,7 +63,6 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
-	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -382,7 +381,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 						},
 					})
 				}
-				cfg := authtest.TestAuthServerConfig{
+				cfg := authtest.AuthServerConfig{
 					Dir:  t.TempDir(),
 					FIPS: tc.fips,
 					AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
@@ -396,7 +395,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 				if tc.hsm {
 					cfg.KeystoreConfig = HSMTestConfig(t)
 				}
-				testAuthServer, err := authtest.NewTestAuthServer(cfg)
+				testAuthServer, err := authtest.NewAuthServer(cfg)
 				require.NoError(t, err)
 				tlsServer, err := testAuthServer.NewTestTLSServer()
 				require.NoError(t, err)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -61,6 +61,9 @@ import (
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/storage"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -216,7 +219,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 		},
 	})
 
-	setupInitConfig := func(t *testing.T, capOrigin string, fips, hsm bool) InitConfig {
+	setupInitConfig := func(t *testing.T, capOrigin string, fips, hsm bool) auth.InitConfig {
 		cfg := setupConfig(t)
 		cfg.FIPS = fips
 		if hsm {
@@ -303,7 +306,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 						// configured gets the expected default suite, whether
 						// or not anything else in the cluster auth preference is set.
 						cfg := setupInitConfig(t, origin, tc.fips, tc.hsm)
-						auth1, err := Init(ctx, cfg)
+						auth1, err := auth.Init(ctx, cfg)
 						require.NoError(t, err)
 						t.Cleanup(func() { auth1.Close() })
 						authPref, err := auth1.GetAuthPreference(ctx)
@@ -313,7 +316,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 
 						// Start a second auth server with the same backend and
 						// config, assert that the default suite remains.
-						auth2, err := Init(ctx, cfg)
+						auth2, err := auth.Init(ctx, cfg)
 						require.NoError(t, err)
 						t.Cleanup(func() { auth2.Close() })
 						authPref, err = auth2.GetAuthPreference(ctx)
@@ -343,7 +346,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 						// server upgraded to v17 will still have an unspecified
 						// signature algorithm suite and won't get a new one
 						// until explicitly opting in.
-						auth3, err := Init(ctx, cfg)
+						auth3, err := auth.Init(ctx, cfg)
 						require.NoError(t, err)
 						t.Cleanup(func() { auth3.Close() })
 						authPref, err = auth3.GetAuthPreference(ctx)
@@ -379,7 +382,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 						},
 					})
 				}
-				cfg := TestAuthServerConfig{
+				cfg := authtest.TestAuthServerConfig{
 					Dir:  t.TempDir(),
 					FIPS: tc.fips,
 					AuthPreferenceSpec: &types.AuthPreferenceSpecV2{
@@ -393,11 +396,11 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 				if tc.hsm {
 					cfg.KeystoreConfig = HSMTestConfig(t)
 				}
-				testAuthServer, err := NewTestAuthServer(cfg)
+				testAuthServer, err := authtest.NewTestAuthServer(cfg)
 				require.NoError(t, err)
 				tlsServer, err := testAuthServer.NewTestTLSServer()
 				require.NoError(t, err)
-				clt, err := tlsServer.NewClient(TestAdmin())
+				clt, err := tlsServer.NewClient(authtest.TestAdmin())
 				require.NoError(t, err)
 
 				for _, suiteValue := range types.SignatureAlgorithmSuite_value {
@@ -586,14 +589,14 @@ func softHSMTestConfig(t *testing.T) (servicecfg.KeystoreConfig, bool) {
 }
 
 type testDynamicallyConfigurableParams struct {
-	withDefaults, withConfigFile, withAnotherConfigFile func(*testing.T, *InitConfig) types.ResourceWithOrigin
-	setDynamic                                          func(*testing.T, *Server)
-	getStored                                           func(*testing.T, *Server) types.ResourceWithOrigin
+	withDefaults, withConfigFile, withAnotherConfigFile func(*testing.T, *auth.InitConfig) types.ResourceWithOrigin
+	setDynamic                                          func(*testing.T, *auth.Server)
+	getStored                                           func(*testing.T, *auth.Server) types.ResourceWithOrigin
 }
 
 func testDynamicallyConfigurable(t *testing.T, p testDynamicallyConfigurableParams) {
-	initAuthServer := func(t *testing.T, conf InitConfig) *Server {
-		authServer, err := Init(context.Background(), conf)
+	initAuthServer := func(t *testing.T, conf auth.InitConfig) *auth.Server {
+		authServer, err := auth.Init(context.Background(), conf)
 		require.NoError(t, err)
 		t.Cleanup(func() { authServer.Close() })
 		return authServer
@@ -713,11 +716,11 @@ func TestAuthPreference(t *testing.T) {
 	ctx := context.Background()
 
 	testDynamicallyConfigurable(t, testDynamicallyConfigurableParams{
-		withDefaults: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withDefaults: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			conf.AuthPreference = types.DefaultAuthPreference()
 			return conf.AuthPreference
 		},
-		withConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			fromConfigFile, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 				Type:                    constants.OIDC,
 				SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
@@ -726,12 +729,12 @@ func TestAuthPreference(t *testing.T) {
 			conf.AuthPreference = fromConfigFile
 			return conf.AuthPreference
 		},
-		withAnotherConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withAnotherConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			conf.AuthPreference = newWebauthnAuthPreferenceConfigFromFile(t)
 			conf.AuthPreference.SetSignatureAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1)
 			return conf.AuthPreference
 		},
-		setDynamic: func(t *testing.T, authServer *Server) {
+		setDynamic: func(t *testing.T, authServer *auth.Server) {
 			dynamically, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 				SecondFactor: constants.SecondFactorOff,
 			})
@@ -739,7 +742,7 @@ func TestAuthPreference(t *testing.T) {
 			_, err = authServer.UpsertAuthPreference(ctx, dynamically)
 			require.NoError(t, err)
 		},
-		getStored: func(t *testing.T, authServer *Server) types.ResourceWithOrigin {
+		getStored: func(t *testing.T, authServer *auth.Server) types.ResourceWithOrigin {
 			authPref, err := authServer.GetAuthPreference(ctx)
 			require.NoError(t, err)
 			return authPref
@@ -751,7 +754,7 @@ func TestVnetConfig(t *testing.T) {
 	t.Parallel()
 
 	conf := setupConfig(t)
-	authServer, err := Init(context.Background(), conf)
+	authServer, err := auth.Init(context.Background(), conf)
 	require.NoError(t, err)
 	t.Cleanup(func() { authServer.Close() })
 
@@ -775,7 +778,7 @@ func TestAuthPreferenceSecondFactorOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	conf.AuthPreference = authPref
-	_, err = Init(ctx, conf)
+	_, err = auth.Init(ctx, conf)
 	require.Error(t, err)
 }
 
@@ -784,11 +787,11 @@ func TestClusterNetworkingConfig(t *testing.T) {
 	ctx := context.Background()
 
 	testDynamicallyConfigurable(t, testDynamicallyConfigurableParams{
-		withDefaults: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withDefaults: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			conf.ClusterNetworkingConfig = types.DefaultClusterNetworkingConfig()
 			return conf.ClusterNetworkingConfig
 		},
-		withConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			fromConfigFile, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
 				ClientIdleTimeout: types.Duration(7 * time.Minute),
 			})
@@ -796,7 +799,7 @@ func TestClusterNetworkingConfig(t *testing.T) {
 			conf.ClusterNetworkingConfig = fromConfigFile
 			return conf.ClusterNetworkingConfig
 		},
-		withAnotherConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withAnotherConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			anotherFromConfigFile, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
 				ClientIdleTimeout: types.Duration(10 * time.Minute),
 				KeepAliveInterval: types.Duration(3 * time.Minute),
@@ -805,7 +808,7 @@ func TestClusterNetworkingConfig(t *testing.T) {
 			conf.ClusterNetworkingConfig = anotherFromConfigFile
 			return conf.ClusterNetworkingConfig
 		},
-		setDynamic: func(t *testing.T, authServer *Server) {
+		setDynamic: func(t *testing.T, authServer *auth.Server) {
 			dynamically, err := types.NewClusterNetworkingConfigFromConfigFile(types.ClusterNetworkingConfigSpecV2{
 				KeepAliveInterval: types.Duration(4 * time.Minute),
 			})
@@ -814,7 +817,7 @@ func TestClusterNetworkingConfig(t *testing.T) {
 			_, err = authServer.UpsertClusterNetworkingConfig(ctx, dynamically)
 			require.NoError(t, err)
 		},
-		getStored: func(t *testing.T, authServer *Server) types.ResourceWithOrigin {
+		getStored: func(t *testing.T, authServer *auth.Server) types.ResourceWithOrigin {
 			authPref, err := authServer.GetClusterNetworkingConfig(ctx)
 			require.NoError(t, err)
 			return authPref
@@ -827,11 +830,11 @@ func TestSessionRecordingConfig(t *testing.T) {
 	ctx := context.Background()
 
 	testDynamicallyConfigurable(t, testDynamicallyConfigurableParams{
-		withDefaults: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withDefaults: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			conf.SessionRecordingConfig = types.DefaultSessionRecordingConfig()
 			return conf.SessionRecordingConfig
 		},
-		withConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			fromConfigFile, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 				Mode: types.RecordOff,
 			})
@@ -839,7 +842,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 			conf.SessionRecordingConfig = fromConfigFile
 			return conf.SessionRecordingConfig
 		},
-		withAnotherConfigFile: func(t *testing.T, conf *InitConfig) types.ResourceWithOrigin {
+		withAnotherConfigFile: func(t *testing.T, conf *auth.InitConfig) types.ResourceWithOrigin {
 			anotherFromConfigFile, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 				Mode: types.RecordAtProxySync,
 			})
@@ -847,7 +850,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 			conf.SessionRecordingConfig = anotherFromConfigFile
 			return conf.SessionRecordingConfig
 		},
-		setDynamic: func(t *testing.T, authServer *Server) {
+		setDynamic: func(t *testing.T, authServer *auth.Server) {
 			dynamically, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{
 				Mode: types.RecordAtNodeSync,
 			})
@@ -856,7 +859,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 			_, err = authServer.UpsertSessionRecordingConfig(ctx, dynamically)
 			require.NoError(t, err)
 		},
-		getStored: func(t *testing.T, authServer *Server) types.ResourceWithOrigin {
+		getStored: func(t *testing.T, authServer *auth.Server) types.ResourceWithOrigin {
 			authPref, err := authServer.GetSessionRecordingConfig(ctx)
 			require.NoError(t, err)
 			return authPref
@@ -867,7 +870,7 @@ func TestSessionRecordingConfig(t *testing.T) {
 func TestClusterID(t *testing.T) {
 	conf := setupConfig(t)
 	ctx := context.Background()
-	authServer, err := Init(ctx, conf)
+	authServer, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -877,7 +880,7 @@ func TestClusterID(t *testing.T) {
 	require.NotEmpty(t, clusterID)
 
 	// do it again and make sure cluster ID hasn't changed
-	authServer, err = Init(ctx, conf)
+	authServer, err = auth.Init(ctx, conf)
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -890,7 +893,7 @@ func TestClusterID(t *testing.T) {
 func TestClusterName(t *testing.T) {
 	conf := setupConfig(t)
 	ctx := context.Background()
-	authServer, err := Init(ctx, conf)
+	authServer, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -901,7 +904,7 @@ func TestClusterName(t *testing.T) {
 		ClusterName: "dev.localhost",
 	})
 	require.NoError(t, err)
-	authServer, err = Init(context.Background(), newConfig)
+	authServer, err = auth.Init(context.Background(), newConfig)
 	require.NoError(t, err)
 	defer authServer.Close()
 
@@ -933,7 +936,7 @@ func TestInitCertFailureRecovery(t *testing.T) {
 	// BootstrapResources have lead to an unrecoverable state in the past.
 	// See https://github.com/gravitational/teleport/pull/49638.
 	conf.BootstrapResources = []types.Resource{cap}
-	_, err = Init(ctx, conf, func(s *Server) error {
+	_, err = auth.Init(ctx, conf, func(s *auth.Server) error {
 		s.TrustInternal = &failingTrustInternal{
 			TrustInternal: s.TrustInternal,
 		}
@@ -941,7 +944,7 @@ func TestInitCertFailureRecovery(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	_, err = Init(ctx, conf)
+	_, err = auth.Init(ctx, conf)
 	require.NoError(t, err)
 }
 
@@ -962,17 +965,17 @@ func TestPresets(t *testing.T) {
 		clock := clockwork.NewFakeClock()
 		as.SetClock(clock)
 
-		err := createPresetRoles(ctx, as)
+		err := auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
 
-		err = createPresetHealthCheckConfig(ctx, as)
+		err = auth.CreatePresetHealthCheckConfig(ctx, as)
 		require.NoError(t, err)
 
 		// Second call should not fail
-		err = createPresetRoles(ctx, as)
+		err = auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
 
-		err = createPresetHealthCheckConfig(ctx, as)
+		err = auth.CreatePresetHealthCheckConfig(ctx, as)
 		require.NoError(t, err)
 
 		// Presets were created
@@ -997,7 +1000,7 @@ func TestPresets(t *testing.T) {
 		access, err := as.CreateRole(ctx, access)
 		require.NoError(t, err)
 
-		err = createPresetRoles(ctx, as)
+		err = auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
 
 		// Presets were created
@@ -1022,7 +1025,7 @@ func TestPresets(t *testing.T) {
 		cfg, err := as.CreateHealthCheckConfig(ctx, cfg)
 		require.NoError(t, err)
 
-		err = createPresetHealthCheckConfig(ctx, as)
+		err = auth.CreatePresetHealthCheckConfig(ctx, as)
 		require.NoError(t, err)
 
 		// Preset was created. Ensure it didn't overwrite the existing config
@@ -1060,7 +1063,7 @@ func TestPresets(t *testing.T) {
 		accessRole, err = as.CreateRole(ctx, accessRole)
 		require.NoError(t, err)
 
-		err = createPresetRoles(ctx, as)
+		err = auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
 
 		outEditor, err := as.GetRole(ctx, editorRole.GetName())
@@ -1124,7 +1127,7 @@ func TestPresets(t *testing.T) {
 		require.NoError(t, err)
 
 		// Apply defaults.
-		err = createPresetRoles(ctx, as)
+		err = auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
 
 		outEditor, err := as.GetRole(ctx, editorRole.GetName())
@@ -1195,7 +1198,7 @@ func TestPresets(t *testing.T) {
 				return r, nil
 			})
 
-		err := createPresetRoles(ctx, roleManager)
+		err := auth.CreatePresetRoles(ctx, roleManager)
 		require.NoError(t, err)
 		require.ElementsMatch(t, slices.Collect(maps.Keys(createdPresets)), expectedPresetRoles)
 		require.ElementsMatch(t, slices.Collect(maps.Keys(createdSystemRoles)), expectedSystemRoles)
@@ -1235,7 +1238,7 @@ func TestPresets(t *testing.T) {
 				Return(role, nil)
 		}
 
-		err = createPresetRoles(ctx, roleManager)
+		err = auth.CreatePresetRoles(ctx, roleManager)
 		require.NoError(t, err)
 		roleManager.AssertExpectations(t)
 
@@ -1292,7 +1295,7 @@ func TestPresets(t *testing.T) {
 				return r, nil
 			})
 
-		err = createPresetRoles(ctx, roleManager)
+		err = auth.CreatePresetRoles(ctx, roleManager)
 		require.NoError(t, err)
 		require.Empty(t, remainingPresets)
 		roleManager.AssertExpectations(t)
@@ -1336,10 +1339,10 @@ func TestPresets(t *testing.T) {
 			// existing cluster and asserting that everything still
 			// returns success
 			for range 2 {
-				err := createPresetRoles(ctx, as)
+				err := auth.CreatePresetRoles(ctx, as)
 				require.NoError(t, err)
 
-				err = createPresetUsers(ctx, as)
+				err = auth.CreatePresetUsers(ctx, as)
 				require.NoError(t, err)
 			}
 
@@ -1365,18 +1368,18 @@ func TestPresets(t *testing.T) {
 			sysUser := services.NewSystemAutomaticAccessBotUser().(*types.UserV2)
 
 			// GIVEN a user database...
-			auth := newMockUserManager(t)
+			manager := newMockUserManager(t)
 
 			// Set the expectation that all user creations will succeed EXCEPT
 			// for our known system user
-			auth.On("CreateUser", mock.Anything, mock.Anything).
+			manager.On("CreateUser", mock.Anything, mock.Anything).
 				Run(requireSystemResource(t, 1)).
 				Maybe().
 				Return(sysUser, nil)
 
 			// All attempts to upsert should succeed, and record the being upserted
 			var upsertedUsers []string
-			auth.On("UpsertUser", mock.Anything, mock.Anything).
+			manager.On("UpsertUser", mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
 					u := args.Get(1).(types.User)
 					upsertedUsers = append(upsertedUsers, u.GetName())
@@ -1384,11 +1387,11 @@ func TestPresets(t *testing.T) {
 				Return(sysUser, nil)
 
 			// WHEN I attempt to create the preset users...
-			err := createPresetUsers(ctx, auth)
+			err := auth.CreatePresetUsers(ctx, manager)
 
 			// EXPECT that the process succeeds and the system user was upserted
 			require.NoError(t, err)
-			auth.AssertExpectations(t)
+			manager.AssertExpectations(t)
 			require.Contains(t, upsertedUsers, sysUser.Metadata.Name)
 		})
 	})
@@ -1399,7 +1402,7 @@ func TestGetPresetUsers(t *testing.T) {
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildOSS,
 	})
-	require.Empty(t, getPresetUsers())
+	require.Empty(t, auth.GetPresetUsers())
 
 	// preset user @teleport-access-approval-bot on enterprise
 	modulestest.SetTestModules(t, modulestest.Modules{
@@ -1407,7 +1410,7 @@ func TestGetPresetUsers(t *testing.T) {
 	})
 	require.Equal(t, []types.User{
 		services.NewSystemAutomaticAccessBotUser(),
-	}, getPresetUsers())
+	}, auth.GetPresetUsers())
 }
 
 type mockUserManager struct {
@@ -1447,13 +1450,13 @@ func (m *mockUserManager) UpsertUser(ctx context.Context, user types.User) (type
 	return args.Get(0).(types.User), args.Error(1)
 }
 
-var _ PresetUsers = &mockUserManager{}
+var _ auth.PresetUsers = &mockUserManager{}
 
 type mockRoleManager struct {
 	mock.Mock
 }
 
-var _ PresetRoleManager = &mockRoleManager{}
+var _ auth.PresetRoleManager = &mockRoleManager{}
 
 func newMockRoleManager(t *testing.T) *mockRoleManager {
 	m := &mockRoleManager{}
@@ -1511,7 +1514,7 @@ func toSet(items []string) map[string]struct{} {
 	return result
 }
 
-func setupConfig(t *testing.T) InitConfig {
+func setupConfig(t *testing.T) auth.InitConfig {
 	tempDir := t.TempDir()
 
 	bk, err := lite.New(context.TODO(), backend.Params{"path": tempDir})
@@ -1533,7 +1536,7 @@ func setupConfig(t *testing.T) InitConfig {
 		processStorage.Close()
 	})
 
-	return InitConfig{
+	return auth.InitConfig{
 		DataDir:                 tempDir,
 		HostUUID:                "00000000-0000-0000-0000-000000000000",
 		NodeName:                "foo",
@@ -1711,13 +1714,13 @@ func TestInit_bootstrap(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		modifyConfig func(*InitConfig)
+		modifyConfig func(*auth.InitConfig)
 		assertError  require.ErrorAssertionFunc
 	}{
 		{
 			// Issue https://github.com/gravitational/teleport/issues/7853.
 			name: "OK bootstrap CAs",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1733,7 +1736,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "OK bootstrap health check config",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					newHealthCheckConfig(t),
@@ -1743,7 +1746,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap health check config invalid",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					newHealthCheckConfig(t, func(hcc *healthcheckconfigv1.HealthCheckConfig) {
@@ -1755,7 +1758,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap Host CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					invalidHostCA.Clone(),
@@ -1771,7 +1774,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap User CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1787,7 +1790,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap JWT CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1803,7 +1806,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap Database CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1818,7 +1821,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap Database Client CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1834,7 +1837,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap OpenSSH CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1850,7 +1853,7 @@ func TestInit_bootstrap(t *testing.T) {
 		},
 		{
 			name: "NOK bootstrap SAML IdP CA missing keys",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.BootstrapResources = append(
 					cfg.BootstrapResources,
 					hostCA.Clone(),
@@ -1870,7 +1873,7 @@ func TestInit_bootstrap(t *testing.T) {
 			cfg := setupConfig(t)
 			test.modifyConfig(&cfg)
 
-			_, err := Init(context.Background(), cfg)
+			_, err := auth.Init(context.Background(), cfg)
 			test.assertError(t, err)
 		})
 	}
@@ -1961,12 +1964,12 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		modifyConfig func(*InitConfig)
+		modifyConfig func(*auth.InitConfig)
 		assertError  require.ErrorAssertionFunc
 	}{
 		{
 			name: "Apply unsupported resource",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, lock)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, user)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
@@ -1976,14 +1979,14 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 		},
 		{
 			name: "Apply ProvisionToken",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, token)
 			},
 			assertError: require.NoError,
 		},
 		{
 			name: "Apply User (invalid, missing role)",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, user)
 			},
 			assertError: require.Error,
@@ -1991,7 +1994,7 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 		// We test both user+role and role+user to validate that ordering doesn't matter
 		{
 			name: "Apply User+Role",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, user)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
 			},
@@ -1999,7 +2002,7 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 		},
 		{
 			name: "Apply Role+User",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, user)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
 			},
@@ -2007,28 +2010,28 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 		},
 		{
 			name: "Apply Role",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
 			},
 			assertError: require.NoError,
 		},
 		{
 			name: "Apply ClusterNetworkingConfig",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, clusterNetworkingConfig)
 			},
 			assertError: require.NoError,
 		},
 		{
 			name: "Apply AuthPreference",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, authPref)
 			},
 			assertError: require.NoError,
 		},
 		{
 			name: "Apply Role+Bot",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, bot)
 			},
@@ -2036,7 +2039,7 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 		},
 		{
 			name: "Apply Bot+Role",
-			modifyConfig: func(cfg *InitConfig) {
+			modifyConfig: func(cfg *auth.InitConfig) {
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, bot)
 				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, role)
 			},
@@ -2048,7 +2051,7 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 			cfg := setupConfig(t)
 			test.modifyConfig(&cfg)
 
-			_, err := Init(context.Background(), cfg)
+			_, err := auth.Init(context.Background(), cfg)
 			test.assertError(t, err)
 		})
 	}
@@ -2087,12 +2090,12 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	ctx := context.Background()
 
 	conf := setupConfig(t)
-	authServer, err := Init(ctx, conf)
+	authServer, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	t.Cleanup(func() { authServer.Close() })
 
 	// no getter is registered, sync should fail
-	require.Error(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.Error(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	// maintenance config does not exist yet
 	cmc, err := authServer.GetClusterMaintenanceConfig(ctx)
@@ -2111,7 +2114,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	})
 
 	// sync should now succeed
-	require.NoError(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.NoError(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2127,7 +2130,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	fakeHour = 16
 	mu.Unlock()
 
-	require.NoError(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.NoError(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2142,7 +2145,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	fakeHour = 36
 	mu.Unlock()
 
-	require.Error(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.Error(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2158,7 +2161,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	fakeHour = math.MaxInt64
 	mu.Unlock()
 
-	require.Error(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.Error(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2174,7 +2177,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	mu.Unlock()
 
 	// sync should now succeed again
-	require.NoError(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.NoError(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2191,7 +2194,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	fakeError = fmt.Errorf("uh-oh")
 	mu.Unlock()
 
-	require.Error(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.Error(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2209,7 +2212,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	mu.Unlock()
 
 	// sync should now succeed again
-	require.NoError(t, authServer.syncUpgradeWindowStartHour(ctx))
+	require.NoError(t, authServer.SyncUpgradeWindowStartHour(ctx))
 
 	cmc, err = authServer.GetClusterMaintenanceConfig(ctx)
 	require.NoError(t, err)
@@ -2227,7 +2230,7 @@ func TestIdentityChecker(t *testing.T) {
 	ctx := context.Background()
 
 	conf := setupConfig(t)
-	authServer, err := Init(ctx, conf)
+	authServer, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	t.Cleanup(func() { authServer.Close() })
 
@@ -2295,7 +2298,7 @@ func TestIdentityChecker(t *testing.T) {
 			t.Cleanup(func() { sshServer.Close() })
 			require.NoError(t, sshServer.Start())
 
-			identity, err := GenerateIdentity(authServer, state.IdentityID{
+			identity, err := auth.GenerateIdentity(authServer, state.IdentityID{
 				Role:     types.RoleNode,
 				HostUUID: uuid.New().String(),
 				NodeName: "node-1",
@@ -2320,7 +2323,7 @@ func TestIdentityChecker(t *testing.T) {
 func TestInitCreatesCertsIfMissing(t *testing.T) {
 	ctx := context.Background()
 	conf := setupConfig(t)
-	auth, err := Init(ctx, conf)
+	auth, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = auth.Close()
@@ -2437,7 +2440,7 @@ func TestTeleportProcessAuthVersionUpgradeCheck(t *testing.T) {
 				authCfg.SkipVersionCheck = true
 			}
 
-			_, err = Init(ctx, authCfg)
+			_, err = auth.Init(ctx, authCfg)
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -2553,7 +2556,7 @@ func Test_createPresetDatabaseObjectImportRule(t *testing.T) {
 				listRules: test.existingRules,
 			}
 
-			err := createPresetDatabaseObjectImportRule(context.Background(), m)
+			err := auth.CreatePresetDatabaseObjectImportRule(context.Background(), m)
 			require.NoError(t, err)
 			require.True(t, proto.Equal(test.expectCreate, m.created))
 			require.True(t, proto.Equal(test.expectUpsert, m.upserted))
@@ -2590,15 +2593,15 @@ version: v1`
 
 	for _, test := range []struct {
 		name string
-		fn   func(cfg *InitConfig)
+		fn   func(cfg *auth.InitConfig)
 	}{
-		{name: "bootstrap", fn: func(cfg *InitConfig) { cfg.BootstrapResources = resources }},
-		{name: "apply", fn: func(cfg *InitConfig) { cfg.ApplyOnStartupResources = resources }},
+		{name: "bootstrap", fn: func(cfg *auth.InitConfig) { cfg.BootstrapResources = resources }},
+		{name: "apply", fn: func(cfg *auth.InitConfig) { cfg.ApplyOnStartupResources = resources }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := setupConfig(t)
 			test.fn(&cfg)
-			auth, err := Init(ctx, cfg)
+			auth, err := auth.Init(ctx, cfg)
 			require.NoError(t, err)
 
 			config, err := auth.GetAutoUpdateConfig(ctx)

--- a/lib/auth/join_azure_devops_test.go
+++ b/lib/auth/join_azure_devops_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/azuredevops"
 )
@@ -85,8 +87,8 @@ func TestAuth_RegisterUsingToken_AzureDevops(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), func(server *Server) error {
-		server.azureDevopsIDTokenValidator = idTokenValidator
+	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
+		server.SetAzureDevopsIDTokenValidator(idTokenValidator)
 		return nil
 	})
 	require.NoError(t, err)
@@ -95,7 +97,7 @@ func TestAuth_RegisterUsingToken_AzureDevops(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -38,28 +38,12 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/fixtures"
 )
-
-func withCerts(certs []*x509.Certificate) azureRegisterOption {
-	return func(cfg *azureRegisterConfig) {
-		cfg.certificateAuthorities = certs
-	}
-}
-
-func withVerifyFunc(verify azureVerifyTokenFunc) azureRegisterOption {
-	return func(cfg *azureRegisterConfig) {
-		cfg.verify = verify
-	}
-}
-
-func withVMClientGetter(getVMClient vmClientGetter) azureRegisterOption {
-	return func(cfg *azureRegisterConfig) {
-		cfg.getVMClient = getVMClient
-	}
-}
 
 type mockAzureVMClient struct {
 	azure.VirtualMachinesClient
@@ -83,7 +67,7 @@ func (m *mockAzureVMClient) GetByVMID(_ context.Context, vmID string) (*azure.Vi
 	return nil, trace.NotFound("no vm with id %q", vmID)
 }
 
-func makeVMClientGetter(clients map[string]*mockAzureVMClient) vmClientGetter {
+func makeVMClientGetter(clients map[string]*mockAzureVMClient) auth.AzureVMClientGetter {
 	return func(subscriptionID string, _ *azure.StaticCredential) (azure.VirtualMachinesClient, error) {
 		if client, ok := clients[subscriptionID]; ok {
 			return client, nil
@@ -119,8 +103,8 @@ func resourceID(resourceType, subscription, resourceGroup, name string) string {
 	)
 }
 
-func mockVerifyToken(err error) azureVerifyTokenFunc {
-	return func(_ context.Context, rawToken string) (*accessTokenClaims, error) {
+func mockVerifyToken(err error) auth.AzureVerifyTokenFunc {
+	return func(_ context.Context, rawToken string) (*auth.AccessTokenClaims, error) {
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +112,7 @@ func mockVerifyToken(err error) azureVerifyTokenFunc {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		var claims accessTokenClaims
+		var claims auth.AccessTokenClaims
 		if err := tok.UnsafeClaimsWithoutVerification(&claims); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -144,10 +128,10 @@ func makeToken(managedIdentityResourceID, azureResourceID string, issueTime time
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	claims := accessTokenClaims{
+	claims := auth.AccessTokenClaims{
 		TokenClaims: oidc.TokenClaims{
 			Issuer:     "https://sts.windows.net/test-tenant-id/",
-			Audience:   []string{azureAccessTokenAudience},
+			Audience:   []string{auth.AzureAccessTokenAudience},
 			Subject:    "test",
 			IssuedAt:   oidc.FromTime(issueTime),
 			NotBefore:  oidc.FromTime(issueTime),
@@ -186,7 +170,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	require.NoError(t, err)
 
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	isAccessDenied := func(t require.TestingT, err error, _ ...any) {
@@ -215,7 +199,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 		challengeResponseOptions       []azureChallengeResponseOption
 		challengeResponseErr           error
 		certs                          []*x509.Certificate
-		verify                         azureVerifyTokenFunc
+		verify                         auth.AzureVerifyTokenFunc
 		assertError                    require.ErrorAssertionFunc
 	}{
 		{
@@ -488,7 +472,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 				mirID = vmResourceID(defaultSubscription, defaultResourceGroup, defaultVMName)
 			}
 
-			accessToken, err := makeToken(mirID, "", a.clock.Now())
+			accessToken, err := makeToken(mirID, "", a.GetClock().Now())
 			require.NoError(t, err)
 
 			vmClient := &mockAzureVMClient{
@@ -512,7 +496,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 					opt(cfg)
 				}
 
-				ad := attestedData{
+				ad := auth.AttestedData{
 					Nonce:          cfg.Challenge,
 					SubscriptionID: tc.tokenSubscription,
 					ID:             tc.tokenVMID,
@@ -524,7 +508,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 				require.NoError(t, s.AddSigner(tlsConfig.Certificate, pkey, pkcs7.SignerInfoConfig{}))
 				signature, err := s.Finish()
 				require.NoError(t, err)
-				signedAD := signedAttestedData{
+				signedAD := auth.SignedAttestedData{
 					Encoding:  "pkcs7",
 					Signature: base64.StdEncoding.EncodeToString(signature),
 				}
@@ -543,7 +527,7 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 					AccessToken:  accessToken,
 				}
 				return req, tc.challengeResponseErr
-			}, withCerts(tc.certs), withVerifyFunc(tc.verify), withVMClientGetter(getVMClient))
+			}, auth.WithAzureCerts(tc.certs), auth.WithAzureVerifyFunc(tc.verify), auth.WithAzureVMClientGetter(getVMClient))
 			tc.assertError(t, err)
 		})
 	}
@@ -571,7 +555,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	require.NoError(t, err)
 
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	isAccessDenied := func(t require.TestingT, err error, _ ...any) {
@@ -594,7 +578,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 		challengeResponseOptions       []azureChallengeResponseOption
 		challengeResponseErr           error
 		certs                          []*x509.Certificate
-		verify                         azureVerifyTokenFunc
+		verify                         auth.AzureVerifyTokenFunc
 		assertError                    require.ErrorAssertionFunc
 	}{
 		{
@@ -793,7 +777,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 
 			mirID := tc.tokenManagedIdentityResourceID
 			azrID := tc.tokenAzureResourceID
-			accessToken, err := makeToken(mirID, azrID, a.clock.Now())
+			accessToken, err := makeToken(mirID, azrID, a.GetClock().Now())
 			require.NoError(t, err)
 
 			vmClient := &mockAzureVMClient{
@@ -809,7 +793,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 					opt(cfg)
 				}
 
-				ad := attestedData{
+				ad := auth.AttestedData{
 					Nonce:          cfg.Challenge,
 					SubscriptionID: tc.tokenSubscription,
 					ID:             tc.tokenVMID,
@@ -821,7 +805,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 				require.NoError(t, s.AddSigner(tlsConfig.Certificate, pkey, pkcs7.SignerInfoConfig{}))
 				signature, err := s.Finish()
 				require.NoError(t, err)
-				signedAD := signedAttestedData{
+				signedAD := auth.SignedAttestedData{
 					Encoding:  "pkcs7",
 					Signature: base64.StdEncoding.EncodeToString(signature),
 				}
@@ -840,7 +824,7 @@ func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 					AccessToken:  accessToken,
 				}
 				return req, tc.challengeResponseErr
-			}, withCerts(tc.certs), withVerifyFunc(tc.verify), withVMClientGetter(getVMClient))
+			}, auth.WithAzureCerts(tc.certs), auth.WithAzureVerifyFunc(tc.verify), auth.WithAzureVMClientGetter(getVMClient))
 			tc.assertError(t, err)
 		})
 	}

--- a/lib/auth/join_bitbucket_test.go
+++ b/lib/auth/join_bitbucket_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/bitbucket"
 	"github.com/gravitational/teleport/lib/modules"
@@ -82,8 +84,8 @@ func TestAuth_RegisterUsingToken_Bitbucket(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), func(server *Server) error {
-		server.bitbucketIDTokenValidator = idTokenValidator
+	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
+		server.SetBitbucketIDTokenValidator(idTokenValidator)
 		return nil
 	})
 	require.NoError(t, err)
@@ -92,7 +94,7 @@ func TestAuth_RegisterUsingToken_Bitbucket(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1091,7 +1091,8 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	tlsCert, err := tls.X509KeyPair(response.Certs.TLS, sshPrivateKey)
 	require.NoError(t, err)
 
-	client := srv.NewClientWithCert(tlsCert)
+	client, err := srv.NewClientWithCert(tlsCert)
+	require.NoError(t, err)
 	_, err = client.Ping(ctx)
 	require.NoError(t, err)
 
@@ -1251,7 +1252,8 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	tlsCert, err := tls.X509KeyPair(secondResponse.Certs.TLS, sshPrivateKey)
 	require.NoError(t, err)
 
-	client := srv.NewClientWithCert(tlsCert)
+	client, err := srv.NewClientWithCert(tlsCert)
+	require.NoError(t, err)
 	_, err = client.Ping(ctx)
 	require.NoError(t, err)
 

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1097,7 +1097,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	require.NoError(t, err)
 
 	// Provide an incorrect generation counter value.
-	response, err = authServer.RegisterUsingBoundKeypairMethod(
+	nextResponse, err := authServer.RegisterUsingBoundKeypairMethod(
 		ctx,
 		makeInitReq(
 			withJoinState(response.JoinState),
@@ -1131,7 +1131,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	// Try registering again now that we know the lock is properly in force.
 	// This should produce a new error message.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		nextResponse, err := auth.RegisterUsingBoundKeypairMethod(
+		nextResponse, err := authServer.RegisterUsingBoundKeypairMethod(
 			ctx,
 			makeInitReq(
 				withJoinState(response.JoinState),
@@ -1288,7 +1288,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	// or may not be in force, but we also need to be absolutely certain to try
 	// to generate at least 2 locking events.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		nextResponse, err := auth.RegisterUsingBoundKeypairMethod(
+		nextResponse, err := authServer.RegisterUsingBoundKeypairMethod(
 			ctx,
 			makeInitReq(withJoinState(firstResponse.JoinState)),
 			solver.solver(),

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -37,6 +37,8 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -110,19 +112,19 @@ func TestServer_RegisterUsingBoundKeypairMethod(t *testing.T) {
 	startTime := clock.Now()
 
 	srv := newTestTLSServer(t, withClock(clock))
-	auth := srv.Auth()
-	auth.createBoundKeypairValidator = func(subject, clusterName string, publicKey crypto.PublicKey) (boundKeypairValidator, error) {
+	authServer := srv.Auth()
+	authServer.SetCreateBoundKeypairValidator(func(subject, clusterName string, publicKey crypto.PublicKey) (auth.BoundKeypairValidator, error) {
 		return &mockBoundKeypairValidator{
 			subject:     subject,
 			clusterName: clusterName,
 			publicKey:   publicKey,
 		}, nil
-	}
+	})
 
-	_, err := CreateRole(ctx, auth, "example", types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
-	adminClient, err := srv.NewClient(TestAdmin())
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
@@ -141,16 +143,16 @@ func TestServer_RegisterUsingBoundKeypairMethod(t *testing.T) {
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
-	jwtCA, err := auth.GetCertAuthority(ctx, types.CertAuthID{
+	jwtCA, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.BoundKeypairCA,
 		DomainName: srv.ClusterName(),
 	}, /* loadKeys */ true)
 	require.NoError(t, err)
 
-	jwtSigner, err := auth.GetKeyStore().GetJWTSigner(ctx, jwtCA)
+	jwtSigner, err := authServer.GetKeyStore().GetJWTSigner(ctx, jwtCA)
 	require.NoError(t, err)
 
 	// An invalid signer for signing "fake" JWTs.
@@ -861,14 +863,14 @@ func TestServer_RegisterUsingBoundKeypairMethod(t *testing.T) {
 			// note: we only override CreateToken in ServerWithRoles, so we'll
 			// need to call CreateBoundKeypairToken() directly to ensure
 			// computed fields (i.e. registration secrets) are handled properly.
-			require.NoError(t, auth.CreateBoundKeypairToken(ctx, token))
+			require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
 			tt.initReq.JoinRequest.Token = tt.name
 
-			response, err := auth.RegisterUsingBoundKeypairMethod(ctx, tt.initReq, tt.solver.wrapped)
+			response, err := authServer.RegisterUsingBoundKeypairMethod(ctx, tt.initReq, tt.solver.wrapped)
 			tt.assertError(t, err)
 
 			if tt.assertResponse != nil {
-				pt, err := auth.GetToken(ctx, tt.name)
+				pt, err := authServer.GetToken(ctx, tt.name)
 				require.NoError(t, err)
 
 				ptv2, ok := pt.(*types.ProvisionTokenV2)
@@ -949,7 +951,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	_, correctPublicKey := testBoundKeypair(t)
@@ -957,19 +959,19 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
 	srv := newTestTLSServer(t, withClock(clock))
-	auth := srv.Auth()
-	auth.createBoundKeypairValidator = func(subject, clusterName string, publicKey crypto.PublicKey) (boundKeypairValidator, error) {
+	authServer := srv.Auth()
+	authServer.SetCreateBoundKeypairValidator(func(subject, clusterName string, publicKey crypto.PublicKey) (auth.BoundKeypairValidator, error) {
 		return &mockBoundKeypairValidator{
 			subject:     subject,
 			clusterName: clusterName,
 			publicKey:   publicKey,
 		}, nil
-	}
+	})
 
-	_, err = CreateRole(ctx, auth, "example", types.RoleSpecV6{})
+	_, err = authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
-	adminClient, err := srv.NewClient(TestAdmin())
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
@@ -1005,7 +1007,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 		&types.ProvisionTokenStatusV2{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateBoundKeypairToken(ctx, token))
+	require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
 
 	makeInitReq := func(mutators ...func(r *proto.RegisterUsingBoundKeypairInitialRequest)) *proto.RegisterUsingBoundKeypairInitialRequest {
 		req := &proto.RegisterUsingBoundKeypairInitialRequest{
@@ -1039,7 +1041,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	}
 
 	solver := newMockSolver(t, correctPublicKey)
-	response, err := auth.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(), solver.solver())
+	response, err := authServer.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(), solver.solver())
 	require.NoError(t, err)
 
 	instance, generation := testExtractBotParamsFromCerts(t, response.Certs)
@@ -1049,7 +1051,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 
 	// Register several times.
 	for i := range 10 {
-		response, err = auth.RegisterUsingBoundKeypairMethod(
+		response, err = authServer.RegisterUsingBoundKeypairMethod(
 			ctx,
 			makeInitReq(withJoinState(response.JoinState), withBotParamsFromIdent(t, response.Certs)),
 			solver.solver(),
@@ -1062,7 +1064,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	}
 
 	// Perform a recovery to get a new instance and reset the counter.
-	response, err = auth.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(withJoinState(response.JoinState)), solver.solver())
+	response, err = authServer.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(withJoinState(response.JoinState)), solver.solver())
 	require.NoError(t, err)
 
 	instance, generation = testExtractBotParamsFromCerts(t, response.Certs)
@@ -1073,7 +1075,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 
 	// Register several more times.
 	for i := range 10 {
-		response, err = auth.RegisterUsingBoundKeypairMethod(
+		response, err = authServer.RegisterUsingBoundKeypairMethod(
 			ctx,
 			makeInitReq(withJoinState(response.JoinState), withBotParamsFromIdent(t, response.Certs)),
 			solver.solver(),
@@ -1094,7 +1096,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	require.NoError(t, err)
 
 	// Provide an incorrect generation counter value.
-	nextResponse, err := auth.RegisterUsingBoundKeypairMethod(
+	response, err = authServer.RegisterUsingBoundKeypairMethod(
 		ctx,
 		makeInitReq(
 			withJoinState(response.JoinState),
@@ -1151,7 +1153,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	_, correctPublicKey := testBoundKeypair(t)
@@ -1159,19 +1161,19 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 
 	srv := newTestTLSServer(t, withClock(clock))
-	auth := srv.Auth()
-	auth.createBoundKeypairValidator = func(subject, clusterName string, publicKey crypto.PublicKey) (boundKeypairValidator, error) {
+	authServer := srv.Auth()
+	authServer.SetCreateBoundKeypairValidator(func(subject, clusterName string, publicKey crypto.PublicKey) (auth.BoundKeypairValidator, error) {
 		return &mockBoundKeypairValidator{
 			subject:     subject,
 			clusterName: clusterName,
 			publicKey:   publicKey,
 		}, nil
-	}
+	})
 
-	_, err = CreateRole(ctx, auth, "example", types.RoleSpecV6{})
+	_, err = authtest.CreateRole(ctx, authServer, "example", types.RoleSpecV6{})
 	require.NoError(t, err)
 
-	adminClient, err := srv.NewClient(TestAdmin())
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	_, err = adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
@@ -1207,7 +1209,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 		&types.ProvisionTokenStatusV2{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, auth.CreateBoundKeypairToken(ctx, token))
+	require.NoError(t, authServer.CreateBoundKeypairToken(ctx, token))
 
 	makeInitReq := func(mutators ...func(r *proto.RegisterUsingBoundKeypairInitialRequest)) *proto.RegisterUsingBoundKeypairInitialRequest {
 		req := &proto.RegisterUsingBoundKeypairInitialRequest{
@@ -1233,11 +1235,11 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 
 	// Perform the initial registration.
 	solver := newMockSolver(t, correctPublicKey)
-	firstResponse, err := auth.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(), solver.solver())
+	firstResponse, err := authServer.RegisterUsingBoundKeypairMethod(ctx, makeInitReq(), solver.solver())
 	require.NoError(t, err)
 
 	// Perform a recovery, this time with a join state.
-	secondResponse, err := auth.RegisterUsingBoundKeypairMethod(
+	secondResponse, err := authServer.RegisterUsingBoundKeypairMethod(
 		ctx,
 		makeInitReq(withJoinState(firstResponse.JoinState)),
 		solver.solver(),
@@ -1254,7 +1256,7 @@ func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try once more, but this time with the first join state.
-	thirdResponse, err := auth.RegisterUsingBoundKeypairMethod(
+	thirdResponse, err := authServer.RegisterUsingBoundKeypairMethod(
 		ctx,
 		makeInitReq(withJoinState(firstResponse.JoinState)),
 		solver.solver(),

--- a/lib/auth/join_circleci_test.go
+++ b/lib/auth/join_circleci_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/circleci"
 )
@@ -43,8 +45,8 @@ func TestAuth_RegisterUsingToken_CircleCI(t *testing.T) {
 		validContextB = "valid-context-b"
 	)
 	// stand up auth server with mocked CircleCI token validator
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.circleCITokenValidate = func(
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetCircleCITokenValidate(func(
 			ctx context.Context, organizationID, token string,
 		) (*circleci.IDTokenClaims, error) {
 			if organizationID == validOrg && token == validIDToken {
@@ -55,7 +57,7 @@ func TestAuth_RegisterUsingToken_CircleCI(t *testing.T) {
 				}, nil
 			}
 			return nil, errMockInvalidToken
-		}
+		})
 		return nil
 	}
 	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
@@ -65,7 +67,7 @@ func TestAuth_RegisterUsingToken_CircleCI(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{

--- a/lib/auth/join_gcp_test.go
+++ b/lib/auth/join_gcp_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/gcp"
 )
@@ -62,8 +64,8 @@ func TestAuth_RegisterUsingToken_GCP(t *testing.T) {
 			},
 		},
 	}
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.gcpIDTokenValidator = idTokenValidator
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetGCPIDTokenValidator(idTokenValidator)
 		return nil
 	}
 	ctx := context.Background()
@@ -74,7 +76,7 @@ func TestAuth_RegisterUsingToken_GCP(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{
@@ -239,7 +241,7 @@ func TestIsGCPZoneInLocation(t *testing.T) {
 	}
 	for _, tc := range passingCases {
 		t.Run("accept "+tc.name, func(t *testing.T) {
-			require.True(t, isGCPZoneInLocation(tc.location, tc.zone))
+			require.True(t, auth.IsGCPZoneInLocation(tc.location, tc.zone))
 		})
 	}
 
@@ -286,7 +288,7 @@ func TestIsGCPZoneInLocation(t *testing.T) {
 	}
 	for _, tc := range failingCases {
 		t.Run("reject "+tc.name, func(t *testing.T) {
-			require.False(t, isGCPZoneInLocation(tc.location, tc.zone))
+			require.False(t, auth.IsGCPZoneInLocation(tc.location, tc.zone))
 		})
 	}
 }

--- a/lib/auth/join_github_test.go
+++ b/lib/auth/join_github_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/githubactions"
 	"github.com/gravitational/teleport/lib/modules"
@@ -89,20 +91,20 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 			},
 		},
 	}
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.ghaIDTokenValidator = idTokenValidator
-		server.ghaIDTokenJWKSValidator = idTokenValidator.ValidateJWKS
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetGHAIDTokenValidator(idTokenValidator)
+		server.SetGHAIDTokenJWKSValidator(idTokenValidator.ValidateJWKS)
 		return nil
 	}
 	ctx := context.Background()
 	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
 	require.NoError(t, err)
-	auth := p.a
+	authServer := p.a
 
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{
@@ -232,7 +234,7 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 			},
 			request: newRequest(validIDToken),
 			assertError: require.ErrorAssertionFunc(func(t require.TestingT, err error, i ...any) {
-				require.ErrorIs(t, err, ErrRequiresEnterprise)
+				require.ErrorIs(t, err, auth.ErrRequiresEnterprise)
 			}),
 		},
 		{
@@ -249,7 +251,7 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 			},
 			request: newRequest(validIDToken),
 			assertError: require.ErrorAssertionFunc(func(t require.TestingT, err error, i ...any) {
-				require.ErrorIs(t, err, ErrRequiresEnterprise)
+				require.ErrorIs(t, err, auth.ErrRequiresEnterprise)
 			}),
 		},
 		{
@@ -411,10 +413,10 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 				tt.name, time.Now().Add(time.Minute), tt.tokenSpec,
 			)
 			require.NoError(t, err)
-			require.NoError(t, auth.CreateToken(ctx, token))
+			require.NoError(t, authServer.CreateToken(ctx, token))
 			tt.request.Token = tt.name
 
-			_, err = auth.RegisterUsingToken(ctx, tt.request)
+			_, err = authServer.RegisterUsingToken(ctx, tt.request)
 			tt.assertError(t, err)
 			if err != nil {
 				return

--- a/lib/auth/join_gitlab_test.go
+++ b/lib/auth/join_gitlab_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/gitlab"
 )
@@ -87,8 +89,8 @@ func TestAuth_RegisterUsingToken_GitLab(t *testing.T) {
 			},
 		},
 	}
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.gitlabIDTokenValidator = idTokenValidator
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetGitlabIDTokenValidator(idTokenValidator)
 		return nil
 	}
 	ctx := context.Background()
@@ -99,7 +101,7 @@ func TestAuth_RegisterUsingToken_GitLab(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{
@@ -603,7 +605,7 @@ func Test_joinRuleGlobMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := joinRuleGlobMatch(tt.rule, tt.claim)
+			got, err := auth.JoinRuleGlobMatch(tt.rule, tt.claim)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/lib/auth/join_iam_test.go
+++ b/lib/auth/join_iam_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"bytes"
@@ -35,11 +35,13 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func responseFromAWSIdentity(id awsIdentity) string {
+func responseFromAWSIdentity(id auth.AWSIdentity) string {
 	return fmt.Sprintf(`{
 		"GetCallerIdentityResponse": {
 			"GetCallerIdentityResult": {
@@ -120,7 +122,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	isAccessDenied := func(t require.TestingT, err error, _ ...any) {
@@ -136,7 +138,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		requestTokenName         string
 		tokenSpec                types.ProvisionTokenSpecV2
 		stsClient                utils.HTTPDoClient
-		iamRegisterOptions       []iamRegisterOption
+		iamRegisterOptions       []auth.IAMRegisterOption
 		challengeResponseOptions []challengeResponseOption
 		challengeResponseErr     error
 		assertError              require.ErrorAssertionFunc
@@ -157,7 +159,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -180,7 +182,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-test",
 				}),
@@ -203,7 +205,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-123",
 				}),
@@ -226,7 +228,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -249,7 +251,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -272,7 +274,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -295,7 +297,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name",
 				}),
@@ -318,7 +320,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name2",
 				}),
@@ -341,7 +343,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -364,7 +366,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -388,7 +390,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-1234",
 				}),
@@ -411,7 +413,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -437,7 +439,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "5678",
 					Arn:     "arn:aws::1111",
 				}),
@@ -480,7 +482,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -506,7 +508,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -532,7 +534,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -558,14 +560,14 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
 			},
-			iamRegisterOptions: []iamRegisterOption{
-				withFips(true),
-				withAuthVersion(&semver.Version{Major: 12}),
+			iamRegisterOptions: []auth.IAMRegisterOption{
+				auth.WithFIPS(true),
+				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts-fips.us-east-1.amazonaws.com"),
@@ -588,14 +590,14 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(awsIdentity{
+				respBody: responseFromAWSIdentity(auth.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
 			},
-			iamRegisterOptions: []iamRegisterOption{
-				withFips(true),
-				withAuthVersion(&semver.Version{Major: 12}),
+			iamRegisterOptions: []auth.IAMRegisterOption{
+				auth.WithFIPS(true),
+				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts.us-east-1.amazonaws.com"),
@@ -607,7 +609,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Set mock client.
-			a.httpClientForAWSSTS = tc.stsClient
+			a.SetHTTPClientForAWSSTS(tc.stsClient)
 
 			// add token to auth server
 			token, err := types.NewProvisionTokenFromSpec(

--- a/lib/auth/join_spacelift_test.go
+++ b/lib/auth/join_spacelift_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -68,8 +70,8 @@ func TestAuth_RegisterUsingToken_Spacelift(t *testing.T) {
 			},
 		},
 	}
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.spaceliftIDTokenValidator = idTokenValidator
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetSpaceliftIDTokenValidator(idTokenValidator)
 		return nil
 	}
 	ctx := context.Background()
@@ -80,7 +82,7 @@ func TestAuth_RegisterUsingToken_Spacelift(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{

--- a/lib/auth/join_terraformcloud_test.go
+++ b/lib/auth/join_terraformcloud_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -75,8 +77,8 @@ func TestAuth_RegisterUsingToken_Terraform(t *testing.T) {
 			},
 		},
 	}
-	var withTokenValidator ServerOption = func(server *Server) error {
-		server.terraformIDTokenValidator = idTokenValidator
+	var withTokenValidator auth.ServerOption = func(server *auth.Server) error {
+		server.SetTerraformIDTokenValidator(idTokenValidator)
 		return nil
 	}
 	ctx := context.Background()
@@ -87,7 +89,7 @@ func TestAuth_RegisterUsingToken_Terraform(t *testing.T) {
 	// helper for creating RegisterUsingTokenRequest
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 	newRequest := func(idToken string) *types.RegisterUsingTokenRequest {
 		return &types.RegisterUsingTokenRequest{

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -34,6 +34,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -82,7 +84,7 @@ func TestAuth_RegisterUsingToken(t *testing.T) {
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
 
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	testcases := []struct {
@@ -262,7 +264,7 @@ func TestAuth_RegisterUsingToken(t *testing.T) {
 				if tc.waitTokenDeleted {
 					require.Eventually(t, func() bool {
 						_, err := p.a.ValidateToken(ctx, tc.req.Token)
-						return err != nil && strings.Contains(err.Error(), TokenExpiredOrNotFound)
+						return err != nil && strings.Contains(err.Error(), auth.TokenExpiredOrNotFound)
 					}, time.Millisecond*100, time.Millisecond*10)
 				}
 				return

--- a/lib/auth/join_tpm_test.go
+++ b/lib/auth/join_tpm_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"bytes"
@@ -37,6 +37,8 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apifixtures "github.com/gravitational/teleport/api/fixtures"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -77,16 +79,16 @@ func (m *mockTPMValidator) validate(
 func TestServer_RegisterUsingTPMMethod(t *testing.T) {
 	ctx := context.Background()
 	mockValidator := &mockTPMValidator{}
-	p, err := newTestPack(ctx, t.TempDir(), func(server *Server) error {
-		server.tpmValidator = mockValidator.validate
+	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
+		server.SetTPMValidator(mockValidator.validate)
 		return nil
 	})
 	require.NoError(t, err)
-	auth := p.a
+	authServer := p.a
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
-	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
 	require.NoError(t, err)
 
 	attParams := &proto.TPMAttestationParameters{
@@ -295,7 +297,7 @@ func TestServer_RegisterUsingTPMMethod(t *testing.T) {
 			name:   "failure, no enterprise",
 			setOSS: true,
 			assertError: func(t require.TestingT, err error, i ...any) {
-				assert.ErrorIs(t, err, ErrRequiresEnterprise)
+				assert.ErrorIs(t, err, auth.ErrRequiresEnterprise)
 			},
 
 			initReq: &proto.RegisterUsingTPMMethodInitialRequest{
@@ -338,10 +340,10 @@ func TestServer_RegisterUsingTPMMethod(t *testing.T) {
 				tt.name, time.Now().Add(time.Minute), tt.tokenSpec,
 			)
 			require.NoError(t, err)
-			require.NoError(t, auth.CreateToken(ctx, token))
+			require.NoError(t, authServer.CreateToken(ctx, token))
 			tt.initReq.JoinRequest.Token = tt.name
 
-			_, err = auth.RegisterUsingTPMMethod(
+			_, err = authServer.RegisterUsingTPMMethod(
 				ctx,
 				tt.initReq,
 				solver(t))

--- a/lib/auth/methods_test.go
+++ b/lib/auth/methods_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 )
@@ -35,15 +36,17 @@ func TestServerAuthenticateUserUserAgentTrim(t *testing.T) {
 	emitter := &eventstest.MockRecorderEmitter{}
 	r := authclient.AuthenticateUserRequest{
 		ClientMetadata: &authclient.ForwardedClientMetadata{
-			UserAgent: strings.Repeat("A", maxUserAgentLen+1),
+			UserAgent: strings.Repeat("A", auth.MaxUserAgentLen+1),
 		},
 	}
 	// Ignoring the error here because we really just care that the event was logged.
-	(&Server{emitter: emitter}).authenticateUserLogin(ctx, r)
+	srv := &auth.Server{}
+	srv.SetEmitter(emitter)
+	srv.AuthenticateUserLogin(ctx, r)
 	event := emitter.LastEvent()
 	loginEvent, ok := event.(*apievents.UserLogin)
 	require.True(t, ok)
-	require.LessOrEqual(t, len(loginEvent.UserAgent), maxUserAgentLen)
+	require.LessOrEqual(t, len(loginEvent.UserAgent), auth.MaxUserAgentLen)
 }
 
 func Test_trimUserAgent(t *testing.T) {
@@ -66,7 +69,7 @@ func Test_trimUserAgent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.wantUserAgent, trimUserAgent(test.inputUserAgent))
+			require.Equal(t, test.wantUserAgent, auth.TrimUserAgent(test.inputUserAgent))
 		})
 	}
 }

--- a/lib/auth/moderated_sessions_test.go
+++ b/lib/auth/moderated_sessions_test.go
@@ -16,16 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -38,9 +38,8 @@ func TestUnmoderatedSessionsAllowed(t *testing.T) {
 	// Use OSS License (which doesn't support moderated sessions).
 	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildOSS})
 
-	srv := &Server{
-		clock:    clockwork.NewRealClock(),
-		Services: &Services{},
+	srv := &auth.Server{
+		Services: &auth.Services{},
 	}
 
 	bk, err := memory.New(memory.Config{})
@@ -66,9 +65,8 @@ func TestModeratedSessionsDisabled(t *testing.T) {
 	// Use OSS License (which doesn't support moderated sessions).
 	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildOSS})
 
-	srv := &Server{
-		clock:    clockwork.NewRealClock(),
-		Services: &Services{},
+	srv := &auth.Server{
+		Services: &auth.Services{},
 	}
 
 	bk, err := memory.New(memory.Config{})
@@ -97,7 +95,7 @@ func TestModeratedSessionsDisabled(t *testing.T) {
 	tracker, err = srv.CreateSessionTracker(context.Background(), tracker)
 	require.Error(t, err)
 	require.Nil(t, tracker)
-	require.ErrorIs(t, err, ErrRequiresEnterprise)
+	require.ErrorIs(t, err, auth.ErrRequiresEnterprise)
 }
 
 // TestModeratedSessionsEnabled verifies that we can create session trackers with moderation
@@ -106,9 +104,8 @@ func TestModeratedSesssionsEnabled(t *testing.T) {
 	// Use Enterprise License (which supports moderated sessions).
 	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
-	srv := &Server{
-		clock:    clockwork.NewRealClock(),
-		Services: &Services{},
+	srv := &auth.Server{
+		Services: &auth.Services{},
 	}
 
 	bk, err := memory.New(memory.Config{})

--- a/lib/auth/notification_test.go
+++ b/lib/auth/notification_test.go
@@ -42,7 +42,7 @@ func TestNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        fakeClock,
 		CacheEnabled: true,

--- a/lib/auth/notification_test.go
+++ b/lib/auth/notification_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -32,6 +32,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -41,7 +42,7 @@ func TestNotifications(t *testing.T) {
 
 	fakeClock := clockwork.NewFakeClock()
 
-	authServer, err := NewTestAuthServer(TestAuthServerConfig{
+	authServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        fakeClock,
 		CacheEnabled: true,
@@ -298,7 +299,7 @@ func TestNotifications(t *testing.T) {
 	}
 
 	// Test fetching notifications for auditor.
-	auditorClient, err := srv.NewClient(TestUser(auditorUsername))
+	auditorClient, err := srv.NewClient(authtest.TestUser(auditorUsername))
 	require.NoError(t, err)
 	defer auditorClient.Close()
 
@@ -397,7 +398,7 @@ func TestNotifications(t *testing.T) {
 	require.Equal(t, auditorExpectedNotifsAfterDismissal, notificationsToTitlesList(t, resp.Notifications))
 
 	// Test fetching notifications for manager.
-	managerClient, err := srv.NewClient(TestUser(managerUsername))
+	managerClient, err := srv.NewClient(authtest.TestUser(managerUsername))
 	require.NoError(t, err)
 	defer managerClient.Close()
 

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -254,7 +254,7 @@ func TestServer_ChangePassword(t *testing.T) {
 		name             string
 		oldPass          string
 		newPass          string
-		device           *authtest.TestDevice
+		device           *authtest.Device
 		challengeRequest *proto.CreateAuthenticateChallengeRequest
 	}{
 		{
@@ -383,7 +383,7 @@ func TestServer_ChangePassword_Fails(t *testing.T) {
 	tests := []struct {
 		name                     string
 		oldPass                  string
-		device                   *authtest.TestDevice
+		device                   *authtest.Device
 		challengeRequest         *proto.CreateAuthenticateChallengeRequest
 		createChallengeAssertion require.ErrorAssertionFunc
 	}{

--- a/lib/auth/sessions_test.go
+++ b/lib/auth/sessions_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -27,12 +27,14 @@ import (
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 )
 
 func TestServer_CreateWebSessionFromReq_deviceWebToken(t *testing.T) {
 	t.Parallel()
 
-	testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir: t.TempDir(),
 	})
 	require.NoError(t, err, "NewTestAuthServer failed")
@@ -57,7 +59,7 @@ func TestServer_CreateWebSessionFromReq_deviceWebToken(t *testing.T) {
 	})
 
 	const userLlama = "llama"
-	user, _, err := CreateUserAndRole(authServer, userLlama, []string{userLlama} /* logins */, nil /* allowRules */)
+	user, _, err := authtest.CreateUserAndRole(authServer, userLlama, []string{userLlama} /* logins */, nil /* allowRules */)
 	require.NoError(t, err, "CreateUserAndRole failed")
 
 	// Arbitrary, real-looking values.
@@ -65,7 +67,7 @@ func TestServer_CreateWebSessionFromReq_deviceWebToken(t *testing.T) {
 	const loginUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
 
 	t.Run("ok", func(t *testing.T) {
-		session, err := authServer.CreateWebSessionFromReq(ctx, NewWebSessionRequest{
+		session, err := authServer.CreateWebSessionFromReq(ctx, auth.NewWebSessionRequest{
 			User:                 userLlama,
 			LoginIP:              loginIP,
 			LoginUserAgent:       loginUserAgent,

--- a/lib/auth/sessions_test.go
+++ b/lib/auth/sessions_test.go
@@ -34,10 +34,10 @@ import (
 func TestServer_CreateWebSessionFromReq_deviceWebToken(t *testing.T) {
 	t.Parallel()
 
-	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir: t.TempDir(),
 	})
-	require.NoError(t, err, "NewTestAuthServer failed")
+	require.NoError(t, err, "NewAuthServer failed")
 	t.Cleanup(func() {
 		assert.NoError(t, testAuthServer.Close(), "testAuthServer.Close() errored")
 	})

--- a/lib/auth/sso_mfa_test.go
+++ b/lib/auth/sso_mfa_test.go
@@ -47,7 +47,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	ctx := context.Background()
 
 	fakeClock := clockwork.NewFakeClock()
-	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})
@@ -363,7 +363,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	ctx := context.Background()
 
 	fakeClock := clockwork.NewFakeClock()
-	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})

--- a/lib/auth/sso_mfa_test.go
+++ b/lib/auth/sso_mfa_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -33,7 +33,9 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/mfatypes"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -45,7 +47,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	ctx := context.Background()
 
 	fakeClock := clockwork.NewFakeClock()
-	testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})
@@ -70,11 +72,11 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a standard user.
-	standardUser, _, err := CreateUserAndRole(a, "standard", []string{"role"}, nil)
+	standardUser, _, err := authtest.CreateUserAndRole(a, "standard", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	// Create a fake saml user with MFA disabled.
-	noMFASAMLUser, noMFASAMLRole, err := CreateUserAndRole(a, "saml-user-no-mfa", []string{"role"}, nil)
+	noMFASAMLUser, noMFASAMLRole, err := authtest.CreateUserAndRole(a, "saml-user-no-mfa", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	noMFASAMLConnector, err := types.NewSAMLConnector("saml-no-mfa", types.SAMLConnectorSpecV2{
@@ -91,7 +93,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	noMFASAMLUser.SetCreatedBy(types.CreatedBy{
-		Time: a.clock.Now(),
+		Time: a.GetClock().Now(),
 		Connector: &types.ConnectorRef{
 			ID:   noMFASAMLConnector.GetName(),
 			Type: noMFASAMLConnector.GetKind(),
@@ -101,7 +103,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake saml user with MFA enabled.
-	samlUser, samlRole, err := CreateUserAndRole(a, "saml-user", []string{"role"}, nil)
+	samlUser, samlRole, err := authtest.CreateUserAndRole(a, "saml-user", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	samlConnector, err := types.NewSAMLConnector("saml", types.SAMLConnectorSpecV2{
@@ -123,7 +125,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	samlUser.SetCreatedBy(types.CreatedBy{
-		Time: a.clock.Now(),
+		Time: a.GetClock().Now(),
 		Connector: &types.ConnectorRef{
 			ID:   samlConnector.GetName(),
 			Type: samlConnector.GetKind(),
@@ -133,7 +135,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake oidc user with MFA enabled.
-	oidcUser, oidcRole, err := CreateUserAndRole(a, "oidc-user", []string{"role"}, nil)
+	oidcUser, oidcRole, err := authtest.CreateUserAndRole(a, "oidc-user", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	oidcConnector, err := types.NewOIDCConnector("oidc", types.OIDCConnectorSpecV3{
@@ -158,7 +160,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 	require.NoError(t, err)
 
 	oidcUser.SetCreatedBy(types.CreatedBy{
-		Time: a.clock.Now(),
+		Time: a.GetClock().Now(),
 		Connector: &types.ConnectorRef{
 			ID:   oidcConnector.GetName(),
 			Type: oidcConnector.GetKind(),
@@ -343,7 +345,7 @@ func TestSSOMFAChallenge_Creation(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			userClient, err := testServer.NewClient(TestUser(tt.username))
+			userClient, err := testServer.NewClient(authtest.TestUser(tt.username))
 			require.NoError(t, err)
 
 			if tt.setup != nil {
@@ -361,7 +363,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	ctx := context.Background()
 
 	fakeClock := clockwork.NewFakeClock()
-	testAuthServer, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuthServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: fakeClock,
 	})
@@ -372,11 +374,11 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	a := testServer.Auth()
 
 	// Create a standard user.
-	standardUser, _, err := CreateUserAndRole(a, "standard", []string{"role"}, nil)
+	standardUser, _, err := authtest.CreateUserAndRole(a, "standard", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	// Create a fake saml user with MFA enabled.
-	samlUser, samlRole, err := CreateUserAndRole(a, "saml-user", []string{"role"}, nil)
+	samlUser, samlRole, err := authtest.CreateUserAndRole(a, "saml-user", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	samlConnector, err := types.NewSAMLConnector("saml", types.SAMLConnectorSpecV2{
@@ -397,7 +399,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	_, err = a.UpsertSAMLConnector(ctx, samlConnector)
 	require.NoError(t, err)
 
-	userCreatedAt := a.clock.Now().UTC()
+	userCreatedAt := a.GetClock().Now().UTC()
 	samlUser.SetCreatedBy(types.CreatedBy{
 		Time: userCreatedAt,
 		Connector: &types.ConnectorRef{
@@ -418,7 +420,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake saml user with MFA disabled.
-	noMFASAMLUser, noMFASAMLRole, err := CreateUserAndRole(a, "saml-user-no-mfa", []string{"role"}, nil)
+	noMFASAMLUser, noMFASAMLRole, err := authtest.CreateUserAndRole(a, "saml-user-no-mfa", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	noMFASAMLConnector, err := types.NewSAMLConnector("saml-no-mfa", types.SAMLConnectorSpecV2{
@@ -435,7 +437,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 	require.NoError(t, err)
 
 	noMFASAMLUser.SetCreatedBy(types.CreatedBy{
-		Time: a.clock.Now(),
+		Time: a.GetClock().Now(),
 		Connector: &types.ConnectorRef{
 			ID:   noMFASAMLConnector.GetName(),
 			Type: noMFASAMLConnector.GetKind(),
@@ -722,7 +724,7 @@ func TestSSOMFAChallenge_Validation(t *testing.T) {
 }
 
 type fakeSSOService struct {
-	a *Server
+	a *auth.Server
 }
 
 func (s *fakeSSOService) CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRequest) (*types.SAMLAuthRequest, error) {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -85,7 +85,7 @@ import (
 
 func TestRejectedClients(t *testing.T) {
 	t.Parallel()
-	server, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	server, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "cluster",
 		Clock:       clockwork.NewFakeClock(),
@@ -150,10 +150,10 @@ func TestRemoteBuiltinRole(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	remoteServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
-		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
+		Clock:       testSrv.AuthServer.AuthServerConfig.Clock,
 	})
 	require.NoError(t, err)
 
@@ -210,7 +210,7 @@ func TestAcceptedUsage(t *testing.T) {
 
 	ctx := context.Background()
 
-	server, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	server, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:           t.TempDir(),
 		ClusterName:   "remote",
 		AcceptedUsage: []string{"usage:k8s"},
@@ -274,10 +274,10 @@ func TestRemoteRotation(t *testing.T) {
 
 	var ok bool
 
-	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	remoteServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
-		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
+		Clock:       testSrv.AuthServer.AuthServerConfig.Clock,
 	})
 	require.NoError(t, err)
 
@@ -381,10 +381,10 @@ func TestLocalProxyPermissions(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	remoteServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
-		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
+		Clock:       testSrv.AuthServer.AuthServerConfig.Clock,
 	})
 	require.NoError(t, err)
 
@@ -804,7 +804,7 @@ func TestAppTokenRotation(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	client, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleApp))
 	require.NoError(t, err)
@@ -957,7 +957,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -1246,9 +1246,9 @@ func TestRemoteUser(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
-	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	remoteServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
 		Clock:       clock,
@@ -1537,7 +1537,7 @@ func TestPasswordCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	// Create a user.
 	u, err := types.NewUser("user1")
@@ -1573,7 +1573,7 @@ func TestOTPCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	user := "user1"
 	pass := []byte("abcdef123456")
@@ -1700,7 +1700,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	t.Cleanup(cancel)
 
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -1912,7 +1912,7 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -2092,7 +2092,7 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	adminClient, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -2621,7 +2621,8 @@ func TestGenerateCerts(t *testing.T) {
 
 		// client that uses impersonated certificate can't impersonate other users
 		// although super impersonator's roles allow it
-		impersonatedClient := srv.NewClientWithCert(clientCert)
+		impersonatedClient, err := srv.NewClientWithCert(clientCert)
+		require.NoError(t, err)
 		_, err = impersonatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
 			SSHPublicKey: sshPubKey,
 			TLSPublicKey: tlsPubKey,
@@ -2895,7 +2896,7 @@ func TestGenerateCerts(t *testing.T) {
 func TestGenerateAppToken(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	authClient, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
@@ -3089,7 +3090,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -3450,7 +3451,7 @@ func TestRegisterCAPin(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 
 	// Generate a token to use.
 	token := generateTestToken(
@@ -3572,7 +3573,7 @@ func TestRegisterCAPath(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+	clock := testSrv.AuthServer.AuthServerConfig.Clock
 	dataDir := testSrv.AuthServer.Dir
 
 	// Generate a token to use.
@@ -5010,12 +5011,12 @@ func withClock(clock clockwork.Clock) testTLSServerOption {
 	}
 }
 
-// newTestTLSServer is a helper that returns a *authtest.TestTLSServer with sensible
+// newTestTLSServer is a helper that returns a *authtest.TLSServer with sensible
 // defaults for most tests that are exercising Auth Service RPCs.
 //
 // For more advanced use-cases, call NewTestAuthServer and NewTestTLSServer
 // to provide a more detailed configuration.
-func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TestTLSServer {
+func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSServer {
 	var options testTLSServerOptions
 	for _, opt := range opts {
 		opt(&options)
@@ -5023,7 +5024,7 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TestT
 	if options.clock == nil {
 		options.clock = clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 	}
-	as, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        options.clock,
 		CacheEnabled: options.cacheEnabled,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -60,7 +60,9 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -83,21 +85,21 @@ import (
 
 func TestRejectedClients(t *testing.T) {
 	t.Parallel()
-	server, err := NewTestAuthServer(TestAuthServerConfig{
+	server, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "cluster",
 		Clock:       clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
 
-	user, _, err := CreateUserAndRole(server.AuthServer, "user", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(server.AuthServer, "user", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	tlsServer, err := server.NewTestTLSServer()
 	require.NoError(t, err)
 	defer tlsServer.Close()
 
-	tlsConfig, err := tlsServer.ClientTLSConfig(TestUser(user.GetName()))
+	tlsConfig, err := tlsServer.ClientTLSConfig(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	clt, err := authclient.NewClient(client.Config{
@@ -148,7 +150,7 @@ func TestRemoteBuiltinRole(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
+	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
 		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
@@ -161,7 +163,7 @@ func TestRemoteBuiltinRole(t *testing.T) {
 	// without trust, proxy server will get rejected
 	// remote auth server will get rejected because it is not supported
 	remoteProxy, err := remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
+		authtest.TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	// certificate authority is not recognized, because
@@ -180,7 +182,7 @@ func TestRemoteBuiltinRole(t *testing.T) {
 	// there's also no reason to retry if somehow we fail to build the client
 	for range 50 {
 		remoteProxy, err = remoteServer.NewRemoteClient(
-			TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
+			authtest.TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
 		require.NoError(t, err)
 
 		_, err = remoteProxy.GetNodes(ctx, apidefaults.Namespace)
@@ -193,7 +195,7 @@ func TestRemoteBuiltinRole(t *testing.T) {
 
 	// remote auth server will get rejected even with established trust
 	remoteAuth, err := remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleAuth), testSrv.Addr(), certPool)
+		authtest.TestBuiltin(types.RoleAuth), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	_, err = remoteAuth.GetDomainName(ctx)
@@ -208,7 +210,7 @@ func TestAcceptedUsage(t *testing.T) {
 
 	ctx := context.Background()
 
-	server, err := NewTestAuthServer(TestAuthServerConfig{
+	server, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:           t.TempDir(),
 		ClusterName:   "remote",
 		AcceptedUsage: []string{"usage:k8s"},
@@ -216,7 +218,7 @@ func TestAcceptedUsage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	user, _, err := CreateUserAndRole(server.AuthServer, "user", []string{"role"}, nil)
+	user, _, err := authtest.CreateUserAndRole(server.AuthServer, "user", []string{"role"}, nil)
 	require.NoError(t, err)
 
 	tlsServer, err := server.NewTestTLSServer()
@@ -224,7 +226,7 @@ func TestAcceptedUsage(t *testing.T) {
 	defer tlsServer.Close()
 
 	// Unrestricted clients can use restricted servers
-	client, err := tlsServer.NewClient(TestUser(user.GetName()))
+	client, err := tlsServer.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 
 	// certificate authority is not recognized, because
@@ -234,7 +236,7 @@ func TestAcceptedUsage(t *testing.T) {
 
 	// restricted clients can use restricted servers if restrictions
 	// exactly match
-	identity := TestUser(user.GetName())
+	identity := authtest.TestUser(user.GetName())
 	identity.AcceptedUsage = []string{"usage:k8s"}
 	client, err = tlsServer.NewClient(identity)
 	require.NoError(t, err)
@@ -243,7 +245,7 @@ func TestAcceptedUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	// restricted clients can will be rejected if usage does not match
-	identity = TestUser(user.GetName())
+	identity = authtest.TestUser(user.GetName())
 	identity.AcceptedUsage = []string{"usage:extra"}
 	client, err = tlsServer.NewClient(identity)
 	require.NoError(t, err)
@@ -253,7 +255,7 @@ func TestAcceptedUsage(t *testing.T) {
 
 	// restricted clients can will be rejected, for now if there is any mismatch,
 	// including extra usage.
-	identity = TestUser(user.GetName())
+	identity = authtest.TestUser(user.GetName())
 	identity.AcceptedUsage = []string{"usage:k8s", "usage:unknown"}
 	client, err = tlsServer.NewClient(identity)
 	require.NoError(t, err)
@@ -272,7 +274,7 @@ func TestRemoteRotation(t *testing.T) {
 
 	var ok bool
 
-	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
+	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
 		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
@@ -287,17 +289,19 @@ func TestRemoteRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	remoteProxy, err := remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
+		authtest.TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	remoteAuth, err := remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleAuth), testSrv.Addr(), certPool)
+		authtest.TestBuiltin(types.RoleAuth), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	// remote cluster starts rotation
 	gracePeriod := time.Hour
-	remoteServer.AuthServer.privateKey, ok = fixtures.PEMBytes["rsa"]
+	privateKey, ok := fixtures.PEMBytes["rsa"]
 	require.True(t, ok)
+
+	testSrv.Auth().SetPrivateKey(privateKey)
 	err = remoteServer.AuthServer.RotateCertAuthority(ctx, types.RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -358,7 +362,7 @@ func TestRemoteRotation(t *testing.T) {
 
 	// newRemoteProxy should be trusted by the auth server
 	newRemoteProxy, err := remoteServer.NewRemoteClient(
-		TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
+		authtest.TestBuiltin(types.RoleProxy), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	_, err = newRemoteProxy.GetNodes(ctx, apidefaults.Namespace)
@@ -377,7 +381,7 @@ func TestLocalProxyPermissions(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
+	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
 		Clock:       testSrv.AuthServer.TestAuthServerConfig.Clock,
@@ -394,7 +398,7 @@ func TestLocalProxyPermissions(t *testing.T) {
 	}, false)
 	require.NoError(t, err)
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// local proxy can't update local cert authorities
@@ -423,7 +427,7 @@ func TestAutoRotation(t *testing.T) {
 	var ok bool
 
 	// create proxy client
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// client works before rotation is initiated
@@ -431,8 +435,9 @@ func TestAutoRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	// starts rotation
-	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
+	privateKey, ok := fixtures.PEMBytes["rsa"]
 	require.True(t, ok)
+	testSrv.Auth().SetPrivateKey(privateKey)
 	gracePeriod := time.Hour
 	err = testSrv.Auth().RotateCertAuthority(ctx, types.RotateRequest{
 		Type:        types.HostCA,
@@ -458,7 +463,7 @@ func TestAutoRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	// new clients work as well
-	_, err = testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	_, err = testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// advance rotation by clock
@@ -478,7 +483,7 @@ func TestAutoRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	// new clients work as well
-	newProxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	newProxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	_, err = newProxy.GetNodes(ctx, apidefaults.Namespace)
@@ -525,7 +530,7 @@ func TestAutoFallback(t *testing.T) {
 	var ok bool
 
 	// create proxy client just for test purposes
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// client works before rotation is initiated
@@ -533,8 +538,10 @@ func TestAutoFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	// starts rotation
-	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
+	privateKey, ok := fixtures.PEMBytes["rsa"]
 	require.True(t, ok)
+
+	testSrv.Auth().SetPrivateKey(privateKey)
 	gracePeriod := time.Hour
 	err = testSrv.Auth().RotateCertAuthority(ctx, types.RotateRequest{
 		Type:        types.HostCA,
@@ -585,7 +592,7 @@ func TestManualRotation(t *testing.T) {
 	var ok bool
 
 	// create proxy client just for test purposes
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// client works before rotation is initiated
@@ -594,8 +601,10 @@ func TestManualRotation(t *testing.T) {
 
 	// can't jump to mid-phase
 	gracePeriod := time.Hour
-	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
+	privateKey, ok := fixtures.PEMBytes["rsa"]
 	require.True(t, ok)
+
+	testSrv.Auth().SetPrivateKey(privateKey)
 	err = testSrv.Auth().RotateCertAuthority(ctx, types.RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -631,7 +640,7 @@ func TestManualRotation(t *testing.T) {
 	require.NoError(t, err)
 
 	// new clients work as well
-	newProxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	newProxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	_, err = newProxy.GetNodes(ctx, apidefaults.Namespace)
@@ -696,7 +705,7 @@ func TestRollback(t *testing.T) {
 	var ok bool
 
 	// create proxy client just for test purposes
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 	defer proxy.Close()
 
@@ -706,8 +715,9 @@ func TestRollback(t *testing.T) {
 
 	// starts rotation
 	gracePeriod := time.Hour
-	testSrv.Auth().privateKey, ok = fixtures.PEMBytes["rsa"]
+	privateKey, ok := fixtures.PEMBytes["rsa"]
 	require.True(t, ok)
+	testSrv.Auth().SetPrivateKey(privateKey)
 	err = testSrv.Auth().RotateCertAuthority(ctx, types.RotateRequest{
 		Type:        types.HostCA,
 		GracePeriod: &gracePeriod,
@@ -726,7 +736,7 @@ func TestRollback(t *testing.T) {
 	require.NoError(t, err)
 
 	// new clients work
-	newProxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	newProxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 	defer newProxy.Close()
 
@@ -796,7 +806,7 @@ func TestAppTokenRotation(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	client, err := testSrv.NewClient(TestBuiltin(types.RoleApp))
+	client, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleApp))
 	require.NoError(t, err)
 
 	// Create a JWT using the current CA, this will become the "old" CA during
@@ -949,7 +959,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	publicAddress := "https://localhost:8080"
@@ -978,7 +988,7 @@ func TestOIDCIdPTokenRotation(t *testing.T) {
 	_, err = clt.CreateIntegration(ctx, ig)
 	require.NoError(t, err)
 
-	client, err := testSrv.NewClient(TestBuiltin(types.RoleDiscovery))
+	client, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleDiscovery))
 	require.NoError(t, err)
 
 	// Create a JWT using the current CA, this will become the "old" CA during
@@ -1107,7 +1117,7 @@ func TestListUsers(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	// set up some users with distinct names/labels (the only to user attributes currently relevant to filtering)
@@ -1238,20 +1248,20 @@ func TestRemoteUser(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	remoteServer, err := NewTestAuthServer(TestAuthServerConfig{
+	remoteServer, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:         t.TempDir(),
 		ClusterName: "remote",
 		Clock:       clock,
 	})
 	require.NoError(t, err)
 
-	remoteUser, remoteRole, err := CreateUserAndRole(remoteServer.AuthServer, "remote-user", []string{"remote-role"}, nil)
+	remoteUser, remoteRole, err := authtest.CreateUserAndRole(remoteServer.AuthServer, "remote-user", []string{"remote-role"}, nil)
 	require.NoError(t, err)
 
 	certPool, err := testSrv.CertPool()
 	require.NoError(t, err)
 
-	remoteClient, err := remoteServer.NewRemoteClient(TestUser(remoteUser.GetName()), testSrv.Addr(), certPool)
+	remoteClient, err := remoteServer.NewRemoteClient(authtest.TestUser(remoteUser.GetName()), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	// User is not authorized to perform any actions
@@ -1265,7 +1275,7 @@ func TestRemoteUser(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fresh client now that trust is established.
-	remoteClient, err = remoteServer.NewRemoteClient(TestUser(remoteUser.GetName()), testSrv.Addr(), certPool)
+	remoteClient, err = remoteServer.NewRemoteClient(authtest.TestUser(remoteUser.GetName()), testSrv.Addr(), certPool)
 	require.NoError(t, err)
 
 	// Validate that the client is not permitted to perform RPCs without a role map.
@@ -1281,7 +1291,7 @@ func TestRemoteUser(t *testing.T) {
 	}
 
 	// Establish trust and map the remote role to the local admin role.
-	_, localRole, err := CreateUserAndRole(testSrv.Auth(), "local-user", []string{"local-role"}, nil)
+	_, localRole, err := authtest.CreateUserAndRole(testSrv.Auth(), "local-user", []string{"local-role"}, nil)
 	require.NoError(t, err)
 
 	err = testSrv.AuthServer.Trust(ctx, remoteServer, types.RoleMap{{Remote: remoteRole.GetName(), Local: []string{localRole.GetName()}}})
@@ -1315,7 +1325,7 @@ func TestNopUser(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	client, err := testSrv.NewClient(TestNop())
+	client, err := testSrv.NewClient(authtest.TestNop())
 	require.NoError(t, err)
 
 	// Nop User can get cluster name
@@ -1337,24 +1347,24 @@ func TestReadOwnRole(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
-	user1, userRole, err := CreateUserAndRoleWithoutRoles(clt, "user1", []string{"user1"})
+	user1, userRole, err := authtest.CreateUserAndRoleWithoutRoles(clt, "user1", []string{"user1"})
 	require.NoError(t, err)
 
-	user2, _, err := CreateUserAndRoleWithoutRoles(clt, "user2", []string{"user2"})
+	user2, _, err := authtest.CreateUserAndRoleWithoutRoles(clt, "user2", []string{"user2"})
 	require.NoError(t, err)
 
 	// user should be able to read their own roles
-	userClient, err := testSrv.NewClient(TestUser(user1.GetName()))
+	userClient, err := testSrv.NewClient(authtest.TestUser(user1.GetName()))
 	require.NoError(t, err)
 
 	_, err = userClient.GetRole(ctx, userRole.GetName())
 	require.NoError(t, err)
 
 	// user2 can't read user1 role
-	userClient2, err := testSrv.NewClient(TestIdentity{I: authz.LocalUser{Username: user2.GetName()}})
+	userClient2, err := testSrv.NewClient(authtest.TestIdentity{I: authz.LocalUser{Username: user2.GetName()}})
 	require.NoError(t, err)
 
 	_, err = userClient2.GetRole(ctx, userRole.GetName())
@@ -1367,10 +1377,10 @@ func TestGetCurrentUser(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	user1, _, err := CreateUserAndRole(srv.Auth(), "user1", []string{"user1"}, nil)
+	user1, _, err := authtest.CreateUserAndRole(srv.Auth(), "user1", []string{"user1"}, nil)
 	require.NoError(t, err)
 
-	client1, err := srv.NewClient(TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
+	client1, err := srv.NewClient(authtest.TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
 	require.NoError(t, err)
 
 	currentUser, err := client1.GetCurrentUser(ctx)
@@ -1396,10 +1406,10 @@ func TestGetCurrentUserRoles(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
 
-	user1, user1Role, err := CreateUserAndRole(srv.Auth(), "user1", []string{"user-role"}, nil)
+	user1, user1Role, err := authtest.CreateUserAndRole(srv.Auth(), "user1", []string{"user-role"}, nil)
 	require.NoError(t, err)
 
-	client1, err := srv.NewClient(TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
+	client1, err := srv.NewClient(authtest.TestIdentity{I: authz.LocalUser{Username: user1.GetName()}})
 	require.NoError(t, err)
 
 	roles, err := client1.GetCurrentUserRoles(ctx)
@@ -1412,7 +1422,7 @@ func TestAuthPreferenceSettings(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -1440,7 +1450,7 @@ func TestTunnelConnectionsCRUD(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
@@ -1455,7 +1465,7 @@ func TestServersCRUD(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
@@ -1470,7 +1480,7 @@ func TestAppServerCRUD(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestBuiltin(types.RoleApp))
+	clt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleApp))
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
@@ -1485,7 +1495,7 @@ func TestUsersCRUD(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	usr, err := types.NewUser("user1")
@@ -1517,7 +1527,7 @@ func TestPasswordGarbage(t *testing.T) {
 		make([]byte, defaults.MinPasswordLength-1),
 	}
 	for _, g := range garbage {
-		_, err := testSrv.Auth().checkPassword(ctx, "user1", g, "123456")
+		err := testSrv.Auth().CheckPassword(ctx, "user1", g, "123456")
 		require.True(t, trace.IsBadParameter(err))
 	}
 }
@@ -1539,7 +1549,7 @@ func TestPasswordCRUD(t *testing.T) {
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, "123456")
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
 	err = testSrv.Auth().UpsertPassword("user1", pass)
@@ -1554,7 +1564,7 @@ func TestPasswordCRUD(t *testing.T) {
 	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
 	require.NoError(t, err)
 
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, validToken)
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 }
 
@@ -1586,7 +1596,7 @@ func TestOTPCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	// a completely invalid token should return access denied
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, "123456")
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, "123456")
 	require.Error(t, err)
 
 	// an invalid token should return access denied
@@ -1598,18 +1608,18 @@ func TestOTPCRUD(t *testing.T) {
 	// invalidity starts at 61 seconds in the future.
 	invalidToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now().Add(61*time.Second))
 	require.NoError(t, err)
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, invalidToken)
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, invalidToken)
 	require.Error(t, err)
 
 	// a valid token (created right now and from a valid key) should return success
 	validToken, err := totp.GenerateCode(otpSecret, testSrv.Clock().Now())
 	require.NoError(t, err)
 
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, validToken)
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
 	require.NoError(t, err)
 
 	// try the same valid token now it should fail because we don't allow re-use of tokens
-	_, err = testSrv.Auth().checkPassword(ctx, "user1", pass, validToken)
+	err = testSrv.Auth().CheckPassword(ctx, "user1", pass, validToken)
 	require.Error(t, err)
 }
 
@@ -1622,16 +1632,16 @@ func TestWebSessionWithoutAccessRequest(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	user := "user1"
 	pass := []byte("abcdef123456")
 
-	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
+	_, _, err = authtest.CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	req := authclient.AuthenticateUserRequest{
@@ -1692,7 +1702,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, clt.Close()) })
 
@@ -1719,7 +1729,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	password := []byte("hunter2hunter2")
 	baseRoleName := services.RoleNameForUser(username)
 	requestableRoleName := "requestable"
-	user, err := CreateUserRoleAndRequestable(clt, username, requestableRoleName)
+	user, err := authtest.CreateUserRoleAndRequestable(clt, username, requestableRoleName)
 	require.NoError(t, err)
 	err = testSrv.Auth().UpsertPassword(username, password)
 	require.NoError(t, err)
@@ -1759,7 +1769,7 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a web session and client for the user.
-	proxyClient, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxyClient, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 	baseWebSession, err := proxyClient.AuthenticateWebUser(ctx, authclient.AuthenticateUserRequest{
 		Username: username,
@@ -1904,18 +1914,18 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	user := "user2"
 	pass := []byte("abcdef123456")
 
-	newUser, err := CreateUserRoleAndRequestable(clt, user, "test-request-role")
+	newUser, err := authtest.CreateUserRoleAndRequestable(clt, user, "test-request-role")
 	require.NoError(t, err)
 	require.Len(t, newUser.GetRoles(), 1)
 	require.Empty(t, cmp.Diff(newUser.GetRoles(), []string{"user:user2"}))
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// Create a user to create a web session for.
@@ -2017,17 +2027,17 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	user := "user2"
 	pass := []byte("abcdef123456")
 
-	newUser, _, err := CreateUserAndRole(clt, user, nil, nil)
+	newUser, _, err := authtest.CreateUserAndRole(clt, user, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, newUser.GetTraits())
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// Create user authn creds and web session.
@@ -2052,7 +2062,7 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	newRoleName := "new-role"
 	newUser.SetLogins([]string{"apple", "banana"})
 	newUser.SetDatabaseUsers([]string{"llama", "alpaca"})
-	_, err = CreateRole(ctx, clt, newRoleName, types.RoleSpecV6{})
+	_, err = authtest.CreateRole(ctx, clt, newRoleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 	newUser.AddRole(newRoleName)
 	_, err = clt.UpdateUser(ctx, newUser)
@@ -2084,21 +2094,21 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	adminClient, err := testSrv.NewClient(TestAdmin())
+	adminClient, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	const user = "user2"
 	const testRequestRole = "test-request-role"
 	pass := []byte("abcdef123456")
 
-	newUser, err := CreateUserRoleAndRequestable(adminClient, user, testRequestRole)
+	newUser, err := authtest.CreateUserRoleAndRequestable(adminClient, user, testRequestRole)
 	require.NoError(t, err)
 	require.Len(t, newUser.GetRoles(), 1)
 
 	require.Len(t, newUser.GetRoles(), 1)
 	require.Empty(t, cmp.Diff(newUser.GetRoles(), []string{"user:user2"}))
 
-	proxyRoleClient, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxyRoleClient, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// Create a user to create a web session for.
@@ -2186,7 +2196,7 @@ func TestGetCertAuthority(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	// generate server keys for node
-	nodeClt, err := testSrv.NewClient(TestIdentity{I: authz.BuiltinRole{Username: "00000000-0000-0000-0000-000000000000", Role: types.RoleNode}})
+	nodeClt, err := testSrv.NewClient(authtest.TestIdentity{I: authz.BuiltinRole{Username: "00000000-0000-0000-0000-000000000000", Role: types.RoleNode}})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, nodeClt.Close()) })
 
@@ -2210,7 +2220,7 @@ func TestGetCertAuthority(t *testing.T) {
 	require.True(t, trace.IsAccessDenied(err))
 
 	// generate server keys for proxy
-	proxyClt, err := testSrv.NewClient(TestIdentity{
+	proxyClt, err := testSrv.NewClient(authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Username: "00000000-0000-0000-0000-000000000001",
 			Role:     types.RoleProxy,
@@ -2261,7 +2271,7 @@ func TestGetCertAuthority(t *testing.T) {
 	user, err = testSrv.Auth().UpsertUser(ctx, user)
 	require.NoError(t, err)
 
-	userClt, err := testSrv.NewClient(TestUser(user.GetName()))
+	userClt, err := testSrv.NewClient(authtest.TestUser(user.GetName()))
 	require.NoError(t, err)
 	defer userClt.Close()
 
@@ -2304,19 +2314,19 @@ func TestPluginData(t *testing.T) {
 
 	user := "user1"
 	role := "some-role"
-	_, err = CreateUserRoleAndRequestable(testSrv.Auth(), user, role)
+	_, err = authtest.CreateUserRoleAndRequestable(testSrv.Auth(), user, role)
 	require.NoError(t, err)
 
-	testUser := TestUser(user)
+	testUser := authtest.TestUser(user)
 	testUser.TTL = time.Hour
 	userClient, err := testSrv.NewClient(testUser)
 	require.NoError(t, err)
 
 	plugin := "my-plugin"
-	_, err = CreateAccessPluginUser(ctx, testSrv.Auth(), plugin)
+	_, err = authtest.CreateAccessPluginUser(ctx, testSrv.Auth(), plugin)
 	require.NoError(t, err)
 
-	pluginUser := TestUser(plugin)
+	pluginUser := authtest.TestUser(plugin)
 	pluginUser.TTL = time.Hour
 	pluginClient, err := testSrv.NewClient(pluginUser)
 	require.NoError(t, err)
@@ -2417,7 +2427,7 @@ func TestGenerateCerts(t *testing.T) {
 
 	// generate server keys for node
 	hostID := "00000000-0000-0000-0000-000000000000"
-	hostClient, err := srv.NewClient(TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
+	hostClient, err := srv.NewClient(authtest.TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
 	require.NoError(t, err)
 
 	certs, err := hostClient.GenerateHostCerts(context.Background(),
@@ -2437,7 +2447,7 @@ func TestGenerateCerts(t *testing.T) {
 
 	// sign server public keys for node
 	hostID = "00000000-0000-0000-0000-000000000000"
-	hostClient, err = srv.NewClient(TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
+	hostClient, err = srv.NewClient(authtest.TestIdentity{I: authz.BuiltinRole{Username: hostID, Role: types.RoleNode}})
 	require.NoError(t, err)
 
 	certs, err = hostClient.GenerateHostCerts(context.Background(),
@@ -2479,15 +2489,15 @@ func TestGenerateCerts(t *testing.T) {
 		require.True(t, trace.IsAccessDenied(err))
 	})
 
-	user1, userRole, err := CreateUserAndRole(srv.Auth(), "user1", []string{"user1"}, nil)
+	user1, userRole, err := authtest.CreateUserAndRole(srv.Auth(), "user1", []string{"user1"}, nil)
 	require.NoError(t, err)
 
-	user2, userRole2, err := CreateUserAndRole(srv.Auth(), "user2", []string{"user2"}, nil)
+	user2, userRole2, err := authtest.CreateUserAndRole(srv.Auth(), "user2", []string{"user2"}, nil)
 	require.NoError(t, err)
 
 	t.Run("Nop", func(t *testing.T) {
 		// unauthenticated client should NOT be able to generate a user cert without auth
-		nopClient, err := srv.NewClient(TestNop())
+		nopClient, err := srv.NewClient(authtest.TestNop())
 		require.NoError(t, err)
 
 		_, err = nopClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
@@ -2501,7 +2511,7 @@ func TestGenerateCerts(t *testing.T) {
 		require.True(t, trace.IsAccessDenied(err), err.Error())
 	})
 
-	testUser2 := TestUser(user2.GetName())
+	testUser2 := authtest.TestUser(user2.GetName())
 	testUser2.TTL = time.Hour
 	userClient2, err := srv.NewClient(testUser2)
 	require.NoError(t, err)
@@ -2548,7 +2558,7 @@ func TestGenerateCerts(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		superImpersonator, err := CreateUser(ctx, srv.Auth(), "superimpersonator", superImpersonatorRole)
+		superImpersonator, err := authtest.CreateUser(ctx, srv.Auth(), "superimpersonator", superImpersonatorRole)
 		require.NoError(t, err)
 
 		// Impersonator can generate certificates for super impersonator
@@ -2562,10 +2572,10 @@ func TestGenerateCerts(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		impersonator, err := CreateUser(ctx, srv.Auth(), "impersonator", role)
+		impersonator, err := authtest.CreateUser(ctx, srv.Auth(), "impersonator", role)
 		require.NoError(t, err)
 
-		iUser := TestUser(impersonator.GetName())
+		iUser := authtest.TestUser(impersonator.GetName())
 		iUser.TTL = time.Hour
 		iClient, err := srv.NewClient(iUser)
 		require.NoError(t, err)
@@ -2649,7 +2659,7 @@ func TestGenerateCerts(t *testing.T) {
 	})
 
 	t.Run("Renew", func(t *testing.T) {
-		testUser2 := TestUser(user2.GetName())
+		testUser2 := authtest.TestUser(user2.GetName())
 		testUser2.TTL = time.Hour
 		userClient2, err := srv.NewClient(testUser2)
 		require.NoError(t, err)
@@ -2685,7 +2695,7 @@ func TestGenerateCerts(t *testing.T) {
 
 	t.Run("Admin", func(t *testing.T) {
 		// Admin should be allowed to generate certs with TTL longer than max.
-		adminClient, err := srv.NewClient(TestAdmin())
+		adminClient, err := srv.NewClient(authtest.TestAdmin())
 		require.NoError(t, err)
 
 		userCerts, err := adminClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
@@ -2799,7 +2809,7 @@ func TestGenerateCerts(t *testing.T) {
 	})
 
 	t.Run("SplitKeys", func(t *testing.T) {
-		testUser2 := TestUser(user2.GetName())
+		testUser2 := authtest.TestUser(user2.GetName())
 		testUser2.TTL = time.Hour
 		userClient2, err := srv.NewClient(testUser2)
 		require.NoError(t, err)
@@ -2887,7 +2897,7 @@ func TestGenerateAppToken(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	authClient, err := testSrv.NewClient(TestBuiltin(types.RoleAdmin))
+	authClient, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
 
 	ca, err := authClient.GetCertAuthority(context.Background(), types.CertAuthID{
@@ -2923,7 +2933,7 @@ func TestGenerateAppToken(t *testing.T) {
 		},
 	}
 	for _, ts := range tests {
-		client, err := testSrv.NewClient(TestBuiltin(ts.inMachineRole))
+		client, err := testSrv.NewClient(authtest.TestBuiltin(ts.inMachineRole))
 		require.NoError(t, err, ts.inComment)
 
 		token, err := client.GenerateAppToken(
@@ -2964,7 +2974,7 @@ func TestCertificateFormat(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	// use admin client to create user and role
-	user, userRole, err := CreateUserAndRole(testSrv.Auth(), "user", []string{"user"}, nil)
+	user, userRole, err := authtest.CreateUserAndRole(testSrv.Auth(), "user", []string{"user"}, nil)
 	require.NoError(t, err)
 
 	pass := []byte("very secure password")
@@ -2997,7 +3007,7 @@ func TestCertificateFormat(t *testing.T) {
 		userRole, err = testSrv.Auth().UpsertRole(ctx, userRole)
 		require.NoError(t, err)
 
-		proxyClient, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+		proxyClient, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 		require.NoError(t, err)
 
 		// authentication attempt fails with password auth only
@@ -3031,7 +3041,7 @@ func TestClusterConfigContext(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	_, pub, err := testauthority.New().GenerateKeyPair()
@@ -3081,7 +3091,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	user := "ws-test"
@@ -3089,7 +3099,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 	rawSecret := "def456"
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
-	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
+	_, _, err = authtest.CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
 
 	err = testSrv.Auth().UpsertPassword(user, pass)
@@ -3104,7 +3114,7 @@ func TestAuthenticateWebUserOTP(t *testing.T) {
 	validToken, err := totp.GenerateCode(otpSecret, clock.Now())
 	require.NoError(t, err)
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
@@ -3166,16 +3176,16 @@ func TestLoginAttempts(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	user := "user1"
 	pass := []byte("abcdef123456")
 
-	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
+	_, _, err = authtest.CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxy, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	err = testSrv.Auth().UpsertPassword(user, pass)
@@ -3235,11 +3245,11 @@ func TestChangeUserAuthenticationSettings(t *testing.T) {
 
 	username := "user1"
 	// Create a local user.
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	t.Run("Reset works when user exists", func(t *testing.T) {
-		_, _, err = CreateUserAndRole(clt, username, []string{"role1"}, nil)
+		_, _, err = authtest.CreateUserAndRole(clt, username, []string{"role1"}, nil)
 		require.NoError(t, err)
 
 		token, err := testSrv.Auth().CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
@@ -3254,7 +3264,7 @@ func TestChangeUserAuthenticationSettings(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, registerSolved, err := NewTestDeviceFromChallenge(res)
+		_, registerSolved, err := authtest.NewTestDeviceFromChallenge(res)
 		require.NoError(t, err)
 
 		_, err = testSrv.Auth().ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{
@@ -3281,7 +3291,7 @@ func TestChangeUserAuthenticationSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			_, registerSolved, err := NewTestDeviceFromChallenge(res)
+			_, registerSolved, err := authtest.NewTestDeviceFromChallenge(res)
 			require.NoError(t, err)
 
 			tokenID = token.GetName()
@@ -3315,9 +3325,9 @@ func TestLoginNoLocalAuth(t *testing.T) {
 	pass := []byte("feefiefoefum")
 
 	// Create a local user.
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
-	_, _, err = CreateUserAndRole(clt, user, []string{user}, nil)
+	_, _, err = authtest.CreateUserAndRole(clt, user, []string{user}, nil)
 	require.NoError(t, err)
 	err = testSrv.Auth().UpsertPassword(user, pass)
 	require.NoError(t, err)
@@ -3364,7 +3374,7 @@ func TestCipherSuites(t *testing.T) {
 	defer otherServer.Close()
 
 	// Create a client with ciphersuites that the server does not support.
-	tlsConfig, err := testSrv.ClientTLSConfig(TestNop())
+	tlsConfig, err := testSrv.ClientTLSConfig(authtest.TestNop())
 	require.NoError(t, err)
 	tlsConfig.CipherSuites = []uint16{
 		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -3400,7 +3410,7 @@ func TestTLSFailover(t *testing.T) {
 	require.NoError(t, err)
 	defer otherServer.Close()
 
-	tlsConfig, err := testSrv.ClientTLSConfig(TestNop())
+	tlsConfig, err := testSrv.ClientTLSConfig(authtest.TestNop())
 	require.NoError(t, err)
 
 	addrs := []string{
@@ -3627,7 +3637,7 @@ func TestClusterAlertAck(t *testing.T) {
 	alert1, err := types.NewClusterAlert("alert-1", "some msg")
 	require.NoError(t, err)
 
-	adminClt, err := testSrv.NewClient(TestBuiltin(types.RoleAdmin))
+	adminClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
 	defer adminClt.Close()
 
@@ -3674,7 +3684,7 @@ func TestClusterAlertClearAckWildcard(t *testing.T) {
 	alert2, err := types.NewClusterAlert("alert-2", "some msg")
 	require.NoError(t, err)
 
-	adminClt, err := testSrv.NewClient(TestBuiltin(types.RoleAdmin))
+	adminClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
 	defer adminClt.Close()
 
@@ -3746,7 +3756,7 @@ func TestClusterAlertAccessControls(t *testing.T) {
 		types.AlertPermitAll: "yes",
 	}
 
-	adminClt, err := testSrv.NewClient(TestBuiltin(types.RoleAdmin))
+	adminClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
 	defer adminClt.Close()
 
@@ -3776,7 +3786,7 @@ func TestClusterAlertAccessControls(t *testing.T) {
 	// verify that some other client with no alert-specific permissions can
 	// see the "permit-all" subset of alerts (using role node here, but any
 	// role with no special provisions for alerts should be equivalent)
-	otherClt, err := testSrv.NewClient(TestBuiltin(types.RoleNode))
+	otherClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNode))
 	require.NoError(t, err)
 	defer otherClt.Close()
 
@@ -3792,7 +3802,7 @@ func TestClusterAlertAccessControls(t *testing.T) {
 	}
 
 	// verify that we still reject unauthenticated clients
-	nopClt, err := testSrv.NewClient(TestBuiltin(types.RoleNop))
+	nopClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNop))
 	require.NoError(t, err)
 	defer nopClt.Close()
 
@@ -3863,7 +3873,7 @@ func TestEventsNodePresence(t *testing.T) {
 		},
 	}
 	node.SetExpiry(time.Now().Add(2 * time.Second))
-	clt, err := testSrv.NewClient(TestIdentity{
+	clt, err := testSrv.NewClient(authtest.TestIdentity{
 		I: authz.BuiltinRole{
 			Role:     types.RoleNode,
 			Username: fmt.Sprintf("%v.%v", node.Metadata.Name, testSrv.ClusterName()),
@@ -3891,7 +3901,7 @@ func TestEventsNodePresence(t *testing.T) {
 	}
 
 	// upsert node and keep alives will fail for users with no privileges
-	nopClt, err := testSrv.NewClient(TestBuiltin(types.RoleNop))
+	nopClt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNop))
 	require.NoError(t, err)
 	defer nopClt.Close()
 
@@ -3926,7 +3936,7 @@ func TestEventsPermissions(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestBuiltin(types.RoleNode))
+	clt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleNode))
 	require.NoError(t, err)
 	defer clt.Close()
 
@@ -3961,29 +3971,29 @@ func TestEventsPermissions(t *testing.T) {
 
 	type testCase struct {
 		name     string
-		identity TestIdentity
+		identity authtest.TestIdentity
 		watches  []types.WatchKind
 	}
 
 	testCases := []testCase{
 		{
 			name:     "node role is not authorized to get certificate authority with secret data loaded",
-			identity: TestBuiltin(types.RoleNode),
+			identity: authtest.TestBuiltin(types.RoleNode),
 			watches:  []types.WatchKind{{Kind: types.KindCertAuthority, LoadSecrets: true}},
 		},
 		{
 			name:     "node role is not authorized to watch static tokens",
-			identity: TestBuiltin(types.RoleNode),
+			identity: authtest.TestBuiltin(types.RoleNode),
 			watches:  []types.WatchKind{{Kind: types.KindStaticTokens}},
 		},
 		{
 			name:     "node role is not authorized to watch provisioning tokens",
-			identity: TestBuiltin(types.RoleNode),
+			identity: authtest.TestBuiltin(types.RoleNode),
 			watches:  []types.WatchKind{{Kind: types.KindToken}},
 		},
 		{
 			name:     "nop role is not authorized to watch users and roles",
-			identity: TestBuiltin(types.RoleNop),
+			identity: authtest.TestBuiltin(types.RoleNop),
 			watches: []types.WatchKind{
 				{Kind: types.KindUser},
 				{Kind: types.KindRole},
@@ -3991,12 +4001,12 @@ func TestEventsPermissions(t *testing.T) {
 		},
 		{
 			name:     "nop role is not authorized to watch cert authorities",
-			identity: TestBuiltin(types.RoleNop),
+			identity: authtest.TestBuiltin(types.RoleNop),
 			watches:  []types.WatchKind{{Kind: types.KindCertAuthority, LoadSecrets: false}},
 		},
 		{
 			name:     "nop role is not authorized to watch cluster config resources",
-			identity: TestBuiltin(types.RoleNop),
+			identity: authtest.TestBuiltin(types.RoleNop),
 			watches: []types.WatchKind{
 				{Kind: types.KindClusterAuthPreference},
 				{Kind: types.KindClusterNetworkingConfig},
@@ -4085,13 +4095,13 @@ func TestEventsPermissionsPartialSuccess(t *testing.T) {
 
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
-	testUser, testRole, err := CreateUserAndRole(testSrv.Auth(), "test", nil, []types.Rule{
+	testUser, testRole, err := authtest.CreateUserAndRole(testSrv.Auth(), "test", nil, []types.Rule{
 		types.NewRule(types.KindStaticTokens, services.RO()),
 	})
 	require.NoError(t, err)
 	_, err = testSrv.Auth().UpsertRole(ctx, testRole)
 	require.NoError(t, err)
-	testIdentity := TestUser(testUser.GetName())
+	testIdentity := authtest.TestUser(testUser.GetName())
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4131,7 +4141,7 @@ func TestEvents(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
@@ -4154,7 +4164,7 @@ func TestEventsClusterConfig(t *testing.T) {
 	ctx := context.Background()
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestBuiltin(types.RoleAdmin))
+	clt, err := testSrv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
 	require.NoError(t, err)
 	defer clt.Close()
 
@@ -4282,7 +4292,7 @@ func TestNetworkRestrictions(t *testing.T) {
 
 	testSrv := newTestTLSServer(t)
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	clt, err := testSrv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
@@ -4348,7 +4358,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 	testSrv.Auth().SetEmitter(mockEmitter)
 
 	// Create a user with the least privilege access to call this RPC.
-	privilegedUser, _, err := CreateUserAndRole(
+	privilegedUser, _, err := authtest.CreateUserAndRole(
 		testSrv.Auth(), "token-creator", nil, []types.Rule{
 			{
 				Resources: []string{types.KindToken},
@@ -4366,7 +4376,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		identity TestIdentity
+		identity authtest.TestIdentity
 		token    types.ProvisionToken
 
 		requireTokenCreated bool
@@ -4375,7 +4385,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 	}{
 		{
 			name:     "success",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token: mustNewTokenFromSpec(
 				t,
 				"success",
@@ -4408,7 +4418,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 		},
 		{
 			name:     "success (trusted cluster)",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token: mustNewTokenFromSpec(
 				t,
 				"success-trusted-cluster",
@@ -4441,7 +4451,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 		},
 		{
 			name:     "access denied",
-			identity: TestNop(),
+			identity: authtest.TestNop(),
 			token: mustNewToken(
 				t, "access denied", types.SystemRoles{types.RoleNode}, time.Time{},
 			),
@@ -4449,7 +4459,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 		},
 		{
 			name:     "already exists",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token:    alreadyExistsToken,
 			requireError: func(t require.TestingT, err error, i ...any) {
 				require.True(
@@ -4461,7 +4471,7 @@ func TestGRPCServer_CreateTokenV2(t *testing.T) {
 		},
 		{
 			name:         "invalid token",
-			identity:     TestUser(privilegedUser.GetName()),
+			identity:     authtest.TestUser(privilegedUser.GetName()),
 			token:        &types.ProvisionTokenV2{},
 			requireError: requireBadParameter,
 		},
@@ -4507,7 +4517,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 	testSrv.Auth().SetEmitter(mockEmitter)
 
 	// Create a user with the least privilege access to call this RPC.
-	privilegedUser, _, err := CreateUserAndRole(
+	privilegedUser, _, err := authtest.CreateUserAndRole(
 		testSrv.Auth(), "token-upserter", nil, []types.Rule{
 			{
 				Resources: []string{types.KindToken},
@@ -4525,7 +4535,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		identity TestIdentity
+		identity authtest.TestIdentity
 		token    types.ProvisionToken
 
 		requireTokenCreated bool
@@ -4534,7 +4544,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 	}{
 		{
 			name:     "success",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token: mustNewTokenFromSpec(
 				t,
 				"success",
@@ -4567,7 +4577,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 		},
 		{
 			name:     "success (trusted cluster)",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token: mustNewTokenFromSpec(
 				t,
 				"success-trusted-cluster",
@@ -4600,7 +4610,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 		},
 		{
 			name:     "existing token replaced",
-			identity: TestUser(privilegedUser.GetName()),
+			identity: authtest.TestUser(privilegedUser.GetName()),
 			token: mustNewTokenFromSpec(
 				t,
 				alreadyExistsToken.GetName(),
@@ -4635,7 +4645,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 		},
 		{
 			name:     "access denied",
-			identity: TestNop(),
+			identity: authtest.TestNop(),
 			token: mustNewToken(
 				t, "access denied", types.SystemRoles{types.RoleNode}, time.Time{},
 			),
@@ -4643,7 +4653,7 @@ func TestGRPCServer_UpsertTokenV2(t *testing.T) {
 		},
 		{
 			name:         "invalid token",
-			identity:     TestUser(privilegedUser.GetName()),
+			identity:     authtest.TestUser(privilegedUser.GetName()),
 			token:        &types.ProvisionTokenV2{},
 			requireError: requireBadParameter,
 		},
@@ -4684,7 +4694,7 @@ func TestGRPCServer_GetTokens(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	// Create a user with the least privilege access to call this RPC.
-	privilegedUser, _, err := CreateUserAndRole(
+	privilegedUser, _, err := authtest.CreateUserAndRole(
 		testSrv.Auth(), "token-reader", nil, []types.Rule{
 			{
 				Resources: []string{types.KindToken},
@@ -4695,7 +4705,7 @@ func TestGRPCServer_GetTokens(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("no extra tokens", func(t *testing.T) {
-		client, err := testSrv.NewClient(TestUser(privilegedUser.GetName()))
+		client, err := testSrv.NewClient(authtest.TestUser(privilegedUser.GetName()))
 		require.NoError(t, err)
 		toks, err := client.GetTokens(ctx)
 		require.NoError(t, err)
@@ -4731,20 +4741,20 @@ func TestGRPCServer_GetTokens(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		identity TestIdentity
+		identity authtest.TestIdentity
 
 		requireResponse bool
 		requireError    require.ErrorAssertionFunc
 	}{
 		{
 			name:            "success",
-			identity:        TestUser(privilegedUser.GetName()),
+			identity:        authtest.TestUser(privilegedUser.GetName()),
 			requireError:    require.NoError,
 			requireResponse: true,
 		},
 		{
 			name:         "access denied",
-			identity:     TestNop(),
+			identity:     authtest.TestNop(),
 			requireError: requireAccessDenied,
 		},
 	}
@@ -4776,7 +4786,7 @@ func TestGRPCServer_GetToken(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	// Create a user with the least privilege access to call this RPC.
-	privilegedUser, _, err := CreateUserAndRole(
+	privilegedUser, _, err := authtest.CreateUserAndRole(
 		testSrv.Auth(), "token-reader", nil, []types.Rule{
 			{
 				Resources: []string{types.KindToken},
@@ -4793,7 +4803,7 @@ func TestGRPCServer_GetToken(t *testing.T) {
 	tests := []struct {
 		name      string
 		tokenName string
-		identity  TestIdentity
+		identity  authtest.TestIdentity
 
 		requireResponse bool
 		requireError    require.ErrorAssertionFunc
@@ -4801,20 +4811,20 @@ func TestGRPCServer_GetToken(t *testing.T) {
 		{
 			name:            "success",
 			tokenName:       pt.GetName(),
-			identity:        TestUser(privilegedUser.GetName()),
+			identity:        authtest.TestUser(privilegedUser.GetName()),
 			requireError:    require.NoError,
 			requireResponse: true,
 		},
 		{
 			name:         "access denied",
-			identity:     TestNop(),
+			identity:     authtest.TestNop(),
 			tokenName:    pt.GetName(),
 			requireError: requireAccessDenied,
 		},
 		{
 			name:         "not found",
 			tokenName:    "does-not-exist",
-			identity:     TestUser(privilegedUser.GetName()),
+			identity:     authtest.TestUser(privilegedUser.GetName()),
 			requireError: requireNotFound,
 		},
 	}
@@ -4846,7 +4856,7 @@ func TestGRPCServer_DeleteToken(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 
 	// Create a user with the least privilege access to call this RPC.
-	privilegedUser, _, err := CreateUserAndRole(
+	privilegedUser, _, err := authtest.CreateUserAndRole(
 		testSrv.Auth(), "token-deleter", nil, []types.Rule{
 			{
 				Resources: []string{types.KindToken},
@@ -4863,7 +4873,7 @@ func TestGRPCServer_DeleteToken(t *testing.T) {
 	tests := []struct {
 		name      string
 		tokenName string
-		identity  TestIdentity
+		identity  authtest.TestIdentity
 
 		requireTokenDeleted bool
 		requireError        require.ErrorAssertionFunc
@@ -4871,20 +4881,20 @@ func TestGRPCServer_DeleteToken(t *testing.T) {
 		{
 			name:                "success",
 			tokenName:           pt.GetName(),
-			identity:            TestUser(privilegedUser.GetName()),
+			identity:            authtest.TestUser(privilegedUser.GetName()),
 			requireError:        require.NoError,
 			requireTokenDeleted: true,
 		},
 		{
 			name:         "access denied",
-			identity:     TestNop(),
+			identity:     authtest.TestNop(),
 			tokenName:    pt.GetName(),
 			requireError: requireAccessDenied,
 		},
 		{
 			name:         "not found",
 			tokenName:    "does-not-exist",
-			identity:     TestUser(privilegedUser.GetName()),
+			identity:     authtest.TestUser(privilegedUser.GetName()),
 			requireError: requireNotFound,
 		},
 	}
@@ -4976,7 +4986,7 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 
 type testTLSServerOptions struct {
 	cacheEnabled bool
-	accessGraph  *AccessGraphConfig
+	accessGraph  *auth.AccessGraphConfig
 	clock        clockwork.Clock
 }
 
@@ -4988,7 +4998,7 @@ func withCacheEnabled(enabled bool) testTLSServerOption {
 	}
 }
 
-func withAccessGraphConfig(cfg AccessGraphConfig) testTLSServerOption {
+func withAccessGraphConfig(cfg auth.AccessGraphConfig) testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.accessGraph = &cfg
 	}
@@ -5000,12 +5010,12 @@ func withClock(clock clockwork.Clock) testTLSServerOption {
 	}
 }
 
-// newTestTLSServer is a helper that returns a *TestTLSServer with sensible
+// newTestTLSServer is a helper that returns a *authtest.TestTLSServer with sensible
 // defaults for most tests that are exercising Auth Service RPCs.
 //
 // For more advanced use-cases, call NewTestAuthServer and NewTestTLSServer
 // to provide a more detailed configuration.
-func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *TestTLSServer {
+func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TestTLSServer {
 	var options testTLSServerOptions
 	for _, opt := range opts {
 		opt(&options)
@@ -5013,15 +5023,15 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *TestTLSServer 
 	if options.clock == nil {
 		options.clock = clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
 	}
-	as, err := NewTestAuthServer(TestAuthServerConfig{
+	as, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		Dir:          t.TempDir(),
 		Clock:        options.clock,
 		CacheEnabled: options.cacheEnabled,
 	})
 	require.NoError(t, err)
-	var tlsServerOpts []TestTLSServerOption
+	var tlsServerOpts []authtest.TestTLSServerOption
 	if options.accessGraph != nil {
-		tlsServerOpts = append(tlsServerOpts, WithAccessGraphConfig(*options.accessGraph))
+		tlsServerOpts = append(tlsServerOpts, authtest.WithAccessGraphConfig(*options.accessGraph))
 	}
 	srv, err := as.NewTestTLSServer(tlsServerOpts...)
 	require.NoError(t, err)
@@ -5199,7 +5209,7 @@ func TestVerifyPeerCert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			verify := caPool.verifyPeerCert()
+			verify := caPool.VerifyPeerCert()
 			err := verify(nil, [][]*x509.Certificate{{tt.peer}})
 			if tt.wantErr {
 				require.ErrorContains(t, err, "access denied: invalid client certificate")
@@ -5210,8 +5220,8 @@ func TestVerifyPeerCert(t *testing.T) {
 	}
 }
 
-func buildPoolInfo(t *testing.T, ca ...types.CertAuthority) *HostAndUserCAPoolInfo {
-	poolInfo := HostAndUserCAPoolInfo{
+func buildPoolInfo(t *testing.T, ca ...types.CertAuthority) *auth.HostAndUserCAPoolInfo {
+	poolInfo := auth.HostAndUserCAPoolInfo{
 		Pool:    x509.NewCertPool(),
 		CATypes: make(authclient.HostAndUserCAInfo),
 	}

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -125,9 +125,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 func TestRefreshRemoteClusters(t *testing.T) {
 	ctx := context.Background()
 
-	auth.RemoteClusterRefreshLimit = 10
-	auth.RemoteClusterRefreshBuckets = 5
-
 	tests := []struct {
 		name               string
 		clustersTotal      int
@@ -165,6 +162,8 @@ func TestRefreshRemoteClusters(t *testing.T) {
 			require.LessOrEqual(t, tt.clustersNeedUpdate, tt.clustersTotal)
 
 			a := newTestAuthServer(ctx, t)
+			a.SetRemoteClusterRefreshLimit(10)
+			a.RemoteClusterRefreshBuckets(5)
 
 			allClusters := make(map[string]types.RemoteCluster)
 			for i := range tt.clustersTotal {

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -32,9 +32,13 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
@@ -52,7 +56,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 	// This scenario deals with only one remote cluster, so it never hits the limit on status updates.
 	// TestRefreshRemoteClusters focuses on verifying the update limit logic.
-	a.refreshRemoteClusters(ctx)
+	a.RefreshRemoteClusters(ctx)
 
 	wantRC := rc
 	// Initially, no tunnels exist and status should be "offline".
@@ -62,7 +66,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.Empty(t, cmp.Diff(wantRC, gotRC, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 	// Create several tunnel connections.
-	lastHeartbeat := a.clock.Now().UTC()
+	lastHeartbeat := a.GetClock().Now().UTC()
 	tc1, err := types.NewTunnelConnection("conn-1", types.TunnelConnectionSpecV2{
 		ClusterName:   rc.GetName(),
 		ProxyName:     "proxy-1",
@@ -82,7 +86,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, a.UpsertTunnelConnection(tc2))
 
-	a.refreshRemoteClusters(ctx)
+	a.RefreshRemoteClusters(ctx)
 
 	// With active tunnels, the status is "online" and last_heartbeat is set to
 	// the latest tunnel heartbeat.
@@ -95,7 +99,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// Delete the latest connection.
 	require.NoError(t, a.DeleteTunnelConnection(tc2.GetClusterName(), tc2.GetName()))
 
-	a.refreshRemoteClusters(ctx)
+	a.RefreshRemoteClusters(ctx)
 
 	// The status should remain the same, since tc1 still exists.
 	// The last_heartbeat should remain the same, since tc1 has an older
@@ -108,7 +112,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	// Delete the remaining connection
 	require.NoError(t, a.DeleteTunnelConnection(tc1.GetClusterName(), tc1.GetName()))
 
-	a.refreshRemoteClusters(ctx)
+	a.RefreshRemoteClusters(ctx)
 
 	// The status should switch to "offline".
 	// The last_heartbeat should remain the same.
@@ -121,8 +125,8 @@ func TestRemoteClusterStatus(t *testing.T) {
 func TestRefreshRemoteClusters(t *testing.T) {
 	ctx := context.Background()
 
-	remoteClusterRefreshLimit = 10
-	remoteClusterRefreshBuckets = 5
+	auth.RemoteClusterRefreshLimit = 10
+	auth.RemoteClusterRefreshBuckets = 5
 
 	tests := []struct {
 		name               string
@@ -172,7 +176,7 @@ func TestRefreshRemoteClusters(t *testing.T) {
 				allClusters[rc.GetName()] = rc
 
 				if i < tt.clustersNeedUpdate {
-					lastHeartbeat := a.clock.Now().UTC()
+					lastHeartbeat := a.GetClock().Now().UTC()
 					tc, err := types.NewTunnelConnection(fmt.Sprintf("conn-%03d", i), types.TunnelConnectionSpecV2{
 						ClusterName:   rc.GetName(),
 						ProxyName:     fmt.Sprintf("proxy-%03d", i),
@@ -184,7 +188,7 @@ func TestRefreshRemoteClusters(t *testing.T) {
 				}
 			}
 
-			a.refreshRemoteClusters(ctx)
+			a.RefreshRemoteClusters(ctx)
 
 			clusters, err := a.GetRemoteClusters(ctx)
 			require.NoError(t, err)
@@ -207,7 +211,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	const validToken = "validtoken"
 	ctx := context.Background()
 
-	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		ClusterName: localClusterName,
 		Dir:         t.TempDir(),
 	})
@@ -226,7 +230,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("invalid cluster token", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: "invalidtoken",
 			CAs:   []types.CertAuthority{},
 		})
@@ -235,7 +239,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("missing CA", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs:   []types.CertAuthority{},
 		})
@@ -244,7 +248,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("more than one CA", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs: []types.CertAuthority{
 				suite.NewTestCA(types.HostCA, "rc1"),
@@ -256,7 +260,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("wrong CA type", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs: []types.CertAuthority{
 				suite.NewTestCA(types.UserCA, "rc3"),
@@ -267,7 +271,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("wrong CA name", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs: []types.CertAuthority{
 				suite.NewTestCA(types.HostCA, localClusterName),
@@ -286,7 +290,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 		_, err = a.Services.UpsertTrustedCluster(ctx, trustedCluster)
 		require.NoError(t, err)
 
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs: []types.CertAuthority{
 				suite.NewTestCA(types.HostCA, trustedCluster.GetName()),
@@ -298,7 +302,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 
 	t.Run("all CAs are returned when v10+", func(t *testing.T) {
 		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-1"))
-		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		resp, err := a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},
 			TeleportVersion: teleport.Version,
@@ -363,7 +367,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 		require.Equal(t, localClusterName, osshCAs[0].GetName())
 
 		// verify that we reject an attempt to re-register the leaf cluster
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs:   []types.CertAuthority{leafClusterCA},
 		})
@@ -373,7 +377,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 
 	t.Run("Host User and Database CA are returned by default", func(t *testing.T) {
 		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-2"))
-		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		resp, err := a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},
 			TeleportVersion: "",
@@ -397,13 +401,13 @@ func TestValidateTrustedCluster(t *testing.T) {
 			CAs:   []types.CertAuthority{},
 		}
 
-		server := ServerWithRoles{authServer: a}
+		server := auth.NewServerWithRoles(a, events.NewDiscardAuditLog(), authz.Context{})
 		_, err := server.ValidateTrustedCluster(ctx, req)
 		require.True(t, trace.IsNotImplemented(err), "ValidateTrustedCluster returned an unexpected error, got = %v (%T), want trace.NotImplementedError", err, err)
 	})
 
 	t.Run("CA cluster name does not match subject organization", func(t *testing.T) {
-		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+		_, err = a.ValidateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token: validToken,
 			CAs: []types.CertAuthority{
 				suite.NewTestCAWithConfig(suite.TestCAConfig{
@@ -418,7 +422,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 }
 
-func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Server {
+func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *auth.Server {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 
@@ -431,14 +435,14 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 		ClusterName: clusterName,
 	})
 	require.NoError(t, err)
-	authConfig := &InitConfig{
+	authConfig := &auth.InitConfig{
 		ClusterName:            clusterNameRes,
 		Backend:                bk,
-		VersionStorage:         NewFakeTeleportVersion(),
+		VersionStorage:         authtest.NewFakeTeleportVersion(),
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	a, err := NewServer(authConfig)
+	a, err := auth.NewServer(authConfig)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -458,7 +462,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 
 func TestUpsertTrustedCluster(t *testing.T) {
 	ctx := context.Background()
-	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		ClusterName: "localcluster",
 		Dir:         t.TempDir(),
 	})
@@ -498,12 +502,12 @@ func TestUpsertTrustedCluster(t *testing.T) {
 
 	ca := suite.NewTestCA(types.UserCA, "trustedcluster")
 
-	configureCAsForTrustedCluster(trustedCluster, []types.CertAuthority{ca})
+	auth.ConfigureCAsForTrustedCluster(trustedCluster, []types.CertAuthority{ca})
 
 	_, err = a.Services.CreateTrustedCluster(ctx, trustedCluster, []types.CertAuthority{ca})
 	require.NoError(t, err)
 
-	err = a.createReverseTunnel(ctx, trustedCluster)
+	err = a.CreateReverseTunnel(ctx, trustedCluster)
 	require.NoError(t, err)
 
 	t.Run("Invalid role change", func(t *testing.T) {
@@ -596,7 +600,7 @@ func TestUpsertTrustedCluster(t *testing.T) {
 
 func TestUpdateTrustedCluster(t *testing.T) {
 	ctx := context.Background()
-	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
+	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
 		ClusterName: "localcluster",
 		Dir:         t.TempDir(),
 	})
@@ -637,12 +641,12 @@ func TestUpdateTrustedCluster(t *testing.T) {
 
 	ca := suite.NewTestCA(types.UserCA, testClusterName)
 
-	configureCAsForTrustedCluster(trustedCluster, []types.CertAuthority{ca})
+	auth.ConfigureCAsForTrustedCluster(trustedCluster, []types.CertAuthority{ca})
 
 	_, err = a.Services.CreateTrustedCluster(ctx, trustedCluster, []types.CertAuthority{ca})
 	require.NoError(t, err)
 
-	err = a.createReverseTunnel(ctx, trustedCluster)
+	err = a.CreateReverseTunnel(ctx, trustedCluster)
 	require.NoError(t, err)
 
 	t.Run("Invalid role change", func(t *testing.T) {

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -210,7 +210,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	const validToken = "validtoken"
 	ctx := context.Background()
 
-	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: localClusterName,
 		Dir:         t.TempDir(),
 	})
@@ -461,7 +461,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *auth.
 
 func TestUpsertTrustedCluster(t *testing.T) {
 	ctx := context.Background()
-	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",
 		Dir:         t.TempDir(),
 	})
@@ -599,7 +599,7 @@ func TestUpsertTrustedCluster(t *testing.T) {
 
 func TestUpdateTrustedCluster(t *testing.T) {
 	ctx := context.Background()
-	testAuth, err := authtest.NewTestAuthServer(authtest.TestAuthServerConfig{
+	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "localcluster",
 		Dir:         t.TempDir(),
 	})

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package auth_test
 
 import (
 	"context"
@@ -37,7 +37,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -48,7 +50,7 @@ func TestCreateResetPasswordToken(t *testing.T) {
 	t.Parallel()
 	srv := newTestTLSServer(t)
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 
 	// Configure cluster and user for MFA, registering various devices.
 	mfa := configureForMFA(t, srv)
@@ -77,7 +79,7 @@ func TestCreateResetPasswordToken(t *testing.T) {
 	require.Empty(t, devs)
 
 	// verify that password was reset
-	err = srv.Auth().checkPasswordWOToken(ctx, username, []byte(pass))
+	err = srv.Auth().CheckPasswordWOToken(ctx, username, []byte(pass))
 	require.Error(t, err)
 
 	// create another reset token for the same user
@@ -97,7 +99,7 @@ func TestCreateResetPasswordTokenErrors(t *testing.T) {
 	ctx := context.Background()
 
 	username := "joe@example.com"
-	_, _, err := CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -217,7 +219,7 @@ func TestFormatAccountName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			accountName, err := formatAccountName(tt.inDebugAuth, "foo", "00000000-0000-0000-0000-000000000000")
+			accountName, err := auth.FormatAccountName(tt.inDebugAuth, "foo", "00000000-0000-0000-0000-000000000000")
 			tt.outError(t, err)
 			require.Equal(t, accountName, tt.outAccountName)
 		})
@@ -229,7 +231,7 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	username := "joe@example.com"
-	_, _, err := CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -263,7 +265,7 @@ func TestUserTokenCreationSettings(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	username := "joe@example.com"
-	_, _, err := CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
+	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
 	require.NoError(t, err)
 
 	req := authclient.CreateUserTokenRequest{
@@ -272,7 +274,7 @@ func TestUserTokenCreationSettings(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPasswordInvite,
 	}
 
-	token, err := srv.Auth().newUserToken(req)
+	token, err := srv.Auth().NewUserToken(req)
 	require.NoError(t, err)
 	require.Equal(t, req.Name, token.GetUser())
 	require.Equal(t, req.Type, token.GetSubKind())
@@ -286,14 +288,14 @@ func TestCreatePrivilegeToken(t *testing.T) {
 	srv := newTestTLSServer(t)
 	fakeClock := srv.Clock().(*clockwork.FakeClock)
 	mockEmitter := &eventstest.MockRecorderEmitter{}
-	srv.Auth().emitter = mockEmitter
+	srv.Auth().SetEmitter(mockEmitter)
 	ctx := context.Background()
 
 	// Create a user and client with identity.
 	username := "joe@example.com"
-	_, _, err := CreateUserAndRoleWithoutRoles(srv.Auth(), username, []string{username})
+	_, _, err := authtest.CreateUserAndRoleWithoutRoles(srv.Auth(), username, []string{username})
 	require.NoError(t, err)
-	clt, err := srv.NewClient(TestUser(username))
+	clt, err := srv.NewClient(authtest.TestUser(username))
 	require.NoError(t, err)
 
 	// Test a failure when second factor isn't enabled.
@@ -416,9 +418,9 @@ func TestCreatePrivilegeToken_WithLock(t *testing.T) {
 
 			// Create a user and client with identity.
 			username := fmt.Sprintf("llama%v@goteleport.com", rand.Int())
-			_, _, err := CreateUserAndRoleWithoutRoles(srv.Auth(), username, []string{username})
+			_, _, err := authtest.CreateUserAndRoleWithoutRoles(srv.Auth(), username, []string{username})
 			require.NoError(t, err)
-			clt, err := srv.NewClient(TestUser(username))
+			clt, err := srv.NewClient(authtest.TestUser(username))
 			require.NoError(t, err)
 
 			// Test lock from max failed auth attempts.
@@ -428,9 +430,9 @@ func TestCreatePrivilegeToken_WithLock(t *testing.T) {
 
 				// Test last attempt returns locked error.
 				if i == defaults.MaxLoginAttempts {
-					require.Equal(t, MaxFailedAttemptsErrMsg, err.Error())
+					require.Equal(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 				} else {
-					require.NotEqual(t, MaxFailedAttemptsErrMsg, err.Error())
+					require.NotEqual(t, auth.MaxFailedAttemptsErrMsg, err.Error())
 				}
 			}
 

--- a/lib/authz/export_test.go
+++ b/lib/authz/export_test.go
@@ -1,0 +1,30 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package authz
+
+// The items exported here exist solely to prevent import cycles and facilitate
+// preexisting tests in lib/authz which relied on unexported items. All new
+// tests in lib/authz should exist in the authz_test package and not rely on
+// internal state.
+
+func DisableContextDeviceRoleMode(ctx *Context) {
+	ctx.disableDeviceRoleMode = true
+}
+
+func ContextDeviceRoleMode(ctx *Context) bool {
+	return ctx.disableDeviceRoleMode
+}

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package authz
+package authz_test
 
 import (
 	"context"
@@ -41,6 +41,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
@@ -125,7 +127,7 @@ func TestGetDisconnectExpiredCertFromIdentity(t *testing.T) {
 			authPref := types.DefaultAuthPreference()
 			authPref.SetDisconnectExpiredCert(test.disconnectExpiredCert)
 
-			ctx := Context{Checker: test.checker, Identity: WrapIdentity(identity)}
+			ctx := authz.Context{Checker: test.checker, Identity: authz.WrapIdentity(identity)}
 
 			got := ctx.GetDisconnectCertExpiry(authPref)
 			require.Equal(t, test.expected, got)
@@ -203,8 +205,8 @@ func TestContextLockTargets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.role.String(), func(t *testing.T) {
-			authContext := &Context{
-				Identity: BuiltinRole{
+			authContext := &authz.Context{
+				Identity: authz.BuiltinRole{
 					Role:        tt.role,
 					ClusterName: "cluster",
 					Identity: tlsca.Identity{
@@ -215,7 +217,7 @@ func TestContextLockTargets(t *testing.T) {
 						},
 					},
 				},
-				UnmappedIdentity: WrapIdentity(tlsca.Identity{
+				UnmappedIdentity: authz.WrapIdentity(tlsca.Identity{
 					Username: "node.cluster",
 					Groups:   []string{"mapped-role"},
 				}),
@@ -231,9 +233,9 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 
 	client, watcher, authorizer := newTestResources(t)
 
-	user, role, err := createUserAndRole(client, "test-user", []string{}, nil)
+	user, role, err := authtest.CreateUserAndRole(client, "test-user", []string{}, nil)
 	require.NoError(t, err)
-	localUser := LocalUser{
+	localUser := authz.LocalUser{
 		Username: user.GetName(),
 		Identity: tlsca.Identity{
 			Username:       user.GetName(),
@@ -250,13 +252,13 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	require.NoError(t, err)
 	upsertLockWithPutEvent(ctx, t, client, watcher, mfaLock)
 
-	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
+	_, err = authorizer.Authorize(authz.ContextWithUser(ctx, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Remove the MFA record from the user value being authorized.
 	localUser.Identity.MFAVerified = ""
-	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
+	_, err = authorizer.Authorize(authz.ContextWithUser(ctx, localUser))
 	require.NoError(t, err)
 
 	// Add an access request lock.
@@ -267,13 +269,13 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	upsertLockWithPutEvent(ctx, t, client, watcher, requestLock)
 
 	// localUser's identity with a locked access request is locked out.
-	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
+	_, err = authorizer.Authorize(authz.ContextWithUser(ctx, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 
 	// Not locked out without the request.
 	localUser.Identity.ActiveRequests = nil
-	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
+	_, err = authorizer.Authorize(authz.ContextWithUser(ctx, localUser))
 	require.NoError(t, err)
 
 	// Create a lock targeting the role written in the user's identity.
@@ -283,7 +285,7 @@ func TestAuthorizeWithLocksForLocalUser(t *testing.T) {
 	require.NoError(t, err)
 	upsertLockWithPutEvent(ctx, t, client, watcher, roleLock)
 
-	_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, localUser))
+	_, err = authorizer.Authorize(authz.ContextWithUser(ctx, localUser))
 	require.Error(t, err)
 	require.True(t, trace.IsAccessDenied(err))
 }
@@ -295,7 +297,7 @@ func TestAuthorizeWithLocksForBuiltinRole(t *testing.T) {
 	client, watcher, authorizer := newTestResources(t)
 	for _, role := range types.LocalServiceMappings() {
 		t.Run(role.String(), func(t *testing.T) {
-			builtinRole := BuiltinRole{
+			builtinRole := authz.BuiltinRole{
 				Username: "node",
 				Role:     role,
 				Identity: tlsca.Identity{
@@ -310,12 +312,12 @@ func TestAuthorizeWithLocksForBuiltinRole(t *testing.T) {
 			require.NoError(t, err)
 			upsertLockWithPutEvent(ctx, t, client, watcher, nodeLock)
 
-			_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, builtinRole))
+			_, err = authorizer.Authorize(authz.ContextWithUser(ctx, builtinRole))
 			require.Error(t, err)
 			require.True(t, trace.IsAccessDenied(err))
 
 			builtinRole.Identity.Username = ""
-			_, err = authorizer.Authorize(context.WithValue(ctx, contextUser, builtinRole))
+			_, err = authorizer.Authorize(authz.ContextWithUser(ctx, builtinRole))
 			require.NoError(t, err)
 		})
 	}
@@ -344,7 +346,7 @@ func upsertLockWithPutEvent(ctx context.Context, t *testing.T, client *testClien
 func TestGetClientUserIsSSO(t *testing.T) {
 	ctx := context.Background()
 
-	u := LocalUser{
+	u := authz.LocalUser{
 		Username: "someuser",
 		Identity: tlsca.Identity{
 			Username: "someuser",
@@ -353,16 +355,16 @@ func TestGetClientUserIsSSO(t *testing.T) {
 	}
 
 	// Non SSO user must return false
-	nonSSOUserCtx := context.WithValue(ctx, contextUser, u)
+	nonSSOUserCtx := authz.ContextWithUser(ctx, u)
 
-	isSSO, err := GetClientUserIsSSO(nonSSOUserCtx)
+	isSSO, err := authz.GetClientUserIsSSO(nonSSOUserCtx)
 	require.NoError(t, err)
 	require.False(t, isSSO, "expected a non-SSO user")
 
 	// An SSO user must return true
 	u.Identity.UserType = types.UserTypeSSO
-	ssoUserCtx := context.WithValue(ctx, contextUser, u)
-	localUserIsSSO, err := GetClientUserIsSSO(ssoUserCtx)
+	ssoUserCtx := authz.ContextWithUser(ctx, u)
+	localUserIsSSO, err := authz.GetClientUserIsSSO(ssoUserCtx)
 	require.NoError(t, err)
 	require.True(t, localUserIsSSO, "expected an SSO user")
 }
@@ -372,10 +374,10 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 
 	ctx := context.Background()
 
-	user, role, err := createUserAndRole(client, "llama", []string{"llama"}, nil)
+	user, role, err := authtest.CreateUserAndRole(client, "llama", []string{"llama"}, nil)
 	require.NoError(t, err, "CreateUserAndRole")
 
-	userWithoutExtensions := LocalUser{
+	userWithoutExtensions := authz.LocalUser{
 		Username: user.GetName(),
 		Identity: tlsca.Identity{
 			Username:   user.GetName(),
@@ -398,8 +400,8 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 	tests := []struct {
 		name                 string
 		deviceMode           string
-		deviceAuthz          DeviceAuthorizationOpts // aka AuthorizerOpts.DeviceAuthorization
-		user                 IdentityGetter
+		deviceAuthz          authz.DeviceAuthorizationOpts // aka AuthorizerOpts.DeviceAuthorization
+		user                 authz.IdentityGetter
 		wantErr              string
 		wantCtxAuthnDisabled bool // defaults to deviceAuthz.disableDeviceRoleMode
 	}{
@@ -417,7 +419,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 		{
 			name:       "global mode disabled only",
 			deviceMode: constants.DeviceTrustModeRequired,
-			deviceAuthz: DeviceAuthorizationOpts{
+			deviceAuthz: authz.DeviceAuthorizationOpts{
 				DisableGlobalMode: true,
 			},
 			user: userWithoutExtensions,
@@ -425,7 +427,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 		{
 			name:       "global and role modes disabled",
 			deviceMode: constants.DeviceTrustModeRequired,
-			deviceAuthz: DeviceAuthorizationOpts{
+			deviceAuthz: authz.DeviceAuthorizationOpts{
 				DisableGlobalMode: true,
 				DisableRoleMode:   true,
 			},
@@ -438,7 +440,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 		},
 		{
 			name: "BuiltinRole: context always disabled",
-			user: BuiltinRole{
+			user: authz.BuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
 				ClusterName: clusterName,
@@ -448,11 +450,11 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 		},
 		{
 			name: "BuiltinRole: device authorization disabled",
-			deviceAuthz: DeviceAuthorizationOpts{
+			deviceAuthz: authz.DeviceAuthorizationOpts{
 				DisableGlobalMode: true,
 				DisableRoleMode:   true,
 			},
-			user: BuiltinRole{
+			user: authz.BuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
 				ClusterName: clusterName,
@@ -461,11 +463,11 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 		},
 		{
 			name: "RemoteBuiltinRole: device authorization disabled",
-			deviceAuthz: DeviceAuthorizationOpts{
+			deviceAuthz: authz.DeviceAuthorizationOpts{
 				DisableGlobalMode: true,
 				DisableRoleMode:   true,
 			},
-			user: RemoteBuiltinRole{
+			user: authz.RemoteBuiltinRole{
 				Role:        types.RoleProxy,
 				Username:    user.GetName(),
 				ClusterName: clusterName,
@@ -486,7 +488,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			require.NoError(t, err, "UpsertAuthPreference failed")
 
 			// Create a new authorizer.
-			authorizer, err := NewAuthorizer(AuthorizerOpts{
+			authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 				ClusterName:         clusterName,
 				AccessPoint:         client,
 				LockWatcher:         watcher,
@@ -495,7 +497,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			require.NoError(t, err, "NewAuthorizer failed")
 
 			// Test!
-			userCtx := context.WithValue(ctx, contextUser, test.user)
+			userCtx := authz.ContextWithUser(ctx, test.user)
 			authCtx, gotErr := authorizer.Authorize(userCtx)
 			if test.wantErr == "" {
 				assert.NoError(t, gotErr, "Authorize returned unexpected error")
@@ -511,7 +513,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 			// value, based on either the global toggle or role mode.
 			wantDisabled := test.deviceAuthz.DisableRoleMode || test.wantCtxAuthnDisabled
 			assert.Equal(
-				t, wantDisabled, authCtx.disableDeviceRoleMode,
+				t, wantDisabled, authz.ContextDeviceRoleMode(authCtx),
 				"auth.Context.disableDeviceAuthorization not inherited from Authorizer")
 		})
 	}
@@ -523,10 +525,10 @@ func hostFQDN(hostUUID, clusterName string) string {
 }
 
 type fakeMFAAuthenticator struct {
-	mfaData map[string]*MFAAuthData // keyed by totp token
+	mfaData map[string]*authz.MFAAuthData // keyed by totp token
 }
 
-func (a *fakeMFAAuthenticator) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, requiredExtensions *mfav1.ChallengeExtensions) (*MFAAuthData, error) {
+func (a *fakeMFAAuthenticator) ValidateMFAAuthResponse(ctx context.Context, resp *proto.MFAAuthenticateResponse, user string, requiredExtensions *mfav1.ChallengeExtensions) (*authz.MFAAuthData, error) {
 	mfaData, ok := a.mfaData[resp.GetTOTP().GetCode()]
 	if !ok {
 		return nil, trace.AccessDenied("invalid MFA")
@@ -551,11 +553,11 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new local user.
-	localUser, _, err := createUserAndRole(client, "localuser", []string{"local"}, nil)
+	localUser, _, err := authtest.CreateUserAndRole(client, "localuser", []string{"local"}, nil)
 	require.NoError(t, err)
 
 	// Create new local user with a host-like username.
-	userWithHostName, _, err := createUserAndRole(client, hostFQDN(uuid.NewString(), clusterName), []string{"local"}, nil)
+	userWithHostName, _, err := authtest.CreateUserAndRole(client, hostFQDN(uuid.NewString(), clusterName), []string{"local"}, nil)
 	require.NoError(t, err)
 
 	// Create a new bot user.
@@ -573,7 +575,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	validTOTPCode := "valid"
 	validReusableTOTPCode := "valid-reusable"
 	fakeMFAAuthentictor := &fakeMFAAuthenticator{
-		mfaData: map[string]*MFAAuthData{
+		mfaData: map[string]*authz.MFAAuthData{
 			validTOTPCode: {},
 			validReusableTOTPCode: {
 				AllowReuse: mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_YES,
@@ -582,7 +584,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	}
 
 	// Create a new authorizer.
-	authorizer, err := NewAuthorizer(AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName:      clusterName,
 		AccessPoint:      client,
 		LockWatcher:      watcher,
@@ -616,7 +618,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 
 	for _, tt := range []struct {
 		name                      string
-		user                      IdentityGetter
+		user                      authz.IdentityGetter
 		withMFA                   *proto.MFAAuthenticateResponse
 		allowedReusedMFA          bool
 		contextGetter             func() context.Context
@@ -625,7 +627,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	}{
 		{
 			name: "NOK local user no mfa",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
@@ -634,7 +636,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: false,
 		}, {
 			name: "NOK local user mfa verified cert",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:    localUser.GetName(),
@@ -644,7 +646,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: false,
 		}, {
 			name: "NOK local user mfa verified private key policy",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:         localUser.GetName(),
@@ -655,7 +657,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 		}, {
 			// edge case for the admin role check.
 			name: "NOK local user with host-like username",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: userWithHostName.GetName(),
 				Identity: tlsca.Identity{
 					Username: userWithHostName.GetName(),
@@ -664,7 +666,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: false,
 		}, {
 			name: "NOK local user invalid mfa",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
@@ -675,7 +677,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "NOK local user reused mfa with reuse not allowed",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
@@ -685,7 +687,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: false,
 		}, {
 			name: "OK local user valid mfa",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
@@ -695,7 +697,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK local user reused mfa with reuse allowed",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
@@ -706,14 +708,14 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK admin",
-			user: BuiltinRole{
+			user: authz.BuiltinRole{
 				Role:     types.RoleAdmin,
 				Username: hostFQDN(uuid.NewString(), clusterName),
 			},
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK bot",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: bot.GetName(),
 				Identity: tlsca.Identity{
 					Username: bot.GetName(),
@@ -722,7 +724,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK admin impersonating local user",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:     localUser.GetName(),
@@ -732,7 +734,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			wantAdminActionAuthorized: true,
 		}, {
 			name: "OK bot impersonating local user",
-			user: LocalUser{
+			user: authz.LocalUser{
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:     localUser.GetName(),
@@ -752,7 +754,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				})
 				ctx = metadata.NewIncomingContext(ctx, md)
 			}
-			userCtx := context.WithValue(ctx, contextUser, tt.user)
+			userCtx := authz.ContextWithUser(ctx, tt.user)
 			authCtx, err := authorizer.Authorize(userCtx)
 			if tt.wantErrContains != "" {
 				require.ErrorContains(t, err, tt.wantErrContains, "Expected matching Authorize error")
@@ -777,10 +779,10 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 }
 
 func TestContext_GetAccessState(t *testing.T) {
-	localCtx := Context{
+	localCtx := authz.Context{
 		User:    &fakeCtxUser{}, // makes no difference in the outcomes.
 		Checker: &fakeCtxChecker{},
-		Identity: LocalUser{Identity: tlsca.Identity{
+		Identity: authz.LocalUser{Identity: tlsca.Identity{
 			Username:   "llama",
 			Groups:     []string{"access", "editor", "llamas"},
 			Principals: []string{"llamas"},
@@ -797,22 +799,22 @@ func TestContext_GetAccessState(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		createAuthCtx func() *Context
+		createAuthCtx func() *authz.Context
 		authSpec      *types.AuthPreferenceSpecV2 // defaults to defaultSpec
 		want          services.AccessState
 	}{
 		{
 			name:          "local user",
-			createAuthCtx: func() *Context { return &localCtx },
+			createAuthCtx: func() *authz.Context { return &localCtx },
 			want: services.AccessState{
 				EnableDeviceVerification: true, // default when acquired from auth.Context
 			},
 		},
 		{
 			name: "builtin role",
-			createAuthCtx: func() *Context {
+			createAuthCtx: func() *authz.Context {
 				ctx := localCtx
-				ctx.Identity = BuiltinRole{}
+				ctx.Identity = authz.BuiltinRole{}
 				return &ctx
 			},
 			want: services.AccessState{
@@ -823,12 +825,12 @@ func TestContext_GetAccessState(t *testing.T) {
 		},
 		{
 			name: "mfa: local user",
-			createAuthCtx: func() *Context {
+			createAuthCtx: func() *authz.Context {
 				ctx := localCtx
 				ctx.Checker = &fakeCtxChecker{state: services.AccessState{
 					MFARequired: services.MFARequiredAlways,
 				}}
-				localUser := ctx.Identity.(LocalUser)
+				localUser := ctx.Identity.(authz.LocalUser)
 				localUser.Identity.MFAVerified = "my-device-UUID"
 				ctx.Identity = localUser
 				return &ctx
@@ -841,9 +843,9 @@ func TestContext_GetAccessState(t *testing.T) {
 		},
 		{
 			name: "device trust: local user",
-			createAuthCtx: func() *Context {
+			createAuthCtx: func() *authz.Context {
 				ctx := localCtx
-				localUser := ctx.Identity.(LocalUser)
+				localUser := ctx.Identity.(authz.LocalUser)
 				localUser.Identity.DeviceExtensions = deviceExt
 				ctx.Identity = localUser
 				return &ctx
@@ -855,12 +857,13 @@ func TestContext_GetAccessState(t *testing.T) {
 		},
 		{
 			name: "device authorization disabled",
-			createAuthCtx: func() *Context {
+			createAuthCtx: func() *authz.Context {
 				ctx := localCtx
-				localUser := ctx.Identity.(LocalUser)
+				localUser := ctx.Identity.(authz.LocalUser)
 				localUser.Identity.DeviceExtensions = deviceExt
 				ctx.Identity = localUser
-				ctx.disableDeviceRoleMode = true
+
+				authz.DisableContextDeviceRoleMode(&ctx)
 				return &ctx
 			},
 			want: services.AccessState{
@@ -907,21 +910,21 @@ func TestCheckIPPinning(t *testing.T) {
 			clientAddr: "127.0.0.1:444",
 			pinnedIP:   "",
 			pinIP:      true,
-			wantErr:    ErrIPPinningMissing.Error(),
+			wantErr:    authz.ErrIPPinningMissing.Error(),
 		},
 		{
 			desc:       "Pinned IP doesn't match",
 			clientAddr: "127.0.0.1:444",
 			pinnedIP:   "127.0.0.2",
 			pinIP:      true,
-			wantErr:    ErrIPPinningMismatch.Error(),
+			wantErr:    authz.ErrIPPinningMismatch.Error(),
 		},
 		{
 			desc:       "Role doesn't require IP pinning now, but old certificate still pinned",
 			clientAddr: "127.0.0.1:444",
 			pinnedIP:   "127.0.0.2",
 			pinIP:      false,
-			wantErr:    ErrIPPinningMismatch.Error(),
+			wantErr:    authz.ErrIPPinningMismatch.Error(),
 		},
 		{
 			desc:     "IP pinning enabled, missing client IP",
@@ -934,7 +937,7 @@ func TestCheckIPPinning(t *testing.T) {
 			clientAddr: "127.0.0.1:0",
 			pinnedIP:   "127.0.0.1",
 			pinIP:      true,
-			wantErr:    ErrIPPinningNotAllowed.Error(),
+			wantErr:    authz.ErrIPPinningNotAllowed.Error(),
 		},
 		{
 			desc:       "correct IP pinning",
@@ -947,11 +950,11 @@ func TestCheckIPPinning(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := context.Background()
 		if tt.clientAddr != "" {
-			ctx = ContextWithClientSrcAddr(ctx, utils.MustParseAddr(tt.clientAddr))
+			ctx = authz.ContextWithClientSrcAddr(ctx, utils.MustParseAddr(tt.clientAddr))
 		}
 		identity := tlsca.Identity{PinnedIP: tt.pinnedIP}
 
-		err := CheckIPPinning(ctx, identity, tt.pinIP, nil)
+		err := authz.CheckIPPinning(ctx, identity, tt.pinIP, nil)
 
 		if tt.wantErr != "" {
 			require.ErrorContains(t, err, tt.wantErr)
@@ -984,7 +987,7 @@ func TestRoleSetForBuiltinRoles(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rs, err := RoleSetForBuiltinRoles(test.clusterName, test.recConfig, test.roles...)
+			rs, err := authz.RoleSetForBuiltinRoles(test.clusterName, test.recConfig, test.roles...)
 			require.NoError(t, err, "RoleSetForBuiltinRoles failed")
 			assert.NotEmpty(t, rs, "RoleSetForBuiltinRoles returned a nil RoleSet")
 			test.assertRoleSet(t, rs)
@@ -993,82 +996,82 @@ func TestRoleSetForBuiltinRoles(t *testing.T) {
 }
 
 func TestIsUserFunctions(t *testing.T) {
-	localIdentity := Context{
-		Identity:         LocalUser{},
-		UnmappedIdentity: LocalUser{},
+	localIdentity := authz.Context{
+		Identity:         authz.LocalUser{},
+		UnmappedIdentity: authz.LocalUser{},
 	}
-	remoteIdentity := Context{
-		Identity:         RemoteUser{},
-		UnmappedIdentity: RemoteUser{},
+	remoteIdentity := authz.Context{
+		Identity:         authz.RemoteUser{},
+		UnmappedIdentity: authz.RemoteUser{},
 	}
-	systemIdentity := Context{
-		Identity:         BuiltinRole{Role: types.RoleProxy},
-		UnmappedIdentity: BuiltinRole{Role: types.RoleProxy},
+	systemIdentity := authz.Context{
+		Identity:         authz.BuiltinRole{Role: types.RoleProxy},
+		UnmappedIdentity: authz.BuiltinRole{Role: types.RoleProxy},
 	}
 
 	tests := []struct {
 		funcName, scenario string
-		isUserFunc         func(Context) bool
-		authCtx            Context
+		isUserFunc         func(authz.Context) bool
+		authCtx            authz.Context
 		want               bool
 	}{
 		{
 			funcName:   "IsLocalUser",
 			scenario:   "local user",
-			isUserFunc: IsLocalUser,
+			isUserFunc: authz.IsLocalUser,
 			authCtx:    localIdentity,
 			want:       true,
 		},
 		{
 			funcName:   "IsLocalUser",
 			scenario:   "remote user",
-			isUserFunc: IsLocalUser,
+			isUserFunc: authz.IsLocalUser,
 			authCtx:    remoteIdentity,
 		},
 		{
 			funcName:   "IsLocalUser",
 			scenario:   "system user",
-			isUserFunc: IsLocalUser,
+			isUserFunc: authz.IsLocalUser,
 			authCtx:    systemIdentity,
 		},
 		{
 			funcName:   "IsRemoteUser",
 			scenario:   "local user",
-			isUserFunc: IsRemoteUser,
+			isUserFunc: authz.IsRemoteUser,
 			authCtx:    localIdentity,
 		},
 		{
 			funcName:   "IsRemoteUser",
 			scenario:   "remote user",
-			isUserFunc: IsRemoteUser,
+			isUserFunc: authz.IsRemoteUser,
 			authCtx:    remoteIdentity,
 			want:       true,
 		},
 		{
 			funcName:   "IsRemoteUser",
 			scenario:   "system user",
-			isUserFunc: IsRemoteUser,
+			isUserFunc: authz.IsRemoteUser,
 			authCtx:    systemIdentity,
 		},
 
 		{
 			funcName:   "IsLocalOrRemoteUser",
 			scenario:   "local user",
-			isUserFunc: IsLocalOrRemoteUser,
+			isUserFunc: authz.IsLocalOrRemoteUser,
 			authCtx:    localIdentity,
 			want:       true,
 		},
 		{
 			funcName:   "IsLocalOrRemoteUser",
 			scenario:   "remote user",
-			isUserFunc: IsLocalOrRemoteUser,
+			isUserFunc: authz.IsLocalOrRemoteUser,
 			authCtx:    remoteIdentity,
 			want:       true,
 		},
 		{
 			funcName:   "IsLocalOrRemoteUser",
 			scenario:   "system user",
-			isUserFunc: IsLocalOrRemoteUser,
+			isUserFunc: authz.IsLocalOrRemoteUser,
 			authCtx:    systemIdentity,
 		},
 	}
@@ -1086,7 +1089,7 @@ func TestConnectionMetadata(t *testing.T) {
 		expectedConnectionMetadata apievents.ConnectionMetadata
 	}{
 		"with client address": {
-			ctx:                        ContextWithClientSrcAddr(context.Background(), &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0), Port: 1234}),
+			ctx:                        authz.ContextWithClientSrcAddr(context.Background(), &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0), Port: 1234}),
 			expectedConnectionMetadata: apievents.ConnectionMetadata{RemoteAddr: "10.255.0.0:1234"},
 		},
 		"empty client address": {
@@ -1095,7 +1098,7 @@ func TestConnectionMetadata(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.Empty(t, cmp.Diff(test.expectedConnectionMetadata, ConnectionMetadata(test.ctx)))
+			require.Empty(t, cmp.Diff(test.expectedConnectionMetadata, authz.ConnectionMetadata(test.ctx)))
 		})
 	}
 }
@@ -1127,7 +1130,7 @@ type testClient struct {
 	types.Events
 }
 
-func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authorizer) {
+func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, authz.Authorizer) {
 	backend, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 
@@ -1173,7 +1176,7 @@ func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authori
 	})
 	require.NoError(t, err)
 
-	authorizer, err := NewAuthorizer(AuthorizerOpts{
+	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: clusterName,
 		AccessPoint: client,
 		LockWatcher: lockWatcher,
@@ -1181,32 +1184,6 @@ func newTestResources(t *testing.T) (*testClient, *services.LockWatcher, Authori
 	require.NoError(t, err)
 
 	return client, lockWatcher, authorizer
-}
-
-func createUserAndRole(client *testClient, username string, allowedLogins []string, allowRules []types.Rule) (types.User, types.Role, error) {
-	ctx := context.Background()
-	user, err := types.NewUser(username)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	role := services.RoleForUser(user)
-	role.SetLogins(types.Allow, allowedLogins)
-	if allowRules != nil {
-		role.SetRules(types.Allow, allowRules)
-	}
-
-	role, err = client.UpsertRole(ctx, role)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	user.AddRole(role.GetName())
-	user, err = client.UpsertUser(ctx, user)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	return user, role, nil
 }
 
 func resourceDiff(res1, res2 types.Resource) string {

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -394,7 +394,7 @@ func TestWithRsync(t *testing.T) {
 					if !assert.NoError(t, err) {
 						return
 					}
-					sshCert, tlsCert, err := asrv.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+					sshCert, tlsCert, err := asrv.GenerateUserTestCertsWithContext(ctx,auth.GenerateUserTestCertsRequest{
 						SSHPubKey:      sshPubKey,
 						TLSPubKey:      tlsPubKey,
 						Username:       accessUser.GetName(),
@@ -1529,7 +1529,7 @@ func TestProxyAppWithIdentity(t *testing.T) {
 	// make other auth API calls beyond just accessing the app.
 	tlsPub, err := privateKey.MarshalTLSPublicKey()
 	require.NoError(t, err)
-	sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+	sshCert, tlsCert, err := authServer.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
 		SSHPubKey:      privateKey.MarshalSSHPublicKey(),
 		TLSPubKey:      tlsPub,
 		Username:       userName,

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -394,7 +394,7 @@ func TestWithRsync(t *testing.T) {
 					if !assert.NoError(t, err) {
 						return
 					}
-					sshCert, tlsCert, err := asrv.GenerateUserTestCertsWithContext(ctx,auth.GenerateUserTestCertsRequest{
+					sshCert, tlsCert, err := asrv.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
 						SSHPubKey:      sshPubKey,
 						TLSPubKey:      tlsPubKey,
 						Username:       accessUser.GetName(),

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -3989,7 +3989,7 @@ func mockSSOLogin(authServer *auth.Server, user types.User) client.SSOLoginFunc 
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		sshCert, tlsCert, err := authServer.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
 			SSHPubKey:               keyRing.SSHPrivateKey.MarshalSSHPublicKey(),
 			TLSPubKey:               tlsPub,
 			Username:                user.GetName(),
@@ -4029,7 +4029,7 @@ func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) c
 		require.NoError(t, err)
 		tlsPub, err := keyRing.TLSPrivateKey.MarshalTLSPublicKey()
 		require.NoError(t, err)
-		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		sshCert, tlsCert, err := authServer.GenerateUserTestCertsWithContext(ctx, auth.GenerateUserTestCertsRequest{
 			SSHPubKey:      keyRing.SSHPrivateKey.MarshalSSHPublicKey(),
 			TLSPubKey:      tlsPub,
 			Username:       user.GetName(),


### PR DESCRIPTION
In an effort to remove testing symbols from the teleport binary the auth helpers in lib/auth/helpers.go are being moved to a new lib/auth/authtest package. This package is to be limited to only being imported within _test.go files to prevent the helpers from slipping back into production code.

All tests within lib/auth that made use of the test helpers in lib/auth/helpers.go now use the equivalent functionality provided by lib/auth/authtest. To prevent import cycles the tests in lib/auth have been moved to the auth_test package. This shift required some extra work as a fair number of the existing tests relied on unexported symbols. To work around this lib/auth/export_test.go has been added for the sole purpose of exporting private types, methods, or extending existing types with new exported received methods. This was chosen over rewriting existing tests for time and simplicity. All future tests should not rely on this hack and should instead stick to testing the publicly exported items from the auth package.

Updates https://github.com/gravitational/teleport/issues/51023.