### PR TITLE
MWI: Introduce `bot.Bot` type

### DIFF
--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -1,0 +1,371 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bot
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/trace"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	apitracing "github.com/gravitational/teleport/api/observability/tracing"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/client"
+	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/tbot/internal/carotation"
+	"github.com/gravitational/teleport/lib/tbot/internal/heartbeat"
+	"github.com/gravitational/teleport/lib/tbot/internal/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+)
+
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/bot")
+
+// Bot runs a collection of services/outputs to generate and renew credentials
+// on behalf of non-human actors (i.e. machines and workloads).
+type Bot struct{ cfg Config }
+
+// New creates a Bot with the given configuration. Call Run to run the bot in
+// long-running "daemon" mode, or OneShot to generate outputs once and then exit.
+func New(cfg Config) (*Bot, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Bot{cfg: cfg}, nil
+}
+
+// Run the bot until the given context is canceled.
+func (b *Bot) Run(ctx context.Context) (err error) {
+	ctx, span := tracer.Start(ctx, "Bot/Run")
+	defer func() { apitracing.EndSpan(span, err) }()
+
+	services, closer, err := b.buildServices(ctx)
+	if err != nil {
+		closer()
+		return trace.Wrap(err)
+	}
+	defer closer()
+
+	b.cfg.Logger.InfoContext(ctx, "Initialization complete. Starting services")
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	for _, svc := range services {
+		svc := svc
+		log := b.cfg.Logger.With("service", svc.String())
+
+		group.Go(func() error {
+			log.InfoContext(groupCtx, "Starting service")
+
+			err := svc.Run(groupCtx)
+			if err != nil {
+				log.ErrorContext(ctx, "Service exited with error", "error", err)
+				return trace.Wrap(err, "service(%s)", svc.String())
+			}
+
+			log.InfoContext(groupCtx, "Service exited")
+			return nil
+		})
+	}
+	return group.Wait()
+}
+
+// OneShot runs the bot in "one shot" mode to generate outputs once and then exits.
+func (b *Bot) OneShot(ctx context.Context) (err error) {
+	ctx, span := tracer.Start(ctx, "Bot/OneShot")
+	defer func() { apitracing.EndSpan(span, err) }()
+
+	services, closer, err := b.buildServices(ctx)
+	if err != nil {
+		closer()
+		return trace.Wrap(err)
+	}
+	defer closer()
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	for _, service := range services {
+		log := b.cfg.Logger.With("service", service.String())
+
+		svc, ok := service.(OneShotService)
+		if !ok {
+			log.InfoContext(ctx, "Service does not support oneshot mode, will not run")
+			continue
+		}
+
+		group.Go(func() error {
+			log.DebugContext(groupCtx, "Running service in oneshot mode")
+
+			err := svc.OneShot(groupCtx)
+			if err != nil {
+				log.ErrorContext(ctx, "Service exited with error", "error", err)
+				return trace.Wrap(err, "service(%s)", svc.String())
+			}
+
+			log.InfoContext(groupCtx, "Service finished")
+			return nil
+		})
+	}
+	return group.Wait()
+}
+
+func (b *Bot) buildServices(ctx context.Context) ([]Service, func(), error) {
+	startedAt := time.Now().UTC()
+	services := make([]Service, 0, len(b.cfg.Services))
+
+	var closers []func()
+	closeFn := func() {
+		for _, fn := range closers {
+			fn()
+		}
+	}
+
+	// Build internal services and dependencies.
+	statusRegistry := readyz.NewRegistry()
+	reloadBroadcaster := b.buildReloadBroadcaster(ctx)
+
+	resolver, err := b.buildResolver(ctx)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building resolver")
+	}
+
+	clientBuilder, err := b.buildClientBuilder(resolver)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building client builder")
+	}
+
+	identityService, closeIdentityService, err := b.buildIdentityService(
+		ctx,
+		reloadBroadcaster,
+		clientBuilder,
+		statusRegistry,
+	)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building identity service")
+	}
+	services = append(services, identityService)
+	closers = append(closers, closeIdentityService)
+
+	heartbeatService, err := b.buildHeartbeatService(
+		identityService,
+		startedAt,
+		statusRegistry,
+	)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building heartbeat service")
+	}
+	services = append(services, heartbeatService)
+
+	caRotationService, err := b.buildCARotationService(
+		reloadBroadcaster,
+		identityService,
+		statusRegistry,
+	)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building CA rotation service")
+	}
+	services = append(services, caRotationService)
+
+	proxyPinger, err := b.buildProxyPinger(identityService)
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building proxy pinger")
+	}
+
+	identityGenerator, err := identityService.GetGenerator()
+	if err != nil {
+		return nil, closeFn, trace.Wrap(err, "building identity generator")
+	}
+
+	// Build user services.
+	for idx, buildService := range b.cfg.Services {
+		reloadCh, unsubscribe := reloadBroadcaster.Subscribe()
+		closers = append(closers, unsubscribe)
+
+		service, err := buildService(ServiceDependencies{
+			Client:             identityService.GetClient(),
+			Resolver:           resolver,
+			Logger:             b.cfg.Logger,
+			ClientBuilder:      clientBuilder,
+			IdentityGenerator:  identityGenerator,
+			ProxyPinger:        proxyPinger,
+			BotIdentity:        identityService.GetIdentity,
+			BotIdentityReadyCh: identityService.Ready(),
+			ReloadCh:           reloadCh,
+			StatusRegistry:     statusRegistry,
+		})
+		if err != nil {
+			return nil, closeFn, trace.Wrap(err, "building service [%d]", idx)
+		}
+		services = append(services, service)
+	}
+	return services, closeFn, nil
+}
+
+func (b *Bot) buildReloadBroadcaster(ctx context.Context) *internal.ChannelBroadcaster {
+	broadcaster := internal.NewChannelBroadcaster()
+	if b.cfg.ReloadCh != nil {
+		go func() {
+			for {
+				select {
+				case <-b.cfg.ReloadCh:
+					broadcaster.Broadcast()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+	return broadcaster
+}
+
+func (b *Bot) buildResolver(ctx context.Context) (reversetunnelclient.Resolver, error) {
+	if b.cfg.Connection.StaticProxyAddress {
+		return reversetunnelclient.StaticResolver(
+			b.cfg.Connection.Address,
+
+			// If the user has indicated they want tbot to prefer using the proxy
+			// address they have configured, we use a static resolver set to this
+			// address. We also assume that they have TLS routing/multiplexing
+			// enabled, since otherwise we'd need them to manually configure an
+			// an entry for each kind of address.
+			types.ProxyListenerMode_Multiplex,
+		), nil
+	}
+
+	return reversetunnelclient.CachingResolver(
+		ctx,
+		reversetunnelclient.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: b.cfg.Connection.Address,
+			Insecure:  b.cfg.Connection.Insecure,
+		}),
+		nil, /* clock */
+	)
+}
+
+func (b *Bot) buildClientBuilder(resolver reversetunnelclient.Resolver) (*client.Builder, error) {
+	return client.NewBuilder(client.BuilderConfig{
+		Connection: b.cfg.Connection,
+		Resolver:   resolver,
+		Logger: b.cfg.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "client"),
+		),
+		Metrics: b.cfg.ClientMetrics,
+	})
+}
+
+func (b *Bot) buildIdentityService(
+	ctx context.Context,
+	reloadBroadcaster *internal.ChannelBroadcaster,
+	clientBuilder *client.Builder,
+	statusRegistry *readyz.Registry,
+) (*identity.Service, func(), error) {
+	reloadCh, unsubscribe := reloadBroadcaster.Subscribe()
+
+	identityService, err := identity.NewService(identity.Config{
+		Connection:      b.cfg.Connection,
+		Onboarding:      b.cfg.Onboarding,
+		Destination:     b.cfg.InternalStorage,
+		TTL:             b.cfg.CredentialLifetime.TTL,
+		RenewalInterval: b.cfg.CredentialLifetime.RenewalInterval,
+		FIPS:            b.cfg.FIPS,
+		Logger: b.cfg.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "identity"),
+		),
+		ClientBuilder:  clientBuilder,
+		ReloadCh:       reloadCh,
+		StatusReporter: statusRegistry.AddService("identity"),
+	})
+	if err != nil {
+		unsubscribe()
+		return nil, nil, trace.Wrap(err, "building identity service")
+	}
+
+	close := func() {
+		if err := identityService.Close(); err != nil {
+			b.cfg.Logger.ErrorContext(
+				ctx,
+				"Failed to close bot identity service",
+				"error", err,
+			)
+		}
+		unsubscribe()
+	}
+
+	if err := identityService.Initialize(ctx); err != nil {
+		close()
+		return nil, nil, trace.Wrap(err, "initializing identity service")
+	}
+
+	return identityService, close, nil
+}
+
+func (b *Bot) buildHeartbeatService(
+	identityService *identity.Service,
+	startedAt time.Time,
+	statusRegistry *readyz.Registry,
+) (*heartbeat.Service, error) {
+	return heartbeat.NewService(heartbeat.Config{
+		Interval:           30 * time.Minute,
+		RetryLimit:         5,
+		Client:             machineidv1.NewBotInstanceServiceClient(identityService.GetClient().GetConnection()),
+		BotIdentityReadyCh: identityService.Ready(),
+		StartedAt:          startedAt,
+		JoinMethod:         b.cfg.Onboarding.JoinMethod,
+		Logger: b.cfg.Logger.With(
+			teleport.ComponentKey, teleport.Component(teleport.ComponentTBot, "heartbeat"),
+		),
+		StatusReporter: statusRegistry.AddService("heartbeat"),
+	})
+}
+
+func (b *Bot) buildProxyPinger(identityService *identity.Service) (connection.ProxyPinger, error) {
+	return internal.NewCachingProxyPinger(internal.CachingProxyPingerConfig{
+		Connection: b.cfg.Connection,
+		Client:     identityService.GetClient(),
+		Logger: b.cfg.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "proxy-pinger"),
+		),
+	})
+}
+
+func (b *Bot) buildCARotationService(
+	reloadBroadcaster *internal.ChannelBroadcaster,
+	identityService *identity.Service,
+	statusRegistry *readyz.Registry,
+) (*carotation.Service, error) {
+	return carotation.NewService(carotation.Config{
+		BroadcastFn:        reloadBroadcaster.Broadcast,
+		Client:             identityService.GetClient(),
+		GetBotIdentityFn:   identityService.GetIdentity,
+		BotIdentityReadyCh: identityService.Ready(),
+		Logger: b.cfg.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "ca-rotation"),
+		),
+		StatusReporter: statusRegistry.AddService("ca-rotation"),
+	})
+}

