### PR TITLE
[v18] Fix Workload API handling of SVID renewal interval

### DIFF
--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -300,8 +300,13 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 	if err != nil {
 		return trace.Wrap(err, "fetching CRL set from cache")
 	}
+	renewalInterval := cmp.Or(
+		s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime,
+	).RenewalInterval
 
 	var svids []*workloadpb.X509SVID
+	renewalTimer := time.NewTimer(renewalInterval)
+	defer renewalTimer.Stop()
 	for {
 		log.InfoContext(ctx, "Starting to issue X509 SVIDs to workload")
 
@@ -311,6 +316,10 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			// Reset our renewal timer to renew these freshly fetched SVIDs
+			// renewal_interval from now.
+			renewalTimer.Reset(renewalInterval)
+
 			// The SPIFFE Workload API (5.2.1):
 			//
 			//   If the client is not entitled to receive any X509-SVIDs, then the
@@ -325,7 +334,6 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 					"workload did not pass attestation for any SVIDs",
 				)
 			}
-
 		}
 
 		resp := &workloadpb.X509SVIDResponse{
@@ -369,7 +377,7 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 			log.DebugContext(ctx, "CRL set has been updated, distributing to client")
 			crlSet = newCRLSet
 			continue
-		case <-time.After(cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).RenewalInterval):
+		case <-renewalTimer.C:
 			log.DebugContext(ctx, "Renewal interval reached, renewing SVIDs")
 			svids = nil
 			continue


### PR DESCRIPTION
Backport #56626 to branch/v18

changelog: Fix `tbot` SPIFFE Workload API failing to renew SPIFFE SVIDs
