### PR TITLE
[v17] Web: move sliding tab logic to a single file for sharing

### DIFF
--- a/web/packages/design/src/Tabs/Tabs.story.tsx
+++ b/web/packages/design/src/Tabs/Tabs.story.tsx
@@ -1,0 +1,91 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react';
+import { useState } from 'react';
+
+import { TabBorder, TabContainer, TabsContainer } from './Tabs';
+import { useSlidingBottomBorderTabs } from './useSlidingBottomBorderTabs';
+
+type StoryProps = {
+  withBottomBorder: boolean;
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Design/Tabs',
+  component: Controls,
+  argTypes: {
+    withBottomBorder: {
+      control: { type: 'boolean' },
+    },
+  },
+  // default
+  args: {
+    withBottomBorder: false,
+  },
+};
+export default meta;
+
+enum Tab {
+  Example1,
+  Example2,
+  Example3,
+}
+
+export function Controls(props: StoryProps) {
+  const [activeTab, setActiveTab] = useState(Tab.Example1);
+
+  const { borderRef, parentRef } = useSlidingBottomBorderTabs({ activeTab });
+
+  return (
+    <>
+      <TabsContainer
+        ref={parentRef}
+        mb={3}
+        withBottomBorder={props.withBottomBorder}
+      >
+        <TabContainer
+          data-tab-id={Tab.Example1}
+          selected={activeTab === Tab.Example1}
+          onClick={() => setActiveTab(Tab.Example1)}
+        >
+          Example Tab 1
+        </TabContainer>
+        <TabContainer
+          data-tab-id={Tab.Example2}
+          selected={activeTab === Tab.Example2}
+          onClick={() => setActiveTab(Tab.Example2)}
+        >
+          Example Tab 2
+        </TabContainer>
+        <TabContainer
+          data-tab-id={Tab.Example3}
+          selected={activeTab === Tab.Example3}
+          onClick={() => setActiveTab(Tab.Example3)}
+        >
+          Example Tab 3
+        </TabContainer>
+        <TabBorder ref={borderRef} />
+      </TabsContainer>
+
+      {activeTab === Tab.Example1 && <div>Example 1 content</div>}
+      {activeTab === Tab.Example2 && <div>Example 2 content</div>}
+      {activeTab === Tab.Example3 && <div>Example 3 content</div>}
+    </>
+  );
+}

--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -19,16 +19,29 @@
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const TabsContainer = styled.div`
+import { space, SpaceProps } from 'design/system';
+
+interface TabsContainerProps extends SpaceProps {
+  /**
+   * It's an underlying background border bottom that
+   * renders underneath the currently active tab border
+   * bottom.
+   */
+  withBottomBorder?: boolean;
+}
+
+export const TabsContainer = styled.div<TabsContainerProps>`
   position: relative;
   display: flex;
   gap: ${p => p.theme.space[5]}px;
   align-items: center;
-  padding: 0 ${p => p.theme.space[5]}px;
-  border-bottom: 1px solid ${p => p.theme.colors.spotBackground[0]};
+  border-bottom: ${p =>
+    p.withBottomBorder ? `1px solid ${p.theme.colors.spotBackground[0]}` : 0};
+
+  ${space}
 `;
 
-export const TabContainer = styled(NavLink)<{ selected?: boolean }>`
+export const TabContainer = styled.div<{ selected?: boolean }>`
   padding: ${p => p.theme.space[1] + p.theme.space[2]}px
     ${p => p.theme.space[2]}px;
   position: relative;
@@ -47,6 +60,10 @@ export const TabContainer = styled(NavLink)<{ selected?: boolean }>`
     opacity: 1;
   }
 `;
+
+export const TabContainerNavLink = styled(TabContainer).attrs({
+  as: NavLink,
+})``;
 
 export const TabBorder = styled.div`
   position: absolute;

--- a/web/packages/design/src/Tabs/index.ts
+++ b/web/packages/design/src/Tabs/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { useSlidingBottomBorderTabs } from './useSlidingBottomBorderTabs';
+export * from './Tabs';

