### PR TITLE
Remove version variables from prerequisites

### DIFF
--- a/docs/pages/admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx
@@ -11,7 +11,7 @@ so that users can access Azure Portal and the Azure CLI by authenticating with T
 
 ## Prerequisites
 
-- A running Teleport Enterprise cluster version (=teleport.version=) or above. If you
+- A running Teleport Enterprise cluster v17.5.1 or higher. If you
   want to get started with Teleport, [sign up](https://goteleport.com/signup)
   for a free trial.
 - If you're new to SAML, consider reviewing our [SAML identity provider (IdP)](../../../reference/access-controls/saml-idp.mdx) 

--- a/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
@@ -35,7 +35,7 @@ learn more.
 The features documented on this page are available in Teleport `15.0.0` and
 higher.
 
-- Teleport v(=teleport.version=) Enterprise (self-hosted).
+- Teleport Enterprise (self-hosted).
 - (!docs/pages/includes/tctl.mdx!)
 - An AWS account.
 

--- a/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
@@ -32,7 +32,7 @@ learn more.
 
 ## Prerequisites
 
-- Teleport v(=teleport.version=) Enterprise (self-hosted).
+- Teleport Enterprise (self-hosted).
 - (!docs/pages/includes/tctl.mdx!)
 - A Google Cloud account.
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
@@ -23,12 +23,6 @@ cluster to Teleport.
 
 ## Prerequisites
 
-<Admonition type="warning">
-Those instructions are both for v12+ Teleport and the v12+ `teleport-cluster` chart.
-If you are running an older Teleport version, use the version selector at the top
-of this page to choose the correct version.
-</Admonition>
-
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)
 
 ## Step 1/3. Add the Teleport Helm chart repository

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -97,8 +97,8 @@ cluster to Teleport.
 
   </details>
 
-- The `tsh` client tool v(=teleport.version=)+ installed on your workstation.
-  You can download this from our [installation page](../../../installation/installation.mdx).
+- The `tsh` client tool installed on your workstation.  You can download this
+  from our [installation page](../../../installation/installation.mdx).
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 

--- a/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
@@ -12,7 +12,7 @@ hardware security module (HSM) to store and handle private keys.
 
 ## Prerequisites
 
-- Teleport v(=teleport.version=) Enterprise (self-hosted).
+- Teleport Enterprise (self-hosted).
 - (!docs/pages/includes/tctl.mdx!)
 - An HSM reachable from your Teleport Auth Service.
 - The PKCS#11 module for your HSM.

--- a/docs/pages/admin-guides/management/admin/trustedclusters.mdx
+++ b/docs/pages/admin-guides/management/admin/trustedclusters.mdx
@@ -154,7 +154,7 @@ To complete the steps in this guide, verify your environment meets the following
   The two clusters should be at the same version or, at most, the leaf cluster can be one major version 
   behind the root cluster version.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The `tctl` admin tool and `tsh` client tool.
   
   You can verify the tools you have installed by running the following commands:
 

--- a/docs/pages/admin-guides/management/guides/github-integration.mdx
+++ b/docs/pages/admin-guides/management/guides/github-integration.mdx
@@ -40,7 +40,7 @@ continue to access GitHub through their browsers.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="17.2" edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v17.2 or higher)"!)
 - Access to GitHub Enterprise and permissions to modify GitHub's SSH certificate
   authorities and configure OAuth applications.
 - (!docs/pages/includes/tctl.mdx!)

--- a/docs/pages/admin-guides/management/operations/scaling.mdx
+++ b/docs/pages/admin-guides/management/operations/scaling.mdx
@@ -11,10 +11,6 @@ self-hosted deployments of Teleport.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
-## Prerequisites
-
-- Teleport v(=teleport.version=) Open Source or Enterprise.
-
 ## Hardware recommendations
 
 Set up Teleport with a [High Availability configuration](../../deploy-a-cluster/high-availability.mdx).