--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -73,11 +73,10 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 	defer cancel()
 
 	services, closer, err := b.buildServices(ctx)
+	defer closer()
 	if err != nil {
-		closer()
 		return trace.Wrap(err)
 	}
-	defer closer()
 
 	b.cfg.Logger.InfoContext(ctx, "Initialization complete. Starting services")
 
@@ -115,11 +114,10 @@ func (b *Bot) OneShot(ctx context.Context) (err error) {
 	defer cancel()
 
 	services, closer, err := b.buildServices(ctx)
+	defer closer()
 	if err != nil {
-		closer()
 		return trace.Wrap(err)
 	}
-	defer closer()
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	for _, service := range services {

--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -61,6 +61,9 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/Run")
 	defer func() { apitracing.EndSpan(span, err) }()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	services, closer, err := b.buildServices(ctx)
 	if err != nil {
 		closer()
@@ -95,6 +98,9 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 func (b *Bot) OneShot(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/OneShot")
 	defer func() { apitracing.EndSpan(span, err) }()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	services, closer, err := b.buildServices(ctx)
 	if err != nil {

--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -23,11 +23,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/webclient"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"

--- a/lib/tbot/bot/config.go
+++ b/lib/tbot/bot/config.go
@@ -1,0 +1,81 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bot
+
+import (
+	"log/slog"
+
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
+	"github.com/gravitational/trace"
+	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+)
+
+// Config contains the core bot's configuration. The tbot binary's configuration
+// file format is handled by the lib/tbot/config package.
+type Config struct {
+	// Connection controls how the bot connects to the cluster.
+	Connection connection.Config
+
+	// Onboarding controls how the bot authenticates and joins the cluster.
+	Onboarding onboarding.Config
+
+	// InternalStorage is the destination to which the bot's internal state and
+	// certificates will be written.
+	InternalStorage destination.Destination
+
+	// CredentialLifetime controls the TTL and renewal interval of the bot's
+	// internal credentials.
+	CredentialLifetime CredentialLifetime
+
+	// FIPS controls whether the bot will run in a mode designed to comply with
+	// Federal Information Processing Standards.
+	FIPS bool
+
+	// Logger to which errors and messages will be written.
+	Logger *slog.Logger
+
+	// ReloadCh can be used to trigger a reload its certificates, etc.
+	ReloadCh <-chan struct{}
+
+	// Services contains constructors that will be called to create the bot's
+	// services.
+	Services []ServiceBuilder
+
+	// ClientMetrics will be used to record the bot's API client metrics.
+	ClientMetrics *prometheus.ClientMetrics
+}
+
+// CheckAndSetDefaults validates the configuration and sets any default values.
+func (c *Config) CheckAndSetDefaults() error {
+	if err := c.Connection.Validate(); err != nil {
+		return trace.Wrap(err, "validating connection")
+	}
+	if c.InternalStorage == nil {
+		c.InternalStorage = destination.NewMemory()
+	}
+	if c.CredentialLifetime.IsEmpty() {
+		c.CredentialLifetime = DefaultCredentialLifetime
+	}
+	if c.Logger == nil {
+		c.Logger = slog.Default()
+	}
+	return nil
+}

--- a/lib/tbot/bot/config.go
+++ b/lib/tbot/bot/config.go
@@ -21,11 +21,12 @@ package bot
 import (
 	"log/slog"
 
+	"github.com/gravitational/trace"
+	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
-	"github.com/gravitational/trace"
-	"github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 )
 
 // Config contains the core bot's configuration. The tbot binary's configuration

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
@@ -93,6 +94,14 @@ type ServiceDependencies struct {
 	// StatusRegistry is the registry the service can register itself with to
 	// report service health.
 	StatusRegistry *readyz.Registry
+}
+
+// LoggerForService returns a logger with the service's name as its component.
+func (deps ServiceDependencies) LoggerForService(svc Service) *slog.Logger {
+	return deps.Logger.With(
+		teleport.ComponentKey,
+		teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+	)
 }
 
 // ServiceBuilder will be called by the bot to create a service.

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -1,0 +1,183 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bot
+
+import (
+	"context"
+	"log/slog"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/client"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"golang.org/x/sync/errgroup"
+)
+
+// Service is a long-running sub-component of tbot.
+type Service interface {
+	// String returns a human-readable name for the service that can be used
+	// in logging. It should identify the type of the service and any top
+	// level configuration that could distinguish it from a same-type service.
+	String() string
+	// Run starts the service and blocks until the service exits. It should
+	// return a nil error if the service exits successfully and an error
+	// if it is unable to proceed. It should exit gracefully if the context
+	// is canceled.
+	Run(ctx context.Context) error
+}
+
+// OneShotService is a [Service] that offers a mode in which it runs a single
+// time and then exits. This aligns with the `--oneshot` mode of tbot.
+type OneShotService interface {
+	Service
+	// OneShot runs the service once and then exits. It should return a nil
+	// error if the service exits successfully and an error if it is unable
+	// to proceed. It should exit gracefully if the context is canceled.
+	OneShot(ctx context.Context) error
+}
+
+// ServiceDependencies will be constructed by the bot and passed to each service
+// constructor.
+type ServiceDependencies struct {
+	// Client that can be used to interact with the auth server.
+	Client *apiclient.Client
+
+	// Resolver that can be used to look up proxy addresses.
+	Resolver reversetunnelclient.Resolver
+
+	// Logger to which errors and messages can be written. It's the service's
+	// responsibility to tag the logger with a component.
+	Logger *slog.Logger
+
+	// ProxyPinger can be used to ping the proxy or auth server to discover
+	// connection information (e.g. whether TLS routing is enabled).
+	ProxyPinger connection.ProxyPinger
+
+	// IdentityGenerator can be used to generate "impersonated" identities.
+	IdentityGenerator *identity.Generator
+
+	// ClientBuilder can be used to build new API clients from impersonated
+	// identities.
+	ClientBuilder *client.Builder
+
+	// BotIdentity is a function that can be called to get the bot's internal
+	// identity.
+	BotIdentity func() *identity.Identity
+
+	// BotIdentityReadyCh is a channel on which the service can receive to block
+	// until the bot's internal identity has been renewed for the first time.
+	BotIdentityReadyCh <-chan struct{}
+
+	// ReloadCh is a channel on which the service can receive notifications that
+	// it's time to reload their certificates (e.g. following a CA rotation).
+	ReloadCh <-chan struct{}
+
+	// StatusRegistry is the registry the service can register itself with to
+	// report service health.
+	StatusRegistry *readyz.Registry
+}
+
+// ServiceBuilder will be called by the bot to create a service.
+type ServiceBuilder func(ServiceDependencies) (Service, error)
+
+// ServicePair combines two related Services.
+type ServicePair struct{ primary, secondary Service }
+
+// NewServicePair combines two related Services, the "primary" and its supporting
+// "secondary" service.
+func NewServicePair(primary, secondary Service) *ServicePair {
+	return &ServicePair{
+		primary:   primary,
+		secondary: secondary,
+	}
+}
+
+// String calls the primary service's String method.
+func (s *ServicePair) String() string {
+	return s.primary.String()
+}
+
+// Run the services in-parallel.
+func (s *ServicePair) Run(ctx context.Context) error {
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return s.primary.Run(groupCtx)
+	})
+	group.Go(func() error {
+		return s.secondary.Run(groupCtx)
+	})
+	return group.Wait()
+}
+
+// OneShotServicePair combines two related OneShotServices.
+type OneShotServicePair struct {
+	*ServicePair
+
+	primary, secondary OneShotService
+}
+
+// NewOneShotServicePair combines two related OneShotServices, the "primary" and
+// its supporting "secondary" service.
+func NewOneShotServicePair(primary, secondary OneShotService) *OneShotServicePair {
+	return &OneShotServicePair{
+		ServicePair: NewServicePair(primary, secondary),
+		primary:     primary,
+		secondary:   secondary,
+	}
+}
+
+// OneShot runs the services' OneShot methods in-parallel.
+func (s *OneShotServicePair) OneShot(ctx context.Context) error {
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return s.primary.OneShot(groupCtx)
+	})
+	group.Go(func() error {
+		return s.secondary.OneShot(groupCtx)
+	})
+	return group.Wait()
+}
+
+// LiteralService create a ServiceBuilder that returns the service as-is.
+func LiteralService(service Service) ServiceBuilder {
+	return func(ServiceDependencies) (Service, error) {
+		return service, nil
+	}
+}
+
+// NewNopService returns a service with the given name that does nothing at all.
+func NewNopService(name string) NopService {
+	return NopService{name: name}
+}
+
+// NopService is a service that does nothing at all.
+type NopService struct{ name string }
+
+func (n NopService) String() string { return n.name }
+
+// Run blocks until the given context is canceled.
+func (NopService) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// OneShot returns nil immediately.
+func (NopService) OneShot(context.Context) error { return nil }

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"log/slog"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -29,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
-	"golang.org/x/sync/errgroup"
 )
 
 // Service is a long-running sub-component of tbot.

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -25,12 +25,14 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -38,6 +40,27 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+func ApplicationTunnelServiceBuilder(botCfg *config.BotConfig, cfg *config.ApplicationTunnelService) bot.ServiceBuilder {
+	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+		svc := &ApplicationTunnelService{
+			getBotIdentity:     deps.BotIdentity,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			proxyPinger:        deps.ProxyPinger,
+			botClient:          deps.Client,
+			botCfg:             botCfg,
+			cfg:                cfg,
+			identityGenerator:  deps.IdentityGenerator,
+			clientBuilder:      deps.ClientBuilder,
+		}
+		svc.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+		)
+		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
+		return svc, nil
+	}
+}
 
 // ApplicationTunnelService is a service that listens on a socket and forwards
 // traffic to an application registered in Teleport Application Access. It is
