### PR TITLE
Introduce logtest package

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -56,7 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestDatabases(t *testing.T) {
@@ -338,7 +338,7 @@ func connectPostgres(t *testing.T, ctx context.Context, info dbUserLogin, dbName
 		_ = conn.Close(ctx)
 	})
 	return &pgConn{
-		logger: utils.NewSlogLoggerForTests().With("test_name", t.Name()),
+		logger: logtest.With("test_name", t.Name()),
 		Conn:   conn,
 	}
 }

--- a/e2e/aws/fixtures_test.go
+++ b/e2e/aws/fixtures_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // hostUser is the name of the host user used for tests.
@@ -190,7 +190,7 @@ func newInstanceConfig(t *testing.T) helpers.InstanceConfig {
 		NodeName:    host,
 		Priv:        priv,
 		Pub:         pub,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 }
 

--- a/e2e/aws/main_test.go
+++ b/e2e/aws/main_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const (
@@ -141,7 +141,7 @@ const (
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	// agents connect over a reverse tunnel to proxy, so we use insecure mode.
 	lib.SetInsecureDevMode(true)
 	helpers.TestMainImplementation(m)

--- a/e2e/web_e2e_test.go
+++ b/e2e/web_e2e_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestSignup sets up a test instance of Teleport and runs a playwright test against it to test the signup flow.
@@ -98,7 +98,7 @@ func createTeleportTestInstanceForWebTests(t *testing.T) (instance *helpers.Tele
 		ClusterName: "test-cluster",
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Host,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 		Priv:        privateKey,
 		Pub:         publicKey,
 	}

--- a/examples/dynamoathenamigration/migration_test.go
+++ b/examples/dynamoathenamigration/migration_test.go
@@ -41,8 +41,8 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMigrateProcessDataObjects(t *testing.T) {
@@ -62,7 +62,7 @@ func TestMigrateProcessDataObjects(t *testing.T) {
 		},
 		eventsEmitter: emitter,
 		Config: Config{
-			Logger:          utils.NewSlogLoggerForTests(),
+			Logger:          logtest.NewLogger(),
 			NoOfEmitWorkers: 5,
 			bufferSize:      10,
 			CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),
@@ -133,7 +133,7 @@ func TestLargeEventsParse(t *testing.T) {
 		},
 		eventsEmitter: emitter,
 		Config: Config{
-			Logger:          utils.NewSlogLoggerForTests(),
+			Logger:          logtest.NewLogger(),
 			NoOfEmitWorkers: 5,
 			bufferSize:      10,
 			CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),
@@ -223,7 +223,7 @@ func TestMigrationCheckpoint(t *testing.T) {
 
 	noOfWorkers := 3
 	defaultConfig := Config{
-		Logger:          utils.NewSlogLoggerForTests(),
+		Logger:          logtest.NewLogger(),
 		NoOfEmitWorkers: noOfWorkers,
 		bufferSize:      noOfWorkers * 5,
 		CheckpointPath:  filepath.Join(t.TempDir(), "migration-tests.json"),

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type AppTestOptions struct {
@@ -65,7 +66,7 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Insecure development mode needs to be set because the web proxy uses a
 	// self-signed certificate during tests.

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -59,6 +59,7 @@ import (
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 	"github.com/gravitational/teleport/lib/web"
 	"github.com/gravitational/teleport/lib/web/app"
@@ -761,7 +762,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 	for i := range count {
 		raConf := servicecfg.MakeDefaultConfig()
 		raConf.Clock = opts.Clock
-		raConf.Logger = utils.NewSlogLoggerForTests()
+		raConf.Logger = logtest.NewLogger()
 		raConf.DataDir = t.TempDir()
 		raConf.SetToken("static-token-value")
 		raConf.SetAuthServerAddress(utils.NetAddr{
@@ -931,7 +932,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 	for i := range count {
 		laConf := servicecfg.MakeDefaultConfig()
 		laConf.Clock = opts.Clock
-		laConf.Logger = utils.NewSlogLoggerForTests()
+		laConf.Logger = logtest.NewLogger()
 		laConf.DataDir = t.TempDir()
 		laConf.SetToken("static-token-value")
 		laConf.SetAuthServerAddress(utils.NetAddr{

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestClientWithExpiredCredentialsAndDetailedErrorMessage creates and connects to the Auth service
@@ -41,7 +41,7 @@ func TestClientWithExpiredCredentialsAndDetailedErrorMessage(t *testing.T) {
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)

--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type DatabasePack struct {
@@ -253,7 +254,7 @@ func SetupDatabaseTest(t *testing.T, options ...TestOptionFunc) *DatabasePack {
 	tracer := utils.NewTracer(utils.ThisFunction()).Start()
 	t.Cleanup(func() { tracer.Stop() })
 	lib.SetInsecureDevMode(true)
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Generate keypair.
 	privateKey, publicKey, err := testauthority.New().GenerateKeyPair()

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // CommandOptions controls how the SSH command is built.
@@ -379,7 +380,7 @@ func MakeTestServers(t *testing.T) (auth *service.TeleportProcess, proxy *servic
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = true
 	cfg.Proxy.Enabled = false
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 
 	auth, err = service.NewTeleport(cfg)
 	require.NoError(t, err)
@@ -417,7 +418,7 @@ func MakeTestServers(t *testing.T) (auth *service.TeleportProcess, proxy *servic
 		cfg.Proxy.WebAddr,
 	}
 	cfg.Proxy.DisableWebInterface = true
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 
 	proxy, err = service.NewTeleport(cfg)
 	require.NoError(t, err)
@@ -454,7 +455,7 @@ func MakeTestDatabaseServer(t *testing.T, proxyAddr utils.NetAddr, token string,
 	cfg.Databases.Enabled = true
 	cfg.Databases.Databases = dbs
 	cfg.Databases.ResourceMatchers = resMatchers
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 
 	db, err := service.NewTeleport(cfg)
 	require.NoError(t, err)
@@ -487,7 +488,7 @@ func MakeAgentServer(t *testing.T, cfg *servicecfg.Config, proxyAddr utils.NetAd
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.Databases.Enabled = false
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 
 	agent, err := service.NewTeleport(cfg)
 	require.NoError(t, err)

--- a/integration/helpers/testmain.go
+++ b/integration/helpers/testmain.go
@@ -26,14 +26,14 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/common"
 )
 
 // TestMainImplementation will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMainImplementation(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	SetTestTimeouts(3 * time.Second)
 	modules.SetInsecureTestMode(true)

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/host"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
 
@@ -652,7 +653,7 @@ func TestRootLoginAsHostUser(t *testing.T) {
 		NodeName:    Host,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	// Create a user that can create a host user.
@@ -752,7 +753,7 @@ func TestRootStaticHostUsers(t *testing.T) {
 		NodeName:    Host,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	require.NoError(t, instance.Create(t, nil, false))

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
@@ -97,7 +98,7 @@ func liteBackendConfig(t *testing.T) *backend.Config {
 func TestHSMRotation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	log := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "TestHSMRotation")
+	log := logtest.With(teleport.ComponentKey, "TestHSMRotation")
 
 	log.DebugContext(ctx, "starting auth server")
 	authConfig := newHSMAuthConfig(t, liteBackendConfig(t), log, clockwork.NewRealClock())
@@ -208,7 +209,7 @@ func TestHSMDualAuthRotation(t *testing.T) {
 	t.Setenv("TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK", "1")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	log := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "TestHSMDualAuthRotation")
+	log := logtest.With(teleport.ComponentKey, "TestHSMDualAuthRotation")
 	storageConfig := liteBackendConfig(t)
 
 	// start a cluster with 1 auth server
@@ -390,7 +391,7 @@ func TestHSMMigrate(t *testing.T) {
 	t.Setenv("TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK", "1")
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	log := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "TestHSMMigrate")
+	log := logtest.With(teleport.ComponentKey, "TestHSMMigrate")
 	storageConfig := liteBackendConfig(t)
 
 	// start a dual auth non-hsm cluster
@@ -537,7 +538,7 @@ func TestHSMRevert(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	log := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "TestHSMRevert")
+	log := logtest.With(teleport.ComponentKey, "TestHSMRevert")
 
 	log.DebugContext(ctx, "starting auth server")
 	auth1Config := newHSMAuthConfig(t, liteBackendConfig(t), log, clock)

--- a/integration/instance_test.go
+++ b/integration/instance_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // basicDirCopy performs a very simplistic recursive copy from one directory to another. this helper was
@@ -123,7 +124,7 @@ func TestInstanceCertReissue(t *testing.T) {
 	authCfg.SSH.Enabled = true
 	authCfg.SSH.Addr.Addr = "localhost:0"
 	authCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
-	authCfg.Logger = utils.NewSlogLoggerForTests()
+	authCfg.Logger = logtest.NewLogger()
 	authCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 
 	authProc, err := service.NewTeleport(authCfg)
@@ -162,7 +163,7 @@ func TestInstanceCertReissue(t *testing.T) {
 
 	agentCfg.WindowsDesktop.Enabled = true
 	agentCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
-	agentCfg.Logger = utils.NewSlogLoggerForTests()
+	agentCfg.Logger = logtest.NewLogger()
 	agentCfg.MaxRetryPeriod = time.Second
 	agentCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -104,6 +104,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -123,7 +124,7 @@ func (s *integrationTestSuite) bind(test integrationTest) func(t *testing.T) {
 		// Attempt to set a logger for the test. Be warned that parts of the
 		// Teleport codebase do not honor the logger passed in via config and
 		// will create their own. Do not expect to catch _all_ output with this.
-		s.Log = utils.NewSlogLoggerForTests()
+		s.Log = logtest.NewLogger()
 		os.RemoveAll(profile.FullProfilePath(""))
 		t.Cleanup(func() { s.Log = nil })
 		test(t, s)
@@ -1901,7 +1902,7 @@ func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
 
 	tconf := servicecfg.MakeDefaultConfig()
 	tconf.SSH.Enabled = true
-	tconf.Logger = utils.NewSlogLoggerForTests()
+	tconf.Logger = logtest.NewLogger()
 	tconf.Proxy.DisableWebService = true
 	tconf.Proxy.DisableWebInterface = true
 	tconf.Auth.NetworkingConfig = netConfig
@@ -7286,7 +7287,7 @@ func TestWebProxyInsecure(t *testing.T) {
 		NodeName:    Host,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	rcConf := servicecfg.MakeDefaultConfig()
@@ -7320,7 +7321,7 @@ func TestWebProxyInsecure(t *testing.T) {
 // roles in root and leaf clusters.
 func TestTraitsPropagation(t *testing.T) {
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	privateKey, publicKey, err := testauthority.New().GenerateKeyPair()
 	require.NoError(t, err)
@@ -8501,7 +8502,7 @@ func TestProxySSHPortMultiplexing(t *testing.T) {
 				NodeName:    Host,
 				Priv:        privateKey,
 				Pub:         publicKey,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			})
 
 			rcConf := servicecfg.MakeDefaultConfig()
@@ -8625,7 +8626,7 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 
 			// Create auth config.
 			authCfg := servicecfg.MakeDefaultConfig()
-			authCfg.Logger = utils.NewSlogLoggerForTests()
+			authCfg.Logger = logtest.NewLogger()
 			authCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 			authCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 			authCfg.Auth.Preference.SetSecondFactor("off")
@@ -8643,7 +8644,7 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 				NodeName:    Host,
 				Priv:        privateKey,
 				Pub:         publicKey,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			})
 
 			// Create a user and role.
@@ -8678,7 +8679,7 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 				NodeName:    Host,
 				Priv:        privateKey,
 				Pub:         publicKey,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			})
 
 			// Create node config.
@@ -8687,7 +8688,7 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 			nodeCfg.SetToken("token")
 			nodeCfg.CachePolicy.Enabled = true
 			nodeCfg.DataDir = t.TempDir()
-			nodeCfg.Logger = utils.NewSlogLoggerForTests()
+			nodeCfg.Logger = logtest.NewLogger()
 			nodeCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 			nodeCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 			nodeCfg.Auth.Enabled = false
@@ -8767,7 +8768,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 
 	// Create auth config.
 	authCfg := servicecfg.MakeDefaultConfig()
-	authCfg.Logger = utils.NewSlogLoggerForTests()
+	authCfg.Logger = logtest.NewLogger()
 	authCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	authCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	authCfg.Auth.Preference.SetSecondFactor("off")
@@ -8785,7 +8786,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 		NodeName:    Host,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	// Create a user and role.
@@ -8817,7 +8818,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 		NodeName:    Host,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	// Create node config.
@@ -8826,7 +8827,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 	nodeCfg.SetToken("token")
 	nodeCfg.CachePolicy.Enabled = true
 	nodeCfg.DataDir = t.TempDir()
-	nodeCfg.Logger = utils.NewSlogLoggerForTests()
+	nodeCfg.Logger = logtest.NewLogger()
 	nodeCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	nodeCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	nodeCfg.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerType("diag"), &node.Fds))

--- a/integration/joinopenssh_test.go
+++ b/integration/joinopenssh_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/openssh"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestJoinOpenSSH(t *testing.T) {
@@ -47,7 +47,7 @@ func TestJoinOpenSSH(t *testing.T) {
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.StandardListenerSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -88,6 +88,7 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web"
 	"github.com/gravitational/teleport/lib/web/terminal"
 )
@@ -170,7 +171,7 @@ type kubeIntegrationTest func(t *testing.T, suite *KubeSuite)
 
 func (s *KubeSuite) bind(test kubeIntegrationTest) func(t *testing.T) {
 	return func(t *testing.T) {
-		s.log = utils.NewSlogLoggerForTests()
+		s.log = logtest.NewLogger()
 		os.RemoveAll(profile.FullProfilePath(""))
 		t.Cleanup(func() { s.log = nil })
 		test(t, s)
@@ -1782,7 +1783,7 @@ func testKubeExecWeb(t *testing.T, suite *KubeSuite) {
 
 		ws := openWebsocketAndReadSession(t, endpoint, req)
 
-		wsStream := terminal.NewWStream(context.Background(), ws, utils.NewSlogLoggerForTests(), nil)
+		wsStream := terminal.NewWStream(context.Background(), ws, logtest.NewLogger(), nil)
 
 		// Check for the expected string in the output.
 		findTextInReader(t, wsStream, testNamespace, time.Second*2)
@@ -1803,7 +1804,7 @@ func testKubeExecWeb(t *testing.T, suite *KubeSuite) {
 
 		ws := openWebsocketAndReadSession(t, endpoint, req)
 
-		wsStream := terminal.NewWStream(context.Background(), ws, utils.NewSlogLoggerForTests(), nil)
+		wsStream := terminal.NewWStream(context.Background(), ws, logtest.NewLogger(), nil)
 
 		// Read first prompt from the server.
 		readData := make([]byte, 255)

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
 
@@ -171,7 +171,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 				NodeName:    Host,
 				Priv:        privateKey,
 				Pub:         publicKey,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			})
 
 			for _, login := range logins {
@@ -197,7 +197,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 				NodeName:    Host,
 				Priv:        privateKey,
 				Pub:         publicKey,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			})
 
 			// Create node config.

--- a/integration/proxy/automaticupgrades_test.go
+++ b/integration/proxy/automaticupgrades_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/constants"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func createProxyWithChannels(t *testing.T, channels automaticupgrades.Channels) string {
@@ -48,7 +48,7 @@ func createProxyWithChannels(t *testing.T, channels automaticupgrades.Channels) 
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -69,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type Suite struct {
@@ -115,7 +116,7 @@ func newSuite(t *testing.T, opts ...proxySuiteOptionsFunc) *Suite {
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    options.rootClusterNodeName,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	rCfg.Listeners = options.rootClusterListeners(t, &rCfg.Fds)
 	rc := helpers.NewInstance(t, rCfg)
@@ -127,7 +128,7 @@ func newSuite(t *testing.T, opts ...proxySuiteOptionsFunc) *Suite {
 		NodeName:    options.leafClusterNodeName,
 		Priv:        rc.Secrets.PrivKey,
 		Pub:         rc.Secrets.PubKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	lCfg.Listeners = options.leafClusterListeners(t, &lCfg.Fds)
 	lc := helpers.NewInstance(t, lCfg)
@@ -195,7 +196,7 @@ func newSuite(t *testing.T, opts ...proxySuiteOptionsFunc) *Suite {
 func (p *Suite) addNodeToLeafCluster(t *testing.T, tunnelNodeHostname string) {
 	nodeConfig := func() *servicecfg.Config {
 		tconf := servicecfg.MakeDefaultConfig()
-		tconf.Logger = utils.NewSlogLoggerForTests()
+		tconf.Logger = logtest.NewLogger()
 		tconf.Hostname = tunnelNodeHostname
 		tconf.SetToken("token")
 		tconf.SetAuthServerAddress(utils.NetAddr{

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestALPNSNIProxyMultiCluster tests SSH connection in multi-cluster setup with.
@@ -562,7 +563,7 @@ func TestKubePROXYProtocol(t *testing.T) {
 				ClusterName: "root.example.com",
 				HostID:      uuid.New().String(),
 				NodeName:    helpers.Loopback,
-				Logger:      utils.NewSlogLoggerForTests(),
+				Logger:      logtest.NewLogger(),
 			}
 			tconf := servicecfg.MakeDefaultConfig()
 			tconf.Proxy.Kube.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyKube, &cfg.Fds))
@@ -1406,7 +1407,7 @@ func TestALPNProxyAuthClientConnectWithUserIdentity(t *testing.T) {
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)
@@ -1510,7 +1511,7 @@ func TestALPNProxyDialProxySSHWithoutInsecureMode(t *testing.T) {
 		NodeName:    helpers.Loopback,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	rootCfg.Listeners = helpers.StandardListenerSetup(t, &rootCfg.Fds)
 	rc := helpers.NewInstance(t, rootCfg)
@@ -1580,7 +1581,7 @@ func TestALPNProxyHTTPProxyNoProxyDial(t *testing.T) {
 		ClusterName: "root.example.com",
 		HostID:      uuid.New().String(),
 		NodeName:    addr,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	instanceCfg.Listeners = helpers.SingleProxyPortSetupOn(addr)(t, &instanceCfg.Fds)
 	rc := helpers.NewInstance(t, instanceCfg)
@@ -1647,7 +1648,7 @@ func TestALPNProxyHTTPProxyBasicAuthDial(t *testing.T) {
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
 
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// We need to use the non-loopback address for our Teleport cluster, as the
 	// Go HTTP library will recognize requests to the loopback address and

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type proxyTunnelStrategy struct {
@@ -300,7 +301,7 @@ func (p *proxyTunnelStrategy) makeAuth(t *testing.T) {
 		NodeName:    helpers.Loopback,
 		Priv:        privateKey,
 		Pub:         publicKey,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	auth.AddUser(p.username, []string{p.username})
@@ -328,7 +329,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 		ClusterName: p.cluster,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	authAddr := utils.MustParseAddr(p.auth.Auth)
@@ -375,7 +376,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 		ClusterName: p.cluster,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	conf := servicecfg.MakeDefaultConfig()
@@ -420,7 +421,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 		ClusterName: p.cluster,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 
 	conf := servicecfg.MakeDefaultConfig()

--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/tctl/common"
 )
 
@@ -62,7 +63,7 @@ func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)
@@ -138,7 +139,7 @@ func TestTCTLTerraformCommand_AuthJoin(t *testing.T) {
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	}
 	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
 	rc := helpers.NewInstance(t, cfg)
@@ -240,7 +241,7 @@ func getAuthClientForProxy(t *testing.T, tc *helpers.TeleInstance, username stri
 		TLS:                  tlsConfig,
 		SSH:                  sshConfig,
 		AuthServers:          []utils.NetAddr{*authAddr},
-		Log:                  utils.NewSlogLoggerForTests(),
+		Log:                  logtest.NewLogger(),
 		CircuitBreakerConfig: breaker.Config{},
 		DialTimeout:          0,
 		DialOpts:             nil,
@@ -293,7 +294,7 @@ func getAuthClientForAuth(t *testing.T, tc *helpers.TeleInstance, username strin
 	clientConfig := &authclient.Config{
 		TLS:                  tlsConfig,
 		AuthServers:          []utils.NetAddr{*authAddr},
-		Log:                  utils.NewSlogLoggerForTests(),
+		Log:                  logtest.NewLogger(),
 		CircuitBreakerConfig: breaker.Config{},
 		DialTimeout:          0,
 		DialOpts:             nil,

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -63,7 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/tlsca"
-	libutils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestTeleterm(t *testing.T) {
@@ -969,7 +969,7 @@ func testWaitForConnectMyComputerNodeJoin(t *testing.T, pack *dbhelpers.Database
 	nodeConfig := newNodeConfig(t, "token", types.JoinMethodToken)
 	nodeConfig.SetAuthServerAddress(pack.Root.Cluster.Config.Auth.ListenAddr)
 	nodeConfig.DataDir = filepath.Join(agentsDir, profileName, "data")
-	nodeConfig.Logger = libutils.NewSlogLoggerForTests()
+	nodeConfig.Logger = logtest.NewLogger()
 	nodeSvc, err := service.NewTeleport(nodeConfig)
 	require.NoError(t, err)
 	require.NoError(t, nodeSvc.Start())
@@ -1044,7 +1044,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 	nodeConfig := newNodeConfig(t, "token", types.JoinMethodToken)
 	nodeConfig.SetAuthServerAddress(pack.Root.Cluster.Config.Auth.ListenAddr)
 	nodeConfig.DataDir = filepath.Join(agentsDir, profileName, "data")
-	nodeConfig.Logger = libutils.NewSlogLoggerForTests()
+	nodeConfig.Logger = logtest.NewLogger()
 	nodeSvc, err := service.NewTeleport(nodeConfig)
 	require.NoError(t, err)
 	require.NoError(t, nodeSvc.Start())

--- a/integrations/access/msteams/bot_test.go
+++ b/integrations/access/msteams/bot_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func mustParseURL(t *testing.T, urlString string) *url.URL {
@@ -31,7 +31,7 @@ func mustParseURL(t *testing.T, urlString string) *url.URL {
 
 func Test_CheckChannelURL(t *testing.T) {
 	b := &Bot{
-		log: utils.NewSlogLoggerForTests(),
+		log: logtest.NewLogger(),
 	}
 	tests := []struct {
 		name             string

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -34,14 +34,14 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestBotJoinAuth(t *testing.T) {
 	// Configure and start Teleport server
 	clusterName := "root.example.com"
 	ctx := context.Background()
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -57,7 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // scheme is our own test-specific scheme to avoid using the global
@@ -218,7 +218,7 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 
 	slogLogger := s.log
 	if slogLogger == nil {
-		slogLogger = utils.NewSlogLoggerForTests()
+		slogLogger = logtest.NewLogger()
 	}
 
 	logger := logr.FromSlogHandler(slogLogger.Handler())

--- a/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
+++ b/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type trustedClusterV2TestingPrimitives struct {
@@ -137,7 +137,7 @@ func (r *trustedClusterV2TestingPrimitives) setupTest(t *testing.T, clusterName 
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logtest.NewLogger(),
 	})
 	r.remoteCluster = remoteCluster
 

--- a/integrations/terraform-mwi/provider/kubernetes_data_source_test.go
+++ b/integrations/terraform-mwi/provider/kubernetes_data_source_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestAccKubernetesDataSource(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := t.Context()
 
 	process, kubeMock := setupKubernetesHarness(t, log)

--- a/integrations/terraform-mwi/provider/kubernetes_ephemeral_resource_test.go
+++ b/integrations/terraform-mwi/provider/kubernetes_ephemeral_resource_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestAccKubernetesEphemeralResource(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := t.Context()
 
 	process, kubeMock := setupKubernetesHarness(t, log)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -87,6 +87,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type testPack struct {
@@ -228,7 +229,7 @@ func newAuthSuite(t *testing.T) *testPack {
 }
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())

--- a/lib/auth/autoupdate_agent_version_report_test.go
+++ b/lib/auth/autoupdate_agent_version_report_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func newFakeControlStream() fakeControlStream {
@@ -245,7 +245,7 @@ func TestServer_generateAgentVersionReport(t *testing.T) {
 			require.NoError(t, err)
 			auth := &Server{
 				cancelFunc: func() {},
-				logger:     utils.NewSlogLoggerForTests(),
+				logger:     logtest.NewLogger(),
 				ServerID:   uuid.NewString(),
 				Services: &Services{
 					// The inventory is running heartbeats on the background.
@@ -321,7 +321,7 @@ func TestServer_reportAgentVersions(t *testing.T) {
 			// If we don't create a presence service this will cause panics.
 			PresenceInternal: local.NewPresenceService(bk),
 		},
-		logger: utils.NewSlogLoggerForTests(),
+		logger: logtest.NewLogger(),
 	}
 	t.Cleanup(func() {
 		auth.Close()

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestSampleAgentsFromGroup(t *testing.T) {
@@ -50,7 +50,7 @@ func TestSampleAgentsFromGroup(t *testing.T) {
 		cancelFunc: func() {},
 		clock:      clock,
 		ServerID:   uuid.NewString(),
-		logger:     utils.NewSlogLoggerForTests(),
+		logger:     logtest.NewLogger(),
 		Services: &Services{
 			// The inventory is running heartbeats on the background.
 			// If we don't create a presence service this will cause panics.
@@ -145,7 +145,7 @@ func TestLookupAgentInInventory(t *testing.T) {
 		cancelFunc: func() {},
 		clock:      clock,
 		ServerID:   uuid.NewString(),
-		logger:     utils.NewSlogLoggerForTests(),
+		logger:     logtest.NewLogger(),
 		Services: &Services{
 			// The inventory is running heartbeats on the background.
 			// If we don't create a presence service this will cause panics.

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -69,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func renewBotCerts(
@@ -840,7 +841,7 @@ func authClientForRegisterResult(t *testing.T, ctx context.Context, addr *utils.
 		nil /* clock */)
 	require.NoError(t, err)
 
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	dialer, err := reversetunnelclient.NewTunnelAuthDialer(reversetunnelclient.TunnelAuthDialerConfig{
 		Resolver:              resolver,
 		ClientConfig:          sshConfig,

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type githubContext struct {
@@ -189,7 +190,7 @@ func TestValidateGithubAuthCallbackEventsEmitted(t *testing.T) {
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
 	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
 	tt := setupGithubContext(ctx, t)
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	auth := &authclient.GithubAuthResponse{
 		Username: "test-name",

--- a/lib/auth/healthcheckconfig/healthcheckconfigv1/service_test.go
+++ b/lib/auth/healthcheckconfig/healthcheckconfigv1/service_test.go
@@ -39,11 +39,11 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -47,11 +47,11 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -49,7 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const (
@@ -550,7 +550,7 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 	var backends []*backendDesc
 
 	hostUUID := uuid.NewString()
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	unusedPKCS11Key, err := keyID{
 		HostID: hostUUID,

--- a/lib/auth/machineid/machineidv1/spiffe_federation_syncer_test.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_syncer_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func makeTrustDomain(t *testing.T, name string) (spiffeid.TrustDomain, *spiffebundle.Bundle) {
@@ -65,7 +65,7 @@ func TestSPIFFEFederationSyncer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	clock := clockwork.NewRealClock()
 	backend, err := memory.New(memory.Config{})
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestSPIFFEFederationSyncer_syncFederation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	clock := clockwork.NewFakeClock()
 	backend, err := memory.New(memory.Config{})
 	require.NoError(t, err)

--- a/lib/auth/migration/migration_test.go
+++ b/lib/auth/migration/migration_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type testMigration struct {
@@ -63,7 +63,7 @@ func (t testMigration) Name() string {
 }
 
 func TestApply(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	cases := []struct {
 		name           string
 		migrations     []migration

--- a/lib/auth/recordingencryption/manager_test.go
+++ b/lib/auth/recordingencryption/manager_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type oaepDecrypter struct {
@@ -137,7 +137,7 @@ func newManagerConfig(t *testing.T, bk backend.Backend, keyType types.PrivateKey
 		Cache:         recordingEncryptionService,
 		ClusterConfig: clusterConfigService,
 		KeyStore:      &fakeKeyStore{keyType: keyType},
-		Logger:        utils.NewSlogLoggerForTests(),
+		Logger:        logtest.NewLogger(),
 		LockConfig: backend.RunWhileLockedConfig{
 			LockConfiguration: backend.LockConfiguration{
 				Backend:            bk,

--- a/lib/auth/stableunixusers/stableunixusers_test.go
+++ b/lib/auth/stableunixusers/stableunixusers_test.go
@@ -37,11 +37,11 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/readonly"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const ownerUser = "owner"
@@ -739,7 +739,7 @@ func initGeneratorSvc(t *testing.T) (*Generator, *svc) {
 	emitter := &eventstest.MockRecorderEmitter{}
 
 	generator, err := NewGenerator(GeneratorConfig{
-		Log:         utils.NewSlogLoggerForTests(),
+		Log:         logtest.NewLogger(),
 		AccessLists: svc,
 		Access:      svc,
 		UsageEvents: svc,

--- a/lib/autoupdate/rollout/reconciler_test.go
+++ b/lib/autoupdate/rollout/reconciler_test.go
@@ -36,7 +36,7 @@ import (
 	update "github.com/gravitational/teleport/api/types/autoupdate"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // rolloutEquals returns a require.ValueAssertionFunc that checks the rollout is identical.
@@ -136,7 +136,7 @@ func TestGetMode(t *testing.T) {
 
 func TestTryReconcile(t *testing.T) {
 	t.Parallel()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -330,7 +330,7 @@ func TestTryReconcile(t *testing.T) {
 }
 
 func TestReconciler_Reconcile(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 	// Test setup: creating fixtures
@@ -727,7 +727,7 @@ func (f *fakeRolloutStrategy) progressRollout(ctx context.Context, spec *autoupd
 }
 
 func Test_reconciler_computeStatus(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	clock := clockwork.NewFakeClock()
 	ctx := context.Background()
 

--- a/lib/autoupdate/rollout/strategy_haltonerror_test.go
+++ b/lib/autoupdate/rollout/strategy_haltonerror_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func Test_canStartHaltOnError(t *testing.T) {
@@ -135,7 +135,7 @@ func Test_canStartHaltOnError(t *testing.T) {
 
 func Test_progressGroupsHaltOnError(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(testSunday)
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	fewSecondsAgo := clock.Now().Add(-3 * time.Second)
 	fewMinutesAgo := clock.Now().Add(-5 * time.Minute)

--- a/lib/autoupdate/rollout/strategy_timebased_test.go
+++ b/lib/autoupdate/rollout/strategy_timebased_test.go
@@ -31,12 +31,12 @@ import (
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func Test_progressGroupsTimeBased(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(testSunday)
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	groupName := "test-group"
 	canStartToday := everyWeekday

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -44,12 +44,12 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -33,8 +33,8 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const (
@@ -43,7 +43,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -52,12 +52,12 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -30,12 +30,12 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -31,12 +31,12 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/pgbk/common/auth_test.go
+++ b/lib/backend/pgbk/common/auth_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/backend/pgbk/pgbk_test.go
+++ b/lib/backend/pgbk/pgbk_test.go
@@ -30,12 +30,12 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/cgroup"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const (
@@ -61,7 +61,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	// Check if the re-exec was requested.
 	if len(os.Args) == 3 {

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -87,6 +87,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const eventBufferSize = 1024
@@ -103,7 +104,7 @@ func TestMain(m *testing.M) {
 			},
 		},
 	})
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestTeleportClient_Login_local(t *testing.T) {
@@ -547,7 +548,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.DataDir = makeDataDir()
 	cfg.Hostname = "localhost"
 	cfg.Clock = clock
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	cfg.SetAuthServerAddress(randomAddr) // must be present
 	cfg.Auth.Preference, err = types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
 		Type:         constants.Local,
@@ -630,7 +631,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	cfg.Hostname = "localhost"
 	cfg.SetToken(staticToken)
 	cfg.Clock = clock
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	cfg.SetAuthServerAddress(*authAddr)
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = true

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -49,10 +49,11 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	os.Exit(m.Run())

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type testConfigFiles struct {
@@ -103,7 +104,7 @@ func (tc testConfigFiles) cleanup() {
 }
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	if err := writeTestConfigs(); err != nil {
 		testConfigs.cleanup()

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -42,11 +42,11 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -37,10 +37,11 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -49,12 +49,13 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const dynamoDBLargeQueryRetries int = 10
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/filesessions/filesessionrecorder_test.go
+++ b/lib/events/filesessions/filesessionrecorder_test.go
@@ -29,12 +29,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestPlainFileOpsReservations(t *testing.T) {
 	ctx := context.Background()
-	rec := NewPlainFileRecorder(utils.NewSlogLoggerForTests(), os.OpenFile)
+	rec := NewPlainFileRecorder(logtest.NewLogger(), os.OpenFile)
 	base := t.TempDir()
 	reservation := filepath.Join(base, "reservation")
 	var fileSize int64 = 512
@@ -58,7 +58,7 @@ func TestPlainFileOpsReservations(t *testing.T) {
 
 func TestPlainFileOpsCombineParts(t *testing.T) {
 	ctx := context.Background()
-	rec := NewPlainFileRecorder(utils.NewSlogLoggerForTests(), os.OpenFile)
+	rec := NewPlainFileRecorder(logtest.NewLogger(), os.OpenFile)
 	base := t.TempDir()
 	parts := []string{"part1", "part2", "part3"}
 	partPaths := make([]string, len(parts))

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -29,11 +29,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/firestoreevents/firestoreevents_test.go
+++ b/lib/events/firestoreevents/firestoreevents_test.go
@@ -31,10 +31,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/gcssessions/gcshandler_test.go
+++ b/lib/events/gcssessions/gcshandler_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/memsessions/memstream_test.go
+++ b/lib/events/memsessions/memstream_test.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/events/pgevents/pgevents_test.go
+++ b/lib/events/pgevents/pgevents_test.go
@@ -37,11 +37,11 @@ import (
 	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 
@@ -226,7 +226,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestBuildSchema(t *testing.T) {
-	testLog := utils.NewSlogLoggerForTests()
+	testLog := logtest.NewLogger()
 
 	testConfig := &Config{
 		Log: testLog,

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -34,11 +34,11 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/healthcheck/manager_test.go
+++ b/lib/healthcheck/manager_test.go
@@ -42,11 +42,11 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/integrations/awsoidc/deployservice_update_test.go
+++ b/lib/integrations/awsoidc/deployservice_update_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestGenerateServiceWithTaskDefinition(t *testing.T) {
@@ -164,7 +164,7 @@ func TestUpdateDeployServices(t *testing.T) {
 	semVer := teleport.SemVer()
 	semVer.PreRelease = ""
 	teleportVersion := semVer.String()
-	log := utils.NewSlogLoggerForTests().With("test", t.Name())
+	log := logtest.With("test", t.Name())
 
 	t.Run("only legacy service present", func(t *testing.T) {
 		m := &mockDeployServiceClient{

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestGetChartUrl(t *testing.T) {
@@ -396,7 +396,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 			}
 
 			response, err := EnrollEKSClusters(
-				ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, tc.enrollClient(t, tc.eksClusters), req)
+				ctx, logtest.With("test", t.Name()), clock, proxyAddr, tc.enrollClient(t, tc.eksClusters), req)
 			require.NoError(t, err)
 
 			tc.responseCheck(t, response)
@@ -422,7 +422,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 		}
 
 		response, err := EnrollEKSClusters(
-			ctx, utils.NewSlogLoggerForTests().With("test", t.Name()), clock, proxyAddr, mockClt, req)
+			ctx, logtest.With("test", t.Name()), clock, proxyAddr, mockClt, req)
 		require.NoError(t, err)
 		require.Len(t, response.Results, 1)
 		require.Equal(t, "EKS1", response.Results[0].ClusterName)

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func stringPointer(s string) *string {
@@ -141,7 +141,7 @@ func TestListDatabases(t *testing.T) {
 
 		t.Run("without vpc filter", func(t *testing.T) {
 			t.Parallel()
-			logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+			logger := logtest.With("test", t.Name())
 			// First page must return pageSize number of DBs
 			req := ListDatabasesRequest{
 				Region:    "us-east-1",
@@ -166,7 +166,7 @@ func TestListDatabases(t *testing.T) {
 
 		t.Run("with vpc filter", func(t *testing.T) {
 			t.Parallel()
-			logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+			logger := logtest.With("test", t.Name())
 			// First page must return at least pageSize number of DBs
 			var gotDatabases []types.Database
 			wantVPC := "vpc-2"
@@ -694,7 +694,7 @@ func TestListDatabases(t *testing.T) {
 				dbInstances: tt.mockInstances,
 				dbClusters:  tt.mockClusters,
 			}
-			logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+			logger := logtest.With("test", t.Name())
 			resp, err := ListDatabases(ctx, mockListClient, logger, tt.req)
 			require.True(t, tt.errCheck(err), "unexpected err: %v", err)
 			if err != nil {

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 /*
@@ -207,7 +207,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 			KeyStoreManager:   keyStoreManager,
 			Cache:             serverClient,
 			AppServerUpserter: serverClient,
-			Logger:            utils.NewSlogLoggerForTests(),
+			Logger:            logtest.NewLogger(),
 			createSession:     mockCreateSession,
 		}
 	}

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -45,10 +45,11 @@ import (
 	"github.com/gravitational/teleport/lib/inventory/metadata"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/inventory/internal/delay/delay_test.go
+++ b/lib/inventory/internal/delay/delay_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/interval"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -67,7 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type TestContext struct {
@@ -286,7 +286,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		GetRotation:          func(role types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
 		ResourceMatchers:     cfg.ResourceMatchers,
 		OnReconcile:          cfg.OnReconcile,
-		Log:                  utils.NewSlogLoggerForTests(),
+		Log:                  logtest.NewLogger(),
 		InventoryHandle:      inventoryHandle,
 		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 	})
@@ -364,7 +364,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		LimiterConfig: limiter.Config{
 			MaxConnections: 1000,
 		},
-		Log:             utils.NewSlogLoggerForTests(),
+		Log:             logtest.NewLogger(),
 		InventoryHandle: inventoryHandle,
 		GetRotation: func(role types.SystemRole) (*types.Rotation, error) {
 			return &types.Rotation{}, nil

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestCheckImpersonationPermissions(t *testing.T) {
@@ -332,7 +332,7 @@ current-context: foo
 					CheckImpersonationPermissions: tt.impersonationCheck,
 					Clock:                         clockwork.NewFakeClock(),
 				},
-				log: utils.NewSlogLoggerForTests(),
+				log: logtest.NewLogger(),
 			}
 			err := fwd.getKubeDetails(ctx)
 			tt.assertErr(t, err)

--- a/lib/kube/proxy/cluster_details_test.go
+++ b/lib/kube/proxy/cluster_details_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestNewClusterDetails(t *testing.T) {
@@ -47,7 +47,7 @@ func TestNewClusterDetails(t *testing.T) {
 				kubeClient: client,
 			},
 			cluster: &types.KubernetesClusterV3{},
-			log:     utils.NewSlogLoggerForTests(),
+			log:     logtest.NewLogger(),
 			clock:   c,
 		}, client
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 var (
@@ -130,7 +131,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 	}
 	f := &Forwarder{
-		log: utils.NewSlogLoggerForTests(),
+		log: logtest.NewLogger(),
 		cfg: ForwarderConfig{
 			ClusterName:       "local",
 			CachingAuthClient: ap,
@@ -1109,7 +1110,7 @@ func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 	require.NoError(t, err)
 
 	return &Forwarder{
-		log:    utils.NewSlogLoggerForTests(),
+		log:    logtest.NewLogger(),
 		router: httprouter.New(),
 		cfg: ForwarderConfig{
 			Keygen:            testauthority.New(),
@@ -1274,7 +1275,7 @@ func (m *mockWatcher) Done() <-chan struct{} {
 
 func newTestForwarder(ctx context.Context, cfg ForwarderConfig) *Forwarder {
 	return &Forwarder{
-		log:            utils.NewSlogLoggerForTests(),
+		log:            logtest.NewLogger(),
 		router:         httprouter.New(),
 		cfg:            cfg,
 		activeRequests: make(map[string]context.Context),
@@ -1631,7 +1632,7 @@ func TestForwarderTLSConfigCAs(t *testing.T) {
 				return x509.NewCertPool(), nil
 			},
 		},
-		log: utils.NewSlogLoggerForTests(),
+		log: logtest.NewLogger(),
 		ctx: context.Background(),
 	}
 

--- a/lib/kube/proxy/kube_creds_test.go
+++ b/lib/kube/proxy/kube_creds_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type mockEKSClientGetter struct {
@@ -365,7 +365,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 					) error {
 						return nil
 					},
-					log:                  utils.NewSlogLoggerForTests(),
+					log:                  logtest.NewLogger(),
 					kubeCluster:          tt.args.cluster,
 					client:               tt.args.client,
 					initialRenewInterval: ttl / 2,

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestPortForwardKubeService(t *testing.T) {
@@ -284,7 +284,7 @@ func TestPortForwardProxy_run_connsClosed(t *testing.T) {
 			context:       context.Background(),
 			onPortForward: func(addr string, success bool) {},
 		},
-		logger:                utils.NewSlogLoggerForTests(),
+		logger:                logtest.NewLogger(),
 		sourceConn:            sourceConn,
 		targetConn:            targetConn,
 		streamChan:            make(chan httpstream.Stream),

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	libslices "github.com/gravitational/teleport/lib/utils/slices"
 )
 
@@ -186,7 +186,7 @@ func Test_filterBuffer(t *testing.T) {
 					},
 					verb: types.KubeVerbList,
 				}
-				err = filterBuffer(newResourceFilterer(mr, &globalKubeCodecs, allowedResources, nil, utils.NewSlogLoggerForTests()), buf)
+				err = filterBuffer(newResourceFilterer(mr, &globalKubeCodecs, allowedResources, nil, logtest.NewLogger()), buf)
 				require.NoError(t, err)
 
 				// Decompress the buffer to compare the result.

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -53,7 +53,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	tkm "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestListPodRBAC(t *testing.T) {
@@ -689,7 +689,7 @@ func TestWatcherResponseWriter(t *testing.T) {
 				},
 				verb: types.KubeVerbWatch,
 			}
-			filterWrapper := newResourceFilterer(mr, &globalKubeCodecs, tt.args.allowed, tt.args.denied, utils.NewSlogLoggerForTests())
+			filterWrapper := newResourceFilterer(mr, &globalKubeCodecs, tt.args.allowed, tt.args.denied, logtest.NewLogger())
 			// watcher parses the data written into itself and if the user is allowed to
 			// receive the update, it writes the event into target.
 			watcher, err := responsewriters.NewWatcherResponseWriter(newFakeResponseWriter(userWriter) /*target*/, negotiator, filterWrapper)

--- a/lib/kube/proxy/scheme_test.go
+++ b/lib/kube/proxy/scheme_test.go
@@ -26,13 +26,13 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestNewClusterSchemaBuilder tests that newClusterSchemaBuilder doesn't panic
 // when it's given types already registered in the global scheme.
 func Test_newClusterSchemaBuilder(t *testing.T) {
-	_, _, _, err := newClusterSchemaBuilder(utils.NewSlogLoggerForTests(), &clientSet{})
+	_, _, _, err := newClusterSchemaBuilder(logtest.NewLogger(), &clientSet{})
 	require.NoError(t, err)
 }
 

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -44,7 +44,7 @@ import (
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestServeConfigureError(t *testing.T) {
@@ -113,7 +113,7 @@ func TestMTLSClientCAs(t *testing.T) {
 	userCert := genCert(t, "user")
 	srv := &TLSServer{
 		TLSServerConfig: TLSServerConfig{
-			Log: utils.NewSlogLoggerForTests(),
+			Log: logtest.NewLogger(),
 			ForwarderConfig: ForwarderConfig{
 				ClusterName: mainClusterName,
 			},
@@ -125,7 +125,7 @@ func TestMTLSClientCAs(t *testing.T) {
 			GetRotation:          func(role types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
 			ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 		},
-		log: utils.NewSlogLoggerForTests(),
+		log: logtest.NewLogger(),
 	}
 
 	lis, err := net.Listen("tcp", "localhost:0")
@@ -207,7 +207,7 @@ func TestGetServerInfo(t *testing.T) {
 
 	srv := &TLSServer{
 		TLSServerConfig: TLSServerConfig{
-			Log: utils.NewSlogLoggerForTests(),
+			Log: logtest.NewLogger(),
 			ForwarderConfig: ForwarderConfig{
 				Clock:       clockwork.NewFakeClock(),
 				ClusterName: "kube-cluster",

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestSessionEndError(t *testing.T) {
@@ -282,7 +282,7 @@ func Test_session_trackSession(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sess := &session{
-				log: utils.NewSlogLoggerForTests(),
+				log: logtest.NewLogger(),
 				id:  uuid.New(),
 				req: &http.Request{
 					URL: &url.URL{

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -67,7 +67,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	sessPkg "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type TestContext struct {
@@ -286,7 +286,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		GetRotation:          func(role types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
 		ResourceMatchers:     cfg.ResourceMatchers,
 		OnReconcile:          cfg.OnReconcile,
-		Log:                  utils.NewSlogLoggerForTests(),
+		Log:                  logtest.NewLogger(),
 		InventoryHandle:      inventoryHandle,
 		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 	})
@@ -364,7 +364,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		LimiterConfig: limiter.Config{
 			MaxConnections: 1000,
 		},
-		Log:             utils.NewSlogLoggerForTests(),
+		Log:             logtest.NewLogger(),
 		InventoryHandle: inventoryHandle,
 		GetRotation: func(role types.SystemRole) (*types.Rotation, error) {
 			return &types.Rotation{}, nil

--- a/lib/labels/labels_test.go
+++ b/lib/labels/labels_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -36,10 +36,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/limiter/internal/ratelimit"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -53,10 +53,11 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/multiplexer/testproxy.go
+++ b/lib/multiplexer/testproxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestProxy is tcp passthrough proxy that sends a proxy-line when connecting
@@ -52,7 +53,7 @@ func NewTestProxy(target string, v2 bool) (*TestProxy, error) {
 		listener: listener,
 		target:   target,
 		closeCh:  make(chan struct{}),
-		log:      utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "test:proxy"),
+		log:      logtest.With(teleport.ComponentKey, "test:proxy"),
 		v2:       v2,
 	}, nil
 }

--- a/lib/pam/pam_test.go
+++ b/lib/pam/pam_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	// Skip this test if the binary was not built with PAM support.
 	if !BuildHasPAM() || !SystemHasPAM() {

--- a/lib/proxy/peer/credentials_test.go
+++ b/lib/proxy/peer/credentials_test.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type testCredentials struct {
@@ -113,7 +113,7 @@ func TestClientCredentials(t *testing.T) {
 				},
 			}
 
-			creds := newClientCredentials(test.expectedPeerID, test.peerAddr, utils.NewSlogLoggerForTests(), newTestCredentials(cert))
+			creds := newClientCredentials(test.expectedPeerID, test.peerAddr, logtest.NewLogger(), newTestCredentials(cert))
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()

--- a/lib/proxy/peer/quic/quic_test.go
+++ b/lib/proxy/peer/quic/quic_test.go
@@ -45,10 +45,11 @@ import (
 	"github.com/gravitational/teleport/lib/proxy/peer/internal"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/reversetunnel/agent_dialer_test.go
+++ b/lib/reversetunnel/agent_dialer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestAgentCertChecker validates that reverse tunnel agents properly validate
@@ -89,7 +90,7 @@ func TestAgentCertChecker(t *testing.T) {
 			dialer := agentDialer{
 				client:      &fakeClient{caKey: ca.PublicKey()},
 				authMethods: []ssh.AuthMethod{ssh.PublicKeys(signer)},
-				logger:      utils.NewSlogLoggerForTests(),
+				logger:      logtest.NewLogger(),
 			}
 
 			_, err = dialer.DialContext(context.Background(), *utils.MustParseAddr(sshServer.Addr()))

--- a/lib/reversetunnel/localsite_test.go
+++ b/lib/reversetunnel/localsite_test.go
@@ -40,10 +40,11 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	os.Exit(m.Run())
 }
@@ -62,7 +63,7 @@ func TestRemoteConnCleanup(t *testing.T) {
 	watcher, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: "test",
-			Logger:    utils.NewSlogLoggerForTests(),
+			Logger:    logtest.NewLogger(),
 			Clock:     clock,
 			Client:    clt,
 		},
@@ -77,7 +78,7 @@ func TestRemoteConnCleanup(t *testing.T) {
 		ctx:              ctx,
 		Config:           Config{Clock: clock},
 		localAuthClient:  &mockLocalSiteClient{},
-		logger:           utils.NewSlogLoggerForTests(),
+		logger:           logtest.NewLogger(),
 		offlineThreshold: time.Second,
 		proxyWatcher:     watcher,
 	}
@@ -257,7 +258,7 @@ func TestProxyResync(t *testing.T) {
 	watcher, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: "test",
-			Logger:    utils.NewSlogLoggerForTests(),
+			Logger:    logtest.NewLogger(),
 			Clock:     clock,
 			Client:    clt,
 		},
@@ -272,7 +273,7 @@ func TestProxyResync(t *testing.T) {
 		ctx:              ctx,
 		Config:           Config{Clock: clock},
 		localAuthClient:  &mockLocalSiteClient{},
-		logger:           utils.NewSlogLoggerForTests(),
+		logger:           logtest.NewLogger(),
 		offlineThreshold: 24 * time.Hour,
 		proxyWatcher:     watcher,
 	}

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func newCAAndSigner(t *testing.T, caType types.CertAuthType, name string) (types.CertAuthority, ssh.Signer) {
@@ -80,7 +81,7 @@ func TestServerKeyAuth(t *testing.T) {
 	leafUserCA, leafUserCASigner := newCAAndSigner(t, types.UserCA, "leaf")
 
 	s := &server{
-		logger: utils.NewSlogLoggerForTests(),
+		logger: logtest.NewLogger(),
 		Config: Config{Clock: clockwork.NewRealClock(), ClusterName: "root"},
 		localAccessPoint: mockAccessPoint{
 			cas: []types.CertAuthority{hostCA, userCA, leafHostCA, leafUserCA},
@@ -346,7 +347,7 @@ func TestOnlyAuthDial(t *testing.T) {
 	badListenerAddr := acceptAndCloseListener(t, true)
 
 	srv := &server{
-		logger: utils.NewSlogLoggerForTests(),
+		logger: logtest.NewLogger(),
 		ctx:    ctx,
 		Config: Config{
 			LocalAuthAddresses: []string{goodListenerAddr},

--- a/lib/secret/secret_test.go
+++ b/lib/secret/secret_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -80,10 +80,11 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }
@@ -517,7 +518,7 @@ func TestAthenaAuditLogSetup(t *testing.T) {
 			exitContext: context.Background(),
 		},
 		backend: backend,
-		logger:  utils.NewSlogLoggerForTests(),
+		logger:  logtest.NewLogger(),
 	}
 
 	integrationSvc, err := local.NewIntegrationsService(backend)
@@ -951,7 +952,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Testing.ConnectFailureC = make(chan time.Duration, 5)
 	cfg.Testing.ClientTimeout = time.Millisecond
 	cfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	process, err := NewTeleport(cfg)
 	require.NoError(t, err)
 
@@ -1274,7 +1275,7 @@ func TestProxyGRPCServers(t *testing.T) {
 	// Create a new Teleport process to initialize the gRPC servers with KubeProxy
 	// enabled.
 	process := &TeleportProcess{
-		Supervisor: NewSupervisor(hostID, utils.NewSlogLoggerForTests()),
+		Supervisor: NewSupervisor(hostID, logtest.NewLogger()),
 		Config: &servicecfg.Config{
 			Proxy: servicecfg.ProxyConfig{
 				Kube: servicecfg.KubeProxyConfig{
@@ -1282,7 +1283,7 @@ func TestProxyGRPCServers(t *testing.T) {
 				},
 			},
 		},
-		logger: utils.NewSlogLoggerForTests(),
+		logger: logtest.NewLogger(),
 	}
 
 	// Create a limiter with no limits.

--- a/lib/services/expiry/expiry_test.go
+++ b/lib/services/expiry/expiry_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestExpiry(t *testing.T) {
@@ -51,7 +51,7 @@ func TestExpiry(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { authServer.Close() })
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	mockEmitter := &eventstest.MockRecorderEmitter{}
 	cfg := &Config{
 		Log:         logger,

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services/suite"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -28,11 +28,11 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/alpnproxy/azure_token_middleware_test.go
+++ b/lib/srv/alpnproxy/azure_token_middleware_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestAzureTokenMiddlewareHandleRequest(t *testing.T) {
@@ -69,7 +69,7 @@ func testAzureTokenMiddlewareHandleRequest(t *testing.T, alg cryptosuites.Algori
 		Identity: "azureTestIdentity",
 		TenantID: "cafecafe-cafe-4aaa-cafe-cafecafecafe",
 		ClientID: "decaffff-cafe-4aaa-cafe-cafecafecafe",
-		Log:      utils.NewSlogLoggerForTests(),
+		Log:      logtest.NewLogger(),
 		Clock:    clockwork.NewFakeClockAt(time.Date(2022, 1, 1, 9, 0, 0, 0, time.UTC)),
 		Secret:   "my-secret",
 	}

--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type Suite struct {
@@ -124,7 +125,7 @@ func (s *Suite) CreateProxyServer(t *testing.T) *Proxy {
 		Listener:          s.serverListener,
 		WebTLSConfig:      tlsConfig,
 		Router:            s.router,
-		Log:               utils.NewSlogLoggerForTests(),
+		Log:               logtest.NewLogger(),
 		AccessPoint:       s.accessPoint,
 		IdentityTLSConfig: tlsConfig,
 		ClusterName:       "root",

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestHandleAWSAccessSigVerification tests if LocalProxy verifies the AWS SigV4 signature of incoming request.
@@ -612,7 +612,7 @@ func TestKubeMiddleware(t *testing.T) {
 			km := NewKubeMiddleware(KubeMiddlewareConfig{
 				Certs:        tt.startCerts,
 				CertReissuer: certReissuer,
-				Logger:       utils.NewSlogLoggerForTests(),
+				Logger:       logtest.NewLogger(),
 				Clock:        tt.clock,
 				CloseContext: context.Background(),
 			})

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -56,10 +56,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -71,10 +71,11 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())

--- a/lib/srv/app/session_test.go
+++ b/lib/srv/app/session_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func newSessionChunk(timeout time.Duration) *sessionChunk {
@@ -37,7 +37,7 @@ func newSessionChunk(timeout time.Duration) *sessionChunk {
 		closeC:       make(chan struct{}),
 		inflightCond: sync.NewCond(&sync.Mutex{}),
 		closeTimeout: timeout,
-		log:          utils.NewSlogLoggerForTests(),
+		log:          logtest.NewLogger(),
 		streamCloser: events.NewDiscardRecorder(),
 	}
 }

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -103,10 +103,11 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	modules.SetInsecureTestMode(true)
 	registerTestSnowflakeEngine()
@@ -2399,7 +2400,7 @@ func setupTestContext(ctx context.Context, t testing.TB, withDatabases ...withDa
 		ServerID:       testCtx.hostID,
 		Emitter:        testCtx.emitter,
 		EmitterContext: ctx,
-		Logger:         utils.NewSlogLoggerForTests(),
+		Logger:         logtest.NewLogger(),
 	})
 	require.NoError(t, err)
 
@@ -2553,7 +2554,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t testing.TB, p a
 		ServerID:       p.HostID,
 		Emitter:        c.emitter,
 		EmitterContext: context.Background(),
-		Logger:         utils.NewSlogLoggerForTests(),
+		Logger:         logtest.NewLogger(),
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/db/cassandra/protocoltest/test.go
+++ b/lib/srv/db/cassandra/protocoltest/test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // Session alias for easier use.
@@ -148,7 +148,7 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 		tlsConfig: tlsConfig,
 		server:    server,
 		ct:        ct,
-		logger: utils.NewSlogLoggerForTests().With(
+		logger: logtest.With(
 			teleport.ComponentKey, defaults.ProtocolCassandra,
 			"name", config.Name,
 		),

--- a/lib/srv/db/clickhouse/protocoltest/test.go
+++ b/lib/srv/db/clickhouse/protocoltest/test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
@@ -95,7 +95,7 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (*T
 		listener:  config.Listener,
 		port:      port,
 		tlsConfig: tlsConfig,
-		logger: utils.NewSlogLoggerForTests().With(
+		logger: logtest.With(
 			teleport.ComponentKey, defaults.ProtocolClickHouse,
 			"name", config.Name,
 		),

--- a/lib/srv/db/cloud/resource_checker_url_aws_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestURLChecker_AWS(t *testing.T) {
@@ -172,7 +172,7 @@ func TestURLChecker_AWS(t *testing.T) {
 		t.Run(method.name, func(t *testing.T) {
 			c := newURLChecker(DiscoveryResourceCheckerConfig{
 				AWSConfigProvider: method.awsConfigProvider,
-				Logger:            utils.NewSlogLoggerForTests(),
+				Logger:            logtest.NewLogger(),
 			})
 			c.awsClients = method.awsClients
 

--- a/lib/srv/db/cloud/resource_checker_url_azure_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_azure_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestURLChecker_Azure(t *testing.T) {
@@ -47,7 +47,7 @@ func TestURLChecker_Azure(t *testing.T) {
 	}
 
 	c := newURLChecker(DiscoveryResourceCheckerConfig{
-		Logger: utils.NewSlogLoggerForTests(),
+		Logger: logtest.NewLogger(),
 	})
 	for _, database := range testCases {
 		t.Run(database.GetName(), func(t *testing.T) {

--- a/lib/srv/db/cloud/users/users_test.go
+++ b/lib/srv/db/cloud/users/users_test.go
@@ -40,11 +40,11 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/secrets"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -47,11 +47,11 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/db/common/connect/connect_test.go
+++ b/lib/srv/db/common/connect/connect_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestGetDatabaseServers(t *testing.T) {
@@ -69,7 +69,7 @@ func TestGetDatabaseServers(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			servers, err := GetDatabaseServers(context.Background(), GetDatabaseServersParams{
-				Logger:                utils.NewSlogLoggerForTests(),
+				Logger:                logtest.NewLogger(),
 				ClusterName:           "root",
 				DatabaseServersGetter: tc.getter,
 				Identity:              tc.identity,
@@ -190,7 +190,7 @@ func TestConnect(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			conn, stats, err := Connect(context.Background(), ConnectParams{
-				Logger:         utils.NewSlogLoggerForTests(),
+				Logger:         logtest.NewLogger(),
 				Identity:       tc.identity,
 				Servers:        tc.dialer.getServers(),
 				ShuffleFunc:    ShuffleSort,

--- a/lib/srv/db/mongodb/test.go
+++ b/lib/srv/db/mongodb/test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/mongodb/protocol"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // MakeTestClient returns MongoDB client connection according to the provided
@@ -132,8 +133,7 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log := utils.NewSlogLoggerForTests().With(
-		teleport.ComponentKey, defaults.ProtocolMongoDB,
+	log := logtest.With(teleport.ComponentKey, defaults.ProtocolMongoDB,
 		"name", config.Name,
 	)
 	server := &TestServer{

--- a/lib/srv/db/mysql/test.go
+++ b/lib/srv/db/mysql/test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestClientConn defines interface for client.Conn.
@@ -151,8 +152,7 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 		listener = tls.NewListener(listener, tlsConfig)
 	}
 
-	log := utils.NewSlogLoggerForTests().With(
-		teleport.ComponentKey, defaults.ProtocolMySQL,
+	log := logtest.With(teleport.ComponentKey, defaults.ProtocolMySQL,
 		"name", config.Name,
 	)
 	server := &TestServer{

--- a/lib/srv/db/opensearch/test.go
+++ b/lib/srv/db/opensearch/test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestServerOption allows setting test server options.
@@ -72,7 +72,7 @@ func NewTestServer(config common.TestServerConfig, opts ...TestServerOption) (sv
 		listener:  config.Listener,
 		port:      port,
 		tlsConfig: tlsConfig,
-		log: utils.NewSlogLoggerForTests().With(
+		log: logtest.With(
 			teleport.ComponentKey, defaults.ProtocolOpenSearch,
 			"name", config.Name,
 		),

--- a/lib/srv/db/sqlserver/test.go
+++ b/lib/srv/db/sqlserver/test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver/protocol"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // MakeTestClient returns SQL Server client used in tests.
@@ -133,8 +134,7 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log := utils.NewSlogLoggerForTests().With(
-		teleport.ComponentKey, defaults.ProtocolSQLServer,
+	log := logtest.With(teleport.ComponentKey, defaults.ProtocolSQLServer,
 		"name", config.Name,
 	)
 	server := &TestServer{

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/services/local"
-	libutils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func discoveryConfigWithAWSMatchers(t *testing.T, discoveryGroup string, m ...types.AWSMatcher) *discoveryconfig.DiscoveryConfig {
@@ -278,7 +278,7 @@ func TestDiscoveryServerEKS(t *testing.T) {
 					Matchers:        Matchers{},
 					Emitter:         tt.emitter,
 					DiscoveryGroup:  defaultDiscoveryGroup,
-					Log:             libutils.NewSlogLoggerForTests(),
+					Log:             logtest.NewLogger(),
 				})
 				require.NoError(t, err)
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -95,7 +95,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
-	libutils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
@@ -731,7 +731,7 @@ func TestDiscoveryServer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			logger := libutils.NewSlogLoggerForTests()
+			logger := logtest.NewLogger()
 
 			reporter := &mockUsageReporter{}
 			installer := &mockSSMInstaller{
@@ -858,7 +858,7 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 func TestDiscoveryServerConcurrency(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := libutils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	defaultDiscoveryGroup := "dg01"
 	awsMatcher := types.AWSMatcher{
@@ -1452,7 +1452,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				require.NoError(t, r.Close())
 				require.NoError(t, w.Close())
 			})
-			logger := libutils.NewSlogLoggerForTests()
+			logger := logtest.NewLogger()
 
 			clustersNotUpdated := make(chan string, 10)
 			go func() {
@@ -3009,7 +3009,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			logger := libutils.NewSlogLoggerForTests()
+			logger := logtest.NewLogger()
 
 			emitter := &mockEmitter{}
 			reporter := &mockUsageReporter{}
@@ -3316,7 +3316,7 @@ func TestGCPVMDiscovery(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			logger := libutils.NewSlogLoggerForTests()
+			logger := logtest.NewLogger()
 			emitter := &mockEmitter{}
 			reporter := &mockUsageReporter{}
 			installer := &mockGCPInstaller{
@@ -3377,7 +3377,7 @@ func TestServer_onCreate(t *testing.T) {
 		Config: &Config{
 			DiscoveryGroup: "test-cluster",
 			AccessPoint:    accessPoint,
-			Log:            libutils.NewSlogLoggerForTests(),
+			Log:            logtest.NewLogger(),
 		},
 	}
 

--- a/lib/srv/discovery/fetchers/aks_test.go
+++ b/lib/srv/discovery/fetchers/aks_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestAKSFetcher(t *testing.T) {
@@ -117,7 +117,7 @@ func TestAKSFetcher(t *testing.T) {
 				FilterLabels:   tt.args.filterLabels,
 				Regions:        tt.args.regions,
 				ResourceGroups: tt.args.resourceGroups,
-				Logger:         utils.NewSlogLoggerForTests(),
+				Logger:         logtest.NewLogger(),
 			}
 			fetcher, err := NewAKSFetcher(cfg)
 			require.NoError(t, err)

--- a/lib/srv/discovery/fetchers/db/azure_managed_sql_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_managed_sql_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestSQLManagedServerFetcher(t *testing.T) {
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	fetcher := &azureManagedSQLServerFetcher{}
 
 	t.Run("NewDatabaseFromServer", func(t *testing.T) {

--- a/lib/srv/discovery/fetchers/eks_test.go
+++ b/lib/srv/discovery/fetchers/eks_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestEKSFetcher(t *testing.T) {
@@ -123,7 +123,7 @@ func TestEKSFetcher(t *testing.T) {
 				AssumeRole:   tt.assumeRole,
 				FilterLabels: tt.args.filterLabels,
 				Region:       tt.args.region,
-				Logger:       utils.NewSlogLoggerForTests(),
+				Logger:       logtest.NewLogger(),
 			}
 			fetcher, err := NewEKSFetcher(cfg)
 			require.NoError(t, err)

--- a/lib/srv/discovery/fetchers/gke_test.go
+++ b/lib/srv/discovery/fetchers/gke_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestGKEFetcher(t *testing.T) {
@@ -136,7 +136,7 @@ func TestGKEFetcher(t *testing.T) {
 				FilterLabels:  tt.args.filterLabels,
 				Location:      tt.args.location,
 				ProjectID:     tt.args.projectID,
-				Logger:        utils.NewSlogLoggerForTests(),
+				Logger:        logtest.NewLogger(),
 			}
 			fetcher, err := NewGKEFetcher(context.Background(), cfg)
 			require.NoError(t, err)

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestKubeAppFetcher_Get(t *testing.T) {
@@ -291,7 +292,7 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 				FilterLabels:     tt.matcherLabels,
 				Namespaces:       tt.matcherNamespaces,
 				ProtocolChecker:  tt.protoChecker,
-				Logger:           utils.NewSlogLoggerForTests(),
+				Logger:           logtest.NewLogger(),
 			})
 			require.NoError(t, err)
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
-	libutils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestServer_getKubeFetchers(t *testing.T) {
@@ -407,7 +407,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 						AWS: tc.awsMatchers,
 					},
 					Emitter:        authClient,
-					Log:            libutils.NewSlogLoggerForTests(),
+					Log:            logtest.NewLogger(),
 					DiscoveryGroup: mainDiscoveryGroup,
 				})
 

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -33,13 +33,13 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/sshutils"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.

--- a/lib/srv/forward/sshserver_test.go
+++ b/lib/srv/forward/sshserver_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshutils"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestSignersWithSHA1Fallback(t *testing.T) {
@@ -217,7 +217,7 @@ func TestDirectTCPIP(t *testing.T) {
 			t.Parallel()
 
 			s := Server{
-				logger:          utils.NewSlogLoggerForTests(),
+				logger:          logtest.NewLogger(),
 				identityContext: srv.IdentityContext{Login: tt.login},
 			}
 
@@ -252,7 +252,7 @@ func TestCheckTCPIPForward(t *testing.T) {
 			t.Parallel()
 
 			s := Server{
-				logger:          utils.NewSlogLoggerForTests(),
+				logger:          logtest.NewLogger(),
 				identityContext: srv.IdentityContext{Login: tt.login},
 			}
 			err := s.checkTCPIPForwardRequest(context.Background(),

--- a/lib/srv/git/forward_test.go
+++ b/lib/srv/git/forward_test.go
@@ -51,10 +51,11 @@ import (
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -41,11 +41,12 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet services.RoleSet, accessPermit *decisionpb.SSHAccessPermit) *ServerContext {
@@ -71,7 +72,7 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 	clusterName := "localhost"
 	_, connCtx := sshutils.NewConnectionContext(ctx, nil, &ssh.ServerConn{Conn: sshConn})
 	scx := &ServerContext{
-		Logger:                 utils.NewSlogLoggerForTests(),
+		Logger:                 logtest.NewLogger(),
 		ConnectionContext:      connCtx,
 		env:                    make(map[string]string),
 		SessionRecordingConfig: recConfig,

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func newTestMonitor(ctx context.Context, t *testing.T, asrv *auth.TestAuthServer, mut ...func(*MonitorConfig)) (*mockTrackingConn, *eventstest.ChannelEmitter, MonitorConfig) {
@@ -54,7 +54,7 @@ func newTestMonitor(ctx context.Context, t *testing.T, asrv *auth.TestAuthServer
 		EmitterContext: ctx,
 		Clock:          asrv.Clock(),
 		Tracker:        &mockActivityTracker{asrv.Clock()},
-		Logger:         utils.NewSlogLoggerForTests(),
+		Logger:         logtest.NewLogger(),
 		LockWatcher:    asrv.LockWatcher,
 		LockTargets:    []types.LockTarget{{User: "test-user"}},
 		LockingMode:    constants.LockingModeBestEffort,
@@ -86,7 +86,7 @@ func TestConnectionMonitorLockInForce(t *testing.T) {
 		Emitter:        emitter,
 		EmitterContext: ctx,
 		Clock:          asrv.Clock(),
-		Logger:         utils.NewSlogLoggerForTests(),
+		Logger:         logtest.NewLogger(),
 		LockWatcher:    asrv.LockWatcher,
 		ServerID:       "test",
 	})

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -79,6 +79,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // teleportTestUser is additional user used for tests
@@ -92,7 +93,7 @@ var wildcardAllow = types.Labels{
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	if srv.IsReexec() {
 		srv.RunAndExit(os.Args[1])

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/azure"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type mockClients struct {
@@ -149,7 +149,7 @@ func TestAzureWatcher(t *testing.T) {
 		},
 	}
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	for _, tc := range tests {
 		tc.matcher.Types = []string{"vm"}
 		tc.matcher.Subscriptions = []string{"sub1"}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -51,6 +51,7 @@ import (
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestIsApprovedFileTransfer(t *testing.T) {
@@ -193,7 +194,7 @@ func TestSession_newRecorder(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	isNotSessionWriter := func(t require.TestingT, i any, i2 ...any) {
 		require.NotNil(t, i)
@@ -214,7 +215,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:     "test",
 				logger: logger,
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -235,7 +236,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:     "test",
 				logger: logger,
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -256,7 +257,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:     "test",
 				logger: logger,
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -285,7 +286,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:     "test",
 				logger: logger,
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -321,7 +322,7 @@ func TestSession_newRecorder(t *testing.T) {
 				id:     "test",
 				logger: logger,
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv: &mockServer{
 							component: teleport.ComponentNode,
@@ -360,7 +361,7 @@ func TestSession_newRecorder(t *testing.T) {
 func TestSession_emitAuditEvent(t *testing.T) {
 	t.Parallel()
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	t.Run("FallbackConcurrency", func(t *testing.T) {
 		srv := newMockServer(t)
@@ -1053,9 +1054,9 @@ func TestTrackingSession(t *testing.T) {
 
 			sess := &session{
 				id:     rsession.NewID(),
-				logger: utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "test-session"),
+				logger: logtest.With(teleport.ComponentKey, "test-session"),
 				registry: &SessionRegistry{
-					logger: utils.NewSlogLoggerForTests(),
+					logger: logtest.NewLogger(),
 					SessionRegistryConfig: SessionRegistryConfig{
 						Srv:                   srv,
 						SessionTrackerService: trackingService,
@@ -1563,7 +1564,7 @@ func TestUpsertHostUser(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			registry := SessionRegistry{
-				logger: utils.NewSlogLoggerForTests(),
+				logger: logtest.NewLogger(),
 				SessionRegistryConfig: SessionRegistryConfig{
 					Srv: &fakeServer{createHostUser: c.createHostUser},
 				},
@@ -1653,7 +1654,7 @@ func TestWriteSudoersFile(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			registry := SessionRegistry{
-				logger: utils.NewSlogLoggerForTests(),
+				logger: logtest.NewLogger(),
 				SessionRegistryConfig: SessionRegistryConfig{
 					Srv: &fakeServer{hostSudoers: c.hostSudoers},
 				},

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -49,10 +49,11 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	os.Exit(m.Run())
 }
@@ -275,7 +276,7 @@ func TestService_GetClusterDetails(t *testing.T) {
 			t.Parallel()
 			srv := newServer(t, ServerConfig{
 				Dialer:            fakeDialer{},
-				Logger:            utils.NewSlogLoggerForTests(),
+				Logger:            logtest.NewLogger(),
 				FIPS:              test.FIPS,
 				SignerFn:          fakeSigner,
 				ConnectionMonitor: fakeMonitor{},
@@ -357,7 +358,7 @@ func TestService_ProxyCluster(t *testing.T) {
 						cluster: conn,
 					},
 				},
-				Logger:            utils.NewSlogLoggerForTests(),
+				Logger:            logtest.NewLogger(),
 				SignerFn:          fakeSigner,
 				ConnectionMonitor: fakeMonitor{},
 				LocalAddr:         utils.MustParseAddr("127.0.0.1:4242"),
@@ -509,7 +510,7 @@ func TestService_ProxySSH_Errors(t *testing.T) {
 				},
 				SignerFn:          fakeSigner,
 				ConnectionMonitor: fakeMonitor{},
-				Logger:            utils.NewSlogLoggerForTests(),
+				Logger:            logtest.NewLogger(),
 				LocalAddr:         utils.MustParseAddr("127.0.0.1:4242"),
 				authzContextFn: func(info credentials.AuthInfo) (*authz.Context, error) {
 					checker, err := test.checkerFn(info)
@@ -572,7 +573,7 @@ func TestService_ProxySSH(t *testing.T) {
 	srv := newServer(t, ServerConfig{
 		Dialer:            sshSrv,
 		SignerFn:          fakeSigner,
-		Logger:            utils.NewSlogLoggerForTests(),
+		Logger:            logtest.NewLogger(),
 		LocalAddr:         utils.MustParseAddr("127.0.0.1:4242"),
 		ConnectionMonitor: fakeMonitor{},
 		agentGetterFn: func(rw io.ReadWriter) teleagent.Getter {
@@ -817,7 +818,7 @@ func TestService_ProxyWindowsDesktopSession(t *testing.T) {
 				},
 				SignerFn:          fakeSigner,
 				ConnectionMonitor: fakeMonitor{},
-				Logger:            utils.NewSlogLoggerForTests(),
+				Logger:            logtest.NewLogger(),
 				LocalAddr:         utils.MustParseAddr("127.0.0.1:4243"),
 				authzContextFn: func(info credentials.AuthInfo) (*authz.Context, error) {
 					checker, err := test.checkerFn(info)

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/host"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type testHostUserBackend struct {
@@ -279,11 +279,11 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
-		log:     utils.NewSlogLoggerForTests(),
+		log:     logtest.NewLogger(),
 	}
 	sudoers := HostSudoersManagement{
 		backend: backend,
-		log:     utils.NewSlogLoggerForTests(),
+		log:     logtest.NewLogger(),
 	}
 
 	closer, err := users.UpsertUser("bob", &decisionpb.HostUsersInfo{
@@ -306,7 +306,7 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		users := HostUserManagement{
 			backend: backend,
 			storage: pres,
-			log:     utils.NewSlogLoggerForTests(),
+			log:     logtest.NewLogger(),
 		}
 		// test user already exists but teleport-service group has not yet
 		// been created
@@ -347,7 +347,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	users := HostUserManagement{
 		backend:   mgmt,
 		storage:   pres,
-		log:       utils.NewSlogLoggerForTests(),
+		log:       logtest.NewLogger(),
 		userGrace: 0,
 	}
 
@@ -373,7 +373,7 @@ func TestUserMgmt_DeleteAllTeleportSystemUsers(t *testing.T) {
 	users = HostUserManagement{
 		backend: newTestUserMgmt(),
 		storage: pres,
-		log:     utils.NewSlogLoggerForTests(),
+		log:     logtest.NewLogger(),
 	}
 	// teleport-system group doesnt exist, DeleteAllUsers will return nil, instead of erroring
 	require.NoError(t, users.DeleteAllUsers())
@@ -731,7 +731,7 @@ func initBackend(t *testing.T, groups []string) (HostUserManagement, *testHostUs
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
-		log:     utils.NewSlogLoggerForTests(),
+		log:     logtest.NewLogger(),
 	}
 
 	for _, group := range groups {
@@ -749,7 +749,7 @@ func TestCreateUserWithExistingPrimaryGroup(t *testing.T) {
 	users := HostUserManagement{
 		backend: backend,
 		storage: pres,
-		log:     utils.NewSlogLoggerForTests(),
+		log:     logtest.NewLogger(),
 	}
 
 	existingGroups := []string{"alice", "simon"}
@@ -1110,7 +1110,7 @@ func TestHostUsersResolveGroups(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			log := utils.NewSlogLoggerForTests()
+			log := logtest.NewLogger()
 			groups, err := ResolveGroups(log, c.hostUser, c.ui, c.takeOwnership)
 			if c.expectErr == nil {
 				assert.NoError(t, err)

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -36,10 +36,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 
@@ -49,7 +50,7 @@ func TestSend(t *testing.T) {
 	atime := testNow.Add(1 * time.Second)
 	dirModtime := testNow.Add(2 * time.Second)
 	dirAtime := testNow.Add(3 * time.Second)
-	logger := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "send")
+	logger := logtest.With(teleport.ComponentKey, "send")
 	testCases := []struct {
 		desc   string
 		config Config
@@ -112,7 +113,7 @@ func TestReceive(t *testing.T) {
 	atime := testNow.Add(1 * time.Second)
 	dirModtime := testNow.Add(2 * time.Second)
 	dirAtime := testNow.Add(3 * time.Second)
-	logger := utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "recv")
+	logger := logtest.With(teleport.ComponentKey, "recv")
 	testCases := []struct {
 		desc       string
 		config     Config
@@ -234,7 +235,7 @@ func TestSCPFailsIfNoSource(t *testing.T) {
 //
 // See https://github.com/gravitational/teleport/issues/5497
 func TestReceiveIntoExistingDirectory(t *testing.T) {
-	logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+	logger := logtest.With("test", t.Name())
 	config := newTargetConfigWithFS("dir",
 		Flags{PreserveAttrs: true, Recursive: true},
 		newTestFS(logger, newDir("dir")),
@@ -277,7 +278,7 @@ func TestReceiveIntoExistingDirectory(t *testing.T) {
 //
 // See https://github.com/gravitational/teleport/issues/5695
 func TestReceiveIntoNonExistingDirectoryFailsWithCorrectMessage(t *testing.T) {
-	logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+	logger := logtest.With("test", t.Name())
 	// Target configuration with no existing directory
 	root := t.TempDir()
 	config := newTargetConfigWithFS(filepath.Join(root, "dir"),
@@ -305,7 +306,7 @@ func TestReceiveIntoNonExistingDirectoryFailsWithCorrectMessage(t *testing.T) {
 // TestCopyIntoNestedNonExistingDirectoriesDoesNotCreateIntermediateDirectories validates that copying a directory
 // into a remote '/path/to/remote' where '/path/to' does not exist causes an error.
 func TestCopyIntoNestedNonExistingDirectoriesDoesNotCreateIntermediateDirectories(t *testing.T) {
-	logger := utils.NewSlogLoggerForTests().With("test", t.Name())
+	logger := logtest.With("test", t.Name())
 
 	config := newTargetConfig("non-existing/remote_dir", Flags{Recursive: true})
 	sourceFS := newTestFS(logger, newDir("dir"))

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -33,10 +33,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -43,13 +43,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const fileMaxSize = 1000
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/tbot/loop_test.go
+++ b/lib/tbot/loop_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func Test_runOnInterval(t *testing.T) {
@@ -39,7 +39,7 @@ func Test_runOnInterval(t *testing.T) {
 	t.Cleanup(cancel)
 
 	taskCh := make(chan struct{}, 3)
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	clock := clockwork.NewFakeClock()
 	cfg := runOnIntervalConfig{
 		name:  "test",
@@ -79,7 +79,7 @@ func Test_runOnInterval_failureExit(t *testing.T) {
 
 	callCount := atomic.Int64{}
 
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	testErr := fmt.Errorf("test error")
 	cfg := runOnIntervalConfig{
 		name:  "test",

--- a/lib/tbot/service_application_tunnel_test.go
+++ b/lib/tbot/service_application_tunnel_test.go
@@ -36,14 +36,14 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestE2E_ApplicationTunnelService(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Spin up a test HTTP server
 	wantStatus := http.StatusTeapot

--- a/lib/tbot/service_ca_rotation_test.go
+++ b/lib/tbot/service_ca_rotation_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func Test_filterCAEvent(t *testing.T) {
@@ -128,7 +128,7 @@ func Test_filterCAEvent(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ignoreReason := filterCAEvent(ctx, log, tt.event, clusterName)

--- a/lib/tbot/service_heartbeat_test.go
+++ b/lib/tbot/service_heartbeat_test.go
@@ -37,7 +37,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type fakeHeartbeatSubmitter struct {
@@ -54,7 +54,7 @@ func (f *fakeHeartbeatSubmitter) SubmitHeartbeat(
 func TestHeartbeatService(t *testing.T) {
 	t.Parallel()
 
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/lib/tbot/service_identity_output_test.go
+++ b/lib/tbot/service_identity_output_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/ssh"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 
@@ -157,7 +157,7 @@ func Test_renderSSHConfig(t *testing.T) {
 
 			err := renderSSHConfig(
 				context.Background(),
-				utils.NewSlogLoggerForTests(),
+				logtest.NewLogger(),
 				&proxyPingResponse{
 					PingResponse: &webclient.PingResponse{
 						ClusterName: mockClusterName,

--- a/lib/tbot/service_kubernetes_output_test.go
+++ b/lib/tbot/service_kubernetes_output_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 
@@ -159,7 +159,7 @@ func TestKubernetesOutputService_render(t *testing.T) {
 					Destination:       dest,
 				},
 				executablePath: fakeGetExecutablePath,
-				log:            utils.NewSlogLoggerForTests(),
+				log:            logtest.NewLogger(),
 			}
 
 			keyRing, err := NewClientKeyRing(

--- a/lib/tbot/service_kubernetes_v2_output_test.go
+++ b/lib/tbot/service_kubernetes_v2_output_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 
@@ -271,7 +271,7 @@ func TestKubernetesV2OutputService_render(t *testing.T) {
 					Destination:       dest,
 				},
 				executablePath: fakeGetExecutablePath,
-				log:            utils.NewSlogLoggerForTests(),
+				log:            logtest.NewLogger(),
 			}
 
 			keyRing, err := NewClientKeyRing(

--- a/lib/tbot/service_spiffe_workload_api_sds_test.go
+++ b/lib/tbot/service_spiffe_workload_api_sds_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -68,7 +68,7 @@ func (m *mockTrustBundleCache) GetBundleSet(ctx context.Context) (*workloadident
 // It tests the generation of the DiscoveryResponses and that authentication
 // is enforced.
 func TestSDS_FetchSecrets(t *testing.T) {
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := context.Background()
 
 	td, err := spiffeid.TrustDomainFromString("example.com")
@@ -217,7 +217,7 @@ func Test_E2E_SPIFFE_SDS(t *testing.T) {
 	}
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))

--- a/lib/tbot/service_spiffe_workload_api_test.go
+++ b/lib/tbot/service_spiffe_workload_api_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/attrs"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -50,7 +50,7 @@ func TestSPIFFEWorkloadAPIService_filterSVIDRequests(t *testing.T) {
 	// This test is more for overall behavior. Use the _field test for
 	// each individual field.
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	tests := []struct {
 		name string
 		att  *workloadidentityv1pb.WorkloadAttrs
@@ -288,7 +288,7 @@ func TestSPIFFEWorkloadAPIService_filterSVIDRequests(t *testing.T) {
 
 func TestSPIFFEWorkloadAPIService_filterSVIDRequests_field(t *testing.T) {
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	tests := []struct {
 		field       string
 		matching    *workloadidentityv1pb.WorkloadAttrs
@@ -441,7 +441,7 @@ func TestSPIFFEWorkloadAPIService_filterSVIDRequests_field(t *testing.T) {
 func TestBotSPIFFEWorkloadAPI(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -48,7 +48,7 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
 	setWorkloadIdentityX509CAOverride(ctx, t, process)

--- a/lib/tbot/service_workload_identity_aws_ra_test.go
+++ b/lib/tbot/service_workload_identity_aws_ra_test.go
@@ -37,7 +37,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -144,7 +144,7 @@ type mockCreateSessionInputBody struct {
 func TestBotWorkloadIdentityAWSRA(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	tests := []struct {
 		name        string

--- a/lib/tbot/service_workload_identity_jwt_test.go
+++ b/lib/tbot/service_workload_identity_jwt_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -39,7 +39,7 @@ func TestBotWorkloadIdentityJWT(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)

--- a/lib/tbot/service_workload_identity_x509_test.go
+++ b/lib/tbot/service_workload_identity_x509_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -47,7 +47,7 @@ func TestBotWorkloadIdentityX509(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
 	setWorkloadIdentityX509CAOverride(ctx, t, process)

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -67,11 +67,12 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	os.Exit(m.Run())
 }
@@ -185,7 +186,7 @@ func defaultBotConfig(
 func TestBot(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	const (
@@ -556,7 +557,7 @@ func tlsIdentFromDest(ctx context.Context, t *testing.T, dest bot.Destination) *
 func TestBot_ResumeFromStorage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
@@ -601,7 +602,7 @@ func TestBot_IdentityRenewalFails(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// This test asserts that we can continue running (and recover) even when
 	// identity renewal fails on-startup.
@@ -828,7 +829,7 @@ func (f *failureProxy) setFailing(failing bool) {
 func TestBot_InsecureViaProxy(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
@@ -997,7 +998,7 @@ func newMockDiscoveredKubeCluster(t *testing.T, name, discoveredName string) *ty
 func TestBotDatabaseTunnel(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Make a new auth server.
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
@@ -1099,7 +1100,7 @@ func TestBotDatabaseTunnel(t *testing.T) {
 func TestBotSSHMultiplexer(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	currentUser, err := user.Current()
 	require.NoError(t, err)
@@ -1243,7 +1244,7 @@ func TestBotSSHMultiplexer(t *testing.T) {
 func TestBotJoiningURI(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	process := testenv.MakeTestServer(
 		t,

--- a/lib/tbot/workloadidentity/trust_bundle_cache_test.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestBundleSet_Clone(t *testing.T) {
@@ -159,7 +159,7 @@ func makeSPIFFEBundle(t *testing.T, td string) *spiffebundle.Bundle {
 func TestTrustBundleCache_Run(t *testing.T) {
 	t.Parallel()
 
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/lib/tbot/workloadidentity/workloadattest/docker_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/docker_unix_test.go
@@ -35,6 +35,7 @@ import (
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestDockerAttestor(t *testing.T) {
@@ -78,7 +79,7 @@ func TestDockerAttestor(t *testing.T) {
 			Enabled: true,
 			Addr:    "unix://" + lis.Addr().String(),
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 
 	attestor.rootPath = t.TempDir()

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -42,11 +42,12 @@ import (
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestKubernetesAttestor_Attest(t *testing.T) {
 	t.Parallel()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	ctx := context.Background()
 
 	mockToken := "FOOBARBUZZ"

--- a/lib/tbot/workloadidentity/workloadattest/podman_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/podman_unix_test.go
@@ -33,6 +33,7 @@ import (
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest/podman"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestPodmanAttestor(t *testing.T) {
@@ -67,7 +68,7 @@ func TestPodmanAttestor(t *testing.T) {
 			Enabled: true,
 			Addr:    server.Addr(),
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 
 	attestor.rootPath = t.TempDir()

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest/sigstore"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest/sigstore/sigstoretest"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 var loopbackPrefixes = []string{"127.0.0.1/8", "::1/128"}
@@ -49,7 +49,7 @@ func TestDiscovery_SimpleSigning(t *testing.T) {
 		fmt.Sprintf("%s/simple-signing:v1", registry),
 		"sha256:21c76c650023cac8d753af4cb591e6f7450c6e2b499b5751d4a21e26e2fc5012",
 		sigstore.DiscoveryConfig{
-			Logger:                        utils.NewSlogLoggerForTests(),
+			Logger:                        logtest.NewLogger(),
 			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)
@@ -128,7 +128,7 @@ func TestDiscovery_Attestations(t *testing.T) {
 		fmt.Sprintf("%s/attestations:v1", registry),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger:                        utils.NewSlogLoggerForTests(),
+			Logger:                        logtest.NewLogger(),
 			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)
@@ -168,7 +168,7 @@ func TestDiscovery_InfiniteRedirects(t *testing.T) {
 		fmt.Sprintf("%s/foo:v1", regURL.Host),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger:                        utils.NewSlogLoggerForTests(),
+			Logger:                        logtest.NewLogger(),
 			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)

--- a/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest/sigstore/sigstoretest"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 var loopbackPrefixes = []string{"127.0.0.1/8", "::1/128"}
@@ -118,7 +118,7 @@ func TestSigstoreAttestor_Attest_WithCredentials(t *testing.T) {
 			CredentialsPath:               dockerConfigFile,
 			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 	require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestSigstoreAttestor_Attest_Caching(t *testing.T) {
 			Enabled:                       true,
 			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 	require.NoError(t, err)
 

--- a/lib/tbot/workloadidentity/workloadattest/systemd_linux_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/systemd_linux_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestSystemdAttestor_Success(t *testing.T) {
@@ -37,7 +37,7 @@ func TestSystemdAttestor_Success(t *testing.T) {
 		SystemdAttestorConfig{
 			Enabled: true,
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 
 	attestor.dbusDialer = func(context.Context) (dbusConn, error) {
@@ -59,7 +59,7 @@ func TestSystemdAttestor_NonService(t *testing.T) {
 		SystemdAttestorConfig{
 			Enabled: true,
 		},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 
 	attestor.dbusDialer = func(context.Context) (dbusConn, error) {

--- a/lib/tbot/workloadidentity/workloadattest/unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/unix_test.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestUnixAttestor_Attest(t *testing.T) {
@@ -48,7 +48,7 @@ func TestUnixAttestor_Attest(t *testing.T) {
 
 	attestor := NewUnixAttestor(
 		UnixAttestorConfig{BinaryHashMaxSizeBytes: -1},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 	attestor.os = testOS{
 		exePath: func(context.Context, *process.Process) (string, error) {
@@ -83,7 +83,7 @@ func TestUnixAttestor_BinaryTooLarge(t *testing.T) {
 
 	attestor := NewUnixAttestor(
 		UnixAttestorConfig{BinaryHashMaxSizeBytes: 1024},
-		utils.NewSlogLoggerForTests(),
+		logtest.NewLogger(),
 	)
 	attestor.os = testOS{
 		exePath: func(context.Context, *process.Process) (string, error) {

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -139,6 +139,8 @@ func InitLogger(purpose LoggingPurpose, level slog.Level, opts ...LoggerOption) 
 var initTestLoggerOnce = sync.Once{}
 
 // InitLoggerForTests initializes the standard logger for tests.
+// Deprecated: prefer using logtest.InitLogger
+// TODO(tross): remove after enterprise references are updated.
 func InitLoggerForTests() {
 	initTestLoggerOnce.Do(func() {
 		if !flag.Parsed() {
@@ -159,6 +161,8 @@ func InitLoggerForTests() {
 }
 
 // NewSlogLoggerForTests creates a new slog logger for test environments.
+// Deprecated: prefer using logtest.NewLogger
+// TODO(tross): remove after enterprise references are updated.
 func NewSlogLoggerForTests() *slog.Logger {
 	InitLoggerForTests()
 	return slog.Default()

--- a/lib/utils/diagnostics/latency/monitor_test.go
+++ b/lib/utils/diagnostics/latency/monitor_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 
 	os.Exit(m.Run())
 }

--- a/lib/utils/hostid/hostid_test.go
+++ b/lib/utils/hostid/hostid_test.go
@@ -32,12 +32,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/utils/log/logtest/log.go
+++ b/lib/utils/log/logtest/log.go
@@ -1,0 +1,59 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logtest
+
+import (
+	"flag"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/teleport/lib/utils/log"
+)
+
+var initLoggerOnce = sync.Once{}
+
+// InitLogger initializes the standard logger.
+func InitLogger(verbose func() bool) {
+	initLoggerOnce.Do(func() {
+		if !flag.Parsed() {
+			// Parse flags to check testing.Verbose().
+			flag.Parse()
+		}
+
+		if !verbose() {
+			slog.SetDefault(slog.New(slog.DiscardHandler))
+			return
+		}
+
+		log.Initialize(log.Config{
+			Severity: slog.LevelDebug.String(),
+			Format:   "json",
+		})
+	})
+}
+
+// With creates a new [slog.Logger] with the provided attributes for test environments.
+func With(args ...any) *slog.Logger {
+	InitLogger(func() bool { return false })
+	return slog.With(args...)
+}
+
+// NewLogger creates a new [slog.Logger] for test environments.
+func NewLogger() *slog.Logger {
+	InitLogger(func() bool { return false })
+	return slog.Default()
+}

--- a/lib/utils/socks/socks_test.go
+++ b/lib/utils/socks/socks_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/proxy"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -143,6 +143,7 @@ import (
 	"github.com/gravitational/teleport/lib/ui"
 	"github.com/gravitational/teleport/lib/utils"
 	utilsaws "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 	"github.com/gravitational/teleport/lib/web/app"
 	websession "github.com/gravitational/teleport/lib/web/session"
@@ -174,7 +175,7 @@ type WebSuite struct {
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	// If the test is re-executing itself, execute the command that comes over
 	// the pipe.
@@ -8461,13 +8462,13 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		ServerID:       proxyID,
 		Emitter:        client,
 		EmitterContext: ctx,
-		Logger:         utils.NewSlogLoggerForTests(),
+		Logger:         logtest.NewLogger(),
 	})
 	require.NoError(t, err)
 
 	transportService, err := transportv1.NewService(transportv1.ServerConfig{
 		FIPS:   false,
-		Logger: utils.NewSlogLoggerForTests(),
+		Logger: logtest.NewLogger(),
 		Dialer: router,
 		SignerFn: func(authzCtx *authz.Context, clusterName string) agentless.SignerCreator {
 			return agentless.SignerFromAuthzContext(authzCtx, client, clusterName)
@@ -10869,7 +10870,7 @@ func TestWebSocketClosedBeforeSSHSessionCreated(t *testing.T) {
 	// not yet established.
 	stream := terminal.NewStream(ctx, terminal.StreamConfig{
 		WS:     ws,
-		Logger: utils.NewSlogLoggerForTests(),
+		Logger: logtest.NewLogger(),
 		Handlers: map[string]terminal.WSHandlerFunc{
 			defaults.WebsocketSessionMetadata: func(ctx context.Context, envelope terminal.Envelope) {
 				if envelope.Type != defaults.WebsocketSessionMetadata {

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func Test_transport_rewriteRedirect(t *testing.T) {
@@ -239,7 +240,7 @@ func TestTransport_DialContextNoServersAvailable(t *testing.T) {
 				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
 				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
 			},
-			log: utils.NewSlogLoggerForTests(),
+			log: logtest.NewLogger(),
 		},
 	}
 

--- a/lib/web/desktop/playback_test.go
+++ b/lib/web/desktop/playback_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/player"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web/desktop"
 )
 
@@ -81,7 +82,7 @@ func newServer(t *testing.T, streamInterval time.Duration, events []apievents.Au
 	t.Helper()
 
 	fs := eventstest.NewFakeStreamer(events, streamInterval)
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upgrader := websocket.Upgrader{

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/deployserviceconfig"
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
@@ -1148,7 +1148,7 @@ func (m *mockDeployedDatabaseServices) ListDeployedDatabaseServices(ctx context.
 
 func TestAWSOIDCListDeployedDatabaseServices(t *testing.T) {
 	ctx := context.Background()
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	for _, tt := range []struct {
 		name              string

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
@@ -243,7 +243,7 @@ func (m *mockUserTasksLister) ListUserTasks(ctx context.Context, pageSize int64,
 
 func TestCollectAWSOIDCAutoDiscoverStats(t *testing.T) {
 	ctx := context.Background()
-	logger := utils.NewSlogLoggerForTests()
+	logger := logtest.NewLogger()
 
 	integrationName := "my-integration"
 	integration, err := types.NewIntegrationAWSOIDC(

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	libui "github.com/gravitational/teleport/lib/ui"
 	utils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
 
@@ -1265,7 +1266,7 @@ func newAutoupdateTestHandler(t *testing.T, config autoupdateTestHandlerConfig) 
 			PublicProxyAddr:           addr,
 			ProxyClient:               clt,
 		},
-		logger: utils.NewSlogLoggerForTests(),
+		logger: logtest.NewLogger(),
 	}
 	h.PublicProxyAddr()
 	return h

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/web/terminal"
 )
 
@@ -78,7 +78,7 @@ func TestTerminalReadFromClosedConn(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	stream := terminal.NewStream(ctx, terminal.StreamConfig{WS: conn, Logger: utils.NewSlogLoggerForTests()})
+	stream := terminal.NewStream(ctx, terminal.StreamConfig{WS: conn, Logger: logtest.NewLogger()})
 
 	// close the stream before we attempt to read from it,
 	// this will produce a net.ErrClosed error on the read

--- a/tool/tbot/anonymous_telemetry_test.go
+++ b/tool/tbot/anonymous_telemetry_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type mockReportingServiceClient struct {
@@ -52,7 +52,7 @@ func mockEnvGetter(data map[string]string) envGetter {
 
 func TestSendTelemetry(t *testing.T) {
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	t.Run("sends telemetry when enabled", func(t *testing.T) {
 		mockClient := &mockReportingServiceClient{}

--- a/tool/tbot/systemd_test.go
+++ b/tool/tbot/systemd_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
 
 func TestInstallSystemdCmd(t *testing.T) {
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	// Create pre-existing file to test --force
 	preExistingDir := t.TempDir()

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	tctl "github.com/gravitational/teleport/tool/tctl/common"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -1187,7 +1188,7 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 	s.localAdminClient, err = authclient.Connect(ctx, &authclient.Config{
 		TLS:         localAdminTLS,
 		AuthServers: []utils.NetAddr{*authAddr},
-		Log:         utils.NewSlogLoggerForTests(),
+		Log:         logtest.NewLogger(),
 	})
 	require.NoError(t, err)
 

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -47,7 +48,7 @@ import (
 // enabling/disabling auto update, setting the target version and retrieve it.
 func TestClientToolsAutoUpdateCommands(t *testing.T) {
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	process := testenv.MakeTestServer(t, testenv.WithLogger(log))
 	authClient := testenv.MakeDefaultAuthClient(t, process)
 

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -42,13 +42,13 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func TestEditResources(t *testing.T) {
 	t.Parallel()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	process := testenv.MakeTestServer(t, testenv.WithLogger(log))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
@@ -368,7 +368,7 @@ func TestEditEnterpriseResources(t *testing.T) {
 			},
 		},
 	})
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 	process := testenv.MakeTestServer(t, testenv.WithLogger(log))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -60,7 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobject"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -1569,7 +1569,7 @@ func requireGotDatabaseServers(t *testing.T, buf *bytes.Buffer, want ...types.Da
 func TestCreateResources(t *testing.T) {
 	t.Parallel()
 
-	process := testenv.MakeTestServer(t, testenv.WithLogger(utils.NewSlogLoggerForTests()))
+	process := testenv.MakeTestServer(t, testenv.WithLogger(logtest.NewLogger()))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
 	// tctlGetAllValidations allows tests to register post-test validations to validate

--- a/tool/tctl/common/terraform_command_test.go
+++ b/tool/tctl/common/terraform_command_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 // Note: due to its complex interactions with Teleport, the `tctl terraform env`
@@ -98,7 +98,7 @@ func TestTerraformCommand_checkIfRoleExists(t *testing.T) {
 			c := &TerraformCommand{
 				existingRole: tt.existingRoleFlag,
 				userOutput:   os.Stderr,
-				log:          utils.NewSlogLoggerForTests(),
+				log:          logtest.NewLogger(),
 			}
 			roleName, err := c.checkIfRoleExists(ctx, adminClient)
 			tt.expectedErr(t, err)

--- a/tool/tctl/common/workload_identity_test.go
+++ b/tool/tctl/common/workload_identity_test.go
@@ -37,7 +37,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -58,7 +58,7 @@ func runWorkloadIdentityCommand(
 func TestWorkloadIdentity(t *testing.T) {
 	t.Parallel()
 
-	process := testenv.MakeTestServer(t, testenv.WithLogger(utils.NewSlogLoggerForTests()))
+	process := testenv.MakeTestServer(t, testenv.WithLogger(logtest.NewLogger()))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
 	yamlData := `kind: workload_identity
@@ -172,7 +172,7 @@ spec:
 func TestWorkloadIdentityRevocation(t *testing.T) {
 	t.Parallel()
 
-	process := testenv.MakeTestServer(t, testenv.WithLogger(utils.NewSlogLoggerForTests()))
+	process := testenv.MakeTestServer(t, testenv.WithLogger(logtest.NewLogger()))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
 	t.Run("workload-identity revocations ls empty", func(t *testing.T) {

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 const initTestSentinel = "init_test"
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/common"
 )
 
@@ -155,7 +156,7 @@ func MakeTestServer(t *testing.T, opts ...TestServerOptFunc) (process *service.T
 
 	cfg.Hostname = "server01"
 	cfg.DataDir = t.TempDir()
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	authAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: NewTCPListener(t, service.ListenerAuth, &cfg.FileDescriptors)}
 	cfg.SetToken(StaticToken)
 	cfg.SetAuthServerAddress(authAddr)

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -50,7 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 type suite struct {
@@ -98,7 +98,7 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	err := config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
 	cfg.FileDescriptors = dynAddr.Descriptors
@@ -195,7 +195,7 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	err := config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
 	cfg.FileDescriptors = dynAddr.Descriptors

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -96,6 +96,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 	"github.com/gravitational/teleport/tool/common"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -131,7 +132,7 @@ func TestMain(m *testing.M) {
 	modules.SetModules(&cliModules{})
 	modules.SetInsecureTestMode(true)
 
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	cryptosuites.PrecomputeRSATestKeys(m)
 	os.Exit(m.Run())
 }
@@ -3887,7 +3888,7 @@ func makeTestSSHNode(t *testing.T, authAddr *utils.NetAddr, opts ...testServerOp
 	cfg.SSH.Addr = *utils.MustParseAddr("127.0.0.1:0")
 	cfg.SSH.PublicAddrs = []utils.NetAddr{cfg.SSH.Addr}
 	cfg.SSH.DisableCreateHostUser = true
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	// Disabling debug service for tests so that it doesn't break if the data
 	// directory path is too long.
 	cfg.DebugService.Enabled = false
@@ -3936,7 +3937,7 @@ func makeTestServers(t *testing.T, opts ...testServerOptFunc) (auth *service.Tel
 	cfg.Proxy.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
 	cfg.Proxy.ReverseTunnelListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
 	cfg.Proxy.DisableWebInterface = true
-	cfg.Logger = utils.NewSlogLoggerForTests()
+	cfg.Logger = logtest.NewLogger()
 	// Disabling debug service for tests so that it doesn't break if the data
 	// directory path is too long.
 	cfg.DebugService.Enabled = false


### PR DESCRIPTION
Moves all test related logger initialization and creation to the logtest package to reduce testing symbols in production code. The existing helpers in lib/utils have been left in place until the enterprise references can be converted.

Updates #51023.