### PR TITLE
[v18] Add TeleportRoleV8 support to the operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -16,6 +16,8 @@ rules:
       - teleportrolesv6/status
       - teleportrolesv7
       - teleportrolesv7/status
+      - teleportrolesv8
+      - teleportrolesv8/status
       - teleportusers
       - teleportusers/status
       - teleportgithubconnectors

--- a/integrations/operator/controllers/resources/rolevX_controller.go
+++ b/integrations/operator/controllers/resources/rolevX_controller.go
@@ -104,3 +104,17 @@ func NewRoleV7Reconciler(client kclient.Client, tClient *client.Client) (control
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
 }
+
+// NewRoleV8Reconciler instantiates a new Kubernetes controller reconciling role v8 resources
+func NewRoleV8Reconciler(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error) {
+	roleClient := &roleClient{
+		teleportClient: tClient,
+	}
+
+	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[types.Role, *resourcesv1.TeleportRoleV8](
+		client,
+		roleClient,
+	)
+
+	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")
+}

--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -42,6 +42,7 @@ func SetupAllControllers(log logr.Logger, mgr manager.Manager, teleportClient *c
 		{"TeleportRole", NewRoleReconciler},
 		{"TeleportRoleV6", NewRoleV6Reconciler},
 		{"TeleportRoleV7", NewRoleV7Reconciler},
+		{"TeleportRoleV8", NewRoleV8Reconciler},
 		{"TeleportUser", NewUserReconciler},
 		{"TeleportGithubConnector", NewGithubConnectorReconciler},
 		{"TeleportProvisionToken", NewProvisionTokenReconciler},


### PR DESCRIPTION
Manual backport of https://github.com/gravitational/teleport/pull/55219 (was not backported due to v18 merge freeze).

Changelog: Added `TeleportRoleV8` support to the Teleport Kubernetes Operator.