### PR TITLE
MWI: Fix bound keypair initial join secret field name

### DIFF
--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -243,7 +243,7 @@ func (s *sharedStartArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 	}
 
 	if s.RegistrationSecret != "" {
-		cfg.Onboarding.BoundKeypair.InitialJoinSecret = s.RegistrationSecret
+		cfg.Onboarding.BoundKeypair.RegistrationSecret = s.RegistrationSecret
 	}
 
 	return nil

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -130,7 +130,7 @@ type BoundKeypairOnboardingConfig struct {
 	// InitialJoinSecret is the name of the initial joining secret, if any. If
 	// not specified, a keypair must be created using `tbot keypair create` and
 	// registered with Teleport in advance.
-	InitialJoinSecret string
+	InitialJoinSecret string `yaml:"initial_join_secret,omitempty"`
 }
 
 // OnboardingConfig contains values relevant to how the bot authenticates with

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -127,10 +127,10 @@ type GitlabOnboardingConfig struct {
 // BoundKeypairOnboardingConfig contains parameters for the `bound_keypair` join
 // method
 type BoundKeypairOnboardingConfig struct {
-	// InitialJoinSecret is the name of the initial joining secret, if any. If
+	// RegistrationSecret is the name of the initial joining secret, if any. If
 	// not specified, a keypair must be created using `tbot keypair create` and
 	// registered with Teleport in advance.
-	InitialJoinSecret string `yaml:"initial_join_secret,omitempty"`
+	RegistrationSecret string `yaml:"registration_secret,omitempty"`
 }
 
 // OnboardingConfig contains values relevant to how the bot authenticates with

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -618,7 +618,7 @@ func botIdentityFromToken(
 			EnvVarName: cfg.Onboarding.Gitlab.TokenEnvVarName,
 		}
 	case types.JoinMethodBoundKeypair:
-		joinSecret := cfg.Onboarding.BoundKeypair.InitialJoinSecret
+		joinSecret := cfg.Onboarding.BoundKeypair.RegistrationSecret
 
 		adapter := config.NewBoundkeypairDestinationAdapter(cfg.Storage.Destination)
 		boundKeypairState, err = boundkeypair.LoadClientState(ctx, adapter)


### PR DESCRIPTION
The `initial_join_secret` field was not given a proper YAML field name and was rendering as `initialjoinsecret`. Additionally, we've tried to standardize on referring to this field as "the registration secret", so this renames the field to match new terminology.

This hopefully does not count as a breaking change as registration secret functionality has not been made available in a release.