--- a/docs/pages/admin-guides/management/operations/tls-routing.mdx
+++ b/docs/pages/admin-guides/management/operations/tls-routing.mdx
@@ -30,9 +30,6 @@ Cloud.
 
 ## Prerequisites
 
-Support for TLS routing behind layer 7 (HTTP/HTTPS) load balancers and reverse
-proxies is available starting from Teleport `13.0`.
-
 If you use Teleport Cloud, see which ports and networking settings the Proxy
 Service is configured to use in your Teleport Cloud tenant. Run the following
 command, replacing `mytenant.teleport.sh` with your tenant address:

--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -51,7 +51,7 @@ PROXY TCP4 127.0.0.1 127.0.0.2 12345 42\r\n
   We recommend reading and understanding this guide completely before
   configuring your Teleport cluster to use the PROXY protocol.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The `tctl` admin tool and `tsh` client tool.
 
   Visit [Installation](../../../installation/installation.mdx) for instructions on downloading
   `tctl` and `tsh`.

--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -21,7 +21,7 @@ Service to execute.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="17.3.0"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v17.3.0 or higher)"!)
 
 - An OCI Compute instance to host a Teleport service.
 - (!docs/pages/includes/tctl.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -21,7 +21,7 @@ In this guide, you will:
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="15.2.4"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v15.2.4 or higher)"!)
 - An Azure Kubernetes Service (AKS) cluster and admin permissions to manage the
   cluster.
 - The ability to manage user-assigned Azure managed identities, role policies,

--- a/docs/pages/enroll-resources/application-access/guides/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/vnet.mdx
@@ -27,7 +27,7 @@ to first update the VNet config in the Auth Service to include a matching DNS zo
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="16.0.0"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v16.0.0 or higher)"!)
 
 - (!docs/pages/includes/tctl.mdx!)
 - A TCP application connected to the cluster.

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -11,7 +11,7 @@ labels:
 
 ## Prerequisites
 
