### PR TITLE
Fix ListUsers pagination

### DIFF
--- a/lib/cache/users.go
+++ b/lib/cache/users.go
@@ -18,14 +18,12 @@ package cache
 
 import (
 	"context"
-	"strings"
 
 	"github.com/gravitational/trace"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -174,8 +172,7 @@ func (c *Cache) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*
 		}
 
 		if len(resp.Users) == pageSize {
-			key := backend.RangeEnd(backend.ExactKey(u.GetName())).String()
-			resp.NextPageToken = strings.Trim(key, string(backend.Separator))
+			resp.NextPageToken = u.GetName()
 			break
 		}
 

--- a/lib/cache/users_test.go
+++ b/lib/cache/users_test.go
@@ -19,8 +19,11 @@ package cache
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -119,4 +122,44 @@ func TestUsers(t *testing.T) {
 		})
 	})
 
+	t.Run("ListUsers pagination", func(t *testing.T) {
+		err := p.usersS.DeleteAllUsers(t.Context())
+		require.NoError(t, err)
+
+		waitForUsersCacheLen := func(expected int) {
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				got, err := p.cache.GetUsers(t.Context(), false)
+				require.NoError(c, err)
+				require.Len(c, got, expected)
+			}, 3*time.Second, time.Millisecond*100)
+		}
+		waitForUsersCacheLen(0)
+
+		usersToCreate := []string{"bob", "alice"}
+		for _, userName := range usersToCreate {
+			user, err := types.NewUser(userName)
+			require.NoError(t, err)
+			_, err = p.usersS.UpsertUser(t.Context(), user)
+			require.NoError(t, err)
+		}
+
+		waitForUsersCacheLen(len(usersToCreate))
+
+		var allUsers []*types.UserV2
+		req := &userspb.ListUsersRequest{
+			PageSize: 1,
+		}
+		for {
+			resp, err := p.cache.ListUsers(t.Context(), req)
+			require.NoError(t, err)
+			require.Len(t, resp.Users, 1)
+
+			allUsers = append(allUsers, resp.Users...)
+			if resp.NextPageToken == "" {
+				break
+			}
+			req.PageToken = resp.NextPageToken
+		}
+		require.Len(t, allUsers, len(usersToCreate))
+	})
 }


### PR DESCRIPTION
### What

Fix Cache.ListUsers pagination

#### Desc
The pagination logic incorrectly evaluated the NextPageToken before including the current user in the response. This led to a bug where the next users in the next page is  skipped entirely from the `List` call

For example, if the page size limit is reached and the current user is bob, the logic would not include bob in the response but would still use bob to calculate the next page token:

```go
NextPageToken = backend.RangeEnd(backend.ExactKey("bob")) // evaluates to "bob0"
```

Since `bob0` is lexicographically after `bob` the next page starts after `bob`, effectively skipping that user.




 
**Related**: Add cache pagination unit tests - https://github.com/gravitational/teleport/pull/56547



changelog: Fix Teleport Cache ListUsers pagination