### PR TITLE
Align Cache Pagination Tests

### DIFF
--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -59,8 +59,8 @@ func TestAccessList(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.accessLists.ListAccessLists))
 		},
 		cacheGet: p.cache.GetAccessList,
-		cacheList: func(ctx context.Context) ([]*accesslist.AccessList, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListAccessLists))
+		cacheList: func(ctx context.Context, pageSize int) ([]*accesslist.AccessList, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListAccessLists, pageSize))
 		},
 		update: func(ctx context.Context, item *accesslist.AccessList) error {
 			_, err := p.accessLists.UpsertAccessList(ctx, item)
@@ -99,7 +99,7 @@ func TestAccessListMembers(t *testing.T) {
 		cacheGet: func(ctx context.Context, name string) (*accesslist.AccessListMember, error) {
 			return p.cache.GetAccessListMember(ctx, al.GetName(), name)
 		},
-		cacheList: func(ctx context.Context) ([]*accesslist.AccessListMember, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]*accesslist.AccessListMember, error) {
 			fn := func(ctx context.Context, pageSize int, startKey string) ([]*accesslist.AccessListMember, string, error) {
 				return p.cache.ListAccessListMembers(ctx, al.GetName(), pageSize, startKey)
 			}
@@ -185,7 +185,7 @@ func TestAccessListReviews(t *testing.T) {
 		list: func(ctx context.Context) ([]*accesslist.Review, error) {
 			return stream.Collect(clientutils.Resources(ctx, p.accessLists.ListAllAccessListReviews))
 		},
-		cacheList: func(ctx context.Context) ([]*accesslist.Review, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]*accesslist.Review, error) {
 			fn := func(ctx context.Context, pageSize int, startKey string) ([]*accesslist.Review, string, error) {
 				return p.cache.ListAccessListReviews(ctx, al.GetName(), pageSize, startKey)
 			}

--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -59,7 +59,7 @@ func TestApps(t *testing.T) {
 			return stream.Collect(p.apps.Apps(ctx, "", ""))
 		},
 		cacheGet: p.cache.GetApp,
-		cacheList: func(ctx context.Context) ([]types.Application, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Application, error) {
 			return stream.Collect(p.cache.Apps(ctx, "", ""))
 		},
 		update:    p.apps.UpdateApp,
@@ -172,7 +172,7 @@ func TestApplicationServers(t *testing.T) {
 			list: func(ctx context.Context) ([]types.AppServer, error) {
 				return p.presenceS.GetApplicationServers(ctx, apidefaults.Namespace)
 			},
-			cacheList: func(ctx context.Context) ([]types.AppServer, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.AppServer, error) {
 				return p.cache.GetApplicationServers(ctx, apidefaults.Namespace)
 			},
 			update: withKeepalive(p.presenceS.UpsertApplicationServer),
@@ -215,9 +215,10 @@ func TestApplicationServers(t *testing.T) {
 
 				return out, nil
 			},
-			cacheList: func(ctx context.Context) ([]types.AppServer, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.AppServer, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindAppServer,
+					Limit:        int32(pageSize),
 				}
 
 				var out []types.AppServer

--- a/lib/cache/auth_server_test.go
+++ b/lib/cache/auth_server_test.go
@@ -46,7 +46,7 @@ func TestAuthServers(t *testing.T) {
 		list: func(_ context.Context) ([]types.Server, error) {
 			return p.presenceS.GetAuthServers()
 		},
-		cacheList: func(_ context.Context) ([]types.Server, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Server, error) {
 			return p.cache.GetAuthServers()
 		},
 		update: p.presenceS.UpsertAuthServer,

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -49,14 +49,14 @@ func TestDatabaseServices(t *testing.T) {
 		},
 		create: withKeepalive(p.databaseServices.UpsertDatabaseService),
 		list: func(ctx context.Context) ([]types.DatabaseService, error) {
-			resources, err := listAllResource(t, p.presenceS, types.KindDatabaseService)
+			resources, err := listAllResource(t, p.presenceS, types.KindDatabaseService, apidefaults.DefaultChunkSize)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return types.ResourcesWithLabels(resources).AsDatabaseServices()
 		},
-		cacheList: func(ctx context.Context) ([]types.DatabaseService, error) {
-			resources, err := listAllResource(t, p.cache, types.KindDatabaseService)
+		cacheList: func(ctx context.Context, pageSize int) ([]types.DatabaseService, error) {
+			resources, err := listAllResource(t, p.cache, types.KindDatabaseService, pageSize)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -84,10 +84,12 @@ func TestDatabases(t *testing.T) {
 				URI:      "localhost:5432",
 			})
 		},
-		create:    p.databases.CreateDatabase,
-		list:      p.databases.GetDatabases,
-		cacheGet:  p.cache.GetDatabase,
-		cacheList: p.cache.GetDatabases,
+		create:   p.databases.CreateDatabase,
+		list:     p.databases.GetDatabases,
+		cacheGet: p.cache.GetDatabase,
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Database, error) {
+			return p.cache.GetDatabases(ctx)
+		},
 		update:    p.databases.UpdateDatabase,
 		deleteAll: p.databases.DeleteAllDatabases,
 	})
@@ -116,7 +118,7 @@ func TestDatabaseServers(t *testing.T) {
 			list: func(ctx context.Context) ([]types.DatabaseServer, error) {
 				return p.presenceS.GetDatabaseServers(ctx, apidefaults.Namespace)
 			},
-			cacheList: func(ctx context.Context) ([]types.DatabaseServer, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.DatabaseServer, error) {
 				return p.cache.GetDatabaseServers(ctx, apidefaults.Namespace)
 			},
 			update: withKeepalive(p.presenceS.UpsertDatabaseServer),
@@ -139,14 +141,14 @@ func TestDatabaseServers(t *testing.T) {
 			},
 			create: withKeepalive(p.presenceS.UpsertDatabaseServer),
 			list: func(ctx context.Context) ([]types.DatabaseServer, error) {
-				resources, err := listAllResource(t, p.presenceS, types.KindDatabaseServer)
+				resources, err := listAllResource(t, p.presenceS, types.KindDatabaseServer, apidefaults.DefaultChunkSize)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
 				return types.ResourcesWithLabels(resources).AsDatabaseServers()
 			},
-			cacheList: func(ctx context.Context) ([]types.DatabaseServer, error) {
-				resources, err := listAllResource(t, p.cache, types.KindDatabaseServer)
+			cacheList: func(ctx context.Context, pageSize int) ([]types.DatabaseServer, error) {
+				resources, err := listAllResource(t, p.cache, types.KindDatabaseServer, pageSize)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}

--- a/lib/cache/discovery_config_test.go
+++ b/lib/cache/discovery_config_test.go
@@ -55,8 +55,8 @@ func TestDiscoveryConfig(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.discoveryConfigs.ListDiscoveryConfigs))
 		},
 		cacheGet: p.cache.GetDiscoveryConfig,
-		cacheList: func(ctx context.Context) ([]*discoveryconfig.DiscoveryConfig, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListDiscoveryConfigs))
+		cacheList: func(ctx context.Context, pageSize int) ([]*discoveryconfig.DiscoveryConfig, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListDiscoveryConfigs, pageSize))
 		},
 		update: func(ctx context.Context, discoveryConfig *discoveryconfig.DiscoveryConfig) error {
 			_, err := p.discoveryConfigs.UpdateDiscoveryConfig(ctx, discoveryConfig)

--- a/lib/cache/git_server_test.go
+++ b/lib/cache/git_server_test.go
@@ -57,7 +57,7 @@ func TestGitServers(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.gitServers.DeleteAllGitServers,
-		cacheList: func(ctx context.Context) ([]types.Server, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Server, error) {
 			return stream.Collect(clientutils.Resources(ctx, p.cache.ListGitServers))
 		},
 		cacheGet: p.cache.GetGitServer,

--- a/lib/cache/installer_test.go
+++ b/lib/cache/installer_test.go
@@ -37,7 +37,7 @@ func TestInstallers(t *testing.T) {
 		list: func(ctx context.Context) ([]types.Installer, error) {
 			return p.clusterConfigS.GetInstallers(ctx)
 		},
-		cacheList: func(ctx context.Context) ([]types.Installer, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Installer, error) {
 			return p.cache.GetInstallers(ctx)
 		},
 		deleteAll: func(ctx context.Context) error {

--- a/lib/cache/integrations_test.go
+++ b/lib/cache/integrations_test.go
@@ -50,8 +50,8 @@ func TestIntegrations(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.integrations.ListIntegrations))
 		},
 		cacheGet: p.cache.GetIntegration,
-		cacheList: func(ctx context.Context) ([]types.Integration, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListIntegrations))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Integration, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListIntegrations, pageSize))
 		},
 		update: func(ctx context.Context, i types.Integration) error {
 			_, err := p.integrations.UpdateIntegration(ctx, i)

--- a/lib/cache/lock_test.go
+++ b/lib/cache/lock_test.go
@@ -48,7 +48,7 @@ func TestLocks(t *testing.T) {
 			return results, err
 		},
 		cacheGet: p.cache.GetLock,
-		cacheList: func(ctx context.Context) ([]types.Lock, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Lock, error) {
 			results, err := p.cache.GetLocks(ctx, false)
 			return results, err
 		},

--- a/lib/cache/networking_restrictions_test.go
+++ b/lib/cache/networking_restrictions_test.go
@@ -40,7 +40,7 @@ func TestNetworkRestrictions(t *testing.T) {
 			restrictions, err := p.restrictions.GetNetworkRestrictions(ctx)
 			return []types.NetworkRestrictions{restrictions}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]types.NetworkRestrictions, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.NetworkRestrictions, error) {
 			restrictions, err := p.cache.GetNetworkRestrictions(ctx)
 			if trace.IsNotFound(err) {
 				return nil, nil

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -52,7 +52,7 @@ func TestNodes(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
 				return p.cache.GetNode(ctx, apidefaults.Namespace, name)
 			},
-			cacheList: func(ctx context.Context) ([]types.Server, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Server, error) {
 				return p.cache.GetNodes(ctx, apidefaults.Namespace)
 			},
 			update: withKeepalive(p.presenceS.UpsertNode),
@@ -101,9 +101,10 @@ func TestNodes(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
 				return p.cache.GetNode(ctx, apidefaults.Namespace, name)
 			},
-			cacheList: func(ctx context.Context) ([]types.Server, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Server, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindNode,
+					Limit:        int32(pageSize),
 				}
 
 				var out []types.Server

--- a/lib/cache/okta_test.go
+++ b/lib/cache/okta_test.go
@@ -75,8 +75,8 @@ func TestOktaImportRules(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.okta.ListOktaImportRules))
 		},
 		cacheGet: p.cache.GetOktaImportRule,
