### PR TITLE
Clarify configs in self-hosted Event Handler guides

### DIFF
--- a/examples/resources/plugins/teleport-discord-helm.yaml
+++ b/examples/resources/plugins/teleport-discord-helm.yaml
@@ -1,10 +1,10 @@
 teleport:
   # Teleport HTTPS Proxy web address, for Teleport Enterprise Cloud should be in the form "your-account.teleport.sh:443"
-  address: "teleport.example.com:443"
-  # Secret containing identity
-  identitySecretName: teleport-plugin-discord-identity
-  # Path within the secret containing the identity file.
-  identitySecretPath: identity
+  address: ""
+  # Secret containing identity, e.g., teleport-plugin-discord-identity
+  identitySecretName: "" 
+  # Path within the secret containing the identity file, e.g., identity
+  identitySecretPath: ""
 
 discord:
   token: "XXXXXXXX"  # Discord Bot OAuth token

--- a/examples/resources/plugins/teleport-email-helm.yaml
+++ b/examples/resources/plugins/teleport-email-helm.yaml
@@ -1,5 +1,5 @@
 teleport:
-  address: ""              # e.g., teleport.example.com:443 
+  address: ""              # e.g., example.teleport.sh:443 
   identitySecretName: ""   # e.g., teleport-plugin-email-identity
   identitySecretPath: ""   # e.g., identity
 

--- a/examples/resources/plugins/teleport-email-helm.yaml
+++ b/examples/resources/plugins/teleport-email-helm.yaml
@@ -1,14 +1,14 @@
 teleport:
-  address: teleport.example.com:443
-  identitySecretName: teleport-plugin-email-identity
-  identitySecretPath: identity
+  address: ""              # e.g., teleport.example.com:443 
+  identitySecretName: ""   # e.g., teleport-plugin-email-identity
+  identitySecretPath: ""   # e.g., identity
 
 mailgun:
   enabled: false
   domain: ""
   privateKey: ""
   privateKeyFromSecret: ""
-  privateKeySecretPath: "mailgunPrivateKey"
+  privateKeySecretPath: "" # e.g., mailgunPrivateKey
 
 smtp:
   enabled: false
@@ -17,8 +17,8 @@ smtp:
   username: ""
   password: ""
   passwordFromSecret: ""
-  passwordSecretPath: "smtpPassword"
-  starttlsPolicy: "mandatory"
+  passwordSecretPath: ""   # e.g., smtpPassword
+  starttlsPolicy: ""       # e.g., mandatory
 
 delivery:
   sender: ""
@@ -26,4 +26,4 @@ delivery:
 
 roleToRecipients: {}
 
-secretVolumeName: "password-file"
+secretVolumeName: ""       # e.g., password-file

--- a/examples/resources/plugins/teleport-jira-cloud.toml
+++ b/examples/resources/plugins/teleport-jira-cloud.toml
@@ -1,24 +1,24 @@
 # Example Jira plugin configuration TOML file
 [teleport]
 # Proxy Service domain and HTTPS port
-auth_server = "myinstance.teleport.sh:443"
+auth_server = ""
 # Teleport identity file location
-identity = "/var/lib/teleport/plugins/jira/identity"
+identity = ""
 # Refresh identity file on a periodic basis.
 refresh_identity = true
 
 [jira]
-url = "https://[my-jira].atlassian.net"    # JIRA URL
-username = "bot@example.com"               # JIRA username
-api_token = "token"                        # JIRA API token
-project = "TAR"                            # JIRA Project key
+url = ""        # JIRA URL
+username = ""   # JIRA username
+api_token = ""  # JIRA API token
+project = ""    # JIRA Project key
 
 [http]
 # URL on which webhook server is accessible externally, for example,
 # [https://]teleport-jira.example.com
-public_addr = "example.com" 
-https_key_file = "/var/lib/teleport/plugins/jira/server.key"  # TLS private key
-https_cert_file = "/var/lib/teleport/plugins/jira/server.crt" # TLS certificate
+public_addr = "" 
+https_key_file = ""  # TLS private key
+https_cert_file = "" # TLS certificate
 
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/jira.log"

--- a/examples/resources/plugins/teleport-jira-cloud.toml
+++ b/examples/resources/plugins/teleport-jira-cloud.toml
@@ -1,25 +1,34 @@
 # Example Jira plugin configuration TOML file
 [teleport]
 # Proxy Service domain and HTTPS port
-auth_server = ""
+# e.g., example.teleport.sh:443
+auth_server = "" 
 # Teleport identity file location
 identity = ""
 # Refresh identity file on a periodic basis.
 refresh_identity = true
 
 [jira]
