### PR TITLE
Follow up to modulestest conversions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,6 +173,11 @@ linters:
           files:
             - '!$test'
             - '!**/integrations/operator/controllers/resources/testlib/**.go'
+            - '!**/e/lib/aws/identitycenter/test/**'
+            - '!**/e/lib/devicetrust/testenv/**'
+            - '!**/e/lib/jamf/testenv/**'
+            - '!**/e/lib/operatortest/**'
+            - '!**/e/tests/**'
           deny:
             - pkg: github.com/gravitational/teleport/e/lib/aws/identitycenter/test
               desc: testing packages should not be imported outside of _test.go files


### PR DESCRIPTION
Update to https://github.com/gravitational/teleport/pull/56721.

Fixes hardware key tests that relied on modifying a pointer to the globally set modules. Tests now set modules multiple times instead.

Updates the golangci-lint rules to allow enterprise tests to consume the modulestest package.