### PR TITLE
Turn on warnings for React Compiler ESLint rule

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.30.0)
       eslint-plugin-react-hooks:
-        specifier: ^5.2.0
-        version: 5.2.0(eslint@9.30.0)
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@9.30.0)
       eslint-plugin-storybook:
         specifier: ^9.0.17
         version: 9.0.17(eslint@9.30.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.6.2))(typescript@5.8.3)
@@ -4091,9 +4091,9 @@ packages:
       jest:
         optional: true
 
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@6.0.0-rc.1:
+    resolution: {integrity: sha512-7C4c7bdtd/B7Q+HruZxYhGjwZVvJawvQpilEYlRG1Jncuk1ZNqrFy9bO8SJNieyj3iDh8WPQA7BzzPO7sNAyEA==}
+    engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
@@ -4481,6 +4481,12 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   highlight-words-core@1.2.3:
     resolution: {integrity: sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==}
@@ -6747,6 +6753,12 @@ packages:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
+
+  zod-validation-error@3.5.3:
+    resolution: {integrity: sha512-OT5Y8lbUadqVZCsnyFaTQ4/O2mys4tj7PqhdbBCp7McPwvIEKfPtdA6QfPeFQK2/Rz5LgwmAXRJTugBNBi0btw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
@@ -11062,9 +11074,17 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.30.0):
+  eslint-plugin-react-hooks@6.0.0-rc.1(eslint@9.30.0):
     dependencies:
+      '@babel/core': 7.27.7
+      '@babel/parser': 7.27.7
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.27.7)
       eslint: 9.30.0
+      hermes-parser: 0.25.1
+      zod: 3.25.67
+      zod-validation-error: 3.5.3(zod@3.25.67)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@9.30.0):
     dependencies:
@@ -11523,6 +11543,12 @@ snapshots:
       function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   highlight-words-core@1.2.3: {}
 
@@ -14141,6 +14167,10 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   zod-to-json-schema@3.24.6(zod@3.25.67):
+    dependencies:
+      zod: 3.25.67
+
+  zod-validation-error@3.5.3(zod@3.25.67):
     dependencies:
       zod: 3.25.67
 

