### PR TITLE
Trace the correct error return value in Router.DialWindowsDesktop

### DIFF
--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -338,8 +338,7 @@ func (r *Router) DialWindowsDesktop(ctx context.Context, clientSrcAddr, clientDs
 			attribute.String("cluster", clusterName),
 		),
 	)
-
-	defer tracing.EndSpan(span, err)
+	defer func() { tracing.EndSpan(span, err) }()
 
 	site := r.localSite
 	if clusterName != r.clusterName {


### PR DESCRIPTION
The arguments to a deferred function call are evaluated at the callsite, not during unwind, so `defer tracing.EndSpan(span, err)` right after defining the span will always result in no error being traced. This PR fixes this error in `(*proxy.Router).DialWindowsDesktop`. The `tracing.EndSpan` utility function seems to be used correctly everywhere else in the codebase at this time.