### PR TITLE
Align Identity Center APIs with other resources

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -1219,9 +1220,11 @@ type Cache interface {
 
 	// GetAccountAssignment fetches specific IdentityCenter Account Assignment
 	GetAccountAssignment(context.Context, services.IdentityCenterAccountAssignmentID) (services.IdentityCenterAccountAssignment, error)
+	GetIdentityCenterAccountAssignment(context.Context, string) (*identitycenterv1.AccountAssignment, error)
 
 	// ListAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
 	ListAccountAssignments(context.Context, int, *pagination.PageRequestToken) ([]services.IdentityCenterAccountAssignment, pagination.NextPageToken, error)
+	ListIdentityCenterAccountAssignments(context.Context, int, string) ([]*identitycenterv1.AccountAssignment, string, error)
 
 	// GetPluginStaticCredentialsByLabels will get a list of plugin static credentials resource by matching labels.
 	GetPluginStaticCredentialsByLabels(ctx context.Context, labels map[string]string) ([]types.PluginStaticCredentials, error)

--- a/lib/cache/identitycenter.go
+++ b/lib/cache/identitycenter.go
@@ -81,13 +81,13 @@ func newIdentityCenterAccountCollection(ic services.IdentityCenter, w types.Watc
 	}, nil
 }
 
-func (c *Cache) GetIdentityCenterAccount(ctx context.Context, name services.IdentityCenterAccountID) (services.IdentityCenterAccount, error) {
+func (c *Cache) GetIdentityCenterAccount(ctx context.Context, name string) (*identitycenterv1.Account, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetIdentityCenterAccount")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.identityCenterAccounts)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer rg.Release()
 
@@ -96,16 +96,38 @@ func (c *Cache) GetIdentityCenterAccount(ctx context.Context, name services.Iden
 		return account, trace.Wrap(err)
 	}
 
-	account, err := rg.store.get(identityCenterAccountNameIndex, string(name))
+	account, err := rg.store.get(identityCenterAccountNameIndex, name)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	return services.IdentityCenterAccount{Account: utils.CloneProtoMsg(account)}, nil
+	return utils.CloneProtoMsg(account), nil
 }
 
 func (c *Cache) ListIdentityCenterAccounts(ctx context.Context, pageSize int, token *pagination.PageRequestToken) ([]services.IdentityCenterAccount, pagination.NextPageToken, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListIdentityCenterAccounts")
+	defer span.End()
+
+	pageToken, err := token.Consume()
+	if err != nil {
+		return nil, "", trace.Wrap(err, "extracting page token")
+	}
+
+	accounts, next, err := c.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	var out []services.IdentityCenterAccount
+	for _, account := range accounts {
+		out = append(out, services.IdentityCenterAccount{Account: account})
+
+	}
+	return out, pagination.NextPageToken(next), nil
+}
+
+func (c *Cache) ListIdentityCenterAccounts2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.Account, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListIdentityCenterAccounts2")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.identityCenterAccounts)
@@ -115,7 +137,7 @@ func (c *Cache) ListIdentityCenterAccounts(ctx context.Context, pageSize int, to
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		accounts, next, err := c.Config.IdentityCenter.ListIdentityCenterAccounts(ctx, pageSize, token)
+		accounts, next, err := c.Config.IdentityCenter.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
 		return accounts, next, trace.Wrap(err)
 	}
 
@@ -123,18 +145,13 @@ func (c *Cache) ListIdentityCenterAccounts(ctx context.Context, pageSize int, to
 		pageSize = 100
 	}
 
-	var accounts []services.IdentityCenterAccount
-	startKey, err := token.Consume()
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	for account := range rg.store.resources(identityCenterAccountNameIndex, startKey, "") {
+	var accounts []*identitycenterv1.Account
+	for account := range rg.store.resources(identityCenterAccountNameIndex, pageToken, "") {
 		if len(accounts) == pageSize {
-			return accounts, pagination.NextPageToken(account.Metadata.GetName()), nil
+			return accounts, account.Metadata.GetName(), nil
 		}
 
-		accounts = append(accounts, services.IdentityCenterAccount{Account: utils.CloneProtoMsg(account)})
+		accounts = append(accounts, utils.CloneProtoMsg(account))
 
 	}
 	return accounts, "", nil
@@ -195,18 +212,7 @@ func (c *Cache) GetAccountAssignment(ctx context.Context, id services.IdentityCe
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccountAssignment")
 	defer span.End()
 
-	rg, err := acquireReadGuard(c, c.collections.identityCenterAccountAssignments)
-	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
-	}
-	defer rg.Release()
-
-	if !rg.ReadCache() {
-		assignment, err := c.Config.IdentityCenter.GetAccountAssignment(ctx, id)
-		return assignment, trace.Wrap(err)
-	}
-
-	assignment, err := rg.store.get(identityCenterAccountAssignmentNameIndex, string(id))
+	assignment, err := c.GetIdentityCenterAccountAssignment(ctx, string(id))
 	if err != nil {
 		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
 	}
@@ -214,9 +220,55 @@ func (c *Cache) GetAccountAssignment(ctx context.Context, id services.IdentityCe
 	return services.IdentityCenterAccountAssignment{AccountAssignment: assignment}, nil
 }
 
+func (c *Cache) GetIdentityCenterAccountAssignment(ctx context.Context, id string) (*identitycenterv1.AccountAssignment, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetIdentityCenterAccountAssignment")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.identityCenterAccountAssignments)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		assignment, err := c.Config.IdentityCenter.GetIdentityCenterAccountAssignment(ctx, id)
+		return assignment, trace.Wrap(err)
+	}
+
+	assignment, err := rg.store.get(identityCenterAccountAssignmentNameIndex, id)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return assignment, nil
+}
+
 // ListAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
 func (c *Cache) ListAccountAssignments(ctx context.Context, pageSize int, pageToken *pagination.PageRequestToken) ([]services.IdentityCenterAccountAssignment, pagination.NextPageToken, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccountAssignments")
+	defer span.End()
+
+	token, err := pageToken.Consume()
+	if err != nil {
+		return nil, "", trace.Wrap(err, "extracting page token")
+	}
+
+	assignments, next, err := c.ListIdentityCenterAccountAssignments(ctx, pageSize, token)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	out := make([]services.IdentityCenterAccountAssignment, 0, len(assignments))
+	for _, assignment := range assignments {
+		out = append(out, services.IdentityCenterAccountAssignment{AccountAssignment: assignment})
+
+	}
+	return out, pagination.NextPageToken(next), nil
+}
+
+// ListIdentityCenterAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
+func (c *Cache) ListIdentityCenterAccountAssignments(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.AccountAssignment, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListIdentityCenterAccountAssignments")
 	defer span.End()
 
 	rg, err := acquireReadGuard(c, c.collections.identityCenterAccountAssignments)
@@ -226,7 +278,7 @@ func (c *Cache) ListAccountAssignments(ctx context.Context, pageSize int, pageTo
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		assignment, next, err := c.Config.IdentityCenter.ListAccountAssignments(ctx, pageSize, pageToken)
+		assignment, next, err := c.Config.IdentityCenter.ListIdentityCenterAccountAssignments(ctx, pageSize, pageToken)
 		return assignment, next, trace.Wrap(err)
 	}
 
@@ -234,21 +286,13 @@ func (c *Cache) ListAccountAssignments(ctx context.Context, pageSize int, pageTo
 		pageSize = 100
 	}
 
-	token, err := pageToken.Consume()
-	if err != nil {
-		return nil, "", trace.Wrap(err, "extracting page token")
-	}
-
-	var assignments []services.IdentityCenterAccountAssignment
-	for assignment := range rg.store.resources(identityCenterAccountAssignmentNameIndex, token, "") {
+	var assignments []*identitycenterv1.AccountAssignment
+	for assignment := range rg.store.resources(identityCenterAccountAssignmentNameIndex, pageToken, "") {
 		if len(assignments) == pageSize {
-			return assignments, pagination.NextPageToken(assignment.GetMetadata().Name), nil
+			return assignments, assignment.GetMetadata().Name, nil
 		}
 
-		assignments = append(assignments, services.IdentityCenterAccountAssignment{
-			AccountAssignment: utils.CloneProtoMsg(assignment),
-		})
-
+		assignments = append(assignments, assignment)
 	}
 	return assignments, "", nil
 }
@@ -323,24 +367,29 @@ func (c *Cache) ListPrincipalAssignments(ctx context.Context, pageSize int, req 
 	ctx, span := c.Tracer.Start(ctx, "cache/ListPrincipalAssignments")
 	defer span.End()
 
-	lister := genericLister[*identitycenterv1.PrincipalAssignment, identityCenterPrincipalAssignmentIndex]{
-		cache:      c,
-		collection: c.collections.identityCenterPrincipalAssignments,
-		index:      identityCenterPrincipalAssignmentNameIndex,
-		upstreamList: func(ctx context.Context, pageSize int, s string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
-			out, next, err := c.Config.IdentityCenter.ListPrincipalAssignments(ctx, pageSize, req)
-			return out, string(next), trace.Wrap(err)
-		},
-		nextToken: func(t *identitycenterv1.PrincipalAssignment) string {
-			return t.GetMetadata().GetName()
-		},
-	}
-
 	nextToken, err := req.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	out, next, err := lister.list(ctx, pageSize, nextToken)
+	out, next, err := c.ListPrincipalAssignments2(ctx, pageSize, nextToken)
 	return out, pagination.NextPageToken(next), trace.Wrap(err)
+}
+
+func (c *Cache) ListPrincipalAssignments2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListPrincipalAssignments")
+	defer span.End()
+
+	lister := genericLister[*identitycenterv1.PrincipalAssignment, identityCenterPrincipalAssignmentIndex]{
+		cache:        c,
+		collection:   c.collections.identityCenterPrincipalAssignments,
+		index:        identityCenterPrincipalAssignmentNameIndex,
+		upstreamList: c.Config.IdentityCenter.ListPrincipalAssignments2,
+		nextToken: func(t *identitycenterv1.PrincipalAssignment) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
 }

--- a/lib/cache/identitycenter_test.go
+++ b/lib/cache/identitycenter_test.go
@@ -25,8 +25,9 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils/pagination"
 )
 
 func newIdentityCenterAccount(id string) *identitycenterv1.Account {
@@ -45,42 +46,27 @@ func newIdentityCenterAccount(id string) *identitycenterv1.Account {
 	}
 }
 
-// TestIdentityCenterAccount asserts that an Identoty Ceneter Account can be cached
+// TestIdentityCenterAccount asserts that an Identity Center Account can be cached
 func TestIdentityCenterAccount(t *testing.T) {
 	t.Parallel()
 
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[services.IdentityCenterAccount]{
-		newResource: func(s string) (services.IdentityCenterAccount, error) {
-			return services.IdentityCenterAccount{Account: newIdentityCenterAccount(s)}, nil
+	testResources153(t, fixturePack, testFuncs153[*identitycenterv1.Account]{
+		newResource: func(s string) (*identitycenterv1.Account, error) {
+			return newIdentityCenterAccount(s), nil
 		},
-		create: func(ctx context.Context, item services.IdentityCenterAccount) error {
-			_, err := fixturePack.identityCenter.CreateIdentityCenterAccount(ctx, item)
+		create: func(ctx context.Context, item *identitycenterv1.Account) error {
+			_, err := fixturePack.identityCenter.CreateIdentityCenterAccount2(ctx, item)
 			return trace.Wrap(err)
 		},
-		update: func(ctx context.Context, item services.IdentityCenterAccount) error {
-			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccount(ctx, item)
+		update: func(ctx context.Context, item *identitycenterv1.Account) error {
+			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccount2(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context) ([]services.IdentityCenterAccount, error) {
-			var result []services.IdentityCenterAccount
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.identityCenter.ListIdentityCenterAccounts(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				pageToken.Update(nextPage)
-				if nextPage == "" {
-					break
-				}
-			}
-
-			return result, nil
+		list: func(ctx context.Context) ([]*identitycenterv1.Account, error) {
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.identityCenter.ListIdentityCenterAccounts2))
 		},
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteIdentityCenterAccount(
@@ -89,26 +75,11 @@ func TestIdentityCenterAccount(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllIdentityCenterAccounts(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]services.IdentityCenterAccount, error) {
-			var result []services.IdentityCenterAccount
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.cache.ListIdentityCenterAccounts(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				pageToken.Update(nextPage)
-				if nextPage == "" {
-					break
-				}
-			}
-
-			return result, nil
+		cacheList: func(ctx context.Context) ([]*identitycenterv1.Account, error) {
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListIdentityCenterAccounts2))
 		},
-		cacheGet: func(ctx context.Context, id string) (services.IdentityCenterAccount, error) {
-			r, err := fixturePack.cache.GetIdentityCenterAccount(ctx, services.IdentityCenterAccountID(id))
+		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.Account, error) {
+			r, err := fixturePack.cache.GetIdentityCenterAccount(ctx, id)
 			return r, trace.Wrap(err)
 		},
 	})
@@ -152,22 +123,7 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		list: func(ctx context.Context) ([]*identitycenterv1.PrincipalAssignment, error) {
-			var result []*identitycenterv1.PrincipalAssignment
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.identityCenter.ListPrincipalAssignments(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				if nextPage == pagination.EndOfList {
-					break
-				}
-
-				pageToken.Update(nextPage)
-			}
-			return result, nil
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.identityCenter.ListPrincipalAssignments2))
 		},
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeletePrincipalAssignment(ctx, services.PrincipalAssignmentID(id)))
@@ -176,22 +132,7 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllPrincipalAssignments(ctx))
 		},
 		cacheList: func(ctx context.Context) ([]*identitycenterv1.PrincipalAssignment, error) {
-			var result []*identitycenterv1.PrincipalAssignment
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.cache.ListPrincipalAssignments(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				if nextPage == pagination.EndOfList {
-					break
-				}
-
-				pageToken.Update(nextPage)
-			}
-			return result, nil
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListPrincipalAssignments2))
 		},
 		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.PrincipalAssignment, error) {
 			r, err := fixturePack.cache.GetPrincipalAssignment(ctx, services.PrincipalAssignmentID(id))
@@ -224,36 +165,20 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[services.IdentityCenterAccountAssignment]{
-		newResource: func(s string) (services.IdentityCenterAccountAssignment, error) {
-			return services.IdentityCenterAccountAssignment{
-				AccountAssignment: newIdentityCenterAccountAssignment(s),
-			}, nil
+	testResources153(t, fixturePack, testFuncs153[*identitycenterv1.AccountAssignment]{
+		newResource: func(s string) (*identitycenterv1.AccountAssignment, error) {
+			return newIdentityCenterAccountAssignment(s), nil
 		},
-		create: func(ctx context.Context, item services.IdentityCenterAccountAssignment) error {
-			_, err := fixturePack.identityCenter.CreateAccountAssignment(ctx, item)
+		create: func(ctx context.Context, item *identitycenterv1.AccountAssignment) error {
+			_, err := fixturePack.identityCenter.CreateIdentityCenterAccountAssignment(ctx, item)
 			return trace.Wrap(err)
 		},
-		update: func(ctx context.Context, item services.IdentityCenterAccountAssignment) error {
-			_, err := fixturePack.identityCenter.UpdateAccountAssignment(ctx, item)
+		update: func(ctx context.Context, item *identitycenterv1.AccountAssignment) error {
+			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccountAssignment(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context) ([]services.IdentityCenterAccountAssignment, error) {
-			var result []services.IdentityCenterAccountAssignment
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.identityCenter.ListAccountAssignments(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				pageToken.Update(nextPage)
-				if nextPage == "" {
-					break
-				}
-			}
-			return result, nil
+		list: func(ctx context.Context) ([]*identitycenterv1.AccountAssignment, error) {
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.identityCenter.ListIdentityCenterAccountAssignments))
 		},
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAccountAssignment(ctx, services.IdentityCenterAccountAssignmentID(id)))
@@ -261,26 +186,12 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllAccountAssignments(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]services.IdentityCenterAccountAssignment, error) {
-			var result []services.IdentityCenterAccountAssignment
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.cache.ListAccountAssignments(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				pageToken.Update(nextPage)
-				if nextPage == "" {
-					break
-				}
-			}
-			return result, nil
+		cacheList: func(ctx context.Context) ([]*identitycenterv1.AccountAssignment, error) {
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListIdentityCenterAccountAssignments))
 		},
-		cacheGet: func(ctx context.Context, id string) (services.IdentityCenterAccountAssignment, error) {
+		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.AccountAssignment, error) {
 			r, err := fixturePack.cache.GetAccountAssignment(ctx, services.IdentityCenterAccountAssignmentID(id))
-			return r, trace.Wrap(err)
+			return r.AccountAssignment, trace.Wrap(err)
 		},
 	})
 }

--- a/lib/cache/provisioning.go
+++ b/lib/cache/provisioning.go
@@ -103,24 +103,29 @@ func (c *Cache) ListProvisioningStatesForAllDownstreams(ctx context.Context, pag
 	ctx, span := c.Tracer.Start(ctx, "cache/ListProvisioningStatesForAllDownstreams")
 	defer span.End()
 
-	lister := genericLister[*provisioningv1.PrincipalState, principalStateIndex]{
-		cache:      c,
-		collection: c.collections.provisioningStates,
-		index:      principalStateNameIndex,
-		upstreamList: func(ctx context.Context, pageSize int, s string) ([]*provisioningv1.PrincipalState, string, error) {
-			out, next, err := c.Config.ProvisioningStates.ListProvisioningStatesForAllDownstreams(ctx, pageSize, req)
-			return out, string(next), trace.Wrap(err)
-		},
-		nextToken: func(t *provisioningv1.PrincipalState) string {
-			return t.GetMetadata().GetName()
-		},
-	}
-
 	nextToken, err := req.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	out, next, err := lister.list(ctx, pageSize, nextToken)
+	out, next, err := c.ListProvisioningStatesForAllDownstreams2(ctx, pageSize, nextToken)
 	return out, pagination.NextPageToken(next), trace.Wrap(err)
+}
+
+func (c *Cache) ListProvisioningStatesForAllDownstreams2(ctx context.Context, pageSize int, pageToken string) ([]*provisioningv1.PrincipalState, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListProvisioningStatesForAllDownstreams2")
+	defer span.End()
+
+	lister := genericLister[*provisioningv1.PrincipalState, principalStateIndex]{
+		cache:        c,
+		collection:   c.collections.provisioningStates,
+		index:        principalStateNameIndex,
+		upstreamList: c.Config.ProvisioningStates.ListProvisioningStatesForAllDownstreams2,
+		nextToken: func(t *provisioningv1.PrincipalState) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
 }

--- a/lib/cache/provisioning_test.go
+++ b/lib/cache/provisioning_test.go
@@ -25,8 +25,9 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils/pagination"
 )
 
 const testDownstreamID = services.DownstreamID("weyland-yutani")
@@ -70,22 +71,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		list: func(ctx context.Context) ([]*provisioningv1.PrincipalState, error) {
-			var result []*provisioningv1.PrincipalState
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				if nextPage == pagination.EndOfList {
-					break
-				}
-
-				pageToken.Update(nextPage)
-			}
-			return result, nil
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams2))
 		},
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteProvisioningState(
@@ -95,22 +81,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteAllProvisioningStates(ctx))
 		},
 		cacheList: func(ctx context.Context) ([]*provisioningv1.PrincipalState, error) {
-			var result []*provisioningv1.PrincipalState
-			var pageToken pagination.PageRequestToken
-			for {
-				page, nextPage, err := fixturePack.cache.ListProvisioningStatesForAllDownstreams(ctx, 0, &pageToken)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				result = append(result, page...)
-
-				if nextPage == pagination.EndOfList {
-					break
-				}
-
-				pageToken.Update(nextPage)
-			}
-			return result, nil
+			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListProvisioningStatesForAllDownstreams2))
 		},
 		cacheGet: func(ctx context.Context, id string) (*provisioningv1.PrincipalState, error) {
 			r, err := fixturePack.provisioningStates.GetProvisioningState(

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -64,9 +64,10 @@ type IdentityCenterAccountGetter interface {
 	// ListIdentityCenterAccounts provides a paged list of all known identity
 	// center accounts
 	ListIdentityCenterAccounts(context.Context, int, *pagination.PageRequestToken) ([]IdentityCenterAccount, pagination.NextPageToken, error)
+	ListIdentityCenterAccounts2(context.Context, int, string) ([]*identitycenterv1.Account, string, error)
 
 	// GetIdentityCenterAccount fetches a specific Identity Center Account
-	GetIdentityCenterAccount(context.Context, IdentityCenterAccountID) (IdentityCenterAccount, error)
+	GetIdentityCenterAccount(context.Context, string) (*identitycenterv1.Account, error)
 }
 
 // IdentityCenterAccounts defines read/write access to Identity Center account
@@ -76,16 +77,18 @@ type IdentityCenterAccounts interface {
 
 	// CreateIdentityCenterAccount creates a new Identity Center Account record
 	CreateIdentityCenterAccount(context.Context, IdentityCenterAccount) (IdentityCenterAccount, error)
+	CreateIdentityCenterAccount2(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
 
 	// UpdateIdentityCenterAccount performs a conditional update on an Identity
 	// Center Account record, returning the updated record on success.
 	UpdateIdentityCenterAccount(context.Context, IdentityCenterAccount) (IdentityCenterAccount, error)
+	UpdateIdentityCenterAccount2(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
 
 	// UpsertIdentityCenterAccount performs an *unconditional* upsert on an
 	// Identity Center Account record, returning the updated record on success.
 	// Be careful when mixing UpsertIdentityCenterAccount() with resources
 	// protected by optimistic locking
-	UpsertIdentityCenterAccount(context.Context, IdentityCenterAccount) (IdentityCenterAccount, error)
+	UpsertIdentityCenterAccount(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
 
 	// DeleteIdentityCenterAccount deletes an Identity Center Account record
 	DeleteIdentityCenterAccount(context.Context, IdentityCenterAccountID) error
@@ -104,6 +107,7 @@ type IdentityCenterPrincipalAssignments interface {
 	// ListPrincipalAssignments lists all PrincipalAssignment records in the
 	// service
 	ListPrincipalAssignments(context.Context, int, *pagination.PageRequestToken) ([]*identitycenterv1.PrincipalAssignment, pagination.NextPageToken, error)
+	ListPrincipalAssignments2(context.Context, int, string) ([]*identitycenterv1.PrincipalAssignment, string, error)
 
 	// CreatePrincipalAssignment creates a new Principal Assignment record in
 	// the service from the supplied in-memory representation. Returns the
@@ -136,6 +140,7 @@ type PermissionSetID string
 type IdentityCenterPermissionSets interface {
 	// ListPermissionSets list the known Permission Sets
 	ListPermissionSets(context.Context, int, *pagination.PageRequestToken) ([]*identitycenterv1.PermissionSet, pagination.NextPageToken, error)
+	ListPermissionSets2(context.Context, int, string) ([]*identitycenterv1.PermissionSet, string, error)
 
 	// CreatePermissionSet creates a new PermissionSet record based on the
 	// supplied in-memory representation, returning the created record on
@@ -187,10 +192,12 @@ type IdentityCenterAccountAssignmentID string
 type IdentityCenterAccountAssignmentGetter interface {
 	// GetAccountAssignment fetches a specific Account Assignment record.
 	GetAccountAssignment(context.Context, IdentityCenterAccountAssignmentID) (IdentityCenterAccountAssignment, error)
+	GetIdentityCenterAccountAssignment(context.Context, string) (*identitycenterv1.AccountAssignment, error)
 
 	// ListAccountAssignments lists all IdentityCenterAccountAssignment record
 	// known to the service
 	ListAccountAssignments(context.Context, int, *pagination.PageRequestToken) ([]IdentityCenterAccountAssignment, pagination.NextPageToken, error)
+	ListIdentityCenterAccountAssignments(context.Context, int, string) ([]*identitycenterv1.AccountAssignment, string, error)
 }
 
 // IdentityCenterAccountAssignments defines the operations to create and maintain
@@ -202,14 +209,16 @@ type IdentityCenterAccountAssignments interface {
 	// the service from the supplied in-memory representation. Returns the
 	// created record on success.
 	CreateAccountAssignment(context.Context, IdentityCenterAccountAssignment) (IdentityCenterAccountAssignment, error)
+	CreateIdentityCenterAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
 
 	// UpdateAccountAssignment performs a conditional update on the supplied
 	// Account Assignment, returning the updated record on success.
 	UpdateAccountAssignment(context.Context, IdentityCenterAccountAssignment) (IdentityCenterAccountAssignment, error)
+	UpdateIdentityCenterAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
 
 	// UpsertAccountAssignment performs an unconditional update on the supplied
 	// Account Assignment, returning the updated record on success.
-	UpsertAccountAssignment(context.Context, IdentityCenterAccountAssignment) (IdentityCenterAccountAssignment, error)
+	UpsertAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
 
 	// DeleteAccountAssignment deletes a specific account assignment
 	DeleteAccountAssignment(context.Context, IdentityCenterAccountAssignmentID) error

--- a/lib/services/local/identitycenter.go
+++ b/lib/services/local/identitycenter.go
@@ -94,6 +94,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsAccountPrefix),
 		MarshalFunc:   services.MarshalProtoResource[*identitycenterv1.Account],
 		UnmarshalFunc: services.UnmarshalProtoResource[*identitycenterv1.Account],
+		PageLimit:     identityCenterPageSize,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating accounts service")
@@ -105,6 +106,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsPermissionSetPrefix),
 		MarshalFunc:   services.MarshalProtoResource[*identitycenterv1.PermissionSet],
 		UnmarshalFunc: services.UnmarshalProtoResource[*identitycenterv1.PermissionSet],
+		PageLimit:     identityCenterPageSize,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating permission sets service")
@@ -116,6 +118,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsPrincipalAssignmentPrefix),
 		MarshalFunc:   services.MarshalProtoResource[*identitycenterv1.PrincipalAssignment],
 		UnmarshalFunc: services.UnmarshalProtoResource[*identitycenterv1.PrincipalAssignment],
+		PageLimit:     identityCenterPageSize,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating principal assignments service")
@@ -127,6 +130,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsAccountAssignmentPrefix),
 		MarshalFunc:   services.MarshalProtoResource[*identitycenterv1.AccountAssignment],
 		UnmarshalFunc: services.UnmarshalProtoResource[*identitycenterv1.AccountAssignment],
+		PageLimit:     identityCenterPageSize,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating account assignments service")
@@ -145,18 +149,14 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 // ListIdentityCenterAccounts provides a paged list of all AWS accounts known
 // to the Identity Center integration
 func (svc *IdentityCenterService) ListIdentityCenterAccounts(ctx context.Context, pageSize int, page *pagination.PageRequestToken) ([]services.IdentityCenterAccount, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = identityCenterPageSize
-	}
-
 	pageToken, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center assignment records")
 	}
 
-	accounts, nextPage, err := svc.accounts.ListResources(ctx, pageSize, pageToken)
+	accounts, nextPage, err := svc.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
 	if err != nil {
-		return nil, "", trace.Wrap(err, "listing identity center assignment records")
+		return nil, "", trace.Wrap(err)
 	}
 
 	result := make([]services.IdentityCenterAccount, len(accounts))
@@ -167,44 +167,74 @@ func (svc *IdentityCenterService) ListIdentityCenterAccounts(ctx context.Context
 	return result, pagination.NextPageToken(nextPage), nil
 }
 
+// ListIdentityCenterAccounts2 provides a paged list of all AWS accounts known
+// to the Identity Center integration
+func (svc *IdentityCenterService) ListIdentityCenterAccounts2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.Account, string, error) {
+	accounts, nextPage, err := svc.accounts.ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "listing identity center assignment records")
+	}
+
+	return accounts, nextPage, nil
+}
+
 // CreateIdentityCenterAccount creates a new Identity Center Account record
 func (svc *IdentityCenterService) CreateIdentityCenterAccount(ctx context.Context, acct services.IdentityCenterAccount) (services.IdentityCenterAccount, error) {
-	created, err := svc.accounts.CreateResource(ctx, acct.Account)
+	created, err := svc.CreateIdentityCenterAccount2(ctx, acct.Account)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err, "creating identity center account")
+		return services.IdentityCenterAccount{}, trace.Wrap(err)
 	}
 	return services.IdentityCenterAccount{Account: created}, nil
 }
 