-- Teleport cluster v14.1.3 or higher with a configured [Amazon
+- Teleport cluster with a configured [Amazon
   Redshift](../enroll-aws-databases/postgres-redshift.mdx) database.
 - Ability to connect to and create user accounts in the target database.
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -11,7 +11,7 @@ labels:
 
 ## Prerequisites
 
-- Teleport cluster v14.1.3 or higher with a configured [self-hosted
+- Teleport cluster with a configured [self-hosted
   MariaDB](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MariaDB](../enroll-aws-databases/rds.mdx)
   database.
 - Ability to connect to and create user accounts in the target database.

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -11,7 +11,7 @@ labels:
 
 ## Prerequisites
 
-- Teleport cluster v14.3 or above.
+- A Teleport cluster.
 - A self-hosted MongoDB database enrolled with your Teleport cluster. Follow
   the [Teleport documentation](../enroll-self-hosted-databases/mongodb-self-hosted.mdx) to learn how
   to enroll your database.

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -32,7 +32,7 @@ stripping its privileges.
 
 ## Prerequisites
 
-- Teleport cluster v14.1 or higher with a configured [self-hosted
+- Teleport cluster with a configured [self-hosted
   MySQL](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MySQL](../enroll-aws-databases/rds.mdx)
   database.
 - Ability to connect to and create user accounts in the target database.

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
@@ -20,7 +20,7 @@ Database Service forwards user traffic to the database.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v17.4.0 or higher)"!)
 
 - An Amazon RDS for Oracle database instance.
 - An AWS Directory Service Managed Microsoft AD.

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -20,33 +20,15 @@ Service for Microsoft Entra ID.
 
 To complete the steps in this guide, verify your environment meets the following requirements:
 
-- Access to a running Teleport cluster, `tctl` admin tool, and `tsh` client tool
-  version >= (=teleport.version=).
-
-  You can verify the tools you have installed by running the following commands:
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
-
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  You can download these tools by following the appropriate [Installation
-  instructions](../../installation/linux.mdx) for the Teleport
-  edition you use.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A Linux server to run the Teleport Windows Desktop Service.
   You can use an existing server that runs the Teleport Agent for other resources.
-
 - An Active Directory domain that is configured for LDAPS. Because Teleport requires an
   encrypted LDAP connection, you should verify that your domain uses Active Directory
   Certificate Services or a non-Microsoft certification authority (CA) to issue LDAPS
   certificates.
-
 - Administrative access to a domain controller.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Option 1: Automated configuration

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -25,21 +25,7 @@ For information about other ways to enroll and discover Kubernetes clusters, see
 
 ## Prerequisites
 
-- Access to a running Teleport cluster, `tctl` admin tool, and `tsh` client tool, 
-  version >= (=teleport.version=). 
-
-  You can verify the tools you have installed by running the following commands:
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-  
-  You can download these tools by following the appropriate [Installation 
-  instructions](../../installation/linux.mdx) for your environment.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 

--- a/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
@@ -36,7 +36,7 @@ For more information, see the [Access Lists reference](../../reference/access-co
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v17.0.1 or higher)"!)
 
 - (!docs/pages/includes/tctl.mdx!)
 - A user with the default `editor` role or equivalent permissions (ability to read, create, and manage Access Lists).

--- a/docs/pages/identity-governance/access-monitoring.mdx
+++ b/docs/pages/identity-governance/access-monitoring.mdx
@@ -26,7 +26,7 @@ Users are able to write their own custom access monitoring queries by querying t
 </Admonition>
 
 ## Prerequisites
-- Teleport v14 or later.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 - For self-hosted Teleport the [Amazon Athena Backend](../reference/backends.mdx) is required.
 
 

--- a/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
@@ -28,7 +28,7 @@ may approve the Access Request automatically.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v17.0.1 or higher)"!)
 
 - A Datadog account with the role "Datadog Admin Role". The admin role is required to
   create a Service Account and generate required credentials for the plugin.

--- a/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
@@ -27,25 +27,9 @@ Teleport [changelog](../../changelog.mdx) to learn about new plugins.
 
 ## Prerequisites
 
-- A managed Teleport Enterprise account.
-
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
-
-  You can verify the tools you have installed by running the following commands:
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
-  
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  You can download these tools by following the appropriate [Installation 
-  instructions](../../installation/installation.mdx) for your environment and Teleport edition.
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise Cloud"!)
 
 - At least one of the Teleport Access Plugins that support Access Monitoring Rules is enrolled.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Create an Access Monitoring Rule

--- a/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
@@ -22,26 +22,10 @@ Opsgenie.
 
 ## Prerequisites
 
-- A Teleport Enterprise Cloud account.
-
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
-  
-  You can verify the tools you have installed by running the following commands:
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  You can download these tools by following the appropriate [Installation 
-  instructions](../../installation/installation.mdx) for your environment and Teleport edition.
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise Cloud"!)
 
 - An Opsgenie account with the ability to create API keys with the 'read' and
   'create and update' access rights.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create services

--- a/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
+++ b/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
@@ -22,7 +22,7 @@ requests access to the `access` role.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v18.0.0 or higher)"!)
 
 - This feature requires Teleport Identity Governance.
 

--- a/docs/pages/identity-governance/okta/user-sync.mdx
+++ b/docs/pages/identity-governance/okta/user-sync.mdx
@@ -22,7 +22,7 @@ integration enrollment flow.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v17.3.0 or higher)"!)
 
 - An Okta authentication connector. 
 

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -14,7 +14,7 @@ This guide will help you set up the service and enable Access Graph in your Tele
 
 ## Prerequisites
 
-- A running Teleport Enterprise cluster v14.3.6 or later.
+- A running Teleport Enterprise cluster.
 - An updated Teleport Enterprise license file with Teleport Identity Security enabled.
 - Docker version v(=docker.version=) or later.
 - A PostgreSQL database server v14 or later.

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -43,7 +43,7 @@ graphical representation thereof.
 
 ## Prerequisites
 
