### PR TITLE
Move (most) AccessList validation to backend

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -40,8 +40,6 @@ const (
 	ThreeMonths ReviewFrequency = 3
 	SixMonths   ReviewFrequency = 6
 	OneYear     ReviewFrequency = 12
-
-	twoWeeks = 24 * time.Hour * 14
 )
 
 func (r ReviewFrequency) String() string {
@@ -196,15 +194,6 @@ const (
 	SCIM Type = "scim"
 )
 
-func validateType(t Type) error {
-	switch t {
-	case DeprecatedDynamic, Default, Static, SCIM:
-		return nil
-	default:
-		return trace.BadParameter("unknown access_list type %q", t)
-	}
-}
-
 // IsReviewable returns true if the AccessList type supports the audit reviews in the web UI.
 func (t Type) IsReviewable() bool {
 	switch t {
@@ -336,7 +325,8 @@ func NewAccessList(metadata header.Metadata, spec Spec) (*AccessList, error) {
 	return accessList, nil
 }
 
-// CheckAndSetDefaults validates fields and populates empty fields with default values.
+// CheckAndSetDefaults performs very basic validation and populates empty fields with default
+// values. The main validation part is performed before the storage.
 func (a *AccessList) CheckAndSetDefaults() error {
 	a.SetKind(types.KindAccessList)
 	a.SetVersion(types.V1)
@@ -350,56 +340,21 @@ func (a *AccessList) CheckAndSetDefaults() error {
 		a.Spec.Type = Default
 	}
 
-	if err := validateType(a.Spec.Type); err != nil {
-		return trace.Wrap(err)
-	}
-
 	if a.Spec.Title == "" {
 		return trace.BadParameter("access list title required")
-	}
-
-	switch a.Spec.Type {
-	case Static, SCIM:
-		// SCIM and Static access lists can have empty owners, as they are managed by external systems.
-	default:
-		if len(a.Spec.Owners) == 0 {
-			return trace.BadParameter("owners are missing")
-		}
 	}
 
 	if a.IsReviewable() {
 		if a.Spec.Audit.Recurrence.Frequency == 0 {
 			a.Spec.Audit.Recurrence.Frequency = SixMonths
 		}
-
-		switch a.Spec.Audit.Recurrence.Frequency {
-		case OneMonth, ThreeMonths, SixMonths, OneYear:
-		default:
-			return trace.BadParameter("recurrence frequency is an invalid value")
-		}
-
 		if a.Spec.Audit.Recurrence.DayOfMonth == 0 {
 			a.Spec.Audit.Recurrence.DayOfMonth = FirstDayOfMonth
 		}
-
-		switch a.Spec.Audit.Recurrence.DayOfMonth {
-		case FirstDayOfMonth, FifteenthDayOfMonth, LastDayOfMonth:
-		default:
-			return trace.BadParameter("recurrence day of month is an invalid value")
-		}
-
 		if a.Spec.Audit.NextAuditDate.IsZero() {
 			if err := a.setInitialAuditDate(clockwork.NewRealClock()); err != nil {
 				return trace.Wrap(err, "setting initial audit date")
 			}
-		}
-
-		if a.Spec.Audit.Notifications.Start == 0 {
-			a.Spec.Audit.Notifications.Start = twoWeeks
-		}
-	} else {
-		if !isZero(a.Spec.Audit) {
-			return trace.BadParameter("audit not supported for non-dynamic access_list")
 		}
 	}
 

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -183,6 +183,8 @@ func TestAuditMarshaling(t *testing.T) {
 }
 
 func TestAuditUnmarshaling(t *testing.T) {
+	const twoWeeks = 14 * 24 * time.Hour
+
 	tests := []struct {
 		name                      string
 		input                     map[string]interface{}
@@ -242,66 +244,6 @@ func TestAuditUnmarshaling(t *testing.T) {
 			require.Equal(t, tt.expectedNotificationStart, audit.Notifications.Start)
 		})
 	}
-}
-
-func TestAccessListDefaults(t *testing.T) {
-	newValidAccessList := func() *AccessList {
-		return &AccessList{
-			ResourceHeader: header.ResourceHeader{
-				Metadata: header.Metadata{
-					Name: "test",
-				},
-			},
-			Spec: Spec{
-				Title:  "test access list",
-				Owners: []Owner{{Name: "Daphne"}},
-				Grants: Grants{Roles: []string{"requester"}},
-				Audit: Audit{
-					NextAuditDate: time.Date(2000, time.September, 12, 1, 2, 3, 4, time.UTC),
-				},
-			},
-		}
-	}
-
-	t.Run("audit is not supported for static access_list", func(t *testing.T) {
-		uut := newValidAccessList()
-		uut.Spec.Type = Static
-		uut.Spec.Audit = Audit{
-			NextAuditDate: time.Date(2000, time.September, 12, 1, 2, 3, 4, time.UTC),
-		}
-
-		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
-		require.ErrorContains(t, err, "audit not supported for non-dynamic access_list")
-	})
-
-	t.Run("owners are not required for static access_list", func(t *testing.T) {
-		uut := newValidAccessList()
-		uut.Spec.Type = Static
-		uut.Spec.Owners = []Owner{}
-		uut.Spec.Audit = Audit{}
-
-		err := uut.CheckAndSetDefaults()
-		require.NoError(t, err)
-	})
-
-	t.Run("otherwise owners are required", func(t *testing.T) {
-		uut := newValidAccessList()
-		uut.Spec.Owners = []Owner{}
-
-		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
-		require.ErrorContains(t, err, "owners")
-	})
-
-	t.Run("type is validated", func(t *testing.T) {
-		uut := newValidAccessList()
-		uut.Spec.Type = "test_unknown_type"
-
-		err := uut.CheckAndSetDefaults()
-		require.Error(t, err)
-		require.ErrorContains(t, err, `unknown access_list type "test_unknown_type"`)
-	})
 }
 
 func TestSelectNextReviewDate(t *testing.T) {

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -151,15 +151,6 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
-func Test_FromProto_withBadType(t *testing.T) {
-	accessList := newAccessList(t, "access-list")
-	accessList.Spec.Type = "test_bad_type"
-
-	_, err := FromProto(ToProto(accessList))
-	require.Error(t, err)
-	require.ErrorContains(t, err, `unknown access_list type "test_bad_type"`)
-}
-
 // Make sure that we don't panic if any of the message fields are missing.
 func TestFromProtoNils(t *testing.T) {
 	t.Parallel()
@@ -177,7 +168,7 @@ func TestFromProtoNils(t *testing.T) {
 		accessList.Spec.Owners = nil
 
 		_, err := FromProto(accessList)
-		require.Error(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("audit", func(t *testing.T) {

--- a/lib/accesslists/funcs.go
+++ b/lib/accesslists/funcs.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package accesslist
+package accesslists
 
 func isZero[T comparable](t T) bool {
 	var zero T


### PR DESCRIPTION
This is because validation in a client causes more harm than good and we struggle with introducing backward compatible changes.

Backports:

- [ ] v18
  - [ ] include https://github.com/gravitational/teleport/pull/57007
- [ ] v17
  - [ ] include https://github.com/gravitational/teleport/pull/57007