-// GetIdentityCenterAccount fetches a specific Identity Center Account
-func (svc *IdentityCenterService) GetIdentityCenterAccount(ctx context.Context, name services.IdentityCenterAccountID) (services.IdentityCenterAccount, error) {
-	acct, err := svc.accounts.GetResource(ctx, string(name))
+// CreateIdentityCenterAccount2 creates a new Identity Center Account record
+func (svc *IdentityCenterService) CreateIdentityCenterAccount2(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
+	created, err := svc.accounts.CreateResource(ctx, acct)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err, "fetching identity center account")
+		return nil, trace.Wrap(err, "creating identity center account")
 	}
-	return services.IdentityCenterAccount{Account: acct}, nil
+	return created, nil
+}
+
+// GetIdentityCenterAccount fetches a specific Identity Center Account
+func (svc *IdentityCenterService) GetIdentityCenterAccount(ctx context.Context, name string) (*identitycenterv1.Account, error) {
+	acct, err := svc.accounts.GetResource(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching identity center account")
+	}
+	return acct, nil
 }
 
 // UpdateIdentityCenterAccount performs a conditional update on an Identity
 // Center Account record, returning the updated record on success.
 func (svc *IdentityCenterService) UpdateIdentityCenterAccount(ctx context.Context, acct services.IdentityCenterAccount) (services.IdentityCenterAccount, error) {
-	updated, err := svc.accounts.ConditionalUpdateResource(ctx, acct.Account)
+	updated, err := svc.UpdateIdentityCenterAccount2(ctx, acct.Account)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err, "updating identity center account record")
+		return services.IdentityCenterAccount{}, trace.Wrap(err)
 	}
 	return services.IdentityCenterAccount{Account: updated}, nil
