### PR TITLE
MWI: Fix flaky test for bound keypair generation counter

### DIFF
--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -1110,9 +1110,9 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	require.Contains(t, locks[0].Message(), "certificate generation mismatch")
 
 	// Using the previously working client, make sure API calls no longer work.
-	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		_, err = client.Ping(ctx)
-		require.ErrorContains(tt, err, "access denied")
+		assert.ErrorContains(t, err, "access denied")
 	}, 5*time.Second, 100*time.Millisecond)
 }
 

--- a/lib/auth/join_bound_keypair_test.go
+++ b/lib/auth/join_bound_keypair_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client"
@@ -1109,8 +1110,10 @@ func TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter(t *testing.T) 
 	require.Contains(t, locks[0].Message(), "certificate generation mismatch")
 
 	// Using the previously working client, make sure API calls no longer work.
-	_, err = client.Ping(ctx)
-	require.ErrorContains(t, err, "access denied")
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		_, err = client.Ping(ctx)
+		require.ErrorContains(tt, err, "access denied")
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func TestServer_RegisterUsingBoundKeypairMethod_JoinStateFailure(t *testing.T) {


### PR DESCRIPTION
This fixes another flaky test in `TestServer_RegisterUsingBoundKeypairMethod_GenerationCounter`, caused by locks occasionally not immediately taking effect.