### PR TITLE
AWS Roles Anywhere: report profile sync status

### DIFF
--- a/api/types/integration.go
+++ b/api/types/integration.go
@@ -53,7 +53,7 @@ const (
 const (
 	// IntegrationAWSRolesAnywhereProfileSyncStatusSuccess indicates that the profile sync was successful.
 	IntegrationAWSRolesAnywhereProfileSyncStatusSuccess = "SUCCESS"
-	// IntegrationAWSRolesAnywhereProfileSyncStatusInProgress indicates that the profile sync failed.
+	// IntegrationAWSRolesAnywhereProfileSyncStatusError indicates that the profile sync failed.
 	IntegrationAWSRolesAnywhereProfileSyncStatusError = "ERROR"
 )
 

--- a/api/types/integration.go
+++ b/api/types/integration.go
@@ -50,6 +50,13 @@ const (
 	IntegrationAWSOIDCAudienceAWSIdentityCenter = "aws-identity-center"
 )
 
+const (
+	// IntegrationAWSRolesAnywhereProfileSyncStatusSuccess indicates that the profile sync was successful.
+	IntegrationAWSRolesAnywhereProfileSyncStatusSuccess = "SUCCESS"
+	// IntegrationAWSRolesAnywhereProfileSyncStatusInProgress indicates that the profile sync failed.
+	IntegrationAWSRolesAnywhereProfileSyncStatusError = "ERROR"
+)
+
 // Integration specifies is a connection configuration between Teleport and a 3rd party system.
 type Integration interface {
 	ResourceWithLabels

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -21,9 +21,13 @@ package awsra
 import (
 	"context"
 	"crypto/x509/pkix"
+	"maps"
+	"net/url"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -89,7 +93,7 @@ type mockCache struct {
 	domainName   string
 	ca           types.CertAuthority
 	appServers   []types.AppServer
-	integrations []types.Integration
+	integrations map[string]types.Integration
 }
 
 func (m *mockCache) GetAuthPreference(context.Context) (types.AuthPreference, error) {
@@ -115,6 +119,13 @@ func (m *mockCache) UpsertApplicationServer(ctx context.Context, server types.Ap
 	if m.appServers == nil {
 		m.appServers = []types.AppServer{}
 	}
+
+	// Ensure the public address is a valid URL.
+	appURL := "https://" + server.GetApp().GetPublicAddr()
+	if _, err := url.Parse(appURL); err != nil {
+		return nil, trace.BadParameter("invalid public address %q for app server %q: %v", server.GetApp().GetPublicAddr(), server.GetName(), err)
+	}
+
 	m.appServers = append(m.appServers, server)
 	return nil, nil
 }
@@ -129,9 +140,21 @@ func (m *mockCache) GetProxies() ([]types.Server, error) {
 
 func (m *mockCache) ListIntegrations(ctx context.Context, pageSize int, nextKey string) ([]types.Integration, string, error) {
 	if m.integrations == nil {
-		m.integrations = []types.Integration{}
+		m.integrations = map[string]types.Integration{}
 	}
-	return m.integrations, "", nil
+	return slices.Collect(maps.Values(m.integrations)), "", nil
+}
+
+func (m *mockCache) UpdateIntegration(ctx context.Context, integration types.Integration) (types.Integration, error) {
+	if m.integrations == nil {
+		m.integrations = map[string]types.Integration{}
+	}
+	if _, exists := m.integrations[integration.GetName()]; !exists {
+		return nil, trace.NotFound("integration %q not found", integration.GetName())
+	}
+
+	m.integrations[integration.GetName()] = integration
+	return integration, nil
 }
 
 func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) types.CertAuthority {

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -229,7 +229,7 @@ func truncateErrorMessage(err error) string {
 	errorMessage := err.Error()
 
 	if len(errorMessage) <= defaults.DefaultMaxErrorMessageSize {
-		return err.Error()
+		return errorMessage
 	}
 
 	return errorMessage[:defaults.DefaultMaxErrorMessageSize]

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -62,8 +62,9 @@ func TestProfileSyncerTestAndSetDefaults(t *testing.T) {
 	baseParams := func() *AWSRolesAnywherProfileSyncerParams {
 		return &AWSRolesAnywherProfileSyncerParams{
 			KeyStoreManager:   keyStoreManager,
-			Cache:             cache,
-			AppServerUpserter: cache,
+			Cache:             &mockCache{},
+			StatusReporter:    &mockCache{},
+			AppServerUpserter: &mockCache{},
 		}
 	}
 
@@ -187,9 +188,9 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 	baseServerClient := func(t *testing.T) *mockCache {
 		t.Helper()
 		return &mockCache{
-			integrations: []types.Integration{
-				integrationWithProfileSync,
-				integrationWithoutProfileSync,
+			integrations: map[string]types.Integration{
+				integrationWithProfileSync.GetName():    integrationWithProfileSync,
+				integrationWithoutProfileSync.GetName(): integrationWithoutProfileSync,
 			},
 			ca: newCertAuthority(t, types.AWSRACA, "cluster-name"),
 		}
@@ -206,6 +207,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 		return AWSRolesAnywherProfileSyncerParams{
 			KeyStoreManager:   keyStoreManager,
 			Cache:             serverClient,
+			StatusReporter:    serverClient,
 			AppServerUpserter: serverClient,
 			Logger:            logtest.NewLogger(),
 			createSession:     mockCreateSession,
@@ -276,6 +278,17 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				"teleport.dev/aws-roles-anywhere-profile-arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
 				"teleport.dev/integration":                    "test-integration",
 			}, appServer.GetAllLabels())
+
+			t.Run("integration status is updated", func(t *testing.T) {
+				status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
+				require.NotNil(t, status)
+				lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
+				require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusSuccess, lastSyncSummary.Status)
+				require.NotEmpty(t, lastSyncSummary.StartTime)
+				require.NotEmpty(t, lastSyncSummary.EndTime)
+				require.Equal(t, int32(1), lastSyncSummary.SyncedProfiles)
+				require.Empty(t, lastSyncSummary.ErrorMessage)
+			})
 		})
 	})
 
@@ -319,6 +332,44 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				"teleport.dev/aws-roles-anywhere-profile-arn": "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1",
 				"teleport.dev/integration":                    "test-integration",
 			}, appServer.GetAllLabels())
+		})
+	})
+
+	t.Run("errors are reported in the integration status", func(t *testing.T) {
+		serverClient := baseServerClient(t)
+
+		params := baseParams(serverClient)
+		tags := map[string][]ratypes.Tag{
+			aws.ToString(exampleProfile.ProfileArn): {
+				{Key: aws.String("TeleportApplicationName"), Value: aws.String("``invalid host $ name")},
+			},
+		}
+		params.rolesAnywhereClient = &mockRolesAnywhereClient{
+			profiles: []ratypes.ProfileDetail{
+				exampleProfile,
+			},
+			tags: tags,
+		}
+
+		synctest.Run(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				err := RunAWSRolesAnywherProfileSyncer(ctx, params)
+				assert.NoError(t, err)
+			}()
+
+			// Wait for the 1st profile sync iteration.
+			synctest.Wait()
+			cancel()
+
+			status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
+			require.NotNil(t, status)
+			lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
+			require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusError, lastSyncSummary.Status)
+			require.NotEmpty(t, lastSyncSummary.StartTime)
+			require.NotEmpty(t, lastSyncSummary.EndTime)
+			require.Equal(t, int32(0), lastSyncSummary.SyncedProfiles)
+			require.NotEmpty(t, lastSyncSummary.ErrorMessage)
 		})
 	})
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2729,6 +2729,7 @@ func (process *TeleportProcess) initAuthService() error {
 			Logger:            logger,
 			KeyStoreManager:   authServer.GetKeyStore(),
 			Cache:             authServer.Cache,
+			StatusReporter:    authServer.Services,
 			AppServerUpserter: authServer.Services,
 			HostUUID:          process.Config.HostUUID,
 		}


