### PR TITLE
Don't omit CDP info for PKINIT certificates

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -208,7 +208,6 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string
 		ClusterName:        clusterName,
 		Domain:             s.ldapConfig.domain,
 		ActiveDirectorySID: s.ldapConfig.serviceAccountSID,
-		OmitCDP:            false,
 	}
 
 	certPEM, keyPEM, caCerts, err := winpki.DatabaseCredentials(ctx, s.authClient, req)

--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -208,7 +208,7 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string
 		ClusterName:        clusterName,
 		Domain:             s.ldapConfig.domain,
 		ActiveDirectorySID: s.ldapConfig.serviceAccountSID,
-		OmitCDP:            true,
+		OmitCDP:            false,
 	}
 
 	certPEM, keyPEM, caCerts, err := winpki.DatabaseCredentials(ctx, s.authClient, req)


### PR DESCRIPTION
Depending on the configuration, the CDP information may be required, so we shouldn't omit this. The change to omit CDP is very recent and didn't cause problems during tests, but some problems were reported later, so this PR changes this back.

Related to: 
- https://github.com/gravitational/teleport/pull/55429

changelog: Improve PKINIT compatibility by always including CDP information in the certificate