### PR TITLE
feat(webapi): Support editing bot traits and max session duration

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1139,7 +1139,10 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Create bot join tokens
 	h.POST("/webapi/sites/:site/machine-id/token", h.WithClusterAuth(h.createBotJoinToken))
 	// PUT Machine ID bot by name
+	// TODO(nicholasmarais1158) DELETE IN v20.0.0 - replaced by PUT /v2/webapi/sites/:site/machine-id/bot/:name
 	h.PUT("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.updateBot))
+	// PUT Machine ID bot by name
+	h.PUT("/v2/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.updateBotV2))
 	// Delete Machine ID bot
 	h.DELETE("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.deleteBot))
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1139,7 +1139,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Create bot join tokens
 	h.POST("/webapi/sites/:site/machine-id/token", h.WithClusterAuth(h.createBotJoinToken))
 	// PUT Machine ID bot by name
-	// TODO(nicholasmarais1158) DELETE IN v20.0.0 - replaced by PUT /v2/webapi/sites/:site/machine-id/bot/:name
+	// TODO(nicholasmarais1158) DELETE IN v20.0.0
+	// Replaced by `PUT /v2/webapi/sites/:site/machine-id/bot/:name` which allows editing more than just roles.
 	h.PUT("/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.updateBot))
 	// PUT Machine ID bot by name
 	h.PUT("/v2/webapi/sites/:site/machine-id/bot/:name", h.WithClusterAuth(h.updateBotV2))

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -265,7 +265,7 @@ type updateBotRequest struct {
 	Roles []string `json:"roles"`
 }
 
-// updateBot updates a bot with provided roles. The only supported change via this endpoint today is roles.
+// updateBotV2 updates a bot with provided roles, traits and max_session_ttl.
 func (h *Handler) updateBotV2(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	var request updateBotRequestV2
 	if err := httplib.ReadResourceJSON(r, &request); err != nil {

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -24,6 +24,7 @@ import (
 	yaml "github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -218,6 +219,7 @@ func (h *Handler) getBot(w http.ResponseWriter, r *http.Request, p httprouter.Pa
 }
 
 // updateBot updates a bot with provided roles. The only supported change via this endpoint today is roles.
+// TODO(nicholasmarais1158) DELETE IN v20.0.0 - replaced by updateBotV2
 func (h *Handler) updateBot(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	var request updateBotRequest
 	if err := httplib.ReadResourceJSON(r, &request); err != nil {
@@ -261,6 +263,90 @@ func (h *Handler) updateBot(w http.ResponseWriter, r *http.Request, p httprouter
 
 type updateBotRequest struct {
 	Roles []string `json:"roles"`
+}
+
+// updateBot updates a bot with provided roles. The only supported change via this endpoint today is roles.
+func (h *Handler) updateBotV2(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	var request updateBotRequestV2
+	if err := httplib.ReadResourceJSON(r, &request); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	botName := p.ByName("name")
+	if botName == "" {
+		return nil, trace.BadParameter("empty name")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	mask, err := fieldmaskpb.New(&machineidv1.Bot{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	spec := machineidv1.BotSpec{}
+
+	if request.Roles != nil {
+		mask.Append(&machineidv1.Bot{}, "spec.roles")
+
+		spec.Roles = request.Roles
+	}
+
+	if request.Traits != nil {
+		mask.Append(&machineidv1.Bot{}, "spec.traits")
+
+		traits := make([]*machineidv1.Trait, len(request.Traits))
+		for i, trait := range request.Traits {
+			traits[i] = &machineidv1.Trait{
+				Name:   trait.Name,
+				Values: trait.Values,
+			}
+		}
+
+		spec.Traits = traits
+	}
+
+	if request.MaxSessionTtl != "" {
+		mask.Append(&machineidv1.Bot{}, "spec.max_session_ttl")
+
+		ttl, err := time.ParseDuration(request.MaxSessionTtl)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		spec.MaxSessionTtl = durationpb.New(ttl)
+	}
+
+	updated, err := clt.BotServiceClient().UpdateBot(r.Context(), &machineidv1.UpdateBotRequest{
+		UpdateMask: mask,
+		Bot: &machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: botName,
+			},
+			Spec: &spec,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "unable to find existing bot")
+	}
+
+	return updated, nil
+}
+
+type updateBotRequestV2 struct {
+	Roles         []string                `json:"roles"`
+	Traits        []updateBotRequestTrait `json:"traits"`
+	MaxSessionTtl string                  `json:"max_session_ttl"`
+}
+
+type updateBotRequestTrait struct {
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
 }
 
 // getBotInstance retrieves a bot instance by id

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -355,6 +356,194 @@ func TestEditBot(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code getting connectors")
 	assert.Equal(t, botName, bot.Metadata.Name)
 	assert.Equal(t, []string{"new-new-role"}, bot.Spec.Roles)
+}
+
+func TestEditBotRoles(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpointV1 := pack.clt.Endpoint(
+		"v1",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+	endpointV2 := pack.clt.Endpoint(
+		"v2",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	// create a bot named `test-bot-edit`
+	botName := "test-bot-edit"
+	_, err := pack.clt.PostJSON(ctx, endpointV1, CreateBotRequest{
+		BotName: botName,
+		Roles:   []string{"test-role"},
+		Traits: []*machineidv1.Trait{
+			{
+				Name:   "test-trait-1",
+				Values: []string{"value-1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	response, err := pack.clt.PutJSON(ctx, fmt.Sprintf("%s/%s", endpointV2, botName), updateBotRequestV2{
+		Roles: []string{"new-new-role"},
+	})
+	require.NoError(t, err)
+
+	var bot machineidv1.Bot
+	require.NoError(t, json.Unmarshal(response.Bytes(), &bot), "invalid response received")
+	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code updating bot")
+	assert.Equal(t, botName, bot.GetMetadata().GetName())
+	assert.Equal(t, []string{"new-new-role"}, bot.GetSpec().GetRoles())
+	assert.Equal(t, []*machineidv1.Trait{
+		{
+			Name:   "test-trait-1",
+			Values: []string{"value-1"},
+		},
+	}, bot.GetSpec().Traits)
+	assert.Equal(t, int64((12*time.Hour)/time.Second), bot.GetSpec().GetMaxSessionTtl().GetSeconds())
+}
+
+func TestEditBotTraits(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpointV1 := pack.clt.Endpoint(
+		"v1",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+	endpointV2 := pack.clt.Endpoint(
+		"v2",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	// create a bot named `test-bot-edit`
+	botName := "test-bot-edit"
+	_, err := pack.clt.PostJSON(ctx, endpointV1, CreateBotRequest{
+		BotName: botName,
+		Roles:   []string{"test-role"},
+		Traits: []*machineidv1.Trait{
+			{
+				Name:   "test-trait-1",
+				Values: []string{"value-1", "value-2"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	response, err := pack.clt.PutJSON(ctx, fmt.Sprintf("%s/%s", endpointV2, botName), updateBotRequestV2{
+		Traits: []updateBotRequestTrait{
+			{
+				Name:   "test-trait-1",
+				Values: []string{"value-1", "value-2", "value-3"},
+			},
+			{
+				Name:   "test-trait-2",
+				Values: []string{"value-1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var bot machineidv1.Bot
+	require.NoError(t, json.Unmarshal(response.Bytes(), &bot), "invalid response received")
+	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code updating bot")
+	assert.Equal(t, botName, bot.GetMetadata().GetName())
+	assert.Equal(t, []string{"test-role"}, bot.GetSpec().GetRoles())
+	assert.Len(t, bot.GetSpec().Traits, 2)
+	for _, trait := range bot.GetSpec().Traits {
+		// Avoid ordering race - traits are stored in a map
+		switch trait.GetName() {
+		case "test-trait-1":
+			assert.Equal(t, []string{"value-1", "value-2", "value-3"}, trait.GetValues())
+		case "test-trait-2":
+			assert.Equal(t, []string{"value-1"}, trait.GetValues())
+		}
+	}
+	assert.Equal(t, int64((12*time.Hour)/time.Second), bot.GetSpec().GetMaxSessionTtl().GetSeconds())
+}
+
+func TestEditBotMaxSessionTtl(t *testing.T) {
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	clusterName := env.server.ClusterName()
+	endpointV1 := pack.clt.Endpoint(
+		"v1",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+	endpointV2 := pack.clt.Endpoint(
+		"v2",
+		"webapi",
+		"sites",
+		clusterName,
+		"machine-id",
+		"bot",
+	)
+
+	// create a bot named `test-bot-edit`
+	botName := "test-bot-edit"
+	_, err := pack.clt.PostJSON(ctx, endpointV1, CreateBotRequest{
+		BotName: botName,
+		Roles:   []string{"test-role"},
+		Traits: []*machineidv1.Trait{
+			{
+				Name:   "test-trait-1",
+				Values: []string{"value-1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	response, err := pack.clt.Get(ctx, fmt.Sprintf("%s/%s", endpointV1, botName), nil)
+	require.NoError(t, err)
+
+	var createdBot machineidv1.Bot
+	require.NoError(t, json.Unmarshal(response.Bytes(), &createdBot), "invalid response received")
+	assert.Equal(t, int64(43200), createdBot.GetSpec().GetMaxSessionTtl().GetSeconds())
+
+	response, err = pack.clt.PutJSON(ctx, fmt.Sprintf("%s/%s", endpointV2, botName), updateBotRequestV2{
+		MaxSessionTtl: "1h2m3s",
+	})
+	require.NoError(t, err)
+
+	var updatedBot machineidv1.Bot
+	require.NoError(t, json.Unmarshal(response.Bytes(), &updatedBot), "invalid response received")
+	assert.Equal(t, http.StatusOK, response.Code(), "unexpected status code updating bot")
+	assert.Equal(t, botName, updatedBot.GetMetadata().GetName())
+	assert.Equal(t, []string{"test-role"}, updatedBot.GetSpec().GetRoles())
+	assert.Equal(t, []*machineidv1.Trait{
+		{
+			Name:   "test-trait-1",
+			Values: []string{"value-1"},
+		},
+	}, updatedBot.GetSpec().Traits)
+	assert.Equal(t, int64((1*time.Hour+2*time.Minute+3*time.Second)/time.Second), updatedBot.GetSpec().GetMaxSessionTtl().GetSeconds())
 }
 
 func TestListBotInstances(t *testing.T) {

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -483,7 +483,7 @@ func TestEditBotTraits(t *testing.T) {
 	assert.Equal(t, int64((12*time.Hour)/time.Second), bot.GetSpec().GetMaxSessionTtl().GetSeconds())
 }
 
-func TestEditBotMaxSessionTtl(t *testing.T) {
+func TestEditBotMaxSessionTTL(t *testing.T) {
 	ctx := context.Background()
 	env := newWebPack(t, 1)
 	proxy := env.proxies[0]

--- a/rfd/0217-bot-details-web.md
+++ b/rfd/0217-bot-details-web.md
@@ -243,16 +243,16 @@ In a scenario where an older version proxy is in place, the endpoint will return
 
 Fetch active instances for a bot by name. Endpoint exists.
 
-##### `PUT /v1/webapi/sites/:site/machine-id/bot/:name`
+##### `PUT /v2/webapi/sites/:site/machine-id/bot/:name`
 
 Update roles, traits and config (`max_session_ttl`).
 
 **Approach**
 
-Existing endpoint with additional capabilities added. Currently only updating roles is supported. Support for updating traits and `max_session_ttl` are already supported by the underlying RPC and will be exposed by this endpoint. Not all items of data are saved to the same resource. As such, it's important to ensure the update happens atomically and rolled back on failure.
+New endpoint supporting updating roles, traits and max session duration. Support for updating traits and `max_session_ttl` are already supported by the underlying RPC and will be exposed by this endpoint. Not all items of data are saved to the same resource. As such, it's important to ensure the update happens atomically and rolled back on failure. The `v1` endpoint will be marked for removal.
 
 **Backwards compatibility**
-In a scenario where an older version proxy is in place, the endpoint will return without an error, but only update roles, silently ignoring any changes to traits and `max_session_ttl`. To mitigate this, the frontend will check the resulting Bot object for the expected changes and show an alert if there is a mismatch.
+In a scenario where an older version proxy is in place, the api will return a 404 (including a `proxyVersion` field), as the new endpoint wont exist. In this case, the frontend will detect the version mismatch and provide the user with an explanation. This is preferable to a partial update, as performing only some of the update (roles only) may introduce a security risk, or simply just be confusing to users.
 
 ##### `DELETE /v1/webapi/sites/:site/machine-id/bot/:name`
 


### PR DESCRIPTION
## Summary

Adds support for updating a bot's traits and max session duration. Introduces a v2 endpoint to manage backwards compatibility.

RFD: [RFD0217 - Bot Details (web)](https://github.com/gravitational/teleport/blob/master/rfd/0217-bot-details-web.md)
Updates: https://github.com/gravitational/teleport/issues/47342

## Changes

- Add `PUT /v2/webapi/sites/:site/machine-id/bot/:name` endpoint
- Mark `v1` endpoint for removal
- Update RFD0217