### PR TITLE
Fix flaky TestApps

### DIFF
--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -60,7 +60,7 @@ func TestApps(t *testing.T) {
 		},
 		cacheGet: p.cache.GetApp,
 		cacheList: func(ctx context.Context) ([]types.Application, error) {
-			return stream.Collect(p.apps.Apps(ctx, "", ""))
+			return stream.Collect(p.cache.Apps(ctx, "", ""))
 		},
 		update:    p.apps.UpdateApp,
 		deleteAll: p.apps.DeleteAllApps,


### PR DESCRIPTION
The cacheList implementation was reading from the upstream instead of the cache causing items to appear replicated to the cache when in fact they were not.

Closes https://github.com/gravitational/teleport/issues/56870.