### PR TITLE
Temp create UpsertAccessListWithMembersV2 to intro signature change

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -358,6 +358,13 @@ func (c *Client) UpsertAccessListWithMembers(ctx context.Context, list *accessli
 	return accessList, updatedMembers, nil
 }
 
+// UpsertAccessListWithMembersV2 creates or updates an access list resource and its members.
+// Replica of UpsertAccessListWithMembers.
+// TODO(kimlisa): delete once UpsertAccessListWithMembers signature gets updated and is consumed by enterprise.
+func (c *Client) UpsertAccessListWithMembersV2(ctx context.Context, req accesslist.UpsertAccessListWithMembersRequest) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+	return c.UpsertAccessListWithMembers(ctx, req.AccessList, req.Members)
+}
+
 // AccessRequestPromote promotes an access request to an access list.
 func (c *Client) AccessRequestPromote(ctx context.Context, req *accesslistv1.AccessRequestPromoteRequest) (*accesslistv1.AccessRequestPromoteResponse, error) {
 	resp, err := c.grpcClient.AccessRequestPromote(ctx, req)

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -580,3 +580,10 @@ func (a *AccessList) setInitialAuditDate(clock clockwork.Clock) (err error) {
 	a.Spec.Audit.NextAuditDate, err = a.SelectNextReviewDate()
 	return trace.Wrap(err)
 }
+
+// UpsertAccessListWithMembersRequest describes request fields
+// for upserting an access list.
+type UpsertAccessListWithMembersRequest struct {
+	AccessList *AccessList
+	Members    []*AccessListMember
+}

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -150,14 +150,16 @@ func TestAccessListReviews(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 
-	al, _, err := p.accessLists.UpsertAccessListWithMembers(context.Background(), newAccessList(t, "access-list", clock),
-		[]*accesslist.AccessListMember{
+	al, _, err := p.accessLists.UpsertAccessListWithMembersV2(context.Background(), accesslist.UpsertAccessListWithMembersRequest{
+		AccessList: newAccessList(t, "access-list", clock),
+		Members: []*accesslist.AccessListMember{
 			newAccessListMember(t, "access-list", "member1"),
 			newAccessListMember(t, "access-list", "member2"),
 			newAccessListMember(t, "access-list", "member3"),
 			newAccessListMember(t, "access-list", "member4"),
 			newAccessListMember(t, "access-list", "member5"),
-		})
+		},
+	})
 	require.NoError(t, err)
 
 	// Keep track of the reviews, as create can update them. We'll use this
@@ -194,18 +196,22 @@ func TestAccessListReviews(t *testing.T) {
 		deleteAll: p.accessLists.DeleteAllAccessListReviews,
 	}, withSkipPaginationTest()) // access list reviews resources have customer pagination test.
 
-	_, _, err = p.accessLists.UpsertAccessListWithMembers(t.Context(), newAccessList(t, "fake-al-1", clock),
-		[]*accesslist.AccessListMember{
+	_, _, err = p.accessLists.UpsertAccessListWithMembersV2(t.Context(), accesslist.UpsertAccessListWithMembersRequest{
+		AccessList: newAccessList(t, "fake-al-1", clock),
+		Members: []*accesslist.AccessListMember{
 			newAccessListMember(t, "fake-al-1", "member1"),
 			newAccessListMember(t, "fake-al-1", "member2"),
-		})
+		},
+	})
 	require.NoError(t, err)
 
-	_, _, err = p.accessLists.UpsertAccessListWithMembers(t.Context(), newAccessList(t, "fake-al-2", clock),
-		[]*accesslist.AccessListMember{
+	_, _, err = p.accessLists.UpsertAccessListWithMembersV2(t.Context(), accesslist.UpsertAccessListWithMembersRequest{
+		AccessList: newAccessList(t, "fake-al-2", clock),
+		Members: []*accesslist.AccessListMember{
 			newAccessListMember(t, "fake-al-2", "member1"),
 			newAccessListMember(t, "fake-al-2", "member2"),
-		})
+		},
+	})
 	require.NoError(t, err)
 
 	review1 := newAccessListReview(t, "fake-al-1", "initial-review-1")
@@ -239,11 +245,13 @@ func TestAccessListReviews(t *testing.T) {
 		)
 	}, 15*time.Second, 100*time.Millisecond)
 
