### PR TITLE
Connect: Stop execution of main process on child process spawn error

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -102,7 +102,7 @@ async function initializeApp(): Promise<void> {
   } catch (error) {
     const message = 'Could not initialize the main process';
     logger.error(message, error);
-    dialog.showErrorBox(message, ensureError(error).message);
+    showDialogWithError(message, error);
     // app.exit(1) isn't equivalent to throwing an error, use an explicit return to stop further
     // execution. See https://github.com/gravitational/teleport/issues/56272.
     app.exit(1);
@@ -177,7 +177,7 @@ async function initializeApp(): Promise<void> {
   })().catch(error => {
     const message = 'Could not initialize the tshd client in the main process';
     logger.error(message, error);
-    dialog.showErrorBox(message, ensureError(error).message);
+    showDialogWithError(message, error);
     app.exit(1);
   });
 
@@ -199,7 +199,7 @@ async function initializeApp(): Promise<void> {
     .catch(error => {
       const message = 'Could not create the main app window';
       logger.error(message, error);
-      dialog.showErrorBox(message, ensureError(error).message);
+      showDialogWithError(message, error);
       app.exit(1);
     });
 
@@ -422,4 +422,11 @@ function launchDeepLink(
   // Always pass the result to the frontend app so that the error can be shown to the user.
   // Otherwise the app would receive focus but nothing would be visible in the UI.
   windowsManager.launchDeepLink(result);
+}
+
+function showDialogWithError(title: string, unknownError: unknown) {
+  const error = ensureError(unknownError);
+  // V8 includes the error message in the stack, so there's no need to append stack to message.
+  const content = error.stack || error.message;
+  dialog.showErrorBox(title, content);
 }

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -84,8 +84,9 @@ async function initializeApp(): Promise<void> {
   const windowsManager = new WindowsManager(appStateFileStorage, settings);
 
   process.on('uncaughtException', (error, origin) => {
-    logger.error(origin, error);
-    app.quit();
+    logger.error('Uncaught exception', origin, error);
+    showDialogWithError(`Uncaught exception (${origin} origin)`, error);
+    app.exit(1);
   });
 
   let mainProcess: MainProcess;
@@ -174,14 +175,10 @@ async function initializeApp(): Promise<void> {
       allowList: rootClusterProxyHostAllowList,
     });
   })().catch(error => {
-    const message =
-      'Could not initialize tsh daemon client in the main process';
+    const message = 'Could not initialize the tshd client in the main process';
     logger.error(message, error);
-    dialog.showErrorBox(
-      'Error during main process startup',
-      `${message}: ${error}`
-    );
-    app.quit();
+    dialog.showErrorBox(message, ensureError(error).message);
+    app.exit(1);
   });
 
   app
@@ -200,13 +197,10 @@ async function initializeApp(): Promise<void> {
       windowsManager.createWindow();
     })
     .catch(error => {
-      const message = 'Could not initialize the app';
+      const message = 'Could not create the main app window';
       logger.error(message, error);
-      dialog.showErrorBox(
-        'Error during app initialization',
-        `${message}: ${error}`
-      );
-      app.quit();
+      dialog.showErrorBox(message, ensureError(error).message);
+      app.exit(1);
     });
 
   // Limit navigation capabilities to reduce the attack surface.

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import { app, dialog, globalShortcut, nativeTheme, shell } from 'electron';
 
 import { CUSTOM_PROTOCOL } from 'shared/deepLinks';
+import { ensureError } from 'shared/utils/error';
 
 import { parseDeepLink } from 'teleterm/deepLinks';
 import Logger from 'teleterm/logger';
@@ -87,15 +88,25 @@ async function initializeApp(): Promise<void> {
     app.quit();
   });
 
-  // init main process
-  const mainProcess = MainProcess.create({
-    settings,
-    logger,
-    configService,
-    appStateFileStorage,
-    configFileStorage,
-    windowsManager,
-  });
+  let mainProcess: MainProcess;
+  try {
+    mainProcess = MainProcess.create({
+      settings,
+      logger,
+      configService,
+      appStateFileStorage,
+      configFileStorage,
+      windowsManager,
+    });
+  } catch (error) {
+    const message = 'Could not initialize the main process';
+    logger.error(message, error);
+    dialog.showErrorBox(message, ensureError(error).message);
+    // app.exit(1) isn't equivalent to throwing an error, use an explicit return to stop further
+    // execution. See https://github.com/gravitational/teleport/issues/56272.
+    app.exit(1);
+    return;
+  }
 
   //TODO(gzdunek): Make sure this is not needed after migrating to Vite.
   app.on(

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -137,6 +137,13 @@ export default class MainProcess {
     );
   }
 