-		cacheList: func(ctx context.Context) ([]types.OktaImportRule, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListOktaImportRules))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.OktaImportRule, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListOktaImportRules, pageSize))
 		},
 		update: func(ctx context.Context, resource types.OktaImportRule) error {
 			_, err := p.okta.UpdateOktaImportRule(ctx, resource)
@@ -123,8 +123,8 @@ func TestOktaAssignments(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.okta.ListOktaAssignments))
 		},
 		cacheGet: p.cache.GetOktaAssignment,
-		cacheList: func(ctx context.Context) ([]types.OktaAssignment, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListOktaAssignments))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.OktaAssignment, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListOktaAssignments, pageSize))
 		},
 		update: func(ctx context.Context, resource types.OktaAssignment) error {
 			_, err := p.okta.UpdateOktaAssignment(ctx, resource)

--- a/lib/cache/plugin_static_credentials_test.go
+++ b/lib/cache/plugin_static_credentials_test.go
@@ -89,7 +89,7 @@ func TestPluginStaticCredentials(t *testing.T) {
 					return err
 				},
 				deleteAll: p.pluginStaticCredentials.DeleteAllPluginStaticCredentials,
-				cacheList: func(ctx context.Context) ([]types.PluginStaticCredentials, error) {
+				cacheList: func(ctx context.Context, pageSize int) ([]types.PluginStaticCredentials, error) {
 					var out []types.PluginStaticCredentials
 					for cred := range p.cache.collections.pluginStaticCredentials.store.resources(pluginStaticCredentialsNameIndex, "", "") {
 						out = append(out, cred.Clone())

--- a/lib/cache/proxy_server_test.go
+++ b/lib/cache/proxy_server_test.go
@@ -47,7 +47,7 @@ func TestProxies(t *testing.T) {
 		list: func(_ context.Context) ([]types.Server, error) {
 			return p.presenceS.GetProxies()
 		},
-		cacheList: func(_ context.Context) ([]types.Server, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.Server, error) {
 			return p.cache.GetProxies()
 		},
 		update: p.presenceS.UpsertProxy,

--- a/lib/cache/remote_cluster_test.go
+++ b/lib/cache/remote_cluster_test.go
@@ -54,7 +54,7 @@ func TestRemoteClusters(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.RemoteCluster, error) {
 				return p.cache.GetRemoteCluster(ctx, name)
 			},
-			cacheList: func(ctx context.Context) ([]types.RemoteCluster, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.RemoteCluster, error) {
 				return p.cache.GetRemoteClusters(ctx)
 			},
 			update: func(ctx context.Context, rc types.RemoteCluster) error {
@@ -87,8 +87,8 @@ func TestRemoteClusters(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.RemoteCluster, error) {
 				return p.cache.GetRemoteCluster(ctx, name)
 			},
-			cacheList: func(ctx context.Context) ([]types.RemoteCluster, error) {
-				return stream.Collect(clientutils.Resources(ctx, p.cache.ListRemoteClusters))
+			cacheList: func(ctx context.Context, pageSize int) ([]types.RemoteCluster, error) {
+				return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListRemoteClusters, pageSize))
 			},
 			update: func(ctx context.Context, rc types.RemoteCluster) error {
 				_, err := p.trustS.UpdateRemoteCluster(ctx, rc)
@@ -121,7 +121,7 @@ func TestTunnelConnections(t *testing.T) {
 		list: func(ctx context.Context) ([]types.TunnelConnection, error) {
 			return p.trustS.GetAllTunnelConnections()
 		},
-		cacheList: func(ctx context.Context) ([]types.TunnelConnection, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.TunnelConnection, error) {
 			return p.cache.GetAllTunnelConnections()
 		},
 		update: modifyNoContext(p.trustS.UpsertTunnelConnection),

--- a/lib/cache/reverse_tunnel_test.go
+++ b/lib/cache/reverse_tunnel_test.go
@@ -52,8 +52,8 @@ func TestReverseTunnels(t *testing.T) {
 		},
 		deleteAll: p.presenceS.DeleteAllReverseTunnels,
 
-		cacheList: func(ctx context.Context) ([]types.ReverseTunnel, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListReverseTunnels))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.ReverseTunnel, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListReverseTunnels, pageSize))
 		},
 	})
 }

