### PR TITLE
MWI: Fall back to registering without an existing auth client

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -343,25 +343,14 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	// If an explicit AuthClient has been provided, we want to go straight to
 	// using that rather than trying both proxy and auth dialing.
 	if params.AuthClient != nil {
-		// Test the auth client before assuming it will work - if the client is
-		// broken (expired certs, etc) we may need to attempt register without
-		// the existing client. For bots, this will probably produce a new bot
-		// instance, but in the case of expired certs, that's expected behavior,
-		// and acceptable otherwise - this would happen if the client was
-		// restarted.
-		_, err := params.AuthClient.Ping(ctx)
+		slog.InfoContext(ctx, "Attempting registration with existing auth client.")
+		result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
 		if err != nil {
-			slog.WarnContext(ctx, "An existing auth client was provided but could not be used", "error", err)
-		} else {
-			slog.InfoContext(ctx, "Attempting registration with existing auth client.")
-			result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
-			if err != nil {
-				slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
-				return nil, trace.Wrap(err)
-			}
-			slog.InfoContext(ctx, "Successfully registered with existing auth client.")
-			return result, nil
+			slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
+			return nil, trace.Wrap(err)
 		}
+		slog.InfoContext(ctx, "Successfully registered with existing auth client.")
+		return result, nil
 	}
 
 	type registerMethod struct {

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -439,6 +439,22 @@ func (s *identityService) unblockWaiters() {
 	s.initializedOnce.Do(func() { close(s.initialized) })
 }
 
+// renewIdentity attempts to renew an existing bot identity. "Renewal" in this
+// case means one of two things:
+//   1. If using an explicitly renewable identity (i.e. `token` joining),
+//      certificates will be renewed directly via Auth using the formal renewal
+//      process.
+//
+//      If the existing identity is expired, this will fail and cannot be
+//      recovered.
+//   2. For all other join methods, a "lightweight renewal" is performed. The
+//      existing client is used to authenticate the request and prove ownership
+//      of the existing bot instance ID, but otherwise the delegated joining
+//      ceremony is performed as usual.
+//
+//      If the existing identity appears to be expired (`time.Now()` >
+//      `NotAfter`), the existing auth client will be discarded and the bot will
+//      try to join without it. This will result in a new bot instance ID.
 func renewIdentity(
 	ctx context.Context,
 	log *slog.Logger,
@@ -470,9 +486,29 @@ func renewIdentity(
 		return newIdentity, nil
 	}
 
+	now := time.Now()
+	if expiry, ok := facade.Expiry(); !ok || now.After(expiry) {
+		slog.WarnContext(
+			ctx,
+			"The bot identity appears to be expired and will not be used to "+
+				"authenticate the identity renewal. If it is possible to "+
+				"rejoin, a new bot instance will be issued. Ensure the "+
+				"certificate TTL and renewal interval are configured properly.",
+			"now", now,
+			"expiry", expiry,
+			"credential_lifetime", botCfg.CredentialLifetime,
+		)
+
+		newIdentity, err := botIdentityFromToken(ctx, log, botCfg, nil)
+		if err != nil {
+			return nil, trace.Wrap(err, "renewing identity using Register without existing auth client")
+		}
+		return newIdentity, nil
+	}
+
 	newIdentity, err := botIdentityFromToken(ctx, log, botCfg, authClient)
 	if err != nil {
-		return nil, trace.Wrap(err, "renewing identity using Register")
+		return nil, trace.Wrap(err, "renewing identity using Register with existing auth client")
 	}
 	return newIdentity, nil
 }

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -488,15 +488,22 @@ func renewIdentity(
 		return newIdentity, nil
 	}
 
+	// Note: This simple expiration check is probably not the best possible
+	// solution to determine when to discard an existing identity: the client
+	// could have severe clock drift, or there could be non-expiry related
+	// reasons that an identity should be thrown out. We may improve this
+	// discard logic in the future if we determine we're still creating  excess
+	// bot instances.
 	now := time.Now()
 	if expiry, ok := facade.Expiry(); !ok || now.After(expiry) {
 		slog.WarnContext(
 			ctx,
 			"The bot identity appears to be expired and will not be used to "+
 				"authenticate the identity renewal. If it is possible to "+
-				"rejoin, a new bot instance will be issued. Ensure the "+
-				"configured certificate TTL is long enough to accommodate "+
-				"your environment and that no external issues will prevent "+
+				"rejoin, a new bot instance will be created. If this occurs "+
+				"repeatedly, ensure the local machine's clock is properly "+
+				"synchronized, the certificate TTL is adjusted to your "+
+				"environment, and that no external issues will prevent "+
 				"the bot from renewing its identity on schedule.",
 			"now", now,
 			"expiry", expiry,

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -495,7 +495,9 @@ func renewIdentity(
 			"The bot identity appears to be expired and will not be used to "+
 				"authenticate the identity renewal. If it is possible to "+
 				"rejoin, a new bot instance will be issued. Ensure the "+
-				"certificate TTL and renewal interval are configured properly.",
+				"configured certificate TTL is long enough to accommodate "+
+				"your environment and that no external issues will prevent "+
+				"the bot from renewing its identity on schedule.",
 			"now", now,
 			"expiry", expiry,
 			"credential_lifetime", botCfg.CredentialLifetime,

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -441,20 +441,22 @@ func (s *identityService) unblockWaiters() {
 
 // renewIdentity attempts to renew an existing bot identity. "Renewal" in this
 // case means one of two things:
-//   1. If using an explicitly renewable identity (i.e. `token` joining),
-//      certificates will be renewed directly via Auth using the formal renewal
-//      process.
 //
-//      If the existing identity is expired, this will fail and cannot be
-//      recovered.
-//   2. For all other join methods, a "lightweight renewal" is performed. The
-//      existing client is used to authenticate the request and prove ownership
-//      of the existing bot instance ID, but otherwise the delegated joining
-//      ceremony is performed as usual.
+//  1. If using an explicitly renewable identity (i.e. `token` joining),
+//     certificates will be renewed directly via Auth using the formal renewal
+//     process.
 //
-//      If the existing identity appears to be expired (`time.Now()` >
-//      `NotAfter`), the existing auth client will be discarded and the bot will
-//      try to join without it. This will result in a new bot instance ID.
+//     If the existing identity is expired, this will fail and cannot be
+//     recovered.
+//
+//  2. For all other join methods, a "lightweight renewal" is performed. The
+//     existing client is used to authenticate the request and prove ownership
+//     of the existing bot instance ID, but otherwise the delegated joining
+//     ceremony is performed as usual.
+//
+//     If the existing identity appears to be expired (`time.Now()` >
+//     `NotAfter`), the existing auth client will be discarded and the bot will
+//     try to join without it. This will result in a new bot instance ID.
 func renewIdentity(
 	ctx context.Context,
 	log *slog.Logger,


### PR DESCRIPTION
This tweaks bot joining logic to discard an existing auth client (i.e. bots, used to verify bot instance IDs between cert refreshes) if the backing identity is expired per the current local time and the certificate's `NotAfter` field.

As an example, currently if you lock a bot, it will get stuck in a bad state, and will not recover until the `tbot` process is restarted:
```
# in one terminal...
$ tbot start identity --join-token=example --certificate-ttl=30s --renewal-interval 20s

# in another terminal...
$ tctl lock --join-token=example # pick your favorite lock target
$ sleep 30                       # observe that the bot fails to renew and enters a failure loop
$ tctl rm lock/$id               # observe that the bot cannot recover after access is restored
```

Notably, after some recent changes, tbot no longer necessarily crashes if renewals fail. We used to be able to assume systemd/etc would restart for us eventually and clumsily resolve the broken client. This was never a good system to rely on, though, so we should probably resolve this class of issue properly.

changelog: Machine and Workload ID: The `tbot` client will now discard expired identities if needed during renewal to allow automatic recovery without restarting the process