### PR TITLE
MWI: Move client credentials service to `lib/tbot/services/clientcredentials`

### DIFF
--- a/integrations/lib/embeddedtbot/bot.go
+++ b/integrations/lib/embeddedtbot/bot.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/services/clientcredentials"
 )
 
 // EmbeddedBot is an embedded tBot instance to renew the operator certificates.
@@ -39,7 +40,7 @@ type EmbeddedBot struct {
 	log *slog.Logger
 	cfg *config.BotConfig
 
-	credential *config.UnstableClientCredentialOutput
+	credential *clientcredentials.UnstableConfig
 
 	// mutex protects started, cancelCtx and errCh
 	mutex     sync.Mutex
@@ -53,7 +54,7 @@ func New(botConfig *BotConfig, log *slog.Logger) (*EmbeddedBot, error) {
 	if log == nil {
 		return nil, trace.BadParameter("missing log")
 	}
-	credential := &config.UnstableClientCredentialOutput{}
+	credential := &clientcredentials.UnstableConfig{}
 
 	cfg := (*config.BotConfig)(botConfig)
 	cfg.Storage = &config.StorageConfig{Destination: destination.NewMemory()}

--- a/lib/tbot/services/clientcredentials/client_credential.go
+++ b/lib/tbot/services/clientcredentials/client_credential.go
@@ -1,0 +1,23 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package clientcredentials
+
+import "go.opentelemetry.io/otel"
+
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/services/clientcredentials")

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -51,10 +51,7 @@ func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifeti
 			reloadCh:           deps.ReloadCh,
 			identityGenerator:  deps.IdentityGenerator,
 		}
-		svc.log = deps.Logger.With(
-			teleport.ComponentKey,
-			teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
-		)
+		svc.log = deps.LoggerForService(svc)
 		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
@@ -73,10 +70,7 @@ func NewSidecar(deps bot.ServiceDependencies, credentialLifetime bot.CredentialL
 		identityGenerator:  deps.IdentityGenerator,
 		statusReporter:     readyz.NoopReporter(),
 	}
-	svc.log = deps.Logger.With(
-		teleport.ComponentKey,
-		teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
-	)
+	svc.log = deps.LoggerForService(svc)
 	return svc, cfg
 }
 

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/identity"

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package tbot
+package clientcredentials
 
 import (
 	"cmp"
@@ -28,18 +28,25 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/lib/tbot/bot"
-	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
 
-func ClientCredentialOutputServiceBuilder(botCfg *config.BotConfig, cfg *config.UnstableClientCredentialOutput) bot.ServiceBuilder {
+// ServiceBuilder creates a new client credential service with the given
+// configuration.
+//
+// Note: when using the client credentials service to provide credentials to
+// another service (e.g. the SPIFFE Workload API service) use NewSidecar instead.
+func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
 	return func(deps bot.ServiceDependencies) (bot.Service, error) {
-		svc := &ClientCredentialOutputService{
+		if err := cfg.CheckAndSetDefaults(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		svc := &Service{
 			botAuthClient:      deps.Client,
 			botIdentityReadyCh: deps.BotIdentityReadyCh,
-			botCfg:             botCfg,
+			credentialLifetime: credentialLifetime,
 			cfg:                cfg,
 			reloadCh:           deps.ReloadCh,
 			identityGenerator:  deps.IdentityGenerator,
@@ -53,39 +60,58 @@ func ClientCredentialOutputServiceBuilder(botCfg *config.BotConfig, cfg *config.
 	}
 }
 
-// ClientCredentialOutputService produces credentials which can be used to
-// connect to Teleport's API or SSH.
-type ClientCredentialOutputService struct {
+// NewSidecar creates a client credential service intended to provide credentials
+// to another service.
+func NewSidecar(deps bot.ServiceDependencies, credentialLifetime bot.CredentialLifetime) (*Service, *UnstableConfig) {
+	cfg := &UnstableConfig{}
+	svc := &Service{
+		botAuthClient:      deps.Client,
+		botIdentityReadyCh: deps.BotIdentityReadyCh,
+		credentialLifetime: credentialLifetime,
+		cfg:                cfg,
+		reloadCh:           deps.ReloadCh,
+		identityGenerator:  deps.IdentityGenerator,
+		statusReporter:     readyz.NoopReporter(),
+	}
+	svc.log = deps.Logger.With(
+		teleport.ComponentKey,
+		teleport.Component(teleport.ComponentTBot, "svc", svc.String()),
+	)
+	return svc, cfg
+}
+
+// Service produces credentials which can be used to connect to Teleport's API or SSH.
+type Service struct {
 	// botAuthClient should be an auth client using the bots internal identity.
 	// This will not have any roles impersonated and should only be used to
 	// fetch CAs.
 	botAuthClient      *apiclient.Client
 	botIdentityReadyCh <-chan struct{}
-	botCfg             *config.BotConfig
-	cfg                *config.UnstableClientCredentialOutput
+	credentialLifetime bot.CredentialLifetime
+	cfg                *UnstableConfig
 	log                *slog.Logger
 	statusReporter     readyz.Reporter
 	reloadCh           <-chan struct{}
 	identityGenerator  *identity.Generator
 }
 
-func (s *ClientCredentialOutputService) String() string {
+func (s *Service) String() string {
 	return cmp.Or(
 		s.cfg.Name,
 		"client-credential-output",
 	)
 }
 
-func (s *ClientCredentialOutputService) OneShot(ctx context.Context) error {
+func (s *Service) OneShot(ctx context.Context) error {
 	return s.generate(ctx)
 }
 
-func (s *ClientCredentialOutputService) Run(ctx context.Context) error {
+func (s *Service) Run(ctx context.Context) error {
 	err := internal.RunOnInterval(ctx, internal.RunOnIntervalConfig{
 		Service:         s.String(),
 		Name:            "output-renewal",
 		F:               s.generate,
-		Interval:        s.botCfg.CredentialLifetime.RenewalInterval,
+		Interval:        s.credentialLifetime.RenewalInterval,
 		RetryLimit:      internal.RenewalRetryLimit,
 		Log:             s.log,
 		ReloadCh:        s.reloadCh,
@@ -95,16 +121,16 @@ func (s *ClientCredentialOutputService) Run(ctx context.Context) error {
 	return trace.Wrap(err)
 }
 
-func (s *ClientCredentialOutputService) generate(ctx context.Context) error {
+func (s *Service) generate(ctx context.Context) error {
 	ctx, span := tracer.Start(
 		ctx,
-		"ClientCredentialOutputService/generate",
+		"Service/generate",
 	)
 	defer span.End()
 	s.log.InfoContext(ctx, "Generating output")
 
 	id, err := s.identityGenerator.Generate(ctx,
-		identity.WithLifetime(s.botCfg.CredentialLifetime.TTL, s.botCfg.CredentialLifetime.RenewalInterval),
+		identity.WithLifetime(s.credentialLifetime.TTL, s.credentialLifetime.RenewalInterval),
 		identity.WithLogger(s.log),
 	)
 	if err != nil {

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/internal/diagnostics"
 	"github.com/gravitational/teleport/lib/tbot/services/application"
 	"github.com/gravitational/teleport/lib/tbot/services/awsra"
+	"github.com/gravitational/teleport/lib/tbot/services/clientcredentials"
 	"github.com/gravitational/teleport/lib/tbot/services/database"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
 	"github.com/gravitational/teleport/lib/utils"
@@ -229,8 +230,8 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			services = append(services, database.OutputServiceBuilder(svcCfg, b.cfg.CredentialLifetime))
 		case *config.IdentityOutput:
 			services = append(services, IdentityOutputServiceBuilder(b.cfg, svcCfg, alpnUpgradeCache))
-		case *config.UnstableClientCredentialOutput:
-			services = append(services, ClientCredentialOutputServiceBuilder(b.cfg, svcCfg))
+		case *clientcredentials.UnstableConfig:
+			services = append(services, clientcredentials.ServiceBuilder(svcCfg, b.cfg.CredentialLifetime))
 		case *application.TunnelConfig:
 			services = append(services, application.TunnelServiceBuilder(svcCfg, b.cfg.ConnectionConfig(), b.cfg.CredentialLifetime))
 		case *config.WorkloadIdentityX509Service:

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/services/clientcredentials"
 	"github.com/gravitational/teleport/lib/tbot/ssh"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -302,7 +303,7 @@ func (c *TerraformCommand) checkIfRoleExists(ctx context.Context, client roleCli
 // Note: the function also returns the SSH Host CA cert encoded in the known host format.
 // The identity.Identity uses a different format (authorized keys).
 func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr utils.NetAddr, token string, clt *authclient.Client) (*identity.Identity, [][]byte, error) {
-	credential := &config.UnstableClientCredentialOutput{}
+	credential := &clientcredentials.UnstableConfig{}
 	cfg := &config.BotConfig{
 		Version: "",
 		Onboarding: onboarding.Config{


### PR DESCRIPTION
## Background

This is part of a series of pull requests to refactor the `lib/tbot` package for better modularity.

Today, all of `tbot`'s services live in the same package which makes it difficult to see the system boundaries, but also means that it's impossible for other binaries that "embed" tbot (e.g. `tctl`, the Kubernetes operator) to pull in just the parts they need - and for the compiler to effectively eliminate unused dependencies.

See the [boxofrad/wip-tbot-refactoring branch](https://github.com/gravitational/teleport/tree/boxofrad/wip-tbot-refactoring) for an idea of the end-state of this stack. In this branch, the `tctl` binary is roughly **13% smaller** largely due to eliminating the unused Sigstore modules.

## Changes

This pull request moves the client credentials service to `lib/tbot/services/clientcredentials` and adds the `NewSidecar` convenience method for use-cases where it provides credentials for another service.
