### PR TITLE
[v18] Don't omit CDP info for PKINIT certificates

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -208,7 +208,6 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string
 		ClusterName:        clusterName,
 		Domain:             s.ldapConfig.domain,
 		ActiveDirectorySID: s.ldapConfig.serviceAccountSID,
-		OmitCDP:            false,
 	}
 
 	certPEM, keyPEM, caCerts, err := winpki.DatabaseCredentials(ctx, s.authClient, req)

--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -208,7 +208,7 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string
 		ClusterName:        clusterName,
 		Domain:             s.ldapConfig.domain,
 		ActiveDirectorySID: s.ldapConfig.serviceAccountSID,
-		OmitCDP:            true,
+		OmitCDP:            false,
 	}
 
 	certPEM, keyPEM, caCerts, err := winpki.DatabaseCredentials(ctx, s.authClient, req)


### PR DESCRIPTION
Backport #56849 to branch/v18

changelog: Improve PKINIT compatibility by always including CDP information in the certificate