@@ -101,9 +124,6 @@ func (s *ApplicationTunnelService) Run(ctx context.Context) error {
 	}()
 	s.log.InfoContext(ctx, "Listening for connections.", "address", l.Addr().String())
 
-	if s.statusReporter == nil {
-		s.statusReporter = readyz.NoopReporter()
-	}
 	s.statusReporter.Report(readyz.Healthy)
 
 	select {

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -25,9 +25,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"

--- a/lib/tbot/service_client_credential.go
+++ b/lib/tbot/service_client_credential.go
@@ -23,9 +23,9 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client/identityfile"

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -25,12 +25,14 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -39,6 +41,27 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+func DatabaseTunnelServiceBuilder(botCfg *config.BotConfig, cfg *config.DatabaseTunnelService) bot.ServiceBuilder {
+	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+		svc := &DatabaseTunnelService{
+			botCfg:             botCfg,
+			cfg:                cfg,
+			proxyPinger:        deps.ProxyPinger,
+			botClient:          deps.Client,
+			getBotIdentity:     deps.BotIdentity,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			identityGenerator:  deps.IdentityGenerator,
+			clientBuilder:      deps.ClientBuilder,
+		}
+		svc.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+		)
+		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
+		return svc, nil
+	}
+}
 
 var _ alpnproxy.LocalProxyMiddleware = (*alpnProxyMiddleware)(nil)
 