+}
+
+// UpdateIdentityCenterAccount2 performs a conditional update on an Identity
+// Center Account record, returning the updated record on success.
+func (svc *IdentityCenterService) UpdateIdentityCenterAccount2(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
+	updated, err := svc.accounts.ConditionalUpdateResource(ctx, acct)
+	if err != nil {
+		return nil, trace.Wrap(err, "updating identity center account record")
+	}
+	return updated, nil
 }
 
 // UpsertIdentityCenterAccount performs an *unconditional* upsert on an
 // Identity Center Account record, returning the updated record on success.
 // Be careful when mixing UpsertIdentityCenterAccount() with resources
 // protected by optimistic locking
-func (svc *IdentityCenterService) UpsertIdentityCenterAccount(ctx context.Context, acct services.IdentityCenterAccount) (services.IdentityCenterAccount, error) {
-	updated, err := svc.accounts.UpsertResource(ctx, acct.Account)
+func (svc *IdentityCenterService) UpsertIdentityCenterAccount(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
+	updated, err := svc.accounts.UpsertResource(ctx, acct)
 	if err != nil {
-		return services.IdentityCenterAccount{}, trace.Wrap(err, "upserting identity center account record")
+		return nil, trace.Wrap(err, "upserting identity center account record")
 	}
-	return services.IdentityCenterAccount{Account: updated}, nil
+	return updated, nil
 }
 
 // DeleteIdentityCenterAccount deletes an Identity Center Account record
@@ -217,22 +247,27 @@ func (svc *IdentityCenterService) DeleteAllIdentityCenterAccounts(ctx context.Co
 	return trace.Wrap(svc.accounts.DeleteAllResources(ctx))
 }
 
-// ListPrincipalAssignments lists all PrincipalAssignment records in the service
+// ListPrincipalAssignments lists a page of PrincipalAssignment records in the service.
 func (svc *IdentityCenterService) ListPrincipalAssignments(ctx context.Context, pageSize int, page *pagination.PageRequestToken) ([]*identitycenterv1.PrincipalAssignment, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = identityCenterPageSize
-	}
-
 	pageToken, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err, "extracting page token")
 	}
 
