### PR TITLE
Remove backend.IterateRange helper function

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -150,30 +150,6 @@ func New(ctx context.Context, backend string, params Params) (Backend, error) {
 	return bk, nil
 }
 
-// IterateRange is a helper for stepping over a range
-func IterateRange(ctx context.Context, bk Backend, startKey, endKey Key, limit int, fn func([]Item) (stop bool, err error)) error {
-	if limit == 0 || limit > 10_000 {
-		limit = 10_000
-	}
-	for {
-		// we load an extra item here so that we can be certain we have a correct
-		// start key for the next range.
-		rslt, err := bk.GetRange(ctx, startKey, endKey, limit+1)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		end := min(len(rslt.Items), limit)
-		stop, err := fn(rslt.Items[0:end])
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if stop || len(rslt.Items) <= limit {
-			return nil
-		}
-		startKey = rslt.Items[limit].Key
-	}
-}
-
 // StreamRange constructs a Stream for the given key range. This helper just
 // uses standard pagination under the hood, lazily loading pages as needed. Streams
 // are currently only used for periodic operations, but if they become more widely

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -21,7 +21,6 @@ package memory
 import (
 	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -67,65 +66,6 @@ func TestMemory(t *testing.T) {
 	}
 
 	test.RunBackendComplianceSuite(t, newBackend)
-}
-
-func TestIterateRange(t *testing.T) {
-	ctx := t.Context()
-
-	bk, err := New(Config{})
-	require.NoError(t, err)
-
-	// set up a generic bulk range to iterate
-	expectedKeys := make(map[string]struct{})
-	for i := range 500 {
-		key := backend.NewKey("bulk", strconv.Itoa(i))
-		expectedKeys[key.String()] = struct{}{}
-
-		_, err = bk.Put(ctx, backend.Item{
-			Key:   key,
-			Value: []byte("v"),
-		})
-		require.NoError(t, err)
-	}
-
-	// check that observed range members match expectations
-	observedKeys := make(map[string]struct{})
-	err = backend.IterateRange(ctx, bk, backend.ExactKey("bulk"), backend.RangeEnd(backend.ExactKey("bulk")), 3, func(items []backend.Item) (stop bool, err error) {
-		for _, item := range items {
-			key := item.Key.String()
-
-			_, dup := observedKeys[key]
-			require.False(t, dup, "duplicate of %q", key)
-
-			_, exp := expectedKeys[key]
-			require.True(t, exp, "unexpected key %q", key)
-
-			observedKeys[key] = struct{}{}
-		}
-
-		return false, nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, expectedKeys, observedKeys)
-
-	// set up a collection of keys that are suffixes of one another (ensures we aren't suffering from the classic 'pagination bug', where
-	// page breaks landing on some key K skip subsequent keys with prefix K).
-	for i := range 20 {
-		_, err = bk.Put(ctx, backend.Item{
-			Key:   backend.NewKey("suff", strings.Repeat("s", i+1)),
-			Value: []byte("s"),
-		})
-
-		require.NoError(t, err)
-	}
-
-	var scount int
-	err = backend.IterateRange(ctx, bk, backend.ExactKey("suff"), backend.RangeEnd(backend.ExactKey("suff")), 2, func(items []backend.Item) (stop bool, err error) {
-		scount += len(items)
-		return false, nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, 20, scount)
 }
 
 func TestStreamRange(t *testing.T) {

--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -261,48 +261,38 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 		}
 	}
 
-	// Get most limit+1 results to determine if there will be a next key.
-	maxLimit := reqLimit + 1
-	var desktops []types.WindowsDesktop
-	if err := backend.IterateRange(ctx, s.Backend, rangeStart, rangeEnd, maxLimit, func(items []backend.Item) (stop bool, err error) {
-		for _, item := range items {
-			if len(desktops) == maxLimit {
-				break
-			}
-
-			desktop, err := s.itemToWindowsDesktop(&item)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-
-			if !req.WindowsDesktopFilter.Match(desktop) {
-				continue
-			}
-
-			switch match, err := services.MatchResourceByFilters(desktop, filter, nil /* ignore dup matches */); {
-			case err != nil:
-				return false, trace.Wrap(err)
-			case match:
-				desktops = append(desktops, desktop)
-			}
+	var resp types.ListWindowsDesktopsResponse
+	for item, err := range s.Backend.Items(ctx, backend.ItemsParams{
+		StartKey: rangeStart,
+		EndKey:   rangeEnd,
+	}) {
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		return len(desktops) == maxLimit, nil
-	}); err != nil {
-		return nil, trace.Wrap(err)
+		desktop, err := s.itemToWindowsDesktop(&item)
+		if err != nil {
+			continue
+		}
+
+		if !req.WindowsDesktopFilter.Match(desktop) {
+			continue
+		}
+
+		switch match, err := services.MatchResourceByFilters(desktop, filter, nil /* ignore dup matches */); {
+		case err != nil:
+			return nil, trace.Wrap(err)
+		case match:
+			if len(resp.Desktops) >= reqLimit {
+				resp.NextKey = backend.GetPaginationKey(desktop)
+				return &resp, nil
+			}
+
+			resp.Desktops = append(resp.Desktops, desktop)
+		}
 	}
 
-	var nextKey string
-	if len(desktops) > reqLimit {
-		nextKey = backend.GetPaginationKey(desktops[len(desktops)-1])
-		// Truncate the last item that was used to determine next row existence.
-		desktops = desktops[:reqLimit]
-	}
-
-	return &types.ListWindowsDesktopsResponse{
-		Desktops: desktops,
-		NextKey:  nextKey,
-	}, nil
+	return &resp, nil
 }
 
 func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, req types.ListWindowsDesktopServicesRequest) (*types.ListWindowsDesktopServicesResponse, error) {
@@ -327,48 +317,38 @@ func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, 
 		filter.PredicateExpression = expression
 	}
 
-	// Get most limit+1 results to determine if there will be a next key.
-	maxLimit := reqLimit + 1
-	var desktopServices []types.WindowsDesktopService
-	if err := backend.IterateRange(ctx, s.Backend, rangeStart, rangeEnd, maxLimit, func(items []backend.Item) (stop bool, err error) {
-		for _, item := range items {
-			if len(desktopServices) == maxLimit {
-				break
-			}
-
-			desktop, err := services.UnmarshalWindowsDesktopService(
-				item.Value,
-				services.WithExpires(item.Expires),
-				services.WithRevision(item.Revision),
-			)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-
-			switch match, err := services.MatchResourceByFilters(desktop, filter, nil /* ignore dup matches */); {
-			case err != nil:
-				return false, trace.Wrap(err)
-			case match:
-				desktopServices = append(desktopServices, desktop)
-			}
+	var resp types.ListWindowsDesktopServicesResponse
+	for item, err := range s.Backend.Items(ctx, backend.ItemsParams{
+		StartKey: rangeStart,
+		EndKey:   rangeEnd,
+	}) {
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		return len(desktopServices) == maxLimit, nil
-	}); err != nil {
-		return nil, trace.Wrap(err)
+		desktop, err := services.UnmarshalWindowsDesktopService(
+			item.Value,
+			services.WithExpires(item.Expires),
+			services.WithRevision(item.Revision),
+		)
+		if err != nil {
+			continue
+		}
+
+		switch match, err := services.MatchResourceByFilters(desktop, filter, nil /* ignore dup matches */); {
+		case err != nil:
+			return nil, trace.Wrap(err)
+		case match:
+			if len(resp.DesktopServices) >= reqLimit {
+				resp.NextKey = backend.GetPaginationKey(desktop)
+				return &resp, nil
+			}
+
+			resp.DesktopServices = append(resp.DesktopServices, desktop)
+		}
 	}
 
-	var nextKey string
-	if len(desktopServices) > reqLimit {
-		nextKey = backend.GetPaginationKey(desktopServices[len(desktopServices)-1])
-		// Truncate the last item that was used to determine next row existence.
-		desktopServices = desktopServices[:reqLimit]
-	}
-
-	return &types.ListWindowsDesktopServicesResponse{
-		DesktopServices: desktopServices,
-		NextKey:         nextKey,
-	}, nil
+	return &resp, nil
 }
 
 const (

--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -158,13 +158,18 @@ func (s *Service[T]) CountResources(ctx context.Context) (uint, error) {
 	rangeEnd := backend.RangeEnd(rangeStart)
 
 	count := uint(0)
-	err := backend.IterateRange(ctx, s.backend, rangeStart, rangeEnd, int(s.pageLimit),
-		func(items []backend.Item) (stop bool, err error) {
-			count += uint(len(items))
-			return false, nil
-		})
+	for _, err := range s.backend.Items(ctx, backend.ItemsParams{
+		StartKey: rangeStart,
+		EndKey:   rangeEnd,
+	}) {
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
 
-	return count, trace.Wrap(err)
+		count++
+	}
+
+	return count, nil
 }
 
 // GetResources returns a list of all resources.

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1333,45 +1333,35 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 		filter.PredicateExpression = expression
 	}
 
-	// Get most limit+1 results to determine if there will be a next key.
 	reqLimit := int(req.Limit)
-	maxLimit := reqLimit + 1
-	var resources []types.ResourceWithLabels
-	if err := backend.IterateRange(ctx, s.Backend, rangeStart, rangeEnd, maxLimit, func(items []backend.Item) (stop bool, err error) {
-		for _, item := range items {
-			if len(resources) == maxLimit {
-				break
-			}
-
-			resource, err := unmarshalItemFunc(item)
-			if err != nil {
-				return false, trace.Wrap(err)
-			}
-
-			switch match, err := services.MatchResourceByFilters(resource, filter, nil /* ignore dup matches */); {
-			case err != nil:
-				return false, trace.Wrap(err)
-			case match:
-				resources = append(resources, resource)
-			}
+	var resp types.ListResourcesResponse
+	for item, err := range s.Backend.Items(ctx, backend.ItemsParams{
+		StartKey: rangeStart,
+		EndKey:   rangeEnd,
+	}) {
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		return len(resources) == maxLimit, nil
-	}); err != nil {
-		return nil, trace.Wrap(err)
+		resource, err := unmarshalItemFunc(item)
+		if err != nil {
+			continue
+		}
+
+		switch match, err := services.MatchResourceByFilters(resource, filter, nil /* ignore dup matches */); {
+		case err != nil:
+			return nil, trace.Wrap(err)
+		case match:
+			if len(resp.Resources) >= reqLimit {
+				resp.NextKey = backend.GetPaginationKey(resource)
+				return &resp, nil
+			}
+
+			resp.Resources = append(resp.Resources, resource)
+		}
 	}
 
-	var nextKey string
-	if len(resources) > reqLimit {
-		nextKey = backend.GetPaginationKey(resources[len(resources)-1])
-		// Truncate the last item that was used to determine next row existence.
-		resources = resources[:reqLimit]
-	}
-
-	return &types.ListResourcesResponse{
-		Resources: resources,
-		NextKey:   nextKey,
-	}, nil
+	return &resp, nil
 }
 
 // listResourcesWithSort supports sorting by falling back to retrieving all resources


### PR DESCRIPTION
The IterateRange function was added to make iteration over the results from backend.GetRange easier. However, it's utility no longer exists now that the backend.Items has been added. To facilitate the removal, all existing calls to IterateRange have been updated to call Items instead and directly loop over all items.