### PR TITLE
Suggested refactor

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1116,8 +1116,13 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 			return nil, nil, trace.Wrap(err)
 		}
 
-		entries, err := s.cfg.LDAPConfig.ReadWithFilter(ctx, domainDN, filter, []string{winpki.AttrObjectSid}, tc)
+		ldapClient, err := winpki.DialLDAP(ctx, &s.cfg.LDAPConfig, tc)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		defer ldapClient.Close()
 
+		entries, err := ldapClient.ReadWithFilter(ctx, domainDN, filter, []string{winpki.AttrObjectSid})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Suggested improvements to #55937. It felt weird for a "config" struct to be doing more than just configuration, and passing around the `*tls.Config` also felt excessive.