+	resp, nextPage, err := svc.ListPrincipalAssignments2(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return resp, pagination.NextPageToken(nextPage), nil
+}
+
+// ListPrincipalAssignments2 lists a page of PrincipalAssignment records in the service.
+func (svc *IdentityCenterService) ListPrincipalAssignments2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
 	resp, nextPage, err := svc.principalAssignments.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center assignment records")
 	}
-	return resp, pagination.NextPageToken(nextPage), nil
+	return resp, nextPage, nil
 }
 
 // CreatePrincipalAssignment creates a new Principal Assignment record in the
@@ -285,20 +320,27 @@ func (svc *IdentityCenterService) DeleteAllPrincipalAssignments(ctx context.Cont
 	return trace.Wrap(svc.principalAssignments.DeleteAllResources(ctx))
 }
 
-// ListPermissionSets list the known Permission Sets in the managed Identity Center
+// ListPermissionSets returns a page of known Permission Sets in the managed Identity Center
 func (svc *IdentityCenterService) ListPermissionSets(ctx context.Context, pageSize int, page *pagination.PageRequestToken) ([]*identitycenterv1.PermissionSet, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = identityCenterPageSize
-	}
 	pageToken, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err, "extracting page token")
 	}
-	resp, nextPage, err := svc.permissionSets.ListResources(ctx, pageSize, pageToken)
+	resp, nextPage, err := svc.ListPermissionSets2(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center permission set records")
 	}
 	return resp, pagination.NextPageToken(nextPage), nil
