### PR TITLE
[v16] Add a make target for running all docs generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1813,3 +1813,9 @@ create-github-release:
 	--latest=$(LATEST) \
 	--verify-tag \
 	-F - <<< "$$NOTES"
+
+.PHONY: gen-docs
+gen-docs:
+	$(MAKE) -C integrations/terraform docs
+	$(MAKE) -C integrations/operator crd-docs
+	$(MAKE) -C examples/chart render-chart-ref


### PR DESCRIPTION
Backports #56189

Closes #52982

Add a target to the root Makefile, `gen-docs`, to run all docs generators. This provides a convenience for developers to sync auto-generated docs with any code changes without worrying about memorizing commands for specific generators.

Note that, for each of the current generators, there is already a make target for checking whether the generator has been run, and there is a GitHub Actions job to execute each target. Since checker executions are split across different GHA jobs, it doesn't make sense to consolidate them into a single checker target to run in CI.