### PR TITLE
AWS Roles Anywhere: implement profile filters (sync and list profiles method)

### DIFF
--- a/api/gen/proto/go/teleport/integration/v1/awsra_service.pb.go
+++ b/api/gen/proto/go/teleport/integration/v1/awsra_service.pb.go
@@ -263,7 +263,8 @@ type ListRolesAnywhereProfilesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Integration is the AWS Roles Anywhere Integration name.
 	Integration string `protobuf:"bytes,1,opt,name=integration,proto3" json:"integration,omitempty"`
-	// page_size is the size of the page to request.
+	// page_size is the max size of the page to request.
+	// Depending on the filters, the actual number of profiles returned may be less than this value.
 	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	// next_page_token is the page token.
 	NextPageToken string `protobuf:"bytes,3,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`

--- a/api/gen/proto/go/teleport/integration/v1/awsra_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/integration/v1/awsra_service_grpc.pb.go
@@ -53,6 +53,9 @@ type AWSRolesAnywhereServiceClient interface {
 	// It uses the following API:
 	// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
 	// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+	//
+	// The number of profiles returned is always between 0 and page_size.
+	// If the number of elements is 0, then there are no more profiles to return and the next page token is empty.
 	ListRolesAnywhereProfiles(ctx context.Context, in *ListRolesAnywhereProfilesRequest, opts ...grpc.CallOption) (*ListRolesAnywhereProfilesResponse, error)
 }
 
@@ -100,6 +103,9 @@ type AWSRolesAnywhereServiceServer interface {
 	// It uses the following API:
 	// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
 	// https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+	//
+	// The number of profiles returned is always between 0 and page_size.
+	// If the number of elements is 0, then there are no more profiles to return and the next page token is empty.
 	ListRolesAnywhereProfiles(context.Context, *ListRolesAnywhereProfilesRequest) (*ListRolesAnywhereProfilesResponse, error)
 	mustEmbedUnimplementedAWSRolesAnywhereServiceServer()
 }

--- a/api/proto/teleport/integration/v1/awsra_service.proto
+++ b/api/proto/teleport/integration/v1/awsra_service.proto
@@ -31,6 +31,9 @@ service AWSRolesAnywhereService {
   // It uses the following API:
   // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
   // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
+  //
+  // The number of profiles returned is always between 0 and page_size.
+  // If the number of elements is 0, then there are no more profiles to return and the next page token is empty.
   rpc ListRolesAnywhereProfiles(ListRolesAnywhereProfilesRequest) returns (ListRolesAnywhereProfilesResponse);
 }
 