-- A running Teleport Enterprise cluster v14.3.20/v15.3.1/v16.0.0 or later.
+- A running Teleport Enterprise cluster v15.3.1 or later.
 - Identity Security enabled for your account.
 - A GitLab instance running GitLab v9.0 or later.
 - For self-hosted clusters:

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,67 +1,70 @@
-{{ version="(=teleport.version=)" edition="Teleport" clients="`tctl` and `tsh` clients" }}
+{{ edition="Teleport" clients="`tctl` and `tsh` clients" }}
 
-- A running {{ edition }} cluster version {{ version }} or above. If you want to
-  get started with Teleport, [sign up](https://goteleport.com/signup) for a free
-  trial or [set up a demo environment](../linux-demo.mdx).
+- A running {{ edition }} cluster. If you want to get started with Teleport,
+  [sign up](https://goteleport.com/signup) for a free trial or [set up a demo
+  environment](../linux-demo.mdx).
 
 - The {{ clients }}.
 
   <details>
   <summary>Installing {{ clients }}</summary>
 
-  <Tabs>
-    <TabItem label="Mac">
+  1. Determine the version of your Teleport cluster. The {{ clients }} must be
+     at most one major version behind your Teleport cluster version. Send a GET
+     request to the Proxy Service at `/v1/webapi/find` and use a JSON query tool
+     to obtain your cluster version:
   
-      Download the signed macOS .pkg installer for Teleport, which includes the {{ clients }}:
-  
-      ```code
-      $ curl -O https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
-      ```
+     ```code
+     $ TELEPORT_DOMAIN=<Var name="example.teleport.com:443" />
+     $ TELEPORT_VERSION="$(curl -s https://$TELEPORT_DOMAIN/v1/webapi/find | jq -r '.server_version')"
+     ```
 
-      In Finder double-click the `pkg` file to begin installation.
-  
-      <Admonition type="danger">
-        Using Homebrew to install Teleport is not supported. The Teleport package in
-        Homebrew is not maintained by Teleport and we can't guarantee its reliability or
-        security.
-      </Admonition>
-  
-    </TabItem>
-  
-    <TabItem label="Windows - Powershell">
-  
-      ```code
-      $ curl.exe -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip
-      # Unzip the archive and move the {{ clients }} to your %PATH%
-      # NOTE: Do not place the {{ clients }} in the System32 directory, as this can cause issues when using WinSCP.
-      # Use %SystemRoot% (C:\Windows) or %USERPROFILE% (C:\Users\<username>) instead.
-      ```
-  
-    </TabItem>
-  
-    <TabItem label="Linux">
-  
-      All of the Teleport binaries in Linux installations include the {{ clients }}.  For more
-      options (including RPM/DEB packages and downloads for i386/ARM/ARM64) see
-      our [installation page](../installation/installation.mdx).
-  
-      ```code
-      $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      $ cd teleport
-      $ sudo ./install
-      # Teleport binaries have been copied to /usr/local/bin
-      ```
-    </TabItem>
-  </Tabs>
-  
-  The {{ clients }} must be at most one major version behind your Teleport
-  cluster version. Send a GET request to the Proxy Service at `/v1/webapi/ping`
-  and use a JSON query tool to obtain your cluster version:
-  
-  ```code
-  $ curl https://example.teleport.sh/v1/webapi/ping | jq -r '.server_version'
-  (=teleport.version=)
-  ```
+  1. Follow the instructions for your platform to install {{ clients }}:
 
+     <Tabs>
+       <TabItem label="Mac">
+     
+         Download the signed macOS .pkg installer for Teleport, which includes the {{ clients }}:
+     
+         ```code
+         $ curl -O https://cdn.teleport.dev/teleport-${TELEPORT_VERSION?}.pkg
+         ```
+   
+         In Finder double-click the `pkg` file to begin installation.
+     
+         <Admonition type="danger">
+           Using Homebrew to install Teleport is not supported. The Teleport package in
+           Homebrew is not maintained by Teleport and we can't guarantee its reliability or
+           security.
+         </Admonition>
+     
+       </TabItem>
+     
+       <TabItem label="Windows - Powershell">
+     
+         ```code
+         $ curl.exe -O https://cdn.teleport.dev/teleport-v${TELEPORT_VERSION?}-windows-amd64-bin.zip
+         # Unzip the archive and move the {{ clients }} to your %PATH%
+         # NOTE: Do not place the {{ clients }} in the System32 directory, as this can cause issues when using WinSCP.
+         # Use %SystemRoot% (C:\Windows) or %USERPROFILE% (C:\Users\<username>) instead.
+         ```
+     
+       </TabItem>
+     
+       <TabItem label="Linux">
+     
+         All of the Teleport binaries in Linux installations include the {{ clients }}.  For more
+         options (including RPM/DEB packages and downloads for i386/ARM/ARM64) see
+         our [installation page](../installation/installation.mdx).
+     
+         ```code
+         $ curl -O https://cdn.teleport.dev/teleport-v${TELEPORT_VERSION?}-linux-amd64-bin.tar.gz
+         $ tar -xzf teleport-v${TELEPORT_VERSION?}-linux-amd64-bin.tar.gz
+         $ cd teleport
+         $ sudo ./install
+         # Teleport binaries have been copied to /usr/local/bin
+         ```
+       </TabItem>
+     </Tabs>
+  
   </details>

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -28,7 +28,7 @@ control.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v17.5.1 or higher)"!)
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
@@ -23,7 +23,7 @@ connect to Teleport as the temporary bot.
 
 ## Prerequisites
 
