### PR TITLE
Remove backend.StreamRange helper function

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -22,7 +22,6 @@ package backend
 import (
 	"context"
 	"fmt"
-	"io"
 	"iter"
 	"sort"
 	"time"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
-	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -148,38 +146,6 @@ func New(ctx context.Context, backend string, params Params) (Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 	return bk, nil
-}
-
-// StreamRange constructs a Stream for the given key range. This helper just
-// uses standard pagination under the hood, lazily loading pages as needed. Streams
-// are currently only used for periodic operations, but if they become more widely
-// used in the future, it may become worthwhile to optimize the streaming of backend
-// items further. Two potential improvements of note:
-//
-// 1. update this helper to concurrently load the next page in the background while
-// items from the current page are being yielded.
-//
-// 2. allow individual backends to expose custom streaming methods s.t. the most performant
-// impl for a given backend may be used.
-func StreamRange(ctx context.Context, bk Backend, startKey, endKey Key, pageSize int) stream.Stream[Item] {
-	var done bool
-	return stream.PageFunc(func() ([]Item, error) {
-		if done {
-			return nil, io.EOF
-		}
-		rslt, err := bk.GetRange(ctx, startKey, endKey, pageSize+1)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if len(rslt.Items) > pageSize {
-			startKey = rslt.Items[pageSize].Key
-			clear(rslt.Items[pageSize:])
-			rslt.Items = rslt.Items[:pageSize]
-		} else {
-			done = true
-		}
-		return rslt.Items, nil
-	})
 }
 
 // Lease represents a lease on the item that can be used

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -20,13 +20,10 @@ package memory
 
 import (
 	"os"
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
@@ -66,31 +63,4 @@ func TestMemory(t *testing.T) {
 	}
 
 	test.RunBackendComplianceSuite(t, newBackend)
-}
-
-func TestStreamRange(t *testing.T) {
-	ctx := t.Context()
-
-	m, err := New(Config{})
-	require.NoError(t, err)
-	defer m.Close()
-
-	const N = 10
-	for i := range 10 * N {
-		_, err := m.Put(ctx, backend.Item{
-			Key:   backend.NewKey("foo", strings.Repeat("a", i+1)),
-			Value: []byte("\x00"),
-		})
-		require.NoError(t, err)
-	}
-
-	var items []string
-	st := backend.StreamRange(ctx, m, backend.ExactKey("foo"), backend.RangeEnd(backend.ExactKey("foo")), N)
-	for st.Next() {
-		items = append(items, st.Item().Key.String())
-	}
-	require.NoError(t, st.Done())
-
-	require.Len(t, items, 10*N)
-	require.True(t, slices.IsSorted(items))
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -34,10 +34,11 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
-	"github.com/gravitational/teleport/api/internalutils/stream"
+	apistream "github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils"
@@ -83,25 +84,27 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 }
 
 // GetServerInfos returns a stream of ServerInfos.
-func (s *PresenceService) GetServerInfos(ctx context.Context) stream.Stream[types.ServerInfo] {
+func (s *PresenceService) GetServerInfos(ctx context.Context) apistream.Stream[types.ServerInfo] {
 	startKey := backend.ExactKey(serverInfoPrefix)
 	endKey := backend.RangeEnd(startKey)
-	items := backend.StreamRange(ctx, s, startKey, endKey, apidefaults.DefaultChunkSize)
-	return stream.FilterMap(items, func(item backend.Item) (types.ServerInfo, bool) {
-		si, err := services.UnmarshalServerInfo(
-			item.Value,
-			services.WithExpires(item.Expires),
-			services.WithRevision(item.Revision),
-		)
-		if err != nil {
-			s.logger.WarnContext(ctx, "Failed to unmarshal server info",
-				"key", item.Key,
-				"error", err,
+	return stream.IntoLegacy(stream.FilterMap(
+		s.Backend.Items(ctx, backend.ItemsParams{StartKey: startKey, EndKey: endKey}),
+		func(item backend.Item) (types.ServerInfo, bool) {
+			si, err := services.UnmarshalServerInfo(
+				item.Value,
+				services.WithExpires(item.Expires),
+				services.WithRevision(item.Revision),
 			)
-			return nil, false
-		}
-		return si, true
-	})
+			if err != nil {
+				s.logger.WarnContext(ctx, "Failed to unmarshal server info",
+					"key", item.Key,
+					"error", err,
+				)
+				return nil, false
+			}
+			return si, true
+		},
+	))
 }
 
 // GetServerInfo returns a ServerInfo by name.

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -26,6 +26,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"iter"
 	"log/slog"
 	"sort"
 	"strings"
@@ -45,12 +46,12 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
-	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -120,13 +121,9 @@ func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersR
 		pageSize = apidefaults.DefaultChunkSize
 	}
 
-	// Artificially inflate the limit to account for user secrets
-	// which have the same prefix.
-	limit := int(pageSize) * 4
+	itemStream := s.Backend.Items(ctx, backend.ItemsParams{StartKey: rangeStart, EndKey: rangeEnd})
 
-	itemStream := backend.StreamRange(ctx, s.Backend, rangeStart, rangeEnd, limit)
-
-	var userStream stream.Stream[*types.UserV2]
+	var userStream iter.Seq2[*types.UserV2, error]
 	if req.WithSecrets {
 		userStream = s.streamUsersWithSecrets(itemStream)
 	} else {
@@ -143,21 +140,20 @@ func (s *IdentityService) ListUsers(ctx context.Context, req *userspb.ListUsersR
 		})
 	}
 
-	users, full := stream.Take(userStream, int(pageSize))
+	var resp userspb.ListUsersResponse
+	for user, err := range userStream {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
-	var nextToken string
-	if full && userStream.Next() {
-		nextToken = nextUserToken(users[len(users)-1])
+		if len(resp.Users) >= int(pageSize) {
+			resp.NextPageToken = nextUserToken(resp.Users[len(resp.Users)-1])
+			return &resp, nil
+		}
+
+		resp.Users = append(resp.Users, user)
 	}
-
-	if err := userStream.Done(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &userspb.ListUsersResponse{
-		Users:         users,
-		NextPageToken: nextToken,
-	}, nil
+	return &resp, nil
 }
 
 // nextUserToken returns the last token for the given user. This
@@ -171,7 +167,7 @@ func nextUserToken(user types.User) string {
 
 // streamUsersWithSecrets is a helper that converts a stream of backend items over the user key range into a stream
 // of users along with their associated secrets.
-func (s *IdentityService) streamUsersWithSecrets(itemStream stream.Stream[backend.Item]) stream.Stream[*types.UserV2] {
+func (s *IdentityService) streamUsersWithSecrets(itemStream iter.Seq2[backend.Item, error]) iter.Seq2[*types.UserV2, error] {
 	type collector struct {
 		items userItems
 		name  string
@@ -241,7 +237,7 @@ func (s *IdentityService) streamUsersWithSecrets(itemStream stream.Stream[backen
 
 // streamUsersWithoutSecrets is a helper that converts a stream of backend items over the user range into a stream of
 // user resources without any included secrets.
-func (s *IdentityService) streamUsersWithoutSecrets(itemStream stream.Stream[backend.Item]) stream.Stream[*types.UserV2] {
+func (s *IdentityService) streamUsersWithoutSecrets(itemStream iter.Seq2[backend.Item, error]) iter.Seq2[*types.UserV2, error] {
 	suffix := backend.NewKey(paramsPrefix)
 	userStream := stream.FilterMap(itemStream, func(item backend.Item) (*types.UserV2, bool) {
 		if !item.Key.HasSuffix(suffix) {

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -1380,7 +1380,7 @@ func TestIdentityService_ListUsers(t *testing.T) {
 	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no more users exist")
 	assert.Empty(t, cmp.Diff(expectedUsers, rsp.Users, cmpopts.IgnoreFields(types.UserSpecV2{}, "LocalAuth")), "not all users returned from listing operation")
 
-	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{})
+	rsp, err = identity.ListUsers(ctx, &userspb.ListUsersRequest{WithSecrets: true})
 	assert.NoError(t, err, "no error returned when no users exist")
 	assert.Empty(t, rsp.NextPageToken, "next page token returned from listing when no users exist")
 	assert.Empty(t, cmp.Diff(expectedUsers, rsp.Users), "not all users returned from listing operation")


### PR DESCRIPTION
The StreamRange function was added to make iteration over the results from backend.GetRange easier. However, it's utility no longer exists now that iterators are a first class citizen in Go and the backend.Items has been added. To facilitate the removal, all existing calls to StreamRange have been updated to call Items instead and directly loop over all items.