### PR TITLE
Add methods to upload session summaries to the upload handler

### DIFF
--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -279,7 +279,8 @@ func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 	return h.uploadBlob(ctx, sessionID, h.sessionBlob(sessionID), reader)
 }
 
-// Upload implements [events.UploadHandler] and uploads a session summary.
+// UploadSummary implements [events.UploadHandler] and uploads a session
+// summary.
 func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
 	return h.uploadBlob(ctx, sessionID, h.summaryBlob(sessionID), reader)
 }

--- a/lib/events/azsessions/azsessions_test.go
+++ b/lib/events/azsessions/azsessions_test.go
@@ -62,6 +62,9 @@ func TestStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("UploadDownloadSummary", func(t *testing.T) {
+		test.UploadDownloadSummary(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -39,9 +39,10 @@ import (
 // upload
 func NewMemoryUploader(eventsC ...chan events.UploadEvent) *MemoryUploader {
 	up := &MemoryUploader{
-		mtx:     &sync.RWMutex{},
-		uploads: make(map[string]*MemoryUpload),
-		objects: make(map[session.ID][]byte),
+		mtx:       &sync.RWMutex{},
+		uploads:   make(map[string]*MemoryUpload),
+		sessions:  make(map[session.ID][]byte),
+		summaries: make(map[session.ID][]byte),
 	}
 	if len(eventsC) != 0 {
 		up.eventsC = eventsC[0]
@@ -51,10 +52,11 @@ func NewMemoryUploader(eventsC ...chan events.UploadEvent) *MemoryUploader {
 
 // MemoryUploader uploads all bytes to memory, used in tests
 type MemoryUploader struct {
-	mtx     *sync.RWMutex
-	uploads map[string]*MemoryUpload
-	objects map[session.ID][]byte
-	eventsC chan events.UploadEvent
+	mtx       *sync.RWMutex
+	uploads   map[string]*MemoryUpload
+	sessions  map[session.ID][]byte
+	summaries map[session.ID][]byte
+	eventsC   chan events.UploadEvent
 
 	// Clock is an optional [clockwork.Clock] to determine the time to associate
 	// with uploads and parts.
@@ -96,7 +98,8 @@ func (m *MemoryUploader) Reset() {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.uploads = make(map[string]*MemoryUpload)
-	m.objects = make(map[session.ID][]byte)
+	m.sessions = make(map[session.ID][]byte)
+	m.summaries = make(map[session.ID][]byte)
 }
 
 // CreateUpload creates a multipart upload
@@ -148,7 +151,7 @@ func (m *MemoryUploader) CompleteUpload(ctx context.Context, upload events.Strea
 			delete(up.parts, number)
 		}
 	}
-	m.objects[upload.SessionID] = result
+	m.sessions[upload.SessionID] = result
 	up.completed = true
 	m.trySendEvent(events.UploadEvent{SessionID: string(upload.SessionID), UploadID: upload.ID})
 	return nil
@@ -253,7 +256,7 @@ func (m *MemoryUploader) ListParts(ctx context.Context, upload events.StreamUplo
 func (m *MemoryUploader) Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	_, ok := m.objects[sessionID]
+	_, ok := m.sessions[sessionID]
 	if ok {
 		return "", trace.AlreadyExists("session %q already exists", sessionID)
 	}
@@ -261,7 +264,24 @@ func (m *MemoryUploader) Upload(ctx context.Context, sessionID session.ID, readC
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
-	m.objects[sessionID] = data
+	m.sessions[sessionID] = data
+	return string(sessionID), nil
+}
+
+// UploadSummary uploads session summary and returns URL with uploaded file in
+// case of success.
+func (m *MemoryUploader) UploadSummary(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	_, ok := m.summaries[sessionID]
+	if ok {
+		return "", trace.AlreadyExists("summary %q already exists", sessionID)
+	}
+	data, err := io.ReadAll(readCloser)
+	if err != nil {
+		return "", trace.ConvertSystemError(err)
+	}
+	m.summaries[sessionID] = data
 	return string(sessionID), nil
 }
 
@@ -270,9 +290,24 @@ func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, wri
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	data, ok := m.objects[sessionID]
+	data, ok := m.sessions[sessionID]
 	if !ok {
 		return trace.NotFound("session %q is not found", sessionID)
+	}
+	_, err := io.Copy(writer.(io.Writer), bytes.NewReader(data))
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	return nil
+}
+
+func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	data, ok := m.summaries[sessionID]
+	if !ok {
+		return trace.NotFound("summary %q is not found", sessionID)
 	}
 	_, err := io.Copy(writer.(io.Writer), bytes.NewReader(data))
 	if err != nil {

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -286,7 +286,7 @@ func (m *MemoryUploader) UploadSummary(ctx context.Context, sessionID session.ID
 }
 
 // Download downloads session tarball and writes it to writer
-func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -294,14 +294,14 @@ func (m *MemoryUploader) Download(ctx context.Context, sessionID session.ID, wri
 	if !ok {
 		return trace.NotFound("session %q is not found", sessionID)
 	}
-	_, err := io.Copy(writer.(io.Writer), bytes.NewReader(data))
+	_, err := io.Copy(writer, bytes.NewReader(data))
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
 	return nil
 }
 
-func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -309,7 +309,7 @@ func (m *MemoryUploader) DownloadSummary(ctx context.Context, sessionID session.
 	if !ok {
 		return trace.NotFound("summary %q is not found", sessionID)
 	}
-	_, err := io.Copy(writer.(io.Writer), bytes.NewReader(data))
+	_, err := io.Copy(writer, bytes.NewReader(data))
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -143,7 +143,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		return trace.Wrap(err)
 	}
 
-	uploadPath := h.path(upload.SessionID)
+	uploadPath := h.recordingPath(upload.SessionID)
 
 	// Prevent other processes from accessing this file until the write is completed
 	f, err := GetOpenFileFunc()(uploadPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
@@ -414,6 +414,8 @@ const (
 	partExt = ".part"
 	// tarExt is a suffix for file uploads
 	tarExt = ".tar"
+	// summaryExt is a suffix for summary files
+	summaryExt = ".summary.json"
 	// checkpointExt is a suffix for checkpoint extensions
 	checkpointExt = ".checkpoint"
 	// errorExt is a suffix for files storing session errors

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -157,7 +157,7 @@ func TestCompleteUpload(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check upload contents
-			uploadPath := handler.path(upload.SessionID)
+			uploadPath := handler.recordingPath(upload.SessionID)
 			f, err := os.Open(uploadPath)
 			require.NoError(t, err)
 

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -110,10 +110,17 @@ func (l *Handler) Close() error {
 	return nil
 }
 
-// Download downloads session recording from storage, in case of file handler reads the
-// file from local directory
+// Download reads a session recording from a local directory.
 func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
-	path := l.path(sessionID)
+	return downloadFile(l.recordingPath(sessionID), writer)
+}
+
+// DownloadSummary reads a session summary from a local directory.
+func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	return downloadFile(l.summaryPath(sessionID), writer)
+}
+
+func downloadFile(path string, writer io.WriterAt) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return trace.ConvertSystemError(err)
@@ -126,10 +133,17 @@ func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.
 	return nil
 }
 
-// Upload uploads session recording to file storage, in case of file handler,
-// writes the file to local directory
+// Upload writes a session recording to a local directory.
 func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	path := l.path(sessionID)
+	return uploadFile(l.recordingPath(sessionID), reader)
+}
+
+// UploadSummary writes a session summary to a local directory.
+func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	return uploadFile(l.summaryPath(sessionID), reader)
+}
+
+func uploadFile(path string, reader io.Reader) (string, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
@@ -141,8 +155,12 @@ func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 	return fmt.Sprintf("%v://%v", teleport.SchemeFile, path), nil
 }
 
-func (l *Handler) path(sessionID session.ID) string {
+func (l *Handler) recordingPath(sessionID session.ID) string {
 	return filepath.Join(l.Directory, string(sessionID)+tarExt)
+}
+
+func (l *Handler) summaryPath(sessionID session.ID) string {
+	return filepath.Join(l.Directory, string(sessionID)+summaryExt)
 }
 
 // sessionIDFromPath extracts session ID from the filename

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -111,22 +111,22 @@ func (l *Handler) Close() error {
 }
 
 // Download reads a session recording from a local directory.
-func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return downloadFile(l.recordingPath(sessionID), writer)
 }
 
 // DownloadSummary reads a session summary from a local directory.
-func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return downloadFile(l.summaryPath(sessionID), writer)
 }
 
-func downloadFile(path string, writer io.WriterAt) error {
+func downloadFile(path string, writer events.RandomAccessWriter) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
 	defer f.Close()
-	_, err = io.Copy(writer.(io.Writer), f)
+	_, err = io.Copy(writer, f)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -71,6 +71,9 @@ func TestStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("UploadDownloadSummary", func(t *testing.T) {
+		test.UploadDownloadSummary(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/gcssessions/gcshandler_test.go
+++ b/lib/events/gcssessions/gcshandler_test.go
@@ -57,7 +57,7 @@ func TestFakeStreams(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
 	t.Run("UploadDownloadSummary", func(t *testing.T) {
-		test.UploadDownload(t, handler)
+		test.UploadDownloadSummary(t, handler)
 	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)

--- a/lib/events/gcssessions/gcshandler_test.go
+++ b/lib/events/gcssessions/gcshandler_test.go
@@ -56,6 +56,9 @@ func TestFakeStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("UploadDownloadSummary", func(t *testing.T) {
+		test.UploadDownload(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/gcssessions/gcsstream.go
+++ b/lib/events/gcssessions/gcsstream.go
@@ -109,7 +109,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	}
 
 	// If the session has been already created, move to cleanup
-	sessionPath := h.path(upload.SessionID)
+	sessionPath := h.recordingPath(upload.SessionID)
 	_, err := h.gcsClient.Bucket(h.Config.Bucket).Object(sessionPath).Attrs(ctx)
 	if !errors.Is(err, storage.ErrObjectNotExist) {
 		if err != nil {
@@ -285,7 +285,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 // GetUploadMetadata gets the metadata for session upload
 func (h *Handler) GetUploadMetadata(s session.ID) events.UploadMetadata {
 	return events.UploadMetadata{
-		URL:       fmt.Sprintf("%v://%v/%v", teleport.SchemeGCS, h.path(s), string(s)),
+		URL:       fmt.Sprintf("%v://%v/%v", teleport.SchemeGCS, h.recordingPath(s), string(s)),
 		SessionID: s,
 	}
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -319,11 +319,20 @@ func (h *Handler) Close() error {
 	return nil
 }
 
-// Upload uploads object to S3 bucket, reads the contents of the object from reader
-// and returns the target S3 bucket path in case of successful upload.
+// Upload reads the content of a session recording from a reader and uploads it
+// to an S3 bucket. If successful, it returns URL of the uploaded object.
 func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	path := h.path(sessionID)
+	return h.uploadFile(ctx, h.recordingPath(sessionID), reader)
+}
 
+// UploadSummary reads the content of a session summary from a reader and
+// uploads it to an S3 bucket. If successful, it returns URL of the uploaded
+// object.
+func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	return h.uploadFile(ctx, h.summaryPath(sessionID), reader)
+}
+
+func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader) (string, error) {
 	uploadInput := &s3.PutObjectInput{
 		Bucket: aws.String(h.Bucket),
 		Key:    aws.String(path),
@@ -345,22 +354,34 @@ func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Re
 	return fmt.Sprintf("%v://%v/%v", teleport.SchemeS3, h.Bucket, path), nil
 }
 
-// Download downloads recorded session from S3 bucket and writes the results
-// into writer return trace.NotFound error is object is not found.
+// Download downloads a session recording from an S3 bucket and writes the
+// result into a writer. Returns trace.NotFound error if the recording is not
+// found.
 func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	return h.downloadFile(ctx, h.recordingPath(sessionID), writer)
+}
+
+// DownloadSummary downloads a session summary from an S3 bucket and writes the
+// results into a writer. Returns trace.NotFound error if the summary is not
+// found.
+func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	return h.downloadFile(ctx, h.summaryPath(sessionID), writer)
+}
+
+func (h *Handler) downloadFile(ctx context.Context, path string, writer io.WriterAt) error {
 	// Get the oldest version of this object. This has to be done because S3
 	// allows overwriting objects in a bucket. To prevent corruption of recording
 	// data, get all versions and always return the first.
-	versionID, err := h.getOldestVersion(ctx, h.Bucket, h.path(sessionID))
+	versionID, err := h.getOldestVersion(ctx, h.Bucket, path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	h.logger.DebugContext(ctx, "Downloading recording from S3", "bucket", h.Bucket, "path", h.path(sessionID), "version_id", versionID)
+	h.logger.DebugContext(ctx, "Downloading file from S3", "bucket", h.Bucket, "path", path, "version_id", versionID)
 
 	_, err = h.downloader.Download(ctx, writer, &s3.GetObjectInput{
 		Bucket:    aws.String(h.Bucket),
-		Key:       aws.String(h.path(sessionID)),
+		Key:       aws.String(path),
 		VersionId: aws.String(versionID),
 	})
 	if err != nil {
@@ -441,11 +462,18 @@ func (h *Handler) deleteBucket(ctx context.Context) error {
 	return awsutils.ConvertS3Error(err)
 }
 
-func (h *Handler) path(sessionID session.ID) string {
+func (h *Handler) recordingPath(sessionID session.ID) string {
 	if h.Path == "" {
 		return string(sessionID) + ".tar"
 	}
 	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".tar"), "/")
+}
+
+func (h *Handler) summaryPath(sessionID session.ID) string {
+	if h.Path == "" {
+		return string(sessionID) + ".summary.json"
+	}
+	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".summary.json"), "/")
 }
 
 func (h *Handler) fromPath(p string) session.ID {

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -357,18 +357,18 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader)
 // Download downloads a session recording from an S3 bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
-func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return h.downloadFile(ctx, h.recordingPath(sessionID), writer)
 }
 
 // DownloadSummary downloads a session summary from an S3 bucket and writes the
 // results into a writer. Returns trace.NotFound error if the summary is not
 // found.
-func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return h.downloadFile(ctx, h.summaryPath(sessionID), writer)
 }
 
-func (h *Handler) downloadFile(ctx context.Context, path string, writer io.WriterAt) error {
+func (h *Handler) downloadFile(ctx context.Context, path string, writer events.RandomAccessWriter) error {
 	// Get the oldest version of this object. This has to be done because S3
 	// allows overwriting objects in a bucket. To prevent corruption of recording
 	// data, get all versions and always return the first.

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -52,6 +52,9 @@ func TestStreams(t *testing.T) {
 	t.Run("UploadDownload", func(t *testing.T) {
 		test.UploadDownload(t, handler)
 	})
+	t.Run("UploadDownloadSummary", func(t *testing.T) {
+		test.UploadDownloadSummary(t, handler)
+	})
 	t.Run("DownloadNotFound", func(t *testing.T) {
 		test.DownloadNotFound(t, handler)
 	})

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -48,7 +48,7 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: aws.String(h.Bucket),
-		Key:    aws.String(h.path(sessionID)),
+		Key:    aws.String(h.recordingPath(sessionID)),
 	}
 	if !h.Config.DisableServerSideEncryption {
 		input.ServerSideEncryption = types.ServerSideEncryptionAwsKms
@@ -85,7 +85,7 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 	}
 
 	start := time.Now()
-	uploadKey := h.path(upload.SessionID)
+	uploadKey := h.recordingPath(upload.SessionID)
 	log := h.logger.With(
 		"upload", upload.ID,
 		"session", upload.SessionID,
@@ -135,7 +135,7 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 }
 
 func (h *Handler) abortUpload(ctx context.Context, upload events.StreamUpload) error {
-	uploadKey := h.path(upload.SessionID)
+	uploadKey := h.recordingPath(upload.SessionID)
 	log := h.logger.With(
 		"upload", upload.ID,
 		"session", upload.SessionID,
@@ -171,7 +171,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	}
 
 	start := time.Now()
-	uploadKey := h.path(upload.SessionID)
+	uploadKey := h.recordingPath(upload.SessionID)
 	log := h.logger.With(
 		"upload", upload.ID,
 		"session", upload.SessionID,
@@ -210,7 +210,7 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 
 // ListParts lists upload parts
 func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]events.StreamPart, error) {
-	uploadKey := h.path(upload.SessionID)
+	uploadKey := h.recordingPath(upload.SessionID)
 	log := h.logger.With(
 		"upload", upload.ID,
 		"session", upload.SessionID,

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -66,6 +66,29 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	require.Equal(t, string(data), val)
 }
 
+// UploadDownloadSummary tests summary uploads and downloads
+func UploadDownloadSummary(t *testing.T, handler events.MultipartHandler) {
+	val := "this is the summary file"
+	id := session.NewID()
+	_, err := handler.UploadSummary(context.TODO(), id, bytes.NewBuffer([]byte(val)))
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", string(id))
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	err = handler.DownloadSummary(context.TODO(), id, f)
+	require.NoError(t, err)
+
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, string(data), val)
+}
+
 // DownloadNotFound tests handling of the scenario when download is not found
 func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 	id := session.NewID()

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -70,7 +70,7 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 func UploadDownloadSummary(t *testing.T, handler events.MultipartHandler) {
 	val := "this is the summary file"
 	id := session.NewID()
-	_, err := handler.UploadSummary(context.TODO(), id, bytes.NewBuffer([]byte(val)))
+	_, err := handler.UploadSummary(t.Context(), id, bytes.NewBuffer([]byte(val)))
 	require.NoError(t, err)
 
 	f, err := os.CreateTemp("", string(id))

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -26,17 +26,22 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 )
 
-// UploadHandler is a function supplied by the user, it will upload
-// the file
+// UploadHandler uploads and downloads session-related files.
 type UploadHandler interface {
-	// Upload uploads session tarball and returns URL with uploaded file
-	// in case of success.
+	// Upload uploads a session recording and returns a URL with uploaded file in
+	// case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
-	// Download downloads session tarball and writes it to writer
+	// Download downloads a session recording and writes it to a writer.
 	Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error
+	// UploadSummary uploads a session summary and returns a URL with uploaded
+	// file in case of success.
+	UploadSummary(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
+	// DownloadSummary downloads a session summary and writes it to a writer.
+	DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error
 }
 
-// MultipartHandler handles both multipart uploads and downloads
+// MultipartHandler handles both multipart and standalone uploads and
+// downloads.
 type MultipartHandler interface {
 	UploadHandler
 	MultipartUploader

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -32,12 +32,17 @@ type UploadHandler interface {
 	// case of success.
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// Download downloads a session recording and writes it to a writer.
-	Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error
+	Download(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
 	// UploadSummary uploads a session summary and returns a URL with uploaded
 	// file in case of success.
 	UploadSummary(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// DownloadSummary downloads a session summary and writes it to a writer.
-	DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error
+	DownloadSummary(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
+}
+
+type RandomAccessWriter interface {
+	io.Writer
+	io.WriterAt
 }
 
 // MultipartHandler handles both multipart and standalone uploads and

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -387,14 +387,14 @@ func (c *ErrorCountingSessionHandler) UploadSummary(ctx context.Context, session
 }
 
 // Download calls [c.wrapped.Download] and counts the error or success.
-func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	err := c.wrapped.Download(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err
 }
 
 // DownloadSummary calls [c.wrapped.DownloadSummary] and counts the error or success.
-func (c *ErrorCountingSessionHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (c *ErrorCountingSessionHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	err := c.wrapped.DownloadSummary(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -379,9 +379,23 @@ func (c *ErrorCountingSessionHandler) Upload(ctx context.Context, sessionID sess
 	return res, err
 }
 
+// UploadSummary calls [c.wrapped.UploadSummary] and counts the error or success.
+func (c *ErrorCountingSessionHandler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	res, err := c.wrapped.UploadSummary(ctx, sessionID, reader)
+	c.uploads.observe(err)
+	return res, err
+}
+
 // Download calls [c.wrapped.Download] and counts the error or success.
 func (c *ErrorCountingSessionHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
 	err := c.wrapped.Download(ctx, sessionID, writer)
+	c.downloads.observe(err)
+	return err
+}
+
+// DownloadSummary calls [c.wrapped.DownloadSummary] and counts the error or success.
+func (c *ErrorCountingSessionHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	err := c.wrapped.DownloadSummary(ctx, sessionID, writer)
 	c.downloads.observe(err)
 	return err
 }

--- a/lib/integrations/externalauditstorage/error_counter_test.go
+++ b/lib/integrations/externalauditstorage/error_counter_test.go
@@ -50,7 +50,7 @@ func TestErrorCounter(t *testing.T) {
 		expectAlerts []alert
 	}{
 		{
-			desc: "upload errors alert",
+			desc: "recording upload errors alert",
 			steps: []testStep{
 				{
 					action: func(pack *testPack) {
@@ -67,12 +67,46 @@ func TestErrorCounter(t *testing.T) {
 			}},
 		},
 		{
-			desc: "download errors alert",
+			desc: "recording download errors alert",
 			steps: []testStep{
 				{
 					action: func(pack *testPack) {
 						pack.errHandler.Download(ctx, "", nil)
 						pack.successHandler.Download(ctx, "", nil)
+					},
+					repeat: 10,
+				},
+			},
+			err: testError,
+			expectAlerts: []alert{{
+				name:    sessionDownloadFailureClusterAlert,
+				message: fmt.Sprintf(sessionDownloadFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "summary upload errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.errHandler.UploadSummary(ctx, "", nil)
+						pack.successHandler.UploadSummary(ctx, "", nil)
+					},
+					repeat: 10,
+				},
+			},
+			err: testError,
+			expectAlerts: []alert{{
+				name:    sessionUploadFailureClusterAlert,
+				message: fmt.Sprintf(sessionUploadFailureClusterAlertMsgTemplate, testError),
+			}},
+		},
+		{
+			desc: "summary download errors alert",
+			steps: []testStep{
+				{
+					action: func(pack *testPack) {
+						pack.errHandler.DownloadSummary(ctx, "", nil)
+						pack.successHandler.DownloadSummary(ctx, "", nil)
 					},
 					repeat: 10,
 				},
@@ -274,6 +308,14 @@ func (h *errorHandler) Upload(ctx context.Context, sessionID session.ID, reader 
 	return "", h.err
 }
 
+func (h *errorHandler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	return "", h.err
+}
+
 func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+	return h.err
+}
+
+func (h *errorHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
 	return h.err
 }

--- a/lib/integrations/externalauditstorage/error_counter_test.go
+++ b/lib/integrations/externalauditstorage/error_counter_test.go
@@ -312,10 +312,10 @@ func (h *errorHandler) UploadSummary(ctx context.Context, sessionID session.ID, 
 	return "", h.err
 }
 
-func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *errorHandler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return h.err
 }
 
-func (h *errorHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer io.WriterAt) error {
+func (h *errorHandler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
 	return h.err
 }


### PR DESCRIPTION
These functions will be called by the enterprise plugin for summarizing session recordings.

RFD: https://github.com/gravitational/teleport.e/blob/master/rfd/0026e-ai-session-summaries.md 

WIP draft of enterprise PR (not yet ready for review, this is for context only): https://github.com/gravitational/teleport.e/pull/6845

Contributes to https://github.com/gravitational/teleport/issues/47083

