### PR TITLE
docs: proxy service page update

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints.mdx
@@ -11,8 +11,7 @@ configure your cluster to handle traffic to the Proxy Service differently
 depending on whether it originates from the public internet or from your
 internal networks.
 
-This guide explains how to set up a self-hosted Teleport cluster to separate
-Proxy Service HTTPS traffic for internal and external clients.
+This guide explains how to set up a self-hosted Teleport cluster to separate Proxy Service HTTPS traffic for internal and external clients. Note that all traffic is routed through external, publicly accessible endpoints.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints.mdx
@@ -1,6 +1,9 @@
 ---
 title: Separate Internal and External Proxy Service Traffic
 description: Explains how to set up the Teleport Proxy Service to isolate traffic from the public internet from internal client traffic.
+labels:
+- how-to
+- platform-wide
 ---
 
 In a typical Teleport cluster, including clusters deployed on Teleport Cloud,
@@ -11,9 +14,8 @@ configure your cluster to handle traffic to the Proxy Service differently
 depending on whether it originates from the public internet or from your
 internal networks.
 
-This guide explains how to set up a self-hosted Teleport cluster to separate Proxy Service HTTPS traffic for internal and external clients. Note that all traffic is routed through external, publicly accessible endpoints.
-
-(!docs/pages/includes/cloud/call-to-action.mdx!)
+This guide explains how to set up a self-hosted Teleport cluster to separate
+Proxy Service HTTPS traffic for internal and external clients.
 
 ## Architecture
 

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -2,8 +2,9 @@
 type="tip" 
 >
 
-Teleport Enterprise Cloud handles this setup for you, allowing you to provide secure access to your infrastructure immediately. 
-All traffic is routed through external, publicly accessible endpoints.
+Teleport Enterprise Cloud takes care of this setup for you so you can provide
+secure access to your infrastructure right away.
+
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
 Teleport Enterprise Cloud.
 

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -2,9 +2,8 @@
 type="tip" 
 >
 
-Teleport Enterprise Cloud takes care of this setup for you so you can provide
-secure access to your infrastructure right away.
-
+Teleport Enterprise Cloud handles this setup for you, allowing you to provide secure access to your infrastructure immediately. 
+All traffic is routed through external, publicly accessible endpoints.
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
 Teleport Enterprise Cloud.
 


### PR DESCRIPTION
Per feedback, the banner on the [proxy traffic](https://goteleport.com/docs/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints/) page needs to be clarified as Cloud does not provide separate internal endpoint for traffic; it uses external, public facing endpoints for all traffic.