+}
+
+// ListPermissionSets2 returns a page of known Permission Sets in the managed Identity Center
+func (svc *IdentityCenterService) ListPermissionSets2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PermissionSet, string, error) {
+
+	resp, nextPage, err := svc.permissionSets.ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "listing identity center permission set records")
+	}
+	return resp, nextPage, nil
 }
 
 // CreatePermissionSet creates a new PermissionSet record based on the supplied
@@ -340,19 +382,15 @@ func (svc *IdentityCenterService) DeleteAllPermissionSets(ctx context.Context) e
 	return trace.Wrap(svc.permissionSets.DeleteAllResources(ctx))
 }
 
-// ListAccountAssignments lists all IdentityCenterAccountAssignment record
-// known to the service
+// ListAccountAssignments returns a page of IdentityCenterAccountAssignment records.
 func (svc *IdentityCenterService) ListAccountAssignments(ctx context.Context, pageSize int, page *pagination.PageRequestToken) ([]services.IdentityCenterAccountAssignment, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = identityCenterPageSize
-	}
 	pageToken, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err, "extracting page token")
 	}
-	assignments, nextPage, err := svc.accountAssignments.ListResources(ctx, pageSize, pageToken)
+	assignments, nextPage, err := svc.ListIdentityCenterAccountAssignments(ctx, pageSize, pageToken)
 	if err != nil {
-		return nil, "", trace.Wrap(err, "listing identity center assignment records")
+		return nil, "", trace.Wrap(err)
 	}
 
 	result := make([]services.IdentityCenterAccountAssignment, len(assignments))
