### PR TITLE
The pagerduty plugin needs privileges for the `access_monitoring_rule` resource.

### DIFF
--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -211,6 +211,8 @@ spec:
         verbs: ['list', 'read']
       - resources: ['access_plugin_data']
         verbs: ['update']
+      - resources: ['access_monitoring_rule']
+        verbs: ['list', 'read']
     review_requests:
       roles: ['demo-role']
       where: 'contains(request.system_annotations["pagerduty_services"], "My Critical Service")'


### PR DESCRIPTION
Another section in the docs got this change. It looks like the example role given on this specific plugin didn't.