### PR TITLE
Support cluster level KMS key filtering during deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -931,6 +931,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 h1:g2AXKrTkVjnWpYXBXJ00lU6
 github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1/go.mod h1:GGQqtUubSmvzcr23P48Qkkv2auTeatL67pL9SO6/b14=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 h1:Tybcb+WE3hbjkF3kfkppyS6qRigIZwlPbtnFdMN9Hvg=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1/go.mod h1:PD4779i8tDuTz0p6k1XSZTF2RrepnIGeZOTCmuFhFOA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 h1:dGw/U6NbhnWoW2gw+75/AZvnYjFuxYRtzUpxALoRhLc=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1/go.mod h1:ZNIISn1QONFDUbTmkIK53IBTrGn1TbsrBH5pG/BCwew=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 h1:CS6N35VnEJGpPbXUoQEm0LBA/uDpTC/jfrAkkNsbjEo=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1/go.mod h1:tlqfSYOwnjSkzCp1Oc5dT44TX1bvy1SchvixKOXPvTI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 h1:Hsqo8+dFxSdDvv9B2PgIx1AJAnDpqgS0znVI+R+MoGY=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.100.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.36.1 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -820,6 +820,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 h1:g2AXKrTkVjnWpYXBXJ00lU6
 github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1/go.mod h1:GGQqtUubSmvzcr23P48Qkkv2auTeatL67pL9SO6/b14=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 h1:Tybcb+WE3hbjkF3kfkppyS6qRigIZwlPbtnFdMN9Hvg=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1/go.mod h1:PD4779i8tDuTz0p6k1XSZTF2RrepnIGeZOTCmuFhFOA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 h1:dGw/U6NbhnWoW2gw+75/AZvnYjFuxYRtzUpxALoRhLc=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1/go.mod h1:ZNIISn1QONFDUbTmkIK53IBTrGn1TbsrBH5pG/BCwew=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 h1:CS6N35VnEJGpPbXUoQEm0LBA/uDpTC/jfrAkkNsbjEo=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1/go.mod h1:tlqfSYOwnjSkzCp1Oc5dT44TX1bvy1SchvixKOXPvTI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 h1:Hsqo8+dFxSdDvv9B2PgIx1AJAnDpqgS0znVI+R+MoGY=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.100.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.36.1 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -879,6 +879,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 h1:g2AXKrTkVjnWpYXBXJ00lU6
 github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1/go.mod h1:GGQqtUubSmvzcr23P48Qkkv2auTeatL67pL9SO6/b14=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 h1:Tybcb+WE3hbjkF3kfkppyS6qRigIZwlPbtnFdMN9Hvg=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1/go.mod h1:PD4779i8tDuTz0p6k1XSZTF2RrepnIGeZOTCmuFhFOA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 h1:dGw/U6NbhnWoW2gw+75/AZvnYjFuxYRtzUpxALoRhLc=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1/go.mod h1:ZNIISn1QONFDUbTmkIK53IBTrGn1TbsrBH5pG/BCwew=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 h1:CS6N35VnEJGpPbXUoQEm0LBA/uDpTC/jfrAkkNsbjEo=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1/go.mod h1:tlqfSYOwnjSkzCp1Oc5dT44TX1bvy1SchvixKOXPvTI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 h1:Hsqo8+dFxSdDvv9B2PgIx1AJAnDpqgS0znVI+R+MoGY=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.100.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.36.1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -899,6 +899,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1 h1:g2AXKrTkVjnWpYXBXJ00lU6
 github.com/aws/aws-sdk-go-v2/service/redshift v1.55.1/go.mod h1:GGQqtUubSmvzcr23P48Qkkv2auTeatL67pL9SO6/b14=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1 h1:Tybcb+WE3hbjkF3kfkppyS6qRigIZwlPbtnFdMN9Hvg=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.28.1/go.mod h1:PD4779i8tDuTz0p6k1XSZTF2RrepnIGeZOTCmuFhFOA=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1 h1:dGw/U6NbhnWoW2gw+75/AZvnYjFuxYRtzUpxALoRhLc=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.27.1/go.mod h1:ZNIISn1QONFDUbTmkIK53IBTrGn1TbsrBH5pG/BCwew=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1 h1:CS6N35VnEJGpPbXUoQEm0LBA/uDpTC/jfrAkkNsbjEo=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.18.1/go.mod h1:tlqfSYOwnjSkzCp1Oc5dT44TX1bvy1SchvixKOXPvTI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.85.1 h1:Hsqo8+dFxSdDvv9B2PgIx1AJAnDpqgS0znVI+R+MoGY=

