### PR TITLE
[v17] chore: update access_graph version to 1.28.0 in config.json

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -6,7 +6,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.24.4"
+      "version": "1.28.0"
     },
     "ansible": {
       "min_version": "2.9.6"


### PR DESCRIPTION
Backport #56880 to branch/v17