### PR TITLE
fix: don't return db_client CA when listing db CAs

### DIFF
--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -170,7 +170,13 @@ func (c *Cache) GetCertAuthorities(ctx context.Context, caType types.CertAuthTyp
 
 	if rg.ReadCache() {
 		cas := make([]types.CertAuthority, 0, rg.store.len())
-		for ca := range rg.store.resources(certAuthorityIDIndex, string(caType), sortcache.NextKey(string(caType))) {
+		// CA keys are suffixed with the cluster name, e.g. db/teleport.example.com
+		// Use the exact key with the trailing slash to avoid matching CA types
+		// with a common prefix, i.e. to avoid matching db_client CAs when
+		// querying for db CAs.
+		startKey := string(caType) + "/"
+		endKey := sortcache.NextKey(startKey)
+		for ca := range rg.store.resources(certAuthorityIDIndex, startKey, endKey) {
 			if loadSigningKeys {
 				cas = append(cas, ca.Clone())
 			} else {


### PR DESCRIPTION
Fixes #56525

This fixes the cache impl of GetCertAuthorities to avoid returning CA types with a common prefix to the queried CA type by appending a slash to the sort key. As described in the bug, the local trust service already handles this correctly, it's only the cache that currently has it wrong.

Most other callers of sortcache.NextKey also append a trailing slash to the key
```
$ rg -B1 sortcache.NextKey
lib/cache/remote_cluster.go
84-     startKey := clusterName + "/"
85:     endKey := sortcache.NextKey(startKey)

lib/cache/web_session.go
225-            startKey := user + "/"
226:            endKey := sortcache.NextKey(startKey)

lib/cache/access_list.go
230-    startUserKey := accessListName + "/" + accesslist.MembershipKindUser + "/"
231:    endUserKey := sortcache.NextKey(startUserKey)
--
234-    startListKey := accessListName + "/" + accesslist.MembershipKindList + "/"
235:    endListKey := sortcache.NextKey(startListKey)
--
260-    start := cmp.Or(pageToken, accessListName)
261:    end := sortcache.NextKey(accessListName + "/")
--
398-    start := accessList
399:    end := sortcache.NextKey(accessList + "/")

lib/services/notifications_cache.go
208-    if startKey == "" {
209:            startKey = sortcache.NextKey(endKey)
```

changelog: fixed duplicated `db_client` CA in `tctl status` and `tctl get cas` output