### PR TITLE
access-graph: Add AWS KMS key discovery to access graph

### DIFF
--- a/gen/proto/go/accessgraph/v1alpha/aws.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/aws.pb.go
@@ -3274,10 +3274,13 @@ type AWSKMSKeyV1 struct {
 	// last_sync_time is the time when the resource was last synced.
 	LastSyncTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=last_sync_time,json=lastSyncTime,proto3" json:"last_sync_time,omitempty"`
 	// aliases is the list of aliases that are attached to the key.
+	// they are prefixed with "alias/", for example "alias/my-key-alias".
 	Aliases []string `protobuf:"bytes,6,rep,name=aliases,proto3" json:"aliases,omitempty"`
-	// policy_document is the JSON document that defines the policy.
+	// policy_document is the JSON document that defines the Key Policy. Every KMS
+	// key must have exactly one key policy.
 	PolicyDocument []byte `protobuf:"bytes,7,opt,name=policy_document,json=policyDocument,proto3" json:"policy_document,omitempty"`
-	// region is the AWS region that the key belongs to.
+	// region is the AWS region that the key belongs to. For multi-region keys,
+	// this is the region where the current key, primary or replica, is located.
 	Region string `protobuf:"bytes,8,opt,name=region,proto3" json:"region,omitempty"`
 	// multi_region_key_type is the type of the multi-region key.
 	// It is set to "PRIMARY", "REPLICA" or left empty for single region keys.

--- a/gen/proto/go/accessgraph/v1alpha/aws.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/aws.pb.go
@@ -143,6 +143,65 @@ func (RolePermissionsBoundaryType) EnumDescriptor() ([]byte, []int) {
 	return file_accessgraph_v1alpha_aws_proto_rawDescGZIP(), []int{1}
 }
 
+// MultiRegionKeyType is the type of a multi-region key type (primary, replica,
+// none for single region).
+type MultiRegionKeyType int32
+
+const (
+	// MULTI_REGION_KEY_TYPE_UNSPECIFIED is a unspecified multi region key type
+	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_UNSPECIFIED MultiRegionKeyType = 0
+	// MULTI_REGION_KEY_TYPE_NONE is not a multi region key type but a local or
+	// single region key.
+	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_NONE MultiRegionKeyType = 1
+	// MULTI_REGION_KEY_TYPE_PRIMARY is a primary multi region key type
+	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_PRIMARY MultiRegionKeyType = 2
+	// MULTI_REGION_KEY_TYPE_REPLICA is a replica multi region key type
+	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_REPLICA MultiRegionKeyType = 3
+)
+
+// Enum value maps for MultiRegionKeyType.
+var (
+	MultiRegionKeyType_name = map[int32]string{
+		0: "MULTI_REGION_KEY_TYPE_UNSPECIFIED",
+		1: "MULTI_REGION_KEY_TYPE_NONE",
+		2: "MULTI_REGION_KEY_TYPE_PRIMARY",
+		3: "MULTI_REGION_KEY_TYPE_REPLICA",
+	}
+	MultiRegionKeyType_value = map[string]int32{
+		"MULTI_REGION_KEY_TYPE_UNSPECIFIED": 0,
+		"MULTI_REGION_KEY_TYPE_NONE":        1,
+		"MULTI_REGION_KEY_TYPE_PRIMARY":     2,
+		"MULTI_REGION_KEY_TYPE_REPLICA":     3,
+	}
+)
+
+func (x MultiRegionKeyType) Enum() *MultiRegionKeyType {
+	p := new(MultiRegionKeyType)
+	*p = x
+	return p
+}
+
+func (x MultiRegionKeyType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MultiRegionKeyType) Descriptor() protoreflect.EnumDescriptor {
+	return file_accessgraph_v1alpha_aws_proto_enumTypes[2].Descriptor()
+}
+
+func (MultiRegionKeyType) Type() protoreflect.EnumType {
+	return &file_accessgraph_v1alpha_aws_proto_enumTypes[2]
+}
+
+func (x MultiRegionKeyType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MultiRegionKeyType.Descriptor instead.
+func (MultiRegionKeyType) EnumDescriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_aws_proto_rawDescGZIP(), []int{2}
+}
+
 // AWSResourceList is a list of AWS resources supported by the access graph.
 type AWSResourceList struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -213,6 +272,7 @@ type AWSResource struct {
 	//	*AWSResource_Rds
 	//	*AWSResource_SamlProvider
 	//	*AWSResource_OidcProvider
+	//	*AWSResource_KmsKey
 	Resource      isAWSResource_Resource `protobuf_oneof:"resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -435,6 +495,15 @@ func (x *AWSResource) GetOidcProvider() *AWSOIDCProviderV1 {
 	return nil
 }
 
+func (x *AWSResource) GetKmsKey() *AWSKMSKeyV1 {
+	if x != nil {
+		if x, ok := x.Resource.(*AWSResource_KmsKey); ok {
+			return x.KmsKey
+		}
+	}
+	return nil
+}
+
 type isAWSResource_Resource interface {
 	isAWSResource_Resource()
 }
@@ -542,6 +611,11 @@ type AWSResource_OidcProvider struct {
 	OidcProvider *AWSOIDCProviderV1 `protobuf:"bytes,20,opt,name=oidc_provider,json=oidcProvider,proto3,oneof"`
 }
 
+type AWSResource_KmsKey struct {
+	// kms_key is an AWS KMS key.
+	KmsKey *AWSKMSKeyV1 `protobuf:"bytes,21,opt,name=kms_key,json=kmsKey,proto3,oneof"`
+}
+
 func (*AWSResource_User) isAWSResource_Resource() {}
 
 func (*AWSResource_Group) isAWSResource_Resource() {}
@@ -581,6 +655,8 @@ func (*AWSResource_Rds) isAWSResource_Resource() {}
 func (*AWSResource_SamlProvider) isAWSResource_Resource() {}
 
 func (*AWSResource_OidcProvider) isAWSResource_Resource() {}
+
+func (*AWSResource_KmsKey) isAWSResource_Resource() {}
 
 // AWSUserInlinePolicyV1 is a policy that is inlined to an AWS user.
 type AWSUserInlinePolicyV1 struct {
@@ -3243,13 +3319,140 @@ func (x *AWSOIDCProviderV1) GetLastSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
+// AWSKMSKeyV1 defines the KMS key details.
+type AWSKMSKeyV1 struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// arn is the key ARN.
+	Arn string `protobuf:"bytes,1,opt,name=arn,proto3" json:"arn,omitempty"`
+	// created_at is the time when the key was created.
+	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// tags is the list of tags that are attached to the key.
+	Tags []*AWSTag `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty"`
+	// account_id is the ID of the AWS account that the key belongs to.
+	AccountId string `protobuf:"bytes,4,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// last_sync_time is the time when the resource was last synced.
+	LastSyncTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=last_sync_time,json=lastSyncTime,proto3" json:"last_sync_time,omitempty"`
+	// aliases is the list of aliases that are attached to the key.
+	Aliases []string `protobuf:"bytes,6,rep,name=aliases,proto3" json:"aliases,omitempty"`
+	// policy_document is the JSON document that defines the policy.
+	PolicyDocument []byte `protobuf:"bytes,7,opt,name=policy_document,json=policyDocument,proto3" json:"policy_document,omitempty"`
+	// region is the AWS region that the key belongs to.
+	Region string `protobuf:"bytes,8,opt,name=region,proto3" json:"region,omitempty"`
+	// multi_region_key_type is the type of the multi-region key.
+	MultiRegionKeyType MultiRegionKeyType `protobuf:"varint,9,opt,name=multi_region_key_type,json=multiRegionKeyType,proto3,enum=accessgraph.v1alpha.MultiRegionKeyType" json:"multi_region_key_type,omitempty"`
+	// hsm_cluster_id is the ID of the HSM cluster that the key belongs to, if any.
+	HsmClusterId  string `protobuf:"bytes,10,opt,name=hsm_cluster_id,json=hsmClusterId,proto3" json:"hsm_cluster_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AWSKMSKeyV1) Reset() {
+	*x = AWSKMSKeyV1{}
+	mi := &file_accessgraph_v1alpha_aws_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWSKMSKeyV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWSKMSKeyV1) ProtoMessage() {}
+
+func (x *AWSKMSKeyV1) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_aws_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWSKMSKeyV1.ProtoReflect.Descriptor instead.
+func (*AWSKMSKeyV1) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_aws_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *AWSKMSKeyV1) GetArn() string {
+	if x != nil {
+		return x.Arn
+	}
+	return ""
+}
+
+func (x *AWSKMSKeyV1) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *AWSKMSKeyV1) GetTags() []*AWSTag {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
+}
+
+func (x *AWSKMSKeyV1) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *AWSKMSKeyV1) GetLastSyncTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastSyncTime
+	}
+	return nil
+}
+
+func (x *AWSKMSKeyV1) GetAliases() []string {
+	if x != nil {
+		return x.Aliases
+	}
+	return nil
+}
+
+func (x *AWSKMSKeyV1) GetPolicyDocument() []byte {
+	if x != nil {
+		return x.PolicyDocument
+	}
+	return nil
+}
+
+func (x *AWSKMSKeyV1) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *AWSKMSKeyV1) GetMultiRegionKeyType() MultiRegionKeyType {
+	if x != nil {
+		return x.MultiRegionKeyType
+	}
+	return MultiRegionKeyType_MULTI_REGION_KEY_TYPE_UNSPECIFIED
+}
+
+func (x *AWSKMSKeyV1) GetHsmClusterId() string {
+	if x != nil {
+		return x.HsmClusterId
+	}
+	return ""
+}
+
 var File_accessgraph_v1alpha_aws_proto protoreflect.FileDescriptor
 
 const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	"\n" +
 	"\x1daccessgraph/v1alpha/aws.proto\x12\x13accessgraph.v1alpha\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"Q\n" +
 	"\x0fAWSResourceList\x12>\n" +
-	"\tresources\x18\x01 \x03(\v2 .accessgraph.v1alpha.AWSResourceR\tresources\"\xf4\f\n" +
+	"\tresources\x18\x01 \x03(\v2 .accessgraph.v1alpha.AWSResourceR\tresources\"\xb1\r\n" +
 	"\vAWSResource\x124\n" +
 	"\x04user\x18\x01 \x01(\v2\x1e.accessgraph.v1alpha.AWSUserV1H\x00R\x04user\x127\n" +
 	"\x05group\x18\x02 \x01(\v2\x1f.accessgraph.v1alpha.AWSGroupV1H\x00R\x05group\x12Z\n" +
@@ -3273,7 +3476,8 @@ const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	"\x1deks_cluster_associated_policy\x18\x11 \x01(\v23.accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1H\x00R\x1aeksClusterAssociatedPolicy\x129\n" +
 	"\x03rds\x18\x12 \x01(\v2%.accessgraph.v1alpha.AWSRDSDatabaseV1H\x00R\x03rds\x12M\n" +
 	"\rsaml_provider\x18\x13 \x01(\v2&.accessgraph.v1alpha.AWSSAMLProviderV1H\x00R\fsamlProvider\x12M\n" +
-	"\roidc_provider\x18\x14 \x01(\v2&.accessgraph.v1alpha.AWSOIDCProviderV1H\x00R\foidcProviderB\n" +
+	"\roidc_provider\x18\x14 \x01(\v2&.accessgraph.v1alpha.AWSOIDCProviderV1H\x00R\foidcProvider\x12;\n" +
+	"\akms_key\x18\x15 \x01(\v2 .accessgraph.v1alpha.AWSKMSKeyV1H\x00R\x06kmsKeyB\n" +
 	"\n" +
 	"\bresource\"\x86\x02\n" +
 	"\x15AWSUserInlinePolicyV1\x12\x1f\n" +
@@ -3533,13 +3737,32 @@ const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	"client_ids\x18\x05 \x03(\tR\tclientIds\x12 \n" +
 	"\vthumbprints\x18\x06 \x03(\tR\vthumbprints\x12\x10\n" +
 	"\x03url\x18\a \x01(\tR\x03url\x12@\n" +
-	"\x0elast_sync_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime*\x90\x01\n" +
+	"\x0elast_sync_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\"\xc9\x03\n" +
+	"\vAWSKMSKeyV1\x12\x10\n" +
+	"\x03arn\x18\x01 \x01(\tR\x03arn\x129\n" +
+	"\n" +
+	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12/\n" +
+	"\x04tags\x18\x03 \x03(\v2\x1b.accessgraph.v1alpha.AWSTagR\x04tags\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x04 \x01(\tR\taccountId\x12@\n" +
+	"\x0elast_sync_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\x12\x18\n" +
+	"\aaliases\x18\x06 \x03(\tR\aaliases\x12'\n" +
+	"\x0fpolicy_document\x18\a \x01(\fR\x0epolicyDocument\x12\x16\n" +
+	"\x06region\x18\b \x01(\tR\x06region\x12Z\n" +
+	"\x15multi_region_key_type\x18\t \x01(\x0e2'.accessgraph.v1alpha.MultiRegionKeyTypeR\x12multiRegionKeyType\x12$\n" +
+	"\x0ehsm_cluster_id\x18\n" +
+	" \x01(\tR\fhsmClusterId*\x90\x01\n" +
 	"\x1cUsersPermissionsBoundaryType\x12/\n" +
 	"+USERS_PERMISSIONS_BOUNDARY_TYPE_UNSPECIFIED\x10\x00\x12?\n" +
 	";USERS_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01*\x8d\x01\n" +
 	"\x1bRolePermissionsBoundaryType\x12.\n" +
 	"*ROLE_PERMISSIONS_BOUNDARY_TYPE_UNSPECIFIED\x10\x00\x12>\n" +
-	":ROLE_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01BWZUgithub.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alphab\x06proto3"
+	":ROLE_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01*\xa1\x01\n" +
+	"\x12MultiRegionKeyType\x12%\n" +
+	"!MULTI_REGION_KEY_TYPE_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aMULTI_REGION_KEY_TYPE_NONE\x10\x01\x12!\n" +
+	"\x1dMULTI_REGION_KEY_TYPE_PRIMARY\x10\x02\x12!\n" +
+	"\x1dMULTI_REGION_KEY_TYPE_REPLICA\x10\x03BWZUgithub.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alphab\x06proto3"
 
 var (
 	file_accessgraph_v1alpha_aws_proto_rawDescOnce sync.Once
@@ -3553,149 +3776,156 @@ func file_accessgraph_v1alpha_aws_proto_rawDescGZIP() []byte {
 	return file_accessgraph_v1alpha_aws_proto_rawDescData
 }
 
-var file_accessgraph_v1alpha_aws_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_accessgraph_v1alpha_aws_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_accessgraph_v1alpha_aws_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_accessgraph_v1alpha_aws_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_accessgraph_v1alpha_aws_proto_goTypes = []any{
 	(UsersPermissionsBoundaryType)(0),      // 0: accessgraph.v1alpha.UsersPermissionsBoundaryType
 	(RolePermissionsBoundaryType)(0),       // 1: accessgraph.v1alpha.RolePermissionsBoundaryType
-	(*AWSResourceList)(nil),                // 2: accessgraph.v1alpha.AWSResourceList
-	(*AWSResource)(nil),                    // 3: accessgraph.v1alpha.AWSResource
-	(*AWSUserInlinePolicyV1)(nil),          // 4: accessgraph.v1alpha.AWSUserInlinePolicyV1
-	(*AWSPolicyV1)(nil),                    // 5: accessgraph.v1alpha.AWSPolicyV1
-	(*AWSGroupV1)(nil),                     // 6: accessgraph.v1alpha.AWSGroupV1
-	(*AWSUserGroupsV1)(nil),                // 7: accessgraph.v1alpha.AWSUserGroupsV1
-	(*AWSUserV1)(nil),                      // 8: accessgraph.v1alpha.AWSUserV1
-	(*AWSTag)(nil),                         // 9: accessgraph.v1alpha.AWSTag
-	(*UsersPermissionsBoundaryV1)(nil),     // 10: accessgraph.v1alpha.UsersPermissionsBoundaryV1
-	(*AWSInstanceV1)(nil),                  // 11: accessgraph.v1alpha.AWSInstanceV1
-	(*AWSUserAttachedPolicies)(nil),        // 12: accessgraph.v1alpha.AWSUserAttachedPolicies
-	(*AttachedPolicyV1)(nil),               // 13: accessgraph.v1alpha.AttachedPolicyV1
-	(*AWSGroupAttachedPolicies)(nil),       // 14: accessgraph.v1alpha.AWSGroupAttachedPolicies
-	(*AWSGroupInlinePolicyV1)(nil),         // 15: accessgraph.v1alpha.AWSGroupInlinePolicyV1
-	(*AWSS3BucketV1)(nil),                  // 16: accessgraph.v1alpha.AWSS3BucketV1
-	(*AWSS3BucketACL)(nil),                 // 17: accessgraph.v1alpha.AWSS3BucketACL
-	(*AWSS3BucketACLGrantee)(nil),          // 18: accessgraph.v1alpha.AWSS3BucketACLGrantee
-	(*AWSRoleV1)(nil),                      // 19: accessgraph.v1alpha.AWSRoleV1
-	(*RolePermissionsBoundaryV1)(nil),      // 20: accessgraph.v1alpha.RolePermissionsBoundaryV1
-	(*RoleLastUsedV1)(nil),                 // 21: accessgraph.v1alpha.RoleLastUsedV1
-	(*AWSRoleInlinePolicyV1)(nil),          // 22: accessgraph.v1alpha.AWSRoleInlinePolicyV1
-	(*AWSRoleAttachedPolicies)(nil),        // 23: accessgraph.v1alpha.AWSRoleAttachedPolicies
-	(*AWSInstanceProfileV1)(nil),           // 24: accessgraph.v1alpha.AWSInstanceProfileV1
-	(*AWSEKSClusterV1)(nil),                // 25: accessgraph.v1alpha.AWSEKSClusterV1
-	(*AWSEKSClusterAccessEntryV1)(nil),     // 26: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
-	(*AWSEKSAssociatedAccessPolicyV1)(nil), // 27: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
-	(*AWSEKSAccessScopeV1)(nil),            // 28: accessgraph.v1alpha.AWSEKSAccessScopeV1
-	(*AWSRDSDatabaseV1)(nil),               // 29: accessgraph.v1alpha.AWSRDSDatabaseV1
-	(*AWSRDSEngineV1)(nil),                 // 30: accessgraph.v1alpha.AWSRDSEngineV1
-	(*AWSSAMLProviderV1)(nil),              // 31: accessgraph.v1alpha.AWSSAMLProviderV1
-	(*AWSOIDCProviderV1)(nil),              // 32: accessgraph.v1alpha.AWSOIDCProviderV1
-	(*timestamppb.Timestamp)(nil),          // 33: google.protobuf.Timestamp
-	(*wrapperspb.StringValue)(nil),         // 34: google.protobuf.StringValue
-	(*durationpb.Duration)(nil),            // 35: google.protobuf.Duration
+	(MultiRegionKeyType)(0),                // 2: accessgraph.v1alpha.MultiRegionKeyType
+	(*AWSResourceList)(nil),                // 3: accessgraph.v1alpha.AWSResourceList
+	(*AWSResource)(nil),                    // 4: accessgraph.v1alpha.AWSResource
+	(*AWSUserInlinePolicyV1)(nil),          // 5: accessgraph.v1alpha.AWSUserInlinePolicyV1
+	(*AWSPolicyV1)(nil),                    // 6: accessgraph.v1alpha.AWSPolicyV1
+	(*AWSGroupV1)(nil),                     // 7: accessgraph.v1alpha.AWSGroupV1
+	(*AWSUserGroupsV1)(nil),                // 8: accessgraph.v1alpha.AWSUserGroupsV1
+	(*AWSUserV1)(nil),                      // 9: accessgraph.v1alpha.AWSUserV1
+	(*AWSTag)(nil),                         // 10: accessgraph.v1alpha.AWSTag
+	(*UsersPermissionsBoundaryV1)(nil),     // 11: accessgraph.v1alpha.UsersPermissionsBoundaryV1
+	(*AWSInstanceV1)(nil),                  // 12: accessgraph.v1alpha.AWSInstanceV1
+	(*AWSUserAttachedPolicies)(nil),        // 13: accessgraph.v1alpha.AWSUserAttachedPolicies
+	(*AttachedPolicyV1)(nil),               // 14: accessgraph.v1alpha.AttachedPolicyV1
+	(*AWSGroupAttachedPolicies)(nil),       // 15: accessgraph.v1alpha.AWSGroupAttachedPolicies
+	(*AWSGroupInlinePolicyV1)(nil),         // 16: accessgraph.v1alpha.AWSGroupInlinePolicyV1
+	(*AWSS3BucketV1)(nil),                  // 17: accessgraph.v1alpha.AWSS3BucketV1
+	(*AWSS3BucketACL)(nil),                 // 18: accessgraph.v1alpha.AWSS3BucketACL
+	(*AWSS3BucketACLGrantee)(nil),          // 19: accessgraph.v1alpha.AWSS3BucketACLGrantee
+	(*AWSRoleV1)(nil),                      // 20: accessgraph.v1alpha.AWSRoleV1
+	(*RolePermissionsBoundaryV1)(nil),      // 21: accessgraph.v1alpha.RolePermissionsBoundaryV1
+	(*RoleLastUsedV1)(nil),                 // 22: accessgraph.v1alpha.RoleLastUsedV1
+	(*AWSRoleInlinePolicyV1)(nil),          // 23: accessgraph.v1alpha.AWSRoleInlinePolicyV1
+	(*AWSRoleAttachedPolicies)(nil),        // 24: accessgraph.v1alpha.AWSRoleAttachedPolicies
+	(*AWSInstanceProfileV1)(nil),           // 25: accessgraph.v1alpha.AWSInstanceProfileV1
+	(*AWSEKSClusterV1)(nil),                // 26: accessgraph.v1alpha.AWSEKSClusterV1
+	(*AWSEKSClusterAccessEntryV1)(nil),     // 27: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
+	(*AWSEKSAssociatedAccessPolicyV1)(nil), // 28: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
+	(*AWSEKSAccessScopeV1)(nil),            // 29: accessgraph.v1alpha.AWSEKSAccessScopeV1
+	(*AWSRDSDatabaseV1)(nil),               // 30: accessgraph.v1alpha.AWSRDSDatabaseV1
+	(*AWSRDSEngineV1)(nil),                 // 31: accessgraph.v1alpha.AWSRDSEngineV1
+	(*AWSSAMLProviderV1)(nil),              // 32: accessgraph.v1alpha.AWSSAMLProviderV1
+	(*AWSOIDCProviderV1)(nil),              // 33: accessgraph.v1alpha.AWSOIDCProviderV1
+	(*AWSKMSKeyV1)(nil),                    // 34: accessgraph.v1alpha.AWSKMSKeyV1
+	(*timestamppb.Timestamp)(nil),          // 35: google.protobuf.Timestamp
+	(*wrapperspb.StringValue)(nil),         // 36: google.protobuf.StringValue
+	(*durationpb.Duration)(nil),            // 37: google.protobuf.Duration
 }
 var file_accessgraph_v1alpha_aws_proto_depIdxs = []int32{
-	3,  // 0: accessgraph.v1alpha.AWSResourceList.resources:type_name -> accessgraph.v1alpha.AWSResource
-	8,  // 1: accessgraph.v1alpha.AWSResource.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	6,  // 2: accessgraph.v1alpha.AWSResource.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	4,  // 3: accessgraph.v1alpha.AWSResource.user_inline_policy:type_name -> accessgraph.v1alpha.AWSUserInlinePolicyV1
-	7,  // 4: accessgraph.v1alpha.AWSResource.user_groups:type_name -> accessgraph.v1alpha.AWSUserGroupsV1
-	11, // 5: accessgraph.v1alpha.AWSResource.instance:type_name -> accessgraph.v1alpha.AWSInstanceV1
-	5,  // 6: accessgraph.v1alpha.AWSResource.policy:type_name -> accessgraph.v1alpha.AWSPolicyV1
-	12, // 7: accessgraph.v1alpha.AWSResource.user_attached_policies:type_name -> accessgraph.v1alpha.AWSUserAttachedPolicies
-	14, // 8: accessgraph.v1alpha.AWSResource.group_attached_policies:type_name -> accessgraph.v1alpha.AWSGroupAttachedPolicies
-	15, // 9: accessgraph.v1alpha.AWSResource.group_inline_policy:type_name -> accessgraph.v1alpha.AWSGroupInlinePolicyV1
-	16, // 10: accessgraph.v1alpha.AWSResource.s3_bucket:type_name -> accessgraph.v1alpha.AWSS3BucketV1
-	19, // 11: accessgraph.v1alpha.AWSResource.role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	22, // 12: accessgraph.v1alpha.AWSResource.role_inline_policy:type_name -> accessgraph.v1alpha.AWSRoleInlinePolicyV1
-	23, // 13: accessgraph.v1alpha.AWSResource.role_attached_policies:type_name -> accessgraph.v1alpha.AWSRoleAttachedPolicies
-	24, // 14: accessgraph.v1alpha.AWSResource.instance_profile:type_name -> accessgraph.v1alpha.AWSInstanceProfileV1
-	25, // 15: accessgraph.v1alpha.AWSResource.eks_cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	26, // 16: accessgraph.v1alpha.AWSResource.eks_cluster_access_entry:type_name -> accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
-	27, // 17: accessgraph.v1alpha.AWSResource.eks_cluster_associated_policy:type_name -> accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
-	29, // 18: accessgraph.v1alpha.AWSResource.rds:type_name -> accessgraph.v1alpha.AWSRDSDatabaseV1
-	31, // 19: accessgraph.v1alpha.AWSResource.saml_provider:type_name -> accessgraph.v1alpha.AWSSAMLProviderV1
-	32, // 20: accessgraph.v1alpha.AWSResource.oidc_provider:type_name -> accessgraph.v1alpha.AWSOIDCProviderV1
-	8,  // 21: accessgraph.v1alpha.AWSUserInlinePolicyV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	33, // 22: accessgraph.v1alpha.AWSUserInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 23: accessgraph.v1alpha.AWSPolicyV1.created_at:type_name -> google.protobuf.Timestamp
-	9,  // 24: accessgraph.v1alpha.AWSPolicyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 25: accessgraph.v1alpha.AWSPolicyV1.updated_at:type_name -> google.protobuf.Timestamp
-	33, // 26: accessgraph.v1alpha.AWSPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 27: accessgraph.v1alpha.AWSGroupV1.created_at:type_name -> google.protobuf.Timestamp
-	33, // 28: accessgraph.v1alpha.AWSGroupV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	8,  // 29: accessgraph.v1alpha.AWSUserGroupsV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	6,  // 30: accessgraph.v1alpha.AWSUserGroupsV1.groups:type_name -> accessgraph.v1alpha.AWSGroupV1
-	33, // 31: accessgraph.v1alpha.AWSUserGroupsV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 32: accessgraph.v1alpha.AWSUserV1.created_at:type_name -> google.protobuf.Timestamp
-	33, // 33: accessgraph.v1alpha.AWSUserV1.password_last_used:type_name -> google.protobuf.Timestamp
-	10, // 34: accessgraph.v1alpha.AWSUserV1.permissions_boundary:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryV1
-	9,  // 35: accessgraph.v1alpha.AWSUserV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 36: accessgraph.v1alpha.AWSUserV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	34, // 37: accessgraph.v1alpha.AWSTag.value:type_name -> google.protobuf.StringValue
-	0,  // 38: accessgraph.v1alpha.UsersPermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryType
-	33, // 39: accessgraph.v1alpha.AWSInstanceV1.launch_time:type_name -> google.protobuf.Timestamp
-	9,  // 40: accessgraph.v1alpha.AWSInstanceV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	34, // 41: accessgraph.v1alpha.AWSInstanceV1.iam_instance_profile_arn:type_name -> google.protobuf.StringValue
-	34, // 42: accessgraph.v1alpha.AWSInstanceV1.launch_key_name:type_name -> google.protobuf.StringValue
-	33, // 43: accessgraph.v1alpha.AWSInstanceV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	8,  // 44: accessgraph.v1alpha.AWSUserAttachedPolicies.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	13, // 45: accessgraph.v1alpha.AWSUserAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	33, // 46: accessgraph.v1alpha.AWSUserAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	6,  // 47: accessgraph.v1alpha.AWSGroupAttachedPolicies.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	13, // 48: accessgraph.v1alpha.AWSGroupAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	33, // 49: accessgraph.v1alpha.AWSGroupAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	6,  // 50: accessgraph.v1alpha.AWSGroupInlinePolicyV1.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	33, // 51: accessgraph.v1alpha.AWSGroupInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	17, // 52: accessgraph.v1alpha.AWSS3BucketV1.acls:type_name -> accessgraph.v1alpha.AWSS3BucketACL
-	9,  // 53: accessgraph.v1alpha.AWSS3BucketV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 54: accessgraph.v1alpha.AWSS3BucketV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	18, // 55: accessgraph.v1alpha.AWSS3BucketACL.grantee:type_name -> accessgraph.v1alpha.AWSS3BucketACLGrantee
-	33, // 56: accessgraph.v1alpha.AWSRoleV1.created_at:type_name -> google.protobuf.Timestamp
-	35, // 57: accessgraph.v1alpha.AWSRoleV1.max_session_duration:type_name -> google.protobuf.Duration
-	20, // 58: accessgraph.v1alpha.AWSRoleV1.permissions_boundary:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryV1
-	9,  // 59: accessgraph.v1alpha.AWSRoleV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	21, // 60: accessgraph.v1alpha.AWSRoleV1.role_last_used:type_name -> accessgraph.v1alpha.RoleLastUsedV1
-	33, // 61: accessgraph.v1alpha.AWSRoleV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	1,  // 62: accessgraph.v1alpha.RolePermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryType
-	33, // 63: accessgraph.v1alpha.RoleLastUsedV1.last_used_date:type_name -> google.protobuf.Timestamp
-	19, // 64: accessgraph.v1alpha.AWSRoleInlinePolicyV1.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	33, // 65: accessgraph.v1alpha.AWSRoleInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	13, // 66: accessgraph.v1alpha.AWSRoleAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	19, // 67: accessgraph.v1alpha.AWSRoleAttachedPolicies.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	33, // 68: accessgraph.v1alpha.AWSRoleAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 69: accessgraph.v1alpha.AWSInstanceProfileV1.created_at:type_name -> google.protobuf.Timestamp
-	19, // 70: accessgraph.v1alpha.AWSInstanceProfileV1.roles:type_name -> accessgraph.v1alpha.AWSRoleV1
-	9,  // 71: accessgraph.v1alpha.AWSInstanceProfileV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 72: accessgraph.v1alpha.AWSInstanceProfileV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 73: accessgraph.v1alpha.AWSEKSClusterV1.created_at:type_name -> google.protobuf.Timestamp
-	9,  // 74: accessgraph.v1alpha.AWSEKSClusterV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 75: accessgraph.v1alpha.AWSEKSClusterV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	25, // 76: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	33, // 77: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.created_at:type_name -> google.protobuf.Timestamp
-	33, // 78: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.modified_at:type_name -> google.protobuf.Timestamp
-	9,  // 79: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 80: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	25, // 81: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	28, // 82: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.scope:type_name -> accessgraph.v1alpha.AWSEKSAccessScopeV1
-	33, // 83: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.associated_at:type_name -> google.protobuf.Timestamp
-	33, // 84: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.modified_at:type_name -> google.protobuf.Timestamp
-	33, // 85: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	30, // 86: accessgraph.v1alpha.AWSRDSDatabaseV1.engine_details:type_name -> accessgraph.v1alpha.AWSRDSEngineV1
-	33, // 87: accessgraph.v1alpha.AWSRDSDatabaseV1.created_at:type_name -> google.protobuf.Timestamp
-	9,  // 88: accessgraph.v1alpha.AWSRDSDatabaseV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 89: accessgraph.v1alpha.AWSRDSDatabaseV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 90: accessgraph.v1alpha.AWSSAMLProviderV1.created_at:type_name -> google.protobuf.Timestamp
-	33, // 91: accessgraph.v1alpha.AWSSAMLProviderV1.valid_until:type_name -> google.protobuf.Timestamp
-	9,  // 92: accessgraph.v1alpha.AWSSAMLProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 93: accessgraph.v1alpha.AWSSAMLProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	33, // 94: accessgraph.v1alpha.AWSOIDCProviderV1.created_at:type_name -> google.protobuf.Timestamp
-	9,  // 95: accessgraph.v1alpha.AWSOIDCProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	33, // 96: accessgraph.v1alpha.AWSOIDCProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	97, // [97:97] is the sub-list for method output_type
-	97, // [97:97] is the sub-list for method input_type
-	97, // [97:97] is the sub-list for extension type_name
-	97, // [97:97] is the sub-list for extension extendee
-	0,  // [0:97] is the sub-list for field type_name
+	4,   // 0: accessgraph.v1alpha.AWSResourceList.resources:type_name -> accessgraph.v1alpha.AWSResource
+	9,   // 1: accessgraph.v1alpha.AWSResource.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	7,   // 2: accessgraph.v1alpha.AWSResource.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	5,   // 3: accessgraph.v1alpha.AWSResource.user_inline_policy:type_name -> accessgraph.v1alpha.AWSUserInlinePolicyV1
+	8,   // 4: accessgraph.v1alpha.AWSResource.user_groups:type_name -> accessgraph.v1alpha.AWSUserGroupsV1
+	12,  // 5: accessgraph.v1alpha.AWSResource.instance:type_name -> accessgraph.v1alpha.AWSInstanceV1
+	6,   // 6: accessgraph.v1alpha.AWSResource.policy:type_name -> accessgraph.v1alpha.AWSPolicyV1
+	13,  // 7: accessgraph.v1alpha.AWSResource.user_attached_policies:type_name -> accessgraph.v1alpha.AWSUserAttachedPolicies
+	15,  // 8: accessgraph.v1alpha.AWSResource.group_attached_policies:type_name -> accessgraph.v1alpha.AWSGroupAttachedPolicies
+	16,  // 9: accessgraph.v1alpha.AWSResource.group_inline_policy:type_name -> accessgraph.v1alpha.AWSGroupInlinePolicyV1
+	17,  // 10: accessgraph.v1alpha.AWSResource.s3_bucket:type_name -> accessgraph.v1alpha.AWSS3BucketV1
+	20,  // 11: accessgraph.v1alpha.AWSResource.role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	23,  // 12: accessgraph.v1alpha.AWSResource.role_inline_policy:type_name -> accessgraph.v1alpha.AWSRoleInlinePolicyV1
+	24,  // 13: accessgraph.v1alpha.AWSResource.role_attached_policies:type_name -> accessgraph.v1alpha.AWSRoleAttachedPolicies
+	25,  // 14: accessgraph.v1alpha.AWSResource.instance_profile:type_name -> accessgraph.v1alpha.AWSInstanceProfileV1
+	26,  // 15: accessgraph.v1alpha.AWSResource.eks_cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	27,  // 16: accessgraph.v1alpha.AWSResource.eks_cluster_access_entry:type_name -> accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
+	28,  // 17: accessgraph.v1alpha.AWSResource.eks_cluster_associated_policy:type_name -> accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
+	30,  // 18: accessgraph.v1alpha.AWSResource.rds:type_name -> accessgraph.v1alpha.AWSRDSDatabaseV1
+	32,  // 19: accessgraph.v1alpha.AWSResource.saml_provider:type_name -> accessgraph.v1alpha.AWSSAMLProviderV1
+	33,  // 20: accessgraph.v1alpha.AWSResource.oidc_provider:type_name -> accessgraph.v1alpha.AWSOIDCProviderV1
+	34,  // 21: accessgraph.v1alpha.AWSResource.kms_key:type_name -> accessgraph.v1alpha.AWSKMSKeyV1
+	9,   // 22: accessgraph.v1alpha.AWSUserInlinePolicyV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	35,  // 23: accessgraph.v1alpha.AWSUserInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 24: accessgraph.v1alpha.AWSPolicyV1.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 25: accessgraph.v1alpha.AWSPolicyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 26: accessgraph.v1alpha.AWSPolicyV1.updated_at:type_name -> google.protobuf.Timestamp
+	35,  // 27: accessgraph.v1alpha.AWSPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 28: accessgraph.v1alpha.AWSGroupV1.created_at:type_name -> google.protobuf.Timestamp
+	35,  // 29: accessgraph.v1alpha.AWSGroupV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	9,   // 30: accessgraph.v1alpha.AWSUserGroupsV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	7,   // 31: accessgraph.v1alpha.AWSUserGroupsV1.groups:type_name -> accessgraph.v1alpha.AWSGroupV1
+	35,  // 32: accessgraph.v1alpha.AWSUserGroupsV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 33: accessgraph.v1alpha.AWSUserV1.created_at:type_name -> google.protobuf.Timestamp
+	35,  // 34: accessgraph.v1alpha.AWSUserV1.password_last_used:type_name -> google.protobuf.Timestamp
+	11,  // 35: accessgraph.v1alpha.AWSUserV1.permissions_boundary:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryV1
+	10,  // 36: accessgraph.v1alpha.AWSUserV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 37: accessgraph.v1alpha.AWSUserV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	36,  // 38: accessgraph.v1alpha.AWSTag.value:type_name -> google.protobuf.StringValue
+	0,   // 39: accessgraph.v1alpha.UsersPermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryType
+	35,  // 40: accessgraph.v1alpha.AWSInstanceV1.launch_time:type_name -> google.protobuf.Timestamp
+	10,  // 41: accessgraph.v1alpha.AWSInstanceV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	36,  // 42: accessgraph.v1alpha.AWSInstanceV1.iam_instance_profile_arn:type_name -> google.protobuf.StringValue
+	36,  // 43: accessgraph.v1alpha.AWSInstanceV1.launch_key_name:type_name -> google.protobuf.StringValue
+	35,  // 44: accessgraph.v1alpha.AWSInstanceV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	9,   // 45: accessgraph.v1alpha.AWSUserAttachedPolicies.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	14,  // 46: accessgraph.v1alpha.AWSUserAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	35,  // 47: accessgraph.v1alpha.AWSUserAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	7,   // 48: accessgraph.v1alpha.AWSGroupAttachedPolicies.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	14,  // 49: accessgraph.v1alpha.AWSGroupAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	35,  // 50: accessgraph.v1alpha.AWSGroupAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	7,   // 51: accessgraph.v1alpha.AWSGroupInlinePolicyV1.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	35,  // 52: accessgraph.v1alpha.AWSGroupInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	18,  // 53: accessgraph.v1alpha.AWSS3BucketV1.acls:type_name -> accessgraph.v1alpha.AWSS3BucketACL
+	10,  // 54: accessgraph.v1alpha.AWSS3BucketV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 55: accessgraph.v1alpha.AWSS3BucketV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	19,  // 56: accessgraph.v1alpha.AWSS3BucketACL.grantee:type_name -> accessgraph.v1alpha.AWSS3BucketACLGrantee
+	35,  // 57: accessgraph.v1alpha.AWSRoleV1.created_at:type_name -> google.protobuf.Timestamp
+	37,  // 58: accessgraph.v1alpha.AWSRoleV1.max_session_duration:type_name -> google.protobuf.Duration
+	21,  // 59: accessgraph.v1alpha.AWSRoleV1.permissions_boundary:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryV1
+	10,  // 60: accessgraph.v1alpha.AWSRoleV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	22,  // 61: accessgraph.v1alpha.AWSRoleV1.role_last_used:type_name -> accessgraph.v1alpha.RoleLastUsedV1
+	35,  // 62: accessgraph.v1alpha.AWSRoleV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	1,   // 63: accessgraph.v1alpha.RolePermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryType
+	35,  // 64: accessgraph.v1alpha.RoleLastUsedV1.last_used_date:type_name -> google.protobuf.Timestamp
+	20,  // 65: accessgraph.v1alpha.AWSRoleInlinePolicyV1.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	35,  // 66: accessgraph.v1alpha.AWSRoleInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	14,  // 67: accessgraph.v1alpha.AWSRoleAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	20,  // 68: accessgraph.v1alpha.AWSRoleAttachedPolicies.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	35,  // 69: accessgraph.v1alpha.AWSRoleAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 70: accessgraph.v1alpha.AWSInstanceProfileV1.created_at:type_name -> google.protobuf.Timestamp
+	20,  // 71: accessgraph.v1alpha.AWSInstanceProfileV1.roles:type_name -> accessgraph.v1alpha.AWSRoleV1
+	10,  // 72: accessgraph.v1alpha.AWSInstanceProfileV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 73: accessgraph.v1alpha.AWSInstanceProfileV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 74: accessgraph.v1alpha.AWSEKSClusterV1.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 75: accessgraph.v1alpha.AWSEKSClusterV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 76: accessgraph.v1alpha.AWSEKSClusterV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	26,  // 77: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	35,  // 78: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.created_at:type_name -> google.protobuf.Timestamp
+	35,  // 79: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.modified_at:type_name -> google.protobuf.Timestamp
+	10,  // 80: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 81: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	26,  // 82: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	29,  // 83: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.scope:type_name -> accessgraph.v1alpha.AWSEKSAccessScopeV1
+	35,  // 84: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.associated_at:type_name -> google.protobuf.Timestamp
+	35,  // 85: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.modified_at:type_name -> google.protobuf.Timestamp
+	35,  // 86: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	31,  // 87: accessgraph.v1alpha.AWSRDSDatabaseV1.engine_details:type_name -> accessgraph.v1alpha.AWSRDSEngineV1
+	35,  // 88: accessgraph.v1alpha.AWSRDSDatabaseV1.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 89: accessgraph.v1alpha.AWSRDSDatabaseV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 90: accessgraph.v1alpha.AWSRDSDatabaseV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 91: accessgraph.v1alpha.AWSSAMLProviderV1.created_at:type_name -> google.protobuf.Timestamp
+	35,  // 92: accessgraph.v1alpha.AWSSAMLProviderV1.valid_until:type_name -> google.protobuf.Timestamp
+	10,  // 93: accessgraph.v1alpha.AWSSAMLProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 94: accessgraph.v1alpha.AWSSAMLProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 95: accessgraph.v1alpha.AWSOIDCProviderV1.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 96: accessgraph.v1alpha.AWSOIDCProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 97: accessgraph.v1alpha.AWSOIDCProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 98: accessgraph.v1alpha.AWSKMSKeyV1.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 99: accessgraph.v1alpha.AWSKMSKeyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 100: accessgraph.v1alpha.AWSKMSKeyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	2,   // 101: accessgraph.v1alpha.AWSKMSKeyV1.multi_region_key_type:type_name -> accessgraph.v1alpha.MultiRegionKeyType
+	102, // [102:102] is the sub-list for method output_type
+	102, // [102:102] is the sub-list for method input_type
+	102, // [102:102] is the sub-list for extension type_name
+	102, // [102:102] is the sub-list for extension extendee
+	0,   // [0:102] is the sub-list for field type_name
 }
 
 func init() { file_accessgraph_v1alpha_aws_proto_init() }
@@ -3724,14 +3954,15 @@ func file_accessgraph_v1alpha_aws_proto_init() {
 		(*AWSResource_Rds)(nil),
 		(*AWSResource_SamlProvider)(nil),
 		(*AWSResource_OidcProvider)(nil),
+		(*AWSResource_KmsKey)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_accessgraph_v1alpha_aws_proto_rawDesc), len(file_accessgraph_v1alpha_aws_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   31,
+			NumEnums:      3,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/proto/go/accessgraph/v1alpha/aws.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/aws.pb.go
@@ -143,65 +143,6 @@ func (RolePermissionsBoundaryType) EnumDescriptor() ([]byte, []int) {
 	return file_accessgraph_v1alpha_aws_proto_rawDescGZIP(), []int{1}
 }
 
-// MultiRegionKeyType is the type of a multi-region key type (primary, replica,
-// none for single region).
-type MultiRegionKeyType int32
-
-const (
-	// MULTI_REGION_KEY_TYPE_UNSPECIFIED is a unspecified multi region key type
-	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_UNSPECIFIED MultiRegionKeyType = 0
-	// MULTI_REGION_KEY_TYPE_NONE is not a multi region key type but a local or
-	// single region key.
-	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_NONE MultiRegionKeyType = 1
-	// MULTI_REGION_KEY_TYPE_PRIMARY is a primary multi region key type
-	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_PRIMARY MultiRegionKeyType = 2
-	// MULTI_REGION_KEY_TYPE_REPLICA is a replica multi region key type
-	MultiRegionKeyType_MULTI_REGION_KEY_TYPE_REPLICA MultiRegionKeyType = 3
-)
-
-// Enum value maps for MultiRegionKeyType.
-var (
-	MultiRegionKeyType_name = map[int32]string{
-		0: "MULTI_REGION_KEY_TYPE_UNSPECIFIED",
-		1: "MULTI_REGION_KEY_TYPE_NONE",
-		2: "MULTI_REGION_KEY_TYPE_PRIMARY",
-		3: "MULTI_REGION_KEY_TYPE_REPLICA",
-	}
-	MultiRegionKeyType_value = map[string]int32{
-		"MULTI_REGION_KEY_TYPE_UNSPECIFIED": 0,
-		"MULTI_REGION_KEY_TYPE_NONE":        1,
-		"MULTI_REGION_KEY_TYPE_PRIMARY":     2,
-		"MULTI_REGION_KEY_TYPE_REPLICA":     3,
-	}
-)
-
-func (x MultiRegionKeyType) Enum() *MultiRegionKeyType {
-	p := new(MultiRegionKeyType)
-	*p = x
-	return p
-}
-
-func (x MultiRegionKeyType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (MultiRegionKeyType) Descriptor() protoreflect.EnumDescriptor {
-	return file_accessgraph_v1alpha_aws_proto_enumTypes[2].Descriptor()
-}
-
-func (MultiRegionKeyType) Type() protoreflect.EnumType {
-	return &file_accessgraph_v1alpha_aws_proto_enumTypes[2]
-}
-
-func (x MultiRegionKeyType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use MultiRegionKeyType.Descriptor instead.
-func (MultiRegionKeyType) EnumDescriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_aws_proto_rawDescGZIP(), []int{2}
-}
-
 // AWSResourceList is a list of AWS resources supported by the access graph.
 type AWSResourceList struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -3339,7 +3280,8 @@ type AWSKMSKeyV1 struct {
 	// region is the AWS region that the key belongs to.
 	Region string `protobuf:"bytes,8,opt,name=region,proto3" json:"region,omitempty"`
 	// multi_region_key_type is the type of the multi-region key.
-	MultiRegionKeyType MultiRegionKeyType `protobuf:"varint,9,opt,name=multi_region_key_type,json=multiRegionKeyType,proto3,enum=accessgraph.v1alpha.MultiRegionKeyType" json:"multi_region_key_type,omitempty"`
+	// It is set to "PRIMARY", "REPLICA" or left empty for single region keys.
+	MultiRegionKeyType string `protobuf:"bytes,9,opt,name=multi_region_key_type,json=multiRegionKeyType,proto3" json:"multi_region_key_type,omitempty"`
 	// hsm_cluster_id is the ID of the HSM cluster that the key belongs to, if any.
 	HsmClusterId  string `protobuf:"bytes,10,opt,name=hsm_cluster_id,json=hsmClusterId,proto3" json:"hsm_cluster_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -3432,11 +3374,11 @@ func (x *AWSKMSKeyV1) GetRegion() string {
 	return ""
 }
 
-func (x *AWSKMSKeyV1) GetMultiRegionKeyType() MultiRegionKeyType {
+func (x *AWSKMSKeyV1) GetMultiRegionKeyType() string {
 	if x != nil {
 		return x.MultiRegionKeyType
 	}
-	return MultiRegionKeyType_MULTI_REGION_KEY_TYPE_UNSPECIFIED
+	return ""
 }
 
 func (x *AWSKMSKeyV1) GetHsmClusterId() string {
@@ -3737,7 +3679,7 @@ const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	"client_ids\x18\x05 \x03(\tR\tclientIds\x12 \n" +
 	"\vthumbprints\x18\x06 \x03(\tR\vthumbprints\x12\x10\n" +
 	"\x03url\x18\a \x01(\tR\x03url\x12@\n" +
-	"\x0elast_sync_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\"\xc9\x03\n" +
+	"\x0elast_sync_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\"\xa0\x03\n" +
 	"\vAWSKMSKeyV1\x12\x10\n" +
 	"\x03arn\x18\x01 \x01(\tR\x03arn\x129\n" +
 	"\n" +
@@ -3748,8 +3690,8 @@ const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	"\x0elast_sync_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\x12\x18\n" +
 	"\aaliases\x18\x06 \x03(\tR\aaliases\x12'\n" +
 	"\x0fpolicy_document\x18\a \x01(\fR\x0epolicyDocument\x12\x16\n" +
-	"\x06region\x18\b \x01(\tR\x06region\x12Z\n" +
-	"\x15multi_region_key_type\x18\t \x01(\x0e2'.accessgraph.v1alpha.MultiRegionKeyTypeR\x12multiRegionKeyType\x12$\n" +
+	"\x06region\x18\b \x01(\tR\x06region\x121\n" +
+	"\x15multi_region_key_type\x18\t \x01(\tR\x12multiRegionKeyType\x12$\n" +
 	"\x0ehsm_cluster_id\x18\n" +
 	" \x01(\tR\fhsmClusterId*\x90\x01\n" +
 	"\x1cUsersPermissionsBoundaryType\x12/\n" +
@@ -3757,12 +3699,7 @@ const file_accessgraph_v1alpha_aws_proto_rawDesc = "" +
 	";USERS_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01*\x8d\x01\n" +
 	"\x1bRolePermissionsBoundaryType\x12.\n" +
 	"*ROLE_PERMISSIONS_BOUNDARY_TYPE_UNSPECIFIED\x10\x00\x12>\n" +
-	":ROLE_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01*\xa1\x01\n" +
-	"\x12MultiRegionKeyType\x12%\n" +
-	"!MULTI_REGION_KEY_TYPE_UNSPECIFIED\x10\x00\x12\x1e\n" +
-	"\x1aMULTI_REGION_KEY_TYPE_NONE\x10\x01\x12!\n" +
-	"\x1dMULTI_REGION_KEY_TYPE_PRIMARY\x10\x02\x12!\n" +
-	"\x1dMULTI_REGION_KEY_TYPE_REPLICA\x10\x03BWZUgithub.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alphab\x06proto3"
+	":ROLE_PERMISSIONS_BOUNDARY_TYPE_PERMISSIONS_BOUNDARY_POLICY\x10\x01BWZUgithub.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alphab\x06proto3"
 
 var (
 	file_accessgraph_v1alpha_aws_proto_rawDescOnce sync.Once
@@ -3776,156 +3713,154 @@ func file_accessgraph_v1alpha_aws_proto_rawDescGZIP() []byte {
 	return file_accessgraph_v1alpha_aws_proto_rawDescData
 }
 
-var file_accessgraph_v1alpha_aws_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_accessgraph_v1alpha_aws_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_accessgraph_v1alpha_aws_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_accessgraph_v1alpha_aws_proto_goTypes = []any{
 	(UsersPermissionsBoundaryType)(0),      // 0: accessgraph.v1alpha.UsersPermissionsBoundaryType
 	(RolePermissionsBoundaryType)(0),       // 1: accessgraph.v1alpha.RolePermissionsBoundaryType
-	(MultiRegionKeyType)(0),                // 2: accessgraph.v1alpha.MultiRegionKeyType
-	(*AWSResourceList)(nil),                // 3: accessgraph.v1alpha.AWSResourceList
-	(*AWSResource)(nil),                    // 4: accessgraph.v1alpha.AWSResource
-	(*AWSUserInlinePolicyV1)(nil),          // 5: accessgraph.v1alpha.AWSUserInlinePolicyV1
-	(*AWSPolicyV1)(nil),                    // 6: accessgraph.v1alpha.AWSPolicyV1
-	(*AWSGroupV1)(nil),                     // 7: accessgraph.v1alpha.AWSGroupV1
-	(*AWSUserGroupsV1)(nil),                // 8: accessgraph.v1alpha.AWSUserGroupsV1
-	(*AWSUserV1)(nil),                      // 9: accessgraph.v1alpha.AWSUserV1
-	(*AWSTag)(nil),                         // 10: accessgraph.v1alpha.AWSTag
-	(*UsersPermissionsBoundaryV1)(nil),     // 11: accessgraph.v1alpha.UsersPermissionsBoundaryV1
-	(*AWSInstanceV1)(nil),                  // 12: accessgraph.v1alpha.AWSInstanceV1
-	(*AWSUserAttachedPolicies)(nil),        // 13: accessgraph.v1alpha.AWSUserAttachedPolicies
-	(*AttachedPolicyV1)(nil),               // 14: accessgraph.v1alpha.AttachedPolicyV1
-	(*AWSGroupAttachedPolicies)(nil),       // 15: accessgraph.v1alpha.AWSGroupAttachedPolicies
-	(*AWSGroupInlinePolicyV1)(nil),         // 16: accessgraph.v1alpha.AWSGroupInlinePolicyV1
-	(*AWSS3BucketV1)(nil),                  // 17: accessgraph.v1alpha.AWSS3BucketV1
-	(*AWSS3BucketACL)(nil),                 // 18: accessgraph.v1alpha.AWSS3BucketACL
-	(*AWSS3BucketACLGrantee)(nil),          // 19: accessgraph.v1alpha.AWSS3BucketACLGrantee
-	(*AWSRoleV1)(nil),                      // 20: accessgraph.v1alpha.AWSRoleV1
-	(*RolePermissionsBoundaryV1)(nil),      // 21: accessgraph.v1alpha.RolePermissionsBoundaryV1
-	(*RoleLastUsedV1)(nil),                 // 22: accessgraph.v1alpha.RoleLastUsedV1
-	(*AWSRoleInlinePolicyV1)(nil),          // 23: accessgraph.v1alpha.AWSRoleInlinePolicyV1
-	(*AWSRoleAttachedPolicies)(nil),        // 24: accessgraph.v1alpha.AWSRoleAttachedPolicies
-	(*AWSInstanceProfileV1)(nil),           // 25: accessgraph.v1alpha.AWSInstanceProfileV1
-	(*AWSEKSClusterV1)(nil),                // 26: accessgraph.v1alpha.AWSEKSClusterV1
-	(*AWSEKSClusterAccessEntryV1)(nil),     // 27: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
-	(*AWSEKSAssociatedAccessPolicyV1)(nil), // 28: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
-	(*AWSEKSAccessScopeV1)(nil),            // 29: accessgraph.v1alpha.AWSEKSAccessScopeV1
-	(*AWSRDSDatabaseV1)(nil),               // 30: accessgraph.v1alpha.AWSRDSDatabaseV1
-	(*AWSRDSEngineV1)(nil),                 // 31: accessgraph.v1alpha.AWSRDSEngineV1
-	(*AWSSAMLProviderV1)(nil),              // 32: accessgraph.v1alpha.AWSSAMLProviderV1
-	(*AWSOIDCProviderV1)(nil),              // 33: accessgraph.v1alpha.AWSOIDCProviderV1
-	(*AWSKMSKeyV1)(nil),                    // 34: accessgraph.v1alpha.AWSKMSKeyV1
-	(*timestamppb.Timestamp)(nil),          // 35: google.protobuf.Timestamp
-	(*wrapperspb.StringValue)(nil),         // 36: google.protobuf.StringValue
-	(*durationpb.Duration)(nil),            // 37: google.protobuf.Duration
+	(*AWSResourceList)(nil),                // 2: accessgraph.v1alpha.AWSResourceList
+	(*AWSResource)(nil),                    // 3: accessgraph.v1alpha.AWSResource
+	(*AWSUserInlinePolicyV1)(nil),          // 4: accessgraph.v1alpha.AWSUserInlinePolicyV1
+	(*AWSPolicyV1)(nil),                    // 5: accessgraph.v1alpha.AWSPolicyV1
+	(*AWSGroupV1)(nil),                     // 6: accessgraph.v1alpha.AWSGroupV1
+	(*AWSUserGroupsV1)(nil),                // 7: accessgraph.v1alpha.AWSUserGroupsV1
+	(*AWSUserV1)(nil),                      // 8: accessgraph.v1alpha.AWSUserV1
+	(*AWSTag)(nil),                         // 9: accessgraph.v1alpha.AWSTag
+	(*UsersPermissionsBoundaryV1)(nil),     // 10: accessgraph.v1alpha.UsersPermissionsBoundaryV1
+	(*AWSInstanceV1)(nil),                  // 11: accessgraph.v1alpha.AWSInstanceV1
+	(*AWSUserAttachedPolicies)(nil),        // 12: accessgraph.v1alpha.AWSUserAttachedPolicies
+	(*AttachedPolicyV1)(nil),               // 13: accessgraph.v1alpha.AttachedPolicyV1
+	(*AWSGroupAttachedPolicies)(nil),       // 14: accessgraph.v1alpha.AWSGroupAttachedPolicies
+	(*AWSGroupInlinePolicyV1)(nil),         // 15: accessgraph.v1alpha.AWSGroupInlinePolicyV1
+	(*AWSS3BucketV1)(nil),                  // 16: accessgraph.v1alpha.AWSS3BucketV1
+	(*AWSS3BucketACL)(nil),                 // 17: accessgraph.v1alpha.AWSS3BucketACL
+	(*AWSS3BucketACLGrantee)(nil),          // 18: accessgraph.v1alpha.AWSS3BucketACLGrantee
+	(*AWSRoleV1)(nil),                      // 19: accessgraph.v1alpha.AWSRoleV1
+	(*RolePermissionsBoundaryV1)(nil),      // 20: accessgraph.v1alpha.RolePermissionsBoundaryV1
+	(*RoleLastUsedV1)(nil),                 // 21: accessgraph.v1alpha.RoleLastUsedV1
+	(*AWSRoleInlinePolicyV1)(nil),          // 22: accessgraph.v1alpha.AWSRoleInlinePolicyV1
+	(*AWSRoleAttachedPolicies)(nil),        // 23: accessgraph.v1alpha.AWSRoleAttachedPolicies
+	(*AWSInstanceProfileV1)(nil),           // 24: accessgraph.v1alpha.AWSInstanceProfileV1
+	(*AWSEKSClusterV1)(nil),                // 25: accessgraph.v1alpha.AWSEKSClusterV1
+	(*AWSEKSClusterAccessEntryV1)(nil),     // 26: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
+	(*AWSEKSAssociatedAccessPolicyV1)(nil), // 27: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
+	(*AWSEKSAccessScopeV1)(nil),            // 28: accessgraph.v1alpha.AWSEKSAccessScopeV1
+	(*AWSRDSDatabaseV1)(nil),               // 29: accessgraph.v1alpha.AWSRDSDatabaseV1
+	(*AWSRDSEngineV1)(nil),                 // 30: accessgraph.v1alpha.AWSRDSEngineV1
+	(*AWSSAMLProviderV1)(nil),              // 31: accessgraph.v1alpha.AWSSAMLProviderV1
+	(*AWSOIDCProviderV1)(nil),              // 32: accessgraph.v1alpha.AWSOIDCProviderV1
+	(*AWSKMSKeyV1)(nil),                    // 33: accessgraph.v1alpha.AWSKMSKeyV1
+	(*timestamppb.Timestamp)(nil),          // 34: google.protobuf.Timestamp
+	(*wrapperspb.StringValue)(nil),         // 35: google.protobuf.StringValue
+	(*durationpb.Duration)(nil),            // 36: google.protobuf.Duration
 }
 var file_accessgraph_v1alpha_aws_proto_depIdxs = []int32{
-	4,   // 0: accessgraph.v1alpha.AWSResourceList.resources:type_name -> accessgraph.v1alpha.AWSResource
-	9,   // 1: accessgraph.v1alpha.AWSResource.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	7,   // 2: accessgraph.v1alpha.AWSResource.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	5,   // 3: accessgraph.v1alpha.AWSResource.user_inline_policy:type_name -> accessgraph.v1alpha.AWSUserInlinePolicyV1
-	8,   // 4: accessgraph.v1alpha.AWSResource.user_groups:type_name -> accessgraph.v1alpha.AWSUserGroupsV1
-	12,  // 5: accessgraph.v1alpha.AWSResource.instance:type_name -> accessgraph.v1alpha.AWSInstanceV1
-	6,   // 6: accessgraph.v1alpha.AWSResource.policy:type_name -> accessgraph.v1alpha.AWSPolicyV1
-	13,  // 7: accessgraph.v1alpha.AWSResource.user_attached_policies:type_name -> accessgraph.v1alpha.AWSUserAttachedPolicies
-	15,  // 8: accessgraph.v1alpha.AWSResource.group_attached_policies:type_name -> accessgraph.v1alpha.AWSGroupAttachedPolicies
-	16,  // 9: accessgraph.v1alpha.AWSResource.group_inline_policy:type_name -> accessgraph.v1alpha.AWSGroupInlinePolicyV1
-	17,  // 10: accessgraph.v1alpha.AWSResource.s3_bucket:type_name -> accessgraph.v1alpha.AWSS3BucketV1
-	20,  // 11: accessgraph.v1alpha.AWSResource.role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	23,  // 12: accessgraph.v1alpha.AWSResource.role_inline_policy:type_name -> accessgraph.v1alpha.AWSRoleInlinePolicyV1
-	24,  // 13: accessgraph.v1alpha.AWSResource.role_attached_policies:type_name -> accessgraph.v1alpha.AWSRoleAttachedPolicies
-	25,  // 14: accessgraph.v1alpha.AWSResource.instance_profile:type_name -> accessgraph.v1alpha.AWSInstanceProfileV1
-	26,  // 15: accessgraph.v1alpha.AWSResource.eks_cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	27,  // 16: accessgraph.v1alpha.AWSResource.eks_cluster_access_entry:type_name -> accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
-	28,  // 17: accessgraph.v1alpha.AWSResource.eks_cluster_associated_policy:type_name -> accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
-	30,  // 18: accessgraph.v1alpha.AWSResource.rds:type_name -> accessgraph.v1alpha.AWSRDSDatabaseV1
-	32,  // 19: accessgraph.v1alpha.AWSResource.saml_provider:type_name -> accessgraph.v1alpha.AWSSAMLProviderV1
-	33,  // 20: accessgraph.v1alpha.AWSResource.oidc_provider:type_name -> accessgraph.v1alpha.AWSOIDCProviderV1
-	34,  // 21: accessgraph.v1alpha.AWSResource.kms_key:type_name -> accessgraph.v1alpha.AWSKMSKeyV1
-	9,   // 22: accessgraph.v1alpha.AWSUserInlinePolicyV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	35,  // 23: accessgraph.v1alpha.AWSUserInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 24: accessgraph.v1alpha.AWSPolicyV1.created_at:type_name -> google.protobuf.Timestamp
-	10,  // 25: accessgraph.v1alpha.AWSPolicyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 26: accessgraph.v1alpha.AWSPolicyV1.updated_at:type_name -> google.protobuf.Timestamp
-	35,  // 27: accessgraph.v1alpha.AWSPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 28: accessgraph.v1alpha.AWSGroupV1.created_at:type_name -> google.protobuf.Timestamp
-	35,  // 29: accessgraph.v1alpha.AWSGroupV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	9,   // 30: accessgraph.v1alpha.AWSUserGroupsV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	7,   // 31: accessgraph.v1alpha.AWSUserGroupsV1.groups:type_name -> accessgraph.v1alpha.AWSGroupV1
-	35,  // 32: accessgraph.v1alpha.AWSUserGroupsV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 33: accessgraph.v1alpha.AWSUserV1.created_at:type_name -> google.protobuf.Timestamp
-	35,  // 34: accessgraph.v1alpha.AWSUserV1.password_last_used:type_name -> google.protobuf.Timestamp
-	11,  // 35: accessgraph.v1alpha.AWSUserV1.permissions_boundary:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryV1
-	10,  // 36: accessgraph.v1alpha.AWSUserV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 37: accessgraph.v1alpha.AWSUserV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	36,  // 38: accessgraph.v1alpha.AWSTag.value:type_name -> google.protobuf.StringValue
+	3,   // 0: accessgraph.v1alpha.AWSResourceList.resources:type_name -> accessgraph.v1alpha.AWSResource
+	8,   // 1: accessgraph.v1alpha.AWSResource.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	6,   // 2: accessgraph.v1alpha.AWSResource.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	4,   // 3: accessgraph.v1alpha.AWSResource.user_inline_policy:type_name -> accessgraph.v1alpha.AWSUserInlinePolicyV1
+	7,   // 4: accessgraph.v1alpha.AWSResource.user_groups:type_name -> accessgraph.v1alpha.AWSUserGroupsV1
+	11,  // 5: accessgraph.v1alpha.AWSResource.instance:type_name -> accessgraph.v1alpha.AWSInstanceV1
+	5,   // 6: accessgraph.v1alpha.AWSResource.policy:type_name -> accessgraph.v1alpha.AWSPolicyV1
+	12,  // 7: accessgraph.v1alpha.AWSResource.user_attached_policies:type_name -> accessgraph.v1alpha.AWSUserAttachedPolicies
+	14,  // 8: accessgraph.v1alpha.AWSResource.group_attached_policies:type_name -> accessgraph.v1alpha.AWSGroupAttachedPolicies
+	15,  // 9: accessgraph.v1alpha.AWSResource.group_inline_policy:type_name -> accessgraph.v1alpha.AWSGroupInlinePolicyV1
+	16,  // 10: accessgraph.v1alpha.AWSResource.s3_bucket:type_name -> accessgraph.v1alpha.AWSS3BucketV1
+	19,  // 11: accessgraph.v1alpha.AWSResource.role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	22,  // 12: accessgraph.v1alpha.AWSResource.role_inline_policy:type_name -> accessgraph.v1alpha.AWSRoleInlinePolicyV1
+	23,  // 13: accessgraph.v1alpha.AWSResource.role_attached_policies:type_name -> accessgraph.v1alpha.AWSRoleAttachedPolicies
+	24,  // 14: accessgraph.v1alpha.AWSResource.instance_profile:type_name -> accessgraph.v1alpha.AWSInstanceProfileV1
+	25,  // 15: accessgraph.v1alpha.AWSResource.eks_cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	26,  // 16: accessgraph.v1alpha.AWSResource.eks_cluster_access_entry:type_name -> accessgraph.v1alpha.AWSEKSClusterAccessEntryV1
+	27,  // 17: accessgraph.v1alpha.AWSResource.eks_cluster_associated_policy:type_name -> accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1
+	29,  // 18: accessgraph.v1alpha.AWSResource.rds:type_name -> accessgraph.v1alpha.AWSRDSDatabaseV1
+	31,  // 19: accessgraph.v1alpha.AWSResource.saml_provider:type_name -> accessgraph.v1alpha.AWSSAMLProviderV1
+	32,  // 20: accessgraph.v1alpha.AWSResource.oidc_provider:type_name -> accessgraph.v1alpha.AWSOIDCProviderV1
+	33,  // 21: accessgraph.v1alpha.AWSResource.kms_key:type_name -> accessgraph.v1alpha.AWSKMSKeyV1
+	8,   // 22: accessgraph.v1alpha.AWSUserInlinePolicyV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	34,  // 23: accessgraph.v1alpha.AWSUserInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 24: accessgraph.v1alpha.AWSPolicyV1.created_at:type_name -> google.protobuf.Timestamp
+	9,   // 25: accessgraph.v1alpha.AWSPolicyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 26: accessgraph.v1alpha.AWSPolicyV1.updated_at:type_name -> google.protobuf.Timestamp
+	34,  // 27: accessgraph.v1alpha.AWSPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 28: accessgraph.v1alpha.AWSGroupV1.created_at:type_name -> google.protobuf.Timestamp
+	34,  // 29: accessgraph.v1alpha.AWSGroupV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	8,   // 30: accessgraph.v1alpha.AWSUserGroupsV1.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	6,   // 31: accessgraph.v1alpha.AWSUserGroupsV1.groups:type_name -> accessgraph.v1alpha.AWSGroupV1
+	34,  // 32: accessgraph.v1alpha.AWSUserGroupsV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 33: accessgraph.v1alpha.AWSUserV1.created_at:type_name -> google.protobuf.Timestamp
+	34,  // 34: accessgraph.v1alpha.AWSUserV1.password_last_used:type_name -> google.protobuf.Timestamp
+	10,  // 35: accessgraph.v1alpha.AWSUserV1.permissions_boundary:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryV1
+	9,   // 36: accessgraph.v1alpha.AWSUserV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 37: accessgraph.v1alpha.AWSUserV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	35,  // 38: accessgraph.v1alpha.AWSTag.value:type_name -> google.protobuf.StringValue
 	0,   // 39: accessgraph.v1alpha.UsersPermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.UsersPermissionsBoundaryType
-	35,  // 40: accessgraph.v1alpha.AWSInstanceV1.launch_time:type_name -> google.protobuf.Timestamp
-	10,  // 41: accessgraph.v1alpha.AWSInstanceV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	36,  // 42: accessgraph.v1alpha.AWSInstanceV1.iam_instance_profile_arn:type_name -> google.protobuf.StringValue
-	36,  // 43: accessgraph.v1alpha.AWSInstanceV1.launch_key_name:type_name -> google.protobuf.StringValue
-	35,  // 44: accessgraph.v1alpha.AWSInstanceV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	9,   // 45: accessgraph.v1alpha.AWSUserAttachedPolicies.user:type_name -> accessgraph.v1alpha.AWSUserV1
-	14,  // 46: accessgraph.v1alpha.AWSUserAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	35,  // 47: accessgraph.v1alpha.AWSUserAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	7,   // 48: accessgraph.v1alpha.AWSGroupAttachedPolicies.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	14,  // 49: accessgraph.v1alpha.AWSGroupAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	35,  // 50: accessgraph.v1alpha.AWSGroupAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	7,   // 51: accessgraph.v1alpha.AWSGroupInlinePolicyV1.group:type_name -> accessgraph.v1alpha.AWSGroupV1
-	35,  // 52: accessgraph.v1alpha.AWSGroupInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	18,  // 53: accessgraph.v1alpha.AWSS3BucketV1.acls:type_name -> accessgraph.v1alpha.AWSS3BucketACL
-	10,  // 54: accessgraph.v1alpha.AWSS3BucketV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 55: accessgraph.v1alpha.AWSS3BucketV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	19,  // 56: accessgraph.v1alpha.AWSS3BucketACL.grantee:type_name -> accessgraph.v1alpha.AWSS3BucketACLGrantee
-	35,  // 57: accessgraph.v1alpha.AWSRoleV1.created_at:type_name -> google.protobuf.Timestamp
-	37,  // 58: accessgraph.v1alpha.AWSRoleV1.max_session_duration:type_name -> google.protobuf.Duration
-	21,  // 59: accessgraph.v1alpha.AWSRoleV1.permissions_boundary:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryV1
-	10,  // 60: accessgraph.v1alpha.AWSRoleV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	22,  // 61: accessgraph.v1alpha.AWSRoleV1.role_last_used:type_name -> accessgraph.v1alpha.RoleLastUsedV1
-	35,  // 62: accessgraph.v1alpha.AWSRoleV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 40: accessgraph.v1alpha.AWSInstanceV1.launch_time:type_name -> google.protobuf.Timestamp
+	9,   // 41: accessgraph.v1alpha.AWSInstanceV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	35,  // 42: accessgraph.v1alpha.AWSInstanceV1.iam_instance_profile_arn:type_name -> google.protobuf.StringValue
+	35,  // 43: accessgraph.v1alpha.AWSInstanceV1.launch_key_name:type_name -> google.protobuf.StringValue
+	34,  // 44: accessgraph.v1alpha.AWSInstanceV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	8,   // 45: accessgraph.v1alpha.AWSUserAttachedPolicies.user:type_name -> accessgraph.v1alpha.AWSUserV1
+	13,  // 46: accessgraph.v1alpha.AWSUserAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	34,  // 47: accessgraph.v1alpha.AWSUserAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	6,   // 48: accessgraph.v1alpha.AWSGroupAttachedPolicies.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	13,  // 49: accessgraph.v1alpha.AWSGroupAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	34,  // 50: accessgraph.v1alpha.AWSGroupAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	6,   // 51: accessgraph.v1alpha.AWSGroupInlinePolicyV1.group:type_name -> accessgraph.v1alpha.AWSGroupV1
+	34,  // 52: accessgraph.v1alpha.AWSGroupInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	17,  // 53: accessgraph.v1alpha.AWSS3BucketV1.acls:type_name -> accessgraph.v1alpha.AWSS3BucketACL
+	9,   // 54: accessgraph.v1alpha.AWSS3BucketV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 55: accessgraph.v1alpha.AWSS3BucketV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	18,  // 56: accessgraph.v1alpha.AWSS3BucketACL.grantee:type_name -> accessgraph.v1alpha.AWSS3BucketACLGrantee
+	34,  // 57: accessgraph.v1alpha.AWSRoleV1.created_at:type_name -> google.protobuf.Timestamp
+	36,  // 58: accessgraph.v1alpha.AWSRoleV1.max_session_duration:type_name -> google.protobuf.Duration
+	20,  // 59: accessgraph.v1alpha.AWSRoleV1.permissions_boundary:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryV1
+	9,   // 60: accessgraph.v1alpha.AWSRoleV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	21,  // 61: accessgraph.v1alpha.AWSRoleV1.role_last_used:type_name -> accessgraph.v1alpha.RoleLastUsedV1
+	34,  // 62: accessgraph.v1alpha.AWSRoleV1.last_sync_time:type_name -> google.protobuf.Timestamp
 	1,   // 63: accessgraph.v1alpha.RolePermissionsBoundaryV1.permissions_boundary_type:type_name -> accessgraph.v1alpha.RolePermissionsBoundaryType
-	35,  // 64: accessgraph.v1alpha.RoleLastUsedV1.last_used_date:type_name -> google.protobuf.Timestamp
-	20,  // 65: accessgraph.v1alpha.AWSRoleInlinePolicyV1.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	35,  // 66: accessgraph.v1alpha.AWSRoleInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	14,  // 67: accessgraph.v1alpha.AWSRoleAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
-	20,  // 68: accessgraph.v1alpha.AWSRoleAttachedPolicies.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
-	35,  // 69: accessgraph.v1alpha.AWSRoleAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 70: accessgraph.v1alpha.AWSInstanceProfileV1.created_at:type_name -> google.protobuf.Timestamp
-	20,  // 71: accessgraph.v1alpha.AWSInstanceProfileV1.roles:type_name -> accessgraph.v1alpha.AWSRoleV1
-	10,  // 72: accessgraph.v1alpha.AWSInstanceProfileV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 73: accessgraph.v1alpha.AWSInstanceProfileV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 74: accessgraph.v1alpha.AWSEKSClusterV1.created_at:type_name -> google.protobuf.Timestamp
-	10,  // 75: accessgraph.v1alpha.AWSEKSClusterV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 76: accessgraph.v1alpha.AWSEKSClusterV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	26,  // 77: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	35,  // 78: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.created_at:type_name -> google.protobuf.Timestamp
-	35,  // 79: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.modified_at:type_name -> google.protobuf.Timestamp
-	10,  // 80: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 81: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	26,  // 82: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
-	29,  // 83: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.scope:type_name -> accessgraph.v1alpha.AWSEKSAccessScopeV1
-	35,  // 84: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.associated_at:type_name -> google.protobuf.Timestamp
-	35,  // 85: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.modified_at:type_name -> google.protobuf.Timestamp
-	35,  // 86: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	31,  // 87: accessgraph.v1alpha.AWSRDSDatabaseV1.engine_details:type_name -> accessgraph.v1alpha.AWSRDSEngineV1
-	35,  // 88: accessgraph.v1alpha.AWSRDSDatabaseV1.created_at:type_name -> google.protobuf.Timestamp
-	10,  // 89: accessgraph.v1alpha.AWSRDSDatabaseV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 90: accessgraph.v1alpha.AWSRDSDatabaseV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 91: accessgraph.v1alpha.AWSSAMLProviderV1.created_at:type_name -> google.protobuf.Timestamp
-	35,  // 92: accessgraph.v1alpha.AWSSAMLProviderV1.valid_until:type_name -> google.protobuf.Timestamp
-	10,  // 93: accessgraph.v1alpha.AWSSAMLProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 94: accessgraph.v1alpha.AWSSAMLProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 95: accessgraph.v1alpha.AWSOIDCProviderV1.created_at:type_name -> google.protobuf.Timestamp
-	10,  // 96: accessgraph.v1alpha.AWSOIDCProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 97: accessgraph.v1alpha.AWSOIDCProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	35,  // 98: accessgraph.v1alpha.AWSKMSKeyV1.created_at:type_name -> google.protobuf.Timestamp
-	10,  // 99: accessgraph.v1alpha.AWSKMSKeyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
-	35,  // 100: accessgraph.v1alpha.AWSKMSKeyV1.last_sync_time:type_name -> google.protobuf.Timestamp
-	2,   // 101: accessgraph.v1alpha.AWSKMSKeyV1.multi_region_key_type:type_name -> accessgraph.v1alpha.MultiRegionKeyType
-	102, // [102:102] is the sub-list for method output_type
-	102, // [102:102] is the sub-list for method input_type
-	102, // [102:102] is the sub-list for extension type_name
-	102, // [102:102] is the sub-list for extension extendee
-	0,   // [0:102] is the sub-list for field type_name
+	34,  // 64: accessgraph.v1alpha.RoleLastUsedV1.last_used_date:type_name -> google.protobuf.Timestamp
+	19,  // 65: accessgraph.v1alpha.AWSRoleInlinePolicyV1.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	34,  // 66: accessgraph.v1alpha.AWSRoleInlinePolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	13,  // 67: accessgraph.v1alpha.AWSRoleAttachedPolicies.policies:type_name -> accessgraph.v1alpha.AttachedPolicyV1
+	19,  // 68: accessgraph.v1alpha.AWSRoleAttachedPolicies.aws_role:type_name -> accessgraph.v1alpha.AWSRoleV1
+	34,  // 69: accessgraph.v1alpha.AWSRoleAttachedPolicies.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 70: accessgraph.v1alpha.AWSInstanceProfileV1.created_at:type_name -> google.protobuf.Timestamp
+	19,  // 71: accessgraph.v1alpha.AWSInstanceProfileV1.roles:type_name -> accessgraph.v1alpha.AWSRoleV1
+	9,   // 72: accessgraph.v1alpha.AWSInstanceProfileV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 73: accessgraph.v1alpha.AWSInstanceProfileV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 74: accessgraph.v1alpha.AWSEKSClusterV1.created_at:type_name -> google.protobuf.Timestamp
+	9,   // 75: accessgraph.v1alpha.AWSEKSClusterV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 76: accessgraph.v1alpha.AWSEKSClusterV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	25,  // 77: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	34,  // 78: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.created_at:type_name -> google.protobuf.Timestamp
+	34,  // 79: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.modified_at:type_name -> google.protobuf.Timestamp
+	9,   // 80: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 81: accessgraph.v1alpha.AWSEKSClusterAccessEntryV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	25,  // 82: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.cluster:type_name -> accessgraph.v1alpha.AWSEKSClusterV1
+	28,  // 83: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.scope:type_name -> accessgraph.v1alpha.AWSEKSAccessScopeV1
+	34,  // 84: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.associated_at:type_name -> google.protobuf.Timestamp
+	34,  // 85: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.modified_at:type_name -> google.protobuf.Timestamp
+	34,  // 86: accessgraph.v1alpha.AWSEKSAssociatedAccessPolicyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	30,  // 87: accessgraph.v1alpha.AWSRDSDatabaseV1.engine_details:type_name -> accessgraph.v1alpha.AWSRDSEngineV1
+	34,  // 88: accessgraph.v1alpha.AWSRDSDatabaseV1.created_at:type_name -> google.protobuf.Timestamp
+	9,   // 89: accessgraph.v1alpha.AWSRDSDatabaseV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 90: accessgraph.v1alpha.AWSRDSDatabaseV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 91: accessgraph.v1alpha.AWSSAMLProviderV1.created_at:type_name -> google.protobuf.Timestamp
+	34,  // 92: accessgraph.v1alpha.AWSSAMLProviderV1.valid_until:type_name -> google.protobuf.Timestamp
+	9,   // 93: accessgraph.v1alpha.AWSSAMLProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 94: accessgraph.v1alpha.AWSSAMLProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 95: accessgraph.v1alpha.AWSOIDCProviderV1.created_at:type_name -> google.protobuf.Timestamp
+	9,   // 96: accessgraph.v1alpha.AWSOIDCProviderV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 97: accessgraph.v1alpha.AWSOIDCProviderV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	34,  // 98: accessgraph.v1alpha.AWSKMSKeyV1.created_at:type_name -> google.protobuf.Timestamp
+	9,   // 99: accessgraph.v1alpha.AWSKMSKeyV1.tags:type_name -> accessgraph.v1alpha.AWSTag
+	34,  // 100: accessgraph.v1alpha.AWSKMSKeyV1.last_sync_time:type_name -> google.protobuf.Timestamp
+	101, // [101:101] is the sub-list for method output_type
+	101, // [101:101] is the sub-list for method input_type
+	101, // [101:101] is the sub-list for extension type_name
+	101, // [101:101] is the sub-list for extension extendee
+	0,   // [0:101] is the sub-list for field type_name
 }
 
 func init() { file_accessgraph_v1alpha_aws_proto_init() }
@@ -3961,7 +3896,7 @@ func file_accessgraph_v1alpha_aws_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_accessgraph_v1alpha_aws_proto_rawDesc), len(file_accessgraph_v1alpha_aws_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      2,
 			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -434,6 +434,8 @@ func StatementAccessGraphAWSSync() *Statement {
 			"iam:GetOpenIDConnectProvider",
 
 			// KMS IAM
+			// If keys disallow IAM policy delegations, these fields need to be
+			// added to the Key policy.
 			"kms:ListKeys",
 			"kms:DescribeKey",
 			"kms:GetKeyPolicy",

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -256,7 +256,7 @@ type ExternalAuditStoragePolicyConfig struct {
 	AthenaWorkgroupName string
 	// GlueDatabaseName is the name of the AWS Glue database.
 	GlueDatabaseName string
-	// GlueTabelName is the name of the AWS Glue table.
+	// GlueTableName is the name of the AWS Glue table.
 	GlueTableName string
 }
 
@@ -432,6 +432,13 @@ func StatementAccessGraphAWSSync() *Statement {
 			"iam:GetSAMLProvider",
 			"iam:ListOpenIDConnectProviders",
 			"iam:GetOpenIDConnectProvider",
+
+			// KMS IAM
+			"kms:ListKeys",
+			"kms:DescribeKey",
+			"kms:GetKeyPolicy",
+			"kms:ListAliases",
+			"kms:ListResourceTags",
 		},
 		Resources: allResources,
 	}

--- a/lib/cloud/mocks/aws_kms.go
+++ b/lib/cloud/mocks/aws_kms.go
@@ -1,0 +1,138 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+type KMSClient struct {
+	Keys        map[string]KMSOutput
+	ListKeysErr error
+}
+
+type KMSOutput struct {
+	ARN          string
+	Aliases      []string
+	CreationDate time.Time
+	HSMClusterID string
+	MultiType    types.MultiRegionKeyType
+	Tags         map[string]string
+	Policy       string
+
+	DescribeKeyErr error
+	TagsErr        error
+	AliasesErr     error
+	PolicyErr      error
+}
+
+func (c *KMSClient) ListKeys(_ context.Context, input *kms.ListKeysInput, _ ...func(*kms.Options)) (*kms.ListKeysOutput, error) {
+	if c.ListKeysErr != nil {
+		return nil, c.ListKeysErr
+	}
+	keyIDs := slices.Collect(maps.Keys(c.Keys))
+	slices.Sort(keyIDs)
+	keys := make([]types.KeyListEntry, len(keyIDs))
+	for i, keyID := range keyIDs {
+		keys[i] = types.KeyListEntry{KeyId: &keyID}
+	}
+	return &kms.ListKeysOutput{Keys: keys}, nil
+}
+
+func (c *KMSClient) ListResourceTags(ctx context.Context, input *kms.ListResourceTagsInput, optFns ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error) {
+	key, ok := c.Keys[*input.KeyId]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found to list tags", *input.KeyId)
+	}
+	if key.TagsErr != nil {
+		return nil, key.TagsErr
+	}
+	tags := make([]types.Tag, 0, len(key.Tags))
+	for key, val := range key.Tags {
+		tag := types.Tag{
+			TagKey:   &key,
+			TagValue: &val,
+		}
+		tags = append(tags, tag)
+	}
+	return &kms.ListResourceTagsOutput{Tags: tags}, nil
+}
+
+func (c *KMSClient) ListAliases(ctx context.Context, input *kms.ListAliasesInput, optFns ...func(*kms.Options)) (*kms.ListAliasesOutput, error) {
+	key, ok := c.Keys[*input.KeyId]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found to list aliases", *input.KeyId)
+	}
+	if key.AliasesErr != nil {
+		return nil, key.AliasesErr
+	}
+	aliases := make([]types.AliasListEntry, len(key.Aliases))
+	for i, alias := range key.Aliases {
+		aliases[i] = types.AliasListEntry{AliasName: &alias}
+	}
+	return &kms.ListAliasesOutput{Aliases: aliases}, nil
+}
+
+func (c *KMSClient) DescribeKey(ctx context.Context, input *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	key, ok := c.Keys[*input.KeyId]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found to describe", *input.KeyId)
+	}
+	if key.DescribeKeyErr != nil {
+		return nil, key.DescribeKeyErr
+	}
+	var multiRegionConfig *types.MultiRegionConfiguration
+	var hsmClusterID *string
+	if key.HSMClusterID != "" {
+		hsmClusterID = &key.HSMClusterID
+	}
+	if key.MultiType != "" {
+		multiRegionConfig = &types.MultiRegionConfiguration{
+			MultiRegionKeyType: key.MultiType,
+		}
+	}
+	output := &kms.DescribeKeyOutput{
+		KeyMetadata: &types.KeyMetadata{
+			Arn:                      &key.ARN,
+			KeyId:                    input.KeyId,
+			CreationDate:             &key.CreationDate,
+			CloudHsmClusterId:        hsmClusterID,
+			MultiRegionConfiguration: multiRegionConfig,
+		},
+	}
+	return output, nil
+}
+
+func (c *KMSClient) GetKeyPolicy(ctx context.Context, input *kms.GetKeyPolicyInput, optFns ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error) {
+	key, ok := c.Keys[*input.KeyId]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found to get policy", *input.KeyId)
+	}
+	if key.PolicyErr != nil {
+		return nil, key.PolicyErr
+	}
+	return &kms.GetKeyPolicyOutput{Policy: &key.Policy}, nil
+}

