### PR TITLE
[v16] Web: fix error when creating IAM token during ec2 ssm flow

### DIFF
--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -36,7 +36,8 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
       allow: [],
       suggested_agent_matcher_labels: {},
     },
-    null
+    null,
+    undefined
   );
 });
 
@@ -59,6 +60,7 @@ test('fetchJoinToken request fields are set as requested', () => {
       allow: [{ aws_account: '1234', aws_arn: 'xxxx' }],
       suggested_agent_matcher_labels: { env: ['dev'] },
     },
-    null
+    null,
+    undefined
   );
 });

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -30,7 +30,8 @@ class JoinTokenService {
   // TODO (avatus) refactor this code to eventually use `createJoinToken`
   fetchJoinToken(
     req: JoinTokenRequest,
-    signal: AbortSignal = null
+    signal: AbortSignal = null,
+    mfaResponse?: WebauthnAssertionResponse
   ): Promise<JoinToken> {
     return api
       .post(
@@ -43,7 +44,8 @@ class JoinTokenService {
             req.suggestedAgentMatcherLabels
           ),
         },
-        signal
+        signal,
+        mfaResponse
       )
       .then(makeJoinToken);
   }


### PR DESCRIPTION
backport #55970 to branch/v16

manual b/c of some difference with function names

changelog: Fixed error on setting up Teleport Discovery Service step of the EC2 SSM web UI flow when admin action is enabled (webauthn).