### PR TITLE
MWI: Remaining `bot` package dependencies

### DIFF
--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
-	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -121,7 +121,7 @@ func TestBotJoinAuth(t *testing.T) {
 	authAddr, err := teleportServer.Process.AuthAddr()
 	require.NoError(t, err)
 	botConfig := &BotConfig{
-		Onboarding: config.OnboardingConfig{
+		Onboarding: onboarding.Config{
 			TokenValue: tokenName,
 			JoinMethod: types.JoinMethodToken,
 		},

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -125,7 +126,7 @@ func TestBotJoinAuth(t *testing.T) {
 			JoinMethod: types.JoinMethodToken,
 		},
 		AuthServer:            authAddr.Addr,
-		AuthServerAddressMode: config.AllowProxyAsAuthServer,
+		AuthServerAddressMode: connection.AllowProxyAsAuthServer,
 		CredentialLifetime: bot.CredentialLifetime{
 			TTL:             defaultCertificateTTL,
 			RenewalInterval: defaultRenewalInterval,

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
-	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -71,7 +71,7 @@ func main() {
 	config := &operatorConfig{}
 	config.BindFlags(flag.CommandLine)
 	botConfig := &embeddedtbot.BotConfig{}
-	botConfig.AuthServerAddressMode = tbotconfig.AllowProxyAsAuthServer
+	botConfig.AuthServerAddressMode = connection.AllowProxyAsAuthServer
 	botConfig.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/integrations/terraform-mwi/provider/provider.go
+++ b/integrations/terraform-mwi/provider/provider.go
@@ -33,6 +33,7 @@ import (
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -79,7 +80,7 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 				MarkdownDescription: "The join method to use to authenticate to the Teleport cluster.",
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf(config.SupportedJoinMethods...),
+					stringvalidator.OneOf(onboarding.SupportedJoinMethods...),
 					// Explicitly prohibit the use of the token join method
 					// as we won't be able to persist state for it to work
 					// effectively.
@@ -118,7 +119,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			Storage: &config.StorageConfig{
 				Destination: botInternalStore,
 			},
-			Onboarding: config.OnboardingConfig{
+			Onboarding: onboarding.Config{
 				JoinMethod: apitypes.JoinMethod(data.JoinMethod.ValueString()),
 				TokenValue: data.JoinToken.ValueString(),
 			},

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -35,6 +35,7 @@ import (
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -517,7 +518,7 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 	}
 	botConfig := &embeddedtbot.BotConfig{
 		AuthServer:            addr,
-		AuthServerAddressMode: tbotconfig.AllowProxyAsAuthServer,
+		AuthServerAddressMode: connection.AllowProxyAsAuthServer,
 		Onboarding: tbotconfig.OnboardingConfig{
 			TokenValue: joinToken,
 			CAPath:     caPath,

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
-	tbotconfig "github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 )
 
 var supportedCredentialSources = CredentialSources{
@@ -519,14 +519,14 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 	botConfig := &embeddedtbot.BotConfig{
 		AuthServer:            addr,
 		AuthServerAddressMode: connection.AllowProxyAsAuthServer,
-		Onboarding: tbotconfig.OnboardingConfig{
+		Onboarding: onboarding.Config{
 			TokenValue: joinToken,
 			CAPath:     caPath,
 			JoinMethod: apitypes.JoinMethod(joinMethod),
-			Terraform: tbotconfig.TerraformOnboardingConfig{
+			Terraform: onboarding.TerraformOnboardingConfig{
 				AudienceTag: audienceTag,
 			},
-			Gitlab: tbotconfig.GitlabOnboardingConfig{
+			Gitlab: onboarding.GitlabOnboardingConfig{
 				TokenEnvVarName: gitlabIDTokenEnvVar,
 			},
 		},

--- a/lib/tbot/bot/connection/config.go
+++ b/lib/tbot/bot/connection/config.go
@@ -1,0 +1,109 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"github.com/gravitational/trace"
+)
+
+// Config controls how the bot will connect to the Teleport cluster.
+type Config struct {
+	// Address contains the address string.
+	Address string
+
+	// AddressKind is the kind of address the user provided (i.e. auth server or
+	// proxy).
+	AddressKind AddressKind
+
+	// AuthServerAddressMode controls the behavior of when a proxy address is
+	// given as an auth server address.
+	AuthServerAddressMode AuthServerAddressMode
+
+	// StaticProxyAddress means the given proxy address will be used as-is
+	// rather than using an address discovered by pinging the proxy or auth
+	// server.
+	//
+	// In tbot, it is controlled using the `TBOT_USE_PROXY_ADDR` env var.
+	StaticProxyAddress bool
+
+	// Insecure allows the bot to trust the auth server or proxy certificate on
+	// first connection without verifying them. It is not recommended for use in
+	// production.
+	Insecure bool
+}
+
+// Validate the connection configuration.
+func (cfg *Config) Validate() error {
+	if cfg.Address == "" {
+		return trace.BadParameter("Address is required")
+	}
+
+	switch cfg.AddressKind {
+	case AddressKindProxy, AddressKindAuth:
+	default:
+		return trace.BadParameter("unsupported address kind: %s", cfg.AddressKind)
+	}
+
+	switch cfg.AuthServerAddressMode {
+	case AllowProxyAsAuthServer, WarnIfAuthServerIsProxy, AuthServerMustBeAuthServer:
+	default:
+		return trace.BadParameter("unsupported auth server address mode: %d", cfg.AuthServerAddressMode)
+	}
+
+	if cfg.StaticProxyAddress && cfg.AddressKind != AddressKindProxy {
+		return trace.BadParameter("static proxy address requested (e.g. via the TBOT_USE_PROXY_ADDR environment variable) but no explicit proxy address was configured")
+	}
+
+	return nil
+}
+
+// AddressKind describes the type of address the user provided.
+type AddressKind string
+
+const (
+	// AddressKindUnspecified means the user did not provide an address.
+	AddressKindUnspecified AddressKind = ""
+
+	// AddressKindProxy means the user provided the `--proxy-server` flag or
+	// `proxy_server` config option.
+	AddressKindProxy AddressKind = "proxy"
+
+	// AddressKindAuth means the user provided the `--auth-server` flag or
+	// `auth_server` config option.
+	AddressKindAuth AddressKind = "auth"
+)
+
+// AuthServerAddressMode controls the behavior when a proxy address is given
+// as an auth server address.
+type AuthServerAddressMode int
+
+const (
+	// AuthServerMustBeAuthServer means that only an actual auth server address
+	// may be given.
+	AuthServerMustBeAuthServer AuthServerAddressMode = iota
+
+	// WarnIfAuthServerIsProxy means that a proxy address will be accepted as an
+	// auth server address, but we will log a warning that this is going away in
+	// v19.
+	WarnIfAuthServerIsProxy
+
+	// AllowProxyAsAuthServer means that a proxy address will be accepted as an
+	// auth server address.
+	AllowProxyAsAuthServer
+)

--- a/lib/tbot/bot/connection/ping.go
+++ b/lib/tbot/bot/connection/ping.go
@@ -1,0 +1,73 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package connection
+
+import (
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+)
+
+// ProxyPinger can be used to ping the proxy or auth server to discover connection
+// information (e.g. whether TLS routing is enabled).
+type ProxyPinger interface {
+	// Ping the proxy.
+	Ping(ctx context.Context) (*ProxyPong, error)
+}
+
+// ProxyPong is the response of a proxy ping request.
+type ProxyPong struct {
+	*webclient.PingResponse
+
+	// StaticProxyAddress is the user-configured proxy address when the user
+	// requests their given address is preferred over pinging the proxy or auth
+	// server.
+	StaticProxyAddress string
+}
+
+// ProxyWebAddr returns the address to use to connect to the proxy web port.
+// In TLS routing mode, this address should be used for most/all connections.
+// This function takes into account the TBOT_USE_PROXY_ADDR environment
+// variable, which can be used to force the use of the proxy address explicitly
+// provided by the user rather than use the one fetched from the proxy ping.
+func (p *ProxyPong) ProxyWebAddr() (string, error) {
+	if p.StaticProxyAddress != "" {
+		return p.StaticProxyAddress, nil
+	}
+	return p.Proxy.SSH.PublicAddr, nil
+}
+
+// ProxySSHAddr returns the address to use to connect to the proxy SSH service.
+// Includes potential override via TBOT_USE_PROXY_ADDR.
+func (p *ProxyPong) ProxySSHAddr() (string, error) {
+	if p.Proxy.TLSRoutingEnabled && p.StaticProxyAddress != "" {
+		return p.StaticProxyAddress, nil
+	}
+	// SSHProxyHostPort returns the host and port to use to connect to the
+	// proxy's SSH service. If TLS routing is enabled, this will return the
+	// proxy's web address, if not, the proxy SSH listener.
+	host, port, err := p.Proxy.SSHProxyHostPort()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return net.JoinHostPort(host, port), nil
+}

--- a/lib/tbot/bot/onboarding/config.go
+++ b/lib/tbot/bot/onboarding/config.go
@@ -1,0 +1,142 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package onboarding
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// SupportedJoinMethods are the supported methods by which bots may join the
+// cluster.
+var SupportedJoinMethods = []string{
+	string(types.JoinMethodAzure),
+	string(types.JoinMethodAzureDevops),
+	string(types.JoinMethodBitbucket),
+	string(types.JoinMethodCircleCI),
+	string(types.JoinMethodGCP),
+	string(types.JoinMethodGitHub),
+	string(types.JoinMethodGitLab),
+	string(types.JoinMethodIAM),
+	string(types.JoinMethodKubernetes),
+	string(types.JoinMethodSpacelift),
+	string(types.JoinMethodToken),
+	string(types.JoinMethodTPM),
+	string(types.JoinMethodTerraformCloud),
+	string(types.JoinMethodBoundKeypair),
+}
+
+// AzureOnboardingConfig holds configuration relevant to the "azure" join method.
+type AzureOnboardingConfig struct {
+	// ClientID of the managed identity to use. Required if the VM has more
+	// than one assigned identity.
+	ClientID string `yaml:"client_id,omitempty"`
+}
+
+// TerraformOnboardingConfig contains parameters for the "terraform" join method
+type TerraformOnboardingConfig struct {
+	// TokenTag is the name of the tag configured via the environment variable
+	// `TERRAFORM_WORKLOAD_IDENTITY_AUDIENCE(_$TAG)`. If unset, the untagged
+	// variant is used.
+	AudienceTag string `yaml:"audience_tag,omitempty"`
+}
+
+// GitlabOnboardingConfig holds configuration relevant to the "gitlab" join method.
+type GitlabOnboardingConfig struct {
+	// TokenEnvVarName is the name of the environment variable that contains the
+	// GitLab ID token. This can be useful to override in cases where a single
+	// gitlab job needs to authenticate to multiple Teleport clusters.
+	TokenEnvVarName string `yaml:"token_env_var_name,omitempty"`
+}
+
+// BoundKeypairOnboardingConfig contains parameters for the `bound_keypair` join
+// method
+type BoundKeypairOnboardingConfig struct {
+	// RegistrationSecret is the name of the initial joining secret, if any. If
+	// not specified, a keypair must be created using `tbot keypair create` and
+	// registered with Teleport in advance.
+	RegistrationSecret string `yaml:"registration_secret,omitempty"`
+}
+
+// Config contains values relevant to how the bot authenticates with
+// and joins the Teleport cluster.
+type Config struct {
+	// TokenValue is either the token needed to join the auth server, or a path pointing to a file
+	// that contains the token
+	//
+	// You should use Token() instead - this has to be an exported field for YAML unmarshaling
+	// to work correctly, but this could be a path instead of a token
+	TokenValue string `yaml:"token,omitempty"`
+
+	// CAPath is an optional path to a CA certificate.
+	CAPath string `yaml:"ca_path,omitempty"`
+
+	// CAPins is a list of certificate authority pins, used to validate the
+	// connection to the Teleport auth server.
+	CAPins []string `yaml:"ca_pins,omitempty"`
+
+	// JoinMethod is the method the bot should use to exchange a token for the
+	// initial certificate
+	JoinMethod types.JoinMethod `yaml:"join_method"`
+
+	// Azure holds configuration relevant to the azure joining method.
+	Azure AzureOnboardingConfig `yaml:"azure,omitempty"`
+
+	// Terraform holds configuration relevant to the `terraform` join method.
+	Terraform TerraformOnboardingConfig `yaml:"terraform,omitempty"`
+
+	// Gitlab holds configuration relevant to the `gitlab` join method.
+	Gitlab GitlabOnboardingConfig `yaml:"gitlab,omitempty"`
+
+	// BoundKeypair holds configuration relevant to the `bound_keypair` join method
+	BoundKeypair BoundKeypairOnboardingConfig `yaml:"bound_keypair,omitempty"`
+}
+
+// HasToken gives the ability to check if there has been a token value stored
+// in the config
+func (conf *Config) HasToken() bool {
+	return conf.TokenValue != ""
+}
+
+// SetToken stores the value for --token or auth_token in the config
+//
+// In the case of the token value pointing to a file, this allows us to
+// fetch the value of the token when it's needed (when connecting for the first time)
+// instead of trying to read the file every time that teleport is launched.
+// This means we can allow temporary token files that are removed after teleport has
+// successfully connected the first time.
+func (conf *Config) SetToken(token string) {
+	conf.TokenValue = token
+}
+
+// Token returns token needed to join the auth server
+//
+// If the value stored points to a file, it will attempt to read the token value from the file
+// and return an error if it wasn't successful
+// If the value stored doesn't point to a file, it'll return the value stored
+func (conf *Config) Token() (string, error) {
+	token, err := utils.TryReadValueAsFile(conf.TokenValue)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return token, nil
+}

--- a/lib/tbot/cli/start_legacy.go
+++ b/lib/tbot/cli/start_legacy.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -138,7 +139,7 @@ type LegacyCommand struct {
 func NewLegacyCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *LegacyCommand {
 	joinMethodList := fmt.Sprintf(
 		"(%s)",
-		strings.Join(config.SupportedJoinMethods, ", "),
+		strings.Join(onboarding.SupportedJoinMethods, ", "),
 	)
 
 	c := &LegacyCommand{
@@ -153,7 +154,7 @@ func NewLegacyCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode C
 	c.cmd.Flag("ca-pin", "CA pin to validate the Teleport Auth Server; used on first connect.").StringsVar(&c.CAPins)
 	c.cmd.Flag("certificate-ttl", "TTL of short-lived machine certificates.").DurationVar(&c.CertificateTTL)
 	c.cmd.Flag("renewal-interval", "Interval at which short-lived certificates are renewed; must be less than the certificate TTL.").DurationVar(&c.RenewalInterval)
-	c.cmd.Flag("join-method", "Method to use to join the cluster. "+joinMethodList).EnumVar(&c.JoinMethod, config.SupportedJoinMethods...)
+	c.cmd.Flag("join-method", "Method to use to join the cluster. "+joinMethodList).EnumVar(&c.JoinMethod, onboarding.SupportedJoinMethods...)
 	c.cmd.Flag("oneshot", "If set, quit after the first renewal.").IsSetByUser(&c.oneshotSetByUser).BoolVar(&c.Oneshot)
 	c.cmd.Flag("diag-addr", "If set and the bot is in debug mode, a diagnostics service will listen on specified address.").StringVar(&c.DiagAddr)
 
@@ -240,7 +241,7 @@ func (c *LegacyCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error
 	// situation where different fields become set weirdly due to struct
 	// merging)
 	if c.Token != "" || c.JoinMethod != "" || len(c.CAPins) > 0 {
-		if !reflect.DeepEqual(cfg.Onboarding, config.OnboardingConfig{}) {
+		if !reflect.DeepEqual(cfg.Onboarding, onboarding.Config{}) {
 			// To be safe, warn about possible confusion.
 			log.WarnContext(
 				context.TODO(),
@@ -251,7 +252,7 @@ func (c *LegacyCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error
 			)
 		}
 
-		cfg.Onboarding = config.OnboardingConfig{
+		cfg.Onboarding = onboarding.Config{
 			CAPins:     c.CAPins,
 			JoinMethod: types.JoinMethod(c.JoinMethod),
 		}

--- a/lib/tbot/client/builder.go
+++ b/lib/tbot/client/builder.go
@@ -26,22 +26,23 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
-	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/trace"
 )
 
 // NewBuilder creates a new Builder.
 func NewBuilder(cfg BuilderConfig) (*Builder, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return &Builder{cfg: cfg}, nil
 }
 
 // BuilderConfig contains the configuration options for a Builder.
 type BuilderConfig struct {
-	// Address that will be dialed to create the client connection.
-	Address Address
-
-	// AuthServerAddressMode controls the behavior when a proxy address is
-	// given as an auth server address.
-	AuthServerAddressMode config.AuthServerAddressMode
+	// Connection contains the address etc. used to dial a connection to the
+	// auth server.
+	Connection connection.Config
 
 	// Resolver that will be used to find the address of a proxy server.
 	Resolver reversetunnelclient.Resolver
@@ -49,11 +50,21 @@ type BuilderConfig struct {
 	// Logger to which log messages will be written.
 	Logger *slog.Logger
 
-	// Insecure controls whether we will skip TLS host verification.
-	Insecure bool
-
 	// Metrics will record gRPC client metrics.
 	Metrics *prometheus.ClientMetrics
+}
+
+func (cfg *BuilderConfig) CheckAndSetDefaults() error {
+	if err := cfg.Connection.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	if cfg.Resolver == nil {
+		return trace.BadParameter("Resolver is required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return nil
 }
 
 // Builder provides a convenient way to create a client for a given identity
@@ -63,13 +74,10 @@ type Builder struct{ cfg BuilderConfig }
 // Build a client for the given identity.
 func (b *Builder) Build(ctx context.Context, id Identity) (*client.Client, error) {
 	return New(ctx, Config{
-		Identity: id,
-
-		Address:               b.cfg.Address,
-		AuthServerAddressMode: b.cfg.AuthServerAddressMode,
-		Resolver:              b.cfg.Resolver,
-		Logger:                b.cfg.Logger,
-		Insecure:              b.cfg.Insecure,
-		Metrics:               b.cfg.Metrics,
+		Identity:   id,
+		Connection: b.cfg.Connection,
+		Resolver:   b.cfg.Resolver,
+		Logger:     b.cfg.Logger,
+		Metrics:    b.cfg.Metrics,
 	})
 }

--- a/lib/tbot/client/builder.go
+++ b/lib/tbot/client/builder.go
@@ -22,12 +22,12 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gravitational/trace"
 	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
-	"github.com/gravitational/trace"
 )
 
 // NewBuilder creates a new Builder.

--- a/lib/tbot/client/client.go
+++ b/lib/tbot/client/client.go
@@ -58,7 +58,6 @@ package client
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log/slog"
 
 	"github.com/gravitational/trace"
@@ -72,37 +71,8 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
-	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 )
-
-// Address contains an address string tagged with whether it belongs to a proxy
-// or auth server.
-type Address struct {
-	// Addr contains the address string.
-	Addr string
-
-	// Kind of address (i.e. auth server or proxy).
-	Kind config.AddressKind
-}
-
-// String implements fmt.Stringer.
-func (a Address) String() string {
-	return fmt.Sprintf("%s: %s", a.Kind, a.Addr)
-}
-
-// Validate the address string and kind.
-func (a Address) Validate() error {
-	if a.Addr == "" {
-		return trace.BadParameter("address is required")
-	}
-
-	switch a.Kind {
-	case config.AddressKindProxy, config.AddressKindAuth:
-		return nil
-	default:
-		return trace.BadParameter("unsupported address type: %s", a.Kind)
-	}
-}
 
 // Identity provides the TLS and SSH credentials required to dial a connection.
 type Identity interface {
@@ -115,12 +85,9 @@ type Identity interface {
 
 // Config contains options used to create the API client.
 type Config struct {
-	// Address that will be dialed to create the client connection.
-	Address Address
-
-	// AuthServerAddressMode controls the behavior when a proxy address is
-	// given as an auth server address.
-	AuthServerAddressMode config.AuthServerAddressMode
+	// Connection contains the address etc. used to dial a connection to the
+	// auth server.
+	Connection connection.Config
 
 	// Identity that will provide the TLS and SSH credentials.
 	Identity Identity
@@ -131,9 +98,6 @@ type Config struct {
 	// Logger to which log messages will be written.
 	Logger *slog.Logger
 
-	// Insecure controls whether we will skip TLS host verification.
-	Insecure bool
-
 	// Metrics will record gRPC client metrics.
 	Metrics *grpcprom.ClientMetrics
 }
@@ -141,7 +105,7 @@ type Config struct {
 // CheckAndSetDefaults checks whether required config options have been provided
 // and sets defaults.
 func (c *Config) CheckAndSetDefaults() error {
-	if err := c.Address.Validate(); err != nil {
+	if err := c.Connection.Validate(); err != nil {
 		return err
 	}
 	if c.Identity == nil {
@@ -164,13 +128,13 @@ func New(ctx context.Context, cfg Config) (*client.Client, error) {
 
 	// If the address is known to be a proxy, dial without testing the
 	// connection.
-	if cfg.Address.Kind == config.AddressKindProxy {
+	if cfg.Connection.AddressKind == connection.AddressKindProxy {
 		return dialViaProxy(ctx, cfg)
 	}
 
 	// If it is known to be an auth server (i.e. we do not support falling back
 	// to treating it as a proxy), dial without testing the connection.
-	if cfg.AuthServerAddressMode == config.AuthServerMustBeAuthServer {
+	if cfg.Connection.AuthServerAddressMode == connection.AuthServerMustBeAuthServer {
 		return dialDirectly(ctx, cfg)
 	}
 
@@ -190,7 +154,7 @@ func New(ctx context.Context, cfg Config) (*client.Client, error) {
 	if proxyErr == nil {
 		// Send a ping to test the connection.
 		if _, proxyErr = clt.Ping(ctx); proxyErr == nil {
-			if cfg.AuthServerAddressMode == config.WarnIfAuthServerIsProxy {
+			if cfg.Connection.AuthServerAddressMode == connection.WarnIfAuthServerIsProxy {
 				cfg.Logger.WarnContext(ctx,
 					"Support for providing a proxy address via the 'auth_server' configuration option or '--auth-server' flag is deprecated and will be removed in v19. Use 'proxy_server' or '--proxy-server' instead.",
 				)
@@ -222,7 +186,7 @@ func dialViaProxy(ctx context.Context, cfg Config) (*client.Client, error) {
 		Resolver:              cfg.Resolver,
 		ClientConfig:          sshConfig,
 		Log:                   cfg.Logger,
-		InsecureSkipTLSVerify: cfg.Insecure,
+		InsecureSkipTLSVerify: cfg.Connection.Insecure,
 		GetClusterCAs:         client.ClusterCAsFromCertPool(tlsConfig.RootCAs),
 	})
 	if err != nil {
@@ -237,7 +201,7 @@ func dialViaProxy(ctx context.Context, cfg Config) (*client.Client, error) {
 		Dialer:                   dialer,
 		DialOpts:                 dialOpts(cfg),
 		CircuitBreakerConfig:     circuitBreakerConfig(),
-		InsecureAddressDiscovery: cfg.Insecure,
+		InsecureAddressDiscovery: cfg.Connection.Insecure,
 	})
 }
 
@@ -248,13 +212,13 @@ func dialDirectly(ctx context.Context, cfg Config) (*client.Client, error) {
 	}
 	return client.New(ctx, client.Config{
 		DialInBackground: true,
-		Addrs:            []string{cfg.Address.Addr},
+		Addrs:            []string{cfg.Connection.Address},
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
 		DialOpts:                 dialOpts(cfg),
 		CircuitBreakerConfig:     circuitBreakerConfig(),
-		InsecureAddressDiscovery: cfg.Insecure,
+		InsecureAddressDiscovery: cfg.Connection.Insecure,
 	})
 }
 

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"regexp"
 	"slices"
 	"strings"
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -218,7 +220,7 @@ type BotConfig struct {
 	// the tbot binary as of v19, but we maintain support for cases where tbot
 	// is embedded in a binary which does not differentiate between address types
 	// such as tctl or the Kubernetes operator.
-	AuthServerAddressMode AuthServerAddressMode `yaml:"-"`
+	AuthServerAddressMode connection.AuthServerAddressMode `yaml:"-"`
 
 	// JoinURI is a joining URI, used to supply connection and authentication
 	// parameters in a single bundle. If set, the value is parsed and merged on
@@ -247,54 +249,47 @@ type BotConfig struct {
 	Insecure bool `yaml:"insecure,omitempty"`
 }
 
-type AddressKind string
-
-const (
-	AddressKindUnspecified AddressKind = ""
-	AddressKindProxy       AddressKind = "proxy"
-	AddressKindAuth        AddressKind = "auth"
-)
-
-// Address returns the address to the auth server, either directly or via
-// a proxy, and the kind of address it is.
-func (conf *BotConfig) Address() (string, AddressKind) {
-	switch {
-	case conf.AuthServer != "" && conf.ProxyServer != "":
-		// This is an error case that should be prevented by the validation.
-		return "", AddressKindUnspecified
-	case conf.ProxyServer != "":
-		return conf.ProxyServer, AddressKindProxy
-	case conf.AuthServer != "":
-		return conf.AuthServer, AddressKindAuth
-	default:
-		return "", AddressKindUnspecified
+// ConnectionConfig creates a connection.Config from the user's configuration.
+func (conf *BotConfig) ConnectionConfig() connection.Config {
+	cc := connection.Config{
+		Insecure:              conf.Insecure,
+		AuthServerAddressMode: conf.AuthServerAddressMode,
+		StaticProxyAddress:    shouldUseProxyAddr(),
 	}
+
+	switch {
+	case conf.ProxyServer != "":
+		cc.Address = conf.ProxyServer
+		cc.AddressKind = connection.AddressKindProxy
+	case conf.AuthServer != "":
+		cc.Address = conf.AuthServer
+		cc.AddressKind = connection.AddressKindAuth
+	}
+
+	return cc
 }
-
-// AuthServerAddressMode controls the behavior when a proxy address is given
-// as an auth server address.
-type AuthServerAddressMode int
-
-const (
-	// AuthServerMustBeAuthServer means that only an actual auth server address
-	// may be given.
-	AuthServerMustBeAuthServer AuthServerAddressMode = iota
-
-	// WarnIfAuthServerIsProxy means that a proxy address will be accepted as an
-	// auth server address, but we will log a warning that this is going away in
-	// v19.
-	WarnIfAuthServerIsProxy
-
-	// AllowProxyAsAuthServer means that a proxy address will be accepted as an
-	// auth server address.
-	AllowProxyAsAuthServer
-)
 
 func (conf *BotConfig) CipherSuites() []uint16 {
 	if conf.FIPS {
 		return defaults.FIPSCipherSuites
 	}
 	return utils.DefaultCipherSuites()
+}
+
+// useProxyAddrEnv is an environment variable which can be set to
+// force `tbot` to prefer using the proxy address explicitly provided by the
+// user over the one fetched from the proxy ping. This is only intended to work
+// in cases where TLS routing is enabled, and is intended to support cases where
+// the Proxy is accessible from multiple addresses, and the one included in the
+// ProxyPing is incorrect.
+const useProxyAddrEnv = "TBOT_USE_PROXY_ADDR"
+
+// shouldUseProxyAddr returns true if the TBOT_USE_PROXY_ADDR environment
+// variable is set to "yes". More generally, this indicates that the user wishes
+// for tbot to prefer using the proxy address that has been explicitly provided
+// by the user rather than the one fetched via a discovery process (e.g ping).
+func shouldUseProxyAddr() bool {
+	return os.Getenv(useProxyAddrEnv) == "yes"
 }
 
 func (conf *BotConfig) UnmarshalYAML(node *yaml.Node) error {

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
@@ -154,13 +153,6 @@ func (conf *BotConfig) ConnectionConfig() connection.Config {
 	}
 
 	return cc
-}
-
-func (conf *BotConfig) CipherSuites() []uint16 {
-	if conf.FIPS {
-		return defaults.FIPSCipherSuites
-	}
-	return utils.DefaultCipherSuites()
 }
 
 // useProxyAddrEnv is an environment variable which can be set to

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
@@ -198,10 +199,10 @@ func TestBotConfig_YAML(t *testing.T) {
 						Symlinks: botfs.SymlinksSecure,
 					},
 				},
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: "gitlab",
 					TokenValue: "my-gitlab-token",
-					Gitlab: GitlabOnboardingConfig{
+					Gitlab: onboarding.GitlabOnboardingConfig{
 						TokenEnvVarName: "MY_CUSTOM_ENV_VAR",
 					},
 				},
@@ -396,7 +397,7 @@ func testYAML[T any](t *testing.T, tests []testYAMLCase[T]) {
 func TestBotConfig_InsecureWithCAPins(t *testing.T) {
 	cfg := &BotConfig{
 		Insecure: true,
-		Onboarding: OnboardingConfig{
+		Onboarding: onboarding.Config{
 			CAPins: []string{"123"},
 		},
 	}
@@ -407,7 +408,7 @@ func TestBotConfig_InsecureWithCAPins(t *testing.T) {
 func TestBotConfig_InsecureWithCAPath(t *testing.T) {
 	cfg := &BotConfig{
 		Insecure: true,
-		Onboarding: OnboardingConfig{
+		Onboarding: onboarding.Config{
 			CAPath: "/tmp/invalid-path/some.crt",
 		},
 	}
@@ -418,7 +419,7 @@ func TestBotConfig_InsecureWithCAPath(t *testing.T) {
 func TestBotConfig_WithCAPathAndCAPins(t *testing.T) {
 	cfg := &BotConfig{
 		Insecure: false,
-		Onboarding: OnboardingConfig{
+		Onboarding: onboarding.Config{
 			CAPath: "/tmp/invalid-path/some.crt",
 			CAPins: []string{"123"},
 		},
@@ -493,7 +494,7 @@ func TestBotConfig_Base64(t *testing.T) {
 			expected: BotConfig{
 				Version:     V2,
 				ProxyServer: "example.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: "token",
 					TokenValue: "my-token",
 				},
@@ -511,7 +512,7 @@ func TestBotConfig_Base64(t *testing.T) {
 			expected: BotConfig{
 				Version:    V2,
 				AuthServer: "example.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: "token",
 					TokenValue: "my-token",
 				},

--- a/lib/tbot/config/migrate.go
+++ b/lib/tbot/config/migrate.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 )
 
 type destinationMixinV1 struct {
@@ -359,14 +360,14 @@ func (c *configV1Destination) migrate() (ServiceConfig, error) {
 }
 
 type configV1 struct {
-	Onboarding      OnboardingConfig `yaml:"onboarding"`
-	Debug           bool             `yaml:"debug"`
-	AuthServer      string           `yaml:"auth_server"`
-	CertificateTTL  time.Duration    `yaml:"certificate_ttl"`
-	RenewalInterval time.Duration    `yaml:"renewal_interval"`
-	Oneshot         bool             `yaml:"oneshot"`
-	FIPS            bool             `yaml:"fips"`
-	DiagAddr        string           `yaml:"diag_addr"`
+	Onboarding      onboarding.Config `yaml:"onboarding"`
+	Debug           bool              `yaml:"debug"`
+	AuthServer      string            `yaml:"auth_server"`
+	CertificateTTL  time.Duration     `yaml:"certificate_ttl"`
+	RenewalInterval time.Duration     `yaml:"renewal_interval"`
+	Oneshot         bool              `yaml:"oneshot"`
+	FIPS            bool              `yaml:"fips"`
+	DiagAddr        string            `yaml:"diag_addr"`
 
 	Destinations  []configV1Destination `yaml:"destinations"`
 	StorageConfig *storageConfigV1      `yaml:"storage"`

--- a/lib/tbot/config/migrate_test.go
+++ b/lib/tbot/config/migrate_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 )
 
@@ -117,7 +118,7 @@ destinations:
 					TTL:             time.Minute * 30,
 				},
 				DiagAddr: "127.0.0.1:621",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "my-token",
 					CAPins: []string{
@@ -204,7 +205,7 @@ destinations:
 				AuthServer: "example.teleport.sh:443",
 				Oneshot:    true,
 				Debug:      true,
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodGitHub,
 					TokenValue: "my-token",
 				},
@@ -245,7 +246,7 @@ destinations:
 				AuthServer: "example.teleport.sh:443",
 				Oneshot:    true,
 				Debug:      true,
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodGitHub,
 					TokenValue: "my-token",
 				},
@@ -287,7 +288,7 @@ destinations:
 				AuthServer: "example.teleport.sh:443",
 				Oneshot:    true,
 				Debug:      true,
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodGitHub,
 					TokenValue: "my-token",
 				},
@@ -324,7 +325,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "auth.example.com:3025",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "00000000000000000000000000000000",
 					CAPins: []string{
@@ -367,7 +368,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -417,7 +418,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -467,7 +468,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -517,7 +518,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -571,7 +572,7 @@ oneshot: false
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "example.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "1234abcd5678efgh9",
 					CAPins: []string{
@@ -617,7 +618,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -660,7 +661,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -701,7 +702,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 					CAPins: []string{
@@ -735,7 +736,7 @@ onboarding:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodToken,
 					TokenValue: "abcd123-insecure-do-not-use-this",
 				},
@@ -771,7 +772,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleport.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					JoinMethod: types.JoinMethodIAM,
 					TokenValue: "iam-token-kube",
 				},
@@ -854,7 +855,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "teleportvm.example.com:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "redacted",
 				},
 				Storage: &StorageConfig{
@@ -893,7 +894,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "redacted.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "redacted-scanner-token",
 					JoinMethod: types.JoinMethodIAM,
 					CAPins: []string{
@@ -951,7 +952,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "redacted.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "redacted-argocd-token",
 					JoinMethod: types.JoinMethodIAM,
 					CAPins: []string{
@@ -1034,7 +1035,7 @@ destinations:
 			wantOutput: &BotConfig{
 				Version:    V2,
 				AuthServer: "redacted.teleport.sh:443",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "redacted",
 					JoinMethod: types.JoinMethodToken,
 				},

--- a/lib/tbot/config/uri.go
+++ b/lib/tbot/config/uri.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 )
 
 const (
@@ -37,7 +38,7 @@ const (
 
 type JoinURIParams struct {
 	// AddressKind is the type of joining address, i.e. proxy or auth.
-	AddressKind AddressKind
+	AddressKind connection.AddressKind
 
 	// JoinMethod is the join method to use when joining, in combination with
 	// the token name.
@@ -86,7 +87,7 @@ func (p *JoinURIParams) ApplyToConfig(cfg *BotConfig) error {
 		errors = append(errors, trace.BadParameter("URI conflicts with configured field: proxy_server"))
 	} else {
 		switch p.AddressKind {
-		case AddressKindAuth:
+		case connection.AddressKindAuth:
 			cfg.AuthServer = p.Address
 		default:
 			// this parameter should not be unspecified due to checks in
@@ -179,16 +180,16 @@ func ParseJoinURI(s string) (*JoinURIParams, error) {
 			uri.Scheme, URISchemePrefix)
 	}
 
-	var kind AddressKind
+	var kind connection.AddressKind
 	switch schemeParts[1] {
-	case string(AddressKindProxy):
-		kind = AddressKindProxy
-	case string(AddressKindAuth):
-		kind = AddressKindAuth
+	case string(connection.AddressKindProxy):
+		kind = connection.AddressKindProxy
+	case string(connection.AddressKindAuth):
+		kind = connection.AddressKindAuth
 	default:
 		return nil, trace.BadParameter(
 			"unsupported joining URI scheme %q: address kind must be one of [%q, %q], got: %q",
-			uri.Scheme, AddressKindProxy, AddressKindAuth, schemeParts[1])
+			uri.Scheme, connection.AddressKindProxy, connection.AddressKindAuth, schemeParts[1])
 	}
 
 	joinMethod, err := MapURLSafeJoinMethod(schemeParts[2])

--- a/lib/tbot/config/uri.go
+++ b/lib/tbot/config/uri.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 )
 
 const (
@@ -142,7 +143,7 @@ func (p *JoinURIParams) ApplyToConfig(cfg *BotConfig) error {
 // method constant.
 func MapURLSafeJoinMethod(name string) (types.JoinMethod, error) {
 	// When given a join method name that is already URL safe, just return it.
-	if slices.Contains(SupportedJoinMethods, name) {
+	if slices.Contains(onboarding.SupportedJoinMethods, name) {
 		return types.JoinMethod(name), nil
 	}
 

--- a/lib/tbot/config/uri_test.go
+++ b/lib/tbot/config/uri_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 )
 
 func TestParseJoinURI(t *testing.T) {
@@ -36,7 +37,7 @@ func TestParseJoinURI(t *testing.T) {
 		{
 			uri: "tbot+proxy+token://asdf@example.com:1234",
 			expect: &JoinURIParams{
-				AddressKind:         AddressKindProxy,
+				AddressKind:         connection.AddressKindProxy,
 				Token:               "asdf",
 				JoinMethod:          types.JoinMethodToken,
 				Address:             "example.com:1234",
@@ -46,7 +47,7 @@ func TestParseJoinURI(t *testing.T) {
 		{
 			uri: "tbot+auth+bound-keypair://token:param@example.com",
 			expect: &JoinURIParams{
-				AddressKind:         AddressKindAuth,
+				AddressKind:         connection.AddressKindAuth,
 				Token:               "token",
 				JoinMethod:          types.JoinMethodBoundKeypair,
 				Address:             "example.com",

--- a/lib/tbot/config/uri_test.go
+++ b/lib/tbot/config/uri_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 )
 
 func TestParseJoinURI(t *testing.T) {
@@ -105,7 +106,7 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+proxy+token://asdf@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "asdf",
 					JoinMethod: types.JoinMethodToken,
 				},
@@ -116,10 +117,10 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+proxy+bound-keypair://some-token:secret@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodBoundKeypair,
-					BoundKeypair: BoundKeypairOnboardingConfig{
+					BoundKeypair: onboarding.BoundKeypairOnboardingConfig{
 						RegistrationSecret: "secret",
 					},
 				},
@@ -130,10 +131,10 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+auth+azure://some-token:client-id@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodAzure,
-					Azure: AzureOnboardingConfig{
+					Azure: onboarding.AzureOnboardingConfig{
 						ClientID: "client-id",
 					},
 				},
@@ -144,10 +145,10 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+auth+gitlab://some-token:var-name@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodGitLab,
-					Gitlab: GitlabOnboardingConfig{
+					Gitlab: onboarding.GitlabOnboardingConfig{
 						TokenEnvVarName: "var-name",
 					},
 				},
@@ -158,7 +159,7 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+auth+azure-devops://some-token@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodAzureDevops,
 				},
@@ -169,10 +170,10 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri:         "tbot+auth+terraform-cloud://some-token:tag@example.com:1234",
 			inputConfig: &BotConfig{},
 			expectConfig: &BotConfig{
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "some-token",
 					JoinMethod: types.JoinMethodTerraformCloud,
-					Terraform: TerraformOnboardingConfig{
+					Terraform: onboarding.TerraformOnboardingConfig{
 						AudienceTag: "tag",
 					},
 				},
@@ -201,10 +202,10 @@ func TestJoinURIApplyToConfig(t *testing.T) {
 			uri: "tbot+auth+bound-keypair://asdf:secret@example.com:1234",
 			inputConfig: &BotConfig{
 				ProxyServer: "example.com",
-				Onboarding: OnboardingConfig{
+				Onboarding: onboarding.Config{
 					TokenValue: "token",
 					JoinMethod: types.JoinMethodBoundKeypair,
-					BoundKeypair: BoundKeypairOnboardingConfig{
+					BoundKeypair: onboarding.BoundKeypairOnboardingConfig{
 						RegistrationSecret: "secret2",
 					},
 				},

--- a/lib/tbot/internal/alpn_upgrade_cache.go
+++ b/lib/tbot/internal/alpn_upgrade_cache.go
@@ -1,0 +1,95 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/singleflight"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+)
+
+// NewALPNUpgradeCache creates a new ALPNUpgradeCache with the given logger.
+func NewALPNUpgradeCache(log *slog.Logger) *ALPNUpgradeCache {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ALPNUpgradeCache{log: log}
+}
+
+// ALPNUpgradeCache can be used to determine whether an ALPN upgrade request is
+// required.
+type ALPNUpgradeCache struct {
+	log *slog.Logger
+
+	mu    sync.Mutex
+	cache map[string]bool
+	group singleflight.Group
+}
+
+// IsUpgradeRequired determines whether an ALPN upgrade request is required and
+// caches the result.
+func (a *ALPNUpgradeCache) IsUpgradeRequired(ctx context.Context, addr string, insecure bool) (bool, error) {
+	key := fmt.Sprintf("%s-%t", addr, insecure)
+
+	a.mu.Lock()
+	if a.cache == nil {
+		a.cache = make(map[string]bool)
+	}
+	v, ok := a.cache[key]
+	if ok {
+		a.mu.Unlock()
+		return v, nil
+	}
+	a.mu.Unlock()
+
+	val, err, _ := a.group.Do(key, func() (any, error) {
+		// Recheck the cache in case we've just missed a previous group
+		// completing
+		a.mu.Lock()
+		v, ok := a.cache[key]
+		if ok {
+			a.mu.Unlock()
+			return v, nil
+		}
+		a.mu.Unlock()
+
+		// Ok, now we know for sure that the work hasn't already been done or
+		// isn't in flight, we can complete it.
+		a.log.DebugContext(ctx, "Testing ALPN upgrade necessary", "addr", addr, "insecure", insecure)
+		v = apiclient.IsALPNConnUpgradeRequired(ctx, addr, insecure)
+		a.log.DebugContext(ctx, "Tested ALPN upgrade necessary", "addr", addr, "insecure", insecure, "result", v)
+		if err := ctx.Err(); err != nil {
+			// Check for case where false is returned because client canceled ctx.
+			// We don't want to cache this result.
+			return v, trace.Wrap(err)
+		}
+
+		a.mu.Lock()
+		a.cache[key] = v
+		a.mu.Unlock()
+		return v, nil
+	})
+	return val.(bool), err
+}

--- a/lib/tbot/internal/caching_proxy_pinger.go
+++ b/lib/tbot/internal/caching_proxy_pinger.go
@@ -1,0 +1,122 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+)
+
+// CachingProxyPingerConfig is the configuration for CachingProxyPinger.
+type CachingProxyPingerConfig struct {
+	Connection connection.Config
+	Client     *client.Client
+	Logger     *slog.Logger
+}
+
+func (cfg *CachingProxyPingerConfig) CheckAndSetDefaults() error {
+	if err := cfg.Connection.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	if cfg.Client == nil {
+		return trace.BadParameter("Client is required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return nil
+}
+
+// NewCachingProxyPinger creates a new CachingProxyPinger with the given configuration.
+func NewCachingProxyPinger(cfg CachingProxyPingerConfig) (*CachingProxyPinger, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &CachingProxyPinger{
+		connCfg: cfg.Connection,
+		client:  cfg.Client,
+		logger:  cfg.Logger,
+	}, nil
+}
+
+// CachingProxyPinger pings the proxy server for connection information caches
+// the result indefinitely. If the user has configured an auth server address,
+// it will be pinged via gRPC to get the proxy address.
+type CachingProxyPinger struct {
+	connCfg connection.Config
+	client  *client.Client
+	logger  *slog.Logger
+
+	mu          sync.Mutex
+	cachedValue *connection.ProxyPong
+}
+
+// Ping the proxy for connection information.
+func (c *CachingProxyPinger) Ping(ctx context.Context) (*connection.ProxyPong, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cachedValue != nil {
+		return c.cachedValue, nil
+	}
+
+	var addr string
+	switch c.connCfg.AddressKind {
+	case connection.AddressKindProxy:
+		// Use the proxy address as-is.
+		addr = c.connCfg.Address
+	case connection.AddressKindAuth:
+		// Ping the auth server to determine the proxy address.
+		authPong, err := c.client.Ping(ctx)
+		if err != nil {
+			c.logger.Debug("Failed to ping auth server", "error", err)
+			return nil, trace.Wrap(err)
+		}
+		addr = authPong.ProxyPublicAddr
+	default:
+		return nil, trace.BadParameter("unsupported address kind: %v", c.connCfg.AddressKind)
+	}
+
+	c.logger.DebugContext(ctx, "Pinging proxy", "addr", addr)
+	res, err := webclient.Find(&webclient.Config{
+		Context:   ctx,
+		ProxyAddr: addr,
+		Insecure:  c.connCfg.Insecure,
+	})
+	if err != nil {
+		c.logger.ErrorContext(ctx, "Failed to ping proxy", "error", err)
+		return nil, trace.Wrap(err)
+	}
+	c.logger.DebugContext(ctx, "Successfully pinged proxy", "pong", res)
+
+	c.cachedValue = &connection.ProxyPong{PingResponse: res}
+	if c.connCfg.AddressKind == connection.AddressKindProxy && c.connCfg.StaticProxyAddress {
+		c.cachedValue.StaticProxyAddress = addr
+	}
+	return c.cachedValue, nil
+}
+
+var _ connection.ProxyPinger = (*CachingProxyPinger)(nil)

--- a/lib/tbot/internal/caching_proxy_pinger.go
+++ b/lib/tbot/internal/caching_proxy_pinger.go
@@ -92,7 +92,7 @@ func (c *CachingProxyPinger) Ping(ctx context.Context) (*connection.ProxyPong, e
 		// Ping the auth server to determine the proxy address.
 		authPong, err := c.client.Ping(ctx)
 		if err != nil {
-			c.logger.Debug("Failed to ping auth server", "error", err)
+			c.logger.DebugContext(ctx, "Failed to ping auth server", "error", err)
 			return nil, trace.Wrap(err)
 		}
 		addr = authPong.ProxyPublicAddr

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package tbot
+package identity
 
 import (
 	"bytes"
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
@@ -41,29 +42,84 @@ import (
 	"github.com/gravitational/teleport/lib/auth/state"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/client"
-	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/internal/identity")
+
+// Config contains configuration and dependencies for the bot identity service.
+type Config struct {
+	Connection  connection.Config
+	Onboarding  onboarding.Config
+	Destination destination.Destination
+
+	TTL             time.Duration
+	RenewalInterval time.Duration
+
+	FIPS bool
+
+	Logger         *slog.Logger
+	ReloadCh       <-chan struct{}
+	ClientBuilder  *client.Builder
+	StatusReporter readyz.Reporter
+}
+
+func (cfg *Config) CheckAndSetDefaults() error {
+	if err := cfg.Connection.Validate(); err != nil {
+		return trace.Wrap(err)
+	}
+	if cfg.TTL <= 0 {
+		return trace.BadParameter("TTL is required")
+	}
+	if cfg.RenewalInterval <= 0 {
+		return trace.BadParameter("RenewalInterval is required")
+	}
+	if cfg.ClientBuilder == nil {
+		return trace.BadParameter("ClientBuilder is required")
+	}
+	if cfg.Destination == nil {
+		cfg.Destination = destination.NewMemory()
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.StatusReporter == nil {
+		cfg.StatusReporter = readyz.NoopReporter()
+	}
+	return nil
+}
+
+// NewService creates a new bot identity service.
+func NewService(cfg Config) (*Service, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Service{
+		cfg:           cfg,
+		log:           cfg.Logger,
+		clientBuilder: cfg.ClientBuilder,
+	}, nil
+}
+
 // botIdentityRenewalRetryLimit is the number of permissible consecutive
 // failures in renewing the bot identity before the loop exits fatally.
 const botIdentityRenewalRetryLimit = 7
 
-// identityService is a [bot.Service] that handles renewing the bot's identity.
+// Service is a [bot.Service] that handles renewing the bot's identity.
 // It renews the bot's identity periodically and when receiving a broadcasted
 // reload signal.
-type identityService struct {
-	log               *slog.Logger
-	reloadBroadcaster *internal.ChannelBroadcaster
-	cfg               *config.BotConfig
-	statusReporter    readyz.Reporter
-	clientBuilder     *client.Builder
+type Service struct {
+	log           *slog.Logger
+	cfg           Config
+	clientBuilder *client.Builder
 
 	mu              sync.Mutex
 	client          *apiclient.Client
@@ -73,7 +129,7 @@ type identityService struct {
 }
 
 // GetIdentity returns the current Bot identity.
-func (s *identityService) GetIdentity() *identity.Identity {
+func (s *Service) GetIdentity() *identity.Identity {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.facade.Get()
@@ -81,13 +137,13 @@ func (s *identityService) GetIdentity() *identity.Identity {
 
 // GetClient returns the facaded client for the Bot identity for use by other
 // components of `tbot`. Consumers should not call `Close` on the client.
-func (s *identityService) GetClient() *apiclient.Client {
+func (s *Service) GetClient() *apiclient.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.client
 }
 
-func (s *identityService) GetGenerator() (*identity.Generator, error) {
+func (s *Service) GetGenerator() (*identity.Generator, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -95,10 +151,10 @@ func (s *identityService) GetGenerator() (*identity.Generator, error) {
 		Client:      s.client,
 		BotIdentity: s.facade,
 		FIPS:        s.cfg.FIPS,
-		Insecure:    s.cfg.Insecure,
+		Insecure:    s.cfg.Connection.Insecure,
 		Logger: s.log.With(
 			teleport.ComponentKey,
-			teleport.Component(componentTBot, "identity-generator"),
+			teleport.Component(teleport.ComponentTBot, "identity-generator"),
 		),
 	})
 }
@@ -106,7 +162,7 @@ func (s *identityService) GetGenerator() (*identity.Generator, error) {
 // Ready returns a channel that will be closed when the initial identity renewal
 // process has completed. It provides a way to "block" startup of services that
 // cannot gracefully handle the API client being unavailable.
-func (s *identityService) Ready() <-chan struct{} {
+func (s *Service) Ready() <-chan struct{} {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -118,7 +174,7 @@ func (s *identityService) Ready() <-chan struct{} {
 }
 
 // IsReady returns whether the initial identity renewal process has completed.
-func (s *identityService) IsReady() bool {
+func (s *Service) IsReady() bool {
 	select {
 	case <-s.Ready():
 		return true
@@ -128,7 +184,7 @@ func (s *identityService) IsReady() bool {
 }
 
 // String returns a human-readable name of the service.
-func (s *identityService) String() string {
+func (s *Service) String() string {
 	return "identity"
 }
 
@@ -145,7 +201,7 @@ func hasTokenChanged(configTokenBytes, identityBytes []byte) bool {
 // If the persisted identity does not match the onboarding profile/join token,
 // a nil identity will be returned. If the identity certificate has expired, the
 // bool return value will be false.
-func (s *identityService) loadIdentityFromStore(ctx context.Context, store destination.Destination) (*identity.Identity, bool) {
+func (s *Service) loadIdentityFromStore(ctx context.Context, store destination.Destination) (*identity.Identity, bool) {
 	ctx, span := tracer.Start(ctx, "identityService/loadIdentityFromStore")
 	defer span.End()
 	s.log.InfoContext(ctx, "Loading existing bot identity from store", "store", store)
@@ -192,7 +248,7 @@ func (s *identityService) loadIdentityFromStore(ctx context.Context, store desti
 	s.log.InfoContext(
 		ctx,
 		"Loaded existing bot identity from store",
-		"identity", describeTLSIdentity(ctx, s.log, loadedIdent),
+		"identity", loadedIdent,
 	)
 
 	now := time.Now().UTC()
@@ -229,12 +285,12 @@ func (s *identityService) loadIdentityFromStore(ctx context.Context, store desti
 //
 // If there is no identity, or the identity is invalid, we'll join using the
 // configured onboarding settings.
-func (s *identityService) Initialize(ctx context.Context) error {
+func (s *Service) Initialize(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "identityService/Initialize")
 	defer span.End()
 
 	s.log.InfoContext(ctx, "Initializing bot identity")
-	loadedIdent, valid := s.loadIdentityFromStore(ctx, s.cfg.Storage.Destination)
+	loadedIdent, valid := s.loadIdentityFromStore(ctx, s.cfg.Destination)
 	if !valid {
 		if !s.cfg.Onboarding.HasToken() {
 			// If there's no pre-existing identity (or it has expired) and the
@@ -283,7 +339,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 		// In one-shot mode, the OneShot method will make a ping RPC to test the
 		// connection and exit immediately if the connection is unavailable.
 		if err != nil {
-			facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Insecure, loadedIdent)
+			facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Connection.Insecure, loadedIdent)
 			client, clientErr := s.clientBuilder.Build(ctx, facade)
 			if clientErr != nil {
 				return trace.Wrap(clientErr)
@@ -300,12 +356,12 @@ func (s *identityService) Initialize(ctx context.Context) error {
 	}
 
 	// We successfully renewed the bot identity!
-	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
-	if err := identity.SaveIdentity(ctx, newIdentity, s.cfg.Storage.Destination, identity.BotKinds()...); err != nil {
+	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", newIdentity)
+	if err := identity.SaveIdentity(ctx, newIdentity, s.cfg.Destination, identity.BotKinds()...); err != nil {
 		return trace.Wrap(err)
 	}
 
-	facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Insecure, newIdentity)
+	facade := identity.NewFacade(s.cfg.FIPS, s.cfg.Connection.Insecure, newIdentity)
 	c, err := s.clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return trace.Wrap(err)
@@ -313,18 +369,16 @@ func (s *identityService) Initialize(ctx context.Context) error {
 	s.mu.Lock()
 	s.client = c
 	s.facade = facade
-	if s.statusReporter == nil {
-		s.statusReporter = readyz.NoopReporter()
-	}
 	s.mu.Unlock()
 
 	s.unblockWaiters()
-	s.statusReporter.Report(readyz.Healthy)
+	s.cfg.StatusReporter.Report(readyz.Healthy)
+
 	s.log.InfoContext(ctx, "Identity initialized successfully")
 	return nil
 }
 
-func (s *identityService) Close() error {
+func (s *Service) Close() error {
 	c := s.GetClient()
 	if c == nil {
 		return nil
@@ -332,22 +386,20 @@ func (s *identityService) Close() error {
 	return trace.Wrap(c.Close())
 }
 
-func (s *identityService) OneShot(ctx context.Context) error {
+func (s *Service) OneShot(ctx context.Context) error {
 	if _, err := s.GetClient().Ping(ctx); err != nil {
 		return trace.Wrap(err, "testing auth service connection")
 	}
 	return nil
 }
 
-func (s *identityService) Run(ctx context.Context) error {
+func (s *Service) Run(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "identityService/Run")
 	defer span.End()
-	reloadCh, unsubscribe := s.reloadBroadcaster.Subscribe()
-	defer unsubscribe()
 
 	// Determine where the bot should write its internal data (renewable cert
 	// etc)
-	storageDestination := s.cfg.Storage.Destination
+	storageDestination := s.cfg.Destination
 
 	// Keep retrying renewal if it failed on startup.
 	if !s.IsReady() {
@@ -381,8 +433,8 @@ func (s *identityService) Run(ctx context.Context) error {
 	s.log.InfoContext(
 		ctx,
 		"Beginning bot identity renewal loop",
-		"ttl", s.cfg.CredentialLifetime.TTL,
-		"interval", s.cfg.CredentialLifetime.RenewalInterval,
+		"ttl", s.cfg.TTL,
+		"interval", s.cfg.RenewalInterval,
 	)
 
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
@@ -391,17 +443,17 @@ func (s *identityService) Run(ctx context.Context) error {
 		F: func(ctx context.Context) error {
 			return s.renew(ctx, storageDestination)
 		},
-		Interval:           s.cfg.CredentialLifetime.RenewalInterval,
+		Interval:           s.cfg.RenewalInterval,
 		RetryLimit:         botIdentityRenewalRetryLimit,
 		Log:                s.log,
-		ReloadCh:           reloadCh,
+		ReloadCh:           s.cfg.ReloadCh,
 		WaitBeforeFirstRun: true,
-		StatusReporter:     s.statusReporter,
+		StatusReporter:     s.cfg.StatusReporter,
 	})
 	return trace.Wrap(err)
 }
 
-func (s *identityService) renew(
+func (s *Service) renew(
 	ctx context.Context,
 	botDestination destination.Destination,
 ) error {
@@ -419,18 +471,18 @@ func (s *identityService) renew(
 		return trace.Wrap(err, "renewing identity")
 	}
 
-	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
+	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", newIdentity)
 	s.facade.Set(newIdentity)
 
 	if err := identity.SaveIdentity(ctx, newIdentity, botDestination, identity.BotKinds()...); err != nil {
 		return trace.Wrap(err, "saving new identity")
 	}
-	s.log.DebugContext(ctx, "Bot identity persisted", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
+	s.log.DebugContext(ctx, "Bot identity persisted", "identity", newIdentity)
 
 	return nil
 }
 
-func (s *identityService) unblockWaiters() {
+func (s *Service) unblockWaiters() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -462,7 +514,7 @@ func (s *identityService) unblockWaiters() {
 func renewIdentity(
 	ctx context.Context,
 	log *slog.Logger,
-	botCfg *config.BotConfig,
+	cfg Config,
 	clientBuilder *client.Builder,
 	oldIdentity *identity.Identity,
 ) (*identity.Identity, error) {
@@ -471,7 +523,7 @@ func renewIdentity(
 	// Explicitly create a new client - this guarantees that requests will be
 	// made with the most recent identity and that a connection associated with
 	// an old identity will not be used.
-	facade := identity.NewFacade(botCfg.FIPS, botCfg.Insecure, oldIdentity)
+	facade := identity.NewFacade(cfg.FIPS, cfg.Connection.Insecure, oldIdentity)
 	authClient, err := clientBuilder.Build(ctx, facade)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating auth client")
@@ -482,7 +534,7 @@ func renewIdentity(
 		// When using a renewable join method, we use GenerateUserCerts to
 		// request a new certificate using our current identity.
 		newIdentity, err := botIdentityFromAuth(
-			ctx, log, oldIdentity, authClient, botCfg.CredentialLifetime.TTL,
+			ctx, log, oldIdentity, authClient, cfg.TTL,
 		)
 		if err != nil {
 			return nil, trace.Wrap(err, "renewing identity using GenerateUserCert")
@@ -509,17 +561,18 @@ func renewIdentity(
 				"the bot from renewing its identity on schedule.",
 			"now", now,
 			"expiry", expiry,
-			"credential_lifetime", botCfg.CredentialLifetime,
+			"ttl", cfg.TTL,
+			"renewal_interval", cfg.RenewalInterval,
 		)
 
-		newIdentity, err := botIdentityFromToken(ctx, log, botCfg, nil)
+		newIdentity, err := botIdentityFromToken(ctx, log, cfg, nil)
 		if err != nil {
 			return nil, trace.Wrap(err, "renewing identity using Register without existing auth client")
 		}
 		return newIdentity, nil
 	}
 
-	newIdentity, err := botIdentityFromToken(ctx, log, botCfg, authClient)
+	newIdentity, err := botIdentityFromToken(ctx, log, cfg, authClient)
 	if err != nil {
 		return nil, trace.Wrap(err, "renewing identity using Register with existing auth client")
 	}
@@ -600,7 +653,7 @@ func botIdentityFromAuth(
 func botIdentityFromToken(
 	ctx context.Context,
 	log *slog.Logger,
-	cfg *config.BotConfig,
+	cfg Config,
 	authClient *apiclient.Client,
 ) (*identity.Identity, error) {
 	_, span := tracer.Start(ctx, "botIdentityFromToken")
@@ -613,7 +666,12 @@ func botIdentityFromToken(
 		return nil, trace.Wrap(err)
 	}
 
-	expires := time.Now().Add(cfg.CredentialLifetime.TTL)
+	cipherSuites := utils.DefaultCipherSuites()
+	if cfg.FIPS {
+		cipherSuites = defaults.FIPSCipherSuites
+	}
+
+	expires := time.Now().Add(cfg.TTL)
 	params := join.RegisterParams{
 		Token: token,
 		ID: state.IdentityID{
@@ -623,33 +681,32 @@ func botIdentityFromToken(
 		Expires:    &expires,
 
 		// Below options are effectively ignored if AuthClient is not-nil
-		Insecure:           cfg.Insecure,
+		Insecure:           cfg.Connection.Insecure,
 		CAPins:             cfg.Onboarding.CAPins,
 		CAPath:             cfg.Onboarding.CAPath,
 		FIPS:               cfg.FIPS,
 		GetHostCredentials: libclient.HostCredentials,
-		CipherSuites:       cfg.CipherSuites(),
+		CipherSuites:       cipherSuites,
 	}
 	if authClient != nil {
 		params.AuthClient = authClient
 	}
 
-	connCfg := cfg.ConnectionConfig()
-	switch connCfg.AddressKind {
+	switch cfg.Connection.AddressKind {
 	case connection.AddressKindAuth:
-		parsed, err := utils.ParseAddr(connCfg.Address)
+		parsed, err := utils.ParseAddr(cfg.Connection.Address)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse addr")
 		}
 		params.AuthServers = []utils.NetAddr{*parsed}
 	case connection.AddressKindProxy:
-		parsed, err := utils.ParseAddr(connCfg.Address)
+		parsed, err := utils.ParseAddr(cfg.Connection.Address)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse addr")
 		}
 		params.ProxyServer = *parsed
 	default:
-		return nil, trace.BadParameter("unsupported address kind: %v", connCfg.AddressKind)
+		return nil, trace.BadParameter("unsupported address kind: %v", cfg.Connection.AddressKind)
 	}
 
 	// Only set during bound keypair joining, but used both before and after.
@@ -669,7 +726,7 @@ func botIdentityFromToken(
 	case types.JoinMethodBoundKeypair:
 		joinSecret := cfg.Onboarding.BoundKeypair.RegistrationSecret
 
-		adapter := destination.NewBoundkeypairDestinationAdapter(cfg.Storage.Destination)
+		adapter := destination.NewBoundkeypairDestinationAdapter(cfg.Destination)
 		boundKeypairState, err = boundkeypair.LoadClientState(ctx, adapter)
 		if trace.IsNotFound(err) && joinSecret != "" {
 			log.InfoContext(ctx, "No existing client state found, will attempt "+

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -45,7 +46,7 @@ import (
 type ApplicationTunnelService struct {
 	botCfg             *config.BotConfig
 	cfg                *config.ApplicationTunnelService
-	proxyPingCache     *proxyPingCache
+	proxyPinger        connection.ProxyPinger
 	log                *slog.Logger
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
@@ -140,11 +141,11 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 		}
 	}
 
-	proxyPing, err := s.proxyPingCache.ping(ctx)
+	proxyPing, err := s.proxyPinger.Ping(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr, err := proxyPing.proxyWebAddr()
+	proxyAddr, err := proxyPing.ProxyWebAddr()
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining proxy web addr")
 	}

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/state"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -633,22 +634,22 @@ func botIdentityFromToken(
 		params.AuthClient = authClient
 	}
 
-	addr, addrKind := cfg.Address()
-	switch addrKind {
-	case config.AddressKindAuth:
-		parsed, err := utils.ParseAddr(addr)
+	connCfg := cfg.ConnectionConfig()
+	switch connCfg.AddressKind {
+	case connection.AddressKindAuth:
+		parsed, err := utils.ParseAddr(connCfg.Address)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse addr")
 		}
 		params.AuthServers = []utils.NetAddr{*parsed}
-	case config.AddressKindProxy:
-		parsed, err := utils.ParseAddr(addr)
+	case connection.AddressKindProxy:
+		parsed, err := utils.ParseAddr(connCfg.Address)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse addr")
 		}
 		params.ProxyServer = *parsed
 	default:
-		return nil, trace.BadParameter("unsupported address kind: %v", addrKind)
+		return nil, trace.BadParameter("unsupported address kind: %v", connCfg.AddressKind)
 	}
 
 	// Only set during bound keypair joining, but used both before and after.

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -66,7 +67,7 @@ func (a alpnProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalPro
 type DatabaseTunnelService struct {
 	botCfg             *config.BotConfig
 	cfg                *config.DatabaseTunnelService
-	proxyPingCache     *proxyPingCache
+	proxyPinger        connection.ProxyPinger
 	log                *slog.Logger
 	botClient          *apiclient.Client
 	getBotIdentity     getBotIdentityFn
@@ -95,11 +96,11 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 		}
 	}
 
-	proxyPing, err := s.proxyPingCache.ping(ctx)
+	proxyPing, err := s.proxyPinger.Ping(ctx)
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr, err := proxyPing.proxyWebAddr()
+	proxyAddr, err := proxyPing.ProxyWebAddr()
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining proxy web address")
 	}

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -62,7 +62,7 @@ type IdentityOutputService struct {
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath    func() (string, error)
-	alpnUpgradeCache  *alpnProxyConnUpgradeRequiredCache
+	alpnUpgradeCache  *internal.ALPNUpgradeCache
 	identityGenerator *identity.Generator
 	clientBuilder     *client.Builder
 }
@@ -230,7 +230,7 @@ type certAuthGetter interface {
 }
 
 type alpnTester interface {
-	isUpgradeRequired(ctx context.Context, addr string, insecure bool) (bool, error)
+	IsUpgradeRequired(ctx context.Context, addr string, insecure bool) (bool, error)
 }
 
 func renderSSHConfig(
@@ -312,7 +312,7 @@ func renderSSHConfig(
 	// are using TLS routing.
 	connUpgradeRequired := false
 	if proxyPing.Proxy.TLSRoutingEnabled {
-		connUpgradeRequired, err = alpnTester.isUpgradeRequired(
+		connUpgradeRequired, err = alpnTester.IsUpgradeRequired(
 			ctx, proxyAddr, botCfg.Insecure,
 		)
 		if err != nil {

--- a/lib/tbot/service_identity_output_test.go
+++ b/lib/tbot/service_identity_output_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -159,7 +160,7 @@ func Test_renderSSHConfig(t *testing.T) {
 			err := renderSSHConfig(
 				context.Background(),
 				logtest.NewLogger(),
-				&proxyPingResponse{
+				&connection.ProxyPong{
 					PingResponse: &webclient.PingResponse{
 						ClusterName: mockClusterName,
 						Proxy: webclient.ProxySettings{

--- a/lib/tbot/service_identity_output_test.go
+++ b/lib/tbot/service_identity_output_test.go
@@ -114,7 +114,7 @@ type mockALPNConnTester struct {
 	isALPNUpgradeRequired bool
 }
 
-func (p *mockALPNConnTester) isUpgradeRequired(ctx context.Context, addr string, insecure bool) (bool, error) {
+func (p *mockALPNConnTester) IsUpgradeRequired(ctx context.Context, addr string, insecure bool) (bool, error) {
 	return p.isALPNUpgradeRequired, nil
 }
 

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -39,6 +39,7 @@ import (
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -62,7 +63,7 @@ type KubernetesOutputService struct {
 	cfg                *config.KubernetesOutput
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
-	proxyPingCache     *proxyPingCache
+	proxyPinger        connection.ProxyPinger
 	reloadBroadcaster  *internal.ChannelBroadcaster
 	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
@@ -167,7 +168,7 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 	)
 
 	// Ping the proxy to resolve connection addresses.
-	proxyPong, err := s.proxyPingCache.ping(ctx)
+	proxyPong, err := s.proxyPinger.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -416,7 +417,7 @@ func getKubeCluster(ctx context.Context, clt apiclient.GetResourcesClient, name 
 
 // selectKubeConnectionMethod determines the address and SNI that should be
 // put into the kubeconfig file.
-func selectKubeConnectionMethod(proxyPong *proxyPingResponse) (
+func selectKubeConnectionMethod(proxyPong *connection.ProxyPong) (
 	clusterAddr string, sni string, err error,
 ) {
 	// First we check for TLS routing. If this is enabled, we use the Proxy's
@@ -425,7 +426,7 @@ func selectKubeConnectionMethod(proxyPong *proxyPingResponse) (
 	// Even if KubePublicAddr is specified, we still use the general
 	// PublicAddr when using TLS routing.
 	if proxyPong.Proxy.TLSRoutingEnabled {
-		addr, err := proxyPong.proxyWebAddr()
+		addr, err := proxyPong.ProxyWebAddr()
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}

--- a/lib/tbot/service_kubernetes_output_test.go
+++ b/lib/tbot/service_kubernetes_output_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -280,7 +281,7 @@ func Test_selectKubeConnectionMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr, sni, err := selectKubeConnectionMethod(&proxyPingResponse{
+			addr, sni, err := selectKubeConnectionMethod(&connection.ProxyPong{
 				PingResponse: tt.proxyPing,
 			})
 			require.NoError(t, err)

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -40,6 +40,7 @@ import (
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -61,7 +62,7 @@ type KubernetesV2OutputService struct {
 	cfg                *config.KubernetesV2Output
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
-	proxyPingCache     *proxyPingCache
+	proxyPinger        connection.ProxyPinger
 	reloadBroadcaster  *internal.ChannelBroadcaster
 	statusReporter     readyz.Reporter
 	// executablePath is called to get the path to the tbot executable.
@@ -156,7 +157,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 	)
 
 	// Ping the proxy to resolve connection addresses.
-	proxyPong, err := s.proxyPingCache.ping(ctx)
+	proxyPong, err := s.proxyPinger.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/config/openssh"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/resumption"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -104,7 +105,7 @@ type SSHMultiplexerService struct {
 	cfg                *config.SSHMultiplexerService
 	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
-	proxyPingCache     *proxyPingCache
+	proxyPinger        connection.ProxyPinger
 	reloadBroadcaster  *internal.ChannelBroadcaster
 	statusReporter     readyz.Reporter
 
@@ -292,11 +293,11 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 	}
 
 	// Ping the proxy and determine if we need to upgrade the connection.
-	proxyPing, err := s.proxyPingCache.ping(ctx)
+	proxyPing, err := s.proxyPinger.Ping(ctx)
 	if err != nil {
 		return nil, nil, "", nil, trace.Wrap(err)
 	}
-	proxyAddr, err := proxyPing.proxySSHAddr()
+	proxyAddr, err := proxyPing.ProxySSHAddr()
 	if err != nil {
 		return nil, nil, "", nil, trace.Wrap(err, "determining proxy ssh addr")
 	}

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -95,7 +95,7 @@ var (
 // socket and has a special client with support for FDPassing with OpenSSH.
 // It places an emphasis on high performance.
 type SSHMultiplexerService struct {
-	alpnUpgradeCache *alpnProxyConnUpgradeRequiredCache
+	alpnUpgradeCache *internal.ALPNUpgradeCache
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
@@ -311,7 +311,7 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 
 	connUpgradeRequired := false
 	if proxyPing.Proxy.TLSRoutingEnabled {
-		connUpgradeRequired, err = s.alpnUpgradeCache.isUpgradeRequired(
+		connUpgradeRequired, err = s.alpnUpgradeCache.IsUpgradeRequired(
 			ctx, proxyAddr, s.botCfg.Insecure,
 		)
 		if err != nil {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	apisshutils "github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -163,7 +164,7 @@ func defaultBotConfig(
 
 	cfg := &config.BotConfig{
 		AuthServer:            authServer,
-		AuthServerAddressMode: config.WarnIfAuthServerIsProxy,
+		AuthServerAddressMode: connection.WarnIfAuthServerIsProxy,
 		Onboarding:            *onboarding,
 		Storage: &config.StorageConfig{
 			Destination: &destination.Memory{},

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -63,6 +63,7 @@ import (
 	apisshutils "github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -105,7 +106,7 @@ func defaultTestServerOpts(t *testing.T, log *slog.Logger) testenv.TestServerOpt
 }
 
 // makeBot creates a server-side bot and returns joining parameters.
-func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*config.OnboardingConfig, *machineidv1pb.Bot) {
+func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
 	ctx := context.TODO()
 	t.Helper()
 
@@ -136,7 +137,7 @@ func makeBot(t *testing.T, client *authclient.Client, name string, roles ...stri
 	err = client.CreateToken(ctx, tok)
 	require.NoError(t, err)
 
-	return &config.OnboardingConfig{
+	return &onboarding.Config{
 		TokenValue: tok.GetName(),
 		JoinMethod: types.JoinMethodToken,
 	}, b
@@ -151,7 +152,7 @@ func makeBot(t *testing.T, client *authclient.Client, name string, roles ...stri
 func defaultBotConfig(
 	t *testing.T,
 	process *service.TeleportProcess,
-	onboarding *config.OnboardingConfig,
+	onboarding *onboarding.Config,
 	serviceConfigs config.ServiceConfigs,
 	opts defaultBotConfigOpts,
 ) *config.BotConfig {

--- a/tool/tbot/anonymous_telemetry_test.go
+++ b/tool/tbot/anonymous_telemetry_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -64,7 +65,7 @@ func TestSendTelemetry(t *testing.T) {
 		}
 		cfg := &config.BotConfig{
 			Oneshot: true,
-			Onboarding: config.OnboardingConfig{
+			Onboarding: onboarding.Config{
 				JoinMethod: types.JoinMethodGitHub,
 			},
 			Services: config.ServiceConfigs{

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/ssh"
@@ -304,7 +305,7 @@ func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr util
 	credential := &config.UnstableClientCredentialOutput{}
 	cfg := &config.BotConfig{
 		Version: "",
-		Onboarding: config.OnboardingConfig{
+		Onboarding: onboarding.Config{
 			TokenValue: token,
 			JoinMethod: types.JoinMethodToken,
 		},

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot"
 	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -319,7 +320,7 @@ func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr util
 	// When setting AuthServerAddressMode to ProxyAllowed, tbot will try both joining as an auth and as a proxy.
 	// This allows us to not care about how the user connects to Teleport (auth vs proxy joining).
 	cfg.AuthServer = addr.String()
-	cfg.AuthServerAddressMode = config.AllowProxyAsAuthServer
+	cfg.AuthServerAddressMode = connection.AllowProxyAsAuthServer
 
 	// Insecure joining is not compatible with CA pinning
 	if !cfg.Insecure {


### PR DESCRIPTION
## Background

This is part of a series of pull requests to refactor the `lib/tbot` package for better modularity.

Today, all of `tbot`'s services live in the same package which makes it difficult to see the system boundaries, but also means that it's impossible for other binaries that "embed" tbot (e.g. `tctl`, the Kubernetes operator) to pull in just the parts they need - and for the compiler to effectively eliminate unused dependencies.

See the [boxofrad/wip-tbot-refactoring branch](https://github.com/gravitational/teleport/tree/boxofrad/wip-tbot-refactoring) for an idea of the end-state of this stack. In this branch, the `tctl` binary is roughly **13% smaller** largely due to eliminating the unused Sigstore modules.

## Changes

This pull request moves the remaining dependencies of the new `bot.Bot` type into place (so that it can be introduced in the next PR). Including:

- Wrapping common connection-related parameters in a `connection.Config` struct
- Moving the onboarding config structs so they can be used without importing `lib/tbot/config`
- Moving the "proxy ping cache" and "ALPN upgrade cache" logic into the `internal` package
- Moving the internal bot identity service into its own package
