### PR TITLE
OktaService: Add more details to "has passed since last transition" error

### DIFF
--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -172,7 +172,7 @@ func (o *OktaService) UpdateOktaAssignmentStatus(ctx context.Context, name, stat
 		// Only update the status if the given duration has passed.
 		sinceLastTransition := o.clock.Since(currentAssignment.GetLastTransition())
 		if sinceLastTransition < timeHasPassed {
-			return trace.BadParameter("only %s has passed since last transition", sinceLastTransition)
+			return trace.BadParameter("only %s has passed since last transition (want at least %s)", sinceLastTransition, timeHasPassed)
 		}
 
 		if err := currentAssignment.SetStatus(status); err != nil {

--- a/lib/services/local/okta_test.go
+++ b/lib/services/local/okta_test.go
@@ -403,7 +403,8 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 
 	// Fail to update the status because not enough time has passed.
 	err = service.UpdateOktaAssignmentStatus(ctx, assignment1.GetName(), constants.OktaAssignmentStatusPending, time.Hour)
-	require.ErrorIs(t, err, trace.BadParameter("only 0s has passed since last transition"))
+	require.ErrorContains(t, err, "only 0s has passed since last transition")
+	require.True(t, trace.IsBadParameter(err))
 
 	// Successfully update the status for an assignment.
 	require.NoError(t, assignment1.SetStatus(constants.OktaAssignmentStatusSuccessful))


### PR DESCRIPTION
This is some transient error we have a hard time to understand why it happens. This change adds how much time is expected to pass to give some more context.