--- a/lib/cache/role_test.go
+++ b/lib/cache/role_test.go
@@ -64,9 +64,11 @@ func TestRoles(t *testing.T) {
 				_, err := p.accessS.UpsertRole(ctx, role)
 				return err
 			},
-			list:      p.accessS.GetRoles,
-			cacheGet:  p.cache.GetRole,
-			cacheList: p.cache.GetRoles,
+			list:     p.accessS.GetRoles,
+			cacheGet: p.cache.GetRole,
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Role, error) {
+				return p.cache.GetRoles(ctx)
+			},
 			update: func(ctx context.Context, role types.Role) error {
 				_, err := p.accessS.UpsertRole(ctx, role)
 				return err
@@ -117,9 +119,11 @@ func TestRoles(t *testing.T) {
 				return out, nil
 			},
 			cacheGet: p.cache.GetRole,
-			cacheList: func(ctx context.Context) ([]types.Role, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.Role, error) {
 				var out []types.Role
-				req := &proto.ListRolesRequest{}
+				req := &proto.ListRolesRequest{
+					Limit: int32(pageSize),
+				}
 				for {
 					resp, err := p.cache.ListRoles(ctx, req)
 					if err != nil {

--- a/lib/cache/saml_idp_test.go
+++ b/lib/cache/saml_idp_test.go
@@ -50,8 +50,8 @@ func TestSAMLIdPServiceProviders(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.samlIDPServiceProviders.ListSAMLIdPServiceProviders))
 		},
 		cacheGet: p.cache.GetSAMLIdPServiceProvider,
-		cacheList: func(ctx context.Context) ([]types.SAMLIdPServiceProvider, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListSAMLIdPServiceProviders))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.SAMLIdPServiceProvider, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListSAMLIdPServiceProviders, pageSize))
 		},
 		update:    p.samlIDPServiceProviders.UpdateSAMLIdPServiceProvider,
 		deleteAll: p.samlIDPServiceProviders.DeleteAllSAMLIdPServiceProviders,

