### PR TITLE
[v17] Add `workload_identity`/`bot` to supported kinds in role reference

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -513,6 +513,8 @@ spec:
     # instance           - a Teleport instance
     # event              - structured audit logging event
     #
+    # workload_identity     - config for Machine & Workload Identity SVIDS
+    # bot                   - config for Machine & Workload Identity bots
     #
     # lock                  - lock resource.
     # network_restrictions  - restrictions for SSH sessions


### PR DESCRIPTION
Backport #56794 to branch/v17