### PR TITLE
[v17] Don't omit CDP info for PKINIT certificates

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -174,7 +174,6 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context) (*tls.Config, erro
 		AuthClient:         s.authClient,
 		Domain:             s.ldapConfig.Domain,
 		ActiveDirectorySID: s.ldapConfig.ServiceAccountSID,
-		OmitCDP:            true,
 	}
 
 	certPEM, keyPEM, caCerts, err := windows.DatabaseCredentials(ctx, req)


### PR DESCRIPTION
Backport #56849 to branch/v17

Manual backport due to merge conflict.

changelog: Improve PKINIT compatibility by always including CDP information in the certificate
