### PR TITLE
AWS Roles Anywhere: List Profiles API: return all profiles

### DIFF
--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -710,12 +710,8 @@ type AWSRolesAnywherePingResponse struct {
 	UserID string `json:"userId"`
 }
 
-// AWSRolesAnywhereListProfilesRequest contains the list of Roles Anywhere Profiles.
+// AWSRolesAnywhereListProfilesRequest contains the request to list Roles Anywhere Profiles.
 type AWSRolesAnywhereListProfilesRequest struct {
-	// StartKey is the token to be used to fetch the next page.
-	// If empty, the first page is fetched.
-	StartKey string `json:"startKey"`
-
 	// Filters are the filters applied to the profiles.
 	// Only matching profiles will be synchronized as application servers.
 	// If empty, no filtering is applied.


### PR DESCRIPTION
This PR changes the `listprofiles` endpoint to return all the profiles at once.

Pagination will be implemented client side.

Why do we need this change?
This endpoint is used to show the list of existing profiles when the user is setting up the profile sync using the AWS IAM Roles Anywhere integration.

Given that we have filters, it might happen that to list X profiles, we might need to do X api calls, which is not ideal.
Instead of asking for a paginated list of Profiles, the WebUI will ask for the whole list.

This list is limited to a max of 250 items as described in the AWS Roles Anywhere quotas:
https://docs.aws.amazon.com/rolesanywhere/latest/userguide/quotas.html

The new flow (after this PR):
```mermaid
sequenceDiagram
    WebUI->>+Proxy: HTTP API ListProfiles
    loop Until there's no profiles left
        Proxy->>+Auth: gRPC API ListProfiles
        Auth->>+AWS-API: HTTP Req ListProfiles
        AWS-API->>+Auth: Paginated List of Profiles
        Auth->>+Auth: Filter profiles
        Auth->>+Proxy: Paginated List of filtered Profiles
    end
    Proxy->>+WebUI: List of all filtered Profiles
```