### PR TITLE
VNet route conflict diag: Handle changes to interface index

### DIFF
--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -273,6 +273,7 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 		return nil, trace.BadParameter("no IPv6 prefix, this is a bug")
 	}
 
+	var ipv4CIDRRanges []string
 	nsa := &diagv1.NetworkStackAttempt{}
 	if ns, err := s.getNetworkStack(ctx); err != nil {
 		nsa.Status = diagv1.CheckAttemptStatus_CHECK_ATTEMPT_STATUS_ERROR
@@ -280,9 +281,10 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 	} else {
 		nsa.Status = diagv1.CheckAttemptStatus_CHECK_ATTEMPT_STATUS_OK
 		nsa.NetworkStack = ns
+		ipv4CIDRRanges = ns.Ipv4CidrRanges
 	}
 
-	diagChecks, err := s.platformDiagChecks(ctx)
+	diagChecks, err := s.platformDiagChecks(ctx, ipv4CIDRRanges)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/vnet/service_darwin.go
+++ b/lib/teleterm/vnet/service_darwin.go
@@ -24,11 +24,12 @@ import (
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
+func (s *Service) platformDiagChecks(ctx context.Context, ipv4CIDRRanges []string) ([]diag.DiagCheck, error) {
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
-		VnetIfaceName: s.networkStackInfo.InterfaceName,
-		Routing:       &diag.DarwinRouting{},
-		Interfaces:    &diag.NetInterfaces{},
+		VnetIfaceName:  s.networkStackInfo.InterfaceName,
+		Routing:        &diag.DarwinRouting{},
+		Interfaces:     &diag.NetInterfaces{},
+		IPv4CIDRRanges: ipv4CIDRRanges,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/vnet/service_other.go
+++ b/lib/teleterm/vnet/service_other.go
@@ -24,6 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
+func (s *Service) platformDiagChecks(ctx context.Context, ipv4CIDRRanges []string) ([]diag.DiagCheck, error) {
 	return nil, nil
 }

--- a/lib/teleterm/vnet/service_windows.go
+++ b/lib/teleterm/vnet/service_windows.go
@@ -24,11 +24,12 @@ import (
 	"github.com/gravitational/teleport/lib/vnet/diag"
 )
 
-func (s *Service) platformDiagChecks(ctx context.Context) ([]diag.DiagCheck, error) {
+func (s *Service) platformDiagChecks(ctx context.Context, ipv4CIDRRanges []string) ([]diag.DiagCheck, error) {
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
-		VnetIfaceName: s.networkStackInfo.InterfaceName,
-		Routing:       &diag.WindowsRouting{},
-		Interfaces:    &diag.NetInterfaces{},
+		VnetIfaceName:  s.networkStackInfo.InterfaceName,
+		Routing:        &diag.WindowsRouting{},
+		Interfaces:     &diag.NetInterfaces{},
+		IPv4CIDRRanges: ipv4CIDRRanges,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/vnet/diag/routeconflict_test.go
+++ b/lib/vnet/diag/routeconflict_test.go
@@ -209,8 +209,50 @@ func TestRouteConflictDiag_RetriesOnNoVnetRouteDestinations(t *testing.T) {
 	require.Equal(t, 3, routing.getRouteDestinationsCallCount, "Unexpected number of calls to Routing.GetRouteDestinations")
 }
 
+func TestRouteConflictDiag_RefetchesVnetIfaceOnNoVnetRouteDestinations(t *testing.T) {
+	const updatedVnetIfaceIndex = vnetIfaceIndex + 12
+	interfaces := &FakeInterfaces{
+		ifaces: map[int]iface{
+			vnetIfaceIndex: {name: vnetIface},
+			quuxIfaceIndex: {name: quuxIface, app: "foobar"},
+		},
+		ifacesAfterFirstFetchByName: &map[int]iface{
+			// Simulate VNet iface index changing between calls.
+			updatedVnetIfaceIndex: {name: vnetIface},
+			quuxIfaceIndex:        {name: quuxIface, app: "foobar"},
+		},
+	}
+	routing := &FakeRouting{
+		// The first pass is going to be repeated because no VNet routes will be detected.
+		dests: []RouteDest{
+			&RouteDestIP{ifaceIndex: quuxIfaceIndex, Addr: netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+		},
+		destsAfterFirstCall: &[]RouteDest{
+			&RouteDestIP{ifaceIndex: quuxIfaceIndex, Addr: netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			// On the second pass, there's going to be a route which matches the updated index.
+			// The test will fail if the code doesn't re-fetch interface index between passes.
+			&RouteDestIP{ifaceIndex: updatedVnetIfaceIndex, Addr: netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+		},
+	}
+
+	routeConflictDiag, err := NewRouteConflictDiag(&RouteConflictConfig{
+		VnetIfaceName: vnetIface, Interfaces: interfaces, Routing: routing, RefetchRoutesDuration: time.Millisecond,
+	})
+	require.NoError(t, err)
+	report, err := routeConflictDiag.Run(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, report.GetRouteConflictReport().RouteConflicts, 1)
+	routeConflict := report.GetRouteConflictReport().RouteConflicts[0]
+	require.Equal(t, "1.2.3.4", routeConflict.VnetDest)
+	require.Equal(t, "1.2.3.4", routeConflict.Dest)
+}
+
 type FakeInterfaces struct {
 	ifaces map[int]iface
+	// ifacesAfterFirstFetchByName are the interfaces FakeInterfaces operates on after the first call
+	// to InterfaceByName, if ifacesAfterFirstFetchByName is not nil.
+	ifacesAfterFirstFetchByName *map[int]iface
 }
 
 type iface struct {
@@ -225,6 +267,13 @@ type iface struct {
 }
 
 func (f *FakeInterfaces) InterfaceByName(ifaceName string) (*net.Interface, error) {
+	defer func() {
+		if f.ifacesAfterFirstFetchByName != nil {
+			f.ifaces = *f.ifacesAfterFirstFetchByName
+			f.ifacesAfterFirstFetchByName = nil
+		}
+	}()
+
 	for index, iface := range f.ifaces {
 		if iface.name != ifaceName {
 			continue
@@ -272,13 +321,19 @@ func (f *FakeInterfaces) InterfaceApp(ctx context.Context, ifaceName string) (st
 }
 
 type FakeRouting struct {
-	dests                         []RouteDest
+	dests []RouteDest
+	// destsAfterFirstCall are the dests that are returned after the first call to
+	// GetRouteDestinations if destsAfterFirstCall is not nil.
+	destsAfterFirstCall           *[]RouteDest
 	getRouteDestinationsCallCount int
 }
 
 func (f *FakeRouting) GetRouteDestinations() ([]RouteDest, error) {
 	f.getRouteDestinationsCallCount++
-	return f.dests, nil
+	if f.destsAfterFirstCall == nil || f.getRouteDestinationsCallCount == 1 {
+		return f.dests, nil
+	}
+	return *f.destsAfterFirstCall, nil
 }
 
 func TestExtractNetworkExtDescFromIfconfigOutput(t *testing.T) {

--- a/lib/vnet/osconfig_darwin.go
+++ b/lib/vnet/osconfig_darwin.go
@@ -33,6 +33,10 @@ type platformOSConfigState struct{}
 // platformConfigureOS configures the host OS according to cfg. It is safe to
 // call repeatedly, and it is meant to be called with an empty osConfig to
 // deconfigure anything necessary before exiting.
+//
+// NOTE: lib/vnet/diag.RouteConflictDiag assumes that any IPv4 route set up for the VNet interface
+// is either equal to one of the CIDR ranges or an address within any of those ranges. Adding any
+// routes that do not confirm to those requirements requires adjusting RouteConflictDiag.
 func platformConfigureOS(ctx context.Context, cfg *osConfig, _ *platformOSConfigState) error {
 	// There is no need to remove IP addresses or routes, they will automatically be cleaned up when the
 	// process exits and the TUN is deleted.

--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -60,6 +60,10 @@ func (p *platformOSConfigState) getIfaceIndex() (string, error) {
 // platformConfigureOS configures the host OS according to cfg. It is safe to
 // call repeatedly, and it is meant to be called with an empty osConfig to
 // deconfigure anything necessary before exiting.
+//
+// NOTE: lib/vnet/diag.RouteConflictDiag assumes that any IPv4 route set up for the VNet interface
+// is either equal to one of the CIDR ranges or an address within any of those ranges. Adding any
+// routes that do not confirm to those requirements requires adjusting RouteConflictDiag.
 func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
 	// There is no need to remove IP addresses or routes, they will automatically be cleaned up when the
 	// process exits and the TUN is deleted.


### PR DESCRIPTION
## The problem

[One of the customers shared a video](https://gravitational.zendesk.com/agent/tickets/14130) showing a problem with VNet. Throughout the video, a VPN software that's running on the device seems to be constantly reconnecting. At one point in the video, the VNet diag report shows this:

<img src="https://github.com/user-attachments/assets/751ddd21-e369-4385-ae41-9c06323bbeb6" alt="VNet diag report" width="652"/>

It means that the diag check classified 4.0.0.0/6 and 8.0.0.0/5 as route destinations belonging to VNet's utun5 interface. However, the report also clearly shows that VNet uses 100.64.0.0/10 as its IPv4 CIDR range. This means that it'd never set up routes like 4.0.0.0/6 (the routes are set up in [`lib/vnet/osconfig_darwin.go`](https://github.com/gravitational/teleport/blob/84590a86ff637bf7ca49556de251324293e354e5/lib/vnet/osconfig_darwin.go#L36)).

The way that the diag check collects the route destinations is as follows:

1. Receive the network interface name as an argument (utun5 in this case).
2. Get the interface index that corresponds to this interface name.
3. Fetch all routes currently set up on the system. Group them into two buckets: ones that have interface index equal to that from step 2 (thus belong to VNet) and ones that don't.
4. Check if there are any destinations in the other group that overlap with VNet destinations.

The only explanation for the behavior from the video that we can think of is the index of VNet's interface suddenly changing. I don' know how this could happen, all I could find on the internet was [a single SO question](https://stackoverflow.com/questions/32859179/is-it-possible-to-modify-interface-index) where someone mentions a similar problem. We suspect it might had to do with the VPN software constantly reconnecting and rebuilding its network interface, but I wasn't able to reproduce this with Tailscale for example. The VPN software the customer uses must be doing something extra.

## The fix

In the current version of VNet, there are two situations where this mismatch could theoretically happen:

* If the diag check doesn't find any destinations that belong to VNet, it sleeps for 500ms and then fetches destinations again, up to two times. This is because the diag check runs soon after VNet starts and it might take a moment for the admin process of VNet to set up those routes. However, between those retries, the diag check doesn't refetch the interface index, assuming it won't change.
   * This can be fixed by always refetching the interface index.
* Even if the diag check never retries fetching destinations, the interface index could potentially change between points 2 and 3 of the logic described above.
   * To fix this, we can check if VNet routes as identified by the diag check indeed belong to the IPv4 CIDR ranges used by VNet, which come from `vnet_config` resource of each root cluster.