### PR TITLE
Add `workload_identity`/`bot` to supported kinds in role reference

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -490,6 +490,8 @@ spec:
     # instance           - a Teleport instance
     # event              - structured audit logging event
     #
+    # workload_identity     - config for Machine & Workload Identity SVIDS
+    # bot                   - config for Machine & Workload Identity bots
     #
     # lock                  - lock resource.
     # network_restrictions  - restrictions for SSH sessions


### PR DESCRIPTION
This list should probably be generated at some-point in the future. One of our customers ran into this while trying to configure Machine & Workload identity.