-	_, _, err = p.accessLists.UpsertAccessListWithMembers(t.Context(), newAccessList(t, "access-list-test", clock),
-		[]*accesslist.AccessListMember{
+	_, _, err = p.accessLists.UpsertAccessListWithMembersV2(t.Context(), accesslist.UpsertAccessListWithMembersRequest{
+		AccessList: newAccessList(t, "access-list-test", clock),
+		Members: []*accesslist.AccessListMember{
 			newAccessListMember(t, "access-list-test", "member1"),
 			newAccessListMember(t, "access-list-test", "member2"),
-		})
+		},
+	})
 	require.NoError(t, err)
 
 	for i := range 10 {

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -70,6 +70,9 @@ type AccessLists interface {
 
 	// UpsertAccessListWithMembers creates or updates an access list resource and its members.
 	UpsertAccessListWithMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
+	// UpsertAccessListWithMembers creates or updates an access list resource and its members.
+	// TODO(kimlisa): delete once UpsertAccessListWithMembers signature gets updated and is consumed by enterprise.
+	UpsertAccessListWithMembersV2(context.Context, accesslist.UpsertAccessListWithMembersRequest) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
 
 	// AccessRequestPromote promotes an access request to an access list.
 	AccessRequestPromote(ctx context.Context, req *accesslistv1.AccessRequestPromoteRequest) (*accesslistv1.AccessRequestPromoteResponse, error)

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -826,6 +826,13 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 	return accessList, membersIn, nil
 }
 
+// UpsertAccessListWithMembersV2 creates or updates an access list resource and its members.
+// Replica of UpsertAccessListWithMembers.
+// TODO(kimlisa): delete once UpsertAccessListWithMembers signature gets updated and is consumed by enterprise.
+func (a *AccessListService) UpsertAccessListWithMembersV2(ctx context.Context, req accesslist.UpsertAccessListWithMembersRequest) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+	return a.UpsertAccessListWithMembers(ctx, req.AccessList, req.Members)
+}
+
 func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslistv1.AccessRequestPromoteRequest) (*accesslistv1.AccessRequestPromoteResponse, error) {
 	return nil, trace.NotImplemented("AccessRequestPromote should not be called")
 }

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -506,7 +506,9 @@ func TestAccessList_EntitlementLimits(t *testing.T) {
 		{
 			name: "UpsertWithMembers",
 			invoke: func(ctx context.Context, uut *AccessListService, acl *accesslist.AccessList) (*accesslist.AccessList, error) {
-				updatedACL, _, err := uut.UpsertAccessListWithMembers(ctx, acl, []*accesslist.AccessListMember{})
+				updatedACL, _, err := uut.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+					AccessList: acl,
+				})
 				return updatedACL, err
 			},
 		},
@@ -655,7 +657,10 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 
 	t.Run("create access list", func(t *testing.T) {
 		// Create both access lists.
-		accessList, _, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{})
+		accessList, _, err := service.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+			AccessList: accessList1,
+			Members:    []*accesslist.AccessListMember{},
+		})
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(accessList1, accessList, cmpOpts...))
 	})
@@ -664,7 +669,10 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 
 	t.Run("add member to the access list", func(t *testing.T) {
 		// Add access list members.
-		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{accessList1Member1})
+		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+			AccessList: accessList1,
+			Members:    []*accesslist.AccessListMember{accessList1Member1},
+		})
 		require.NoError(t, err)
 		// Assert that access list is returned.
 		require.Empty(t, cmp.Diff(updatedAccessList, updatedAccessList, cmpOpts...))
@@ -681,7 +689,10 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 
 	t.Run("add another member to the access list", func(t *testing.T) {
 		// Add access list members.
-		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{accessList1Member1, accessList1Member2})
+		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+			AccessList: accessList1,
+			Members:    []*accesslist.AccessListMember{accessList1Member1, accessList1Member2},
+		})
 		require.NoError(t, err)
 		// Assert that access list is returned.
 		require.Empty(t, cmp.Diff(updatedAccessList, updatedAccessList, cmpOpts...))
@@ -699,7 +710,10 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 	})
 
 	t.Run("empty members removes all members", func(t *testing.T) {
-		_, _, err = service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{})
+		_, _, err = service.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+			AccessList: accessList1,
+			Members:    []*accesslist.AccessListMember{},
+		})
 		require.NoError(t, err)
 
 		members, _, err := service.ListAccessListMembers(ctx, accessList1.GetName(), 0 /* default size*/, "")
@@ -1039,7 +1053,10 @@ func TestUpsertAndUpdateAccessListWithMembers_PreservesIdentityCenterLablesForEx
 		))
 
 	dupeMemberButWithoutOriginLabel := newAccessListMember(t, accessList1.GetName(), "aws-ic-user")
-	_, updatedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{dupeMemberButWithoutOriginLabel})
+	_, updatedMembers, err := service.UpsertAccessListWithMembersV2(ctx, accesslist.UpsertAccessListWithMembersRequest{
+		AccessList: accessList1,
+		Members:    []*accesslist.AccessListMember{dupeMemberButWithoutOriginLabel},
+	})
 	require.NoError(t, err)
 	require.Equal(t, "bar", updatedMembers[0].GetMetadata().Labels["foo"])
 


### PR DESCRIPTION
To prevent build breakage, UpsertAccessListWithMembersV2 will be used to temporary replace it's original func then removed once original's func signature is updated.

No behavioral changes, other than updating `UpsertAccessListWithMembers` usage with V2 version, where all the access list specific related fields gets wrapped into a struct.

This is to aid in future work where another request field can be sent related to templated access lists. It will be like a configuration field where client provides resource access specs.

Pinpointing where the signature  needs to be updated:

[signature change 1](https://github.com/gravitational/teleport/blob/8fa500079196541ad1f9ca1c17528e43c9c4e481/lib/services/access_list.go#L71)
[signature change 2](https://github.com/gravitational/teleport/blob/8fa500079196541ad1f9ca1c17528e43c9c4e481/lib/services/local/access_list.go#L669)