@@ -227,9 +250,6 @@ func (s *DatabaseTunnelService) Run(ctx context.Context) error {
 	}()
 	s.log.InfoContext(ctx, "Listening for connections.", "address", l.Addr().String())
 
-	if s.statusReporter == nil {
-		s.statusReporter = readyz.NoopReporter()
-	}
 	s.statusReporter.Report(readyz.Healthy)
 
 	select {

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -25,9 +25,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -27,9 +27,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"path/filepath"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -39,6 +40,7 @@ import (
 	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/client"
@@ -51,6 +53,28 @@ import (
 
 const defaultKubeconfigPath = "kubeconfig.yaml"
 
+func KubernetesOutputServiceBuilder(botCfg *config.BotConfig, cfg *config.KubernetesOutput) bot.ServiceBuilder {
+	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+		svc := &KubernetesOutputService{
+			botAuthClient:      deps.Client,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			botCfg:             botCfg,
+			cfg:                cfg,
+			proxyPinger:        deps.ProxyPinger,
+			reloadCh:           deps.ReloadCh,
+			executablePath:     autoupdate.StableExecutable,
+			identityGenerator:  deps.IdentityGenerator,
+			clientBuilder:      deps.ClientBuilder,
+		}
+		svc.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+		)
+		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
+		return svc, nil
+	}
+}
+
 // KubernetesOutputService produces credentials which can be used to connect to
 // a Kubernetes Cluster through teleport.
 type KubernetesOutputService struct {
@@ -61,11 +85,10 @@ type KubernetesOutputService struct {
 	botIdentityReadyCh <-chan struct{}
 	botCfg             *config.BotConfig
 	cfg                *config.KubernetesOutput
-	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
 	proxyPinger        connection.ProxyPinger
-	reloadBroadcaster  *internal.ChannelBroadcaster
 	statusReporter     readyz.Reporter
+	reloadCh           <-chan struct{}
 	// executablePath is called to get the path to the tbot executable.
 	// Usually this is os.Executable
 	executablePath func() (string, error)
@@ -86,9 +109,6 @@ func (s *KubernetesOutputService) OneShot(ctx context.Context) error {
 }
 
 func (s *KubernetesOutputService) Run(ctx context.Context) error {
-	reloadCh, unsubscribe := s.reloadBroadcaster.Subscribe()
-	defer unsubscribe()
-
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
@@ -96,7 +116,7 @@ func (s *KubernetesOutputService) Run(ctx context.Context) error {
 		Interval:        cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).RenewalInterval,
 		RetryLimit:      renewalRetryLimit,
 		Log:             s.log,
-		ReloadCh:        reloadCh,
+		ReloadCh:        s.reloadCh,
 		IdentityReadyCh: s.botIdentityReadyCh,
 		StatusReporter:  s.statusReporter,
 	})

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -28,11 +28,11 @@ import (
 	"net"
 	"path/filepath"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -28,11 +28,11 @@ import (
 	"log/slog"
 	"path/filepath"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -29,10 +29,10 @@ import (
 	"math"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"

--- a/lib/tbot/service_spiffe_workload_api.go
+++ b/lib/tbot/service_spiffe_workload_api.go
@@ -55,6 +55,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -63,6 +64,45 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
 	"github.com/gravitational/teleport/lib/uds"
 )
+
+func SPIFFEWorkloadAPIServiceBuilder(
+	botCfg *config.BotConfig,
+	cfg *config.SPIFFEWorkloadAPIService,
+	trustBundleCache TrustBundleGetter,
+) bot.ServiceBuilder {
+	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+		clientCredential := &config.UnstableClientCredentialOutput{}
+		svcIdentity := &ClientCredentialOutputService{
+			botAuthClient:      deps.Client,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			botCfg:             botCfg,
+			cfg:                clientCredential,
+			reloadCh:           deps.ReloadCh,
+			identityGenerator:  deps.IdentityGenerator,
+		}
+		svcIdentity.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svcIdentity.String()),
+		)
+		svc := &SPIFFEWorkloadAPIService{
+			svcIdentity:      clientCredential,
+			botCfg:           botCfg,
+			cfg:              cfg,
+			trustBundleCache: trustBundleCache,
+			clientBuilder:    deps.ClientBuilder,
+		}
+		svc.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+		)
+		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
+		return bot.NewServicePair(svc, svcIdentity), nil
+	}
+}
+
+type TrustBundleGetter interface {
+	GetBundleSet(ctx context.Context) (*workloadidentity.BundleSet, error)
+}
 
 // SPIFFEWorkloadAPIService implements a gRPC server that fulfills the SPIFFE
 // Workload API specification. It provides X509 SVIDs and trust bundles to