-url = ""        # JIRA URL
-username = ""   # JIRA username
-api_token = ""  # JIRA API token
-project = ""    # JIRA Project key
+# JIRA URL
+url = ""        
+# JIRA username
+username = ""   
+# JIRA API token
+api_token = ""  
+# JIRA Project key
+project = ""    
 
 [http]
 # URL on which webhook server is accessible externally, for example,
 # [https://]teleport-jira.example.com
 public_addr = "" 
-https_key_file = ""  # TLS private key
-https_cert_file = "" # TLS certificate
+# TLS private key
+https_key_file = ""  
+# TLS certificate
+https_cert_file = "" 
 
 [log]
-output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/jira.log"
-severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+# Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/jira.log"
+output = "stderr" 
+# Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+severity = "INFO" 

--- a/examples/resources/plugins/teleport-jira-helm-cloud.yaml
+++ b/examples/resources/plugins/teleport-jira-helm-cloud.yaml
@@ -1,22 +1,22 @@
 teleport:
   # Teleport Proxy Service domain name and HTTPS port. If you are using Teleport
   # Enterprise Cloud, this should be in the form "your-account.teleport.sh:443"
-  address: "teleport.example.com:443"
-  # Secret containing a Teleport identity document
-  identityFromSecret: teleport-plugin-jira-identity
+  address: ""
+  # Secret containing a Teleport identity document, e.g., teleport-plugin-jira-identity
+  identityFromSecret: ""
   # Path within the secret containing the identity file.
-  identitySecretPath: identity
+  identitySecretPath: ""
 
 jira:
-  url: "https://[my-jira].atlassian.net"      # URL of the Jira instance
-  username: bot@example.com                   # Email of the bot user
-  apiToken: token                             # Token of the bot user
-  project: TAR                                # Project where issues will be created
+  url: ""       # URL of the Jira instance
+  username: ""  # Email of the bot user
+  apiToken: ""  # Token of the bot user
+  project: ""   # Project where issues will be created
 
 http:
-  publicAddress: https://jira-teleport.example.com/ 
-  # Secret containing the TLS certificate
-  tlsFromSecret: teleport-plugin-jira-tls            
+  publicAddress: "" 
+  # Secret containing the TLS certificate, e.g., teleport-plugin-jira-tls
+  tlsFromSecret: ""
   # tlsKeySecretPath:  tls.key                # Name of the key inside the secret
   # tlsCertSecretPath: tls.crt                # Name of the certificate inside the secret
 

--- a/examples/resources/plugins/teleport-mattermost-helm-cloud.yaml
+++ b/examples/resources/plugins/teleport-mattermost-helm-cloud.yaml
@@ -1,17 +1,17 @@
 teleport:
   # Teleport HTTPS Proxy web address, for Teleport Enterprise Cloud should be in the form "your-account.teleport.sh:443"
-  address: "teleport.example.com:443"
+  address: ""            # e.g., teleport.example.com:443
   # Secret containing identity
-  identitySecretName: teleport-plugin-mattermost-identity
+  identitySecretName: "" # e.g., teleport-plugin-mattermost-identity 
   # Path within the secret containing the identity file.
-  identitySecretPath: identity
+  identitySecretPath: "" # e.g., identity
 
 mattermost:
-  url: https://mattermost.example.com/  # URL of the Mattermost instance
-  token: mattermosttoken                # Mattermost token of the bot
+  url: ""          # URL of the Mattermost instance, e.g., https://mattermost.example.com/
+  token: ""        # Mattermost token of the bot
   recipients:
-    - "access-requests@example.com"     # User
-    - "team/example-channel"            # Channel
+    - ""           # User, e.g., access-requests@example.com
+    - ""           # Channel, e.g., team/example-channel
 
 log:
   output: "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/mattermost.log"

--- a/examples/resources/plugins/teleport-msteams-helm.yaml
+++ b/examples/resources/plugins/teleport-msteams-helm.yaml
@@ -6,14 +6,14 @@
 # Plugin specific options
 #
 teleport:
-  address: "teleport.example.com:443"
-  identitySecretName: teleport-plugin-msteams-identity
-  identitySecretPath: identity
+  address: ""            # e.g., teleport.example.com:443
+  identitySecretName: "" # e.g., teleport-plugin-msteams-identity
+  identitySecretPath: "" # e.g., identity
 
 msTeams:
-  appID: "APP_ID"
-  tenantID: "TENANT_ID"
-  teamsAppID: "TEAMS_APP_ID"
+  appID: ""
+  tenantID: ""
+  teamsAppID: ""
 
 roleToRecipients: {}
   # "*": "admin@example.com"

--- a/examples/resources/plugins/teleport-msteams.toml
+++ b/examples/resources/plugins/teleport-msteams.toml
@@ -8,25 +8,29 @@
 preload = true
 
 [teleport]
-# Teleport Auth/Proxy Server address.
-# addr = "example.com:3025"
+# Teleport Auth Service or Proxy Service address.
+# Example: examples/resources/plugins/teleport-msteams.toml
+# addr = ""
 #
