### PR TITLE
Complete logtest migration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -203,6 +203,8 @@ linters:
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/modules/modulestest
               desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/utils/logtesttest
+              desc: testing packages should not be imported outside of _test.go files
         testify:
           files:
             - '!$test'

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,8 +30,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
-	"testing"
 	"unicode"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -134,38 +131,6 @@ func InitLogger(purpose LoggingPurpose, level slog.Level, opts ...LoggerOption) 
 		OSLogSubsystem: o.osLogSubsystem,
 	})
 	return logger, trace.Wrap(err)
-}
-
-var initTestLoggerOnce = sync.Once{}
-
-// InitLoggerForTests initializes the standard logger for tests.
-// Deprecated: prefer using logtest.InitLogger
-// TODO(tross): remove after enterprise references are updated.
-func InitLoggerForTests() {
-	initTestLoggerOnce.Do(func() {
-		if !flag.Parsed() {
-			// Parse flags to check testing.Verbose().
-			flag.Parse()
-		}
-
-		if !testing.Verbose() {
-			slog.SetDefault(slog.New(slog.DiscardHandler))
-			return
-		}
-
-		logutils.Initialize(logutils.Config{
-			Severity: slog.LevelDebug.String(),
-			Format:   LogFormatJSON,
-		})
-	})
-}
-
-// NewSlogLoggerForTests creates a new slog logger for test environments.
-// Deprecated: prefer using logtest.NewLogger
-// TODO(tross): remove after enterprise references are updated.
-func NewSlogLoggerForTests() *slog.Logger {
-	InitLoggerForTests()
-	return slog.Default()
 }
 
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -32,10 +32,11 @@ import (
 
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport.e/compare/489f3a7731c0297fd1a557c891dbfb0d074288ba...300b64c3806ba92a5cb9da66e7fbb1d014fef756  to include https://github.com/gravitational/teleport.e/pull/6906 so that utils.InitLoggerForTests and utils.NewSlogLoggerForTests can be removed.

Updates https://github.com/gravitational/teleport/issues/51023.