### PR TITLE
MWI: Extract config test helpers into `testutils` package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,7 @@ linters:
             - '!**/lib/services/local/users.go'
             - '!**/lib/services/server.go'
             - '!**/lib/services/user.go'
+            - '!**/lib/tbot/internal/testutils/**'
           deny:
             - pkg: github.com/google/go-cmp/cmp
               desc: '"github.com/google/go-cmp/cmp" should only be used in tests'
@@ -172,6 +173,7 @@ linters:
         test_packages:
           files:
             - '!$test'
+            - '!**/lib/tbot/internal/testutils/**'
           deny:
             - pkg: github.com/gravitational/teleport/e/lib/aws/identitycenter/test
               desc: testing packages should not be imported outside of _test.go files
@@ -194,6 +196,8 @@ linters:
             - pkg: github.com/gravitational/teleport/lib/srv/db/spanner/protocoltest
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/srv/db/clickhouse/protocoltest
+              desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/tbot/internal/testutils
               desc: testing packages should not be imported outside of _test.go files
         testify:
           files:

--- a/lib/tbot/config/destination_directory_test.go
+++ b/lib/tbot/config/destination_directory_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -58,24 +59,24 @@ func TestDestinationDirectory_Lock(t *testing.T) {
 }
 
 func TestDestinationDirectory_YAML(t *testing.T) {
-	tests := []testYAMLCase[DestinationDirectory]{
+	tests := []testutils.TestYAMLCase[DestinationDirectory]{
 		{
-			name: "full",
-			in: DestinationDirectory{
+			Name: "full",
+			In: DestinationDirectory{
 				Path:     "/my/path",
 				ACLs:     botfs.ACLRequired,
 				Symlinks: botfs.SymlinksSecure,
 			},
 		},
 		{
-			name: "minimal",
-			in: DestinationDirectory{
+			Name: "minimal",
+			In: DestinationDirectory{
 				Path: "/my/path",
 			},
 		},
 		{
-			name: "acl readers",
-			in: DestinationDirectory{
+			Name: "acl readers",
+			In: DestinationDirectory{
 				Path: "/my/path",
 				ACLs: botfs.ACLRequired,
 				Readers: []*botfs.ACLSelector{
@@ -89,7 +90,7 @@ func TestDestinationDirectory_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestDestinationDirectory_ACLs(t *testing.T) {

--- a/lib/tbot/config/destination_kubernetes_secret_test.go
+++ b/lib/tbot/config/destination_kubernetes_secret_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestDestinationKubernetesSecret(t *testing.T) {
@@ -140,38 +142,38 @@ func TestDestinationKubernetesSecret(t *testing.T) {
 }
 
 func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*DestinationKubernetesSecret]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*DestinationKubernetesSecret]{
 		{
-			name: "valid",
-			in: func() *DestinationKubernetesSecret {
+			Name: "valid",
+			In: func() *DestinationKubernetesSecret {
 				return &DestinationKubernetesSecret{
 					Name: "my-secret",
 				}
 			},
 		},
 		{
-			name: "missing name",
-			in: func() *DestinationKubernetesSecret {
+			Name: "missing name",
+			In: func() *DestinationKubernetesSecret {
 				return &DestinationKubernetesSecret{
 					Name: "",
 				}
 			},
-			wantErr: "name must not be empty",
+			WantErr: "name must not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }
 
 func TestDestinationKubernetesSecret_YAML(t *testing.T) {
-	tests := []testYAMLCase[*DestinationKubernetesSecret]{
+	tests := []testutils.TestYAMLCase[*DestinationKubernetesSecret]{
 		{
-			name: "full",
-			in: &DestinationKubernetesSecret{
+			Name: "full",
+			In: &DestinationKubernetesSecret{
 				Name: "my-secret",
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestDestinationKubernetesSecret_String(t *testing.T) {

--- a/lib/tbot/config/service_application_test.go
+++ b/lib/tbot/config/service_application_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestApplicationOutput_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[ApplicationOutput]{
+	tests := []testutils.TestYAMLCase[ApplicationOutput]{
 		{
-			name: "full",
-			in: ApplicationOutput{
+			Name: "full",
+			In: ApplicationOutput{
 				Destination: dest,
 				Roles:       []string{"access"},
 				AppName:     "my-app",
@@ -39,21 +41,21 @@ func TestApplicationOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: ApplicationOutput{
+			Name: "minimal",
+			In: ApplicationOutput{
 				Destination: dest,
 				AppName:     "my-app",
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*ApplicationOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*ApplicationOutput]{
 		{
-			name: "valid",
-			in: func() *ApplicationOutput {
+			Name: "valid",
+			In: func() *ApplicationOutput {
 				return &ApplicationOutput{
 					Destination: memoryDestForTest(),
 					Roles:       []string{"access"},
@@ -62,24 +64,24 @@ func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *ApplicationOutput {
+			Name: "missing destination",
+			In: func() *ApplicationOutput {
 				return &ApplicationOutput{
 					Destination: nil,
 					AppName:     "app",
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing app_name",
-			in: func() *ApplicationOutput {
+			Name: "missing app_name",
+			In: func() *ApplicationOutput {
 				return &ApplicationOutput{
 					Destination: memoryDestForTest(),
 				}
 			},
-			wantErr: "app_name must not be empty",
+			WantErr: "app_name must not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_application_tunnel_test.go
+++ b/lib/tbot/config/service_application_tunnel_test.go
@@ -21,15 +21,17 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestApplicationTunnelService_YAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []testYAMLCase[ApplicationTunnelService]{
+	tests := []testutils.TestYAMLCase[ApplicationTunnelService]{
 		{
-			name: "full",
-			in: ApplicationTunnelService{
+			Name: "full",
+			In: ApplicationTunnelService{
 				Listen:  "tcp://0.0.0.0:3621",
 				AppName: "my-app",
 				CredentialLifetime: CredentialLifetime{
@@ -39,55 +41,55 @@ func TestApplicationTunnelService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*ApplicationTunnelService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*ApplicationTunnelService]{
 		{
-			name: "valid",
-			in: func() *ApplicationTunnelService {
+			Name: "valid",
+			In: func() *ApplicationTunnelService {
 				return &ApplicationTunnelService{
 					Listen:  "tcp://0.0.0.0:3621",
 					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 				}
 			},
-			wantErr: "",
+			WantErr: "",
 		},
 		{
-			name: "missing listen",
-			in: func() *ApplicationTunnelService {
+			Name: "missing listen",
+			In: func() *ApplicationTunnelService {
 				return &ApplicationTunnelService{
 					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 				}
 			},
-			wantErr: "listen: should not be empty",
+			WantErr: "listen: should not be empty",
 		},
 		{
-			name: "listen not url",
-			in: func() *ApplicationTunnelService {
+			Name: "listen not url",
+			In: func() *ApplicationTunnelService {
 				return &ApplicationTunnelService{
 					Listen:  "\x00",
 					Roles:   []string{"role1", "role2"},
 					AppName: "my-app",
 				}
 			},
-			wantErr: "parsing listen",
+			WantErr: "parsing listen",
 		},
 		{
-			name: "missing app name",
-			in: func() *ApplicationTunnelService {
+			Name: "missing app name",
+			In: func() *ApplicationTunnelService {
 				return &ApplicationTunnelService{
 					Listen: "tcp://0.0.0.0:3621",
 					Roles:  []string{"role1", "role2"},
 				}
 			},
-			wantErr: "app_name: should not be empty",
+			WantErr: "app_name: should not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_database_test.go
+++ b/lib/tbot/config/service_database_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestDatabaseOutput_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[DatabaseOutput]{
+	tests := []testutils.TestYAMLCase[DatabaseOutput]{
 		{
-			name: "full",
-			in: DatabaseOutput{
+			Name: "full",
+			In: DatabaseOutput{
 				Destination: dest,
 				Roles:       []string{"access"},
 				Format:      TLSDatabaseFormat,
@@ -42,21 +44,21 @@ func TestDatabaseOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: DatabaseOutput{
+			Name: "minimal",
+			In: DatabaseOutput{
 				Destination: dest,
 				Service:     "my-database-service",
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestDatabaseOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*DatabaseOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*DatabaseOutput]{
 		{
-			name: "valid",
-			in: func() *DatabaseOutput {
+			Name: "valid",
+			In: func() *DatabaseOutput {
 				return &DatabaseOutput{
 					Destination: memoryDestForTest(),
 					Roles:       []string{"access"},
@@ -67,35 +69,35 @@ func TestDatabaseOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *DatabaseOutput {
+			Name: "missing destination",
+			In: func() *DatabaseOutput {
 				return &DatabaseOutput{
 					Destination: nil,
 					Service:     "service",
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing service",
-			in: func() *DatabaseOutput {
+			Name: "missing service",
+			In: func() *DatabaseOutput {
 				return &DatabaseOutput{
 					Destination: memoryDestForTest(),
 				}
 			},
-			wantErr: "service must not be empty",
+			WantErr: "service must not be empty",
 		},
 		{
-			name: "invalid format",
-			in: func() *DatabaseOutput {
+			Name: "invalid format",
+			In: func() *DatabaseOutput {
 				return &DatabaseOutput{
 					Destination: memoryDestForTest(),
 					Service:     "service",
 					Format:      "no-such-format",
 				}
 			},
-			wantErr: "unrecognized format (no-such-format)",
+			WantErr: "unrecognized format (no-such-format)",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_database_tunnel_test.go
+++ b/lib/tbot/config/service_database_tunnel_test.go
@@ -21,15 +21,17 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestDatabaseTunnelService_YAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []testYAMLCase[DatabaseTunnelService]{
+	tests := []testutils.TestYAMLCase[DatabaseTunnelService]{
 		{
-			name: "full",
-			in: DatabaseTunnelService{
+			Name: "full",
+			In: DatabaseTunnelService{
 				Listen:   "tcp://0.0.0.0:3621",
 				Roles:    []string{"role1", "role2"},
 				Service:  "service",
@@ -42,16 +44,16 @@ func TestDatabaseTunnelService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*DatabaseTunnelService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*DatabaseTunnelService]{
 		{
-			name: "valid",
-			in: func() *DatabaseTunnelService {
+			Name: "valid",
+			In: func() *DatabaseTunnelService {
 				return &DatabaseTunnelService{
 					Listen:   "tcp://0.0.0.0:3621",
 					Roles:    []string{"role1", "role2"},
@@ -60,11 +62,11 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Username: "username",
 				}
 			},
-			wantErr: "",
+			WantErr: "",
 		},
 		{
-			name: "missing listen",
-			in: func() *DatabaseTunnelService {
+			Name: "missing listen",
+			In: func() *DatabaseTunnelService {
 				return &DatabaseTunnelService{
 					Roles:    []string{"role1", "role2"},
 					Service:  "service",
@@ -72,11 +74,11 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Username: "username",
 				}
 			},
-			wantErr: "listen: should not be empty",
+			WantErr: "listen: should not be empty",
 		},
 		{
-			name: "missing service",
-			in: func() *DatabaseTunnelService {
+			Name: "missing service",
+			In: func() *DatabaseTunnelService {
 				return &DatabaseTunnelService{
 					Listen:   "tcp://0.0.0.0:3621",
 					Roles:    []string{"role1", "role2"},
@@ -84,11 +86,11 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Username: "username",
 				}
 			},
-			wantErr: "service: should not be empty",
+			WantErr: "service: should not be empty",
 		},
 		{
-			name: "missing database",
-			in: func() *DatabaseTunnelService {
+			Name: "missing database",
+			In: func() *DatabaseTunnelService {
 				return &DatabaseTunnelService{
 					Listen:   "tcp://0.0.0.0:3621",
 					Roles:    []string{"role1", "role2"},
@@ -96,11 +98,11 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Username: "username",
 				}
 			},
-			wantErr: "database: should not be empty",
+			WantErr: "database: should not be empty",
 		},
 		{
-			name: "missing username",
-			in: func() *DatabaseTunnelService {
+			Name: "missing username",
+			In: func() *DatabaseTunnelService {
 				return &DatabaseTunnelService{
 					Listen:   "tcp://0.0.0.0:3621",
 					Roles:    []string{"role1", "role2"},
@@ -108,8 +110,8 @@ func TestDatabaseTunnelService_CheckAndSetDefaults(t *testing.T) {
 					Database: "database",
 				}
 			},
-			wantErr: "username: should not be empty",
+			WantErr: "username: should not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_identity_test.go
+++ b/lib/tbot/config/service_identity_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestIdentityOutput_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[IdentityOutput]{
+	tests := []testutils.TestYAMLCase[IdentityOutput]{
 		{
-			name: "full",
-			in: IdentityOutput{
+			Name: "full",
+			In: IdentityOutput{
 				Destination:   dest,
 				Roles:         []string{"access"},
 				Cluster:       "leaf.example.com",
@@ -41,20 +43,20 @@ func TestIdentityOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: IdentityOutput{
+			Name: "minimal",
+			In: IdentityOutput{
 				Destination: dest,
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*IdentityOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*IdentityOutput]{
 		{
-			name: "valid",
-			in: func() *IdentityOutput {
+			Name: "valid",
+			In: func() *IdentityOutput {
 				return &IdentityOutput{
 					Destination:   memoryDestForTest(),
 					Roles:         []string{"access"},
@@ -63,36 +65,36 @@ func TestIdentityOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "ssh config mode defaults",
-			in: func() *IdentityOutput {
+			Name: "ssh config mode defaults",
+			In: func() *IdentityOutput {
 				return &IdentityOutput{
 					Destination: memoryDestForTest(),
 				}
 			},
-			want: &IdentityOutput{
+			Want: &IdentityOutput{
 				Destination:   memoryDestForTest(),
 				SSHConfigMode: SSHConfigModeOn,
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *IdentityOutput {
+			Name: "missing destination",
+			In: func() *IdentityOutput {
 				return &IdentityOutput{
 					Destination: nil,
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "invalid ssh config mode",
-			in: func() *IdentityOutput {
+			Name: "invalid ssh config mode",
+			In: func() *IdentityOutput {
 				return &IdentityOutput{
 					Destination:   memoryDestForTest(),
 					SSHConfigMode: "invalid",
 				}
 			},
-			wantErr: "ssh_config: unrecognized value \"invalid\"",
+			WantErr: "ssh_config: unrecognized value \"invalid\"",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_kubernetes_test.go
+++ b/lib/tbot/config/service_kubernetes_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestKubernetesOutput_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[KubernetesOutput]{
+	tests := []testutils.TestYAMLCase[KubernetesOutput]{
 		{
-			name: "full",
-			in: KubernetesOutput{
+			Name: "full",
+			In: KubernetesOutput{
 				Destination:       dest,
 				Roles:             []string{"access"},
 				KubernetesCluster: "k8s.example.com",
@@ -39,21 +41,21 @@ func TestKubernetesOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: KubernetesOutput{
+			Name: "minimal",
+			In: KubernetesOutput{
 				Destination:       dest,
 				KubernetesCluster: "k8s.example.com",
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestKubernetesOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*KubernetesOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*KubernetesOutput]{
 		{
-			name: "valid",
-			in: func() *KubernetesOutput {
+			Name: "valid",
+			In: func() *KubernetesOutput {
 				return &KubernetesOutput{
 					Destination:       memoryDestForTest(),
 					Roles:             []string{"access"},
@@ -62,24 +64,24 @@ func TestKubernetesOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *KubernetesOutput {
+			Name: "missing destination",
+			In: func() *KubernetesOutput {
 				return &KubernetesOutput{
 					Destination:       nil,
 					KubernetesCluster: "my-cluster",
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing kubernetes_config",
-			in: func() *KubernetesOutput {
+			Name: "missing kubernetes_config",
+			In: func() *KubernetesOutput {
 				return &KubernetesOutput{
 					Destination: memoryDestForTest(),
 				}
 			},
-			wantErr: "kubernetes_cluster must not be empty",
+			WantErr: "kubernetes_cluster must not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_kubernetes_v2_test.go
+++ b/lib/tbot/config/service_kubernetes_v2_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestKubernetesV2Output_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[KubernetesV2Output]{
+	tests := []testutils.TestYAMLCase[KubernetesV2Output]{
 		{
-			name: "full",
-			in: KubernetesV2Output{
+			Name: "full",
+			In: KubernetesV2Output{
 				Destination:       dest,
 				DisableExecPlugin: true,
 				Selectors: []*KubernetesSelector{
@@ -55,8 +57,8 @@ func TestKubernetesV2Output_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: KubernetesV2Output{
+			Name: "minimal",
+			In: KubernetesV2Output{
 				Destination: dest,
 				Selectors: []*KubernetesSelector{
 					{
@@ -67,14 +69,14 @@ func TestKubernetesV2Output_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*KubernetesV2Output]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*KubernetesV2Output]{
 		{
-			name: "valid_name",
-			in: func() *KubernetesV2Output {
+			Name: "valid_name",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: memoryDestForTest(),
 					Selectors: []*KubernetesSelector{
@@ -84,8 +86,8 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid_label",
-			in: func() *KubernetesV2Output {
+			Name: "valid_label",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: memoryDestForTest(),
 					Selectors: []*KubernetesSelector{
@@ -97,8 +99,8 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *KubernetesV2Output {
+			Name: "missing destination",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: nil,
 					Selectors: []*KubernetesSelector{
@@ -106,20 +108,20 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing selectors",
-			in: func() *KubernetesV2Output {
+			Name: "missing selectors",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: memoryDestForTest(),
 				}
 			},
-			wantErr: "at least one selector must be provided",
+			WantErr: "at least one selector must be provided",
 		},
 		{
-			name: "empty selector",
-			in: func() *KubernetesV2Output {
+			Name: "empty selector",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: memoryDestForTest(),
 					Selectors: []*KubernetesSelector{
@@ -127,11 +129,11 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "selectors: one of 'name' and 'labels' must be specified",
+			WantErr: "selectors: one of 'name' and 'labels' must be specified",
 		},
 		{
-			name: "both name and label in selector",
-			in: func() *KubernetesV2Output {
+			Name: "both name and label in selector",
+			In: func() *KubernetesV2Output {
 				return &KubernetesV2Output{
 					Destination: memoryDestForTest(),
 					Selectors: []*KubernetesSelector{
@@ -144,8 +146,8 @@ func TestKubernetesV2Output_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "selectors: only one of 'name' and 'labels' may be specified",
+			WantErr: "selectors: only one of 'name' and 'labels' may be specified",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_spiffe_svid_test.go
+++ b/lib/tbot/config/service_spiffe_svid_test.go
@@ -21,16 +21,18 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestSPIFFESVIDOutput_YAML(t *testing.T) {
 	t.Parallel()
 
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[SPIFFESVIDOutput]{
+	tests := []testutils.TestYAMLCase[SPIFFESVIDOutput]{
 		{
-			name: "full",
-			in: SPIFFESVIDOutput{
+			Name: "full",
+			In: SPIFFESVIDOutput{
 				Destination: dest,
 				SVID: SVIDRequest{
 					Path: "/foo",
@@ -58,8 +60,8 @@ func TestSPIFFESVIDOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: SPIFFESVIDOutput{
+			Name: "minimal",
+			In: SPIFFESVIDOutput{
 				Destination: dest,
 				SVID: SVIDRequest{
 					Path: "/foo",
@@ -67,14 +69,14 @@ func TestSPIFFESVIDOutput_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*SPIFFESVIDOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*SPIFFESVIDOutput]{
 		{
-			name: "valid",
-			in: func() *SPIFFESVIDOutput {
+			Name: "valid",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -95,8 +97,8 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing jwt name",
-			in: func() *SPIFFESVIDOutput {
+			Name: "missing jwt name",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -114,11 +116,11 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "name: should not be empty",
+			WantErr: "name: should not be empty",
 		},
 		{
-			name: "missing jwt audience",
-			in: func() *SPIFFESVIDOutput {
+			Name: "missing jwt audience",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -136,11 +138,11 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "audience: should not be empty",
+			WantErr: "audience: should not be empty",
 		},
 		{
-			name: "missing destination",
-			in: func() *SPIFFESVIDOutput {
+			Name: "missing destination",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: nil,
 					SVID: SVIDRequest{
@@ -153,11 +155,11 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing path",
-			in: func() *SPIFFESVIDOutput {
+			Name: "missing path",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -170,11 +172,11 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "svid.path: should not be empty",
+			WantErr: "svid.path: should not be empty",
 		},
 		{
-			name: "path missing leading slash",
-			in: func() *SPIFFESVIDOutput {
+			Name: "path missing leading slash",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -187,11 +189,11 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "svid.path: should be prefixed with /",
+			WantErr: "svid.path: should be prefixed with /",
 		},
 		{
-			name: "invalid ip",
-			in: func() *SPIFFESVIDOutput {
+			Name: "invalid ip",
+			In: func() *SPIFFESVIDOutput {
 				return &SPIFFESVIDOutput{
 					Destination: memoryDestForTest(),
 					SVID: SVIDRequest{
@@ -204,8 +206,8 @@ func TestSPIFFESVIDOutput_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "ip_sans[0]: invalid IP address",
+			WantErr: "ip_sans[0]: invalid IP address",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_spiffe_workload_api_test.go
+++ b/lib/tbot/config/service_spiffe_workload_api_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
 )
 
@@ -32,10 +33,10 @@ func ptr[T any](v T) *T {
 func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []testYAMLCase[SPIFFEWorkloadAPIService]{
+	tests := []testutils.TestYAMLCase[SPIFFEWorkloadAPIService]{
 		{
-			name: "full",
-			in: SPIFFEWorkloadAPIService{
+			Name: "full",
+			In: SPIFFEWorkloadAPIService{
 				Listen:     "unix:///var/run/spiffe.sock",
 				JWTSVIDTTL: time.Minute * 5,
 				Attestors: workloadattest.Config{
@@ -63,14 +64,14 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 						Rules: []SVIDRequestRule{
 							{
 								Unix: SVIDRequestRuleUnix{
-									PID: ptr(100),
-									UID: ptr(1000),
-									GID: ptr(1234),
+									PID: testutils.Pointer(100),
+									UID: testutils.Pointer(1000),
+									GID: testutils.Pointer(1234),
 								},
 							},
 							{
 								Unix: SVIDRequestRuleUnix{
-									PID: ptr(100),
+									PID: testutils.Pointer(100),
 								},
 								Kubernetes: SVIDRequestRuleKubernetes{
 									Namespace:      "my-namespace",
@@ -88,8 +89,8 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: SPIFFEWorkloadAPIService{
+			Name: "minimal",
+			In: SPIFFEWorkloadAPIService{
 				Listen: "unix:///var/run/spiffe.sock",
 				SVIDs: []SVIDRequestWithRules{
 					{
@@ -101,16 +102,16 @@ func TestSPIFFEWorkloadAPIService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*SPIFFEWorkloadAPIService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*SPIFFEWorkloadAPIService]{
 		{
-			name: "valid",
-			in: func() *SPIFFEWorkloadAPIService {
+			Name: "valid",
+			In: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					JWTSVIDTTL: time.Minute,
 					Listen:     "unix:///var/run/spiffe.sock",
@@ -128,7 +129,7 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			want: &SPIFFEWorkloadAPIService{
+			Want: &SPIFFEWorkloadAPIService{
 				JWTSVIDTTL: time.Minute,
 				Listen:     "unix:///var/run/spiffe.sock",
 				SVIDs: []SVIDRequestWithRules{
@@ -151,8 +152,8 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing path",
-			in: func() *SPIFFEWorkloadAPIService {
+			Name: "missing path",
+			In: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
 					SVIDs: []SVIDRequestWithRules{
@@ -169,11 +170,11 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "svid.path: should not be empty",
+			WantErr: "svid.path: should not be empty",
 		},
 		{
-			name: "path missing leading slash",
-			in: func() *SPIFFEWorkloadAPIService {
+			Name: "path missing leading slash",
+			In: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
 					SVIDs: []SVIDRequestWithRules{
@@ -190,11 +191,11 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "svid.path: should be prefixed with /",
+			WantErr: "svid.path: should be prefixed with /",
 		},
 		{
-			name: "missing listen addr",
-			in: func() *SPIFFEWorkloadAPIService {
+			Name: "missing listen addr",
+			In: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "",
 					SVIDs: []SVIDRequestWithRules{
@@ -211,11 +212,11 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "listen: should not be empty",
+			WantErr: "listen: should not be empty",
 		},
 		{
-			name: "invalid ip",
-			in: func() *SPIFFEWorkloadAPIService {
+			Name: "invalid ip",
+			In: func() *SPIFFEWorkloadAPIService {
 				return &SPIFFEWorkloadAPIService{
 					Listen: "unix:///var/run/spiffe.sock",
 					SVIDs: []SVIDRequestWithRules{
@@ -232,8 +233,8 @@ func TestSPIFFEWorkloadAPIService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "ip_sans[0]: invalid IP address",
+			WantErr: "ip_sans[0]: invalid IP address",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_ssh_host_test.go
+++ b/lib/tbot/config/service_ssh_host_test.go
@@ -21,14 +21,16 @@ package config
 import (
 	"testing"
 	"time"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestSSHHostOutput_YAML(t *testing.T) {
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[SSHHostOutput]{
+	tests := []testutils.TestYAMLCase[SSHHostOutput]{
 		{
-			name: "full",
-			in: SSHHostOutput{
+			Name: "full",
+			In: SSHHostOutput{
 				Destination: dest,
 				Roles:       []string{"access"},
 				Principals:  []string{"host.example.com"},
@@ -39,21 +41,21 @@ func TestSSHHostOutput_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: SSHHostOutput{
+			Name: "minimal",
+			In: SSHHostOutput{
 				Destination: dest,
 				Principals:  []string{"host.example.com"},
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
-	tests := []testCheckAndSetDefaultsCase[*SSHHostOutput]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*SSHHostOutput]{
 		{
-			name: "valid",
-			in: func() *SSHHostOutput {
+			Name: "valid",
+			In: func() *SSHHostOutput {
 				return &SSHHostOutput{
 					Destination: memoryDestForTest(),
 					Roles:       []string{"access"},
@@ -62,24 +64,24 @@ func TestSSHHostOutput_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *SSHHostOutput {
+			Name: "missing destination",
+			In: func() *SSHHostOutput {
 				return &SSHHostOutput{
 					Destination: nil,
 					Principals:  []string{"host.example.com"},
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing principals",
-			in: func() *SSHHostOutput {
+			Name: "missing principals",
+			In: func() *SSHHostOutput {
 				return &SSHHostOutput{
 					Destination: memoryDestForTest(),
 				}
 			},
-			wantErr: "at least one principal must be specified",
+			WantErr: "at least one principal must be specified",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_ssh_multiplexer_test.go
+++ b/lib/tbot/config/service_ssh_multiplexer_test.go
@@ -23,15 +23,16 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestSSHMultiplexerService_YAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []testYAMLCase[SSHMultiplexerService]{
+	tests := []testutils.TestYAMLCase[SSHMultiplexerService]{
 		{
-			name: "full",
-			in: SSHMultiplexerService{
+			Name: "full",
+			In: SSHMultiplexerService{
 				Destination: &DestinationDirectory{
 					Path: "/opt/machine-id",
 				},
@@ -45,16 +46,16 @@ func TestSSHMultiplexerService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestSSHMultiplexerService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*SSHMultiplexerService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*SSHMultiplexerService]{
 		{
-			name: "valid",
-			in: func() *SSHMultiplexerService {
+			Name: "valid",
+			In: func() *SSHMultiplexerService {
 				return &SSHMultiplexerService{
 					Destination: &DestinationDirectory{
 						Path:     "/opt/machine-id",
@@ -65,23 +66,23 @@ func TestSSHMultiplexerService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing destination",
-			in: func() *SSHMultiplexerService {
+			Name: "missing destination",
+			In: func() *SSHMultiplexerService {
 				return &SSHMultiplexerService{
 					Destination: nil,
 				}
 			},
-			wantErr: "destination: must be specified",
+			WantErr: "destination: must be specified",
 		},
 		{
-			name: "wrong destination type",
-			in: func() *SSHMultiplexerService {
+			Name: "wrong destination type",
+			In: func() *SSHMultiplexerService {
 				return &SSHMultiplexerService{
 					Destination: &DestinationMemory{},
 				}
 			},
-			wantErr: "destination: must be of type `directory`",
+			WantErr: "destination: must be of type `directory`",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_workload_identity_api_test.go
+++ b/lib/tbot/config/service_workload_identity_api_test.go
@@ -20,16 +20,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
 )
 
 func TestWorkloadIdentityAPIService_YAML(t *testing.T) {
 	t.Parallel()
 
-	tests := []testYAMLCase[WorkloadIdentityAPIService]{
+	tests := []testutils.TestYAMLCase[WorkloadIdentityAPIService]{
 		{
-			name: "full",
-			in: WorkloadIdentityAPIService{
+			Name: "full",
+			In: WorkloadIdentityAPIService{
 				Listen: "tcp://0.0.0.0:4040",
 				Attestors: workloadattest.Config{
 					Kubernetes: workloadattest.KubernetesAttestorConfig{
@@ -53,8 +54,8 @@ func TestWorkloadIdentityAPIService_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: WorkloadIdentityAPIService{
+			Name: "minimal",
+			In: WorkloadIdentityAPIService{
 				Listen: "tcp://0.0.0.0:4040",
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -62,16 +63,16 @@ func TestWorkloadIdentityAPIService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*WorkloadIdentityAPIService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*WorkloadIdentityAPIService]{
 		{
-			name: "valid",
-			in: func() *WorkloadIdentityAPIService {
+			Name: "valid",
+			In: func() *WorkloadIdentityAPIService {
 				return &WorkloadIdentityAPIService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -79,7 +80,7 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 					Listen: "tcp://0.0.0.0:4040",
 				}
 			},
-			want: &WorkloadIdentityAPIService{
+			Want: &WorkloadIdentityAPIService{
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
 				},
@@ -92,8 +93,8 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid with labels",
-			in: func() *WorkloadIdentityAPIService {
+			Name: "valid with labels",
+			In: func() *WorkloadIdentityAPIService {
 				return &WorkloadIdentityAPIService{
 					Selector: WorkloadIdentitySelector{
 						Labels: map[string][]string{
@@ -103,7 +104,7 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 					Listen: "tcp://0.0.0.0:4040",
 				}
 			},
-			want: &WorkloadIdentityAPIService{
+			Want: &WorkloadIdentityAPIService{
 				Selector: WorkloadIdentitySelector{
 					Labels: map[string][]string{
 						"key": {"value"},
@@ -118,18 +119,18 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing selectors",
-			in: func() *WorkloadIdentityAPIService {
+			Name: "missing selectors",
+			In: func() *WorkloadIdentityAPIService {
 				return &WorkloadIdentityAPIService{
 					Selector: WorkloadIdentitySelector{},
 					Listen:   "tcp://0.0.0.0:4040",
 				}
 			},
-			wantErr: "one of ['name', 'labels'] must be set",
+			WantErr: "one of ['name', 'labels'] must be set",
 		},
 		{
-			name: "too many selectors",
-			in: func() *WorkloadIdentityAPIService {
+			Name: "too many selectors",
+			In: func() *WorkloadIdentityAPIService {
 				return &WorkloadIdentityAPIService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -140,19 +141,19 @@ func TestWorkloadIdentityAPIService_CheckAndSetDefaults(t *testing.T) {
 					Listen: "tcp://0.0.0.0:4040",
 				}
 			},
-			wantErr: "at most one of ['name', 'labels'] can be set",
+			WantErr: "at most one of ['name', 'labels'] can be set",
 		},
 		{
-			name: "missing listen",
-			in: func() *WorkloadIdentityAPIService {
+			Name: "missing listen",
+			In: func() *WorkloadIdentityAPIService {
 				return &WorkloadIdentityAPIService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
 					},
 				}
 			},
-			wantErr: "listen: should not be empty",
+			WantErr: "listen: should not be empty",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_workload_identity_aws_ra_test.go
+++ b/lib/tbot/config/service_workload_identity_aws_ra_test.go
@@ -21,16 +21,17 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestWorkloadIdentityAWSRAService_YAML(t *testing.T) {
 	t.Parallel()
 
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[WorkloadIdentityAWSRAService]{
+	tests := []testutils.TestYAMLCase[WorkloadIdentityAWSRAService]{
 		{
-			name: "full",
-			in: WorkloadIdentityAWSRAService{
+			Name: "full",
+			In: WorkloadIdentityAWSRAService{
 				Destination: dest,
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -47,8 +48,8 @@ func TestWorkloadIdentityAWSRAService_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "simple",
-			in: WorkloadIdentityAWSRAService{
+			Name: "simple",
+			In: WorkloadIdentityAWSRAService{
 				Destination: dest,
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -62,16 +63,16 @@ func TestWorkloadIdentityAWSRAService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*WorkloadIdentityAWSRAService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*WorkloadIdentityAWSRAService]{
 		{
-			name: "valid",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "valid",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -87,7 +88,7 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			want: &WorkloadIdentityAWSRAService{
+			Want: &WorkloadIdentityAWSRAService{
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
 				},
@@ -105,8 +106,8 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid with labels",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "valid with labels",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Labels: map[string][]string{
@@ -128,8 +129,8 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing selectors",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "missing selectors",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{},
 					Destination: &DestinationDirectory{
@@ -143,11 +144,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "one of ['name', 'labels'] must be set",
+			WantErr: "one of ['name', 'labels'] must be set",
 		},
 		{
-			name: "too many selectors",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "too many selectors",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -166,11 +167,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "at most one of ['name', 'labels'] can be set",
+			WantErr: "at most one of ['name', 'labels'] can be set",
 		},
 		{
-			name: "missing destination",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "missing destination",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Destination: nil,
 					Selector: WorkloadIdentitySelector{
@@ -182,11 +183,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 		{
-			name: "missing role_arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "missing role_arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -201,11 +202,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "role_arn: must be set",
+			WantErr: "role_arn: must be set",
 		},
 		{
-			name: "missing trust_anchor_arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "missing trust_anchor_arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -220,11 +221,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:     "us-east-1",
 				}
 			},
-			wantErr: "trust_anchor_arn: must be set",
+			WantErr: "trust_anchor_arn: must be set",
 		},
 		{
-			name: "missing profile_arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "missing profile_arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -239,11 +240,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "profile_arn: must be set",
+			WantErr: "profile_arn: must be set",
 		},
 		{
-			name: "invalid role arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "invalid role arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -259,11 +260,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "arn: invalid prefix",
+			WantErr: "arn: invalid prefix",
 		},
 		{
-			name: "invalid trust anchor arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "invalid trust anchor arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -279,11 +280,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "arn: invalid prefix",
+			WantErr: "arn: invalid prefix",
 		},
 		{
-			name: "invalid profile arn",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "invalid profile arn",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -299,11 +300,11 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1",
 				}
 			},
-			wantErr: "arn: invalid prefix",
+			WantErr: "arn: invalid prefix",
 		},
 		{
-			name: "invalid region",
-			in: func() *WorkloadIdentityAWSRAService {
+			Name: "invalid region",
+			In: func() *WorkloadIdentityAWSRAService {
 				return &WorkloadIdentityAWSRAService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -319,8 +320,8 @@ func TestWorkloadIdentityAWSRAService_CheckAndSetDefaults(t *testing.T) {
 					Region:         "us-east-1!!!!",
 				}
 			},
-			wantErr: "validating region",
+			WantErr: "validating region",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_workload_identity_jwt_test.go
+++ b/lib/tbot/config/service_workload_identity_jwt_test.go
@@ -21,16 +21,17 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestWorkloadIdentityJWTService_YAML(t *testing.T) {
 	t.Parallel()
 
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[WorkloadIdentityJWTService]{
+	tests := []testutils.TestYAMLCase[WorkloadIdentityJWTService]{
 		{
-			name: "full",
-			in: WorkloadIdentityJWTService{
+			Name: "full",
+			In: WorkloadIdentityJWTService{
 				Destination: dest,
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -43,16 +44,16 @@ func TestWorkloadIdentityJWTService_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*WorkloadIdentityJWTService]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*WorkloadIdentityJWTService]{
 		{
-			name: "valid",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "valid",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -67,8 +68,8 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid with labels",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "valid with labels",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Selector: WorkloadIdentitySelector{
 						Labels: map[string][]string{
@@ -85,8 +86,8 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing audience",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "missing audience",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -98,11 +99,11 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "audiences: must have at least one value",
+			WantErr: "audiences: must have at least one value",
 		},
 		{
-			name: "missing selectors",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "missing selectors",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Selector: WorkloadIdentitySelector{},
 					Destination: &DestinationDirectory{
@@ -113,11 +114,11 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 					Audiences: []string{"audience1", "audience2"},
 				}
 			},
-			wantErr: "one of ['name', 'labels'] must be set",
+			WantErr: "one of ['name', 'labels'] must be set",
 		},
 		{
-			name: "too many selectors",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "too many selectors",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -133,11 +134,11 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 					Audiences: []string{"audience1", "audience2"},
 				}
 			},
-			wantErr: "at most one of ['name', 'labels'] can be set",
+			WantErr: "at most one of ['name', 'labels'] can be set",
 		},
 		{
-			name: "missing destination",
-			in: func() *WorkloadIdentityJWTService {
+			Name: "missing destination",
+			In: func() *WorkloadIdentityJWTService {
 				return &WorkloadIdentityJWTService{
 					Destination: nil,
 					Selector: WorkloadIdentitySelector{
@@ -146,8 +147,8 @@ func TestWorkloadIdentityJWTService_CheckAndSetDefaults(t *testing.T) {
 					Audiences: []string{"audience1", "audience2"},
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/config/service_workload_identity_x509_test.go
+++ b/lib/tbot/config/service_workload_identity_x509_test.go
@@ -21,16 +21,17 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
 func TestWorkloadIdentityX509Service_YAML(t *testing.T) {
 	t.Parallel()
 
 	dest := &DestinationMemory{}
-	tests := []testYAMLCase[WorkloadIdentityX509Service]{
+	tests := []testutils.TestYAMLCase[WorkloadIdentityX509Service]{
 		{
-			name: "full",
-			in: WorkloadIdentityX509Service{
+			Name: "full",
+			In: WorkloadIdentityX509Service{
 				Destination: dest,
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -43,8 +44,8 @@ func TestWorkloadIdentityX509Service_YAML(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal",
-			in: WorkloadIdentityX509Service{
+			Name: "minimal",
+			In: WorkloadIdentityX509Service{
 				Destination: dest,
 				Selector: WorkloadIdentitySelector{
 					Name: "my-workload-identity",
@@ -52,16 +53,16 @@ func TestWorkloadIdentityX509Service_YAML(t *testing.T) {
 			},
 		},
 	}
-	testYAML(t, tests)
+	testutils.TestYAML(t, tests)
 }
 
 func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 
-	tests := []testCheckAndSetDefaultsCase[*WorkloadIdentityX509Service]{
+	tests := []testutils.TestCheckAndSetDefaultsCase[*WorkloadIdentityX509Service]{
 		{
-			name: "valid",
-			in: func() *WorkloadIdentityX509Service {
+			Name: "valid",
+			In: func() *WorkloadIdentityX509Service {
 				return &WorkloadIdentityX509Service{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -75,8 +76,8 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "valid with labels",
-			in: func() *WorkloadIdentityX509Service {
+			Name: "valid with labels",
+			In: func() *WorkloadIdentityX509Service {
 				return &WorkloadIdentityX509Service{
 					Selector: WorkloadIdentitySelector{
 						Labels: map[string][]string{
@@ -92,8 +93,8 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "missing selectors",
-			in: func() *WorkloadIdentityX509Service {
+			Name: "missing selectors",
+			In: func() *WorkloadIdentityX509Service {
 				return &WorkloadIdentityX509Service{
 					Selector: WorkloadIdentitySelector{},
 					Destination: &DestinationDirectory{
@@ -103,11 +104,11 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "one of ['name', 'labels'] must be set",
+			WantErr: "one of ['name', 'labels'] must be set",
 		},
 		{
-			name: "too many selectors",
-			in: func() *WorkloadIdentityX509Service {
+			Name: "too many selectors",
+			In: func() *WorkloadIdentityX509Service {
 				return &WorkloadIdentityX509Service{
 					Selector: WorkloadIdentitySelector{
 						Name: "my-workload-identity",
@@ -122,17 +123,17 @@ func TestWorkloadIdentityX509Service_CheckAndSetDefaults(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "at most one of ['name', 'labels'] can be set",
+			WantErr: "at most one of ['name', 'labels'] can be set",
 		},
 		{
-			name: "missing destination",
-			in: func() *WorkloadIdentityX509Service {
+			Name: "missing destination",
+			In: func() *WorkloadIdentityX509Service {
 				return &WorkloadIdentityX509Service{
 					Destination: nil,
 				}
 			},
-			wantErr: "no destination configured for output",
+			WantErr: "no destination configured for output",
 		},
 	}
-	testCheckAndSetDefaults(t, tests)
+	testutils.TestCheckAndSetDefaults(t, tests)
 }

--- a/lib/tbot/internal/testutils/testutils.go
+++ b/lib/tbot/internal/testutils/testutils.go
@@ -1,0 +1,168 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package testutils contains commonly used helpers for testing bot services.
+//
+// Note: we do not import the testing or testify packages to avoid accidentally
+// bringing these dependencies into our production binaries.
+package testutils
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+// TestingT is a subset of *testing.T's interface. It is intentionally *NOT*
+// compatible with testify's require and assert packages to avoid accidentally
+// bringing those packages into production code. See: TestNotTestifyCompatible.
+type TestingT interface {
+	Cleanup(fn func())
+	Context() context.Context
+	Fatalf(format string, args ...any)
+	Helper()
+	Name() string
+}
+
+// Pointer returns a pointer to v. It's useful in expressions where it's
+// impossible to take a pointer of a literal value.
+//
+// Example: &"hi" doesn't work but Pointer("hi") does.
+func Pointer[T any](v T) *T {
+	return &v
+}
+
+// Subtester extends TestingT with the Run method for subtests.
+type Subtester[T TestingT] interface {
+	TestingT
+
+	Run(name string, fn func(T)) bool
+}
+
+// TestYAML marshals the given test structs to YAML, compares them to golden
+// files, and then unmarshals them to check nothing is lost in the round-trip.
+func TestYAML[T TestingT, CaseT any](t Subtester[T], tests []TestYAMLCase[CaseT]) {
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t T) {
+			b := bytes.NewBuffer(nil)
+			encoder := yaml.NewEncoder(b)
+			encoder.SetIndent(2)
+
+			if err := encoder.Encode(&tt.In); err != nil {
+				t.Fatalf("failed to encode: %v", err)
+			}
+
+			if golden.ShouldSet() {
+				golden.Set(t, b.Bytes())
+			}
+
+			if diff := cmp.Diff(
+				string(golden.Get(t)),
+				b.String(),
+			); diff != "" {
+				t.Fatalf("results of marshal did not match golden file, rerun tests with GOLDEN_UPDATE=1\n\n%s", diff)
+			}
+
+			// Now test unmarshaling to see if we get the same object back.
+			var unmarshaled CaseT
+			decoder := yaml.NewDecoder(b)
+			if err := decoder.Decode(&unmarshaled); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+
+			if diff := cmp.Diff(
+				tt.In,
+				unmarshaled,
+				exportAll,
+			); diff != "" {
+				t.Fatalf("unmarshaling did not result in same object as input\n\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestYAMLCase is a test case for TestYAML.
+type TestYAMLCase[CaseT any] struct {
+	// Name of this case.
+	Name string
+
+	// In is the input struct that will be marshaled.
+	In CaseT
+}
+
+// TestCheckAndSetDefaults tests the CheckAndSetDefaults method.
+func TestCheckAndSetDefaults[T TestingT, CaseT CheckAndSetDefaulter](t Subtester[T], tests []TestCheckAndSetDefaultsCase[CaseT]) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t T) {
+			got := tt.In()
+			err := got.CheckAndSetDefaults()
+			if tt.WantErr != "" {
+				if !strings.Contains(err.Error(), tt.WantErr) {
+					t.Fatalf("error %v does not contain %q", err, tt.WantErr)
+				}
+				return
+			}
+
+			want := tt.Want
+			if want == nil {
+				want = tt.In()
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(
+				want,
+				got,
+				exportAll,
+			); diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+type CheckAndSetDefaulter interface {
+	CheckAndSetDefaults() error
+}
+
+// TestCheckAndSetDefaultsCase is a case for TestCheckAndSetDefaults.
+type TestCheckAndSetDefaultsCase[T CheckAndSetDefaulter] struct {
+	Name string
+
+	// In returns the input struct.
+	In func() T
+
+	// Want specifies the desired state of the checkAndSetDefaulter after
+	// check and set defaults has been run. If Want is nil, the Output is
+	// compared to its initial state.
+	Want CheckAndSetDefaulter
+
+	// WantErr is the error that is expected from calling CheckAndSetDefault.
+	WantErr string
+}
+
+// exportAll allows go-cmp to compare all fields (even unexported ones).
+var exportAll = cmp.Exporter(func(reflect.Type) bool { return true })

--- a/lib/tbot/internal/testutils/testutils_test.go
+++ b/lib/tbot/internal/testutils/testutils_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,12 +16,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package config
+package testutils_test
 
 import (
-	"github.com/gravitational/teleport/lib/tbot/bot"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/tbot/internal/testutils"
 )
 
-func memoryDestForTest() bot.Destination {
-	return &DestinationMemory{store: map[string][]byte{}}
+func TestNotTestifyCompatible(t *testing.T) {
+	var testingT testutils.TestingT = struct{ testutils.TestingT }{}
+	if _, ok := testingT.(require.TestingT); ok {
+		t.Fatal("testutils.TestingT must not be testify compatible")
+	}
+	if _, ok := testingT.(assert.TestingT); ok {
+		t.Fatal("testutils.TestingT must not be testify compatible")
+	}
 }


### PR DESCRIPTION
## Background

This is part of a series of pull requests to refactor the `lib/tbot` package for better modularity.

Today, all of `tbot`'s services live in the same package which makes it difficult to see the system boundaries, but also means that it's impossible for other binaries that "embed" tbot (e.g. `tctl`, the Kubernetes operator) to pull in just the parts they need - and for the compiler to effectively eliminate unused dependencies.

See the [boxofrad/wip-tbot-refactoring branch](https://github.com/gravitational/teleport/tree/boxofrad/wip-tbot-refactoring) for an idea of the end-state of this stack. In this branch, the `tctl` binary is roughly **13% smaller** largely due to eliminating the unused Sigstore modules.

## Changes

This pull request introduces the `lib/tbot/internal/testutils` package and moves the `testYAML` and `testCheckAndSetDefault` helper methods to it, which is necessary because each service's config will live in a separate package.

To avoid further exacerbating #51023, the test helpers take a `TestingT` interface which is intentionally incompatible with testify's `assert` and `require` packages.