### PR DESCRIPTION
When executing the Roles Anywhere Profile sync, it will now report the summary of each iteration.

This summary is visible on the integration and looks like this:
```yaml
kind: integration
metadata:
  name: raa
  revision: ca78c141-344a-4374-9c75-f166ff8e1752
spec:
  aws_oidc: {}
  aws_ra:
    profile_sync_config:
      enabled: true
      profile_accepts_role_session_name: false
      profile_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:profile/uuid1
      role_arn: arn:aws:iam::123456789012:role/MarcoRASyncRole
    trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/uuid2
  azure_oidc: {}
  github: {}
status:
  aws_ra:
    last_profile_sync:
      end_time: "2025-07-10T14:27:32.226599Z"
      error_message: ""
      start_time: "2025-07-10T14:27:31.045549Z"
      status: SUCCESS
      synced_profiles: 4
sub_kind: aws-ra
version: v1
```
```yaml
kind: integration
metadata:
  name: raa
  revision: 25297617-fde6-4a7e-b6a6-a47de938ca3f
spec:
// ...
status:
  aws_ra:
    last_profile_sync:
      end_time: "2025-07-10T15:12:28.300588Z"
      error_message: 'failed to create session Post "https://rolesanywhere.eu-west-2.amazonaws.com/sessions":
        dial tcp: lookup rolesanywhere.eu-west-2.amazonaws.com: no such host'
      start_time: "2025-07-10T15:12:28.297951Z"
      status: ERROR
      synced_profiles: 0
sub_kind: aws-ra
version: v1
```