### PR TITLE
Extend AccessListService with *Static*Member RPCs

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
@@ -1076,8 +1076,7 @@ func (x *UpsertAccessListWithMembersResponse) GetMembers() []*Member {
 	return nil
 }
 
-// GetAccessListMemberRequest is the request for retrieving an access list
-// member.
+// GetAccessListMemberRequest is the request for retrieving an access_list_member.
 type GetAccessListMemberRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// access_list is the name of the access list that the member belongs to.
@@ -1132,6 +1131,109 @@ func (x *GetAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+// GetStaticAccessListMemberRequest is the request for retrieving an access_list_member of a static
+// type access_list.
+type GetStaticAccessListMemberRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// access_list is the name of the access_list that the member belongs to.
+	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
+	// member_name is the name of the user that belongs to the access_list.
+	MemberName    string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetStaticAccessListMemberRequest) Reset() {
+	*x = GetStaticAccessListMemberRequest{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetStaticAccessListMemberRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetStaticAccessListMemberRequest) ProtoMessage() {}
+
+func (x *GetStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
+func (*GetStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *GetStaticAccessListMemberRequest) GetAccessList() string {
+	if x != nil {
+		return x.AccessList
+	}
+	return ""
+}
+
+func (x *GetStaticAccessListMemberRequest) GetMemberName() string {
+	if x != nil {
+		return x.MemberName
+	}
+	return ""
+}
+
+// GetStaticAccessListMemberResponse is the response containing the access_list_member of the
+// target access_list of static type.
+type GetStaticAccessListMemberResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// member of the target static access_list.
+	Member        *Member `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetStaticAccessListMemberResponse) Reset() {
+	*x = GetStaticAccessListMemberResponse{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetStaticAccessListMemberResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetStaticAccessListMemberResponse) ProtoMessage() {}
+
+func (x *GetStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
+func (*GetStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetStaticAccessListMemberResponse) GetMember() *Member {
+	if x != nil {
+		return x.Member
+	}
+	return nil
+}
+
 // GetAccessListOwnersRequest is the request for getting a list of all owners
 // in an Access List, including those inherited from nested Access Lists.
 type GetAccessListOwnersRequest struct {
@@ -1144,7 +1246,7 @@ type GetAccessListOwnersRequest struct {
 
 func (x *GetAccessListOwnersRequest) Reset() {
 	*x = GetAccessListOwnersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1156,7 +1258,7 @@ func (x *GetAccessListOwnersRequest) String() string {
 func (*GetAccessListOwnersRequest) ProtoMessage() {}
 
 func (x *GetAccessListOwnersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1169,7 +1271,7 @@ func (x *GetAccessListOwnersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListOwnersRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessListOwnersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{22}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetAccessListOwnersRequest) GetAccessList() string {
@@ -1192,7 +1294,7 @@ type GetAccessListOwnersResponse struct {
 
 func (x *GetAccessListOwnersResponse) Reset() {
 	*x = GetAccessListOwnersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1306,7 @@ func (x *GetAccessListOwnersResponse) String() string {
 func (*GetAccessListOwnersResponse) ProtoMessage() {}
 
 func (x *GetAccessListOwnersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1319,7 @@ func (x *GetAccessListOwnersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListOwnersResponse.ProtoReflect.Descriptor instead.
 func (*GetAccessListOwnersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{23}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetAccessListOwnersResponse) GetOwners() []*AccessListOwner {
@@ -1239,7 +1341,7 @@ type UpsertAccessListMemberRequest struct {
 
 func (x *UpsertAccessListMemberRequest) Reset() {
 	*x = UpsertAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1251,7 +1353,7 @@ func (x *UpsertAccessListMemberRequest) String() string {
 func (*UpsertAccessListMemberRequest) ProtoMessage() {}
 
 func (x *UpsertAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1264,10 +1366,104 @@ func (x *UpsertAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*UpsertAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{24}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *UpsertAccessListMemberRequest) GetMember() *Member {
+	if x != nil {
+		return x.Member
+	}
+	return nil
+}
+
+// UpsertStaticAccessListMemberRequest is the request for upserting an access_list_member to an
+// access_list of type static.
+type UpsertStaticAccessListMemberRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// member is the access_list_member to upsert.
+	Member        *Member `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertStaticAccessListMemberRequest) Reset() {
+	*x = UpsertStaticAccessListMemberRequest{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertStaticAccessListMemberRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertStaticAccessListMemberRequest) ProtoMessage() {}
+
+func (x *UpsertStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
+func (*UpsertStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *UpsertStaticAccessListMemberRequest) GetMember() *Member {
+	if x != nil {
+		return x.Member
+	}
+	return nil
+}
+
+// UpsertStaticAccessListMemberResponse is the response of upserting an access_list_member to an
+// static_access of type static.
+type UpsertStaticAccessListMemberResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// member is the upserted access_list_member.
+	Member        *Member `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertStaticAccessListMemberResponse) Reset() {
+	*x = UpsertStaticAccessListMemberResponse{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertStaticAccessListMemberResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertStaticAccessListMemberResponse) ProtoMessage() {}
+
+func (x *UpsertStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
+func (*UpsertStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *UpsertStaticAccessListMemberResponse) GetMember() *Member {
 	if x != nil {
 		return x.Member
 	}
@@ -1286,7 +1482,7 @@ type UpdateAccessListMemberRequest struct {
 
 func (x *UpdateAccessListMemberRequest) Reset() {
 	*x = UpdateAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1298,7 +1494,7 @@ func (x *UpdateAccessListMemberRequest) String() string {
 func (*UpdateAccessListMemberRequest) ProtoMessage() {}
 
 func (x *UpdateAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1311,7 +1507,7 @@ func (x *UpdateAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{25}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *UpdateAccessListMemberRequest) GetMember() *Member {
@@ -1335,7 +1531,7 @@ type DeleteAccessListMemberRequest struct {
 
 func (x *DeleteAccessListMemberRequest) Reset() {
 	*x = DeleteAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1347,7 +1543,7 @@ func (x *DeleteAccessListMemberRequest) String() string {
 func (*DeleteAccessListMemberRequest) ProtoMessage() {}
 
 func (x *DeleteAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1360,7 +1556,7 @@ func (x *DeleteAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{26}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DeleteAccessListMemberRequest) GetAccessList() string {
@@ -1377,6 +1573,100 @@ func (x *DeleteAccessListMemberRequest) GetMemberName() string {
 	return ""
 }
 
+// DeleteStaticAccessListMemberRequest is the request for deleting an access_list_member from an
+// access_list of type static.
+type DeleteStaticAccessListMemberRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// access_list is the name of access list.
+	AccessList string `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
+	// member_name is the name of the user to delete.
+	MemberName    string `protobuf:"bytes,2,opt,name=member_name,json=memberName,proto3" json:"member_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteStaticAccessListMemberRequest) Reset() {
+	*x = DeleteStaticAccessListMemberRequest{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteStaticAccessListMemberRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteStaticAccessListMemberRequest) ProtoMessage() {}
+
+func (x *DeleteStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
+func (*DeleteStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *DeleteStaticAccessListMemberRequest) GetAccessList() string {
+	if x != nil {
+		return x.AccessList
+	}
+	return ""
+}
+
+func (x *DeleteStaticAccessListMemberRequest) GetMemberName() string {
+	if x != nil {
+		return x.MemberName
+	}
+	return ""
+}
+
+// DeleteStaticAccessListMemberResponse is the response of deleting an access_list_member from an
+// access_list of type static.
+type DeleteStaticAccessListMemberResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteStaticAccessListMemberResponse) Reset() {
+	*x = DeleteStaticAccessListMemberResponse{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteStaticAccessListMemberResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteStaticAccessListMemberResponse) ProtoMessage() {}
+
+func (x *DeleteStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
+func (*DeleteStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{32}
+}
+
 // DeleteAllAccessListMembersForAccessListRequest is the request for deleting
 // all members from an access list.
 type DeleteAllAccessListMembersForAccessListRequest struct {
@@ -1389,7 +1679,7 @@ type DeleteAllAccessListMembersForAccessListRequest struct {
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) Reset() {
 	*x = DeleteAllAccessListMembersForAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1401,7 +1691,7 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) String() string {
 func (*DeleteAllAccessListMembersForAccessListRequest) ProtoMessage() {}
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1414,7 +1704,7 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) ProtoReflect() protoref
 
 // Deprecated: Use DeleteAllAccessListMembersForAccessListRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllAccessListMembersForAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{27}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessList() string {
@@ -1434,7 +1724,7 @@ type DeleteAllAccessListMembersRequest struct {
 
 func (x *DeleteAllAccessListMembersRequest) Reset() {
 	*x = DeleteAllAccessListMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1446,7 +1736,7 @@ func (x *DeleteAllAccessListMembersRequest) String() string {
 func (*DeleteAllAccessListMembersRequest) ProtoMessage() {}
 
 func (x *DeleteAllAccessListMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1459,7 +1749,7 @@ func (x *DeleteAllAccessListMembersRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use DeleteAllAccessListMembersRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllAccessListMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{28}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{34}
 }
 
 // ListAccessListReviewsRequest is the request for getting paginated access list
@@ -1478,7 +1768,7 @@ type ListAccessListReviewsRequest struct {
 
 func (x *ListAccessListReviewsRequest) Reset() {
 	*x = ListAccessListReviewsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1490,7 +1780,7 @@ func (x *ListAccessListReviewsRequest) String() string {
 func (*ListAccessListReviewsRequest) ProtoMessage() {}
 
 func (x *ListAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1503,7 +1793,7 @@ func (x *ListAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListReviewsRequest.ProtoReflect.Descriptor instead.
 func (*ListAccessListReviewsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{29}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListAccessListReviewsRequest) GetAccessList() string {
@@ -1541,7 +1831,7 @@ type ListAccessListReviewsResponse struct {
 
 func (x *ListAccessListReviewsResponse) Reset() {
 	*x = ListAccessListReviewsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1843,7 @@ func (x *ListAccessListReviewsResponse) String() string {
 func (*ListAccessListReviewsResponse) ProtoMessage() {}
 
 func (x *ListAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1856,7 @@ func (x *ListAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListReviewsResponse.ProtoReflect.Descriptor instead.
 func (*ListAccessListReviewsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{30}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListAccessListReviewsResponse) GetReviews() []*Review {
@@ -1597,7 +1887,7 @@ type ListAllAccessListReviewsRequest struct {
 
 func (x *ListAllAccessListReviewsRequest) Reset() {
 	*x = ListAllAccessListReviewsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1609,7 +1899,7 @@ func (x *ListAllAccessListReviewsRequest) String() string {
 func (*ListAllAccessListReviewsRequest) ProtoMessage() {}
 
 func (x *ListAllAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1622,7 +1912,7 @@ func (x *ListAllAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListReviewsRequest.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListReviewsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{31}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ListAllAccessListReviewsRequest) GetPageSize() int32 {
@@ -1653,7 +1943,7 @@ type ListAllAccessListReviewsResponse struct {
 
 func (x *ListAllAccessListReviewsResponse) Reset() {
 	*x = ListAllAccessListReviewsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1665,7 +1955,7 @@ func (x *ListAllAccessListReviewsResponse) String() string {
 func (*ListAllAccessListReviewsResponse) ProtoMessage() {}
 
 func (x *ListAllAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1678,7 +1968,7 @@ func (x *ListAllAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListReviewsResponse.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListReviewsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{32}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListAllAccessListReviewsResponse) GetReviews() []*Review {
@@ -1707,7 +1997,7 @@ type CreateAccessListReviewRequest struct {
 
 func (x *CreateAccessListReviewRequest) Reset() {
 	*x = CreateAccessListReviewRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1719,7 +2009,7 @@ func (x *CreateAccessListReviewRequest) String() string {
 func (*CreateAccessListReviewRequest) ProtoMessage() {}
 
 func (x *CreateAccessListReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1732,7 +2022,7 @@ func (x *CreateAccessListReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessListReviewRequest.ProtoReflect.Descriptor instead.
 func (*CreateAccessListReviewRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{33}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CreateAccessListReviewRequest) GetReview() *Review {
@@ -1756,7 +2046,7 @@ type CreateAccessListReviewResponse struct {
 
 func (x *CreateAccessListReviewResponse) Reset() {
 	*x = CreateAccessListReviewResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1768,7 +2058,7 @@ func (x *CreateAccessListReviewResponse) String() string {
 func (*CreateAccessListReviewResponse) ProtoMessage() {}
 
 func (x *CreateAccessListReviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,7 +2071,7 @@ func (x *CreateAccessListReviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessListReviewResponse.ProtoReflect.Descriptor instead.
 func (*CreateAccessListReviewResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{34}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CreateAccessListReviewResponse) GetReviewName() string {
@@ -1812,7 +2102,7 @@ type DeleteAccessListReviewRequest struct {
 
 func (x *DeleteAccessListReviewRequest) Reset() {
 	*x = DeleteAccessListReviewRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1824,7 +2114,7 @@ func (x *DeleteAccessListReviewRequest) String() string {
 func (*DeleteAccessListReviewRequest) ProtoMessage() {}
 
 func (x *DeleteAccessListReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1837,7 +2127,7 @@ func (x *DeleteAccessListReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessListReviewRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessListReviewRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{35}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *DeleteAccessListReviewRequest) GetReviewName() string {
@@ -1870,7 +2160,7 @@ type AccessRequestPromoteRequest struct {
 
 func (x *AccessRequestPromoteRequest) Reset() {
 	*x = AccessRequestPromoteRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1882,7 +2172,7 @@ func (x *AccessRequestPromoteRequest) String() string {
 func (*AccessRequestPromoteRequest) ProtoMessage() {}
 
 func (x *AccessRequestPromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1895,7 +2185,7 @@ func (x *AccessRequestPromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestPromoteRequest.ProtoReflect.Descriptor instead.
 func (*AccessRequestPromoteRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{36}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AccessRequestPromoteRequest) GetRequestId() string {
@@ -1931,7 +2221,7 @@ type AccessRequestPromoteResponse struct {
 
 func (x *AccessRequestPromoteResponse) Reset() {
 	*x = AccessRequestPromoteResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1943,7 +2233,7 @@ func (x *AccessRequestPromoteResponse) String() string {
 func (*AccessRequestPromoteResponse) ProtoMessage() {}
 
 func (x *AccessRequestPromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2246,7 @@ func (x *AccessRequestPromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestPromoteResponse.ProtoReflect.Descriptor instead.
 func (*AccessRequestPromoteResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{37}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *AccessRequestPromoteResponse) GetAccessRequest() *types.AccessRequestV3 {
@@ -1978,7 +2268,7 @@ type GetSuggestedAccessListsRequest struct {
 
 func (x *GetSuggestedAccessListsRequest) Reset() {
 	*x = GetSuggestedAccessListsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1990,7 +2280,7 @@ func (x *GetSuggestedAccessListsRequest) String() string {
 func (*GetSuggestedAccessListsRequest) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2003,7 +2293,7 @@ func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsRequest.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{38}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetSuggestedAccessListsRequest) GetAccessRequestId() string {
@@ -2025,7 +2315,7 @@ type GetSuggestedAccessListsResponse struct {
 
 func (x *GetSuggestedAccessListsResponse) Reset() {
 	*x = GetSuggestedAccessListsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2037,7 +2327,7 @@ func (x *GetSuggestedAccessListsResponse) String() string {
 func (*GetSuggestedAccessListsResponse) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2050,7 +2340,7 @@ func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsResponse.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{39}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *GetSuggestedAccessListsResponse) GetAccessLists() []*AccessList {
@@ -2128,21 +2418,38 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x02 \x01(\tR\n" +
-	"memberName\"=\n" +
+	"memberName\"d\n" +
+	" GetStaticAccessListMemberRequest\x12\x1f\n" +
+	"\vaccess_list\x18\x01 \x01(\tR\n" +
+	"accessList\x12\x1f\n" +
+	"\vmember_name\x18\x02 \x01(\tR\n" +
+	"memberName\"[\n" +
+	"!GetStaticAccessListMemberResponse\x126\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"=\n" +
 	"\x1aGetAccessListOwnersRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\"^\n" +
 	"\x1bGetAccessListOwnersResponse\x12?\n" +
 	"\x06owners\x18\x01 \x03(\v2'.teleport.accesslist.v1.AccessListOwnerR\x06owners\"\x84\x01\n" +
 	"\x1dUpsertAccessListMemberRequest\x126\n" +
-	"\x06member\x18\x04 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06memberJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vaccess_listR\x04nameR\x06reason\"W\n" +
+	"\x06member\x18\x04 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06memberJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vaccess_listR\x04nameR\x06reason\"]\n" +
+	"#UpsertStaticAccessListMemberRequest\x126\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"^\n" +
+	"$UpsertStaticAccessListMemberResponse\x126\n" +
+	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"W\n" +
 	"\x1dUpdateAccessListMemberRequest\x126\n" +
 	"\x06member\x18\x01 \x01(\v2\x1e.teleport.accesslist.v1.MemberR\x06member\"m\n" +
 	"\x1dDeleteAccessListMemberRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\x12\x1f\n" +
 	"\vmember_name\x18\x03 \x01(\tR\n" +
-	"memberNameJ\x04\b\x02\x10\x03R\x04name\"Q\n" +
+	"memberNameJ\x04\b\x02\x10\x03R\x04name\"g\n" +
+	"#DeleteStaticAccessListMemberRequest\x12\x1f\n" +
+	"\vaccess_list\x18\x01 \x01(\tR\n" +
+	"accessList\x12\x1f\n" +
+	"\vmember_name\x18\x02 \x01(\tR\n" +
+	"memberName\"&\n" +
+	"$DeleteStaticAccessListMemberResponse\"Q\n" +
 	".DeleteAllAccessListMembersForAccessListRequest\x12\x1f\n" +
 	"\vaccess_list\x18\x01 \x01(\tR\n" +
 	"accessList\"6\n" +
@@ -2185,7 +2492,7 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1eGetSuggestedAccessListsRequest\x12*\n" +
 	"\x11access_request_id\x18\x01 \x01(\tR\x0faccessRequestId\"h\n" +
 	"\x1fGetSuggestedAccessListsResponse\x12E\n" +
-	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists2\xfe\x18\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists2\xc9\x1c\n" +
 	"\x11AccessListService\x12o\n" +
 	"\x0eGetAccessLists\x12-.teleport.accesslist.v1.GetAccessListsRequest\x1a..teleport.accesslist.v1.GetAccessListsResponse\x12r\n" +
 	"\x0fListAccessLists\x12..teleport.accesslist.v1.ListAccessListsRequest\x1a/.teleport.accesslist.v1.ListAccessListsResponse\x12a\n" +
@@ -2198,11 +2505,14 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x16CountAccessListMembers\x125.teleport.accesslist.v1.CountAccessListMembersRequest\x1a6.teleport.accesslist.v1.CountAccessListMembersResponse\x12\x84\x01\n" +
 	"\x15ListAccessListMembers\x124.teleport.accesslist.v1.ListAccessListMembersRequest\x1a5.teleport.accesslist.v1.ListAccessListMembersResponse\x12\x8d\x01\n" +
 	"\x18ListAllAccessListMembers\x127.teleport.accesslist.v1.ListAllAccessListMembersRequest\x1a8.teleport.accesslist.v1.ListAllAccessListMembersResponse\x12i\n" +
-	"\x13GetAccessListMember\x122.teleport.accesslist.v1.GetAccessListMemberRequest\x1a\x1e.teleport.accesslist.v1.Member\x12~\n" +
+	"\x13GetAccessListMember\x122.teleport.accesslist.v1.GetAccessListMemberRequest\x1a\x1e.teleport.accesslist.v1.Member\x12\x90\x01\n" +
+	"\x19GetStaticAccessListMember\x128.teleport.accesslist.v1.GetStaticAccessListMemberRequest\x1a9.teleport.accesslist.v1.GetStaticAccessListMemberResponse\x12~\n" +
 	"\x13GetAccessListOwners\x122.teleport.accesslist.v1.GetAccessListOwnersRequest\x1a3.teleport.accesslist.v1.GetAccessListOwnersResponse\x12o\n" +
-	"\x16UpsertAccessListMember\x125.teleport.accesslist.v1.UpsertAccessListMemberRequest\x1a\x1e.teleport.accesslist.v1.Member\x12o\n" +
+	"\x16UpsertAccessListMember\x125.teleport.accesslist.v1.UpsertAccessListMemberRequest\x1a\x1e.teleport.accesslist.v1.Member\x12\x99\x01\n" +
+	"\x1cUpsertStaticAccessListMember\x12;.teleport.accesslist.v1.UpsertStaticAccessListMemberRequest\x1a<.teleport.accesslist.v1.UpsertStaticAccessListMemberResponse\x12o\n" +
 	"\x16UpdateAccessListMember\x125.teleport.accesslist.v1.UpdateAccessListMemberRequest\x1a\x1e.teleport.accesslist.v1.Member\x12g\n" +
-	"\x16DeleteAccessListMember\x125.teleport.accesslist.v1.DeleteAccessListMemberRequest\x1a\x16.google.protobuf.Empty\x12\x89\x01\n" +
+	"\x16DeleteAccessListMember\x125.teleport.accesslist.v1.DeleteAccessListMemberRequest\x1a\x16.google.protobuf.Empty\x12\x99\x01\n" +
+	"\x1cDeleteStaticAccessListMember\x12;.teleport.accesslist.v1.DeleteStaticAccessListMemberRequest\x1a<.teleport.accesslist.v1.DeleteStaticAccessListMemberResponse\x12\x89\x01\n" +
 	"'DeleteAllAccessListMembersForAccessList\x12F.teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest\x1a\x16.google.protobuf.Empty\x12o\n" +
 	"\x1aDeleteAllAccessListMembers\x129.teleport.accesslist.v1.DeleteAllAccessListMembersRequest\x1a\x16.google.protobuf.Empty\x12\x96\x01\n" +
 	"\x1bUpsertAccessListWithMembers\x12:.teleport.accesslist.v1.UpsertAccessListWithMembersRequest\x1a;.teleport.accesslist.v1.UpsertAccessListWithMembersResponse\x12\x84\x01\n" +
@@ -2226,7 +2536,7 @@ func file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP() []byte {
 	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescData
 }
 
-var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*GetAccessListsRequest)(nil),                          // 0: teleport.accesslist.v1.GetAccessListsRequest
 	(*GetAccessListsResponse)(nil),                         // 1: teleport.accesslist.v1.GetAccessListsResponse
@@ -2250,112 +2560,127 @@ var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*UpsertAccessListWithMembersRequest)(nil),             // 19: teleport.accesslist.v1.UpsertAccessListWithMembersRequest
 	(*UpsertAccessListWithMembersResponse)(nil),            // 20: teleport.accesslist.v1.UpsertAccessListWithMembersResponse
 	(*GetAccessListMemberRequest)(nil),                     // 21: teleport.accesslist.v1.GetAccessListMemberRequest
-	(*GetAccessListOwnersRequest)(nil),                     // 22: teleport.accesslist.v1.GetAccessListOwnersRequest
-	(*GetAccessListOwnersResponse)(nil),                    // 23: teleport.accesslist.v1.GetAccessListOwnersResponse
-	(*UpsertAccessListMemberRequest)(nil),                  // 24: teleport.accesslist.v1.UpsertAccessListMemberRequest
-	(*UpdateAccessListMemberRequest)(nil),                  // 25: teleport.accesslist.v1.UpdateAccessListMemberRequest
-	(*DeleteAccessListMemberRequest)(nil),                  // 26: teleport.accesslist.v1.DeleteAccessListMemberRequest
-	(*DeleteAllAccessListMembersForAccessListRequest)(nil), // 27: teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	(*DeleteAllAccessListMembersRequest)(nil),              // 28: teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	(*ListAccessListReviewsRequest)(nil),                   // 29: teleport.accesslist.v1.ListAccessListReviewsRequest
-	(*ListAccessListReviewsResponse)(nil),                  // 30: teleport.accesslist.v1.ListAccessListReviewsResponse
-	(*ListAllAccessListReviewsRequest)(nil),                // 31: teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	(*ListAllAccessListReviewsResponse)(nil),               // 32: teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	(*CreateAccessListReviewRequest)(nil),                  // 33: teleport.accesslist.v1.CreateAccessListReviewRequest
-	(*CreateAccessListReviewResponse)(nil),                 // 34: teleport.accesslist.v1.CreateAccessListReviewResponse
-	(*DeleteAccessListReviewRequest)(nil),                  // 35: teleport.accesslist.v1.DeleteAccessListReviewRequest
-	(*AccessRequestPromoteRequest)(nil),                    // 36: teleport.accesslist.v1.AccessRequestPromoteRequest
-	(*AccessRequestPromoteResponse)(nil),                   // 37: teleport.accesslist.v1.AccessRequestPromoteResponse
-	(*GetSuggestedAccessListsRequest)(nil),                 // 38: teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	(*GetSuggestedAccessListsResponse)(nil),                // 39: teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	(*AccessList)(nil),                                     // 40: teleport.accesslist.v1.AccessList
-	(*AccessListGrants)(nil),                               // 41: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                                         // 42: teleport.accesslist.v1.Member
-	(*AccessListOwner)(nil),                                // 43: teleport.accesslist.v1.AccessListOwner
-	(*Review)(nil),                                         // 44: teleport.accesslist.v1.Review
-	(*timestamppb.Timestamp)(nil),                          // 45: google.protobuf.Timestamp
-	(*types.AccessRequestV3)(nil),                          // 46: types.AccessRequestV3
-	(*emptypb.Empty)(nil),                                  // 47: google.protobuf.Empty
+	(*GetStaticAccessListMemberRequest)(nil),               // 22: teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	(*GetStaticAccessListMemberResponse)(nil),              // 23: teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	(*GetAccessListOwnersRequest)(nil),                     // 24: teleport.accesslist.v1.GetAccessListOwnersRequest
+	(*GetAccessListOwnersResponse)(nil),                    // 25: teleport.accesslist.v1.GetAccessListOwnersResponse
+	(*UpsertAccessListMemberRequest)(nil),                  // 26: teleport.accesslist.v1.UpsertAccessListMemberRequest
+	(*UpsertStaticAccessListMemberRequest)(nil),            // 27: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	(*UpsertStaticAccessListMemberResponse)(nil),           // 28: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	(*UpdateAccessListMemberRequest)(nil),                  // 29: teleport.accesslist.v1.UpdateAccessListMemberRequest
+	(*DeleteAccessListMemberRequest)(nil),                  // 30: teleport.accesslist.v1.DeleteAccessListMemberRequest
+	(*DeleteStaticAccessListMemberRequest)(nil),            // 31: teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	(*DeleteStaticAccessListMemberResponse)(nil),           // 32: teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	(*DeleteAllAccessListMembersForAccessListRequest)(nil), // 33: teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	(*DeleteAllAccessListMembersRequest)(nil),              // 34: teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	(*ListAccessListReviewsRequest)(nil),                   // 35: teleport.accesslist.v1.ListAccessListReviewsRequest
+	(*ListAccessListReviewsResponse)(nil),                  // 36: teleport.accesslist.v1.ListAccessListReviewsResponse
+	(*ListAllAccessListReviewsRequest)(nil),                // 37: teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	(*ListAllAccessListReviewsResponse)(nil),               // 38: teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	(*CreateAccessListReviewRequest)(nil),                  // 39: teleport.accesslist.v1.CreateAccessListReviewRequest
+	(*CreateAccessListReviewResponse)(nil),                 // 40: teleport.accesslist.v1.CreateAccessListReviewResponse
+	(*DeleteAccessListReviewRequest)(nil),                  // 41: teleport.accesslist.v1.DeleteAccessListReviewRequest
+	(*AccessRequestPromoteRequest)(nil),                    // 42: teleport.accesslist.v1.AccessRequestPromoteRequest
+	(*AccessRequestPromoteResponse)(nil),                   // 43: teleport.accesslist.v1.AccessRequestPromoteResponse
+	(*GetSuggestedAccessListsRequest)(nil),                 // 44: teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	(*GetSuggestedAccessListsResponse)(nil),                // 45: teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	(*AccessList)(nil),                                     // 46: teleport.accesslist.v1.AccessList
+	(*AccessListGrants)(nil),                               // 47: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                                         // 48: teleport.accesslist.v1.Member
+	(*AccessListOwner)(nil),                                // 49: teleport.accesslist.v1.AccessListOwner
+	(*Review)(nil),                                         // 50: teleport.accesslist.v1.Review
+	(*timestamppb.Timestamp)(nil),                          // 51: google.protobuf.Timestamp
+	(*types.AccessRequestV3)(nil),                          // 52: types.AccessRequestV3
+	(*emptypb.Empty)(nil),                                  // 53: google.protobuf.Empty
 }
 var file_teleport_accesslist_v1_accesslist_service_proto_depIdxs = []int32{
-	40, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	40, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	41, // 2: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	40, // 3: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	40, // 4: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	40, // 5: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	42, // 6: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	42, // 7: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	40, // 8: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	42, // 9: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
-	40, // 10: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	42, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	43, // 12: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	42, // 13: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	42, // 14: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	44, // 15: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	44, // 16: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	44, // 17: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
-	45, // 18: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
-	46, // 19: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
-	40, // 20: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	0,  // 21: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
-	2,  // 22: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
-	6,  // 23: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
-	7,  // 24: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
-	8,  // 25: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
-	9,  // 26: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
-	10, // 27: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
-	11, // 28: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
-	13, // 29: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
-	15, // 30: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
-	17, // 31: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
-	21, // 32: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
-	22, // 33: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
-	24, // 34: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
-	25, // 35: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
-	26, // 36: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
-	27, // 37: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	28, // 38: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	19, // 39: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	29, // 40: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
-	31, // 41: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	33, // 42: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
-	35, // 43: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
-	36, // 44: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
-	38, // 45: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	4,  // 46: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
-	1,  // 47: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
-	3,  // 48: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
-	40, // 49: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
-	40, // 50: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
-	40, // 51: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
-	47, // 52: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
-	47, // 53: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
-	12, // 54: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
-	14, // 55: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
-	16, // 56: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
-	18, // 57: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
-	42, // 58: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
-	23, // 59: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
-	42, // 60: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
-	42, // 61: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
-	47, // 62: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
-	47, // 63: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
-	47, // 64: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
-	20, // 65: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	30, // 66: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
-	32, // 67: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	34, // 68: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
-	47, // 69: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
-	37, // 70: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
-	39, // 71: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	5,  // 72: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
-	47, // [47:73] is the sub-list for method output_type
-	21, // [21:47] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	46, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	46, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	47, // 2: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	46, // 3: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	46, // 4: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	46, // 5: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	48, // 6: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	48, // 7: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	46, // 8: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	48, // 9: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
+	46, // 10: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	48, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	48, // 12: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	49, // 13: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	48, // 14: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	48, // 15: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	48, // 16: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	48, // 17: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	50, // 18: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	50, // 19: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	50, // 20: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
+	51, // 21: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
+	52, // 22: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
+	46, // 23: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	0,  // 24: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
+	2,  // 25: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
+	6,  // 26: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
+	7,  // 27: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
+	8,  // 28: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
+	9,  // 29: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
+	10, // 30: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
+	11, // 31: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
+	13, // 32: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
+	15, // 33: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
+	17, // 34: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
+	21, // 35: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
+	22, // 36: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	24, // 37: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
+	26, // 38: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
+	27, // 39: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	29, // 40: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
+	30, // 41: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
+	31, // 42: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	33, // 43: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	34, // 44: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	19, // 45: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	35, // 46: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
+	37, // 47: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	39, // 48: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
+	41, // 49: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
+	42, // 50: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
+	44, // 51: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	4,  // 52: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
+	1,  // 53: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
+	3,  // 54: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
+	46, // 55: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
+	46, // 56: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
+	46, // 57: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
+	53, // 58: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
+	53, // 59: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
+	12, // 60: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
+	14, // 61: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
+	16, // 62: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
+	18, // 63: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
+	48, // 64: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
+	23, // 65: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	25, // 66: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
+	48, // 67: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
+	28, // 68: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	48, // 69: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
+	53, // 70: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
+	32, // 71: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	53, // 72: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
+	53, // 73: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
+	20, // 74: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	36, // 75: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
+	38, // 76: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	40, // 77: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
+	53, // 78: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
+	43, // 79: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
+	45, // 80: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	5,  // 81: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
+	53, // [53:82] is the sub-list for method output_type
+	24, // [24:53] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_service_proto_init() }
@@ -2370,7 +2695,7 @@ func file_teleport_accesslist_v1_accesslist_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   40,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
@@ -46,10 +46,13 @@ const (
 	AccessListService_ListAccessListMembers_FullMethodName                   = "/teleport.accesslist.v1.AccessListService/ListAccessListMembers"
 	AccessListService_ListAllAccessListMembers_FullMethodName                = "/teleport.accesslist.v1.AccessListService/ListAllAccessListMembers"
 	AccessListService_GetAccessListMember_FullMethodName                     = "/teleport.accesslist.v1.AccessListService/GetAccessListMember"
+	AccessListService_GetStaticAccessListMember_FullMethodName               = "/teleport.accesslist.v1.AccessListService/GetStaticAccessListMember"
 	AccessListService_GetAccessListOwners_FullMethodName                     = "/teleport.accesslist.v1.AccessListService/GetAccessListOwners"
 	AccessListService_UpsertAccessListMember_FullMethodName                  = "/teleport.accesslist.v1.AccessListService/UpsertAccessListMember"
+	AccessListService_UpsertStaticAccessListMember_FullMethodName            = "/teleport.accesslist.v1.AccessListService/UpsertStaticAccessListMember"
 	AccessListService_UpdateAccessListMember_FullMethodName                  = "/teleport.accesslist.v1.AccessListService/UpdateAccessListMember"
 	AccessListService_DeleteAccessListMember_FullMethodName                  = "/teleport.accesslist.v1.AccessListService/DeleteAccessListMember"
+	AccessListService_DeleteStaticAccessListMember_FullMethodName            = "/teleport.accesslist.v1.AccessListService/DeleteStaticAccessListMember"
 	AccessListService_DeleteAllAccessListMembersForAccessList_FullMethodName = "/teleport.accesslist.v1.AccessListService/DeleteAllAccessListMembersForAccessList"
 	AccessListService_DeleteAllAccessListMembers_FullMethodName              = "/teleport.accesslist.v1.AccessListService/DeleteAllAccessListMembers"
 	AccessListService_UpsertAccessListWithMembers_FullMethodName             = "/teleport.accesslist.v1.AccessListService/UpsertAccessListWithMembers"
@@ -95,16 +98,28 @@ type AccessListServiceClient interface {
 	ListAllAccessListMembers(ctx context.Context, in *ListAllAccessListMembersRequest, opts ...grpc.CallOption) (*ListAllAccessListMembersResponse, error)
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(ctx context.Context, in *GetAccessListMemberRequest, opts ...grpc.CallOption) (*Member, error)
+	// GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+	// if the target access_list is not of type static.  This API is there for the IaC tools to
+	// prevent them from making changes to members of dynamic access lists.
+	GetStaticAccessListMember(ctx context.Context, in *GetStaticAccessListMemberRequest, opts ...grpc.CallOption) (*GetStaticAccessListMemberResponse, error)
 	// GetAccessListOwners returns a list of all owners in an Access List,
 	// including those inherited from nested Access Lists.
 	GetAccessListOwners(ctx context.Context, in *GetAccessListOwnersRequest, opts ...grpc.CallOption) (*GetAccessListOwnersResponse, error)
 	// UpsertAccessListMember creates or updates an access list member resource.
 	UpsertAccessListMember(ctx context.Context, in *UpsertAccessListMemberRequest, opts ...grpc.CallOption) (*Member, error)
+	// UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+	// error and does nothing if the target access_list is not of type static. This API is there for
+	// the IaC tools to prevent them from making changes to members of dynamic access lists.
+	UpsertStaticAccessListMember(ctx context.Context, in *UpsertStaticAccessListMemberRequest, opts ...grpc.CallOption) (*UpsertStaticAccessListMemberResponse, error)
 	// UpdateAccessListMember conditionally updates an access list member resource.
 	UpdateAccessListMember(ctx context.Context, in *UpdateAccessListMemberRequest, opts ...grpc.CallOption) (*Member, error)
 	// DeleteAccessListMember hard deletes the specified access list member
 	// resource.
 	DeleteAccessListMember(ctx context.Context, in *DeleteAccessListMemberRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+	// and does nothing if the target access_list is not of static type. This API is there for the
+	// IaC tools to prevent them from making changes to members of dynamic access lists.
+	DeleteStaticAccessListMember(ctx context.Context, in *DeleteStaticAccessListMemberRequest, opts ...grpc.CallOption) (*DeleteStaticAccessListMemberResponse, error)
 	// DeleteAllAccessListMembers hard deletes all access list members for an
 	// access list.
 	DeleteAllAccessListMembersForAccessList(ctx context.Context, in *DeleteAllAccessListMembersForAccessListRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -262,6 +277,16 @@ func (c *accessListServiceClient) GetAccessListMember(ctx context.Context, in *G
 	return out, nil
 }
 
+func (c *accessListServiceClient) GetStaticAccessListMember(ctx context.Context, in *GetStaticAccessListMemberRequest, opts ...grpc.CallOption) (*GetStaticAccessListMemberResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetStaticAccessListMemberResponse)
+	err := c.cc.Invoke(ctx, AccessListService_GetStaticAccessListMember_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *accessListServiceClient) GetAccessListOwners(ctx context.Context, in *GetAccessListOwnersRequest, opts ...grpc.CallOption) (*GetAccessListOwnersResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetAccessListOwnersResponse)
@@ -282,6 +307,16 @@ func (c *accessListServiceClient) UpsertAccessListMember(ctx context.Context, in
 	return out, nil
 }
 
+func (c *accessListServiceClient) UpsertStaticAccessListMember(ctx context.Context, in *UpsertStaticAccessListMemberRequest, opts ...grpc.CallOption) (*UpsertStaticAccessListMemberResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertStaticAccessListMemberResponse)
+	err := c.cc.Invoke(ctx, AccessListService_UpsertStaticAccessListMember_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *accessListServiceClient) UpdateAccessListMember(ctx context.Context, in *UpdateAccessListMemberRequest, opts ...grpc.CallOption) (*Member, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(Member)
@@ -296,6 +331,16 @@ func (c *accessListServiceClient) DeleteAccessListMember(ctx context.Context, in
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, AccessListService_DeleteAccessListMember_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *accessListServiceClient) DeleteStaticAccessListMember(ctx context.Context, in *DeleteStaticAccessListMemberRequest, opts ...grpc.CallOption) (*DeleteStaticAccessListMemberResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteStaticAccessListMemberResponse)
+	err := c.cc.Invoke(ctx, AccessListService_DeleteStaticAccessListMember_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -435,16 +480,28 @@ type AccessListServiceServer interface {
 	ListAllAccessListMembers(context.Context, *ListAllAccessListMembersRequest) (*ListAllAccessListMembersResponse, error)
 	// GetAccessListMember returns the specified access list member resource.
 	GetAccessListMember(context.Context, *GetAccessListMemberRequest) (*Member, error)
+	// GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+	// if the target access_list is not of type static.  This API is there for the IaC tools to
+	// prevent them from making changes to members of dynamic access lists.
+	GetStaticAccessListMember(context.Context, *GetStaticAccessListMemberRequest) (*GetStaticAccessListMemberResponse, error)
 	// GetAccessListOwners returns a list of all owners in an Access List,
 	// including those inherited from nested Access Lists.
 	GetAccessListOwners(context.Context, *GetAccessListOwnersRequest) (*GetAccessListOwnersResponse, error)
 	// UpsertAccessListMember creates or updates an access list member resource.
 	UpsertAccessListMember(context.Context, *UpsertAccessListMemberRequest) (*Member, error)
+	// UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+	// error and does nothing if the target access_list is not of type static. This API is there for
+	// the IaC tools to prevent them from making changes to members of dynamic access lists.
+	UpsertStaticAccessListMember(context.Context, *UpsertStaticAccessListMemberRequest) (*UpsertStaticAccessListMemberResponse, error)
 	// UpdateAccessListMember conditionally updates an access list member resource.
 	UpdateAccessListMember(context.Context, *UpdateAccessListMemberRequest) (*Member, error)
 	// DeleteAccessListMember hard deletes the specified access list member
 	// resource.
 	DeleteAccessListMember(context.Context, *DeleteAccessListMemberRequest) (*emptypb.Empty, error)
+	// DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+	// and does nothing if the target access_list is not of static type. This API is there for the
+	// IaC tools to prevent them from making changes to members of dynamic access lists.
+	DeleteStaticAccessListMember(context.Context, *DeleteStaticAccessListMemberRequest) (*DeleteStaticAccessListMemberResponse, error)
 	// DeleteAllAccessListMembers hard deletes all access list members for an
 	// access list.
 	DeleteAllAccessListMembersForAccessList(context.Context, *DeleteAllAccessListMembersForAccessListRequest) (*emptypb.Empty, error)
@@ -518,17 +575,26 @@ func (UnimplementedAccessListServiceServer) ListAllAccessListMembers(context.Con
 func (UnimplementedAccessListServiceServer) GetAccessListMember(context.Context, *GetAccessListMemberRequest) (*Member, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAccessListMember not implemented")
 }
+func (UnimplementedAccessListServiceServer) GetStaticAccessListMember(context.Context, *GetStaticAccessListMemberRequest) (*GetStaticAccessListMemberResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStaticAccessListMember not implemented")
+}
 func (UnimplementedAccessListServiceServer) GetAccessListOwners(context.Context, *GetAccessListOwnersRequest) (*GetAccessListOwnersResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAccessListOwners not implemented")
 }
 func (UnimplementedAccessListServiceServer) UpsertAccessListMember(context.Context, *UpsertAccessListMemberRequest) (*Member, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpsertAccessListMember not implemented")
 }
+func (UnimplementedAccessListServiceServer) UpsertStaticAccessListMember(context.Context, *UpsertStaticAccessListMemberRequest) (*UpsertStaticAccessListMemberResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpsertStaticAccessListMember not implemented")
+}
 func (UnimplementedAccessListServiceServer) UpdateAccessListMember(context.Context, *UpdateAccessListMemberRequest) (*Member, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateAccessListMember not implemented")
 }
 func (UnimplementedAccessListServiceServer) DeleteAccessListMember(context.Context, *DeleteAccessListMemberRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteAccessListMember not implemented")
+}
+func (UnimplementedAccessListServiceServer) DeleteStaticAccessListMember(context.Context, *DeleteStaticAccessListMemberRequest) (*DeleteStaticAccessListMemberResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteStaticAccessListMember not implemented")
 }
 func (UnimplementedAccessListServiceServer) DeleteAllAccessListMembersForAccessList(context.Context, *DeleteAllAccessListMembersForAccessListRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteAllAccessListMembersForAccessList not implemented")
@@ -797,6 +863,24 @@ func _AccessListService_GetAccessListMember_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AccessListService_GetStaticAccessListMember_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetStaticAccessListMemberRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessListServiceServer).GetStaticAccessListMember(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccessListService_GetStaticAccessListMember_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessListServiceServer).GetStaticAccessListMember(ctx, req.(*GetStaticAccessListMemberRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _AccessListService_GetAccessListOwners_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetAccessListOwnersRequest)
 	if err := dec(in); err != nil {
@@ -833,6 +917,24 @@ func _AccessListService_UpsertAccessListMember_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AccessListService_UpsertStaticAccessListMember_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertStaticAccessListMemberRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessListServiceServer).UpsertStaticAccessListMember(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccessListService_UpsertStaticAccessListMember_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessListServiceServer).UpsertStaticAccessListMember(ctx, req.(*UpsertStaticAccessListMemberRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _AccessListService_UpdateAccessListMember_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(UpdateAccessListMemberRequest)
 	if err := dec(in); err != nil {
@@ -865,6 +967,24 @@ func _AccessListService_DeleteAccessListMember_Handler(srv interface{}, ctx cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AccessListServiceServer).DeleteAccessListMember(ctx, req.(*DeleteAccessListMemberRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AccessListService_DeleteStaticAccessListMember_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteStaticAccessListMemberRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessListServiceServer).DeleteStaticAccessListMember(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccessListService_DeleteStaticAccessListMember_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessListServiceServer).DeleteStaticAccessListMember(ctx, req.(*DeleteStaticAccessListMemberRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1105,6 +1225,10 @@ var AccessListService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _AccessListService_GetAccessListMember_Handler,
 		},
 		{
+			MethodName: "GetStaticAccessListMember",
+			Handler:    _AccessListService_GetStaticAccessListMember_Handler,
+		},
+		{
 			MethodName: "GetAccessListOwners",
 			Handler:    _AccessListService_GetAccessListOwners_Handler,
 		},
@@ -1113,12 +1237,20 @@ var AccessListService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _AccessListService_UpsertAccessListMember_Handler,
 		},
 		{
+			MethodName: "UpsertStaticAccessListMember",
+			Handler:    _AccessListService_UpsertStaticAccessListMember_Handler,
+		},
+		{
 			MethodName: "UpdateAccessListMember",
 			Handler:    _AccessListService_UpdateAccessListMember_Handler,
 		},
 		{
 			MethodName: "DeleteAccessListMember",
 			Handler:    _AccessListService_DeleteAccessListMember_Handler,
+		},
+		{
+			MethodName: "DeleteStaticAccessListMember",
+			Handler:    _AccessListService_DeleteStaticAccessListMember_Handler,
 		},
 		{
 			MethodName: "DeleteAllAccessListMembersForAccessList",

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -53,16 +53,28 @@ service AccessListService {
   rpc ListAllAccessListMembers(ListAllAccessListMembersRequest) returns (ListAllAccessListMembersResponse);
   // GetAccessListMember returns the specified access list member resource.
   rpc GetAccessListMember(GetAccessListMemberRequest) returns (Member);
+  // GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+  // if the target access_list is not of type static.  This API is there for the IaC tools to
+  // prevent them from making changes to members of dynamic access lists.
+  rpc GetStaticAccessListMember(GetStaticAccessListMemberRequest) returns (GetStaticAccessListMemberResponse);
   // GetAccessListOwners returns a list of all owners in an Access List,
   // including those inherited from nested Access Lists.
   rpc GetAccessListOwners(GetAccessListOwnersRequest) returns (GetAccessListOwnersResponse);
   // UpsertAccessListMember creates or updates an access list member resource.
   rpc UpsertAccessListMember(UpsertAccessListMemberRequest) returns (Member);
+  // UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+  // error and does nothing if the target access_list is not of type static. This API is there for
+  // the IaC tools to prevent them from making changes to members of dynamic access lists.
+  rpc UpsertStaticAccessListMember(UpsertStaticAccessListMemberRequest) returns (UpsertStaticAccessListMemberResponse);
   // UpdateAccessListMember conditionally updates an access list member resource.
   rpc UpdateAccessListMember(UpdateAccessListMemberRequest) returns (Member);
   // DeleteAccessListMember hard deletes the specified access list member
   // resource.
   rpc DeleteAccessListMember(DeleteAccessListMemberRequest) returns (google.protobuf.Empty);
+  // DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+  // and does nothing if the target access_list is not of static type. This API is there for the
+  // IaC tools to prevent them from making changes to members of dynamic access lists.
+  rpc DeleteStaticAccessListMember(DeleteStaticAccessListMemberRequest) returns (DeleteStaticAccessListMemberResponse);
   // DeleteAllAccessListMembers hard deletes all access list members for an
   // access list.
   rpc DeleteAllAccessListMembersForAccessList(DeleteAllAccessListMembersForAccessListRequest) returns (google.protobuf.Empty);
@@ -247,14 +259,28 @@ message UpsertAccessListWithMembersResponse {
   repeated Member members = 2;
 }
 
-// GetAccessListMemberRequest is the request for retrieving an access list
-// member.
+// GetAccessListMemberRequest is the request for retrieving an access_list_member.
 message GetAccessListMemberRequest {
   // access_list is the name of the access list that the member belongs to.
   string access_list = 1;
-
   // member_name is the name of the user that belongs to the access list.
   string member_name = 2;
+}
+
+// GetStaticAccessListMemberRequest is the request for retrieving an access_list_member of a static
+// type access_list.
+message GetStaticAccessListMemberRequest {
+  // access_list is the name of the access_list that the member belongs to.
+  string access_list = 1;
+  // member_name is the name of the user that belongs to the access_list.
+  string member_name = 2;
+}
+
+// GetStaticAccessListMemberResponse is the response containing the access_list_member of the
+// target access_list of static type.
+message GetStaticAccessListMemberResponse {
+  // member of the target static access_list.
+  Member member = 1;
 }
 
 // GetAccessListOwnersRequest is the request for getting a list of all owners
@@ -282,6 +308,20 @@ message UpsertAccessListMemberRequest {
   Member member = 4;
 }
 
+// UpsertStaticAccessListMemberRequest is the request for upserting an access_list_member to an
+// access_list of type static.
+message UpsertStaticAccessListMemberRequest {
+  // member is the access_list_member to upsert.
+  Member member = 1;
+}
+
+// UpsertStaticAccessListMemberResponse is the response of upserting an access_list_member to an
+// static_access of type static.
+message UpsertStaticAccessListMemberResponse {
+  // member is the upserted access_list_member.
+  Member member = 1;
+}
+
 // UpdateAccessListMemberRequest is the request for updating an access list
 // member.
 message UpdateAccessListMemberRequest {
@@ -300,6 +340,19 @@ message DeleteAccessListMemberRequest {
   // member_name is the name of the user to delete.
   string member_name = 3;
 }
+
+// DeleteStaticAccessListMemberRequest is the request for deleting an access_list_member from an
+// access_list of type static.
+message DeleteStaticAccessListMemberRequest {
+  // access_list is the name of access list.
+  string access_list = 1;
+  // member_name is the name of the user to delete.
+  string member_name = 2;
+}
+
+// DeleteStaticAccessListMemberResponse is the response of deleting an access_list_member from an
+// access_list of type static.
+message DeleteStaticAccessListMemberResponse {}
 
 // DeleteAllAccessListMembersForAccessListRequest is the request for deleting
 // all members from an access list.

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.client.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.client.ts
@@ -38,11 +38,17 @@ import type { UpsertAccessListWithMembersResponse } from "./accesslist_service_p
 import type { UpsertAccessListWithMembersRequest } from "./accesslist_service_pb";
 import type { DeleteAllAccessListMembersRequest } from "./accesslist_service_pb";
 import type { DeleteAllAccessListMembersForAccessListRequest } from "./accesslist_service_pb";
+import type { DeleteStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import type { DeleteStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import type { DeleteAccessListMemberRequest } from "./accesslist_service_pb";
 import type { UpdateAccessListMemberRequest } from "./accesslist_service_pb";
+import type { UpsertStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import type { UpsertStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import type { UpsertAccessListMemberRequest } from "./accesslist_service_pb";
 import type { GetAccessListOwnersResponse } from "./accesslist_service_pb";
 import type { GetAccessListOwnersRequest } from "./accesslist_service_pb";
+import type { GetStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import type { GetStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import type { Member } from "./accesslist_pb";
 import type { GetAccessListMemberRequest } from "./accesslist_service_pb";
 import type { ListAllAccessListMembersResponse } from "./accesslist_service_pb";
@@ -149,6 +155,14 @@ export interface IAccessListServiceClient {
      */
     getAccessListMember(input: GetAccessListMemberRequest, options?: RpcOptions): UnaryCall<GetAccessListMemberRequest, Member>;
     /**
+     * GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+     * if the target access_list is not of type static.  This API is there for the IaC tools to
+     * prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: GetStaticAccessListMember(teleport.accesslist.v1.GetStaticAccessListMemberRequest) returns (teleport.accesslist.v1.GetStaticAccessListMemberResponse);
+     */
+    getStaticAccessListMember(input: GetStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse>;
+    /**
      * GetAccessListOwners returns a list of all owners in an Access List,
      * including those inherited from nested Access Lists.
      *
@@ -162,6 +176,14 @@ export interface IAccessListServiceClient {
      */
     upsertAccessListMember(input: UpsertAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertAccessListMemberRequest, Member>;
     /**
+     * UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+     * error and does nothing if the target access_list is not of type static. This API is there for
+     * the IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: UpsertStaticAccessListMember(teleport.accesslist.v1.UpsertStaticAccessListMemberRequest) returns (teleport.accesslist.v1.UpsertStaticAccessListMemberResponse);
+     */
+    upsertStaticAccessListMember(input: UpsertStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse>;
+    /**
      * UpdateAccessListMember conditionally updates an access list member resource.
      *
      * @generated from protobuf rpc: UpdateAccessListMember(teleport.accesslist.v1.UpdateAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
@@ -174,6 +196,14 @@ export interface IAccessListServiceClient {
      * @generated from protobuf rpc: DeleteAccessListMember(teleport.accesslist.v1.DeleteAccessListMemberRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListMember(input: DeleteAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteAccessListMemberRequest, Empty>;
+    /**
+     * DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+     * and does nothing if the target access_list is not of static type. This API is there for the
+     * IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: DeleteStaticAccessListMember(teleport.accesslist.v1.DeleteStaticAccessListMemberRequest) returns (teleport.accesslist.v1.DeleteStaticAccessListMemberResponse);
+     */
+    deleteStaticAccessListMember(input: DeleteStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse>;
     /**
      * DeleteAllAccessListMembers hard deletes all access list members for an
      * access list.
@@ -365,13 +395,24 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
         return stackIntercept<GetAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
     }
     /**
+     * GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+     * if the target access_list is not of type static.  This API is there for the IaC tools to
+     * prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: GetStaticAccessListMember(teleport.accesslist.v1.GetStaticAccessListMemberRequest) returns (teleport.accesslist.v1.GetStaticAccessListMemberResponse);
+     */
+    getStaticAccessListMember(input: GetStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse> {
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        return stackIntercept<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * GetAccessListOwners returns a list of all owners in an Access List,
      * including those inherited from nested Access Lists.
      *
      * @generated from protobuf rpc: GetAccessListOwners(teleport.accesslist.v1.GetAccessListOwnersRequest) returns (teleport.accesslist.v1.GetAccessListOwnersResponse);
      */
     getAccessListOwners(input: GetAccessListOwnersRequest, options?: RpcOptions): UnaryCall<GetAccessListOwnersRequest, GetAccessListOwnersResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAccessListOwnersRequest, GetAccessListOwnersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -380,8 +421,19 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertAccessListMember(teleport.accesslist.v1.UpsertAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
      */
     upsertAccessListMember(input: UpsertAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertAccessListMemberRequest, Member> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+     * error and does nothing if the target access_list is not of type static. This API is there for
+     * the IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: UpsertStaticAccessListMember(teleport.accesslist.v1.UpsertStaticAccessListMemberRequest) returns (teleport.accesslist.v1.UpsertStaticAccessListMemberResponse);
+     */
+    upsertStaticAccessListMember(input: UpsertStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse> {
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * UpdateAccessListMember conditionally updates an access list member resource.
@@ -389,7 +441,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpdateAccessListMember(teleport.accesslist.v1.UpdateAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
      */
     updateAccessListMember(input: UpdateAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpdateAccessListMemberRequest, Member> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
     }
     /**
@@ -399,8 +451,19 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAccessListMember(teleport.accesslist.v1.DeleteAccessListMemberRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListMember(input: DeleteAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteAccessListMemberRequest, Empty> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAccessListMemberRequest, Empty>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+     * and does nothing if the target access_list is not of static type. This API is there for the
+     * IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: DeleteStaticAccessListMember(teleport.accesslist.v1.DeleteStaticAccessListMemberRequest) returns (teleport.accesslist.v1.DeleteStaticAccessListMemberResponse);
+     */
+    deleteStaticAccessListMember(input: DeleteStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse> {
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        return stackIntercept<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * DeleteAllAccessListMembers hard deletes all access list members for an
@@ -409,7 +472,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAllAccessListMembersForAccessList(teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest) returns (google.protobuf.Empty);
      */
     deleteAllAccessListMembersForAccessList(input: DeleteAllAccessListMembersForAccessListRequest, options?: RpcOptions): UnaryCall<DeleteAllAccessListMembersForAccessListRequest, Empty> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAllAccessListMembersForAccessListRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -419,7 +482,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAllAccessListMembers(teleport.accesslist.v1.DeleteAllAccessListMembersRequest) returns (google.protobuf.Empty);
      */
     deleteAllAccessListMembers(input: DeleteAllAccessListMembersRequest, options?: RpcOptions): UnaryCall<DeleteAllAccessListMembersRequest, Empty> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAllAccessListMembersRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -428,7 +491,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertAccessListWithMembers(teleport.accesslist.v1.UpsertAccessListWithMembersRequest) returns (teleport.accesslist.v1.UpsertAccessListWithMembersResponse);
      */
     upsertAccessListWithMembers(input: UpsertAccessListWithMembersRequest, options?: RpcOptions): UnaryCall<UpsertAccessListWithMembersRequest, UpsertAccessListWithMembersResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertAccessListWithMembersRequest, UpsertAccessListWithMembersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -438,7 +501,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAccessListReviews(teleport.accesslist.v1.ListAccessListReviewsRequest) returns (teleport.accesslist.v1.ListAccessListReviewsResponse);
      */
     listAccessListReviews(input: ListAccessListReviewsRequest, options?: RpcOptions): UnaryCall<ListAccessListReviewsRequest, ListAccessListReviewsResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAccessListReviewsRequest, ListAccessListReviewsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -448,7 +511,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAllAccessListReviews(teleport.accesslist.v1.ListAllAccessListReviewsRequest) returns (teleport.accesslist.v1.ListAllAccessListReviewsResponse);
      */
     listAllAccessListReviews(input: ListAllAccessListReviewsRequest, options?: RpcOptions): UnaryCall<ListAllAccessListReviewsRequest, ListAllAccessListReviewsResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAllAccessListReviewsRequest, ListAllAccessListReviewsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -459,7 +522,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: CreateAccessListReview(teleport.accesslist.v1.CreateAccessListReviewRequest) returns (teleport.accesslist.v1.CreateAccessListReviewResponse);
      */
     createAccessListReview(input: CreateAccessListReviewRequest, options?: RpcOptions): UnaryCall<CreateAccessListReviewRequest, CreateAccessListReviewResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
         return stackIntercept<CreateAccessListReviewRequest, CreateAccessListReviewResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -468,7 +531,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAccessListReview(teleport.accesslist.v1.DeleteAccessListReviewRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListReview(input: DeleteAccessListReviewRequest, options?: RpcOptions): UnaryCall<DeleteAccessListReviewRequest, Empty> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAccessListReviewRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -477,7 +540,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: AccessRequestPromote(teleport.accesslist.v1.AccessRequestPromoteRequest) returns (teleport.accesslist.v1.AccessRequestPromoteResponse);
      */
     accessRequestPromote(input: AccessRequestPromoteRequest, options?: RpcOptions): UnaryCall<AccessRequestPromoteRequest, AccessRequestPromoteResponse> {
-        const method = this.methods[23], opt = this._transport.mergeOptions(options);
+        const method = this.methods[26], opt = this._transport.mergeOptions(options);
         return stackIntercept<AccessRequestPromoteRequest, AccessRequestPromoteResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -487,7 +550,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetSuggestedAccessLists(teleport.accesslist.v1.GetSuggestedAccessListsRequest) returns (teleport.accesslist.v1.GetSuggestedAccessListsResponse);
      */
     getSuggestedAccessLists(input: GetSuggestedAccessListsRequest, options?: RpcOptions): UnaryCall<GetSuggestedAccessListsRequest, GetSuggestedAccessListsResponse> {
-        const method = this.methods[24], opt = this._transport.mergeOptions(options);
+        const method = this.methods[27], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSuggestedAccessListsRequest, GetSuggestedAccessListsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -496,7 +559,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetInheritedGrants(teleport.accesslist.v1.GetInheritedGrantsRequest) returns (teleport.accesslist.v1.GetInheritedGrantsResponse);
      */
     getInheritedGrants(input: GetInheritedGrantsRequest, options?: RpcOptions): UnaryCall<GetInheritedGrantsRequest, GetInheritedGrantsResponse> {
-        const method = this.methods[25], opt = this._transport.mergeOptions(options);
+        const method = this.methods[28], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetInheritedGrantsRequest, GetInheritedGrantsResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.grpc-server.ts
@@ -35,11 +35,17 @@ import { UpsertAccessListWithMembersResponse } from "./accesslist_service_pb";
 import { UpsertAccessListWithMembersRequest } from "./accesslist_service_pb";
 import { DeleteAllAccessListMembersRequest } from "./accesslist_service_pb";
 import { DeleteAllAccessListMembersForAccessListRequest } from "./accesslist_service_pb";
+import { DeleteStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import { DeleteStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import { DeleteAccessListMemberRequest } from "./accesslist_service_pb";
 import { UpdateAccessListMemberRequest } from "./accesslist_service_pb";
+import { UpsertStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import { UpsertStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import { UpsertAccessListMemberRequest } from "./accesslist_service_pb";
 import { GetAccessListOwnersResponse } from "./accesslist_service_pb";
 import { GetAccessListOwnersRequest } from "./accesslist_service_pb";
+import { GetStaticAccessListMemberResponse } from "./accesslist_service_pb";
+import { GetStaticAccessListMemberRequest } from "./accesslist_service_pb";
 import { Member } from "./accesslist_pb";
 import { GetAccessListMemberRequest } from "./accesslist_service_pb";
 import { ListAllAccessListMembersResponse } from "./accesslist_service_pb";
@@ -144,6 +150,14 @@ export interface IAccessListService extends grpc.UntypedServiceImplementation {
      */
     getAccessListMember: grpc.handleUnaryCall<GetAccessListMemberRequest, Member>;
     /**
+     * GetStaticAccessListMember returns the specified access_list_member resource. If returns error
+     * if the target access_list is not of type static.  This API is there for the IaC tools to
+     * prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: GetStaticAccessListMember(teleport.accesslist.v1.GetStaticAccessListMemberRequest) returns (teleport.accesslist.v1.GetStaticAccessListMemberResponse);
+     */
+    getStaticAccessListMember: grpc.handleUnaryCall<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse>;
+    /**
      * GetAccessListOwners returns a list of all owners in an Access List,
      * including those inherited from nested Access Lists.
      *
@@ -157,6 +171,14 @@ export interface IAccessListService extends grpc.UntypedServiceImplementation {
      */
     upsertAccessListMember: grpc.handleUnaryCall<UpsertAccessListMemberRequest, Member>;
     /**
+     * UpsertStaticAccessListMember creates or updates an access_list_member resource. It returns
+     * error and does nothing if the target access_list is not of type static. This API is there for
+     * the IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: UpsertStaticAccessListMember(teleport.accesslist.v1.UpsertStaticAccessListMemberRequest) returns (teleport.accesslist.v1.UpsertStaticAccessListMemberResponse);
+     */
+    upsertStaticAccessListMember: grpc.handleUnaryCall<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse>;
+    /**
      * UpdateAccessListMember conditionally updates an access list member resource.
      *
      * @generated from protobuf rpc: UpdateAccessListMember(teleport.accesslist.v1.UpdateAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
@@ -169,6 +191,14 @@ export interface IAccessListService extends grpc.UntypedServiceImplementation {
      * @generated from protobuf rpc: DeleteAccessListMember(teleport.accesslist.v1.DeleteAccessListMemberRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListMember: grpc.handleUnaryCall<DeleteAccessListMemberRequest, Empty>;
+    /**
+     * DeleteStaticAccessListMember hard deletes the specified access_list_member. It returns error
+     * and does nothing if the target access_list is not of static type. This API is there for the
+     * IaC tools to prevent them from making changes to members of dynamic access lists.
+     *
+     * @generated from protobuf rpc: DeleteStaticAccessListMember(teleport.accesslist.v1.DeleteStaticAccessListMemberRequest) returns (teleport.accesslist.v1.DeleteStaticAccessListMemberResponse);
+     */
+    deleteStaticAccessListMember: grpc.handleUnaryCall<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse>;
     /**
      * DeleteAllAccessListMembers hard deletes all access list members for an
      * access list.
@@ -369,6 +399,16 @@ export const accessListServiceDefinition: grpc.ServiceDefinition<IAccessListServ
         responseSerialize: value => Buffer.from(Member.toBinary(value)),
         requestSerialize: value => Buffer.from(GetAccessListMemberRequest.toBinary(value))
     },
+    getStaticAccessListMember: {
+        path: "/teleport.accesslist.v1.AccessListService/GetStaticAccessListMember",
+        originalName: "GetStaticAccessListMember",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => GetStaticAccessListMemberResponse.fromBinary(bytes),
+        requestDeserialize: bytes => GetStaticAccessListMemberRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(GetStaticAccessListMemberResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(GetStaticAccessListMemberRequest.toBinary(value))
+    },
     getAccessListOwners: {
         path: "/teleport.accesslist.v1.AccessListService/GetAccessListOwners",
         originalName: "GetAccessListOwners",
@@ -389,6 +429,16 @@ export const accessListServiceDefinition: grpc.ServiceDefinition<IAccessListServ
         responseSerialize: value => Buffer.from(Member.toBinary(value)),
         requestSerialize: value => Buffer.from(UpsertAccessListMemberRequest.toBinary(value))
     },
+    upsertStaticAccessListMember: {
+        path: "/teleport.accesslist.v1.AccessListService/UpsertStaticAccessListMember",
+        originalName: "UpsertStaticAccessListMember",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => UpsertStaticAccessListMemberResponse.fromBinary(bytes),
+        requestDeserialize: bytes => UpsertStaticAccessListMemberRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(UpsertStaticAccessListMemberResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(UpsertStaticAccessListMemberRequest.toBinary(value))
+    },
     updateAccessListMember: {
         path: "/teleport.accesslist.v1.AccessListService/UpdateAccessListMember",
         originalName: "UpdateAccessListMember",
@@ -408,6 +458,16 @@ export const accessListServiceDefinition: grpc.ServiceDefinition<IAccessListServ
         requestDeserialize: bytes => DeleteAccessListMemberRequest.fromBinary(bytes),
         responseSerialize: value => Buffer.from(Empty.toBinary(value)),
         requestSerialize: value => Buffer.from(DeleteAccessListMemberRequest.toBinary(value))
+    },
+    deleteStaticAccessListMember: {
+        path: "/teleport.accesslist.v1.AccessListService/DeleteStaticAccessListMember",
+        originalName: "DeleteStaticAccessListMember",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => DeleteStaticAccessListMemberResponse.fromBinary(bytes),
+        requestDeserialize: bytes => DeleteStaticAccessListMemberRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(DeleteStaticAccessListMemberResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(DeleteStaticAccessListMemberRequest.toBinary(value))
     },
     deleteAllAccessListMembersForAccessList: {
         path: "/teleport.accesslist.v1.AccessListService/DeleteAllAccessListMembersForAccessList",

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.ts
@@ -360,8 +360,7 @@ export interface UpsertAccessListWithMembersResponse {
     members: Member[];
 }
 /**
- * GetAccessListMemberRequest is the request for retrieving an access list
- * member.
+ * GetAccessListMemberRequest is the request for retrieving an access_list_member.
  *
  * @generated from protobuf message teleport.accesslist.v1.GetAccessListMemberRequest
  */
@@ -378,6 +377,40 @@ export interface GetAccessListMemberRequest {
      * @generated from protobuf field: string member_name = 2;
      */
     memberName: string;
+}
+/**
+ * GetStaticAccessListMemberRequest is the request for retrieving an access_list_member of a static
+ * type access_list.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.GetStaticAccessListMemberRequest
+ */
+export interface GetStaticAccessListMemberRequest {
+    /**
+     * access_list is the name of the access_list that the member belongs to.
+     *
+     * @generated from protobuf field: string access_list = 1;
+     */
+    accessList: string;
+    /**
+     * member_name is the name of the user that belongs to the access_list.
+     *
+     * @generated from protobuf field: string member_name = 2;
+     */
+    memberName: string;
+}
+/**
+ * GetStaticAccessListMemberResponse is the response containing the access_list_member of the
+ * target access_list of static type.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.GetStaticAccessListMemberResponse
+ */
+export interface GetStaticAccessListMemberResponse {
+    /**
+     * member of the target static access_list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.Member member = 1;
+     */
+    member?: Member;
 }
 /**
  * GetAccessListOwnersRequest is the request for getting a list of all owners
@@ -423,6 +456,34 @@ export interface UpsertAccessListMemberRequest {
     member?: Member;
 }
 /**
+ * UpsertStaticAccessListMemberRequest is the request for upserting an access_list_member to an
+ * access_list of type static.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+ */
+export interface UpsertStaticAccessListMemberRequest {
+    /**
+     * member is the access_list_member to upsert.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.Member member = 1;
+     */
+    member?: Member;
+}
+/**
+ * UpsertStaticAccessListMemberResponse is the response of upserting an access_list_member to an
+ * static_access of type static.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+ */
+export interface UpsertStaticAccessListMemberResponse {
+    /**
+     * member is the upserted access_list_member.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.Member member = 1;
+     */
+    member?: Member;
+}
+/**
  * UpdateAccessListMemberRequest is the request for updating an access list
  * member.
  *
@@ -455,6 +516,34 @@ export interface DeleteAccessListMemberRequest {
      * @generated from protobuf field: string member_name = 3;
      */
     memberName: string;
+}
+/**
+ * DeleteStaticAccessListMemberRequest is the request for deleting an access_list_member from an
+ * access_list of type static.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+ */
+export interface DeleteStaticAccessListMemberRequest {
+    /**
+     * access_list is the name of access list.
+     *
+     * @generated from protobuf field: string access_list = 1;
+     */
+    accessList: string;
+    /**
+     * member_name is the name of the user to delete.
+     *
+     * @generated from protobuf field: string member_name = 2;
+     */
+    memberName: string;
+}
+/**
+ * DeleteStaticAccessListMemberResponse is the response of deleting an access_list_member from an
+ * access_list of type static.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+ */
+export interface DeleteStaticAccessListMemberResponse {
 }
 /**
  * DeleteAllAccessListMembersForAccessListRequest is the request for deleting
@@ -1738,6 +1827,107 @@ class GetAccessListMemberRequest$Type extends MessageType<GetAccessListMemberReq
  */
 export const GetAccessListMemberRequest = new GetAccessListMemberRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class GetStaticAccessListMemberRequest$Type extends MessageType<GetStaticAccessListMemberRequest> {
+    constructor() {
+        super("teleport.accesslist.v1.GetStaticAccessListMemberRequest", [
+            { no: 1, name: "access_list", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "member_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<GetStaticAccessListMemberRequest>): GetStaticAccessListMemberRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.accessList = "";
+        message.memberName = "";
+        if (value !== undefined)
+            reflectionMergePartial<GetStaticAccessListMemberRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetStaticAccessListMemberRequest): GetStaticAccessListMemberRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string access_list */ 1:
+                    message.accessList = reader.string();
+                    break;
+                case /* string member_name */ 2:
+                    message.memberName = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetStaticAccessListMemberRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string access_list = 1; */
+        if (message.accessList !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.accessList);
+        /* string member_name = 2; */
+        if (message.memberName !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.memberName);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.GetStaticAccessListMemberRequest
+ */
+export const GetStaticAccessListMemberRequest = new GetStaticAccessListMemberRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class GetStaticAccessListMemberResponse$Type extends MessageType<GetStaticAccessListMemberResponse> {
+    constructor() {
+        super("teleport.accesslist.v1.GetStaticAccessListMemberResponse", [
+            { no: 1, name: "member", kind: "message", T: () => Member }
+        ]);
+    }
+    create(value?: PartialMessage<GetStaticAccessListMemberResponse>): GetStaticAccessListMemberResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<GetStaticAccessListMemberResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetStaticAccessListMemberResponse): GetStaticAccessListMemberResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.accesslist.v1.Member member */ 1:
+                    message.member = Member.internalBinaryRead(reader, reader.uint32(), options, message.member);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: GetStaticAccessListMemberResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.accesslist.v1.Member member = 1; */
+        if (message.member)
+            Member.internalBinaryWrite(message.member, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.GetStaticAccessListMemberResponse
+ */
+export const GetStaticAccessListMemberResponse = new GetStaticAccessListMemberResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class GetAccessListOwnersRequest$Type extends MessageType<GetAccessListOwnersRequest> {
     constructor() {
         super("teleport.accesslist.v1.GetAccessListOwnersRequest", [
@@ -1878,6 +2068,98 @@ class UpsertAccessListMemberRequest$Type extends MessageType<UpsertAccessListMem
  */
 export const UpsertAccessListMemberRequest = new UpsertAccessListMemberRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class UpsertStaticAccessListMemberRequest$Type extends MessageType<UpsertStaticAccessListMemberRequest> {
+    constructor() {
+        super("teleport.accesslist.v1.UpsertStaticAccessListMemberRequest", [
+            { no: 1, name: "member", kind: "message", T: () => Member }
+        ]);
+    }
+    create(value?: PartialMessage<UpsertStaticAccessListMemberRequest>): UpsertStaticAccessListMemberRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<UpsertStaticAccessListMemberRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpsertStaticAccessListMemberRequest): UpsertStaticAccessListMemberRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.accesslist.v1.Member member */ 1:
+                    message.member = Member.internalBinaryRead(reader, reader.uint32(), options, message.member);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UpsertStaticAccessListMemberRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.accesslist.v1.Member member = 1; */
+        if (message.member)
+            Member.internalBinaryWrite(message.member, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+ */
+export const UpsertStaticAccessListMemberRequest = new UpsertStaticAccessListMemberRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class UpsertStaticAccessListMemberResponse$Type extends MessageType<UpsertStaticAccessListMemberResponse> {
+    constructor() {
+        super("teleport.accesslist.v1.UpsertStaticAccessListMemberResponse", [
+            { no: 1, name: "member", kind: "message", T: () => Member }
+        ]);
+    }
+    create(value?: PartialMessage<UpsertStaticAccessListMemberResponse>): UpsertStaticAccessListMemberResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<UpsertStaticAccessListMemberResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpsertStaticAccessListMemberResponse): UpsertStaticAccessListMemberResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.accesslist.v1.Member member */ 1:
+                    message.member = Member.internalBinaryRead(reader, reader.uint32(), options, message.member);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UpsertStaticAccessListMemberResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.accesslist.v1.Member member = 1; */
+        if (message.member)
+            Member.internalBinaryWrite(message.member, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+ */
+export const UpsertStaticAccessListMemberResponse = new UpsertStaticAccessListMemberResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class UpdateAccessListMemberRequest$Type extends MessageType<UpdateAccessListMemberRequest> {
     constructor() {
         super("teleport.accesslist.v1.UpdateAccessListMemberRequest", [
@@ -1978,6 +2260,86 @@ class DeleteAccessListMemberRequest$Type extends MessageType<DeleteAccessListMem
  * @generated MessageType for protobuf message teleport.accesslist.v1.DeleteAccessListMemberRequest
  */
 export const DeleteAccessListMemberRequest = new DeleteAccessListMemberRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DeleteStaticAccessListMemberRequest$Type extends MessageType<DeleteStaticAccessListMemberRequest> {
+    constructor() {
+        super("teleport.accesslist.v1.DeleteStaticAccessListMemberRequest", [
+            { no: 1, name: "access_list", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "member_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<DeleteStaticAccessListMemberRequest>): DeleteStaticAccessListMemberRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.accessList = "";
+        message.memberName = "";
+        if (value !== undefined)
+            reflectionMergePartial<DeleteStaticAccessListMemberRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DeleteStaticAccessListMemberRequest): DeleteStaticAccessListMemberRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string access_list */ 1:
+                    message.accessList = reader.string();
+                    break;
+                case /* string member_name */ 2:
+                    message.memberName = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DeleteStaticAccessListMemberRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string access_list = 1; */
+        if (message.accessList !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.accessList);
+        /* string member_name = 2; */
+        if (message.memberName !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.memberName);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+ */
+export const DeleteStaticAccessListMemberRequest = new DeleteStaticAccessListMemberRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DeleteStaticAccessListMemberResponse$Type extends MessageType<DeleteStaticAccessListMemberResponse> {
+    constructor() {
+        super("teleport.accesslist.v1.DeleteStaticAccessListMemberResponse", []);
+    }
+    create(value?: PartialMessage<DeleteStaticAccessListMemberResponse>): DeleteStaticAccessListMemberResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<DeleteStaticAccessListMemberResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DeleteStaticAccessListMemberResponse): DeleteStaticAccessListMemberResponse {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: DeleteStaticAccessListMemberResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+ */
+export const DeleteStaticAccessListMemberResponse = new DeleteStaticAccessListMemberResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class DeleteAllAccessListMembersForAccessListRequest$Type extends MessageType<DeleteAllAccessListMembersForAccessListRequest> {
     constructor() {
@@ -2652,10 +3014,13 @@ export const AccessListService = new ServiceType("teleport.accesslist.v1.AccessL
     { name: "ListAccessListMembers", options: {}, I: ListAccessListMembersRequest, O: ListAccessListMembersResponse },
     { name: "ListAllAccessListMembers", options: {}, I: ListAllAccessListMembersRequest, O: ListAllAccessListMembersResponse },
     { name: "GetAccessListMember", options: {}, I: GetAccessListMemberRequest, O: Member },
+    { name: "GetStaticAccessListMember", options: {}, I: GetStaticAccessListMemberRequest, O: GetStaticAccessListMemberResponse },
     { name: "GetAccessListOwners", options: {}, I: GetAccessListOwnersRequest, O: GetAccessListOwnersResponse },
     { name: "UpsertAccessListMember", options: {}, I: UpsertAccessListMemberRequest, O: Member },
+    { name: "UpsertStaticAccessListMember", options: {}, I: UpsertStaticAccessListMemberRequest, O: UpsertStaticAccessListMemberResponse },
     { name: "UpdateAccessListMember", options: {}, I: UpdateAccessListMemberRequest, O: Member },
     { name: "DeleteAccessListMember", options: {}, I: DeleteAccessListMemberRequest, O: Empty },
+    { name: "DeleteStaticAccessListMember", options: {}, I: DeleteStaticAccessListMemberRequest, O: DeleteStaticAccessListMemberResponse },
     { name: "DeleteAllAccessListMembersForAccessList", options: {}, I: DeleteAllAccessListMembersForAccessListRequest, O: Empty },
     { name: "DeleteAllAccessListMembers", options: {}, I: DeleteAllAccessListMembersRequest, O: Empty },
     { name: "UpsertAccessListWithMembers", options: {}, I: UpsertAccessListWithMembersRequest, O: UpsertAccessListWithMembersResponse },


### PR DESCRIPTION
Implementation PR https://github.com/gravitational/teleport.e/pull/6835

This is for teleport_access_list_member Terraform resource as described in [RFD 218](https://github.com/gravitational/teleport/pull/55868)

Backports:
- [ ] https://github.com/gravitational/teleport/pull/56769
- [x] https://github.com/gravitational/teleport/pull/56770 - no v17 backport for now for the Terraform member feature.