### PR TITLE
Update docs for MWI GitHub Actions integration

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
@@ -195,12 +195,14 @@ jobs:
     - name: Fetch Teleport binaries
       uses: teleport-actions/setup@v1
       with:
-        version: (=teleport.version=)
+        version: auto
+        # Use the address of the proxy server for your own cluster.
+        proxy: example.teleport.sh:443
     - name: Fetch credentials using Machine ID
       id: auth
       uses: teleport-actions/auth@v2
       with:
-        # Use the address of the auth/proxy server for your own cluster.
+        # Use the address of the proxy server for your own cluster.
         proxy: example.teleport.sh:443
         # Use the name of the join token resource you created in step 1.
         token: example-bot
@@ -313,11 +315,13 @@ jobs:
     - name: Fetch Teleport binaries
       uses: teleport-actions/setup@v1
       with:
-        version: (=teleport.version=)
+        version: auto
+        # Use the address of the proxy server for your own cluster.
+        proxy: example.teleport.sh:443
     - name: Fetch credentials using Machine ID
       uses: teleport-actions/auth-k8s@v2
       with:
-        # Use the address of the auth/proxy server for your own cluster.
+        # Use the address of the proxy server for your own cluster.
         proxy: example.teleport.sh:443
         # Use the name of the join token resource you created in step 1.
         token: example-bot
@@ -409,7 +413,9 @@ jobs:
     - name: Fetch Teleport binaries
       uses: teleport-actions/setup@v1
       with:
-        version: (=teleport.version=)
+        version: auto
+        # Use the address of the proxy server for your own cluster.
+        proxy: example.teleport.sh:443
     - name: Execute Machine ID
       env:
         # TELEPORT_ANONYMOUS_TELEMETRY enables the submission of anonymous

--- a/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
@@ -196,13 +196,13 @@ jobs:
       uses: teleport-actions/setup@v1
       with:
         version: auto
-        # Use the address of the proxy server for your own cluster.
+        # Replace with the address of your Teleport Proxy Service.
         proxy: example.teleport.sh:443
     - name: Fetch credentials using Machine ID
       id: auth
       uses: teleport-actions/auth@v2
       with:
-        # Use the address of the proxy server for your own cluster.
+        # Replace with the address of your Teleport Proxy Service.
         proxy: example.teleport.sh:443
         # Use the name of the join token resource you created in step 1.
         token: example-bot
@@ -316,12 +316,12 @@ jobs:
       uses: teleport-actions/setup@v1
       with:
         version: auto
-        # Use the address of the proxy server for your own cluster.
+        # Replace with the address of your Teleport Proxy Service.
         proxy: example.teleport.sh:443
     - name: Fetch credentials using Machine ID
       uses: teleport-actions/auth-k8s@v2
       with:
-        # Use the address of the proxy server for your own cluster.
+        # Replace with the address of your Teleport Proxy Service.
         proxy: example.teleport.sh:443
         # Use the name of the join token resource you created in step 1.
         token: example-bot
@@ -337,8 +337,7 @@ jobs:
 
 Replace:
 
-- `example.teleport.sh:443` with the address of your Teleport Proxy or cloud
-  tenant.
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
 - `example-bot` with the name of the token you created in a previous step.
 - `my-kubernetes-cluster` with the name of your Kubernetes cluster.
 
@@ -380,8 +379,7 @@ outputs: []
 
 Replace:
 
-- `example.teleport.sh:443` with the address of your Teleport Proxy or
-  Auth Service. Prefer using the address of a Teleport Proxy.
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
 - `example-bot` with the name of the token you created in the first step.
 
 Now you can define a GitHub Actions workflow that will start `tbot` with this
@@ -414,7 +412,7 @@ jobs:
       uses: teleport-actions/setup@v1
       with:
         version: auto
-        # Use the address of the proxy server for your own cluster.
+        # Replace with the address of your Teleport Proxy Service.
         proxy: example.teleport.sh:443
     - name: Execute Machine ID
       env:


### PR DESCRIPTION
We've added support for automatically fetching the correct version of the binaries based in https://github.com/teleport-actions/root/pull/54 - this PR updates the documentation to use this automatic method.