@@ -363,44 +401,84 @@ func (svc *IdentityCenterService) ListAccountAssignments(ctx context.Context, pa
 	return result, pagination.NextPageToken(nextPage), nil
 }
 
+// ListIdentityCenterAccountAssignments returns a page of IdentityCenterAccountAssignment records.
+func (svc *IdentityCenterService) ListIdentityCenterAccountAssignments(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.AccountAssignment, string, error) {
+	assignments, nextPage, err := svc.accountAssignments.ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "listing identity center assignment records")
+	}
+
+	return assignments, nextPage, nil
+}
+
 // CreateAccountAssignment creates a new Account Assignment record in
 // the service from the supplied in-memory representation. Returns the
 // created record on success.
 func (svc *IdentityCenterService) CreateAccountAssignment(ctx context.Context, asmt services.IdentityCenterAccountAssignment) (services.IdentityCenterAccountAssignment, error) {
-	created, err := svc.accountAssignments.CreateResource(ctx, asmt.AccountAssignment)
+	created, err := svc.CreateIdentityCenterAccountAssignment(ctx, asmt.AccountAssignment)
 	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err, "creating principal assignment")
+		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
 	}
 	return services.IdentityCenterAccountAssignment{AccountAssignment: created}, nil
 }
 
+// CreateIdentityCenterAccountAssignment creates a new Account Assignment record in
+// the service from the supplied in-memory representation. Returns the
+// created record on success.
+func (svc *IdentityCenterService) CreateIdentityCenterAccountAssignment(ctx context.Context, asmt *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error) {
+	created, err := svc.accountAssignments.CreateResource(ctx, asmt)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating principal assignment")
+	}
+	return created, nil
+}
+
 // GetAccountAssignment fetches a specific Account Assignment record.
 func (svc *IdentityCenterService) GetAccountAssignment(ctx context.Context, name services.IdentityCenterAccountAssignmentID) (services.IdentityCenterAccountAssignment, error) {
-	asmt, err := svc.accountAssignments.GetResource(ctx, string(name))
+	asmt, err := svc.GetIdentityCenterAccountAssignment(ctx, string(name))
 	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err, "fetching principal assignment")
+		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
 	}
 	return services.IdentityCenterAccountAssignment{AccountAssignment: asmt}, nil
+}
+
+// GetIdentityCenterAccountAssignment fetches a specific Account Assignment record.
+func (svc *IdentityCenterService) GetIdentityCenterAccountAssignment(ctx context.Context, name string) (*identitycenterv1.AccountAssignment, error) {
+	asmt, err := svc.accountAssignments.GetResource(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err, "fetching principal assignment")
+	}
+	return asmt, nil
 }
 
 // UpdateAccountAssignment performs a conditional update on the supplied
 // Account Assignment, returning the updated record on success.
 func (svc *IdentityCenterService) UpdateAccountAssignment(ctx context.Context, asmt services.IdentityCenterAccountAssignment) (services.IdentityCenterAccountAssignment, error) {
-	updated, err := svc.accountAssignments.ConditionalUpdateResource(ctx, asmt.AccountAssignment)
+	updated, err := svc.UpdateIdentityCenterAccountAssignment(ctx, asmt.AccountAssignment)
 	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err, "updating principal assignment record")
