### PR TITLE
Reduce Connect subprocesses entitlements to just allow-jit

### DIFF
--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -116,6 +116,9 @@ module.exports = {
     notarize: true,
     hardenedRuntime: true,
     gatekeeperAssess: false,
+    // Use the same entitlements for Electron subprocesses (e.g., renderer, GPU)
+    // as those defined for the main app.
+    entitlementsInherit: 'build_resources/entitlements.mac.plist',
     // If CONNECT_TSH_APP_PATH is provided, we assume that tsh.app is already signed.
     signIgnore: env.CONNECT_TSH_APP_PATH && ['tsh.app'],
     icon: 'build_resources/icon-mac.png',


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/51422, we reduced the macOS entitlements for Teleport Connect.app to only allow-jit.

However, this change did not affect subprocesses such as Teleport Connect Helper (Renderer).app, which still use the default entitlements provided by electron-builder:

1. [macPackager.ts#L409-L419](https://github.com/electron-userland/electron-builder/blob/bff46ec41c4a7715cc06f7dfd6ff95f8e4bbe869/packages/app-builder-lib/src/macPackager.ts#L409-L419)
2. [entitlements.mac.plist (template)](https://github.com/electron-userland/electron-builder/blob/692091b981f120274aa2941ab038137dceddef92/packages/app-builder-lib/templates/entitlements.mac.plist)

To override these defaults, we can use the [entitlementsInherit](https://www.electron.build/mac#entitlementsinherit) option in the Electron builder configuration.

Before (for the renderer process):
```
% codesign -d --entitlements - --xml Teleport\ Connect\ Helper\ \(Renderer\).app
Executable=/Applications/Teleport Connect.app/Contents/Frameworks/Teleport Connect Helper (Renderer).app/Contents/MacOS/Teleport Connect Helper (Renderer)
<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key><true/><key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>
```
After 
 ```
% codesign -d --entitlements - --xml Teleport\ Connect\ Helper\ \(Renderer\).app 
Executable=/Applications/Teleport Connect.app/Contents/Frameworks/Teleport Connect Helper (Renderer).app/Contents/MacOS/Teleport Connect Helper (Renderer)
<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key><true/></dict></plist>
```

I've tested the app with the reduced entitlements, and it appears to work correctly. I also confirmed that this change does not interfere with the upcoming auto-update functionality.
Tag build https://github.com/gravitational/teleport.e/actions/runs/16417042830.

changelog: Removed unnecessary macOS entitlements from Teleport Connect subprocesses 