### PR TITLE
Introduce modulestest package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,6 +172,7 @@ linters:
         test_packages:
           files:
             - '!$test'
+            - '!**/integrations/operator/controllers/resources/testlib/**.go'
           deny:
             - pkg: github.com/gravitational/teleport/e/lib/aws/identitycenter/test
               desc: testing packages should not be imported outside of _test.go files
@@ -194,6 +195,8 @@ linters:
             - pkg: github.com/gravitational/teleport/lib/srv/db/spanner/protocoltest
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/srv/db/clickhouse/protocoltest
+              desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/modules/modulestest
               desc: testing packages should not be imported outside of _test.go files
         testify:
           files:
@@ -263,6 +266,7 @@ linters:
             - '!**/lib/cryptosuites/precompute.go'
             - '!**/lib/cryptosuites/internal/rsa/rsa.go'
             - '!**/lib/events/test/**'
+            - '!**/lib/modules/modulestest/**'
             - '!**/lib/modules/test.go'
             - '!**/lib/service/service.go'
             - '!**/lib/services/local/users.go'

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/app/common"
@@ -266,7 +267,7 @@ func testForwardModes(p *Pack, t *testing.T) {
 // testClientCert tests mutual TLS authentication flow with application
 // access typically used in CLI by curl and other clients.
 func testClientCert(p *Pack, t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/integration/autoupdate/tools/main_test.go
+++ b/integration/autoupdate/tools/main_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/integration/helpers/archive"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 const (
@@ -61,7 +62,7 @@ var (
 
 func TestMain(m *testing.M) {
 	modules.SetInsecureTestMode(true)
-	modules.SetModules(&modules.TestModules{TestBuildType: modules.BuildCommunity})
+	modules.SetModules(&modulestest.Modules{TestBuildType: modules.BuildCommunity})
 	ctx := context.Background()
 	tmp, err := os.MkdirTemp(os.TempDir(), testBinaryName)
 	if err != nil {

--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db"
@@ -100,7 +101,7 @@ func TestDatabaseAccessSeparateListeners(t *testing.T) {
 // testIPPinning tests a scenario where a user with IP pinning
 // connects to a database
 func (p *DatabasePack) testIPPinning(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -59,7 +60,7 @@ func TestMain(m *testing.M) {
 	// Enable HSM feature.
 	// This is safe to do here, as all tests in this package require HSM to be
 	// enabled.
-	modules.SetModules(&modules.TestModules{
+	modules.SetModules(&modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -90,6 +90,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -206,7 +207,7 @@ func TestIntegrations(t *testing.T) {
 
 // testDifferentPinnedIP tests connection is rejected when source IP doesn't match the pinned one
 func testDifferentPinnedIP(t *testing.T, suite *integrationTestSuite) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
@@ -7758,7 +7759,7 @@ func isNilOrEOFErr(t *testing.T, err error) {
 }
 
 func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 
@@ -8562,7 +8563,7 @@ func TestProxySSHPortMultiplexing(t *testing.T) {
 // can/cannot be established with an existing certificate
 // based on cluster configuration or roles.
 func TestConnectivityWithoutAuth(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	tests := []struct {
 		name         string
@@ -8921,7 +8922,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 }
 
 func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	const password = "supersecretpassword"
 	inputReader := prompt.NewFakeReader().

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -81,6 +81,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -1367,7 +1368,7 @@ func testKubeTransportProtocol(t *testing.T, suite *KubeSuite) {
 
 // TODO: test against tsh kubectl
 func testKubeEphemeralContainers(t *testing.T, suite *KubeSuite) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -153,7 +154,7 @@ func TestProxyTunnelStrategyProxyPeering(t *testing.T) {
 	t.Skip("this test is flaky as it very sensitive to our timeouts")
 
 	// This test cannot run in parallel as set module changes the global state.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -53,6 +53,7 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -1120,7 +1121,7 @@ func testListDatabaseUsers(t *testing.T, pack *dbhelpers.DatabasePack) {
 	// Allow resource access requests to be created.
 	currentModules := modules.GetModules()
 	t.Cleanup(func() { modules.SetModules(currentModules) })
-	modules.SetModules(&modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modules.SetModules(&modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	rootClusterName, _, err := net.SplitHostPort(pack.Root.Cluster.Web)
 	require.NoError(t, err)

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -270,7 +271,7 @@ func TestAccessListReminders_NoneForNonDynamic(t *testing.T) {
 }
 
 func TestAccessListReminders_Batched(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Identity: {Enabled: true},

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -97,7 +98,7 @@ func ValidRandomResourceName(prefix string) string {
 }
 
 func defaultTeleportServiceConfig(t *testing.T) (*helpers.TeleInstance, string) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -189,7 +190,7 @@ func newAccessRequestTestPack(ctx context.Context, t *testing.T) *accessRequestT
 }
 
 func TestAccessRequest(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -1440,7 +1441,7 @@ func TestCreateSuggestions(t *testing.T) {
 }
 
 func TestPromotedRequest(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -1542,7 +1543,7 @@ func TestPromotedRequest(t *testing.T) {
 func TestUpdateAccessRequestWithAdditionalReviewers(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Identity: {Enabled: true},
@@ -1911,7 +1912,7 @@ type accessRequestWithStartTime struct {
 func createAccessRequestWithStartTime(t *testing.T) accessRequestWithStartTime {
 	t.Helper()
 
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 // TestGenerateAndUpsertRecoveryCodes tests the following:
@@ -141,7 +142,7 @@ func TestStartAccountRecovery(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -209,7 +210,7 @@ func TestStartAccountRecovery_WithLock(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -234,7 +235,7 @@ func TestStartAccountRecovery_UserErrors(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -296,7 +297,7 @@ func TestVerifyAccountRecovery_WithAuthnErrors(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -419,7 +420,7 @@ func TestVerifyAccountRecovery_WithLock(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -450,7 +451,7 @@ func TestVerifyAccountRecovery_WithErrors(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -549,7 +550,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -670,7 +671,7 @@ func TestCompleteAccountRecovery_WithErrors(t *testing.T) {
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	srv.Auth().emitter = mockEmitter
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -847,7 +848,7 @@ func TestAccountRecoveryFlow(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -1100,7 +1101,7 @@ func TestCreateAccountRecoveryCodes(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -1208,7 +1209,7 @@ func TestGetAccountRecoveryCodes(t *testing.T) {
 	srv := newTestTLSServer(t)
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -1611,7 +1612,7 @@ func TestSSOAccountRecoveryProhibited(t *testing.T) {
 	ctx := context.Background()
 
 	// Enable RecoveryCodes feature.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -79,6 +79,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -487,7 +488,7 @@ func TestAuthenticateWebUser_deviceWebToken(t *testing.T) {
 
 func TestAuthenticateWebUser_trustedDeviceRequirement(t *testing.T) {
 	// Can't t.Parallel because of modules.SetTestModules.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 
@@ -2377,7 +2378,7 @@ func setupUserForAugmentWebSessionCertificatesTest(t *testing.T, testServer *Tes
 }
 
 func TestGenerateUserCertIPPinning(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	s := newAuthSuite(t)
 
@@ -3007,7 +3008,7 @@ func TestGenerateUserCertWithHardwareKeySupport(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				MockAttestationData: tt.mockAttestationData,
 			})
 
@@ -4624,7 +4625,7 @@ func TestCleanupNotifications(t *testing.T) {
 func TestCreateAccessListReminderNotifications(t *testing.T) {
 	ctx := context.Background()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -4769,14 +4770,14 @@ func createAccessList(t *testing.T, authServer *Server, name string, opts ...cre
 func TestServer_GetAnonymizationKey(t *testing.T) {
 	tests := []struct {
 		name        string
-		testModules *modules.TestModules
+		testModules modulestest.Modules
 		license     *license.License
 		want        string
 		errCheck    require.ErrorAssertionFunc
 	}{
 		{
 			name: "returns CloudAnonymizationKey if present",
-			testModules: &modules.TestModules{
+			testModules: modulestest.Modules{
 				TestFeatures: modules.Features{CloudAnonymizationKey: []byte("cloud-key")},
 			},
 			license: &license.License{
@@ -4787,7 +4788,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 		},
 		{
 			name:        "Returns license AnonymizationKey if no Cloud Key is present",
-			testModules: &modules.TestModules{},
+			testModules: modulestest.Modules{},
 			license: &license.License{
 				AnonymizationKey: []byte("license-key"),
 			},
@@ -4796,7 +4797,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 		},
 		{
 			name:        "Returns clusterID if no cloud key nor license key is present",
-			testModules: &modules.TestModules{},
+			testModules: modulestest.Modules{},
 			license:     &license.License{},
 			want:        "cluster-id",
 			errCheck:    require.NoError,
@@ -4817,7 +4818,7 @@ func TestServer_GetAnonymizationKey(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, testTLSServer.Close()) })
 
-			modules.SetTestModules(t, tt.testModules)
+			modulestest.SetTestModules(t, tt.testModules)
 
 			testTLSServer.AuthServer.AuthServer.SetLicense(tt.license)
 
@@ -5061,7 +5062,7 @@ func TestValidServerHostname(t *testing.T) {
 func TestCreateAuthPreference(t *testing.T) {
 	cases := []struct {
 		name       string
-		modules    modules.Modules
+		modules    *modulestest.Modules
 		preference func(p types.AuthPreference)
 		assertion  func(t *testing.T, created types.AuthPreference, err error)
 	}{
@@ -5078,7 +5079,7 @@ func TestCreateAuthPreference(t *testing.T) {
 		},
 		{
 			name:    "creation allowed when hardware key policy is set in enterprise",
-			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			modules: &modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 			preference: func(p types.AuthPreference) {
 				pp := p.(*types.AuthPreferenceV2)
 				pp.Spec.RequireMFAType = types.RequireMFAType_HARDWARE_KEY_PIN
@@ -5105,7 +5106,7 @@ func TestCreateAuthPreference(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
+				modulestest.SetTestModules(t, *test.modules)
 			}
 
 			bk, err := memory.New(memory.Config{})

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -77,6 +77,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/okta/oktatest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
@@ -1991,7 +1992,7 @@ func TestClusterNetworkingCloudUpdates(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
 					Cloud: tc.cloud,
@@ -3220,7 +3221,7 @@ func TestGetAndList_ApplicationServers(t *testing.T) {
 
 func TestListSAMLIdPServiceProviderWithCache(t *testing.T) {
 	// Set license to enterprise in order to be able to list SAML IdP service providers.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 	ctx := context.Background()
@@ -3271,7 +3272,7 @@ func TestListSAMLIdPServiceProviderWithCache(t *testing.T) {
 // RBAC and search filters when fetching SAML IdP service providers.
 func TestListSAMLIdPServiceProviderAndListResources(t *testing.T) {
 	// Set license to enterprise in order to be able to list SAML IdP service providers.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 
@@ -10129,7 +10130,7 @@ func TestCloudDefaultPasswordless(t *testing.T) {
 			ctx := context.Background()
 			srv := newTestTLSServer(t)
 
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
 					Cloud: tc.cloud,

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -38,6 +38,7 @@ import (
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
@@ -879,12 +880,12 @@ func generateGroups(n int, days []string) []*autoupdatev1pb.AgentAutoUpdateGroup
 }
 
 func TestValidateServerSideAgentConfig(t *testing.T) {
-	cloudModules := &modules.TestModules{
+	cloudModules := modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 		},
 	}
-	cloudUnlimitedModules := &modules.TestModules{
+	cloudUnlimitedModules := modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -892,7 +893,7 @@ func TestValidateServerSideAgentConfig(t *testing.T) {
 			},
 		},
 	}
-	selfHostedModules := &modules.TestModules{
+	selfHostedModules := modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: false,
 		},
@@ -900,7 +901,7 @@ func TestValidateServerSideAgentConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		config    *autoupdatev1pb.AutoUpdateConfigSpecAgents
-		modules   modules.Modules
+		modules   modulestest.Modules
 		expectErr require.ErrorAssertionFunc
 	}{
 		{
@@ -1049,7 +1050,7 @@ func TestValidateServerSideAgentConfig(t *testing.T) {
 					Agents: tt.config,
 				})
 			require.NoError(t, err)
-			modules.SetTestModules(t, tt.modules)
+			modulestest.SetTestModules(t, tt.modules)
 
 			// Test execution.
 			tt.expectErr(t, validateServerSideAgentConfig(config))

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -422,7 +423,7 @@ func TestCreateClusterNetworkingConfig(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		modules    modules.Modules
+		modules    *modulestest.Modules
 		authorizer authz.Authorizer
 		config     func(p types.ClusterNetworkingConfig)
 		assertion  func(t *testing.T, created types.ClusterNetworkingConfig, err error)
@@ -472,7 +473,7 @@ func TestCreateClusterNetworkingConfig(t *testing.T) {
 			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
 				return authRoleContext, nil
 			}),
-			modules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+			modules: &modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 			config: func(p types.ClusterNetworkingConfig) {
 				p.SetTunnelStrategy(&types.TunnelStrategyV1{
 					Strategy: &types.TunnelStrategyV1_ProxyPeering{
@@ -490,7 +491,7 @@ func TestCreateClusterNetworkingConfig(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
+				modulestest.SetTestModules(t, *test.modules)
 			}
 
 			var opts []serviceOpt
@@ -655,7 +656,7 @@ func TestUpdateClusterNetworkingConfig(t *testing.T) {
 				return cnc
 			}(),
 			config: func(p types.ClusterNetworkingConfig) {
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestBuildType: modules.BuildEnterprise,
 					TestFeatures: modules.Features{
 						Cloud: true,
@@ -683,7 +684,7 @@ func TestUpdateClusterNetworkingConfig(t *testing.T) {
 				}, nil
 			}),
 			config: func(p types.ClusterNetworkingConfig) {
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestBuildType: modules.BuildEnterprise,
 					TestFeatures: modules.Features{
 						Cloud: true,
@@ -716,7 +717,7 @@ func TestUpdateClusterNetworkingConfig(t *testing.T) {
 				return cnc
 			}(),
 			config: func(p types.ClusterNetworkingConfig) {
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestBuildType: modules.BuildEnterprise,
 					TestFeatures: modules.Features{
 						Cloud: true,
@@ -966,7 +967,7 @@ func TestCreateSessionRecordingConfig(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		modules    modules.Modules
+		modules    *modulestest.Modules
 		authorizer authz.Authorizer
 		assertion  func(t *testing.T, created types.SessionRecordingConfig, err error)
 	}{
@@ -998,7 +999,7 @@ func TestCreateSessionRecordingConfig(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			if test.modules != nil {
-				modules.SetTestModules(t, test.modules)
+				modulestest.SetTestModules(t, *test.modules)
 			}
 
 			var opts []serviceOpt
@@ -1866,14 +1867,14 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			name: "authorized proxy with non empty access graph config; Policy module is enabled",
 			role: types.RoleProxy,
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			accessGraphConfig: cfgEnabled,
 			errorAssertion:    require.NoError,
@@ -1891,14 +1892,14 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			name: "authorized discovery with non empty access graph config; Policy module is enabled",
 			role: types.RoleDiscovery,
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			accessGraphConfig: cfgEnabled,
 			errorAssertion:    require.NoError,
@@ -1916,14 +1917,14 @@ func TestGetAccessGraphConfig(t *testing.T) {
 			name: "Policy module is enabled with secrets scan option",
 			role: types.RoleDiscovery,
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			accessGraphConfig:   cfgEnabled,
 			accessGraphSettings: settings,
@@ -2074,14 +2075,14 @@ func TestUpdateAccessGraphSettings(t *testing.T) {
 		{
 			name: "updated",
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
 				return &authz.Context{
@@ -2199,14 +2200,14 @@ func TestUpsertAccessGraphSettings(t *testing.T) {
 		{
 			name: "upserted",
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
 				return &authz.Context{
@@ -2293,14 +2294,14 @@ func TestResetAccessGraphSettings(t *testing.T) {
 		{
 			name: "reset",
 			testSetup: func(t *testing.T) {
-				m := modules.TestModules{
+				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 							entitlements.Policy: {Enabled: true},
 						},
 					},
 				}
-				modules.SetTestModules(t, &m)
+				modulestest.SetTestModules(t, m)
 			},
 			authorizer: authz.AuthorizerFunc(func(ctx context.Context) (*authz.Context, error) {
 				return &authz.Context{

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -27,12 +27,13 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 // TestDesktopAccessDisabled makes sure desktop access can be disabled via modules.
 // Since desktop connections require a cert, this is mediated via the cert generating function.
 func TestDesktopAccessDisabled(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Desktop: {Enabled: false}, // Explicitly turn off desktop access.

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/loginrule"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -523,7 +524,7 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 			}
 
 			if tt.isEnterprise {
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestBuildType: modules.BuildEnterprise,
 				})
 			}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -81,6 +81,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
@@ -1038,7 +1039,7 @@ func TestGenerateUserCerts_deviceExtensions(t *testing.T) {
 }
 
 func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -1282,7 +1283,7 @@ func TestGenerateUserCerts_deviceAuthz(t *testing.T) {
 
 // Test that device trust is required for a user registering their first MFA device.
 func TestRegisterFirstDevice_deviceAuthz(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise, // required for Device Trust.
 	})
 
@@ -1410,7 +1411,7 @@ func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.Databas
 }
 
 func TestGenerateUserCerts_singleUseCerts(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise, // required for IP pinning.
 		TestFeatures:  modules.GetModules().Features(),
 	})
@@ -2436,11 +2437,11 @@ var requireMFATypes = []types.RequireMFAType{
 }
 
 func TestIsMFARequired(t *testing.T) {
-	testModules := &modules.TestModules{
+	testModules := modulestest.Modules{
 		TestBuildType:       modules.BuildEnterprise,
 		MockAttestationData: &keys.AttestationData{},
 	}
-	modules.SetTestModules(t, testModules)
+	modulestest.SetTestModules(t, testModules)
 
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
@@ -2616,7 +2617,7 @@ func TestIsMFARequired_unauthorized(t *testing.T) {
 }
 
 func TestIsMFARequired_nodeMatch(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	ctx := context.Background()
 	srv := newTestTLSServer(t)
@@ -4689,7 +4690,7 @@ func TestExport(t *testing.T) {
 // request if the calling user does not have permissions to create or update
 // a SAML connector.
 func TestSAMLValidation(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.SAML: {Enabled: true},
@@ -5258,7 +5259,7 @@ func TestUpsertApplicationServerOrigin(t *testing.T) {
 }
 
 func TestGetAccessGraphConfig(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Policy: {Enabled: true},

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -207,7 +208,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 		assert.Equal(t, suiteName(expected), suiteName(actual))
 	}
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.HSM: {Enabled: true},
@@ -288,7 +289,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 				for desc, tc := range testCases {
 					t.Run(desc, func(t *testing.T) {
 						if tc.cloud {
-							modules.SetTestModules(t, &modules.TestModules{
+							modulestest.SetTestModules(t, modulestest.Modules{
 								TestFeatures: modules.Features{
 									Cloud: true,
 									Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -369,7 +370,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 		for desc, tc := range testCases {
 			t.Run(desc, func(t *testing.T) {
 				if tc.cloud {
-					modules.SetTestModules(t, &modules.TestModules{
+					modulestest.SetTestModules(t, modulestest.Modules{
 						TestFeatures: modules.Features{
 							Cloud: true,
 							Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -1302,7 +1303,7 @@ func TestPresets(t *testing.T) {
 	})
 
 	t.Run("Enterprise", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestBuildType: modules.BuildEnterprise,
 		})
 
@@ -1395,13 +1396,13 @@ func TestPresets(t *testing.T) {
 
 func TestGetPresetUsers(t *testing.T) {
 	// no preset users for OSS
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildOSS,
 	})
 	require.Empty(t, getPresetUsers())
 
 	// preset user @teleport-access-approval-bot on enterprise
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 	require.Equal(t, []types.User{

--- a/lib/auth/integration/integrationv1/credentials_test.go
+++ b/lib/auth/integration/integrationv1/credentials_test.go
@@ -30,10 +30,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestExportIntegrationCertAuthorities(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	ca := newCertAuthority(t, types.HostCA, "test-cluster")
 	ctx, localClient, resourceSvc := initSvc(t, ca, ca.GetClusterName(), "127.0.0.1")

--- a/lib/auth/integration/integrationv1/github_test.go
+++ b/lib/auth/integration/integrationv1/github_test.go
@@ -33,10 +33,11 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestGenerateGitHubUserCert(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	ca := newCertAuthority(t, types.HostCA, "test-cluster")
 	ctx, _, resourceSvc := initSvc(t, ca, ca.GetClusterName(), "127.0.0.1.nip.io")

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -55,7 +56,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationCRUD(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	clusterName := "test-cluster"
 	proxyPublicAddr := "127.0.0.1.nip.io"

--- a/lib/auth/join_bitbucket_test.go
+++ b/lib/auth/join_bitbucket_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/bitbucket"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 const fakeBitbucketIDPURL = "https://api.bitbucket.org/2.0/workspaces/example/pipelines-config/identity/oidc"
@@ -265,9 +266,9 @@ func TestAuth_RegisterUsingToken_Bitbucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnterprise {
-				modules.SetTestModules(
+				modulestest.SetTestModules(
 					t,
-					&modules.TestModules{TestBuildType: modules.BuildEnterprise},
+					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
 

--- a/lib/auth/join_github_test.go
+++ b/lib/auth/join_github_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/githubactions"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 type mockIDTokenValidator struct {
@@ -401,9 +402,9 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(idTokenValidator.reset)
 			if tt.setEnterprise {
-				modules.SetTestModules(
+				modulestest.SetTestModules(
 					t,
-					&modules.TestModules{TestBuildType: modules.BuildEnterprise},
+					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
 			token, err := types.NewProvisionTokenFromSpec(

--- a/lib/auth/join_spacelift_test.go
+++ b/lib/auth/join_spacelift_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/spacelift"
 )
 
@@ -262,9 +263,9 @@ func TestAuth_RegisterUsingToken_Spacelift(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnterprise {
-				modules.SetTestModules(
+				modulestest.SetTestModules(
 					t,
-					&modules.TestModules{TestBuildType: modules.BuildEnterprise},
+					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
 

--- a/lib/auth/join_terraformcloud_test.go
+++ b/lib/auth/join_terraformcloud_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/terraformcloud"
 )
 
@@ -395,9 +396,9 @@ func TestAuth_RegisterUsingToken_Terraform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnterprise {
-				modules.SetTestModules(
+				modulestest.SetTestModules(
 					t,
-					&modules.TestModules{TestBuildType: modules.BuildEnterprise},
+					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
 

--- a/lib/auth/join_tpm_test.go
+++ b/lib/auth/join_tpm_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/tpm"
 )
 
@@ -327,9 +328,9 @@ func TestServer_RegisterUsingTPMMethod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockValidator.setup(tt.validateReturnTPM, tt.validateReturnErr)
 			if !tt.setOSS {
-				modules.SetTestModules(
+				modulestest.SetTestModules(
 					t,
-					&modules.TestModules{TestBuildType: modules.BuildEnterprise},
+					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
 

--- a/lib/auth/moderated_sessions_test.go
+++ b/lib/auth/moderated_sessions_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -35,7 +36,7 @@ import (
 // license does not support the moderated sessions feature.
 func TestUnmoderatedSessionsAllowed(t *testing.T) {
 	// Use OSS License (which doesn't support moderated sessions).
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildOSS})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildOSS})
 
 	srv := &Server{
 		clock:    clockwork.NewRealClock(),
@@ -63,7 +64,7 @@ func TestUnmoderatedSessionsAllowed(t *testing.T) {
 // Since moderated sessions require trackers, we mediate this in the tracker creation function.
 func TestModeratedSessionsDisabled(t *testing.T) {
 	// Use OSS License (which doesn't support moderated sessions).
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildOSS})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildOSS})
 
 	srv := &Server{
 		clock:    clockwork.NewRealClock(),
@@ -103,7 +104,7 @@ func TestModeratedSessionsDisabled(t *testing.T) {
 // requirements when the license supports it.
 func TestModeratedSesssionsEnabled(t *testing.T) {
 	// Use Enterprise License (which supports moderated sessions).
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	srv := &Server{
 		clock:    clockwork.NewRealClock(),

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -1683,7 +1684,7 @@ func TestWebSessionWithoutAccessRequest(t *testing.T) {
 
 func TestWebSessionMultiAccessRequests(t *testing.T) {
 	// Can not use t.Parallel() when changing modules
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/lib/auth/trust/trustv1/trustedcluster_test.go
+++ b/lib/auth/trust/trustv1/trustedcluster_test.go
@@ -29,6 +29,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -50,7 +51,7 @@ func TestCloudProhibited(t *testing.T) {
 	service, err := NewService(cfg)
 	require.NoError(t, err)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{Cloud: true},
 	})
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -36,6 +36,7 @@ import (
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 )
@@ -387,7 +388,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("Cloud prohibits adding leaf clusters", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{Cloud: true},
 		})
 

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	eventstest "github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -75,7 +76,7 @@ func TestAccessRequest_WithAndWithoutLimit(t *testing.T) {
 
 	// Lift limit, expect no limit error.
 	s.features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Enabled: true, Limit: 0}
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: s.features,
 	})
 	_, err = s.testpack.a.CreateAccessRequestV2(ctx, req, tlsca.Identity{})
@@ -83,7 +84,7 @@ func TestAccessRequest_WithAndWithoutLimit(t *testing.T) {
 
 	// Put back limit, expect limit error.
 	s.features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Enabled: true, Limit: 1}
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: s.features,
 	})
 	_, err = s.testpack.a.CreateAccessRequestV2(ctx, req, tlsca.Identity{})
@@ -113,7 +114,7 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 	features := modules.GetModules().Features()
 	features.IsUsageBasedBilling = true
 	features.Entitlements[entitlements.AccessRequests] = modules.EntitlementInfo{Limit: monthlyLimit, Enabled: true}
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: features,
 	})
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
@@ -567,7 +568,7 @@ func TestAccessLists(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: modules.BuildEnterprise,
 				TestFeatures: modules.Features{
 					Cloud: test.cloud,

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/readonly"
@@ -390,7 +391,7 @@ func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
 	}
 
 	// Enterprise is necessary for mode=optional and mode=required to work.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -79,7 +79,8 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
-	modules "github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -91,7 +92,7 @@ import (
 const eventBufferSize = 1024
 
 func TestMain(m *testing.M) {
-	modules.SetModules(&modules.TestModules{
+	modules.SetModules(&modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Identity: {Enabled: true},

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -5257,7 +5258,7 @@ func TestSignatureAlgorithmSuite(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: tc.cloud,
 				},

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -38,6 +38,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 )
 
@@ -735,7 +736,7 @@ func TestAuthenticationConfig_RequireSessionMFA(t *testing.T) {
 
 func TestAuthenticationConfig_Parse_deviceTrustPB(t *testing.T) {
 	// Device trust mode=required is an Enterprise feature.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -240,7 +241,7 @@ func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.Device
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: test.buildType,
 			})
 

--- a/lib/devicetrust/config/config_test.go
+++ b/lib/devicetrust/config/config_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestValidateConfigAgainstModules(t *testing.T) {
@@ -98,7 +99,7 @@ func TestValidateConfigAgainstModules(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: test.buildType,
 			})
 
@@ -159,7 +160,7 @@ func TestGetEnforcementMode(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: test.buildType,
 			})
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -46,7 +46,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -642,7 +642,7 @@ func TestEndpoints(t *testing.T) {
 			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
 			if tt.fips {
 				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					FIPS: true,
 				})
 			}

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -205,7 +205,7 @@ func TestEndpoints(t *testing.T) {
 			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
 			if tt.fips {
 				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					FIPS: true,
 				})
 			}

--- a/lib/integrations/awsoidc/credprovider/credentialscache_test.go
+++ b/lib/integrations/awsoidc/credprovider/credentialscache_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
 
@@ -75,7 +76,7 @@ func TestCredentialsCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -75,13 +76,13 @@ func TestConfiguratorIsUsed(t *testing.T) {
 	draftConfig := testDraftExternalAuditStorage(t)
 	tests := []struct {
 		name              string
-		modules           *modules.TestModules
+		modules           modulestest.Modules
 		resourceServiceFn func(t *testing.T, s *local.ExternalAuditStorageService)
 		wantIsUsed        bool
 	}{
 		{
 			name: "not cloud",
-			modules: &modules.TestModules{
+			modules: modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: false,
 				},
@@ -90,7 +91,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 		},
 		{
 			name: "cloud team",
-			modules: &modules.TestModules{
+			modules: modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud:               true,
 					IsUsageBasedBilling: true,
@@ -100,7 +101,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 		},
 		{
 			name: "cloud enterprise without config",
-			modules: &modules.TestModules{
+			modules: modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: true,
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -112,7 +113,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 		},
 		{
 			name: "cloud enterprise with only draft",
-			modules: &modules.TestModules{
+			modules: modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: true,
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -131,7 +132,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 		},
 		{
 			name: "cloud enterprise with cluster config",
-			modules: &modules.TestModules{
+			modules: modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: true,
 					Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -164,7 +165,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 				tt.resourceServiceFn(t, ecaSvc)
 			}
 
-			modules.SetTestModules(t, tt.modules)
+			modulestest.SetTestModules(t, tt.modules)
 
 			c, err := NewConfigurator(ctx, ecaSvc, integrationSvc, nil /*alertService*/)
 			require.NoError(t, err)
@@ -180,7 +181,7 @@ func TestConfiguratorIsUsed(t *testing.T) {
 func TestCredentialsCache(t *testing.T) {
 	ctx := t.Context()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -336,7 +337,7 @@ func TestCredentialsCache(t *testing.T) {
 func TestDraftConfigurator(t *testing.T) {
 	ctx := t.Context()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -46,11 +46,12 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestModeratedSessions(t *testing.T) {
 	// enable enterprise features to have access to ModeratedSessions.
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
 		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 			entitlements.K8s: {Enabled: true},
 		},
@@ -500,7 +501,7 @@ func validateSessionTracker(testCtx *TestContext, sessionID string, reason strin
 // Lock watcher connection to be stale and it takes ~5 minutes to happen.
 func TestInteractiveSessionsNoAuth(t *testing.T) {
 	// enable enterprise features to have access to ModeratedSessions.
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise, TestFeatures: modules.Features{
 		Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 			entitlements.K8s: {Enabled: true},
 		},

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestMain(m *testing.M) {
@@ -51,7 +52,7 @@ func TestValidateAuthPreferenceOnCloud(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Cloud: true,
@@ -98,7 +99,7 @@ func TestValidateSessionRecordingConfigOnCloud(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Cloud: true,

--- a/lib/modules/modulestest/modules.go
+++ b/lib/modules/modulestest/modules.go
@@ -1,0 +1,150 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package modulestest
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// Modules is an implementation of [modules.Modules] to be
+// used in tests that need to exercise various conditions
+// dictacted by a specific feature set.
+type Modules struct {
+	// TestBuild is returned from the BuildType function.
+	TestBuildType string
+	// TestFeatures is returned from the Features function.
+	TestFeatures modules.Features
+	// FIPS is returned from the IsBoringBinary function.
+	FIPS bool
+	// MockAttestationData is fake attestation data to return
+	// during tests when hardware key support is enabled. This
+	// attestation data is shared by all logins when set.
+	MockAttestationData *keys.AttestationData
+
+	GenerateAccessRequestPromotionsFn func(ctx context.Context, accessListGetter modules.AccessResourcesGetter, accessReq types.AccessRequest) (*types.AccessRequestAllowedPromotions, error)
+}
+
+// AttestHardwareKey implements modules.Modules.
+func (m *Modules) AttestHardwareKey(context.Context, any, *hardwarekey.AttestationStatement, crypto.PublicKey, time.Duration) (*keys.AttestationData, error) {
+	if m.MockAttestationData != nil {
+		return m.MockAttestationData, nil
+	}
+	return nil, trace.NotFound("no attestation data for the given key")
+}
+
+// BuildType implements modules.Modules.
+func (m *Modules) BuildType() string {
+	return m.TestBuildType
+}
+
+// EnableAccessGraph implements modules.Modules.
+func (m *Modules) EnableAccessGraph() {}
+
+// EnableAccessMonitoring implements modules.Modules.
+func (m *Modules) EnableAccessMonitoring() {}
+
+// EnablePlugins implements modules.Modules.
+func (m *Modules) EnablePlugins() {}
+
+// EnableRecoveryCodes implements modules.Modules.
+func (m *Modules) EnableRecoveryCodes() {}
+
+// Features implements modules.Modules.
+func (m *Modules) Features() modules.Features {
+	return m.TestFeatures
+}
+
+// GenerateAccessRequestPromotions implements modules.Modules.
+func (m *Modules) GenerateAccessRequestPromotions(ctx context.Context, getter modules.AccessResourcesGetter, request types.AccessRequest) (*types.AccessRequestAllowedPromotions, error) {
+	if m.GenerateAccessRequestPromotionsFn != nil {
+		return m.GenerateAccessRequestPromotionsFn(ctx, getter, request)
+	}
+	return types.NewAccessRequestAllowedPromotions(nil), nil
+}
+
+// GetSuggestedAccessLists implements modules.Modules.
+func (m *Modules) GetSuggestedAccessLists(ctx context.Context, identity *tlsca.Identity, clt modules.AccessListSuggestionClient, accessListGetter modules.AccessListAndMembersGetter, requestID string) ([]*accesslist.AccessList, error) {
+	return nil, trace.NotImplemented("GetSuggestedAccessLists not implemented")
+}
+
+// IsBoringBinary implements modules.Modules.
+func (m *Modules) IsBoringBinary() bool {
+	return m.FIPS
+}
+
+// IsEnterpriseBuild implements modules.Modules.
+func (m *Modules) IsEnterpriseBuild() bool {
+	return m.BuildType() == modules.BuildEnterprise
+}
+
+// IsOSSBuild implements modules.Modules.
+func (m *Modules) IsOSSBuild() bool {
+	return m.BuildType() != modules.BuildEnterprise
+}
+
+// LicenseExpiry implements modules.Modules.
+func (m *Modules) LicenseExpiry() time.Time {
+	return time.Time{}
+}
+
+// PrintVersion implements modules.Modules.
+func (m *Modules) PrintVersion() {
+	fmt.Printf("Teleport v%s git:%s %s\n", teleport.Version, teleport.Gitref, runtime.Version())
+}
+
+// SetFeatures implements modules.Modules.
+func (m *Modules) SetFeatures(features modules.Features) {}
+
+// SetTestModules sets the value returned from GetModules to testModules
+// and reverts the change in the test cleanup function.
+// It cannot be used in parallel tests.
+//
+//	func TestWithFakeModules(t *testing.T) {
+//	   modules.SetTestModules(t, &modulestest.Modules{
+//	     TestBuildType: modules.BuildEnterprise,
+//	     TestFeatures: modules.Features{
+//	        Cloud: true,
+//	     },
+//	   })
+//
+//	   // test implementation
+//
+//	   // cleanup will revert module changes after test completes
+//	}
+//
+// TODO(tross): Get rid of global modules so this can be removed.
+func SetTestModules(t *testing.T, testModules Modules) {
+	defaultModules := modules.GetModules()
+	t.Cleanup(func() { modules.SetModules(defaultModules) })
+	t.Setenv("TELEPORT_TEST_NOT_SAFE_FOR_PARALLEL", "true")
+	modules.SetModules(&testModules)
+}

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -37,6 +37,7 @@ import (
 // same values from default modules.
 //
 // See SetTestModules for an example.
+// TODO(tross): Remove once e is using modulestest.
 type TestModules struct {
 	// TestBuildType is returned from the BuiltType function.
 	TestBuildType string
@@ -58,7 +59,7 @@ type TestModules struct {
 // It must not be used in parallel tests.
 //
 //	func TestWithFakeModules(t *testing.T) {
-//	   modules.SetTestModules(t, &modules.TestModules{
+//	   modulestest.SetTestModules(t, modulestest.Modules{
 //	     TestBuildType: modules.BuildEnterprise,
 //	     TestFeatures: modules.Features{
 //	        Cloud: true,
@@ -69,6 +70,8 @@ type TestModules struct {
 //
 //	   // cleanup will revert module changes after test completes
 //	}
+//
+// TODO(tross): Remove once e is using modulestest.
 func SetTestModules(t *testing.T, testModules Modules) {
 	defaultModules := GetModules()
 	t.Cleanup(func() { SetModules(defaultModules) })

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -29,6 +29,7 @@ import (
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
 )
@@ -68,7 +69,7 @@ func TestTeleportProcessIntegrationsOnly(t *testing.T) {
 				},
 			}
 
-			modules.SetTestModules(t, &modules.TestModules{TestFeatures: modules.Features{
+			modulestest.SetTestModules(t, modulestest.Modules{TestFeatures: modules.Features{
 				Cloud: tt.inputFeatureCloud,
 			}})
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -497,7 +498,7 @@ func TestServiceInitExternalLog(t *testing.T) {
 
 func TestAthenaAuditLogSetup(t *testing.T) {
 	ctx := context.Background()
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud: true,
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -1460,7 +1461,7 @@ func TestEnterpriseServicesEnabled(t *testing.T) {
 			if tt.enterprise {
 				buildType = modules.BuildEnterprise
 			}
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: buildType,
 			})
 

--- a/lib/services/configuration_test.go
+++ b/lib/services/configuration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestAuthPreferenceValidate(t *testing.T) {
@@ -181,7 +182,7 @@ func TestAuthPreferenceValidate(t *testing.T) {
 					t.Setenv(teleport.EnvVarAllowNoSecondFactor, "true")
 				}
 
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestFeatures: tc.features,
 				})
 

--- a/lib/services/github_test.go
+++ b/lib/services/github_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -117,7 +118,7 @@ func TestMarshal(t *testing.T) {
 	})
 
 	t.Run("enterprise", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+		modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 		marshaled, err := MarshalGithubConnector(connectorWithPrivateEndpoint)
 		require.NoError(t, err)

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.
@@ -313,7 +314,7 @@ func TestAccessList_EntitlementLimits(t *testing.T) {
 					// target because the `newAccessListService()` fixture also sets the
 					// test modules, and that would clobber our test setup if we went
 					// first
-					modules.SetTestModules(t, &modules.TestModules{
+					modulestest.SetTestModules(t, modulestest.Modules{
 						TestBuildType: modules.BuildEnterprise,
 						TestFeatures: modules.Features{
 							Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
@@ -1307,7 +1308,7 @@ func TestAccessListService_ListAllAccessListReviews(t *testing.T) {
 func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Clock, igsEnabled bool) *AccessListService {
 	t.Helper()
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.Identity:    {Enabled: igsEnabled},

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestAddRoleDefaults(t *testing.T) {
@@ -772,7 +773,7 @@ func TestAddRoleDefaults(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.enterprise {
-				modules.SetTestModules(t, &modules.TestModules{
+				modulestest.SetTestModules(t, modulestest.Modules{
 					TestBuildType: modules.BuildEnterprise,
 				})
 			}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -1113,7 +1114,7 @@ func TestMongoDBMaxMessageSize(t *testing.T) {
 
 // TestAccessDisabled makes sure database access can be disabled via modules.
 func TestAccessDisabled(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.DB: {Enabled: false},

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
@@ -54,7 +55,7 @@ import (
 
 func TestIsApprovedFileTransfer(t *testing.T) {
 	// set enterprise for tests
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	srv := newMockServer(t)
 	srv.component = teleport.ComponentNode
 
@@ -640,7 +641,7 @@ func TestNonInteractiveSession(t *testing.T) {
 
 // TestStopUnstarted tests that a session may be stopped before it launches.
 func TestStopUnstarted(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	srv := newMockServer(t)
 	srv.component = teleport.ComponentNode
 

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/sshca"
 )
 
@@ -437,7 +438,7 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 			if buildType == "" {
 				buildType = modules.BuildOSS
 			}
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: buildType,
 			})
 

--- a/lib/utils/aws/dynamodbutils/dynamo_test.go
+++ b/lib/utils/aws/dynamodbutils/dynamo_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils/aws/dynamodbutils"
 )
 
@@ -54,7 +54,7 @@ func TestIsFIPSEnabled(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("TELEPORT_UNSTABLE_DISABLE_AWS_FIPS", test.envVarValue)
 
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				FIPS: test.fips,
 			})
 

--- a/lib/utils/teleportassets/teleportassets_test.go
+++ b/lib/utils/teleportassets/teleportassets_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestDistrolessTeleportImageRepo(t *testing.T) {
@@ -75,7 +76,7 @@ func TestDistrolessTeleportImageRepo(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			semVer, err := semver.NewVersion(test.version)
 			require.NoError(t, err)
-			modules.SetTestModules(t, &modules.TestModules{TestBuildType: test.buildType})
+			modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: test.buildType})
 			require.Equal(t, test.want, DistrolessImage(*semVer))
 		})
 	}

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -203,7 +203,7 @@ func TestWebauthnLogin_webWithPrivateKeyEnabledError(t *testing.T) {
 	_, err = authServer.UpsertAuthPreference(ctx, cap)
 	require.NoError(t, err)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		MockAttestationData: &keys.AttestationData{
 			PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
 		},

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestPing(t *testing.T) {
@@ -216,7 +217,7 @@ func TestPing(t *testing.T) {
 			if buildType == "" {
 				buildType = modules.BuildOSS
 			}
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestBuildType: buildType,
 			})
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -122,6 +122,7 @@ import (
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/player"
@@ -2493,7 +2494,7 @@ func TestWebAgentForward(t *testing.T) {
 
 func TestActiveSessions(t *testing.T) {
 	// Use enterprise license (required for moderated sessions).
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	s := newWebSuite(t)
 	pack := s.authPack(t, "foo")
@@ -2643,7 +2644,7 @@ type httpErrorResponse struct {
 }
 
 func TestLogin_PrivateKeyEnabledError(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		MockAttestationData: &keys.AttestationData{
 			PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
 		},
@@ -2823,7 +2824,7 @@ func TestMotD(t *testing.T) {
 func TestPingAutomaticUpgrades(t *testing.T) {
 	t.Run("Automatic Upgrades are enabled", func(t *testing.T) {
 		// Enable Automatic Upgrades
-		modules.SetTestModules(t, &modules.TestModules{TestFeatures: modules.Features{
+		modulestest.SetTestModules(t, modulestest.Modules{TestFeatures: modules.Features{
 			AutomaticUpgrades: true,
 		}})
 
@@ -2841,7 +2842,7 @@ func TestPingAutomaticUpgrades(t *testing.T) {
 	})
 	t.Run("Automatic Upgrades are disabled", func(t *testing.T) {
 		// Disable Automatic Upgrades
-		modules.SetTestModules(t, &modules.TestModules{TestFeatures: modules.Features{
+		modulestest.SetTestModules(t, modulestest.Modules{TestFeatures: modules.Features{
 			AutomaticUpgrades: false,
 		}})
 
@@ -2862,7 +2863,7 @@ func TestPingAutomaticUpgrades(t *testing.T) {
 // TestInstallerRepoChannel ensures the returned installer script has the proper repo channel
 func TestInstallerRepoChannel(t *testing.T) {
 	t.Run("cloud with automatic upgrades", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
 				Cloud:             true,
 				AutomaticUpgrades: true,
@@ -2936,7 +2937,7 @@ echo AutomaticUpgrades: {{ .AutomaticUpgrades }}
 	})
 
 	t.Run("cloud without automatic upgrades", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
 				Cloud:             true,
 				AutomaticUpgrades: false,
@@ -2993,7 +2994,7 @@ echo AutomaticUpgrades: {{ .AutomaticUpgrades }}
 	})
 
 	t.Run("oss or enterprise with automatic upgrades", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestBuildType: modules.BuildOSS,
 			TestFeatures: modules.Features{
 				Cloud:             false,
@@ -3738,7 +3739,7 @@ func TestKnownWebPathsWithAndWithoutV1Prefix(t *testing.T) {
 
 func TestInstallDatabaseScriptGeneration(t *testing.T) {
 	const username = "test-user@example.com"
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildCommunity})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildCommunity})
 
 	// Users should be able to create Tokens even if they can't update them
 	roleTokenCRD, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
@@ -4335,7 +4336,7 @@ func TestClusterKubeResourcesGet(t *testing.T) {
 // TestApplicationAccessDisabled makes sure application access can be disabled
 // via modules.
 func TestApplicationAccessDisabled(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
 				entitlements.App: {Enabled: false},
@@ -4666,7 +4667,7 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 	require.Equal(t, expectedCfg, cfg)
 
 	// update features and assert that it is properly updated on the config object
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud:               true,
 			IsUsageBasedBilling: true,
@@ -4734,7 +4735,7 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 	expectedCfg.Entitlements[string(entitlements.DeviceTrust)] = webclient.EntitlementInfo{Enabled: false}
 
 	// update modules but NOT the expected config
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Cloud:               false,
 			IsUsageBasedBilling: false,
@@ -4761,7 +4762,7 @@ func TestGetWebConfig_LegacyFeatureLimits(t *testing.T) {
 	ctx := context.Background()
 	env := newWebPack(t, 1)
 
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			ProductType:         modules.ProductTypeTeam,
 			IsUsageBasedBilling: true,
@@ -5772,7 +5773,7 @@ func TestChangeUserAuthentication_recoveryCodesReturnedForCloud(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable cloud feature.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -5862,7 +5863,7 @@ func TestChangeUserAuthentication_WithPrivacyPolicyEnabledError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable cloud feature.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			RecoveryCodes: true,
 		},
@@ -5964,7 +5965,7 @@ func TestChangeUserAuthentication_settingDefaultClusterAuthPreference(t *testing
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			modules.SetTestModules(t, &modules.TestModules{
+			modulestest.SetTestModules(t, modulestest.Modules{
 				TestFeatures: modules.Features{
 					Cloud: tc.cloud,
 				},
@@ -10064,7 +10065,7 @@ func (m mockedPingTestProxy) Ping(ctx context.Context) (authproto.PingResponse, 
 // is allowed to access the host and start entering input and receiving
 // output until the moderator terminates the session.
 func TestModeratedSession(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	s := newWebSuiteWithConfig(t, webSuiteConfig{disableDiskBasedRecording: true})
 
@@ -10146,7 +10147,7 @@ func TestModeratedSession(t *testing.T) {
 // presence checks are performed by the moderator. When presence checks are not performed
 // the session is aborted.
 func TestModeratedSessionWithMFA(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	const RPID = "localhost"
 

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/lib/auth/integration/credentials"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
 	"github.com/gravitational/teleport/lib/utils"
@@ -793,7 +794,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 // The test cases in this test are performed sequentially and each test case
 // depends on the previous state.
 func TestGitHubIntegration(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	wPack := newWebPack(t, 1 /* proxies */)
 	proxy := wPack.proxies[0]

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
 	utils "github.com/gravitational/teleport/lib/utils"
@@ -473,7 +474,7 @@ func TestEditToken(t *testing.T) {
 func TestCreateTokenExpiry(t *testing.T) {
 	// Can't t.Parallel because of modules.SetTestModules.
 	// Use enterprise build to access token types such as TPM and Spacelift
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Cloud: false,
@@ -1212,7 +1213,7 @@ func (a *autoupdateProxyClientMock) GetClusterCACert(ctx context.Context) (*prot
 }
 
 type autoupdateTestHandlerConfig struct {
-	testModules *modules.TestModules
+	testModules *modulestest.Modules
 	hostname    string
 	port        int
 	channels    automaticupgrades.Channels
@@ -1251,11 +1252,11 @@ func newAutoupdateTestHandler(t *testing.T, config autoupdateTestHandlerConfig) 
 	clt.On("GetClusterCACert", mock.Anything).Return(&proto.GetClusterCACertResponse{TLSCA: []byte(fixtures.SigningCertPEM)}, nil)
 
 	if config.testModules == nil {
-		config.testModules = &modules.TestModules{
+		config.testModules = &modulestest.Modules{
 			TestBuildType: modules.BuildCommunity,
 		}
 	}
-	modules.SetTestModules(t, config.testModules)
+	modulestest.SetTestModules(t, *config.testModules)
 	h := &Handler{
 		clusterFeatures: *config.testModules.Features().ToProto(),
 		cfg: Config{
@@ -1839,7 +1840,7 @@ func TestJoinScript(t *testing.T) {
 		t.Run("ent", func(t *testing.T) {
 			// Using the Enterprise Version, the package name must be teleport-ent
 			h := newAutoupdateTestHandler(t, autoupdateTestHandlerConfig{
-				testModules: &modules.TestModules{TestBuildType: modules.BuildEnterprise},
+				testModules: &modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				token:       token,
 			})
 			script, err := h.getJoinScript(context.Background(), scriptSettings{token: validToken})
@@ -1860,7 +1861,7 @@ func TestJoinScript(t *testing.T) {
 		t.Run("installUpdater is true", func(t *testing.T) {
 			currentStableCloudVersion := "1.2.3"
 			h := newAutoupdateTestHandler(t, autoupdateTestHandlerConfig{
-				testModules: &modules.TestModules{TestFeatures: modules.Features{Cloud: true, AutomaticUpgrades: true}},
+				testModules: &modulestest.Modules{TestFeatures: modules.Features{Cloud: true, AutomaticUpgrades: true}},
 				token:       token,
 				channels: automaticupgrades.Channels{
 					automaticupgrades.DefaultChannelName: &automaticupgrades.Channel{StaticVersion: currentStableCloudVersion},
@@ -1901,7 +1902,7 @@ func TestJoinScript(t *testing.T) {
 		t.Run("rollout exists and autoupdates are on", func(t *testing.T) {
 			currentStableCloudVersion := "1.1.1"
 			config := autoupdateTestHandlerConfig{
-				testModules: &modules.TestModules{TestFeatures: modules.Features{Cloud: true, AutomaticUpgrades: true}},
+				testModules: &modulestest.Modules{TestFeatures: modules.Features{Cloud: true, AutomaticUpgrades: true}},
 				channels: automaticupgrades.Channels{
 					automaticupgrades.DefaultChannelName: &automaticupgrades.Channel{StaticVersion: currentStableCloudVersion},
 				},
@@ -1932,7 +1933,7 @@ func TestJoinScript(t *testing.T) {
 
 func TestAutomaticUpgrades(t *testing.T) {
 	t.Run("cloud and automatic upgrades enabled", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
 				Cloud:             true,
 				AutomaticUpgrades: true,
@@ -1943,7 +1944,7 @@ func TestAutomaticUpgrades(t *testing.T) {
 		require.True(t, got)
 	})
 	t.Run("cloud but automatic upgrades disabled", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
 				Cloud:             true,
 				AutomaticUpgrades: false,
@@ -1955,7 +1956,7 @@ func TestAutomaticUpgrades(t *testing.T) {
 	})
 
 	t.Run("automatic upgrades enabled but is not cloud", func(t *testing.T) {
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestBuildType: modules.BuildEnterprise,
 			TestFeatures: modules.Features{
 				Cloud:             false,

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -326,7 +327,7 @@ func TestOneOffScript(t *testing.T) {
 			assert.NoError(t, teleportMock.Close())
 		})
 
-		modules.SetTestModules(t, &modules.TestModules{
+		modulestest.SetTestModules(t, modulestest.Modules{
 			TestBuildType: modules.BuildEnterprise,
 		})
 		teleportBinTarball, err := utils.CompressTarGzArchive([]string{"teleport-ent/teleport"}, singleFileFS{file: teleportMock.Path})

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
@@ -190,7 +191,7 @@ func TestSessionCache_watcher(t *testing.T) {
 	// Can't t.Parallel because of modules.SetTestModules.
 
 	// Requires Enterprise to work.
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 	})
 

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -52,6 +52,7 @@ import (
 	libmfa "github.com/gravitational/teleport/lib/client/mfa"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -1050,7 +1051,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 
 	t.Helper()
 	ctx := context.Background()
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -358,7 +359,7 @@ func testEditSessionRecordingConfig(t *testing.T, clt *authclient.Client) {
 // The tests are grouped to amortize the cost of creating and auth server since
 // that is the most expensive part of testing editing the resource.
 func TestEditEnterpriseResources(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -2314,7 +2315,7 @@ version: v1
 // The tests are grouped to amortize the cost of creating and auth server since
 // that is the most expensive part of testing editing the resource.
 func TestCreateEnterpriseResources(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -33,12 +33,13 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestAccessRequestSearch(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{
+	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -72,8 +73,8 @@ func TestTshDB(t *testing.T) {
 	// will fail. The fake engine registered are not functional. But other
 	// Enterprise features like Access Request can still be tested.
 	registerFakeEnterpriseDBEngines(t)
-	modules.SetTestModules(t,
-		&modules.TestModules{
+	modulestest.SetTestModules(t,
+		modulestest.Modules{
 			TestBuildType: modules.BuildEnterprise,
 			TestFeatures: modules.Features{
 				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	kubeserver "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -322,8 +323,8 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 
 // Tests `tsh kube login`, `tsh proxy kube`.
 func TestKubeSelection(t *testing.T) {
-	modules.SetTestModules(t,
-		&modules.TestModules{
+	modulestest.SetTestModules(t,
+		modulestest.Modules{
 			TestBuildType: modules.BuildEnterprise,
 			TestFeatures: modules.Features{
 				Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -87,6 +87,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -1938,7 +1939,7 @@ func TestNoRelogin(t *testing.T) {
 // ssh server using a resource access request when "tsh ssh" fails with
 // AccessDenied.
 func TestSSHAccessRequest(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -2377,7 +2378,7 @@ func TestAccessRequestOnLeaf(t *testing.T) {
 
 // TestSSHCommand tests that a user can access a single SSH node and run commands.
 func TestSSHCommands(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx := t.Context()
 
 	accessRoleName := "access"
@@ -2880,7 +2881,7 @@ func TestSSHHeadlessCLIFlags(t *testing.T) {
 }
 
 func TestSSHHeadless(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -3010,7 +3011,7 @@ func TestSSHHeadless(t *testing.T) {
 }
 
 func TestHeadlessDoesNotAddKeysToAgent(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	agentKeyring, _ := createAgent(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -6609,7 +6610,7 @@ func TestRolesToString(t *testing.T) {
 // TestResolve tests that host resolution works for various inputs and
 // that proxy templates are respected.
 func TestResolve(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx := t.Context()
 
 	accessRoleName := "access"
@@ -6899,7 +6900,7 @@ func TestVersionCompatibilityFlags(t *testing.T) {
 // TestSCP validates that tsh scp correctly copy file content while also
 // ensuring that proxy templates are respected.
 func TestSCP(t *testing.T) {
-	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	modulestest.SetTestModules(t, modulestest.Modules{TestBuildType: modules.BuildEnterprise})
 	ctx := t.Context()
 
 	accessRoleName := "access"


### PR DESCRIPTION
The new package is meant to house a test friendly implementation of modules.Modules. Due to the pervasive and global nature of modules, this package also contains a copy of of `modules.SetTestModules`. In a perfect world this function wouldn't be needed and modules would be injected where required, however, that would take considerable effort. The existing test modules are temporarily left in place until the enterprise tests can be updated to use modulestest.

Updates https://github.com/gravitational/teleport/issues/51023.