-- A running Teleport Cluster whose version is higher than 16.2
+- A running Teleport cluster, version 16.2 or higher
 - Local tsh/tctl clients with versions higher than 16.2
 - Being locally logged in Teleport with a role that allows creating Bot and Token resources.
   You can use the default `editor` role for this.

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -39,7 +39,7 @@ resources:
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="16.2.0"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v16.2.0 or higher)"!)
 
 <Admonition type="tip">
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -38,7 +38,7 @@ resources that an attacker can compromise.
 This guide assumes that you have completed [Part 1: Enroll Infrastructure with
 Terraform](./enroll-resources.mdx).
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx version="16.2.0"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v16.2.0 or higher)"!)
 
 - Resources enrolled with Teleport that include the `dev` and `prod` labels. We
   show you how to enroll these resources using Terraform in Part One.


### PR DESCRIPTION
Including version variables such as `(=teleport.version=)` in the Prerequisites section of how-to guides can confuse users, since it can imply that the user needs a later version of Teleport than they run, even when they do not need the most recent version.

- Restructure `edition-prereqs-tabs.mdx`. Remove the `version` parameter, which currently has the `teleport.version` variable as its default value.
- In `edition-prereqs-tabs.mdx`, tell the user how to get the version of their cluster before having them install client tools so they're not always installing the most recent tools.
- Edit existing assignments of the `version` parameter in `edition-prereqs-tabs.mdx` to fit the new design of `edition-prereqs-tabs.mdx`. With the plugin the docs engine uses for partials, it is not currently possible to have an optional parameter with an empty value, so we'll need to use the `edition` parameter. While this approach is not ideal, applying it consistently allows us to change it once we introduce more ergonomic partial loading.
- Edit how-to guide prerequisites in guides that do not include `edition-prereqs-tabs.mdx` to remove Teleport version variables and mentions of unsupported versions (v14 and below). If it is trivial to do so, add `edition-prereqs-tabs.mdx` to these pages, since it contains versioning information. Otherwise, do not include the partial in these pages.
- Add hardcoded versions to Prerequisites sections in features introduced by supported versions of Teleport (v16-v18).