### PR TITLE
[vnet] fix: mask default IP route on windows

### DIFF
--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -18,6 +18,7 @@ package vnet
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"os/exec"
 	"strings"
@@ -29,6 +30,7 @@ import (
 type osConfig struct {
 	tunName    string
 	tunIPv4    string
+	tunIPv4Net *net.IPNet
 	tunIPv6    string
 	cidrRanges []string
 	dnsAddrs   []string

--- a/lib/vnet/osconfig_provider.go
+++ b/lib/vnet/osconfig_provider.go
@@ -111,7 +111,7 @@ func ipsForCIDR(cidrRange string) (tunIP net.IP, tunIPNet *net.IPNet, dnsIP net.
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "parsing CIDR %q", cidrRange)
 	}
-	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
+	// tunIPNet.IP is the network address, ending in 0s, like 100.64.0.0
 	// Add 1 to assign the TUN address, like 100.64.0.1
 	tunIP = slices.Clone(tunIPNet.IP)
 	tunIP[len(tunIP)-1]++

--- a/lib/vnet/osconfig_provider_test.go
+++ b/lib/vnet/osconfig_provider_test.go
@@ -65,8 +65,9 @@ func TestOSConfigProvider(t *testing.T) {
 			expectTargetOSConfig: &osConfig{
 				tunName: "testtun1",
 				// Should be the first non-broadcast address in the CIDR range.
-				tunIPv4: "192.168.1.1",
-				tunIPv6: "fd01:2345:6789::1",
+				tunIPv4:    "192.168.1.1",
+				tunIPv4Net: &net.IPNet{IP: []byte{192, 168, 1, 0}, Mask: []byte{255, 255, 255, 0}},
+				tunIPv6:    "fd01:2345:6789::1",
 				// Should include the second non-broadcast address in the CIDR range.
 				dnsAddrs:   []string{"fd01:2345:6789::2", "192.168.1.2"},
 				dnsZones:   []string{"test.example.com"},
@@ -79,15 +80,16 @@ func TestOSConfigProvider(t *testing.T) {
 			ipv6Prefix:     "fd01:2345:6789::",
 			dnsIPv6:        "fd01:2345:6789::2",
 			dnsZones:       []string{"test.example.com"},
-			ipv4CIDRRanges: []string{"10.64.0.0/16", "192.168.1.0/24"},
+			ipv4CIDRRanges: []string{"10.64.0.0/10", "192.168.1.0/24"},
 			expectTargetOSConfig: &osConfig{
 				tunName: "testtun1",
 				// Should be chosen from the first CIDR range.
 				tunIPv4:    "10.64.0.1",
+				tunIPv4Net: &net.IPNet{IP: []byte{10, 64, 0, 0}, Mask: []byte{255, 192, 0, 0}},
 				tunIPv6:    "fd01:2345:6789::1",
 				dnsAddrs:   []string{"fd01:2345:6789::2", "10.64.0.2"},
 				dnsZones:   []string{"test.example.com"},
-				cidrRanges: []string{"10.64.0.0/16", "192.168.1.0/24"},
+				cidrRanges: []string{"10.64.0.0/10", "192.168.1.0/24"},
 			},
 		},
 	} {

--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -68,8 +68,9 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 		if !state.configuredV4Address {
 			log.InfoContext(ctx, "Setting IPv4 address for the TUN device",
 				"device", cfg.tunName, "address", cfg.tunIPv4)
+			netMask := maskForIPNet(cfg.tunIPv4Net)
 			if err := runCommand(ctx,
-				"netsh", "interface", "ip", "set", "address", cfg.tunName, "static", cfg.tunIPv4,
+				"netsh", "interface", "ip", "set", "address", cfg.tunName, "static", cfg.tunIPv4, netMask,
 			); err != nil {
 				return trace.Wrap(err)
 			}
@@ -126,7 +127,11 @@ func addrMaskForCIDR(cidr string) (string, string, error) {
 	if err != nil {
 		return "", "", trace.Wrap(err, "parsing CIDR range %s", cidr)
 	}
-	return ipNet.IP.String(), net.IP(ipNet.Mask).String(), nil
+	return ipNet.IP.String(), maskForIPNet(ipNet), nil
+}
+
+func maskForIPNet(ipNet *net.IPNet) string {
+	return net.IP(ipNet.Mask).String()
 }
 
 const (


### PR DESCRIPTION
This commit updates the `netsh interface ip set address` command used to set the v4 IP address for the TUN interface on Windows to include a mask for the correct CIDR range. Without the mask, Windows assigns a default route for the nearest /8, /16, or /24 range to the address. With the default range of 100.64.0.0/10, this was causing  a route for 100.0.0.0/8 to be assigned to VNet, which should not handle all of that range.

Before this change the assigned routes looked like this:
```
IPv4 Route Table
===========================================================================
Active Routes:
Network Destination        Netmask          Gateway       Interface  Metric
          0.0.0.0          0.0.0.0     192.168.50.1    192.168.50.16     30
        100.0.0.0        255.0.0.0         On-link        100.64.0.1    261
       100.64.0.0      255.192.0.0       100.64.0.1       100.64.0.1      6
       100.64.0.1  255.255.255.255         On-link        100.64.0.1    261
```

With the fix it looks like
```
IPv4 Route Table
===========================================================================
Active Routes:
Network Destination        Netmask          Gateway       Interface  Metric
          0.0.0.0          0.0.0.0     192.168.50.1    192.168.50.16     30
       100.64.0.0      255.192.0.0       100.64.0.1       100.64.0.1      6
       100.64.0.1  255.255.255.255         On-link        100.64.0.1    261
```

note that the extra route for `100.0.0.0` with a mask of `255.0.0.0` has been removed.

This is not an issue on darwin.

changelog: fixed a default IPv4 route assigned to the VNet interface on Windows