--- a/lib/auth/keystore/aws_kms.go
+++ b/lib/auth/keystore/aws_kms.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -36,6 +37,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/tracing/smithyoteltracing"
 	"github.com/gravitational/trace"
@@ -65,6 +68,7 @@ const (
 type awsKMSKeystore struct {
 	kms                kmsClient
 	mrk                mrkClient
+	rgt                rgtClient
 	awsAccount         string
 	awsRegion          string
 	multiRegionEnabled bool
@@ -76,10 +80,10 @@ type awsKMSKeystore struct {
 }
 
 func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *Options) (*awsKMSKeystore, error) {
-	stsClient, kmsClient := opts.awsSTSClient, opts.awsKMSClient
+	stsClient, kmsClient, rgtClient := opts.awsSTSClient, opts.awsKMSClient, opts.awsRGTClient
 	mrkClient := opts.mrkClient
 
-	if stsClient == nil || kmsClient == nil {
+	if stsClient == nil || kmsClient == nil || rgtClient == nil {
 		useFIPSEndpoint := aws.FIPSEndpointStateUnset
 		if opts.FIPS {
 			useFIPSEndpoint = aws.FIPSEndpointStateEnabled
@@ -108,6 +112,12 @@ func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *
 			if mrkClient == nil {
 				mrkClient = realKMS
 			}
+		}
+		if rgtClient == nil {
+			rgtClient = resourcegroupstaggingapi.NewFromConfig(awsCfg, func(o *resourcegroupstaggingapi.Options) {
+				o.TracerProvider = smithyoteltracing.Adapt(otel.GetTracerProvider())
+				o.Region = cfg.AWSRegion
+			})
 		}
 	}
 	id, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -149,6 +159,7 @@ func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *
 		replicaRegions:     replicas,
 		kms:                kmsClient,
 		mrk:                mrkClient,
+		rgt:                rgtClient,
 		clock:              clock,
 		logger:             opts.Logger,
 	}, nil
@@ -529,7 +540,11 @@ func (a *awsKMSKeystore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 
 	var keysToDelete []string
 	var mu sync.RWMutex
-	err := a.forEachKey(ctx, func(ctx context.Context, arn string) error {
+	keyListFn := a.forEachKey
+	if os.Getenv("TELEPORT_UNSTABLE_SCOPED_KMS_KEY_DELETION") == "yes" {
+		keyListFn = a.forEachOwnedKey
+	}
+	err := keyListFn(ctx, func(ctx context.Context, arn string) error {
 		key, err := keyIDFromArn(arn)
 		if err != nil {
 			return trace.Wrap(err)
@@ -650,6 +665,50 @@ func (a *awsKMSKeystore) forEachKey(ctx context.Context, fn func(ctx context.Con
 			})
 		}
 	}
+	return trace.Wrap(errGroup.Wait())
+}
+
+// forEachOwnedKey calls fn with the AWS key ID of all owned keys in the AWS account and
+// region that would be returned by GetResources. It may call fn concurrently.
+func (a *awsKMSKeystore) forEachOwnedKey(ctx context.Context, fn func(ctx context.Context, keyARN string) error) error {
+	errGroup, ctx := errgroup.WithContext(ctx)
+	paginationToken := ""
+	more := true
+
+	var tagFilters []rgttypes.TagFilter
+	for k, v := range a.tags {
+		tagFilters = append(tagFilters, rgttypes.TagFilter{
+			Key: aws.String(k),
+			Values: []string{
+				v,
+			},
+		})
+	}
+
+	for more {
+		var paginationTokenInput *string
+		if paginationToken != "" {
+			paginationTokenInput = aws.String(paginationToken)
+		}
+		var output, err = a.rgt.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []string{"kms:key"},
+			TagFilters:          tagFilters,
+			ResourcesPerPage:    aws.Int32(100),
+			PaginationToken:     paginationTokenInput,
+		})
+		if err != nil {
+			return trace.Wrap(err, "failed to list AWS KMS keys")
+		}
+		paginationToken = aws.ToString(output.PaginationToken)
+		more = paginationToken != ""
+		for _, keyEntry := range output.ResourceTagMappingList {
+			keyID := aws.ToString(keyEntry.ResourceARN)
+			errGroup.Go(func() error {
+				return trace.Wrap(fn(ctx, keyID))
+			})
+		}
+	}
+
 	return trace.Wrap(errGroup.Wait())
 }
 
@@ -862,4 +921,8 @@ type mrkClient interface {
 
 type stsClient interface {
 	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+type rgtClient interface {
+	GetResources(context.Context, *resourcegroupstaggingapi.GetResourcesInput, ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 }

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -376,17 +376,18 @@ func (f *fakeAWSRGTService) GetResources(_ context.Context, input *resourcegroup
 	pageLimit := min(int(aws.ToInt32(input.ResourcesPerPage)), f.pageLimit)
 	output := &resourcegroupstaggingapi.GetResourcesOutput{}
 	i := 0
-	if input.PaginationToken != nil {
+	if input.PaginationToken != nil && *input.PaginationToken != "" {
 		var err error
 		i, err = strconv.Atoi(aws.ToString(input.PaginationToken))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
+keys:
 	for ; i < len(f.kms.keys) && len(output.ResourceTagMappingList) < pageLimit; i++ {
 		for _, t := range input.TagFilters {
 			if !f.kms.keys[i].satisfiesFilter(t) {
-				continue
+				continue keys
 			}
 		}
 		convertedTags := convertKMSTagsToRGT(f.kms.keys[i].tags)

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -367,11 +367,6 @@ func newFakeAWSRGTService(t *testing.T, clock clockwork.Clock, account string, r
 	}
 }
 
-type fakeAWSRGTResource struct {
-	arn  arn.ARN
-	tags []rgttypes.Tag
-}
-
 func (f *fakeAWSRGTService) GetResources(_ context.Context, input *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	pageLimit := min(int(aws.ToInt32(input.ResourcesPerPage)), f.pageLimit)
 	output := &resourcegroupstaggingapi.GetResourcesOutput{}

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -398,7 +398,7 @@ keys:
 }
 
 func convertKMSTagsToRGT(kmsTags []kmstypes.Tag) []rgttypes.Tag {
-	var out []rgttypes.Tag
+	out := make([]rgttypes.Tag, 0, len(kmsTags))
 	for _, t := range kmsTags {
 		out = append(out, rgttypes.Tag{
 			Key:   t.TagKey,

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -60,6 +62,7 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		tags map[string]string
+		env  map[string]string
 	}{
 		{
 			name: "delete keys with default tags",
@@ -76,10 +79,20 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 				"TeleportCluster": "test-cluster-2",
 			},
 		},
+		{
+			name: "delete keys with tagging api lookup",
+			env: map[string]string{
+				"TELEPORT_UNSTABLE_SCOPED_KMS_KEY_DELETION": "yes",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			const pageSize int = 4
 			fakeKMS := newFakeAWSKMSService(t, clock, "123456789012", "us-west-2", pageSize)
+			fakeRGT := newFakeAWSRGTService(t, clock, "123456789012", "us-west-2", pageSize, fakeKMS)
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
 			cfg := servicecfg.KeystoreConfig{
 				AWSKMS: &servicecfg.AWSKMSConfig{
 					AWSAccount: "123456789012",
@@ -94,6 +107,7 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 				HostUUID:             "uuid",
 				AuthPreferenceGetter: &fakeAuthPreferenceGetter{types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1},
 				awsKMSClient:         fakeKMS,
+				awsRGTClient:         fakeRGT,
 				awsSTSClient: &fakeAWSSTSClient{
 					account: "123456789012",
 				},
@@ -335,6 +349,69 @@ func TestAWSKeyCreationParameters(t *testing.T) {
 	}
 }
 
+type fakeAWSRGTService struct {
+	kms       *fakeAWSKMSService
+	clock     clockwork.Clock
+	account   string
+	region    string
+	pageLimit int
+}
+
+func newFakeAWSRGTService(t *testing.T, clock clockwork.Clock, account string, region string, pageLimit int, kms *fakeAWSKMSService) *fakeAWSRGTService {
+	return &fakeAWSRGTService{
+		clock:     clock,
+		account:   account,
+		region:    region,
+		pageLimit: pageLimit,
+		kms:       kms,
+	}
+}
+
+type fakeAWSRGTResource struct {
+	arn  arn.ARN
+	tags []rgttypes.Tag
+}
+
+func (f *fakeAWSRGTService) GetResources(_ context.Context, input *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	pageLimit := min(int(aws.ToInt32(input.ResourcesPerPage)), f.pageLimit)
+	output := &resourcegroupstaggingapi.GetResourcesOutput{}
+	i := 0
+	if input.PaginationToken != nil {
+		var err error
+		i, err = strconv.Atoi(aws.ToString(input.PaginationToken))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	for ; i < len(f.kms.keys) && len(output.ResourceTagMappingList) < pageLimit; i++ {
+		for _, t := range input.TagFilters {
+			if !f.kms.keys[i].satisfiesFilter(t) {
+				continue
+			}
+		}
+		convertedTags := convertKMSTagsToRGT(f.kms.keys[i].tags)
+		output.ResourceTagMappingList = append(output.ResourceTagMappingList, rgttypes.ResourceTagMapping{
+			ResourceARN: aws.String(f.kms.keys[i].arn.String()),
+			Tags:        convertedTags,
+		})
+	}
+	if i < len(f.kms.keys) {
+		output.PaginationToken = aws.String(strconv.Itoa(i))
+	}
+	return output, nil
+}
+
+func convertKMSTagsToRGT(kmsTags []kmstypes.Tag) []rgttypes.Tag {
+	var out []rgttypes.Tag
+	for _, t := range kmsTags {
+		out = append(out, rgttypes.Tag{
+			Key:   t.TagKey,
+			Value: t.TagValue,
+		})
+	}
+	return out
+}
+
 type fakeAWSKMSService struct {
 	keys               []*fakeAWSKMSKey
 	clock              clockwork.Clock
@@ -372,6 +449,24 @@ func (f fakeAWSKMSKey) replicaArn(region string) string {
 
 func (f fakeAWSKMSKey) hasReplica(region string) bool {
 	return region == f.region || slices.Contains(f.replicas, region)
+}
+
+func (f *fakeAWSKMSKey) satisfiesFilter(filter rgttypes.TagFilter) bool {
+	for _, tag := range f.tags {
+		if aws.ToString(tag.TagKey) != aws.ToString(filter.Key) {
+			continue
+		}
+		if len(filter.Values) == 0 {
+			return true
+		}
+		for _, val := range filter.Values {
+			if aws.ToString(tag.TagValue) == aws.ToString(&val) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (f *fakeAWSKMSService) CreateKey(_ context.Context, input *kms.CreateKeyInput, _ ...func(*kms.Options)) (*kms.CreateKeyOutput, error) {

--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -204,6 +204,7 @@ type Options struct {
 	mrkClient    mrkClient
 	awsSTSClient stsClient
 	kmsClient    *kms.KeyManagementClient
+	awsRGTClient rgtClient
 
 	clockworkOverride clockwork.Clock
 	// GCPKMS uses a special fake clock that seemed more testable at the time.


### PR DESCRIPTION
Scanning all KMS keys in an account can cause slow startup times and excessive resource consumption. Add the option to use the `ResourceGroupsTaggingApi` to enabled filtered KMS key listing.

Resolves https://github.com/gravitational/cloud/issues/12537

Changelog: Allow the use of ResourceGroupsTaggingApi for KMS Key deletion