--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -138,6 +138,7 @@ export default tseslint.config(
 
       'react-hooks/rules-of-hooks': 'warn',
       'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/react-compiler': 'warn',
     },
   },
   {

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-jest": "^28.14.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "eslint-plugin-storybook": "^9.0.17",
     "eslint-plugin-testing-library": "7.4.0",
     "eslint-plugin-unused-imports": "^4.1.4",


### PR DESCRIPTION
I propose that we enable the React Compiler ESLint rule to emit warnings so that we can spot problematic patterns when writing new code. Let's create #dev-temp-react-compiler to discuss warnings that pose problems or are otherwise hard to deal with.

## React Compiler

I think that we should aim to enable [React Compiler](https://react.dev/learn/react-compiler) at some point, either on parts of the codebase or the whole project. [Ryan reported mixed results](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1738147226307339?thread_ts=1738036389.780379&cid=C02DQ1C2BMW) when enabling it on TAG. The details of the Compiler rollout are still something to be discussed, however despite potential problems, in my opinion these two things are true:

1. React Compiler is [the future of React](https://react.dev/blog/2024/10/21/react-compiler-beta-release#roadmap-to-stable):
   * > The Stable Release will mark the beginning of a new foundation for React, and all apps and libraries will be strongly recommended to use the compiler and ESLint plugin.
3. Writing code that can be optimized by the Compiler will result in better overall quality of code.

## The ESLint rule

Many parts of the app in their current state won't be optimized because they're breaking the rules of React. React Compiler is in RC but it's [near stable](https://github.com/reactjs/react.dev/pull/7868). In the meantime, we can start addressing issues in our code to make the compiler more effective when enabled.

I propose that we enable the React Compiler ESLint rule to emit warnings so that we can spot problematic patterns when writing new code. Many of those might surprise us or be patterns that we've learned to accept, see [my question about `useRef`](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1729589946322669) from a couple of months ago for an example. To help with that, we can create #temp-dev-react-compiler channel to discuss warnings that pose problems.

From [the React Compiler docs](https://react.dev/learn/react-compiler/installation#eslint-integration):

> React Compiler includes an ESLint rule that helps identify code that can't be optimized. When the ESLint rule reports an error, it means the compiler will skip optimizing that specific component or hook. This is safe: the compiler will continue optimizing other parts of your codebase. You don't need to fix all violations immediately. Address them at your own pace to gradually increase the number of optimized components.
>
> The ESLint rule will:
>
> -   Identify violations of the Rules of React
> -   Show which components can't be optimized
> -   Provide helpful error messages for fixing issues

## List of warnings reported by the `react-hooks/react-compiler` rule

<details>

```
web/packages/shared/components/FieldCheckbox/FieldCheckbox.test.tsx
  56:5  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

web/packages/shared/components/TextSelectCopy/TextSelectCopy.tsx
  36:30  warning  Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)  react-hooks/react-compiler

web/packages/shared/components/Validation/Validation.test.tsx
   93:5  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler
  129:5  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

web/packages/shared/hooks/useRefAutoFocus/useRefAutoFocus.test.tsx
  92:3  warning  Mutating a value returned from a function whose return value should not be mutated  react-hooks/react-compiler

web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/GitHubConnectorEditor.tsx
  73:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
  121:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Console/DocumentSsh/Terminal/Terminal.tsx
   95:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Console/consoleContextProvider.tsx
  39:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Console/useTabRouting.ts
  62:7  warning  Mutating a value returned from a function whose return value should not be mutated                                                                                                                                                                     react-hooks/react-compiler

web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.story.tsx
  52:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
  77:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Discover/Database/IamPolicy/useIamPolicy.ts
  39:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
  68:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Discover/Fixtures/fixtures.tsx
  68:5  warning  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-hooks/react-compiler

web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
  119:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
  190:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.story.tsx
   54:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
   95:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  110:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.ts
  78:5  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

web/packages/teleport/src/Integrations/Enroll/AwsOidc/useAwsOidcIntegration.tsx
  82:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/JoinTokens/JoinTokens.tsx
  139:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
  249:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/LocksV2/NewLock/NewLock.tsx
  174:25  warning  Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)  react-hooks/react-compiler

web/packages/teleport/src/Login/Login.story.tsx
  54:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleport/src/Main/Main.tsx
  113:7  warning  Mutating a value returned from a function whose return value should not be mutated                                                                react-hooks/react-compiler

web/packages/teleport/src/Notifications/Notification.tsx
  70:49  warning  Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)  react-hooks/react-compiler
  82:55  warning  Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)  react-hooks/react-compiler
  95:61  warning  Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)  react-hooks/react-compiler

web/packages/teleport/src/Player/Xterm/Xterm.tsx
  80:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
  79:5   warning  Expected the first argument to be an inline function expression                                                   react-hooks/react-compiler

web/packages/teleport/src/Roles/Roles.tsx
  253:10  warning  Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values  react-hooks/react-compiler
  253:10  warning  Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values  react-hooks/react-compiler
  270:9   warning  Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values  react-hooks/react-compiler

web/packages/teleport/src/useTeleport.ts
  30:11  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
   54:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks                                                      react-hooks/react-compiler

web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
  188:3   warning  Mutating component props or hook arguments is not allowed. Consider using a local variable instead                                                                                                                                                                         react-hooks/react-compiler

web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
  233:3  warning  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentAccessRequests/NewRequest/NewRequest.tsx
  44:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
  46:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
  39:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
  253:5  warning  Reassigning a variable after render has completed can cause inconsistent behavior on subsequent renders. Consider using state instead  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
  42:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
  174:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
   48:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks                                         react-hooks/react-compiler
  101:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
  78:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
   82:6   warning  Expected the dependency list to be an array of simple expressions (e.g. `x`, `x.y.z`, `x?.y?.z`)                                        react-hooks/react-compiler

web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
  40:5  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/Search/SearchBar.tsx
  72:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
    72:3   warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
  64:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

web/packages/teleterm/src/ui/StatusBar/ShareFeedback/useShareFeedback.ts
  37:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/TopBar/Clusters/useClusters.ts
  28:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
  34:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsSliderStep.tsx
  32:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/TopBar/Identity/useIdentity.ts
  32:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

web/packages/teleterm/src/ui/appContextProvider.tsx
  37:5  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

web/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
  26:3  warning  Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-hooks/react-compiler

e/web/teleport/src/AccessListManagement/AccessListManagementContext.tsx
  170:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/AccessListManagement/AccessLists/AccessLists.tsx
  129:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler
  754:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/AccessListManagement/CreateAccessList/CreateAccessList.tsx
   98:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler
  115:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/AccessListManagement/ViewEditAccessList/ReviewAccessList/ReviewAccessList.tsx
  125:11  warning  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-hooks/react-compiler

e/web/teleport/src/AccessListManagement/ViewEditAccessList/ViewEditAccessList.tsx
  151:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler
  183:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler
  192:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/AccessMonitoring/Timeframe.story.tsx
  33:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  42:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditor.tsx
  59:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/AuthConnectors/AuthConnectors.tsx
  108:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/DeviceTrust/DeviceTrust.story.tsx
  33:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  49:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  80:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  97:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/Discover/SamlApplication/GcpWorkforce/AddWorkforcePool/AddWorkforcePool.story.tsx
  38:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/ExternalAuditStorage/ExternalAuditStorage.tsx
  52:9  warning  Mutating a value returned from a function whose return value should not be mutated                                                               react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/IntegrationPick/IntegrationPick.tsx
  121:5   warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/Okta/PluginEnrollOkta.story.tsx
  299:3  warning  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/PluginEnrollSuccess.tsx
  31:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/MultiStep/usePlugin.tsx
  84:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/PluginEnrollOauth.tsx
  103:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/Integrations/IntegrationEnroll/PluginEnroll/PluginEnrollSingleStep.tsx
  58:5  warning  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-hooks/react-compiler

e/web/teleport/src/InviteCollaborators/InviteCollaboratorsForm.test.tsx
   99:7  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler
  123:7  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler
  152:7  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler
  180:7  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

e/web/teleport/src/Login/Login.tsx
  10:3  warning  Mutating a value returned from a function whose return value should not be mutated  react-hooks/react-compiler

e/web/teleport/src/SAMLIdPLogin/SAMLIdPLogin.story.tsx
  23:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/SamlApplication/MicrosoftEntraId/AddEntraSpToTeleport/AddEntraSpToTeleport.story.tsx
  25:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/SamlApplication/components/AttributeMapping.test.tsx
  15:5  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

e/web/teleport/src/SamlApplication/components/ConfigureServiceProvider.test.tsx
  397:9  warning  Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render)  react-hooks/react-compiler

e/web/teleport/src/Support/Support.story.tsx
  20:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  40:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler

e/web/teleport/src/UnifiedResources/UnifiedResourcesE.story.tsx
  33:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  44:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
  54:3  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-hooks/react-compiler
```

</details>