### PR TITLE
Add EC2 cross-account discovery docs and testplan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -2093,6 +2093,7 @@ Verify that SSH works, and that resumable SSH is not interrupted across a contro
   - [ ] New EC2 instances with matching AWS tags are discovered and added to the teleport cluster
     - [ ] Large numbers of EC2 instances (51+) are all successfully added to the cluster
   - [ ] Nodes that have been discovered do not have the install script run on the node multiple times
+  - [ ] EC2 instances can be discovered in multiple accounts
 
 ## Azure Discovery
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -158,7 +158,7 @@ discovery_service:
        "env": "prod" # Match EC2 instances where tag:env=prod
 ```
 
-- Edit the `teleport.auth_servers` key to match your Auth Service or Proxy Service's URI
+- Edit the `teleport.proxy_server` key to match your Proxy Service's URI
   and port.
 - Adjust the keys under `discovery_service.aws` to match your EC2 environment,
   specifically the regions and tags you want to associate with the Discovery
@@ -325,6 +325,48 @@ This policy includes the following permissions:
 
 Once you have started the Discovery Service, EC2 instances matching the tags you
 specified earlier will begin to be added to the Teleport cluster automatically.
+
+## Discovering instances in multiple AWS accounts
+
+To discover EC2 instances in AWS accounts other than the account your Teleport
+Discovery Service is running in, Teleport must have permission to assume an IAM
+role in each of those accounts.
+
+In each AWS account where your want to discover EC2 instances:
+
+1. Create a new role and note its ARN. Create an IAM policy as described in
+  [Step 2](#step-27-define-an-iam-policy) and attach it to the new role.
+1. Add an entry to the `discovery_service.aws` section of your `teleport.yaml`
+  file as described in [Step 4](#step-47-configure-teleport-to-discover-ec2-instances):
+```yaml
+# ...
+discovery_service:
+  enabled: true
+  discovery_group: "aws-prod"
+  aws:
+  - types: ["ec2"]
+    regions: ["us-east-1","us-west-1"]
+    install:
+      join_params:
+        token_name: aws-discovery-iam-token
+        method: iam
+    tags:
+      "env": "prod" # Match EC2 instances where tag:env=prod
+    assume_role_arn: "<Var name="role ARN" />"
+    external_id: "<Var name="optional external ID" />"
+  - types: ["ec2"]
+    # Add a new entry for each account.
+    # ...
+  ```
+
+Set `assume_role_arn` to the ARN of your new role. Optionally, set
+`external_id` to the external ID Teleport should use when assuming this role.
+
+When all of your accounts are ready, run `teleport discovery bootstrap` again
+to generate the remaining IAM policies and SSM documents, as described in
+[Step 5](#step-57-bootstrap-the-discovery-service-aws-configuration). For each
+distinct `assume_role_arn`/`external_id`, Teleport will assume that role and
+attach the new policies to it (unless overridden by `--attach-to-user` or `--attach-to-role`).
 
 ## Troubleshooting
 


### PR DESCRIPTION
This change adds docs and updates the testplan for EC2 cross-account discovery.

Follow-up to #55897 and #56693.