### PR TITLE
Add "How it works" sections to 16 docs guides

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -38,7 +38,7 @@ Request. The plugin then manages updates in a third-party communication
 platform, in this case, Mattermost. Users can then approve and deny Access
 Requests by following a message link.
 
-![The Mattermost Access Request plugin](../../../img/enterprise/plugins/mattermost/diagram.png)
+![The Mattermost Access Request plugin](../../../../img/enterprise/plugins/mattermost/diagram.png)
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -21,9 +21,24 @@ The steps below describe how to use Teleport with Mattermost. You can also
 
 <Admonition type="warning">
 
-Dual Authorization requires Teleport Enterprise.
+Dual Authorization requires Teleport Identity Governance.
 
 </Admonition>
+
+## How it works
+
+Teleport administrators can configure a role that allows elevated privileges as
+long as multiple additional users approve a request for that role. When a user
+requests access to the elevated role, they create an Access Request resource on
+the Teleport Auth Service backend. 
+
+A Teleport Access Request plugin connects to the Teleport Auth Service and
+receives a gRPC message whenever a Teleport user creates or updates an Access
+Request. The plugin then manages updates in a third-party communication
+platform, in this case, Mattermost. Users can then approve and deny Access
+Requests by following a message link.
+
+![The Mattermost Access Request plugin](../../../img/enterprise/plugins/mattermost/diagram.png)
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/guides/headless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/headless.mdx
@@ -26,6 +26,24 @@ For example:
   In the future, Headless WebAuthn will be extended to other `tsh` commands.
 </Admonition>
 
+## How it works
+
+In the Headless WebAuthn flow, a user on a remote machine requests headless
+authentication when running `tsh` commands. `tsh` sends a request to an API path
+on the Teleport Proxy Service, `/webapi/login/headless`, and the Teleport Proxy
+Service sends a request to the Teleport Auth Service to store a headless
+authentication request on its backend. `tsh` then obtains the ID of the request
+and prints a URL containing the ID in the user's terminal. The user accesses the
+URL on their browser and completes a WebAuthn flow with the Teleport Auth
+Service.
+
+Once the Teleport Auth Service authenticates the user, `tsh` generates a new
+private key in memory, and shares its public key only to obtain user
+certificates. `tsh` then holds user certificates in memory with a one-minute TTL
+to reduce the impact of exfiltration. Since TLS credentials exist only in
+memory, it is not possible for users of a shared remote machine to leak
+credentials to one another when using `tsh`.
+
 ## Prerequisites
 
 - A Teleport cluster with WebAuthn configured.

--- a/docs/pages/admin-guides/access-controls/guides/headless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/headless.mdx
@@ -40,9 +40,7 @@ Service.
 Once the Teleport Auth Service authenticates the user, `tsh` generates a new
 private key in memory, and shares its public key only to obtain user
 certificates. `tsh` then holds user certificates in memory with a one-minute TTL
-to reduce the impact of exfiltration. Since TLS credentials exist only in
-memory, it is not possible for users of a shared remote machine to leak
-credentials to one another when using `tsh`.
+to reduce the impact of exfiltration.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/guides/impersonation.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/impersonation.mdx
@@ -14,6 +14,16 @@ users and robots to create short-lived certs for other users and roles.
 Let's explore how interactive user Alice can create credentials for a
 non-interactive CI/CD user Jenkins and a security scanner.
 
+## How it works
+
+A Teleport role allows a Teleport user to impersonate other roles or users. When
+a Teleport user authenticates with a role that allows impersonation, they can
+execute the `tctl auth sign` command to instruct the Teleport Auth Service to
+sign a certificate for another Teleport user. As with all Teleport user
+certificates, the certificate written by `tctl auth sign` includes the names of
+a Teleport user and that user's roles. TLS or SSH clients can then load the
+certificate in order to authenticate to Teleport as the impersonated user.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
@@ -30,6 +30,8 @@ requires the following resources, which we show you how to create in this guide:
   `cert-manager`, AWS Certificate Manager, and your own TLS credentials.
   Depending on the method you choose, you may also need to create IAM
   permissions to allow the provisioning system to interact with AWS APIs.
