### PR TITLE
properly handle errors wrapping `*trace.Err`

### DIFF
--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -47,10 +47,8 @@ func ConvertError(err error) error {
 		return nil
 	}
 	// Unwrap original error first.
-	var traceErr *trace.TraceErr
-	if errors.As(err, &traceErr) {
-		return ConvertError(trace.Unwrap(err))
-	}
+	err = trace.Unwrap(err)
+	
 	var pgErr pgError
 	if errors.As(err, &pgErr) {
 		return ConvertError(pgErr.Unwrap())

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -48,7 +48,7 @@ func ConvertError(err error) error {
 	}
 	// Unwrap original error first.
 	err = trace.Unwrap(err)
-	
+
 	var pgErr pgError
 	if errors.As(err, &pgErr) {
 		return ConvertError(pgErr.Unwrap())

--- a/lib/srv/db/common/errors_test.go
+++ b/lib/srv/db/common/errors_test.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -47,4 +48,21 @@ func Test_isRDSMySQLIAMAuthError(t *testing.T) {
 	require.False(t, isRDSMySQLIAMAuthError(dbAccessError))
 	require.False(t, isRDSMySQLIAMAuthError(noDBError))
 	require.False(t, isRDSMySQLIAMAuthError(trace.AccessDenied("access denied")))
+}
+
+type someErr struct {
+	inner error
+}
+
+func (e *someErr) Error() string {
+	return "inner: " + e.inner.Error()
+}
+func (e *someErr) Unwrap() error {
+	return e.inner
+}
+
+func TestConvertErrorWrappedError(t *testing.T) {
+	nestedErr := &someErr{inner: trace.Wrap(fmt.Errorf("dummy"))}
+	out := ConvertError(nestedErr)
+	require.Equal(t, nestedErr, out)
 }

--- a/lib/srv/db/common/errors_test.go
+++ b/lib/srv/db/common/errors_test.go
@@ -62,7 +62,7 @@ func (e *someErr) Unwrap() error {
 }
 
 func TestConvertErrorWrappedError(t *testing.T) {
-	nestedErr := &someErr{inner: trace.Wrap(fmt.Errorf("dummy"))}
+	nestedErr := &someErr{inner: trace.Wrap(fmt.Errorf("dummy error"))}
 	out := ConvertError(nestedErr)
-	require.Equal(t, nestedErr, out)
+	require.ErrorContains(t, out, "dummy error")
 }


### PR DESCRIPTION
`ConvertError` will infinitely recurse itself if there is non-trace error wraping `*trace.TraceErr`. `pgconn` can return such an error:

```
type connectError struct {
	config *Config
	msg    string
	err    error
}

func (e *connectError) Error() string {
	sb := &strings.Builder{}
	fmt.Fprintf(sb, "failed to connect to `host=%s user=%s database=%s`: %s", e.config.Host, e.config.User, e.config.Database, e.msg)
	if e.err != nil {
		fmt.Fprintf(sb, " (%s)", e.err.Error())
	}
	return sb.String()
}

func (e *connectError) Unwrap() error {
	return e.err
}
```

The current logic is flawed because:
- `errors.As` works recursively
- `trace.Unwrap` only unwraps outermost layers

The fix here is to always call `trace.Unwrap` which is no-op for non-wrapped errors, yet still unwraps multiple layers if needed.