+		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
 	}
 	return services.IdentityCenterAccountAssignment{AccountAssignment: updated}, nil
 }
 
+// UpdateIdentityCenterAccountAssignment performs a conditional update on the supplied
+// Account Assignment, returning the updated record on success.
+func (svc *IdentityCenterService) UpdateIdentityCenterAccountAssignment(ctx context.Context, asmt *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error) {
+	updated, err := svc.accountAssignments.ConditionalUpdateResource(ctx, asmt)
+	if err != nil {
+		return nil, trace.Wrap(err, "updating principal assignment record")
+	}
+	return updated, nil
+}
+
 // UpsertAccountAssignment performs an unconditional upsert on the supplied
 // Account Assignment, returning the updated record on success.
-func (svc *IdentityCenterService) UpsertAccountAssignment(ctx context.Context, asmt services.IdentityCenterAccountAssignment) (services.IdentityCenterAccountAssignment, error) {
-	updated, err := svc.accountAssignments.UpsertResource(ctx, asmt.AccountAssignment)
+func (svc *IdentityCenterService) UpsertAccountAssignment(ctx context.Context, asmt *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error) {
+	updated, err := svc.accountAssignments.UpsertResource(ctx, asmt)
 	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err, "upserting principal assignment record")
+		return nil, trace.Wrap(err, "upserting principal assignment record")
 	}
-	return services.IdentityCenterAccountAssignment{AccountAssignment: updated}, nil
+	return updated, nil
 }
 
 // DeleteAccountAssignment deletes a specific account assignment

--- a/lib/services/local/identitycenter_test.go
+++ b/lib/services/local/identitycenter_test.go
@@ -65,14 +65,14 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 				return makeTestIdentityCenterAccount(subtestT, subtestCtx, svc, id)
 			},
 			getResource: func(subtestCtx context.Context, svc services.IdentityCenter, id string) (types.Resource153, error) {
-				return svc.GetIdentityCenterAccount(subtestCtx, services.IdentityCenterAccountID(id))
+				return svc.GetIdentityCenterAccount(subtestCtx, id)
 			},
 			updateResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
-				acct := r.(services.IdentityCenterAccount)
-				return svc.UpdateIdentityCenterAccount(subtestCtx, acct)
+				acct := r.(*identitycenterv1.Account)
+				return svc.UpdateIdentityCenterAccount2(subtestCtx, acct)
 			},
 			upsertResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
-				acct := r.(services.IdentityCenterAccount)
+				acct := r.(*identitycenterv1.Account)
 				return svc.UpsertIdentityCenterAccount(subtestCtx, acct)
 			},
 			deleteAllResources: func(subtestCtx context.Context, svc services.IdentityCenter) error {
@@ -101,14 +101,14 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 				return makeTestIdentityCenterAccountAssignment(subtestT, subtestCtx, svc, id)
 			},
 			getResource: func(subtestCtx context.Context, svc services.IdentityCenter, id string) (types.Resource153, error) {
-				return svc.GetAccountAssignment(subtestCtx, services.IdentityCenterAccountAssignmentID(id))
+				return svc.GetIdentityCenterAccountAssignment(subtestCtx, id)
 			},
 			updateResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
-				asmt := r.(services.IdentityCenterAccountAssignment)
-				return svc.UpdateAccountAssignment(subtestCtx, asmt)
+				asmt := r.(*identitycenterv1.AccountAssignment)
+				return svc.UpdateIdentityCenterAccountAssignment(subtestCtx, asmt)
 			},
 			upsertResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
-				asmt := r.(services.IdentityCenterAccountAssignment)
+				asmt := r.(*identitycenterv1.AccountAssignment)
 				return svc.UpsertAccountAssignment(subtestCtx, asmt)
 			},
 			deleteAllResources: func(subtestCtx context.Context, svc services.IdentityCenter) error {
@@ -268,22 +268,20 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 	}
 }
 
