### PR TITLE
Fix Workload API handling of SVID renewal interval

### DIFF
--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -309,8 +309,13 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 	if err != nil {
 		return trace.Wrap(err, "fetching CRL set from cache")
 	}
+	renewalInterval := cmp.Or(
+		s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime,
+	).RenewalInterval
 
 	var svids []*workloadpb.X509SVID
+	renewalTimer := time.NewTimer(renewalInterval)
+	defer renewalTimer.Stop()
 	for {
 		log.InfoContext(ctx, "Starting to issue X509 SVIDs to workload")
 
@@ -320,6 +325,10 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			// Reset our renewal timer to renew these freshly fetched SVIDs
+			// renewal_interval from now.
+			renewalTimer.Reset(renewalInterval)
+
 			// The SPIFFE Workload API (5.2.1):
 			//
 			//   If the client is not entitled to receive any X509-SVIDs, then the
@@ -334,7 +343,6 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 					"workload did not pass attestation for any SVIDs",
 				)
 			}
-
 		}
 
 		resp := &workloadpb.X509SVIDResponse{
@@ -378,7 +386,7 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 			log.DebugContext(ctx, "CRL set has been updated, distributing to client")
 			crlSet = newCRLSet
 			continue
-		case <-time.After(cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).RenewalInterval):
+		case <-renewalTimer.C:
 			log.DebugContext(ctx, "Renewal interval reached, renewing SVIDs")
 			svids = nil
 			continue


### PR DESCRIPTION
When I introduced the CRL functionality, I introduced a bug where the broadcasting of a new CRL would reset the timer for renewing the SVIDs. In cases where the CRL renewal interval was shorter than the SVID renewal interval, this would lead to the SVIDs never being renewed.

I've resolved this bug by using a proper `time.Timer` instead of using `time.After` on each iteration.

changelog: Fix `tbot` SPIFFE Workload API failing to renew SPIFFE SVIDs