### PR TITLE
Move (almost) all AccessListMember validation to backend 

### DIFF
--- a/api/types/accesslist/convert/v1/member_test.go
+++ b/api/types/accesslist/convert/v1/member_test.go
@@ -71,12 +71,12 @@ func TestMemberFromProtoNils(t *testing.T) {
 		{
 			name:     "accesslist",
 			mutate:   func(m *accesslistv1.Member) { m.Spec.AccessList = "" },
-			checkErr: require.Error,
+			checkErr: require.NoError,
 		},
 		{
 			name:     "joined",
 			mutate:   func(m *accesslistv1.Member) { m.Spec.Joined = nil },
-			checkErr: require.Error,
+			checkErr: require.NoError,
 		},
 		{
 			name:     "expires",
@@ -91,7 +91,7 @@ func TestMemberFromProtoNils(t *testing.T) {
 		{
 			name:     "added by",
 			mutate:   func(m *accesslistv1.Member) { m.Spec.AddedBy = "" },
-			checkErr: require.Error,
+			checkErr: require.NoError,
 		},
 	}
 

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -67,7 +67,7 @@ type AccessListMemberSpec struct {
 	MembershipKind string `json:"membership_kind" yaml:"membership_kind"`
 }
 
-// NewAccessListMember will create a new access listm member.
+// NewAccessListMember will create a new AccessListMember.
 func NewAccessListMember(metadata header.Metadata, spec AccessListMemberSpec) (*AccessListMember, error) {
 	member := &AccessListMember{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
@@ -81,35 +81,16 @@ func NewAccessListMember(metadata header.Metadata, spec AccessListMemberSpec) (*
 	return member, nil
 }
 
-// CheckAndSetDefaults validates fields and populates empty fields with default values.
+// CheckAndSetDefaults defaults empty fields and performs metadata validation.
 func (a *AccessListMember) CheckAndSetDefaults() error {
 	a.SetKind(types.KindAccessListMember)
 	a.SetVersion(types.V1)
-
 	if err := a.ResourceHeader.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-
 	if a.Spec.MembershipKind == "" {
 		a.Spec.MembershipKind = MembershipKindUser
 	}
-
-	if a.Spec.AccessList == "" {
-		return trace.BadParameter("access list is missing")
-	}
-
-	if a.Spec.Name == "" {
-		return trace.BadParameter("member name is missing")
-	}
-
-	if a.Spec.Joined.IsZero() || a.Spec.Joined.Unix() == 0 {
-		return trace.BadParameter("member %s: joined field empty or missing", a.Spec.Name)
-	}
-
-	if a.Spec.AddedBy == "" {
-		return trace.BadParameter("member %s: added_by field is empty", a.Spec.Name)
-	}
-
 	return nil
 }
 

--- a/api/types/accesslist/member_test.go
+++ b/api/types/accesslist/member_test.go
@@ -50,19 +50,12 @@ func TestAccessListMemberDefaults(t *testing.T) {
 		}
 	}
 
-	t.Run("join date required for member", func(t *testing.T) {
+	t.Run("membership kind defaults to user", func(t *testing.T) {
 		uut := newValidAccessListMember()
-		uut.Spec.Joined = time.Time{}
+		uut.Spec.MembershipKind = ""
 
 		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
-	})
-
-	t.Run("added-by required", func(t *testing.T) {
-		uut := newValidAccessListMember()
-		uut.Spec.AddedBy = ""
-
-		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
+		require.NoError(t, err)
+		require.Equal(t, MembershipKindUser, uut.Spec.MembershipKind)
 	})
 }

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -26,8 +26,9 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 )
 
-// ValidateAccessListWithMembers validates AccessList with a list of its members. If the
-// existingAccessList is non-nil it also checks if this is a valid update transition.
+// ValidateAccessListWithMembers makes sure the given AccessList and it's members is valid before
+// storing it. If the existingAccessList is non-nil it also checks if this is a valid update
+// transition. It takes into account validation of the nested access lists membership.
 func ValidateAccessListWithMembers(ctx context.Context, existingAccessList, accessList *accesslist.AccessList, members []*accesslist.AccessListMember, g AccessListAndMembersGetter) error {
 	if err := validateAccessListUpdate(existingAccessList, accessList); err != nil {
 		return trace.Wrap(err)
@@ -55,73 +56,83 @@ func validateAccessListUpdate(existingAccessList, accessList *accesslist.AccessL
 // 10) requirement and don't create cycles.
 func validateAccessListNesting(ctx context.Context, accessList *accesslist.AccessList, members []*accesslist.AccessListMember, g AccessListAndMembersGetter) error {
 	for _, owner := range accessList.Spec.Owners {
-		if owner.MembershipKind != accesslist.MembershipKindList {
-			continue
-		}
-		ownerList, err := g.GetAccessList(ctx, owner.Name)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if err := validateAddition(ctx, accessList, ownerList, RelationshipKindOwner, g); err != nil {
+		if err := validateAccessListOwner(ctx, accessList, owner, g); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 	for _, member := range members {
-		if member.Spec.MembershipKind != accesslist.MembershipKindList {
-			continue
-		}
-		memberList, err := g.GetAccessList(ctx, member.GetName())
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if err := validateAddition(ctx, accessList, memberList, RelationshipKindMember, g); err != nil {
+		if err := ValidateAccessListMember(ctx, accessList, member, g); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 	return nil
 }
 
-// ValidateAccessListMember validates a new or existing AccessListMember for an Access List.
+// ValidateAccessListMember validates AccessListMember. That includes nested AccessList members
+// validation.
 func ValidateAccessListMember(
 	ctx context.Context,
 	parentList *accesslist.AccessList,
 	member *accesslist.AccessListMember,
 	g AccessListAndMembersGetter,
 ) error {
-	if member.Spec.MembershipKind != accesslist.MembershipKindList {
-		return nil
+	if err := validateAccessListMemberBasic(member); err != nil {
+		return trace.Wrap(err)
 	}
-	return validateAccessListMemberOrOwner(ctx, parentList, member.GetName(), RelationshipKindMember, g)
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, member.GetName(), RelationshipKindMember, member.Spec.MembershipKind, g); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
-// ValidateAccessListOwner validates a new or existing AccessListOwner for an Access List.
-func ValidateAccessListOwner(
+// validateAccessListMemberBasic performs basic fields validation for AccessListMember.
+func validateAccessListMemberBasic(member *accesslist.AccessListMember) error {
+	if member.Spec.AccessList == "" {
+		return trace.BadParameter("member %s: access_list field empty", member.Metadata.Name)
+	}
+	if member.Spec.Name != member.Metadata.Name {
+		return trace.BadParameter("member metadata name = %q and spec name = %q must be equal", member.Metadata.Name, member.Spec.Name)
+	}
+	if member.Spec.Joined.IsZero() || member.Spec.Joined.Unix() == 0 {
+		return trace.BadParameter("member %s: joined field empty or missing", member.Metadata.Name)
+	}
+	if member.Spec.AddedBy == "" {
+		return trace.BadParameter("member %s: added_by field is empty", member.Metadata.Name)
+	}
+	return nil
+}
+
+// validateAccessListOwner Owner for an AccessList. That includes nested AccessList owners
+// validation.
+func validateAccessListOwner(
 	ctx context.Context,
 	parentList *accesslist.AccessList,
-	owner *accesslist.Owner,
+	owner accesslist.Owner,
 	g AccessListAndMembersGetter,
 ) error {
-	if owner.MembershipKind != accesslist.MembershipKindList {
-		return nil
+	if err := validateAccessListMemberOrOwnerNesting(ctx, parentList, owner.Name, RelationshipKindOwner, owner.MembershipKind, g); err != nil {
+		return trace.Wrap(err)
 	}
-	return validateAccessListMemberOrOwner(ctx, parentList, owner.Name, RelationshipKindOwner, g)
+	return nil
 }
 
-func validateAccessListMemberOrOwner(
+func validateAccessListMemberOrOwnerNesting(
 	ctx context.Context,
 	parentList *accesslist.AccessList,
 	memberOrOwnerName string,
-	kind RelationshipKind,
+	relationshipKind RelationshipKind,
+	membershipKind string,
 	g AccessListAndMembersGetter,
 ) error {
-	// Ensure member or owner list exists
+	if membershipKind != accesslist.MembershipKindList {
+		return nil
+	}
+	// If it is a AccessList member/owner then the referenced AccessList must exist.
 	memberOrOwnerList, err := g.GetAccessList(ctx, memberOrOwnerName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Validate addition
-	if err := validateAddition(ctx, parentList, memberOrOwnerList, kind, g); err != nil {
+	if err := validateAddition(ctx, parentList, memberOrOwnerList, relationshipKind, g); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -560,6 +560,10 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 		return nil
 	}
 
+	// without this check creating the lock may fail with "special characters are not allowed in resource names"
+	if member.Spec.AccessList == "" {
+		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	}
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, action)
 	})
@@ -569,6 +573,10 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 // UpdateAccessListMember conditionally updates an access list member resource.
 func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
 	var updated *accesslist.AccessListMember
+	// without this check creating the lock may fail with "special characters are not allowed in resource names"
+	if member.Spec.AccessList == "" {
+		return nil, trace.BadParameter("access_list_member %s: spec.access_list field empty", member.GetName())
+	}
 	err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 			memberList, err := a.service.GetResource(ctx, member.Spec.AccessList)


### PR DESCRIPTION
Replacement of https://github.com/gravitational/teleport/pull/56218

Changes in this PR:

- removed AccessListMember.Spec.Name defaulting in the client because [it's done in gRPC](https://github.com/gravitational/teleport.e/blob/288ab08bdb541f29f94323b784aa7a6161af822b/lib/accesslist/service.go#L1070) and then validated before storage (done with this change)
- moved almost all AccessListMember validation from client to backend, making it IaC friendly and better suited for making changes which don't break the cache
- unexported validateAccessListOwner (it wasn't used at all so far)
- reused ValidateAccessListMember+validateAccessListOwner in ValidateAccessListWithMembers