-# Should be port 3025 for Auth Server and 3080 or 443 for Proxy.
+# Should be port 3025 for the Auth Service and 3080 or 443 for the Proxy
+# Service.
 # For Teleport Cloud, should be in the form "your-account.teleport.sh:443".
 
 # Credentials generated with `tctl auth sign`.
 #
 # When using --format=file:
-# identity = "/var/lib/teleport/plugins/msteams/identity"   # Identity file
-# refresh_identity = true                                   # Refresh identity file periodically
+# Identity file, e.g., /var/lib/teleport/plugins/msteams/identity
+identity = ""   
+# Refresh identity file periodically
+refresh_identity = true                                   
 #
 # When using --format=tls:
-# client_key = "/var/lib/teleport/plugins/msteams/auth.key" # Teleport TLS secret key
-# client_crt = "/var/lib/teleport/plugins/msteams/auth.crt" # Teleport TLS certificate
-# root_cas = "/var/lib/teleport/plugins/msteams/auth.cas"   # Teleport CA certs
-addr = "" # e.g., localhost:3025
-identity = ""
-refresh_identity = true
+# Teleport TLS secret key, e.g., /var/lib/teleport/plugins/msteams/auth.key
+# client_key = "" 
+# Teleport TLS certificate, e.g., /var/lib/teleport/plugins/msteams/auth.crt
+# client_crt = "" 
+# Teleport CA certs, e.g., /var/lib/teleport/plugins/msteams/auth.cas
+# root_cas = ""   
 
 [msapi]
 # MS API IDs. Please, check the documentation.
@@ -48,5 +52,7 @@ teams_app_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 "*" = []
 
 [log]
-output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/msteams.log"
-severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+# Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/msteams.log"
+output = "stderr" 
+# Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+severity = "INFO" 

--- a/examples/resources/plugins/teleport-msteams.toml
+++ b/examples/resources/plugins/teleport-msteams.toml
@@ -24,8 +24,8 @@ preload = true
 # client_key = "/var/lib/teleport/plugins/msteams/auth.key" # Teleport TLS secret key
 # client_crt = "/var/lib/teleport/plugins/msteams/auth.crt" # Teleport TLS certificate
 # root_cas = "/var/lib/teleport/plugins/msteams/auth.cas"   # Teleport CA certs
-addr = "localhost:3025"
-identity = "identity"
+addr = "" # e.g., localhost:3025
+identity = ""
 refresh_identity = true
 
 [msapi]
@@ -45,7 +45,7 @@ teams_app_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 #
 # "dev" = "devs-msteams-channel"
 # "*" = ["admin@email.com", "admin-msteams-channel"]
-"*" = ["foo@example.com"]
+"*" = []
 
 [log]
 output = "stderr" # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/msteams.log"

--- a/examples/resources/plugins/teleport-slack-helm.yaml
+++ b/examples/resources/plugins/teleport-slack-helm.yaml
@@ -1,13 +1,13 @@
 teleport:
   # Teleport HTTPS Proxy Web Address, for Teleport Enterprise Cloud should be in the form "your-account.teleport.sh:443"
-  address: "teleport.example.com:443"
-  # Secret containing identity
-  identitySecretName: teleport-plugin-slack-identity
+  address: ""
+  # Secret containing identity, e.g., teleport-plugin-slack-identity
+  identitySecretName: ""
   # Path within the secret containing the identity file.
-  identitySecretPath: identity
+  identitySecretPath: ""
 
 slack:
-  token: "xoxb-11xx"  # Slack Bot OAuth token
+  token: ""  # Slack Bot OAuth token
 
 # Mapping from role to recipients
 roleToRecipients: {}

--- a/examples/resources/plugins/teleport-slack.toml
+++ b/examples/resources/plugins/teleport-slack.toml
@@ -23,7 +23,7 @@
 # Slack Bot OAuth token
 # You can also use an absolute path to a token file, e.g., 
 # "/var/lib/teleport/token"
-token = "xoxb-11xx"
+token = ""
 
 [role_to_recipients]
 # Map roles to recipients.


### PR DESCRIPTION
Closes #38184

Prevent users from using example Event Handler configurations without modifying the placeholder values. Remove placeholder values from example Event Handler configs and add them to the comments accompanying the modified fields.

Exceptions are if the accompanying guide does not explain the placeholder, e.g., `serviceType` and the `log` section. In these cases, we expect users to copy the placeholders and use them as they are.

Skip purely hosted Event Handler guides, which don't include instructions for configuring the Event Handler.

Note that in the MS Teams guide, the TOML example includes clear placeholders to indicate format, and this change leaves these in.

Also note that some guides, like the PagerDuty guide, include an example of the final config files after providing lists of instructions. This change does not touch the example configs in this case.