-func makeTestIdentityCenterAccount(t *testing.T, ctx context.Context, svc services.IdentityCenter, id string) services.IdentityCenterAccount {
+func makeTestIdentityCenterAccount(t *testing.T, ctx context.Context, svc services.IdentityCenter, id string) *identitycenterv1.Account {
 	t.Helper()
-	created, err := svc.CreateIdentityCenterAccount(ctx, services.IdentityCenterAccount{
-		Account: &identitycenterv1.Account{
-			Kind:     types.KindIdentityCenterAccount,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{Name: id},
-			Spec: &identitycenterv1.AccountSpec{
-				Id:          "aws-account-id-" + id,
-				Arn:         fmt.Sprintf("arn:aws:sso::%s:", id),
-				Description: "Test account " + id,
-				PermissionSetInfo: []*identitycenterv1.PermissionSetInfo{
-					{
-						Name: "dummy",
-						Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
-					},
+	created, err := svc.CreateIdentityCenterAccount2(ctx, &identitycenterv1.Account{
+		Kind:     types.KindIdentityCenterAccount,
+		Version:  types.V1,
+		Metadata: &headerv1.Metadata{Name: id},
+		Spec: &identitycenterv1.AccountSpec{
+			Id:          "aws-account-id-" + id,
+			Arn:         fmt.Sprintf("arn:aws:sso::%s:", id),
+			Description: "Test account " + id,
+			PermissionSetInfo: []*identitycenterv1.PermissionSetInfo{
+				{
+					Name: "dummy",
+					Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
 				},
 			},
 		},
@@ -308,22 +306,20 @@ func makeTestIdentityCenterPermissionSet(t *testing.T, ctx context.Context, svc 
 	return created
 }
 
-func makeTestIdentityCenterAccountAssignment(t *testing.T, ctx context.Context, svc services.IdentityCenter, id string) services.IdentityCenterAccountAssignment {
+func makeTestIdentityCenterAccountAssignment(t *testing.T, ctx context.Context, svc services.IdentityCenter, id string) *identitycenterv1.AccountAssignment {
 	t.Helper()
-	created, err := svc.CreateAccountAssignment(ctx, services.IdentityCenterAccountAssignment{
-		AccountAssignment: &identitycenterv1.AccountAssignment{
-			Kind:     types.KindIdentityCenterAccountAssignment,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{Name: id},
-			Spec: &identitycenterv1.AccountAssignmentSpec{
-				Display: "Some-Permission-set on Some-AWS-account",
-				PermissionSet: &identitycenterv1.PermissionSetInfo{
-					Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
-					Name: "some permission set",
-				},
-				AccountName: "Some Account Name",
-				AccountId:   "some account id",
+	created, err := svc.CreateIdentityCenterAccountAssignment(ctx, &identitycenterv1.AccountAssignment{
+		Kind:     types.KindIdentityCenterAccountAssignment,
+		Version:  types.V1,
+		Metadata: &headerv1.Metadata{Name: id},
+		Spec: &identitycenterv1.AccountAssignmentSpec{
+			Display: "Some-Permission-set on Some-AWS-account",
+			PermissionSet: &identitycenterv1.PermissionSetInfo{
+				Arn:  "arn:aws:sso:::permissionSet/ic-instance/ps-instance",
+				Name: "some permission set",
 			},
+			AccountName: "Some Account Name",
+			AccountId:   "some account id",
 		},
 	})
 	require.NoError(t, err)

--- a/lib/services/local/provisioningstates.go
+++ b/lib/services/local/provisioningstates.go
@@ -50,6 +50,7 @@ func NewProvisioningStateService(backendInstance backend.Backend) (*Provisioning
 		BackendPrefix: backend.NewKey(provisioningStatePrefix),
 		MarshalFunc:   services.MarshalProtoResource[*provisioningv1.PrincipalState],
 		UnmarshalFunc: services.UnmarshalProtoResource[*provisioningv1.PrincipalState],
+		PageLimit:     provisioningStatePageSize,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -122,22 +123,28 @@ func (ss *ProvisioningStateService) GetProvisioningState(ctx context.Context, do
 	return state, nil
 }
 
-// GetProvisioningState fetches a provisioning state record from the supplied
+// ListProvisioningStates fetches a page of provisioning state records from the supplied
 // downstream
 func (ss *ProvisioningStateService) ListProvisioningStates(ctx context.Context, downstreamID services.DownstreamID, pageSize int, page *pagination.PageRequestToken) ([]*provisioningv1.PrincipalState, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = provisioningStatePageSize
-	}
-
 	token, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	resp, nextPage, err := ss.service.WithPrefix(string(downstreamID)).ListResources(ctx, pageSize, token)
+	resp, nextPage, err := ss.ListProvisioningStates2(ctx, downstreamID, pageSize, token)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing provisioning state records")
 	}
 	return resp, pagination.NextPageToken(nextPage), nil
+}
+
+// ListProvisioningStates fetches a page of provisioning state records from the supplied
+// downstream
+func (ss *ProvisioningStateService) ListProvisioningStates2(ctx context.Context, downstreamID services.DownstreamID, pageSize int, pageToken string) ([]*provisioningv1.PrincipalState, string, error) {
+	resp, nextPage, err := ss.service.WithPrefix(string(downstreamID)).ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "listing provisioning state records")
+	}
+	return resp, nextPage, nil
 }
 
 // ListProvisioningStatesForAllDownstreams lists all provisioning state records for all
@@ -149,19 +156,31 @@ func (ss *ProvisioningStateService) ListProvisioningStatesForAllDownstreams(
 	pageSize int,
 	page *pagination.PageRequestToken,
 ) ([]*provisioningv1.PrincipalState, pagination.NextPageToken, error) {
-	if pageSize == 0 {
-		pageSize = provisioningStatePageSize
-	}
-
 	token, err := page.Consume()
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
+	resp, nextPage, err := ss.ListProvisioningStatesForAllDownstreams2(ctx, pageSize, token)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return resp, pagination.NextPageToken(nextPage), nil
+}
+
+// ListProvisioningStatesForAllDownstreams2 lists all provisioning state records for all
+// downstream receivers. Note that the returned record names may not be unique
+// across all downstream receivers. Check the records' `DownstreamID` field
+// to disambiguate.
+func (ss *ProvisioningStateService) ListProvisioningStatesForAllDownstreams2(
+	ctx context.Context,
+	pageSize int,
+	token string,
+) ([]*provisioningv1.PrincipalState, string, error) {
 	resp, nextPage, err := ss.service.ListResources(ctx, pageSize, token)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing provisioning state records")
 	}
-	return resp, pagination.NextPageToken(nextPage), nil
+	return resp, nextPage, nil
 }
 
 // DeleteProvisioningState deletes a given principal's provisioning state

--- a/lib/services/provisioningstates.go
+++ b/lib/services/provisioningstates.go
@@ -47,6 +47,7 @@ type DownstreamProvisioningStates interface {
 	// ListProvisioningStates lists all provisioning state records for a given
 	// downstream receiver.
 	ListProvisioningStates(context.Context, DownstreamID, int, *pagination.PageRequestToken) ([]*provisioningv1.PrincipalState, pagination.NextPageToken, error)
+	ListProvisioningStates2(context.Context, DownstreamID, int, string) ([]*provisioningv1.PrincipalState, string, error)
 
 	// Creates a new backend PrincipalState record. The target DownstreamID is
 	// drawn from the supplied record.
@@ -82,6 +83,7 @@ type ProvisioningStates interface {
 	// may not be unique across all downstream receivers. Check the records'
 	// `DownstreamID` field to disambiguate.
 	ListProvisioningStatesForAllDownstreams(context.Context, int, *pagination.PageRequestToken) ([]*provisioningv1.PrincipalState, pagination.NextPageToken, error)
+	ListProvisioningStatesForAllDownstreams2(context.Context, int, string) ([]*provisioningv1.PrincipalState, string, error)
 
 	// DeleteAllProvisioningStates deletes all provisioning state records for
 	// all downstream receivers.


### PR DESCRIPTION
This is the first in a series of changes to migrate the identity center APIs away from `lib/utils/pagination` with the end goal of removing the pagination package entirely.

### Why?

Pagination bugs have been a major problem historically. Having multiple implementations for iterating pages of resources increases the chances of a bug. By consolidating our pagination APIs to a single shape, we can reduce the number of hand rolled implementations to consume an entire set of pages.

https://github.com/gravitational/teleport/pull/56418 and https://github.com/gravitational/teleport/pull/56581 have recently consolidated _most_ consumption of pagination APIs to a single helper in `api/utils/clientutils`. However, due to the use of the pagination.NextKey by the Identity Center APIs they need either special cases, or their own special implementation.

The IdentityCenterAccount and IdentityCenterAccountAssignment wrapper types are exposed outside of where they are required. They were added solely for the unified resource cache, and should not have been included in the APIs for the resources. The unified resource cache no longer uses the wrappers but they cannot be removed until the APIs no longer reference them.

### How?

These APIs are consumed in both OSS and Enterprise code which means they cannot be changed directly without breaking builds. The plan is to provide equivalent methods with different names to allow the transition to occur over a series of changes.