### PR TITLE
Align Cache Test: Use Memory Backend

### DIFF
--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -77,7 +77,7 @@ func TestAccessListMembers(t *testing.T) {
 
 	const numMembers = 32
 
-	p := newTestPack(t, ForAuth, memoryBackend(true))
+	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
 	clock := clockwork.NewFakeClock()
@@ -277,7 +277,7 @@ func TestAccessListReviews(t *testing.T) {
 func TestCountAccessListMembersScoping(t *testing.T) {
 	t.Parallel()
 
-	p := newTestPack(t, ForAuth, memoryBackend(true))
+	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
 	ctx := context.Background()

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -223,15 +223,15 @@ func newTestPackWithoutCache(t *testing.T) *testPack {
 }
 
 type packCfg struct {
-	memoryBackend bool
-	ignoreKinds   []types.WatchKind
+	withSQLite  bool
+	ignoreKinds []types.WatchKind
 }
 
 type packOption func(cfg *packCfg)
 
-func memoryBackend(bool) packOption {
+func withSQLiteBackend() packOption {
 	return func(cfg *packCfg) {
-		cfg.memoryBackend = true
+		cfg.withSQLite = true
 	}
 }
 
@@ -256,15 +256,15 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	}
 	var bk backend.Backend
 	var err error
-	if cfg.memoryBackend {
-		bk, err = memory.New(memory.Config{
-			Context: ctx,
-			Mirror:  true,
-		})
-	} else {
+	if cfg.withSQLite {
 		bk, err = lite.NewWithConfig(ctx, lite.Config{
 			Path:             p.dataDir,
 			PollStreamPeriod: 200 * time.Millisecond,
+		})
+	} else {
+		bk, err = memory.New(memory.Config{
+			Context: ctx,
+			Mirror:  true,
 		})
 	}
 	if err != nil {
@@ -902,7 +902,7 @@ cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
 BenchmarkListResourcesWithSort-8               1        2351035036 ns/op
 */
 func BenchmarkListResourcesWithSort(b *testing.B) {
-	p, err := newPack(b.TempDir(), ForAuth, memoryBackend(true))
+	p, err := newPack(b.TempDir(), ForAuth)
 	require.NoError(b, err)
 	defer p.Close()
 

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -139,7 +139,7 @@ func BenchmarkGetMaxNodes(b *testing.B) {
 }
 
 func benchGetNodes(b *testing.B, nodeCount int) {
-	p, err := newPack(b.TempDir(), ForAuth, memoryBackend(true))
+	p, err := newPack(b.TempDir(), ForAuth)
 	require.NoError(b, err)
 	defer p.Close()
 

--- a/lib/cache/web_ui_config_test.go
+++ b/lib/cache/web_ui_config_test.go
@@ -28,7 +28,7 @@ import (
 func TestWebUIConfig(t *testing.T) {
 	t.Parallel()
 
-	p := newTestPack(t, ForProxy)
+	p := newTestPack(t, ForProxy, withSQLiteBackend())
 	t.Cleanup(p.Close)
 
 	testResources(t, p, testFuncs[types.UIConfig]{


### PR DESCRIPTION
### What

Use memory backend for cache tests

Cache test are slow making the flaky tests failures. 