@@ -80,8 +120,8 @@ type SPIFFEWorkloadAPIService struct {
 	botCfg           *config.BotConfig
 	cfg              *config.SPIFFEWorkloadAPIService
 	log              *slog.Logger
-	trustBundleCache *workloadidentity.TrustBundleCache
 	statusReporter   readyz.Reporter
+	trustBundleCache TrustBundleGetter
 	clientBuilder    *client.Builder
 
 	// client holds the impersonated client for the service

--- a/lib/tbot/service_spiffe_workload_api_sds.go
+++ b/lib/tbot/service_spiffe_workload_api_sds.go
@@ -59,10 +59,6 @@ const (
 	envoyAllBundlesName = "ALL"
 )
 
-type bundleSetGetter interface {
-	GetBundleSet(ctx context.Context) (*workloadidentity.BundleSet, error)
-}
-
 type svidFetcher func(ctx context.Context, localBundle *spiffebundle.Bundle) ([]*workloadpb.X509SVID, error)
 
 // spiffeSDSHandler implements an Envoy SDS API.
@@ -72,7 +68,7 @@ type svidFetcher func(ctx context.Context, localBundle *spiffebundle.Bundle) ([]
 type spiffeSDSHandler struct {
 	log              *slog.Logger
 	botCfg           *config.BotConfig
-	trustBundleCache bundleSetGetter
+	trustBundleCache TrustBundleGetter
 
 	clientAuthenticator func(ctx context.Context) (*slog.Logger, svidFetcher, error)
 }

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
@@ -43,15 +45,34 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
+func SSHHostOutputServiceBuilder(botCfg *config.BotConfig, cfg *config.SSHHostOutput) bot.ServiceBuilder {
+	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+		svc := &SSHHostOutputService{
+			botAuthClient:      deps.Client,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			botCfg:             botCfg,
+			cfg:                cfg,
+			reloadCh:           deps.ReloadCh,
+			identityGenerator:  deps.IdentityGenerator,
+			clientBuilder:      deps.ClientBuilder,
+		}
+		svc.log = deps.Logger.With(
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+		)
+		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
+		return svc, nil
+	}
+}
+
 type SSHHostOutputService struct {
 	botAuthClient      *apiclient.Client
 	botIdentityReadyCh <-chan struct{}
 	botCfg             *config.BotConfig
 	cfg                *config.SSHHostOutput
-	getBotIdentity     getBotIdentityFn
 	log                *slog.Logger
-	reloadBroadcaster  *internal.ChannelBroadcaster
 	statusReporter     readyz.Reporter
+	reloadCh           <-chan struct{}
 	identityGenerator  *identity.Generator
 	clientBuilder      *client.Builder
 }
@@ -68,9 +89,6 @@ func (s *SSHHostOutputService) OneShot(ctx context.Context) error {
 }
 
 func (s *SSHHostOutputService) Run(ctx context.Context) error {
-	reloadCh, unsubscribe := s.reloadBroadcaster.Subscribe()
-	defer unsubscribe()
-
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
@@ -78,7 +96,7 @@ func (s *SSHHostOutputService) Run(ctx context.Context) error {
 		Interval:        cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).RenewalInterval,
 		RetryLimit:      renewalRetryLimit,
 		Log:             s.log,
-		ReloadCh:        reloadCh,
+		ReloadCh:        s.reloadCh,
 		IdentityReadyCh: s.botIdentityReadyCh,
 		StatusReporter:  s.statusReporter,
 	})

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -25,10 +25,10 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -37,7 +37,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -45,6 +44,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	proxyclient "github.com/gravitational/teleport/api/client/proxy"
 	"github.com/gravitational/teleport/api/observability/tracing"