+  /**
+   * create starts necessary child processes such as tsh daemon and the shared process. It also sets
+   * up IPC handlers and resolves the network addresses under which the child processes set up gRPC
+   * servers.
+   *
+   * create might throw an error if spawning a child process fails, see initTshd for more details.
+   */
   static create(opts: Options) {
     const instance = new MainProcess(opts);
     instance.init();
@@ -162,15 +169,10 @@ export default class MainProcess {
   private init() {
     this.updateAboutPanelIfNeeded();
     this.setAppMenu();
-    try {
-      this.initTshd();
-      this.initSharedProcess();
-      this.initResolvingChildProcessAddresses();
-      this.initIpc();
-    } catch (err) {
-      this.logger.error('Failed to start main process: ', err.message);
-      app.exit(1);
-    }
+    this.initTshd();
+    this.initSharedProcess();
+    this.initResolvingChildProcessAddresses();
+    this.initIpc();
   }
 
   async getTshdClient(): Promise<TshdClient> {
@@ -191,6 +193,15 @@ export default class MainProcess {
     const { binaryPath, homeDir } = this.settings.tshd;
     this.logger.info(`Starting tsh daemon from ${binaryPath}`);
 
+    // spawn might either fail immediately by throwing an error or cause the error event to be emitted
+    // on the process value returned by spawn.
+    //
+    // Some spawn failures result in an error being thrown immediately such as EPERM on Windows [1].
+    // This might be related to the fact that in Node.js, an error event causes an error to be
+    // thrown if there are no listeners for the error event itself [2].
+    //
+    // [1] https://stackoverflow.com/a/42262771
+    // [2] https://nodejs.org/docs/latest-v22.x/api/errors.html#error-propagation-and-interception
     this.tshdProcess = spawn(
       binaryPath,
       ['daemon', 'start', ...this.getTshdFlags()],


### PR DESCRIPTION
Closes #56272

This PR makes it so that when tshd or the shared process fails to spawn, we show a dialog box with a relevant error message rather than with "Cannot read properties of undefined (reading 'then')", as shown in #56272. It makes it so that when a user sends a screenshot of the dialog, we can identify the process which caused the problem instead of having to ask the user for logs.

I posted an RCA under the issue (https://github.com/gravitational/teleport/issues/56272#issuecomment-3101904652) if you'd like to learn more about the problem. In short, we thought that Electron's `app.exit(1)` immediately stops the execution of a program, but that is not the case. On top of that, macOS and Windows behave differently when attempting to spawn a child process (this is described below in the Screenshots section), so the original issue could be reproduced only on Windows.

## Screenshots

The screenshots both show the error that is shown after trying to start the dev version of the app with `README.md` as the tsh binary.

```
E_DO_NOT_USE=1 CONNECT_TSH_BIN_PATH=$PWD/README.md pnpm start-term
```

(`E_DO_NOT_USE` is just so that I don't execute this by mistake when going through my shell history)

On Windows, `child_process.spawn` throws a sync error. The error message doesn't indicate which process failed to spawn, but the stacktrace does include this information (`MainProcess.initTshd`).

<img width="556" height="266" alt="windows-spawn-error" src="https://github.com/user-attachments/assets/7f408a4e-70ca-49dd-88e8-fbd2eeae22be" />

On macOS, the error isn't thrown immediately on spawn, rather it's emitted with the error event on a process. Thus the title of the dialog is different as the error is surfaced later in the initialization process. On macOS, the error dialog content is unfortunately centered, so the stacktrace looks a bit weird. We're forced to use it though, as according to [the docs of `dialog.showErrorBox`](https://www.electronjs.org/docs/latest/api/dialog#dialogshowerrorboxtitle-content):

> This API can be called safely before the ready event the app module emits, it is usually used to report errors in early stage of startup.

<img width="260" height="332" alt="macos-spawn-error" src="https://github.com/user-attachments/assets/843ff5ca-e2ef-4e36-88bd-fa96db04b032" />