### PR TITLE
[v17] Fix collection unwrapping of RFD153 resources

### DIFF
--- a/lib/cache/collection.go
+++ b/lib/cache/collection.go
@@ -72,6 +72,12 @@ func (c *collection[T, _]) onDelete(r types.Resource) error {
 		}
 
 		return trace.Wrap(c.store.delete(tt))
+	case interface{ Unwrap() types.Resource153 }:
+		tt, ok := t.Unwrap().(T)
+		if !ok {
+			return trace.BadParameter("unexpected type %T (expected %v)", r, reflect.TypeFor[T]())
+		}
+		return trace.Wrap(c.store.delete(tt))
 	case *types.ResourceHeader:
 		if c.headerTransform == nil {
 			return trace.BadParameter("unable to convert types.ResourceHeader to %v (no transform specified, this is a bug)", reflect.TypeFor[T]())
@@ -106,6 +112,13 @@ func (c *collection[T, _]) onPut(r types.Resource) error {
 			return nil
 		}
 
+		c.store.put(tt)
+		return nil
+	case interface{ Unwrap() types.Resource153 }:
+		tt, ok := t.Unwrap().(T)
+		if !ok {
+			return trace.BadParameter("unexpected type %T (expected %v)", r, reflect.TypeFor[T]())
+		}
 		c.store.put(tt)
 		return nil
 	case T:

--- a/lib/cache/collection.go
+++ b/lib/cache/collection.go
@@ -73,9 +73,10 @@ func (c *collection[T, _]) onDelete(r types.Resource) error {
 
 		return trace.Wrap(c.store.delete(tt))
 	case interface{ Unwrap() types.Resource153 }:
-		tt, ok := t.Unwrap().(T)
+		unwrapped := t.Unwrap()
+		tt, ok := unwrapped.(T)
 		if !ok {
-			return trace.BadParameter("unexpected type %T (expected %v)", r, reflect.TypeFor[T]())
+			return trace.BadParameter("unexpected type when calling Unwrap: %T (expected %v)", unwrapped, reflect.TypeFor[T]())
 		}
 		return trace.Wrap(c.store.delete(tt))
 	case *types.ResourceHeader:
@@ -115,9 +116,10 @@ func (c *collection[T, _]) onPut(r types.Resource) error {
 		c.store.put(tt)
 		return nil
 	case interface{ Unwrap() types.Resource153 }:
-		tt, ok := t.Unwrap().(T)
+		unwrapped := t.Unwrap()
+		tt, ok := unwrapped.(T)
 		if !ok {
-			return trace.BadParameter("unexpected type %T (expected %v)", r, reflect.TypeFor[T]())
+			return trace.BadParameter("unexpected type when calling Unwrap: %T (expected %v)", unwrapped, reflect.TypeFor[T]())
 		}
 		c.store.put(tt)
 		return nil


### PR DESCRIPTION
The new cache `collection` mechanism relies on the `UnwrapT` method to support RFD153 resources. The `UnwrapT` mechanism (https://github.com/gravitational/teleport/pull/53567) was included in v18/master, but not v17. The new cache collection mechanism was backported to v17.

This means in the current state, the v17 cache will crash out and re-init when attempting to handle a RFD153 resource with the new collection:

```
{"caller":"cache/cache.go:1382","component":"cache","level":"warning","message":"Re-init the cache on error: unexpected type *types.resource153ToLegacyAdapter (expected *machineidv1.BotInstance)","timestamp":"2025-07-11T13:01:09+01:00"}
```

Fortunately, there are no resources on v17 that leverage the new collection mechanism. This issue has only arisen when trying to backport the new Bot Instance cache to v17.