--- a/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigOuput.golden
+++ b/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigOuput.golden
@@ -55,7 +55,12 @@ PutRolePolicy: {
                     "iam:ListSAMLProviders",
                     "iam:GetSAMLProvider",
                     "iam:ListOpenIDConnectProviders",
-                    "iam:GetOpenIDConnectProvider"
+                    "iam:GetOpenIDConnectProvider",
+                    "kms:ListKeys",
+                    "kms:DescribeKey",
+                    "kms:GetKeyPolicy",
+                    "kms:ListAliases",
+                    "kms:ListResourceTags"
                 ],
                 "Resource": "*"
             }

--- a/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
+++ b/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
@@ -55,7 +55,12 @@ PutRolePolicy: {
                     "iam:ListSAMLProviders",
                     "iam:GetSAMLProvider",
                     "iam:ListOpenIDConnectProviders",
-                    "iam:GetOpenIDConnectProvider"
+                    "iam:GetOpenIDConnectProvider",
+                    "kms:ListKeys",
+                    "kms:DescribeKey",
+                    "kms:GetKeyPolicy",
+                    "kms:ListAliases",
+                    "kms:ListResourceTags"
                 ],
                 "Resource": "*"
             },

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -530,7 +530,7 @@ func (s *Server) initTAGAWSWatchers(ctx context.Context, cfg *Config) error {
 				// We will wait for the config to change and re-evaluate the fetchers
 				// before starting the sync.
 				if len(allFetchers) == 0 {
-					s.Log.DebugContext(ctx, "No AWS sync fetchers with trail enabled configured. Access graph sync will not be enabled.")
+					s.Log.DebugContext(ctx, "No AWS sync fetchers with CloudTrail configured. Access graph sync will not be enabled.")
 					select {
 					case <-ctx.Done():
 						return

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -498,7 +498,7 @@ func (s *Server) initTAGAWSWatchers(ctx context.Context, cfg *Config) error {
 				// We will wait for the config to change and re-evaluate the fetchers
 				// before starting the sync.
 				if len(allFetchers) == 0 {
-					s.Log.DebugContext(ctx, "No AWS sync fetchers configured. Access graph sync will not be enabled.")
+					s.Log.DebugContext(ctx, "No AWS sync fetchers without CloudTrail configured. Access graph sync without CloudTrail will will not be enabled.")
 					select {
 					case <-ctx.Done():
 						return
@@ -530,7 +530,7 @@ func (s *Server) initTAGAWSWatchers(ctx context.Context, cfg *Config) error {
 				// We will wait for the config to change and re-evaluate the fetchers
 				// before starting the sync.
 				if len(allFetchers) == 0 {
-					s.Log.DebugContext(ctx, "No AWS sync fetchers with CloudTrail configured. Access graph sync will not be enabled.")
+					s.Log.DebugContext(ctx, "No AWS sync fetchers with CloudTrail configured. Access graph sync with CloudTrail will not be enabled.")
 					select {
 					case <-ctx.Done():
 						return

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -530,7 +530,7 @@ func (s *Server) initTAGAWSWatchers(ctx context.Context, cfg *Config) error {
 				// We will wait for the config to change and re-evaluate the fetchers
 				// before starting the sync.
 				if len(allFetchers) == 0 {
-					s.Log.DebugContext(ctx, "No AWS sync fetchers configured. Access graph sync will not be enabled.")
+					s.Log.DebugContext(ctx, "No AWS sync fetchers with trail enabled configured. Access graph sync will not be enabled.")
 					select {
 					case <-ctx.Done():
 						return

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -119,6 +120,8 @@ type awsClientProvider interface {
 	getS3Client(cfg aws.Config, optFns ...func(*s3.Options)) s3Client
 	// getSTSClient provides an [stsClient].
 	getSTSClient(cfg aws.Config, optFns ...func(*sts.Options)) stsClient
+	// getKMSClient provides a [kmsClient].
+	getKMSClient(cfg aws.Config, optFns ...func(*kms.Options)) kmsClient
 }
 
 type defaultAWSClients struct{}
@@ -137,6 +140,10 @@ func (defaultAWSClients) getS3Client(cfg aws.Config, optFns ...func(*s3.Options)
 
 func (defaultAWSClients) getSTSClient(cfg aws.Config, optFns ...func(*sts.Options)) stsClient {
 	return stsutils.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) getKMSClient(cfg aws.Config, optFns ...func(*kms.Options)) kmsClient {
+	return kms.NewFromConfig(cfg, optFns...)
 }
 
 // AssumeRole is the configuration for assuming an AWS role.
@@ -201,6 +208,8 @@ type Resources struct {
 	SAMLProviders []*accessgraphv1alpha.AWSSAMLProviderV1
 	// OIDCProviders is a list of OIDC providers.
 	OIDCProviders []*accessgraphv1alpha.AWSOIDCProviderV1
+	// KMSKeys is a list of KMS keys.
+	KMSKeys []*accessgraphv1alpha.AWSKMSKeyV1
 }
 
 func (r *Resources) count() int {
@@ -356,6 +365,11 @@ func (a *Fetcher) poll(ctx context.Context, features Features) (*Resources, erro
 	if features.IDP {
 		eGroup.Go(a.pollAWSSAMLProviders(ctx, result, collectErr))
 		eGroup.Go(a.pollAWSOIDCProviders(ctx, result, collectErr))
+	}
+
+	// fetch AWS KMS keys, including HSM keys
+	if features.KMS {
+		eGroup.Go(a.pollAWSKMSKeys(ctx, result, collectErr))
 	}
 
 	if err := eGroup.Wait(); err != nil {

--- a/lib/srv/discovery/fetchers/aws-sync/features.go
+++ b/lib/srv/discovery/fetchers/aws-sync/features.go
@@ -28,6 +28,7 @@ const (
 	awsS3        = awsNamespace + "/" + "s3"
 	awsRoles     = awsNamespace + "/" + "roles"
 	awsIDP       = awsNamespace + "/" + "idp"
+	awsKMS       = awsNamespace + "/" + "kms"
 )
 
 // Features is the list of supported resources by the server.
@@ -48,6 +49,8 @@ type Features struct {
 	S3 bool
 	// IDP enables sync of AWS IAM identity providers.
 	IDP bool
+	// KMS enables AWS KMS sync.
+	KMS bool
 }
 
 // BuildFeatures builds the feature flags based on supported types returned by Access Graph
@@ -72,6 +75,8 @@ func BuildFeatures(values ...string) Features {
 			features.Roles = true
 		case awsIDP:
 			features.IDP = true
+		case awsKMS:
+			features.KMS = true
 		}
 	}
 	return features

--- a/lib/srv/discovery/fetchers/aws-sync/kms.go
+++ b/lib/srv/discovery/fetchers/aws-sync/kms.go
@@ -1,0 +1,214 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+)
+
+type kmsClient interface {
+	kms.ListKeysAPIClient
+	kms.ListResourceTagsAPIClient
+	kms.ListAliasesAPIClient
+	DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+	GetKeyPolicy(ctx context.Context, params *kms.GetKeyPolicyInput, optFns ...func(*kms.Options)) (*kms.GetKeyPolicyOutput, error)
+}
+
+// pollAWSKMSKeys is a function that returns a function that fetches
+// AWS KMS keys and their inline and attached policies.
+func (a *Fetcher) pollAWSKMSKeys(ctx context.Context, result *Resources, collectErr func(error)) func() error {
+	return func() error {
+		var err error
+		result.KMSKeys, err = a.fetchKMSKeys(ctx)
+		if err != nil {
+			collectErr(trace.Wrap(err, "failed to fetch kms"))
+		}
+		return nil
+	}
+}
+
+func (a *Fetcher) fetchKMSKeys(ctx context.Context) ([]*pb.AWSKMSKeyV1, error) {
+	var keys []*pb.AWSKMSKeyV1
+	var errs []error
+	var mu sync.Mutex
+
+	collectKeys := func(nextKeys []*pb.AWSKMSKeyV1, nextErrs ...error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(nextErrs) > 0 {
+			errs = append(errs, nextErrs...)
+		}
+		if nextKeys != nil {
+			keys = append(keys, nextKeys...)
+		}
+	}
+
+	errGroup := errgroup.Group{}
+	// Set the limit to 5 to avoid too many concurrent requests.
+	// This is a temporary solution until we have a better way to limit the
+	// number of concurrent requests.
+	errGroup.SetLimit(5)
+
+	for _, region := range a.Regions {
+		errGroup.Go(func() error {
+			awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, region, a.getAWSOptions()...)
+			if err != nil {
+				collectKeys(nil, trace.Wrap(err))
+				return nil
+			}
+			client := a.awsClients.getKMSClient(awsCfg)
+			a.collectKMSKeys(ctx, client, collectKeys, region)
+			return nil
+		})
+	}
+
+	err := errGroup.Wait()
+	return keys, trace.NewAggregate(append(errs, err)...)
+}
+
+type kmsKeyCollector func(newKeys []*pb.AWSKMSKeyV1, errs ...error)
+
+func (a *Fetcher) collectKMSKeys(ctx context.Context, client kmsClient, collectKeys kmsKeyCollector, region string) {
+	input := &kms.ListKeysInput{}
+	opt := func(opt *kms.ListKeysPaginatorOptions) { opt.StopOnDuplicateToken = true }
+	pager := kms.NewListKeysPaginator(client, input, opt)
+
+	var keys []*pb.AWSKMSKeyV1
+	var errs []error
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			collectKeys(nil, trace.Wrap(err))
+			return
+		}
+		for _, key := range page.Keys {
+			key, err := a.fetchKMSKey(ctx, client, key.KeyId, region)
+			if err != nil {
+				collectKeys(nil, err)
+			}
+			if key != nil {
+				keys = append(keys, key)
+			}
+		}
+	}
+	collectKeys(keys, errs...)
+}
+
+func (a *Fetcher) fetchKMSKey(ctx context.Context, client kmsClient, keyID *string, region string) (*pb.AWSKMSKeyV1, error) {
+	input := &kms.DescribeKeyInput{KeyId: keyID}
+	output, err := client.DescribeKey(ctx, input)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to describe KMS key %q", *keyID)
+	}
+	var errs []error
+	result := awsToProtoKMSKey(output, a.AccountID, region)
+	result.Tags, err = getTags(ctx, client, keyID)
+	if err != nil {
+		errs = append(errs, trace.Wrap(err, "cannot fetch tags for KMS key %q", *keyID))
+	}
+	result.Aliases, err = getAliases(ctx, client, keyID)
+	if err != nil {
+		errs = append(errs, trace.Wrap(err, "cannot fetch aliases for KMS key %q", *keyID))
+	}
+	result.PolicyDocument, err = getPolicy(ctx, client, keyID)
+	if err != nil {
+		errs = append(errs, trace.Wrap(err, "cannot fetch policy for KMS key %q", *keyID))
+	}
+	if len(errs) > 0 {
+		return result, trace.NewAggregate(errs...)
+	}
+	return result, nil
+}
+
+func awsToProtoKMSKey(output *kms.DescribeKeyOutput, accountID, region string) *pb.AWSKMSKeyV1 {
+	var multiRegionType pb.MultiRegionKeyType
+	cfg := output.KeyMetadata.MultiRegionConfiguration
+	switch {
+	case cfg == nil:
+		multiRegionType = pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_NONE // single region
+	case cfg.MultiRegionKeyType == types.MultiRegionKeyTypePrimary:
+		multiRegionType = pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_PRIMARY
+	case cfg.MultiRegionKeyType == types.MultiRegionKeyTypeReplica:
+		multiRegionType = pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_REPLICA
+	}
+	return &pb.AWSKMSKeyV1{
+		Arn:                aws.ToString(output.KeyMetadata.Arn),
+		CreatedAt:          awsTimeToProtoTime(output.KeyMetadata.CreationDate),
+		Region:             region,
+		AccountId:          accountID,
+		LastSyncTime:       timestamppb.Now(),
+		HsmClusterId:       aws.ToString(output.KeyMetadata.CloudHsmClusterId),
+		MultiRegionKeyType: multiRegionType,
+	}
+}
+
+func getTags(ctx context.Context, client kmsClient, keyID *string) ([]*pb.AWSTag, error) {
+	input := &kms.ListResourceTagsInput{KeyId: keyID}
+	pager := kms.NewListResourceTagsPaginator(client, input)
+	var tags []*pb.AWSTag
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to list tags for key %s", aws.ToString(keyID))
+		}
+		for _, t := range page.Tags {
+			tag := &pb.AWSTag{
+				Key:   aws.ToString(t.TagKey),
+				Value: strPtrToWrapper(t.TagValue),
+			}
+			tags = append(tags, tag)
+		}
+	}
+	return tags, nil
+}
+
+func getAliases(ctx context.Context, client kmsClient, keyID *string) ([]string, error) {
+	input := &kms.ListAliasesInput{KeyId: keyID}
+	pager := kms.NewListAliasesPaginator(client, input)
+	var aliases []string
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to list aliases for key %s", aws.ToString(keyID))
+		}
+		for _, alias := range page.Aliases {
+			aliases = append(aliases, aws.ToString(alias.AliasName))
+		}
+	}
+	return aliases, nil
+}
+
+func getPolicy(ctx context.Context, client kmsClient, keyID *string) ([]byte, error) {
+	input := &kms.GetKeyPolicyInput{KeyId: keyID}
+	output, err := client.GetKeyPolicy(ctx, input)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to get key policy for key %s", aws.ToString(keyID))
+	}
+	return []byte(aws.ToString(output.Policy)), nil
+}

--- a/lib/srv/discovery/fetchers/aws-sync/kms_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/kms_test.go
@@ -1,0 +1,235 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws_sync
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	pb "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
+	"github.com/gravitational/teleport/lib/cloud/mocks"
+)
+
+var kmsTests = []struct {
+	name       string
+	mockOutput map[string]mocks.KMSOutput
+	mockError  error
+}{
+	{
+		name: "single, simple key",
+		mockOutput: map[string]mocks.KMSOutput{
+			"key1": {
+				ARN:          "arn1",
+				CreationDate: time.Now(),
+			},
+		},
+	},
+	{
+		name: "key with tags, policy, multiple regions, aliases, hsm cluster",
+		mockOutput: map[string]mocks.KMSOutput{
+			"key1": {
+				ARN:          "arn1",
+				CreationDate: time.Now(),
+				Tags:         map[string]string{"key1": "value1"},
+				Policy:       "policy1",
+				Aliases:      []string{"alias1"},
+				MultiType:    types.MultiRegionKeyTypePrimary,
+				HSMClusterID: "hsm-cluster1",
+			},
+		},
+	},
+	{
+		name: "multiple keys",
+		mockOutput: map[string]mocks.KMSOutput{
+			"key1": {
+				ARN:          "arn1",
+				CreationDate: time.Now(),
+				Tags:         map[string]string{"key1": "value1"},
+				Policy:       "policy1",
+				Aliases:      []string{"alias1"},
+			},
+			"key2": {
+				ARN:          "arn2",
+				CreationDate: time.Now(),
+				MultiType:    types.MultiRegionKeyTypeReplica,
+				HSMClusterID: "hsm-cluster2",
+			},
+			"key3": {
+				ARN:          "arn3",
+				CreationDate: time.Now(),
+				HSMClusterID: "hsm-cluster3",
+			},
+		},
+	},
+	{
+		name:      "error listing keys",
+		mockError: errors.New("mock error"),
+	},
+	{
+		name: "multiple key errors",
+		mockOutput: map[string]mocks.KMSOutput{
+			"key1": {
+				ARN:          "arn1",
+				CreationDate: time.Now(),
+				Tags:         map[string]string{"key1": "value1"},
+				Policy:       "policy1",
+				Aliases:      []string{"alias1"},
+
+				DescribeKeyErr: errors.New("describeKey"),
+			},
+			"key2": {
+				ARN:          "arn2",
+				CreationDate: time.Now(),
+				MultiType:    types.MultiRegionKeyTypeReplica,
+				HSMClusterID: "hsm-cluster2",
+
+				TagsErr: errors.New("tags"),
+			},
+			"key3": {
+				ARN:          "arn3",
+				CreationDate: time.Now(),
+				HSMClusterID: "hsm-cluster3",
+
+				AliasesErr: errors.New("aliases"),
+			},
+			"key4": {
+				ARN:          "arn4",
+				CreationDate: time.Now(),
+				HSMClusterID: "hsm-cluster3",
+				Aliases:      []string{"alias1"},
+
+				PolicyErr: errors.New("policy"),
+			},
+		},
+	},
+}
+
+func TestPollAWSKMS(t *testing.T) {
+	const accountID = "12345678"
+	var regions = []string{"us-west-2"}
+	fetcherConfig := Config{
+		AccountID:         accountID,
+		Regions:           regions,
+		AWSConfigProvider: &mocks.AWSConfigProvider{},
+	}
+
+	for _, tt := range kmsTests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetcher := &Fetcher{Config: fetcherConfig}
+			kmsClient := &mocks.KMSClient{Keys: tt.mockOutput, ListKeysErr: tt.mockError}
+			fetcher.awsClients = fakeAWSClients{kmsClient: kmsClient}
+			got := &Resources{}
+			var gotErr error
+			collectErr := func(err error) { gotErr = err }
+			pollFn := fetcher.pollAWSKMSKeys(context.Background(), got, collectErr)
+			err := pollFn()
+			require.NoError(t, err)
+			want, wantErr := kmsMockToProto(kmsClient, accountID, regions[0])
+			requireResourceEqual(t, want, got)
+			requireAggregateErrorEqual(t, wantErr, gotErr)
+		})
+	}
+}
+
+func requireResourceEqual(t *testing.T, want, got *Resources) {
+	tagCmp := func(a, b *pb.AWSTag) bool {
+		return a.Key < b.Key
+	}
+	opts := []cmp.Option{
+		protocmp.Transform(),
+		protocmp.SortRepeated(tagCmp),
+		protocmp.IgnoreFields(&pb.AWSKMSKeyV1{}, "last_sync_time"),
+	}
+	require.Empty(t, cmp.Diff(want, got, opts...))
+}
+
+func requireAggregateErrorEqual(t *testing.T, want, got error) {
+	if want == nil {
+		require.NoError(t, got)
+		return
+	}
+	require.Error(t, got)
+	var wantAggregate, gotAggregate trace.Aggregate
+	require.ErrorAs(t, want, &wantAggregate)
+	require.ErrorAs(t, got, &gotAggregate)
+	wantLen := len(wantAggregate.Errors())
+	require.Len(t, gotAggregate.Errors(), wantLen)
+}
+
+func kmsMockToProto(c *mocks.KMSClient, accountID, region string) (*Resources, error) {
+	var errs []error
+	if c.ListKeysErr != nil {
+		return &Resources{}, trace.NewAggregate(c.ListKeysErr)
+	}
+
+	keyIDs := slices.Collect(maps.Keys(c.Keys))
+	slices.Sort(keyIDs)
+	var keys []*pb.AWSKMSKeyV1
+
+	for _, keyID := range keyIDs {
+		k, ok := c.Keys[keyID]
+		if !ok {
+			errs = append(errs, trace.Errorf("key %q not found", keyID))
+			continue
+		}
+		if k.DescribeKeyErr != nil {
+			errs = append(errs, k.DescribeKeyErr)
+			continue
+		}
+		var tags []*pb.AWSTag
+		for key, val := range k.Tags {
+			tag := &pb.AWSTag{Key: key, Value: wrapperspb.String(val)}
+			tags = append(tags, tag)
+		}
+		multiRegionKeyType := pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_NONE
+		switch k.MultiType {
+		case types.MultiRegionKeyTypePrimary:
+			multiRegionKeyType = pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_PRIMARY
+		case types.MultiRegionKeyTypeReplica:
+			multiRegionKeyType = pb.MultiRegionKeyType_MULTI_REGION_KEY_TYPE_REPLICA
+		}
+
+		key := &pb.AWSKMSKeyV1{
+			Arn:                k.ARN,
+			CreatedAt:          timestamppb.New(k.CreationDate),
+			AccountId:          accountID,
+			Region:             region,
+			HsmClusterId:       k.HSMClusterID,
+			PolicyDocument:     []byte(k.Policy),
+			Aliases:            k.Aliases,
+			Tags:               tags,
+			MultiRegionKeyType: multiRegionKeyType,
+		}
+		keys = append(keys, key)
+		errs = append(errs, k.DescribeKeyErr, k.TagsErr, k.AliasesErr, k.PolicyErr)
+	}
+	return &Resources{KMSKeys: keys}, trace.NewAggregate(errs...)
+}

--- a/lib/srv/discovery/fetchers/aws-sync/merge.go
+++ b/lib/srv/discovery/fetchers/aws-sync/merge.go
@@ -51,6 +51,7 @@ func MergeResources(results ...*Resources) *Resources {
 		result.RDSDatabases = append(result.RDSDatabases, r.RDSDatabases...)
 		result.SAMLProviders = append(result.SAMLProviders, r.SAMLProviders...)
 		result.OIDCProviders = append(result.OIDCProviders, r.OIDCProviders...)
+		result.KMSKeys = append(result.KMSKeys, r.KMSKeys...)
 	}
 
 	deduplicateResources(result)
@@ -78,4 +79,5 @@ func deduplicateResources(result *Resources) {
 	result.RDSDatabases = deduplicateSlice(result.RDSDatabases, rdsDbKey)
 	result.SAMLProviders = deduplicateSlice(result.SAMLProviders, samlProvKey)
 	result.OIDCProviders = deduplicateSlice(result.OIDCProviders, oidcProvKey)
+	result.KMSKeys = deduplicateSlice(result.KMSKeys, kmsKeyKey)
 }

--- a/lib/srv/discovery/fetchers/aws-sync/rds_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -223,6 +224,7 @@ type fakeAWSClients struct {
 	rdsClient rdsClient
 	s3Client  s3Client
 	stsClient stsClient
+	kmsClient kmsClient
 }
 
 func (f fakeAWSClients) getIAMClient(cfg aws.Config, optFns ...func(*iam.Options)) iamClient {
@@ -239,4 +241,8 @@ func (f fakeAWSClients) getS3Client(cfg aws.Config, optFns ...func(*s3.Options))
 
 func (f fakeAWSClients) getSTSClient(cfg aws.Config, optFns ...func(*sts.Options)) stsClient {
 	return f.stsClient
+}
+
+func (f fakeAWSClients) getKMSClient(cfg aws.Config, optFns ...func(*kms.Options)) kmsClient {
+	return f.kmsClient
 }

--- a/lib/srv/discovery/fetchers/aws-sync/reconcile.go
+++ b/lib/srv/discovery/fetchers/aws-sync/reconcile.go
@@ -59,6 +59,7 @@ func ReconcileResults(old *Resources, new *Resources) (upsert, delete *accessgra
 		reconcile(old.RDSDatabases, new.RDSDatabases, rdsDbKey, rdsDbWrap),
 		reconcile(old.SAMLProviders, new.SAMLProviders, samlProvKey, samlProvWrap),
 		reconcile(old.OIDCProviders, new.OIDCProviders, oidcProvKey, oidcProvWrap),
+		reconcile(old.KMSKeys, new.KMSKeys, kmsKeyKey, kmsKeyWrap),
 	}
 	for _, res := range reconciledResources {
 		upsert.Resources = append(upsert.Resources, res.upsert.Resources...)
@@ -295,4 +296,12 @@ func oidcProvKey(provider *accessgraphv1alpha.AWSOIDCProviderV1) string {
 
 func oidcProvWrap(provider *accessgraphv1alpha.AWSOIDCProviderV1) *accessgraphv1alpha.AWSResource {
 	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_OidcProvider{OidcProvider: provider}}
+}
+
+func kmsKeyKey(key *accessgraphv1alpha.AWSKMSKeyV1) string {
+	return fmt.Sprintf("%s;%s", key.AccountId, key.Arn)
+}
+
+func kmsKeyWrap(key *accessgraphv1alpha.AWSKMSKeyV1) *accessgraphv1alpha.AWSResource {
+	return &accessgraphv1alpha.AWSResource{Resource: &accessgraphv1alpha.AWSResource_KmsKey{KmsKey: key}}
 }

--- a/proto/accessgraph/v1alpha/aws.proto
+++ b/proto/accessgraph/v1alpha/aws.proto
@@ -77,6 +77,8 @@ message AWSResource {
     AWSSAMLProviderV1 saml_provider = 19;
     // oidc_provider is an AWS IAM OpenID Connect Identity Provider
     AWSOIDCProviderV1 oidc_provider = 20;
+    // kms_key is an AWS KMS key.
+    AWSKMSKeyV1 kms_key = 21;
   }
 }
 
@@ -583,4 +585,42 @@ message AWSOIDCProviderV1 {
   string url = 7;
   // last_sync_time is the time when the resource was last synced.
   google.protobuf.Timestamp last_sync_time = 8;
+}
+
+// AWSKMSKeyV1 defines the KMS key details.
+message AWSKMSKeyV1 {
+  // arn is the key ARN.
+  string arn = 1;
+  // created_at is the time when the key was created.
+  google.protobuf.Timestamp created_at = 2;
+  // tags is the list of tags that are attached to the key.
+  repeated AWSTag tags = 3;
+  // account_id is the ID of the AWS account that the key belongs to.
+  string account_id = 4;
+  // last_sync_time is the time when the resource was last synced.
+  google.protobuf.Timestamp last_sync_time = 5;
+  // aliases is the list of aliases that are attached to the key.
+  repeated string aliases = 6;
+  // policy_document is the JSON document that defines the policy.
+  bytes policy_document = 7;
+  // region is the AWS region that the key belongs to.
+  string region = 8;
+  // multi_region_key_type is the type of the multi-region key.
+  MultiRegionKeyType multi_region_key_type = 9;
+  // hsm_cluster_id is the ID of the HSM cluster that the key belongs to, if any.
+  string hsm_cluster_id = 10;
+}
+
+// MultiRegionKeyType is the type of a multi-region key type (primary, replica,
+// none for single region).
+enum MultiRegionKeyType {
+  // MULTI_REGION_KEY_TYPE_UNSPECIFIED is a unspecified multi region key type
+  MULTI_REGION_KEY_TYPE_UNSPECIFIED = 0;
+  // MULTI_REGION_KEY_TYPE_NONE is not a multi region key type but a local or
+  // single region key.
+  MULTI_REGION_KEY_TYPE_NONE = 1;
+  // MULTI_REGION_KEY_TYPE_PRIMARY is a primary multi region key type
+  MULTI_REGION_KEY_TYPE_PRIMARY = 2;
+  // MULTI_REGION_KEY_TYPE_REPLICA is a replica multi region key type
+  MULTI_REGION_KEY_TYPE_REPLICA = 3;
 }

--- a/proto/accessgraph/v1alpha/aws.proto
+++ b/proto/accessgraph/v1alpha/aws.proto
@@ -600,10 +600,13 @@ message AWSKMSKeyV1 {
   // last_sync_time is the time when the resource was last synced.
   google.protobuf.Timestamp last_sync_time = 5;
   // aliases is the list of aliases that are attached to the key.
+  // they are prefixed with "alias/", for example "alias/my-key-alias".
   repeated string aliases = 6;
-  // policy_document is the JSON document that defines the policy.
+  // policy_document is the JSON document that defines the Key Policy. Every KMS
+  // key must have exactly one key policy.
   bytes policy_document = 7;
-  // region is the AWS region that the key belongs to.
+  // region is the AWS region that the key belongs to. For multi-region keys,
+  // this is the region where the current key, primary or replica, is located.
   string region = 8;
   // multi_region_key_type is the type of the multi-region key.
   // It is set to "PRIMARY", "REPLICA" or left empty for single region keys.

--- a/proto/accessgraph/v1alpha/aws.proto
+++ b/proto/accessgraph/v1alpha/aws.proto
@@ -606,21 +606,8 @@ message AWSKMSKeyV1 {
   // region is the AWS region that the key belongs to.
   string region = 8;
   // multi_region_key_type is the type of the multi-region key.
-  MultiRegionKeyType multi_region_key_type = 9;
+  // It is set to "PRIMARY", "REPLICA" or left empty for single region keys.
+  string multi_region_key_type = 9;
   // hsm_cluster_id is the ID of the HSM cluster that the key belongs to, if any.
   string hsm_cluster_id = 10;
-}
-
-// MultiRegionKeyType is the type of a multi-region key type (primary, replica,
-// none for single region).
-enum MultiRegionKeyType {
-  // MULTI_REGION_KEY_TYPE_UNSPECIFIED is a unspecified multi region key type
-  MULTI_REGION_KEY_TYPE_UNSPECIFIED = 0;
-  // MULTI_REGION_KEY_TYPE_NONE is not a multi region key type but a local or
-  // single region key.
-  MULTI_REGION_KEY_TYPE_NONE = 1;
-  // MULTI_REGION_KEY_TYPE_PRIMARY is a primary multi region key type
-  MULTI_REGION_KEY_TYPE_PRIMARY = 2;
-  // MULTI_REGION_KEY_TYPE_REPLICA is a replica multi region key type
-  MULTI_REGION_KEY_TYPE_REPLICA = 3;
 }


### PR DESCRIPTION
Implement AWS KMS keys discovery and ingest into access graph. The
fetcher discovers keys across all specified regions.

For each KMS key, the fetcher retrieves the following details:

* Key metadata, including ARN, creation date, and HSM cluster ID
* Resource tags
* Key aliases
* The key policy document

Add a mock KMS client  to support comprehensive unit testing of the new
fetcher, covering various key configurations and error cases.

The new KMS key resource is integrated into the existing discovery framework,
including the merge, deduplication, and reconciliation steps.

The required IAM policy for access graph discovery is updated to include the
necessary `kms:` permissions.

Correct typo in the `GlueTableName` field name.

Add the `AWSKMSKeyV1` protobuf messages to support importing KMS keys
into the access graph. This new type is added to the `AWSResource` oneof.
Gegenerat go bindings with `make grpc`.