### PR TITLE
[tctl] add display of running services to top command

### DIFF
--- a/tool/tctl/common/top/model.go
+++ b/tool/tctl/common/top/model.go
@@ -315,7 +315,7 @@ func renderCommon(report *Report, width int) string {
 	runtimeContent := boxedView("Go Runtime Stats", runtimeTable, columnWidth)
 
 	serviceKeys := slices.Sorted(maps.Keys(report.Service))
-	serviceCounts := []string{}
+	serviceCounts := make([]string, 0, len(serviceKeys))
 	for _, k := range serviceKeys {
 		serviceCounts = append(serviceCounts, humanize.FormatFloat("#.", report.Service[k]))
 	}
@@ -346,10 +346,14 @@ func renderCommon(report *Report, width int) string {
 				clusterContent,
 				processContent,
 				runtimeContent,
+			),
+		),
+		style.Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				certLatencyContent,
 				servicesContent,
 			),
 		),
-		style.Render(certLatencyContent),
 	)
 }
 

--- a/tool/tctl/common/top/model.go
+++ b/tool/tctl/common/top/model.go
@@ -350,8 +350,8 @@ func renderCommon(report *Report, width int) string {
 		),
 		style.Render(
 			lipgloss.JoinVertical(lipgloss.Left,
-				certLatencyContent,
 				servicesContent,
+				certLatencyContent,
 			),
 		),
 	)

--- a/tool/tctl/common/top/model.go
+++ b/tool/tctl/common/top/model.go
@@ -20,6 +20,8 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -312,6 +314,24 @@ func renderCommon(report *Report, width int) string {
 	)
 	runtimeContent := boxedView("Go Runtime Stats", runtimeTable, columnWidth)
 
+	serviceKeys := slices.Sorted(maps.Keys(report.Service))
+	serviceCounts := []string{}
+	for _, k := range serviceKeys {
+		serviceCounts = append(serviceCounts, humanize.FormatFloat("#.", report.Service[k]))
+	}
+	servicesTable := tableView(
+		columnWidth,
+		column{
+			width:   columnWidth * 8 / 10,
+			content: serviceKeys,
+		},
+		column{
+			width:   columnWidth * 2 / 10,
+			content: serviceCounts,
+		},
+	)
+	servicesContent := boxedView("Services", servicesTable, columnWidth)
+
 	certLatencyContent := boxedView("Generate Server Certificates Percentiles", "No data", columnWidth)
 
 	style := lipgloss.NewStyle().
@@ -326,6 +346,7 @@ func renderCommon(report *Report, width int) string {
 				clusterContent,
 				processContent,
 				runtimeContent,
+				servicesContent,
 			),
 		),
 		style.Render(certLatencyContent),

--- a/tool/tctl/common/top/report.go
+++ b/tool/tctl/common/top/report.go
@@ -714,7 +714,7 @@ func getServices(family *dto.MetricFamily) Services {
 		return nil
 	}
 
