### PR TITLE
Fix missing `require.True` for `slices.ContainsFunc` in tests

### DIFF
--- a/lib/services/local/spiffe_federations_test.go
+++ b/lib/services/local/spiffe_federations_test.go
@@ -166,9 +166,9 @@ func TestSPIFFEFederationService_ListSPIFFEFederations(t *testing.T) {
 
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(page, func(federation *machineidv1.SPIFFEFederation) bool {
+			require.True(t, slices.ContainsFunc(page, func(federation *machineidv1.SPIFFEFederation) bool {
 				return proto.Equal(created, federation)
-			})
+			}))
 		}
 	})
 	t.Run("pagination", func(t *testing.T) {
@@ -190,9 +190,9 @@ func TestSPIFFEFederationService_ListSPIFFEFederations(t *testing.T) {
 		require.Len(t, fetched, 49)
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(fetched, func(federation *machineidv1.SPIFFEFederation) bool {
+			require.True(t, slices.ContainsFunc(fetched, func(federation *machineidv1.SPIFFEFederation) bool {
 				return proto.Equal(created, federation)
-			})
+			}))
 		}
 	})
 }

--- a/lib/services/local/workload_identity_test.go
+++ b/lib/services/local/workload_identity_test.go
@@ -164,9 +164,9 @@ func TestWorkloadIdentityService_ListWorkloadIdentities(t *testing.T) {
 
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
+			require.True(t, slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
 				return proto.Equal(created, resource)
-			})
+			}))
 		}
 	})
 	t.Run("pagination", func(t *testing.T) {
@@ -188,9 +188,9 @@ func TestWorkloadIdentityService_ListWorkloadIdentities(t *testing.T) {
 		require.Len(t, fetched, 49)
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
+			require.True(t, slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentity) bool {
 				return proto.Equal(created, resource)
-			})
+			}))
 		}
 	})
 }

--- a/lib/services/local/workload_identity_x509_revocation_test.go
+++ b/lib/services/local/workload_identity_x509_revocation_test.go
@@ -170,9 +170,9 @@ func TestWorkloadIdentityX509RevocationService_List(t *testing.T) {
 
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
+			require.True(t, slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
 				return proto.Equal(created, resource)
-			})
+			}))
 		}
 	})
 	t.Run("pagination", func(t *testing.T) {
@@ -194,9 +194,9 @@ func TestWorkloadIdentityX509RevocationService_List(t *testing.T) {
 		require.Len(t, fetched, 49)
 		// Expect that we get all the things we have created
 		for _, created := range createdObjects {
-			slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
+			require.True(t, slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
 				return proto.Equal(created, resource)
-			})
+			}))
 		}
 	})
 }


### PR DESCRIPTION
Looks like I copy-pasted this a few times in some CRUD tests. These calls to `slices.ContainsFunc` need some kind of assertion on their result.