@@ -73,7 +76,8 @@ message AWSRolesAnywherePingResponse {
 message ListRolesAnywhereProfilesRequest {
   // Integration is the AWS Roles Anywhere Integration name.
   string integration = 1;
-  // page_size is the size of the page to request.
+  // page_size is the max size of the page to request.
+  // Depending on the filters, the actual number of profiles returned may be less than this value.
   int32 page_size = 2;
   // next_page_token is the page token.
   string next_page_token = 3;

--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -230,7 +230,9 @@ func (s *AWSRolesAnywhereService) ListRolesAnywhereProfiles(ctx context.Context,
 	}
 
 	profileList, err := awsra.ListRolesAnywhereProfiles(ctx, listRolesAnywhereClient, awsra.ListRolesAnywhereProfilesRequest{
-		NextToken: req.GetNextPageToken(),
+		NextToken:          req.GetNextPageToken(),
+		ProfileNameFilters: req.GetProfileNameFilters(),
+		PageSize:           int(req.GetPageSize()),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -362,7 +362,7 @@ func validateAWSRolesAnywhereProfileFilters(ig types.Integration) error {
 
 	for _, profileNameFilter := range rolesAnywhereSpec.ProfileSyncConfig.ProfileNameFilters {
 		if _, err := utils.CompileExpression(profileNameFilter); err != nil {
-			return trace.BadParameter("profile name filter %q must be valid expressions: %v", profileNameFilter, err)
+			return trace.BadParameter("invalid filter %q, use glob-like matching or regex by adding the anchors (eg, ^regex$): %v", profileNameFilter, err)
 		}
 	}
 	return nil

--- a/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
+++ b/lib/integrations/awsra/list_rolesanywhere_profiles_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 )
 
 func TestListRolesAnywhereProfiles(t *testing.T) {
@@ -61,6 +64,111 @@ func TestListRolesAnywhereProfiles(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, resp.Profiles, 3)
+}
+
+func TestListRolesAnywhereProfilesPage(t *testing.T) {
+	baseRequestWithMockedProfiles := func(profiles map[string]ratypes.ProfileDetail) func() listRolesAnywhereProfilesRequest {
+		return func() listRolesAnywhereProfilesRequest {
+			return listRolesAnywhereProfilesRequest{
+				raClient: &mockIAMRolesAnywhere{
+					profilesByID: profiles,
+				},
+			}
+		}
+	}
+	rolesAnywhereProfileWithName := func(name string) ratypes.ProfileDetail {
+		return ratypes.ProfileDetail{
+			Name:       aws.String(name),
+			ProfileArn: aws.String(uuid.NewString()),
+		}
+	}
+
+	for _, tt := range []struct {
+		name             string
+		req              func() listRolesAnywhereProfilesRequest
+		expectedResp     func(t *testing.T, page []*integrationv1.RolesAnywhereProfile)
+		expectedErrCheck require.ErrorAssertionFunc
+	}{
+		{
+			name: "no resources",
+			req:  baseRequestWithMockedProfiles(nil),
+			expectedResp: func(t *testing.T, page []*integrationv1.RolesAnywhereProfile) {
+				require.Empty(t, page)
+			},
+			expectedErrCheck: require.NoError,
+		},
+		{
+			name: "some resources",
+			req: baseRequestWithMockedProfiles(map[string]ratypes.ProfileDetail{
+				"id1": rolesAnywhereProfileWithName("ExampleProfile"),
+			}),
+			expectedResp: func(t *testing.T, page []*integrationv1.RolesAnywhereProfile) {
+				require.Len(t, page, 1)
+				require.Equal(t, "ExampleProfile", page[0].Name)
+			},
+			expectedErrCheck: require.NoError,
+		},
+		{
+			name: "with filters using glob",
+			req: func() listRolesAnywhereProfilesRequest {
+				baseReq := baseRequestWithMockedProfiles(map[string]ratypes.ProfileDetail{
+					"id1": rolesAnywhereProfileWithName("TeamA-subteam1"),
+					"id2": rolesAnywhereProfileWithName("TeamA-subteam2"),
+					"id3": rolesAnywhereProfileWithName("TeamA-subteam3"),
+
+					"id4": rolesAnywhereProfileWithName("TeamB-subteam1"),
+					"id5": rolesAnywhereProfileWithName("TeamB-subteam2"),
+					"id6": rolesAnywhereProfileWithName("TeamB-subteam3"),
+				})()
+				baseReq.filters = []string{"TeamB-*"}
+				return baseReq
+			},
+			expectedResp: func(t *testing.T, page []*integrationv1.RolesAnywhereProfile) {
+				require.Len(t, page, 3)
+				profile := page[0]
+				require.NotEmpty(t, profile.Arn)
+				require.Contains(t, profile.Name, "TeamB-subteam")
+			},
+			expectedErrCheck: require.NoError,
+		},
+		{
+			name: "with filters using regex",
+			req: func() listRolesAnywhereProfilesRequest {
+				baseReq := baseRequestWithMockedProfiles(map[string]ratypes.ProfileDetail{
+					"id1": rolesAnywhereProfileWithName("TeamA-subteam1"),
+					"id2": rolesAnywhereProfileWithName("TeamA-subteam2"),
+					"id3": rolesAnywhereProfileWithName("TeamA-subteam3"),
+
+					"id4": rolesAnywhereProfileWithName("TeamB-subteam1"),
+					"id5": rolesAnywhereProfileWithName("TeamB-subteam2"),
+					"id6": rolesAnywhereProfileWithName("TeamB-subteam3"),
+
+					"id7": rolesAnywhereProfileWithName("TeamC-subteam1"),
+					"id8": rolesAnywhereProfileWithName("TeamC-subteam2"),
+					"id9": rolesAnywhereProfileWithName("TeamC-subteam3"),
+
+					"id10": rolesAnywhereProfileWithName("AnotherTeam"),
+				})()
+				baseReq.filters = []string{`^Team[A,B]{1}\-subteam\d$`}
+				return baseReq
+			},
+			expectedResp: func(t *testing.T, page []*integrationv1.RolesAnywhereProfile) {
+				require.Len(t, page, 6)
+				profileNames := make([]string, 0, len(page))
+				for _, profile := range page {
+					profileNames = append(profileNames, profile.Name)
+				}
+				require.Contains(t, profileNames, "TeamA-subteam1")
+			},
+			expectedErrCheck: require.NoError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, _, err := listRolesAnywhereProfilesPage(t.Context(), tt.req())
+			tt.expectedErrCheck(t, err)
+			tt.expectedResp(t, resp)
+		})
+	}
 }
 
 type mockListRolesAnywhereProfiles struct {

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -81,10 +81,9 @@ func Ping(ctx context.Context, clt PingClient) (*PingResponse, error) {
 	var nextToken *string
 	for {
 		listReq := listRolesAnywhereProfilesRequest{
-			raClient: clt,
 			nextPage: nextToken,
 		}
-		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, listReq)
+		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, listReq)
 		if err != nil {
 			errs = append(errs, err)
 			break

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -80,8 +80,11 @@ func Ping(ctx context.Context, clt PingClient) (*PingResponse, error) {
 	profileCounter := 0
 	var nextToken *string
 	for {
-		const useAPIDefaultPageSize = 0
-		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, nextToken, useAPIDefaultPageSize)
+		listReq := listRolesAnywhereProfilesRequest{
+			raClient: clt,
+			nextPage: nextToken,
+		}
+		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, listReq)
 		if err != nil {
 			errs = append(errs, err)
 			break

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -388,10 +388,16 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 		return ret
 	}
 
+	profileNameFilters := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileNameFilters
+
 	var nextPage *string
 	for {
-		const useAPIDefaultPageSize = 0
-		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, nextPage, useAPIDefaultPageSize)
+		listReq := listRolesAnywhereProfilesRequest{
+			raClient: raClient,
+			nextPage: nextPage,
+			filters:  profileNameFilters,
+		}
+		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, listReq)
 		if err != nil {
 			ret.setupError = trace.Wrap(err)
 			return ret

--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -393,11 +393,10 @@ func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfil
 	var nextPage *string
 	for {
 		listReq := listRolesAnywhereProfilesRequest{
-			raClient: raClient,
 			nextPage: nextPage,
 			filters:  profileNameFilters,
 		}
-		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, listReq)
+		profilesListResp, respNextToken, err := listRolesAnywhereProfilesPage(ctx, raClient, listReq)
 		if err != nil {
 			ret.setupError = trace.Wrap(err)
 			return ret

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -110,9 +110,10 @@ func (h *Handler) integrationsCreate(w http.ResponseWriter, r *http.Request, p h
 		}, &types.AWSRAIntegrationSpecV1{
 			TrustAnchorARN: req.Integration.AWSRA.TrustAnchorARN,
 			ProfileSyncConfig: &types.AWSRolesAnywhereProfileSyncConfig{
-				Enabled:    req.Integration.AWSRA.ProfileSyncConfig.Enabled,
-				ProfileARN: req.Integration.AWSRA.ProfileSyncConfig.ProfileARN,
-				RoleARN:    req.Integration.AWSRA.ProfileSyncConfig.RoleARN,
+				Enabled:            req.Integration.AWSRA.ProfileSyncConfig.Enabled,
+				ProfileARN:         req.Integration.AWSRA.ProfileSyncConfig.ProfileARN,
+				RoleARN:            req.Integration.AWSRA.ProfileSyncConfig.RoleARN,
+				ProfileNameFilters: req.Integration.AWSRA.ProfileSyncConfig.ProfileNameFilters,
 			},
 		})
 		if err != nil {
@@ -212,9 +213,10 @@ func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p h
 		spec := integration.GetAWSRolesAnywhereIntegrationSpec()
 		spec.TrustAnchorARN = req.AWSRA.TrustAnchorARN
 		spec.ProfileSyncConfig = &types.AWSRolesAnywhereProfileSyncConfig{
-			Enabled:    req.AWSRA.ProfileSyncConfig.Enabled,
-			ProfileARN: req.AWSRA.ProfileSyncConfig.ProfileARN,
-			RoleARN:    req.AWSRA.ProfileSyncConfig.RoleARN,
+			Enabled:            req.AWSRA.ProfileSyncConfig.Enabled,
+			ProfileARN:         req.AWSRA.ProfileSyncConfig.ProfileARN,
+			RoleARN:            req.AWSRA.ProfileSyncConfig.RoleARN,
+			ProfileNameFilters: req.AWSRA.ProfileSyncConfig.ProfileNameFilters,
 
 			ProfileAcceptsRoleSessionName: spec.ProfileSyncConfig.ProfileAcceptsRoleSessionName,
 		}

--- a/lib/web/integrations_awsra.go
+++ b/lib/web/integrations_awsra.go
@@ -223,8 +223,9 @@ func (h *Handler) awsRolesAnywhereListProfiles(w http.ResponseWriter, r *http.Re
 	}
 
 	listResp, err := clt.IntegrationAWSRolesAnywhereClient().ListRolesAnywhereProfiles(ctx, &integrationv1.ListRolesAnywhereProfilesRequest{
-		Integration:   integrationName,
-		NextPageToken: req.StartKey,
+		Integration:        integrationName,
+		NextPageToken:      req.StartKey,
+		ProfileNameFilters: req.Filters,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -171,9 +171,10 @@ func TestIntegrationsCRUDRolesAnywhere(t *testing.T) {
 		AWSRA: &ui.IntegrationAWSRASpec{
 			TrustAnchorARN: updatedTrustAnchor,
 			ProfileSyncConfig: ui.AWSRAProfileSync{
-				Enabled:    true,
-				ProfileARN: syncProfileARN,
-				RoleARN:    syncRoleARN,
+				Enabled:            true,
+				ProfileARN:         syncProfileARN,
+				RoleARN:            syncRoleARN,
+				ProfileNameFilters: []string{"ExposedProfile-*"},
 			},
 		},
 	}
@@ -197,6 +198,8 @@ func TestIntegrationsCRUDRolesAnywhere(t *testing.T) {
 	require.True(t, integrationObject.AWSRA.ProfileSyncConfig.Enabled)
 	require.Equal(t, syncProfileARN, integrationObject.AWSRA.ProfileSyncConfig.ProfileARN)
 	require.Equal(t, syncRoleARN, integrationObject.AWSRA.ProfileSyncConfig.RoleARN)
+	require.Len(t, integrationObject.AWSRA.ProfileSyncConfig.ProfileNameFilters, 1)
+	require.Equal(t, "ExposedProfile-*", integrationObject.AWSRA.ProfileSyncConfig.ProfileNameFilters[0])
 
 	// Delete Integration
 	err = wPack.server.Auth().DeleteIntegration(ctx, integrationName)

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -68,6 +68,21 @@ type AWSRAProfileSync struct {
 
 	// RoleARN is the ARN of the IAM Role that is used to sync profiles.
 	RoleARN string `json:"roleArn"`
+
+	// ProfileNameFilters are the filters applied to the profiles.
+	// Only matching profiles will be synchronized as application servers.
+	// If empty, no filtering is applied.
+	//
+	// Filters can be globs, for example:
+	//
+	//	profile*
+	//	*name*
+	//
+	// Or regexes if they're prefixed and suffixed with ^ and $, for example:
+	//
+	//	^profile.*$
+	//	^.*name.*$
+	ProfileNameFilters []string `json:"filters"`
 }
 
 // CheckAndSetDefaults for the aws oidc integration spec.
@@ -355,9 +370,10 @@ func MakeIntegration(ig types.Integration) (*Integration, error) {
 		ret.AWSRA = &IntegrationAWSRASpec{
 			TrustAnchorARN: spec.TrustAnchorARN,
 			ProfileSyncConfig: AWSRAProfileSync{
-				Enabled:    spec.ProfileSyncConfig.Enabled,
-				ProfileARN: spec.ProfileSyncConfig.ProfileARN,
-				RoleARN:    spec.ProfileSyncConfig.RoleARN,
+				Enabled:            spec.ProfileSyncConfig.Enabled,
+				ProfileARN:         spec.ProfileSyncConfig.ProfileARN,
+				RoleARN:            spec.ProfileSyncConfig.RoleARN,
+				ProfileNameFilters: spec.ProfileSyncConfig.ProfileNameFilters,
 			},
 		}
 	}
@@ -699,4 +715,19 @@ type AWSRolesAnywhereListProfilesRequest struct {
 	// StartKey is the token to be used to fetch the next page.
 	// If empty, the first page is fetched.
 	StartKey string `json:"startKey"`
+
+	// Filters are the filters applied to the profiles.
+	// Only matching profiles will be synchronized as application servers.
+	// If empty, no filtering is applied.
+	//
+	// Filters can be globs, for example:
+	//
+	//	profile*
+	//	*name*
+	//
+	// Or regexes if they're prefixed and suffixed with ^ and $, for example:
+	//
+	//	^profile.*$
+	//	^.*name.*$
+	Filters []string `json:"filters"`
 }


### PR DESCRIPTION
This PR implements the Profile filter by name in two places:
- profile sync
- list profiles (used by WebUI to let the user know how what the sync process will filter)

It's trying to mimic the Okta Group/App and AWS IC filters, where we support both globing and regex.