### PR TITLE
Bumping shared-workflows references

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
 
       - name: Setup base cache
         uses: actions/cache/restore@v3
@@ -93,7 +93,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   dependency-review:
-    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 51eaeb3e0b3f52e597cad453130ca72d372d0364 # workflows/v0.0.2
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2 
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
 
       - name: Find excluded tests
         id: find_excluded

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
       - name: Installing Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   terraform-lint:
-    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
     with:
       # TODO: Fix Terraform linting issues and stop using force to pass the job.
       tflint_force: true

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trivy:
-    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@5213479ba6a7b41a0ee5e5adf72360e6ac4e9b93 # workflows/v0.0.1
+    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
This is mainly to include https://github.com/gravitational/shared-workflows/pull/381

This removes an extra check that occurs on the v18 branch that existed before the release. This check enforced admin approvals to backport to branch/v18. This is no longer needed as v18 is released.