### PR TITLE
Web: move notifcation actions to shared file

### DIFF
--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -320,3 +320,13 @@ const Container = styled(Box)`
 
   ${borderColor}
 `;
+
+export const BottomRightNotificationContainer = styled.div`
+  position: absolute;
+  bottom: ${p => p.theme.space[2]}px;
+  right: ${p => p.theme.space[5]}px;
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space[3]}px;
+  margin-bottom: ${p => p.theme.space[3]}px;
+`;

--- a/web/packages/shared/components/Notification/index.ts
+++ b/web/packages/shared/components/Notification/index.ts
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Notification } from './Notification';
+export { Notification, BottomRightNotificationContainer } from './Notification';
+export * from './useNotifications';
 export type {
   NotificationItem,
   NotificationItemContent,

--- a/web/packages/shared/components/Notification/useNotifications.ts
+++ b/web/packages/shared/components/Notification/useNotifications.ts
@@ -1,0 +1,47 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import { NotificationItem, NotificationSeverity } from './types';
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+
+  function removeNotification(id: string) {
+    setNotifications(n => n.filter(item => item.id !== id));
+  }
+
+  function addNotification(content: string, severity: NotificationSeverity) {
+    setNotifications(notifications => [
+      ...notifications,
+      { id: crypto.randomUUID(), content, severity },
+    ]);
+  }
+
+  return {
+    notifications,
+    removeNotification,
+    addNotification,
+  };
+}
+
+export type AddNotification = (
+  content: string,
+  severity: NotificationSeverity
+) => void;

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -17,15 +17,14 @@
  */
 
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
 
 import { Alert, Box, Button, Flex, Link } from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 import { MissingPermissionsTooltip } from 'shared/components/MissingPermissionsTooltip';
 import {
+  BottomRightNotificationContainer,
   Notification,
-  NotificationItem,
-  NotificationSeverity,
+  useNotifications,
 } from 'shared/components/Notification';
 import {
   InfoExternalTextLink,
@@ -96,18 +95,8 @@ const useNewRoleEditor = storageService.getUseNewRoleEditor();
 export function Roles(props: State & RolesProps) {
   const { remove, create, update, fetch, rolesAcl } = props;
   const [search, setSearch] = useState('');
-  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
-
-  function addNotification(content: string, severity: NotificationSeverity) {
-    setNotifications(notifications => [
-      ...notifications,
-      { id: crypto.randomUUID(), content, severity },
-    ]);
-  }
-
-  function removeNotification(id: string) {
-    setNotifications(n => n.filter(item => item.id !== id));
-  }
+  const { notifications, addNotification, removeNotification } =
+    useNotifications();
 
   const serverSidePagination = useServerSidePagination<RoleResource>({
     pageSize: 20,
@@ -290,16 +279,15 @@ export function Roles(props: State & RolesProps) {
         />
       )}
 
-      <NotificationContainer>
+      <BottomRightNotificationContainer>
         {notifications.map(item => (
           <Notification
-            mb={3}
             key={item.id}
             item={item}
             onRemove={() => removeNotification(item.id)}
           />
         ))}
-      </NotificationContainer>
+      </BottomRightNotificationContainer>
     </FeatureBox>
   );
 }
@@ -356,9 +344,3 @@ function InfoGuide() {
     </Box>
   );
 }
-
-const NotificationContainer = styled.div`
-  position: absolute;
-  bottom: ${props => props.theme.space[2]}px;
-  right: ${props => props.theme.space[5]}px;
-`;


### PR DESCRIPTION
Just moves notifcation actions to a shared file since I'll be using same logic elsewhere, no behavioral/spacing changes (tested role notications)