### PR TITLE
[v17] Docs: fix fmt in example code and missing space in doc

### DIFF
--- a/docs/pages/admin-guides/api/getting-started.mdx
+++ b/docs/pages/admin-guides/api/getting-started.mdx
@@ -108,7 +108,7 @@ func main() {
 	}
 
 	log.Printf("Example success!")
-	log.Printf("Example server response: %s", resp)
+	log.Printf("Example server response: %v", resp)
 	log.Printf("Server version: %s", resp.ServerVersion)
 }
 ```

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -220,7 +220,7 @@ We recommend configuring Teleport as per the below steps:
 
 <Tabs>
 	<TabItem label="Teleport Community Edition" scope="oss">
-**1. Configure Teleport Auth Service** using the below example `teleport.yaml`,and start it
+**1. Configure Teleport Auth Service** using the below example `teleport.yaml`, and start it
 using [systemd](../../management/admin/daemon.mdx). The DEB/RPM installations will
 automatically include the `systemd` configuration.
 


### PR DESCRIPTION
Backport #56697 to branch/v17