+- **Amazon S3 bucket and DynamoDB database** for the Teleport Auth Service
+  backend.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
@@ -17,6 +17,20 @@ cluster to Teleport.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
+## How it works
+
+The `teleport-cluster` Helm chart deploys the Teleport Auth Service and Teleport
+Proxy Service on your Amazon Elastic Kubernetes Service cluster. The chart
+requires the following resources, which we show you how to create in this guide:
+
+- **IAM permissions for the Teleport Auth Service**. The Auth Service requires
+  permissions to manage resources on its backend. 
+- **A system to provision TLS credentials** that the Proxy Service uses to run
+  its HTTPS server. In this guide, we show you how to do this with
+  `cert-manager`, AWS Certificate Manager, and your own TLS credentials.
+  Depending on the method you choose, you may also need to create IAM
+  permissions to allow the provisioning system to interact with AWS APIs.
+
 ## Prerequisites
 
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
@@ -20,6 +20,22 @@ cluster to Teleport.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
+## How it works
+
+The `teleport-cluster` Helm chart deploys the Teleport Auth Service and Teleport
+Proxy Service on your Azure Kubernetes Service cluster. The chart requires the
+following resources, which we show you how to create in this guide:
+
+- **IAM permissions for the Teleport Auth Service**. The Auth Service requires
+  permissions to manage resources on its backend. 
+- **cert-manager** for obtaining and renewing TLS credentials that the Proxy
+  Service uses to run its HTTPS server.
+- **IAM permissions for cert-manager**. In the setup we show in this guide,
+  `cert-manager` modifies DNS records to demonstrate domain ownership and
+  receive TLS credentials from Let's Encrypt. To do so, the Proxy Service
+  completes the [ACME DNS-01
+  challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+
 ## Prerequisites
 
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
@@ -35,6 +35,8 @@ following resources, which we show you how to create in this guide:
   receive TLS credentials from Let's Encrypt. To do so, the Proxy Service
   completes the [ACME DNS-01
   challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+- **Teleport Auth Service backend components:** PostgreSQL database and an
+  Amazon S3-compatible object storage solution.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
@@ -21,6 +21,15 @@ existing Teleport deployment to access your Kubernetes cluster. [Follow our
 guide](../../../enroll-resources/kubernetes-access/getting-started.mdx) to connect your Kubernetes
 cluster to Teleport.
 
+## How it works
+
+The `teleport-cluster` Helm chart deploys the Teleport Auth Service and Proxy
+Service. You can modify the chart's values file to include a custom
+configuration for each service. The Helm chart applies Auth Service and Proxy
+Service configurations to their respective pods, which load each configuration
+as a ConfigMap. The chart applies Teleport-recommended defaults for any field
+not included in your custom configurations.
+
 ## Prerequisites
 
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -31,6 +31,8 @@ following resources, which we show you how to create in this guide:
   receive TLS credentials from Let's Encrypt. To do so, the Proxy Service
   completes the [ACME DNS-01
   challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+- **Teleport Auth Service backend components:** A Google Cloud Storage bucket and
+  Firestore database.
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -16,6 +16,22 @@ cluster to Teleport.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
+## How it works
+
+The `teleport-cluster` Helm chart deploys the Teleport Auth Service and Teleport
+Proxy Service on your Google Kubernetes Engine cluster. The chart requires the
+following resources, which we show you how to create in this guide:
+
+- **IAM permissions for the Teleport Auth Service**. The Auth Service requires
+  permissions to manage resources on its backend. 
+- **cert-manager** for obtaining and renewing TLS credentials that the Proxy
+  Service uses to run its HTTPS server.
+- **IAM permissions for cert-manager**. In the setup we show in this guide,
+  `cert-manager` modifies DNS records to demonstrate domain ownership and
+  receive TLS credentials from Let's Encrypt. To do so, the Proxy Service
+  completes the [ACME DNS-01
+  challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+
 ## Prerequisites
 
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
@@ -13,6 +13,13 @@ machine without using a third-party client.
 
 This guide explains how to use Teleport and a JetBrains IDE to access files with SFTP.
 
+## How it works
+
+JetBrains IDEs can use the local SSH client to access a remote server. You can
+use Teleport to generate a configuration for your local SSH client that
+instructs the client to connect to a Teleport-protected Linux server using a
+Teleport-issued OpenSSH certificate. 
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx clients="\`tsh\` client"!)

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -9,6 +9,13 @@ labels:
 
 This guide explains how to use Teleport and Visual Studio Code's remote SSH extension.
 
+## How it works
+
+The Visual Studio Code Remote - SSH extension uses the local SSH client to
+access a remote server. You can use Teleport to generate a configuration for
+your local SSH client that instructs the client to connect to a
+Teleport-protected Linux server using a Teleport-issued OpenSSH certificate. 
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx clients="\`tsh\` client"!)

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
@@ -15,14 +15,23 @@ on [the IaC users and roles guide](./user-and-role.mdx) by allowing users with
 the `manager` role to grant the `support-engineer` role to users meeting
 specific criteria.
 
-Please note that Access Lists can be managed via IaC but Access List memberships
-cannot. The goal of Access Lists is to decentralize granting and reviewing
-access. By allowing managers to grant access within specific guidelines and
-automatically enforcing review, users can request common access rights without
-having to go through the centralized team managing the Teleport IaC.
-This reduces the load on the centralized IaC/security team, ensures the access
-reviewer is aware of the context, reduces the request resolution time, and
-ensures access grants are periodically reviewed.
+## How it works
+
+Access Lists are registered with the Teleport Auth Service as resources stored
+on the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
+enables clients to create, delete, or modify backend resources, including Access
+Lists. The Teleport Kubernetes Operator and Terraform provider, along with the
+`tctl` command-line tool, can manage agentless SSH services by authenticating to
+the Teleport Auth Service and interacting with its gRPC API.
+
+Access Lists can be managed via IaC but Access List memberships cannot. The goal
+of Access Lists is to decentralize granting and reviewing access. By allowing
+managers to grant access within specific guidelines and automatically enforcing
+review, users can request common access rights without having to go through the
+centralized team managing the Teleport IaC. This reduces the load on the
+centralized IaC/security team, ensures the access reviewer is aware of the
+context, reduces the request resolution time, and ensures access grants are
+periodically reviewed.
 
 ## Prerequisites
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
@@ -16,7 +16,23 @@ dynamically create resources from code:
 - The `tctl` CLI, which allows you to manage Teleport resources from your local
   computer or your CI environment
 
-## Prerequisites
+## How it works
+
+Teleport can route SSH connections through the Teleport Proxy Service to SSH
+nodes. Once you have configured your SSH nodes to trust the Teleport certificate
+authority for OpenSSH (see the [Agentless OpenSSH
+guide](../../../enroll-resources/server-access/openssh/openssh-agentless.mdx),
+the Proxy Service can present a Teleport-signed certificate to the node and
+establish a connection.
+
+Agentless SSH servers are registered with the Teleport Auth Service as resources
+stored on the Auth Service backend. The Teleport Auth Service exposes a gRPC API
+that enables clients to create, delete, or modify backend resources, including
+agentless SSH servers. The Teleport Kubernetes Operator and Terraform provider,
+along with the `tctl` command-line tool, can manage agentless SSH services by
+authenticating to the Teleport Auth Service and interacting with its gRPC API.
+
+# Prerequisites
 
 To follow this guide, you must have:
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
@@ -23,7 +23,8 @@ nodes. Once you have configured your SSH nodes to trust the Teleport certificate
 authority for OpenSSH (see the [Agentless OpenSSH
 guide](../../../enroll-resources/server-access/openssh/openssh-agentless.mdx),
 the Proxy Service can present a Teleport-signed certificate to the node and
-establish a connection.
+establish a connection. For this to work, the Teleport Proxy Service must be
+able to dial the node.
 
 Agentless SSH servers are registered with the Teleport Auth Service as resources
 stored on the Auth Service backend. The Teleport Auth Service exposes a gRPC API

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
@@ -17,6 +17,14 @@ contains `resource` blocks that represent your existing Teleport resources.
 By defining all Teleport resources in one place, you can help ensure that your
 cluster configuration matches your expectations.
 
+## How it works
+
+As with any compliant Terraform provider, the Teleport provider allows you to
+generate a Terraform configuration based on existing resources that the Teleport
+Auth Service has stored on its backend. For all of the Teleport resources that
+the Terraform provider supports, see the [Terraform resource
+reference](../../../reference/terraform-provider/resources/resources.mdx).
+
 ## Step 1/3. Add an `import` block
 
 1. On your workstation, navigate to your root Teleport Terraform module.

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
@@ -14,6 +14,14 @@ This guide will explain how to:
 This guide is applicable if you self-host Teleport in Kubernetes using the
 `teleport-cluster` Helm chart.
 
+## How it works
+
+Login Rules are registered with the Teleport Auth Service as resources stored on
+the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
+enables clients to create, delete, or modify backend resources, including Login
+Rules. The Teleport Kubernetes Operator can manage agentless SSH services by
+authenticating to the Teleport Auth Service and interacting with its gRPC API.
+
 ## Prerequisites
 
 - A Teleport Enterprise license

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
@@ -11,6 +11,14 @@ This guide will explain how to:
 - Use Teleport's Terraform Provider to deploy Login Rules to your Teleport cluster
 - Edit deployed Login Rules via Terraform
 
+## How it works
+
+Login Rules are registered with the Teleport Auth Service as resources stored on
+the Auth Service backend. The Teleport Auth Service exposes a gRPC API that
+enables clients to create, delete, or modify backend resources, including Login
+Rules. The Teleport Terraform Provider can manage agentless SSH services by
+authenticating to the Teleport Auth Service and interacting with its gRPC API.
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
@@ -17,6 +17,15 @@ create resources from code:
 - The `tctl` CLI, which allows you to manage Teleport resources from your local
   computer or your CI environment
 
+## How it works
+
+In Teleport, users and roles are backend resources managed by the Teleport Auth
+Service. The Teleport Auth Service exposes a gRPC API that enables clients to
+create, delete, or modify backend resources, including users and roles. The
+Teleport Kubernetes Operator and Terraform provider, along with the `tctl`
+command-line tool, can manage Teleport users and roles by authenticating to the
+Teleport Auth Service and interacting with its gRPC API.
+
 ## Prerequisites
 
 To follow this guide, you must have:

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -9,25 +9,35 @@ labels:
 This guide explains you how to create a Terraform user and have the Teleport Auth Service sign long-lived credentials
 for it. The Teleport Terraform Provider can then user those credentials to interact with Teleport.
 
+## How it works
+
+A Teleport administrator defines a role for the Teleport Terraform provider, as
+well as a role that can
+[impersonate](../../../admin-guides/access-controls/guides/impersonation.mdx)
+the Terraform provider role. A Teleport user assumes the impersonator role and
+executes a `tctl` command to instruct the Teleport Auth Service to sign a user
+certificate for the Terraform provider. The provider then loads the certificate
+in order to authenticate to your Teleport cluster and manage resources on the
+Teleport Auth Service backend.
+
 <Admonition type="warning">
 
-Long-lived credentials are less secure and their usage is discouraged. You must protect and rotate the credentials as
-they hold full Teleport administrative access. You should prefer
-using [`tbot`](./dedicated-server.mdx), [native MachineID joining](./ci-or-cloud.mdx) in CI or Cloud environments,
-or [create temporary bots for local use](./local.mdx) when possible.
-
-See [the list of possible Terraform provider setups](terraform-provider.mdx) to find which one fits your
-use-case.
+Long-lived credentials are less secure than other Teleport credentials and their
+usage is discouraged. 
 
 </Admonition>
 
+You must protect and rotate the credentials as they hold full Teleport
+administrative access. You should prefer using [`tbot`](./dedicated-server.mdx),
+[native MachineID joining](./ci-or-cloud.mdx) in CI or Cloud environments, or
+[create temporary bots for local use](./local.mdx) when possible.
 
-<Admonition type="important">
+See [the list of possible Terraform provider setups](terraform-provider.mdx) to
+find which one fits your use-case.
 
-Long-lived credentials are not compatible with MFA for administrative actions (MFA4A)
-which is an additional security layer that protects Teleport in case of Identity Provider (IdP) compromise.
-
-</Admonition>
+Long-lived credentials are not compatible with MFA for administrative actions
+(MFA4A) which is an additional security layer that protects Teleport in case of
+Identity Provider (IdP) compromise.
 
 ## Prerequisites
 


### PR DESCRIPTION
In the Teleport documentation, we are standardizing our how-to guides on including a "How it works" section after the introduction and before the prerequisites. This ensures that each guide includes an architectural overview, which allows the reader to form a mental model of the instructions before following them.

This change adds "How it works" sections to 16 docs guides related to access controls, infrastructure as code, and Helm deployments.