### PR TITLE
[v17] chore: Bump Go to 1.23.11

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.4
+FROM docker.io/golang:1.24.5
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.10
+go 1.23.11
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.10
+GOLANG_VERSION ?= go1.23.11
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.10
+go 1.23.11
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.12.1

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.10
+go 1.23.11
 
 require (
 	github.com/alecthomas/kong v1.2.1

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.10
+go 1.23.11
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced


### PR DESCRIPTION
The update addresses CVE-2025-4674.

Changelog: Updated Go to 1.23.11.