### PR TITLE
[v18] fix: don't return db_client CA when listing db CAs

### DIFF
--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -170,7 +170,13 @@ func (c *Cache) GetCertAuthorities(ctx context.Context, caType types.CertAuthTyp
 
 	if rg.ReadCache() {
 		cas := make([]types.CertAuthority, 0, rg.store.len())
-		for ca := range rg.store.resources(certAuthorityIDIndex, string(caType), sortcache.NextKey(string(caType))) {
+		// CA keys are suffixed with the cluster name, e.g. db/teleport.example.com
+		// Use the exact key with the trailing slash to avoid matching CA types
+		// with a common prefix, i.e. to avoid matching db_client CAs when
+		// querying for db CAs.
+		startKey := string(caType) + "/"
+		endKey := sortcache.NextKey(startKey)
+		for ca := range rg.store.resources(certAuthorityIDIndex, startKey, endKey) {
 			if loadSigningKeys {
 				cas = append(cas, ca.Clone())
 			} else {


### PR DESCRIPTION
Backport #56533 to branch/v18

changelog: fixed duplicated `db_client` CA in `tctl status` and `tctl get cas` output