--- a/lib/tbot/service_workload_identity_aws_ra.go
+++ b/lib/tbot/service_workload_identity_aws_ra.go
@@ -26,13 +26,13 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	awsspiffe "github.com/spiffe/aws-spiffe-workload-helper"
 	"github.com/spiffe/aws-spiffe-workload-helper/vendoredaws"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"gopkg.in/ini.v1"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/tbot/bot"

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -24,9 +24,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -28,9 +28,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/utils/retryutils"

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -24,11 +24,11 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	apiclient "github.com/gravitational/teleport/api/client"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -29,7 +29,6 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client"
 	apiclient "github.com/gravitational/teleport/api/client"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
@@ -60,7 +59,7 @@ type Bot struct {
 	mu       sync.Mutex
 	started  bool
 	identity getBotIdentityFn
-	client   *client.Client
+	client   *apiclient.Client
 }
 
 func New(cfg *config.BotConfig, log *slog.Logger) *Bot {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -382,7 +382,7 @@ func TestBot(t *testing.T) {
 	t.Run("bot identity", func(t *testing.T) {
 		// Some rough checks to ensure the bot identity used follows our
 		// expected rules for bot identities.
-		botIdent := b.BotIdentity()
+		botIdent := b.getBotIdentity()
 		tlsIdent, err := tlsca.FromSubject(
 			botIdent.X509Cert.Subject, botIdent.X509Cert.NotAfter,
 		)
@@ -703,7 +703,7 @@ func TestBot_IdentityRenewalFails(t *testing.T) {
 	// Wait for the client to be available.
 	var client *client.Client
 	require.Eventually(t, func() bool {
-		client = thirdBot.Client()
+		client = thirdBot.getClient()
 		return client != nil
 	}, 5*time.Second, 100*time.Millisecond, "timeout waiting for client to become available")
 

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1296,7 +1296,7 @@ func TestBotJoiningURI(t *testing.T) {
 
 	// Perform some cursory checks on the identity to make sure a cert bundle
 	// was actually produced.
-	id := bot.BotIdentity()
+	id := bot.getBotIdentity()
 	tlsIdent, err := tlsca.FromSubject(
 		id.X509Cert.Subject, id.X509Cert.NotAfter,
 	)

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -69,16 +69,22 @@ func (b *CRLSet) Stale() <-chan struct{} {
 	return b.stale
 }
 
+// NewCRLCacheFacade creates a new TrustBundleCacheFacade.
 func NewCRLCacheFacade() *CRLCacheFacade {
 	return &CRLCacheFacade{ready: make(chan struct{})}
 }
 
+// CRLCacheFacade wraps a CRLCache to provide lazy initialization using its
+// BuildService method. It allows you to create a cache and pass it to service
+// builders before it has been initialized by running the bot.
 type CRLCacheFacade struct {
 	mu       sync.Mutex
 	ready    chan struct{}
 	crlCache *CRLCache
 }
 
+// BuildService implements bot.ServiceBuilder to build the CRLCache once when the
+// bot starts up.
 func (f *CRLCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -26,9 +26,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
@@ -65,6 +67,52 @@ func (b *CRLSet) Marshal() []byte {
 // and a new CRLSet is available.
 func (b *CRLSet) Stale() <-chan struct{} {
 	return b.stale
+}
+
+func NewCRLCacheFacade() *CRLCacheFacade {
+	return &CRLCacheFacade{ready: make(chan struct{})}
+}
+
+type CRLCacheFacade struct {
+	mu       sync.Mutex
+	ready    chan struct{}
+	crlCache *CRLCache
+}
+
+func (f *CRLCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.crlCache == nil {
+		var err error
+		f.crlCache, err = NewCRLCache(CRLCacheConfig{
+			RevocationsClient: deps.Client.WorkloadIdentityRevocationServiceClient(),
+			Logger: deps.Logger.With(
+				teleport.ComponentKey,
+				teleport.Component(teleport.ComponentTBot, "crl-cache"),
+			),
+			StatusReporter: deps.StatusRegistry.AddService("crl-cache"),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		close(f.ready)
+	}
+
+	return f.crlCache, nil
+}
+
+func (m *CRLCacheFacade) GetCRLSet(ctx context.Context) (*CRLSet, error) {
+	select {
+	case <-m.ready:
+		m.mu.Lock()
+		cache := m.crlCache
+		m.mu.Unlock()
+
+		return cache.GetCRLSet(ctx)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // CRLCache streams CRLs from the revocations service and caches them. It

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/readyz"

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -40,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
@@ -201,6 +203,56 @@ type TrustBundleCacheConfig struct {
 	Logger             *slog.Logger
 	BotIdentityReadyCh <-chan struct{}
 	StatusReporter     readyz.Reporter
+}
+
+type TrustBundleCacheFacade struct {
+	mu          sync.Mutex
+	ready       chan struct{}
+	bundleCache *TrustBundleCache
+}
+
+func NewTrustBundleCacheFacade() *TrustBundleCacheFacade {
+	return &TrustBundleCacheFacade{ready: make(chan struct{})}
+}
+
+func (f *TrustBundleCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.bundleCache == nil {
+		var err error
+		f.bundleCache, err = NewTrustBundleCache(TrustBundleCacheConfig{
+			FederationClient:   deps.Client.SPIFFEFederationServiceClient(),
+			TrustClient:        deps.Client.TrustClient(),
+			EventsClient:       deps.Client,
+			ClusterName:        deps.BotIdentity().ClusterName,
+			BotIdentityReadyCh: deps.BotIdentityReadyCh,
+			Logger: deps.Logger.With(
+				teleport.ComponentKey,
+				teleport.Component(teleport.ComponentTBot, "spiffe-trust-bundle-cache"),
+			),
+			StatusReporter: deps.StatusRegistry.AddService("spiffe-trust-bundle-cache"),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		close(f.ready)
+	}
+
+	return f.bundleCache, nil
+}
+
+func (f *TrustBundleCacheFacade) GetBundleSet(ctx context.Context) (*BundleSet, error) {
+	select {
+	case <-f.ready:
+		f.mu.Lock()
+		cache := f.bundleCache
+		f.mu.Unlock()
+
+		return cache.GetBundleSet(ctx)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // NewTrustBundleCache creates a new TrustBundleCache.

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -205,16 +205,22 @@ type TrustBundleCacheConfig struct {
 	StatusReporter     readyz.Reporter
 }
 
+// TrustBundleCacheFacade wraps a TrustBundleCache to provide lazy initialization
+// using its BuildService method. It allows you to create a cache and pass it to
+// service builders before it has been initialized by running the bot.
 type TrustBundleCacheFacade struct {
 	mu          sync.Mutex
 	ready       chan struct{}
 	bundleCache *TrustBundleCache
 }
 
+// NewTrustBundleCacheFacade creates a new TrustBundleCacheFacade.
 func NewTrustBundleCacheFacade() *TrustBundleCacheFacade {
 	return &TrustBundleCacheFacade{ready: make(chan struct{})}
 }
 
+// BuildService implements bot.ServiceBuilder to build the TrustBundleCache once
+// when the bot starts up.
 func (f *TrustBundleCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -35,6 +34,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"go.opentelemetry.io/otel"
 
+	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	trustv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"


### PR DESCRIPTION
## Background

This is part of a series of pull requests to refactor the `lib/tbot` package for better modularity.

Today, all of `tbot`'s services live in the same package which makes it difficult to see the system boundaries, but also means that it's impossible for other binaries that "embed" tbot (e.g. `tctl`, the Kubernetes operator) to pull in just the parts they need - and for the compiler to effectively eliminate unused dependencies.

See the [boxofrad/wip-tbot-refactoring branch](https://github.com/gravitational/teleport/tree/boxofrad/wip-tbot-refactoring) for an idea of the end-state of this stack. In this branch, the `tctl` binary is roughly **13% smaller** largely due to eliminating the unused Sigstore modules.

## Changes

This pull request moves the core orchestration logic into the `bot.Bot` type, making the outer `tbot.Bot` type just responsible for wiring user services up.

It establishes the `ServiceBuilder` pattern as a way for services to construct themselves from the dependencies the bot provides.
