### PR TITLE
AccessList.Spec.Type: Rename ImplicitDynamic -> Default ; Remove Dynamic

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -180,12 +180,9 @@ type Spec struct {
 type Type string
 
 const (
-	// ImplicitDynamic type is for backward compatibility. It has the same semantics as
-	// [Dynamic].
-	ImplicitDynamic Type = ""
-	// Dynamic Access Lists are the default type supposed to be managed with the web UI. They
+	// Default Access Lists are the default type supposed to be managed with the web UI. They
 	// require periodic audit reviews.
-	Dynamic Type = "dynamic"
+	Default Type = ""
 	// Static Access Lists are supposed to be managed with the IaC tools like Terraform. Audit
 	// reviews are not supported for them and the ownership is optional.
 	Static Type = "static"
@@ -196,8 +193,8 @@ const (
 
 func NewTypeFromString(s string) (Type, error) {
 	switch s {
-	case string(ImplicitDynamic), string(Dynamic):
-		return Dynamic, nil
+	case string(Default):
+		return Default, nil
 	case string(Static):
 		return Static, nil
 	case string(SCIM):
@@ -210,10 +207,11 @@ func NewTypeFromString(s string) (Type, error) {
 // IsReviewable returns true if the AccessList type supports the audit reviews in the web UI.
 func (t Type) IsReviewable() bool {
 	switch t {
-	case ImplicitDynamic, Dynamic:
+	case Default:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // Owner is an owner of an access list.

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -318,7 +318,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 	}{
 		{
 			name:              "one month, first day",
-			accessListTypes:   []Type{"", Dynamic},
+			accessListTypes:   []Type{"", Default},
 			frequency:         OneMonth,
 			dayOfMonth:        FirstDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -327,7 +327,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 		},
 		{
 			name:              "one month, fifteenth day",
-			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
+			accessListTypes:   []Type{Default},
 			frequency:         OneMonth,
 			dayOfMonth:        FifteenthDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -336,7 +336,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 		},
 		{
 			name:              "one month, last day",
-			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
+			accessListTypes:   []Type{Default},
 			frequency:         OneMonth,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -345,7 +345,7 @@ func TestSelectNextReviewDate(t *testing.T) {
 		},
 		{
 			name:              "six months, last day",
-			accessListTypes:   []Type{ImplicitDynamic, Dynamic},
+			accessListTypes:   []Type{Default},
 			frequency:         SixMonths,
 			dayOfMonth:        LastDayOfMonth,
 			currentReviewDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -112,7 +112,7 @@ func TestRoundtrip(t *testing.T) {
 		{
 			name: "dynamic-type",
 			modificationFn: func(accessList *accesslist.AccessList) {
-				accessList.Spec.Type = accesslist.Dynamic
+				accessList.Spec.Type = accesslist.Default
 			},
 		},
 		{

--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -170,10 +170,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		}
 
 		for _, accessList := range accessLists {
-			switch accessList.Spec.Type {
-			case accesslist.ImplicitDynamic, accesslist.Dynamic:
-				// ok, we want reviews for those
-			default:
+			if !accessList.IsReviewable() {
 				continue
 			}
 			recipients, err := a.getRecipientsRequiringReminders(ctx, accessList)


### PR DESCRIPTION
This change is driven by [this comment](https://github.com/gravitational/teleport/pull/55868/files#r2195964503).

`Dynamic` is safe to remove because we have never converted any type since [the conversion was removed here](https://github.com/gravitational/teleport/pull/56346/files#diff-0c2d9fa09f787d007619a03fe021c319b957500a8d2a71476047b3d8b41faeb2L326-L328) and [promptly backported to v17](https://github.com/gravitational/teleport/pull/56352). The v18 backport is still hanging so I'll fix it before merging and align the other changes.

`teleport.e` doesn't require any changes because we only use `IsReviewable` there. That confirms the `spec.type` field is read-only right now.

Backports:

- [x] included in https://github.com/gravitational/teleport/pull/56640
- [x] https://github.com/gravitational/teleport/pull/56677