--- a/lib/cache/user_group_test.go
+++ b/lib/cache/user_group_test.go
@@ -53,8 +53,8 @@ func TestUserGroups(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.userGroups.ListUserGroups))
 		},
 		cacheGet: p.cache.GetUserGroup,
-		cacheList: func(ctx context.Context) ([]types.UserGroup, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListUserGroups))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.UserGroup, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListUserGroups, pageSize))
 		},
 		update:    p.userGroups.UpdateUserGroup,
 		deleteAll: p.userGroups.DeleteAllUserGroups,

--- a/lib/cache/user_login_state_test.go
+++ b/lib/cache/user_login_state_test.go
@@ -41,9 +41,11 @@ func TestUserLoginStates(t *testing.T) {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)
 		},
-		list:      p.userLoginStates.GetUserLoginStates,
-		cacheGet:  p.cache.GetUserLoginState,
-		cacheList: p.cache.GetUserLoginStates,
+		list:     p.userLoginStates.GetUserLoginStates,
+		cacheGet: p.cache.GetUserLoginState,
+		cacheList: func(ctx context.Context, pageSize int) ([]*userloginstate.UserLoginState, error) {
+			return p.cache.GetUserLoginStates(ctx)
+		},
 		update: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)

--- a/lib/cache/users_test.go
+++ b/lib/cache/users_test.go
@@ -48,7 +48,7 @@ func TestUsers(t *testing.T) {
 			list: func(ctx context.Context) ([]types.User, error) {
 				return p.usersS.GetUsers(ctx, false)
 			},
-			cacheList: func(ctx context.Context) ([]types.User, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.User, error) {
 				return p.cache.GetUsers(ctx, false)
 			},
 			update: func(ctx context.Context, user types.User) error {
@@ -91,9 +91,11 @@ func TestUsers(t *testing.T) {
 
 				return out, nil
 			},
-			cacheList: func(ctx context.Context) ([]types.User, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.User, error) {
 				var out []types.User
-				req := &userspb.ListUsersRequest{}
+				req := &userspb.ListUsersRequest{
+					PageSize: int32(pageSize),
+				}
 				for {
 					resp, err := p.cache.ListUsers(ctx, req)
 					if err != nil {

--- a/lib/cache/web_tokens_test.go
+++ b/lib/cache/web_tokens_test.go
@@ -17,6 +17,7 @@
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,9 +37,11 @@ func TestWebTokens(t *testing.T) {
 				User:  "llama",
 			})
 		},
-		create:    p.webTokenS.Upsert,
-		list:      p.webTokenS.List,
-		cacheList: p.cache.GetWebTokens,
+		create: p.webTokenS.Upsert,
+		list:   p.webTokenS.List,
+		cacheList: func(ctx context.Context, pageSize int) ([]types.WebToken, error) {
+			return p.cache.GetWebTokens(ctx)
+		},
 		deleteAll: p.webTokenS.DeleteAll,
 	})
 }