--- a/web/packages/design/src/Tabs/useSlidingBottomBorderTabs.ts
+++ b/web/packages/design/src/Tabs/useSlidingBottomBorderTabs.ts
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useLayoutEffect, useRef } from 'react';
+
+/**
+ * On selecting a new tab, produces a bottom border sliding animation
+ * from the current tab to the newly selected tab.
+ *
+ * Requires that each TabContainer defines a prop called "data-tab-id".
+ *
+ * TODO: mimics the implementation of tabs in
+ * e/web/teleport/src/AccessMonitoring/AccessMonitoring.tsx.
+ * Consider updating useSlidingBottomBorderTabs to be plain css.
+ */
+export function useSlidingBottomBorderTabs<T>({ activeTab }: { activeTab: T }) {
+  const borderRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!parentRef.current || !borderRef.current) {
+      return;
+    }
+
+    const activeElement = parentRef.current.querySelector(
+      `[data-tab-id="${activeTab}"]`
+    );
+
+    if (activeElement) {
+      const parentBounds = parentRef.current.getBoundingClientRect();
+      const activeBounds = activeElement.getBoundingClientRect();
+
+      const left = activeBounds.left - parentBounds.left;
+      const width = activeBounds.width;
+
+      borderRef.current.style.left = `${left}px`;
+      borderRef.current.style.width = `${width}px`;
+    }
+  }, [activeTab]);
+
+  return { borderRef, parentRef };
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
@@ -16,10 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef } from 'react';
 import { useLocation, useParams } from 'react-router';
 
-import { TabBorder, TabContainer, TabsContainer } from 'design/Tabs/Tabs';
+import {
+  TabBorder,
+  TabContainerNavLink,
+  TabsContainer,
+  useSlidingBottomBorderTabs,
+} from 'design/Tabs';
 
 import cfg from 'teleport/config';
 import { Agents } from 'teleport/Integrations/status/AwsOidc/Details/Agents';
@@ -43,38 +47,14 @@ export function Rds() {
   const searchParams = new URLSearchParams(search);
   const tab = (searchParams.get('tab') as RdsTab) || RdsTab.Rules;
 
-  const borderRef = useRef<HTMLDivElement>(null);
-  const parentRef = useRef<HTMLDivElement>();
-
-  // todo (michellescripts) the following implementation mimics the implementation of tabs in
-  //  e/web/teleport/src/AccessMonitoring/AccessMonitoring.tsx which is refactored/moved into a shared
-  //  design component, web/packages/design/src/Tabs/Tabs.ts. When refactoring AccessMonitoring to use the shared
-  //  component, consider updating both instances logic to be plain css
-  useEffect(() => {
-    if (!parentRef.current || !borderRef.current) {
-      return;
-    }
-
-    const activeElement = parentRef.current.querySelector(
-      `[data-tab-id="${tab}"]`
-    );
-
-    if (activeElement) {
-      const parentBounds = parentRef.current.getBoundingClientRect();
-      const activeBounds = activeElement.getBoundingClientRect();
-
-      const left = activeBounds.left - parentBounds.left;
-      const width = activeBounds.width;
-
-      borderRef.current.style.left = `${left}px`;
-      borderRef.current.style.width = `${width}px`;
-    }
-  }, [tab]);
+  const { borderRef, parentRef } = useSlidingBottomBorderTabs({
+    activeTab: tab,
+  });
 
   return (
     <>
-      <TabsContainer ref={parentRef}>
-        <TabContainer
+      <TabsContainer ref={parentRef} withBottomBorder px={5}>
+        <TabContainerNavLink
           data-tab-id={RdsTab.Rules}
           selected={tab === RdsTab.Rules}
           to={`${cfg.getIntegrationStatusResourcesRoute(
@@ -84,8 +64,8 @@ export function Rds() {
           )}?tab=${RdsTab.Rules}`}
         >
           Enrollment Rules
-        </TabContainer>
-        <TabContainer
+        </TabContainerNavLink>
+        <TabContainerNavLink
           data-tab-id={RdsTab.Agents}
           selected={tab === RdsTab.Agents}
           to={`${cfg.getIntegrationStatusResourcesRoute(
@@ -95,7 +75,7 @@ export function Rds() {
           )}?tab=${RdsTab.Agents}`}
         >
           Agents
-        </TabContainer>
+        </TabContainerNavLink>
         <TabBorder ref={borderRef} />
       </TabsContainer>
       {tab === RdsTab.Rules && <Rules />}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
+import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
+
 import { ContextProvider } from 'teleport';
 import { Route } from 'teleport/components/Router';
 import {
@@ -43,9 +45,11 @@ export const MockAwsOidcStatusProvider = ({
   return (
     <MemoryRouter initialEntries={initialEntries}>
       <ContextProvider ctx={ctx}>
-        <awsOidcStatusContext.Provider value={value}>
-          <Route path={path} render={() => <>{children}</>} />
-        </awsOidcStatusContext.Provider>
+        <InfoGuidePanelProvider>
+          <awsOidcStatusContext.Provider value={value}>
+            <Route path={path} render={() => <>{children}</>} />
+          </awsOidcStatusContext.Provider>
+        </InfoGuidePanelProvider>
       </ContextProvider>
     </MemoryRouter>
   );


### PR DESCRIPTION
backport of #56382 to branch/v17

manual because conflict with ButtonIcon difference (tsx and jsx diff)