### PR TITLE
Fix /var/log/wtmp not updating on session exit

### DIFF
--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -351,8 +351,8 @@ func checkSpuriousENOENT(target string, f func() (C.int, error)) (C.int, error) 
 	if status != C.UACC_UTMP_PATH_DOES_NOT_EXIST {
 		return status, err
 	}
-	afterStat, err := os.Stat(target)
-	if err != nil {
+	afterStat, statErr := os.Stat(target)
+	if statErr != nil {
 		return status, err
 	}
 	if afterStat.ModTime().After(beforeStat.ModTime()) {


### PR DESCRIPTION
This change fixes a bug where the user accounting log file (/var/log/wtmp) would not be updated when a session finished.

Fixes #54606.

Changelog: Fixed /var/log/wtmp not updating on session exit