--- a/lib/cache/web_ui_config_test.go
+++ b/lib/cache/web_ui_config_test.go
@@ -51,7 +51,7 @@ func TestWebUIConfig(t *testing.T) {
 
 			return []types.UIConfig{cfg}, nil
 		},
-		cacheList: func(ctx context.Context) ([]types.UIConfig, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.UIConfig, error) {
 			cfg, err := p.cache.GetUIConfig(ctx)
 			if err != nil {
 				if trace.IsNotFound(err) {

--- a/lib/cache/windows_desktop_test.go
+++ b/lib/cache/windows_desktop_test.go
@@ -86,12 +86,13 @@ func TestWindowsDesktop(t *testing.T) {
 			return desktops[0], nil
 
 		},
-		cacheList: func(ctx context.Context) ([]types.WindowsDesktop, error) {
+		cacheList: func(ctx context.Context, pageSize int) ([]types.WindowsDesktop, error) {
 			var start string
 			var desktops []types.WindowsDesktop
 			for {
 				req := types.ListWindowsDesktopsRequest{
 					StartKey: start,
+					Limit:    pageSize,
 				}
 
 				resp, err := p.cache.ListWindowsDesktops(ctx, req)
@@ -195,10 +196,12 @@ func TestWindowsDesktopService(t *testing.T) {
 					},
 				)
 			},
-			create:    withKeepalive(p.presenceS.UpsertWindowsDesktopService),
-			list:      p.presenceS.GetWindowsDesktopServices,
-			cacheGet:  p.cache.GetWindowsDesktopService,
-			cacheList: p.cache.GetWindowsDesktopServices,
+			create:   withKeepalive(p.presenceS.UpsertWindowsDesktopService),
+			list:     p.presenceS.GetWindowsDesktopServices,
+			cacheGet: p.cache.GetWindowsDesktopService,
+			cacheList: func(ctx context.Context, pageSize int) ([]types.WindowsDesktopService, error) {
+				return p.cache.GetWindowsDesktopServices(ctx)
+			},
 			update:    withKeepalive(p.presenceS.UpsertWindowsDesktopService),
 			deleteAll: p.presenceS.DeleteAllWindowsDesktopServices,
 		})
@@ -243,9 +246,10 @@ func TestWindowsDesktopService(t *testing.T) {
 				return out, nil
 			},
 			cacheGet: p.cache.GetWindowsDesktopService,
-			cacheList: func(ctx context.Context) ([]types.WindowsDesktopService, error) {
+			cacheList: func(ctx context.Context, pageSize int) ([]types.WindowsDesktopService, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindWindowsDesktopService,
+					Limit:        int32(pageSize),
 				}
 
 				var out []types.WindowsDesktopService
@@ -296,8 +300,8 @@ func TestDynamicWindowsDesktop(t *testing.T) {
 			return stream.Collect(clientutils.Resources(ctx, p.dynamicWindowsDesktops.ListDynamicWindowsDesktops))
 		},
 		cacheGet: p.cache.GetDynamicWindowsDesktop,
-		cacheList: func(ctx context.Context) ([]types.DynamicWindowsDesktop, error) {
-			return stream.Collect(clientutils.Resources(ctx, p.cache.ListDynamicWindowsDesktops))
+		cacheList: func(ctx context.Context, pageSize int) ([]types.DynamicWindowsDesktop, error) {
+			return stream.Collect(clientutils.ResourcesWithPageSize(ctx, p.cache.ListDynamicWindowsDesktops, pageSize))
 		},
 		update: func(ctx context.Context, dwd types.DynamicWindowsDesktop) error {
 			_, err := p.dynamicWindowsDesktops.UpdateDynamicWindowsDesktop(ctx, dwd)


### PR DESCRIPTION
### What

Default pagination tests were introduced for all resource sets with a default chunk size of 1000.
As a result, each test creates 1000 elements, which can be slow for certain resources.

This can lead to flaky tests that exceed the 10-minute timeout when new cache resources are added.
To address this, instead of testing all resources against pagination by default, a new function collectResourcesWithSmallPageSize has been introduced.
This function allows testing collections with a smaller pageSize (set to 1), and the test setup creates only 2 elements.
```
go test -count=1 -json ./... | jq -r 'select(.Action == "pass" or .Action == "fail") | "\(.Elapsed) \(.Test)"' | sort -nr | awk '{print $2 ": " $1 " seconds"}'
null: 23.08 seconds
TestAccessList: 13.04 seconds
TestPluginStaticCredentials: 10.69 seconds
TestDatabaseServers: 9.57 seconds
TestRoles: 9.25 seconds
TestSAMLIdPServiceProviders: 8.05 seconds
TestKubernetesServers: 7.79 seconds
TestWindowsDesktopService: 7.59 seconds
TestRelativeExpiryLimit: 7.27 seconds
TestOktaAssignments: 5.71 seconds
TestOktaImportRules: 5.7 seconds
TestTunnelConnections: 5.66 seconds
TestProxies: 5.63 seconds
TestGitServers: 5.6 seconds
TestUserGroups: 5.58 seconds
TestApplicationServers: 5.47 seconds
TestRoles/GetRoles: 5.46 seconds
TestUsers: 5.45 seconds
TestUserLoginStates: 5.45 seconds
TestReverseTunnels: 5.45 seconds
TestPluginStaticCredentials/GetPluginStaticCredentials: 5.36 seconds
TestKubernetes: 5.3 seconds
TestWindowsDesktop: 5.28 seconds
TestDynamicWindowsDesktop: 5.28 seconds
TestWebTokens: 5.25 seconds
TestLocks: 5.24 seconds
TestIntegrations: 5.24 seconds
TestSecurityReports: 5.16 seconds
TestPluginStaticCredentials/GetPluginStaticCredentialsByLabels: 5.07 seconds
TestAuditQuery: 5.03 seconds
TestDiscoveryConfig: 4.98 seconds
TestKubernetesServers/GetKubernetesServers: 4.97 seconds
TestDatabaseServers/ListResources: 4.83 seconds
TestWindowsDesktopService/GetWindowsDesktopServices: 4.76 seconds
TestDatabases: 4.42 seconds
TestRelativeExpiryOnlyForAuth: 4.41 seconds
TestApps: 4.23 seconds
TestDatabaseServers/GetDatabaseServers: 4.01 seconds
TestAuthServers: 3.87 seconds
TestRoles/ListRoles: 3.55 seconds
TestRemoteClusters/GetRemoteClusters: 3.46 seconds
TestRemoteClusters/ListRemoteClusters: 3.45 seconds
TestApplicationServers/GetApplicationServers: 3.44 seconds
TestListResources_NodesTTLVariant: 3.43 seconds
TestSecurityReportState: 3.24 seconds
TestSecurityReports/GetSecurityReports: 3.22 seconds
TestNodes/GetNodes: 3.22 seconds
TestAuditQuery/GetSecurityAuditQueries: 3.19 seconds
TestNodes/ListResources: 2.97 seconds
TestRelativeExpiry: 2.84 seconds
TestUsers/ListUsers: 2.67 seconds
TestWindowsDesktopService/ListResources: 2.61 seconds
TestKubernetesServers/ListResources: 2.61 seconds
TestUsers/GetUsers: 2.37 seconds
TestDatabaseServices: 2.18 seconds
TestListAccessMonitoringRulesWithFilter: 2.06 seconds
TestInstallers: 2.06 seconds
TestApplicationServers/ListResources: 1.82 seconds
TestSecurityReports/ListSecurityReports: 1.73 seconds
TestAuditQuery/ListSecurityAuditQueries: 1.64 seconds
TestInvalidDatabases/UpdateDatabase: 1.52 seconds
TestAccessListReviews: 1.44 seconds
TestProvisioningPrincipalState: 1.23 seconds
TestBotInstanceCache: 1.23 seconds
TestWatchers: 1.21 seconds
TestInvalidDatabases/CreateDatabase: 1.21 seconds
TestIdentityCenterPrincipalAssignment: 1.21 seconds
TestIdentityCenterAccountAssignment: 1.21 seconds
TestIdentityCenterAccount: 1.21 seconds
TestAccessListMembers: 1 seconds
TestWebUIConfig: 0.98 seconds
TestNetworkRestrictions: 0.98 seconds
TestRecordingEncryption: 0.82 seconds
TestHealthCheckConfig: 0.81 seconds
TestAccessMonitoringRules: 0.81 seconds
TestNodeCAFiltering: 0.8 seconds
TestAppSessions: 0.7 seconds
TestWebSessions: 0.64 seconds
TestSnowflakeSessions: 0.63 seconds
TestWorkloadIdentity: 0.62 seconds
TestUserNotifications: 0.62 seconds
TestStaticHostUsers: 0.62 seconds
TestSPIFFEFederations: 0.62 seconds
TestRecovery: 0.62 seconds
TestDynamicTokens: 0.62 seconds
TestAutoUpdateVersion: 0.62 seconds
TestUserTasks: 0.61 seconds
TestGlobalNotifications: 0.61 seconds
TestAutoUpdateConfig: 0.61 seconds
TestAutoUpdateAgentRollout: 0.61 seconds
TestAccessGraphSettings: 0.61 seconds
TestCA: 0.6 seconds
TestClusterName: 0.43 seconds
TestListAccessMonitoringRulesWithFilter/filter_by_automatic_review_integration: 0.42 seconds
TestSessionRecordingConfig: 0.41 seconds
TestListAccessMonitoringRulesWithFilter/no_match: 0.41 seconds
TestListAccessMonitoringRulesWithFilter/filter_by_notification_integration: 0.41 seconds
TestListAccessMonitoringRulesWithFilter/filter_by_builtin_automatic_review_rules: 0.41 seconds
TestListAccessMonitoringRulesWithFilter/filter_by_both_notification_and_automatic_review_integration: 0.41 seconds
TestInitStrategy: 0.41 seconds
TestClusterNetworkingConfig: 0.41 seconds
TestClusterAuditConfig: 0.41 seconds
TestBotInstanceCacheSorting: 0.41 seconds
TestBotInstanceCacheSearchFilter: 0.41 seconds
TestBotInstanceCachePaging: 0.41 seconds
TestBotInstanceCacheBotFilter: 0.41 seconds
TestAuthPreference: 0.41 seconds
TestStaticTokens: 0.4 seconds
TestPartialHealth: 0.4 seconds
TestCompletenessReset: 0.36 seconds
TestDatabaseObjects: 0.35 seconds
TestBotInstanceCacheFallback: 0.31 seconds
TestCompletenessInit: 0.3 seconds
TestRoleNotFound: 0.24 seconds
TestCrownJewel: 0.24 seconds
TestCAWatcherFilters: 0.21 seconds
TestUsers/ListUsers_pagination: 0.2 seconds
TestCache_Backoff: 0.2 seconds
TestSetupConfigFns/ForWindowsDesktop: 0 seconds
TestSetupConfigFns/ForRemoteProxy: 0 seconds
TestSetupConfigFns/ForProxy: 0 seconds
TestSetupConfigFns/ForOkta: 0 seconds
TestSetupConfigFns/ForNode: 0 seconds
TestSetupConfigFns/ForKubernetes: 0 seconds
TestSetupConfigFns/ForDiscovery: 0 seconds
TestSetupConfigFns/ForDatabases: 0 seconds
TestSetupConfigFns/ForApps: 0 seconds
TestSetupConfigFns: 0 seconds
TestResourceStore: 0 seconds
TestRemoteClusters: 0 seconds
TestNodesDontCacheHighVolumeResources: 0 seconds
TestNodes: 0 seconds
TestInvalidDatabases: 0 seconds
TestCountAccessListMembersScoping: 0 seconds
TestCAWatcherFilters/empty_filter: 0 seconds
TestCAWatcherFilters/all_CAs_filter: 0 seconds
TestCAWatcherFilters/all_CAs_and_a_new_CA_filter: 0 seconds
TestCacheWatchKindExistsInEvents/ForRemoteProxy: 0 seconds
TestCacheWatchKindExistsInEvents/ForProxy: 0 seconds
TestCacheWatchKindExistsInEvents/ForOkta: 0 seconds
TestCacheWatchKindExistsInEvents/ForNode: 0 seconds
TestCacheWatchKindExistsInEvents/ForKubernetes: 0 seconds
TestCacheWatchKindExistsInEvents/ForDatabases: 0 seconds
TestCacheWatchKindExistsInEvents/ForAuth: 0 seconds
TestCacheWatchKindExistsInEvents/ForApps: 0 seconds
TestCacheWatchKindExistsInEvents: 0 seconds
```