-	var out = make(Services)
+	out := make(Services)
 	for _, metric := range family.Metric {
 		if metric.Gauge == nil || metric.Gauge.Value == nil {
 			continue

--- a/tool/tctl/common/top/report.go
+++ b/tool/tctl/common/top/report.go
@@ -61,7 +61,12 @@ type Report struct {
 	Watcher *WatcherStats
 	// Audit contains stats for audit event backends.
 	Audit *AuditStats
+	// Service contains status of active services.
+	Service Services
 }
+
+// Services is a map of service name to a gauge value of how many services of that type are currently running.
+type Services map[string]float64
 
 // AuditStats contains metrics related to the audit log.
 type AuditStats struct {
@@ -470,6 +475,8 @@ func generateReport(metrics map[string]*dto.MetricFamily, prev *Report, period t
 		Roles:                          getGaugeValue(metrics[prometheus.BuildFQName(teleport.MetricNamespace, "", "roles_total")]),
 	}
 
+	re.Service = getServices(metrics[prometheus.BuildFQName(teleport.MetricNamespace, "", teleport.MetricTeleportServices)])
+
 	var auditStats *AuditStats
 	if prev != nil {
 		auditStats = prev.Audit
@@ -699,6 +706,27 @@ func getActiveMigrations(metric *dto.MetricFamily) []string {
 			}
 		}
 	}
+	return out
+}
+
+func getServices(family *dto.MetricFamily) Services {
+	if family == nil || family.GetType() != dto.MetricType_GAUGE || len(family.Metric) == 0 {
+		return nil
+	}
+
+	out := make(Services)
+	for _, metric := range family.Metric {
+		if metric.Gauge == nil || metric.Gauge.Value == nil {
+			continue
+		}
+		for _, label := range metric.Label {
+			if label.GetName() == teleport.TagServiceName {
+				out[label.GetValue()] = *metric.Gauge.Value
+				break
+			}
+		}
+	}
+
 	return out
 }
 

--- a/tool/tctl/common/top/report.go
+++ b/tool/tctl/common/top/report.go
@@ -714,7 +714,7 @@ func getServices(family *dto.MetricFamily) Services {
 		return nil
 	}
 
-	out := make(Services)
+	var out = make(Services)
 	for _, metric := range family.Metric {
 		if metric.Gauge == nil || metric.Gauge.Value == nil {
 			continue

--- a/tool/tctl/common/top/report.go
+++ b/tool/tctl/common/top/report.go
@@ -61,12 +61,9 @@ type Report struct {
 	Watcher *WatcherStats
 	// Audit contains stats for audit event backends.
 	Audit *AuditStats
-	// Service contains status of active services.
-	Service Services
+	// Service is a map of service name to a gauge value of how many services of that type are currently running.
+	Service map[string]float64
 }
-
-// Services is a map of service name to a gauge value of how many services of that type are currently running.
-type Services map[string]float64
 
 // AuditStats contains metrics related to the audit log.
 type AuditStats struct {
@@ -475,7 +472,7 @@ func generateReport(metrics map[string]*dto.MetricFamily, prev *Report, period t
 		Roles:                          getGaugeValue(metrics[prometheus.BuildFQName(teleport.MetricNamespace, "", "roles_total")]),
 	}
 
-	re.Service = getServices(metrics[prometheus.BuildFQName(teleport.MetricNamespace, "", teleport.MetricTeleportServices)])
+	re.Service = getGaugeValuesForLabelKey(metrics[prometheus.BuildFQName(teleport.MetricNamespace, "", teleport.MetricTeleportServices)], teleport.TagServiceName)
 
 	var auditStats *AuditStats
 	if prev != nil {
@@ -709,19 +706,17 @@ func getActiveMigrations(metric *dto.MetricFamily) []string {
 	return out
 }
 
-func getServices(family *dto.MetricFamily) Services {
-	if family == nil || family.GetType() != dto.MetricType_GAUGE || len(family.Metric) == 0 {
+// For a given `family` of metrics, return all gauge values that match a given `labelKey` as a map keyed by the label value.
+func getGaugeValuesForLabelKey(family *dto.MetricFamily, labelKey string) map[string]float64 {
+	if family.GetType() != dto.MetricType_GAUGE {
 		return nil
 	}
 
-	out := make(Services)
-	for _, metric := range family.Metric {
-		if metric.Gauge == nil || metric.Gauge.Value == nil {
-			continue
-		}
-		for _, label := range metric.Label {
-			if label.GetName() == teleport.TagServiceName {
-				out[label.GetValue()] = *metric.Gauge.Value
+	out := make(map[string]float64)
+	for _, metric := range family.GetMetric() {
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == labelKey {
+				out[label.GetValue()] = metric.GetGauge().GetValue()
 				break
 			}
 		}


### PR DESCRIPTION
This commit adds the rendering of `teleport_services` metric to `tctl top` showing the number of running services. 

Note that only initialized services are displayed which mimics the prometheus metric registration. 
This allows the user to quickly glance at the common section to confirm a certain expected service is present and running. 

Example output:
<img width="1120" height="523" alt="example" src="https://github.com/user-attachments/assets/58e4f74a-34d1-4e94-8d6a-672891e05f40" />

Closes: #56672
