### PR TITLE
[v18] Align Access List Conv

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -306,10 +306,6 @@ func convertAuditToProto(audit accesslist.Audit) *accesslistv1.AccessListAudit {
 }
 
 func convertRequiresToProto(requires accesslist.Requires) *accesslistv1.AccessListRequires {
-	if len(requires.Roles) == 0 && len(requires.Traits) == 0 {
-		return nil
-	}
-
 	return &accesslistv1.AccessListRequires{
 		Roles:  requires.Roles,
 		Traits: traitv1.ToProto(requires.Traits),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -185,6 +185,20 @@ func TestFromProtoNils(t *testing.T) {
 		_, err := FromProto(msg)
 		require.NoError(t, err)
 	})
+
+	t.Run("requires is not set to nil", func(t *testing.T) {
+		acl := newAccessList(t, "access-list")
+		acl.Spec.MembershipRequires = accesslist.Requires{}
+		acl.Spec.OwnershipRequires = accesslist.Requires{}
+		msg := ToProto(acl)
+		// Ensure Requires fields are not set to nil for backward compatibility.
+		// Older implementations of FromProto (e.g., in Teleport v16) may incorrectly set these fields to nil:
+		// https://github.com/gravitational/teleport/blob/branch/v16/api/types/accesslist/convert/v1/accesslist.go#L46
+		// Since FromProto is invoked client-side (e.g., by the Terraform provider),
+		// setting Requires to nil could introduce breaking changes for existing clients.
+		require.NotNil(t, msg.Spec.MembershipRequires)
+		require.NotNil(t, msg.Spec.OwnershipRequires)
+	})
 }
 
 func newAccessList(t *testing.T, name string) *accesslist.AccessList {
@@ -290,8 +304,10 @@ func TestConvAccessList(t *testing.T) {
 					},
 				},
 				Spec: &accesslistv1.AccessListSpec{
-					Title:       "test access list",
-					Description: "test description",
+					Title:              "test access list",
+					Description:        "test description",
+					OwnershipRequires:  &accesslistv1.AccessListRequires{},
+					MembershipRequires: &accesslistv1.AccessListRequires{},
 					Owners: []*accesslistv1.AccessListOwner{
 						{
 							Name: "test-user1",
@@ -330,8 +346,10 @@ func TestConvAccessList(t *testing.T) {
 					},
 				},
 				Spec: &accesslistv1.AccessListSpec{
-					Title:       "test access list",
-					Description: "test description",
+					Title:              "test access list",
+					Description:        "test description",
+					OwnershipRequires:  &accesslistv1.AccessListRequires{},
+					MembershipRequires: &accesslistv1.AccessListRequires{},
 					Owners: []*accesslistv1.AccessListOwner{
 						{
 							Name: "test-user1",
@@ -368,10 +386,12 @@ func TestConvAccessList(t *testing.T) {
 					},
 				},
 				Spec: &accesslistv1.AccessListSpec{
-					Type:        string(accesslist.SCIM),
-					Title:       "test access list",
-					Description: "test description",
-					Owners:      []*accesslistv1.AccessListOwner{},
+					Type:               string(accesslist.SCIM),
+					Title:              "test access list",
+					Description:        "test description",
+					Owners:             []*accesslistv1.AccessListOwner{},
+					OwnershipRequires:  &accesslistv1.AccessListRequires{},
+					MembershipRequires: &accesslistv1.AccessListRequires{},
 					Audit: &accesslistv1.AccessListAudit{
 						Recurrence: &accesslistv1.Recurrence{
 							Frequency:  1,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/56737 to v18

changelog: Fix backward compatibility for Access List 'membershipRequires is missing' for older terraform providers