### PR TITLE
Prefer net.JoinHostPort over fmt.Sprintf

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -563,7 +565,8 @@ func connectAsRDSMySQLAdmin(t *testing.T, ctx context.Context, instanceID string
 		})
 		return nil
 	}
-	endpoint := fmt.Sprintf("%s:%d", info.address, info.port)
+
+	endpoint := net.JoinHostPort(info.address, strconv.Itoa(info.port))
 	conn, err := mysqlclient.Connect(endpoint, info.username, info.password, dbName, opt)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/gen/go/eventschema/getters.go
+++ b/gen/go/eventschema/getters.go
@@ -212,7 +212,6 @@ func (field *EventField) TableSchemaDetails(path []string) ([]*ColumnSchemaDetai
 	default:
 		return nil, trace.NotImplemented("field type '%s' not supported", field.Type)
 	}
-	return nil, nil
 }
 
 func (field *EventField) dmlType() string {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7748,7 +7748,7 @@ func getRemoteAddrString(sshClientString string) string {
 	if len(parts) != 3 {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", parts[0], parts[1])
+	return net.JoinHostPort(parts[0], parts[1])
 }
 
 func isNilOrEOFErr(t *testing.T, err error) {

--- a/lib/client/conntest/database/mysql.go
+++ b/lib/client/conntest/database/mysql.go
@@ -21,9 +21,9 @@ package database
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/go-mysql-org/go-mysql/client"
@@ -60,7 +60,7 @@ func (p *MySQLPinger) Ping(ctx context.Context, params PingParams) error {
 	}
 
 	var nd net.Dialer
-	addr := fmt.Sprintf("%s:%d", params.Host, params.Port)
+	addr := net.JoinHostPort(params.Host, strconv.Itoa(params.Port))
 	conn, err := client.ConnectWithDialer(ctx, "tcp", addr,
 		params.Username,
 		"", // no password, we're dialing into a tunnel.

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -588,7 +589,7 @@ func (c *CLICommandBuilder) getMongoAddress() string {
 
 	address := url.URL{
 		Scheme:   connstring.SchemeMongoDB,
-		Host:     fmt.Sprintf("%s:%d", c.host, c.port),
+		Host:     net.JoinHostPort(c.host, strconv.Itoa(c.port)),
 		RawQuery: query.Encode(),
 		Path:     fmt.Sprintf("/%s", c.db.Database),
 	}

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -236,7 +236,7 @@ func (c ProxyConfig) PublicPeerAddr() (*utils.NetAddr, error) {
 	}
 
 	port := addr.Port(defaults.ProxyPeeringListenPort)
-	addr, err = utils.ParseAddr(fmt.Sprintf("%s:%d", ip.String(), port))
+	addr, err = utils.ParseAddr(net.JoinHostPort(ip.String(), strconv.Itoa(port)))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -218,7 +220,7 @@ func GetServiceFQDN(service corev1.Service) string {
 func buildAppURI(protocol, serviceFQDN, path string, port int32) string {
 	return (&url.URL{
 		Scheme: protocol,
-		Host:   fmt.Sprintf("%s:%d", serviceFQDN, port),
+		Host:   net.JoinHostPort(serviceFQDN, strconv.Itoa(int(port))),
 		Path:   path,
 	}).String()
 }

--- a/lib/srv/discovery/common/database.go
+++ b/lib/srv/discovery/common/database.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -330,7 +332,7 @@ func NewDatabaseFromRDSV2Instance(instance *rdstypes.DBInstance) (types.Database
 	uri := ""
 	if instance.Endpoint != nil && instance.Endpoint.Address != nil {
 		if instance.Endpoint.Port != nil {
-			uri = fmt.Sprintf("%s:%d", aws.ToString(instance.Endpoint.Address), *instance.Endpoint.Port)
+			uri = net.JoinHostPort(aws.ToString(instance.Endpoint.Address), strconv.Itoa(int(*instance.Endpoint.Port)))
 		} else {
 			uri = aws.ToString(instance.Endpoint.Address)
 		}
@@ -734,7 +736,7 @@ func NewDatabaseFromRDSProxy(dbProxy *rdstypes.DBProxy, tags []rdstypes.Tag) (ty
 		}, aws.ToString(dbProxy.DBProxyName)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
-			URI:      fmt.Sprintf("%s:%d", aws.ToString(dbProxy.Endpoint), port),
+			URI:      net.JoinHostPort(aws.ToString(dbProxy.Endpoint), strconv.Itoa(port)),
 			AWS:      *metadata,
 		})
 }
@@ -757,7 +759,7 @@ func NewDatabaseFromRDSProxyCustomEndpoint(dbProxy *rdstypes.DBProxy, customEndp
 		}, aws.ToString(dbProxy.DBProxyName), aws.ToString(customEndpoint.DBProxyEndpointName)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
-			URI:      fmt.Sprintf("%s:%d", aws.ToString(customEndpoint.Endpoint), port),
+			URI:      net.JoinHostPort(aws.ToString(customEndpoint.Endpoint), strconv.Itoa(port)),
 			AWS:      *metadata,
 
 			// RDS proxies serve wildcard certificates like this:

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -312,8 +312,8 @@ type mockProtocolChecker struct {
 }
 
 func (m *mockProtocolChecker) CheckProtocol(service corev1.Service, port corev1.ServicePort) string {
-	uri := fmt.Sprintf("%s:%d", services.GetServiceFQDN(service), port.Port)
-	if result, ok := m.results[uri]; ok {
+	hostport := net.JoinHostPort(services.GetServiceFQDN(service), strconv.Itoa(int(port.Port)))
+	if result, ok := m.results[hostport]; ok {
 		return result
 	}
 	return "tcp"

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1108,7 +1108,7 @@ func TestAdvertiseAddr(t *testing.T) {
 	)
 	// IP-only advertiseAddr should use the port from srvAddress.
 	f.ssh.srv.setAdvertiseAddr(advIP)
-	require.Equal(t, fmt.Sprintf("%s:%s", advIP, f.ssh.srvPort), f.ssh.srv.AdvertiseAddr())
+	require.Equal(t, net.JoinHostPort(advIP.String(), f.ssh.srvPort), f.ssh.srv.AdvertiseAddr())
 
 	// IP and port advertiseAddr should fully override srvAddress.
 	f.ssh.srv.setAdvertiseAddr(advIPPort)

--- a/lib/teleterm/gateway/base.go
+++ b/lib/teleterm/gateway/base.go
@@ -21,7 +21,6 @@ package gateway
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log/slog"
 	"net"
 	"strconv"
@@ -231,7 +230,7 @@ type TCPPortAllocator interface {
 type NetTCPPortAllocator struct{}
 
 func (n NetTCPPortAllocator) Listen(localAddress, port string) (net.Listener, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", localAddress, port))
+	listener, err := net.Listen("tcp", net.JoinHostPort(localAddress, port))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/gatewaytest/helpers.go
+++ b/lib/teleterm/gatewaytest/helpers.go
@@ -21,7 +21,6 @@ package gatewaytest
 import (
 	"crypto/tls"
 	"crypto/x509/pkix"
-	"fmt"
 	"io"
 	"net"
 	"slices"
@@ -82,7 +81,7 @@ func (m *MockTCPPortAllocator) Listen(localAddress, localPort string) (net.Liste
 		return nil, trace.BadParameter("address already in use")
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", "localhost", "0"))
+	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -129,7 +128,7 @@ func (m *MockListener) Addr() net.Addr {
 		return m.realListener.Addr()
 	}
 
-	addr, err := net.ResolveTCPAddr("", fmt.Sprintf("%s:%s", "localhost", m.fakePort))
+	addr, err := net.ResolveTCPAddr("", net.JoinHostPort("localhost", m.fakePort))
 
 	if err != nil {
 		panic(err)

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1430,7 +1431,7 @@ func TestSSH(t *testing.T) {
 				},
 			}
 
-			sshConn, chans, reqs, err := ssh.NewClientConn(conn, fmt.Sprintf("%s:%d", tc.dialAddr, tc.dialPort), clientConfig)
+			sshConn, chans, reqs, err := ssh.NewClientConn(conn, net.JoinHostPort(tc.dialAddr, strconv.Itoa(tc.dialPort)), clientConfig)
 			assert.Equal(t, tc.expectBannerMessages, bannerMessages, "actual banner messages did not match the expected")
 			if tc.expectSSHHandshakeToFail {
 				assert.Error(t, err, "expected SSH handshake to fail")

--- a/lib/web/proxy_settings.go
+++ b/lib/web/proxy_settings.go
@@ -18,7 +18,8 @@ package web
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -157,5 +158,5 @@ func (p *ProxySettings) getPostgresPublicAddr() string {
 	} else {
 		host = p.ServiceConfig.Proxy.WebAddr.Host()
 	}
-	return fmt.Sprintf("%s:%d", host, p.ServiceConfig.Proxy.PostgresAddr.Port(defaults.PostgresListenPort))
+	return net.JoinHostPort(host, strconv.Itoa(p.ServiceConfig.Proxy.PostgresAddr.Port(defaults.PostgresListenPort)))
 }

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -245,7 +247,7 @@ func printAppCommand(cf *CLIConf, tc *client.TeleportClient, app types.Applicati
 	case app.IsTCP():
 		appNameWithOptionalTargetPort := app.GetName()
 		if routeToApp.TargetPort != 0 {
-			appNameWithOptionalTargetPort = fmt.Sprintf("%s:%d", app.GetName(), routeToApp.TargetPort)
+			appNameWithOptionalTargetPort = net.JoinHostPort(app.GetName(), strconv.Itoa(int(routeToApp.GetTargetPort())))
 		}
 
 		return tcpAppLoginTemplate.Execute(output, map[string]string{

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -529,7 +529,7 @@ func onProxyCommandApp(cf *CLIConf) error {
 
 	appName := cf.AppName
 	if portMapping.TargetPort != 0 {
-		appName = fmt.Sprintf("%s:%d", appName, portMapping.TargetPort)
+		appName = net.JoinHostPort(appName, strconv.Itoa(portMapping.TargetPort))
 	}
 	fmt.Printf("Proxying connections to %s on %v\n", appName, proxyApp.GetAddr())
 	// If target port is not equal to zero, the user must know about the port flag.

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1641,7 +1641,7 @@ func TestProxyAppMultiPort(t *testing.T) {
 		"--insecure",
 		"--proxy", process.Config.Proxy.WebAddr.Addr,
 		"proxy", "app", appName,
-		"--port", fmt.Sprintf("%s:%d", fooProxyPort, fooServerPort),
+		"--port", net.JoinHostPort(fooProxyPort, strconv.Itoa(fooServerPort)),
 	}
 	testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
 		Name: "tsh proxy app (foo)",
@@ -1674,7 +1674,7 @@ func TestProxyAppMultiPort(t *testing.T) {
 		"--insecure",
 		"--proxy", process.Config.Proxy.WebAddr.Addr,
 		"proxy", "app", appName,
-		"--port", fmt.Sprintf("%s:%d", barProxyPort, barServerPort),
+		"--port", net.JoinHostPort(barProxyPort, strconv.Itoa(barServerPort)),
 	}
 	testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
 		Name: "tsh proxy app (bar)",


### PR DESCRIPTION
net.JoinHostPart is the more specific tool, and handles things like IPv6 addresses.