### PR TITLE
[v18] Web: role related tweaks

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -47,10 +47,12 @@ export function RoleEditorAdapter({
   onSave,
   onCancel,
   roleDiffProps,
+  forceProcessingStatus = false,
 }: {
   resources: ResourcesState;
   onSave: (role: Partial<RoleWithYaml>) => Promise<void>;
   onCancel: () => void;
+  forceProcessingStatus?: boolean;
 } & RolesProps) {
   const showRoleDiff = roleDiffProps && shouldShowRoleDiff(roleDiffProps);
   const theme = useTheme();
@@ -94,7 +96,7 @@ export function RoleEditorAdapter({
         minWidth="494px"
         maxWidth="672px"
       >
-        {convertAttempt.status === 'processing' && (
+        {(convertAttempt.status === 'processing' || forceProcessingStatus) && (
           <Flex
             flexDirection="column"
             alignItems="center"
@@ -108,7 +110,7 @@ export function RoleEditorAdapter({
           <Danger>{convertAttempt.statusText}</Danger>
         )}
 
-        {convertAttempt.status === 'success' && (
+        {convertAttempt.status === 'success' && !forceProcessingStatus && (
           <RoleEditor
             originalRole={convertAttempt.data}
             roleDiffAttempt={roleDiffProps?.roleDiffAttempt}

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorDialog.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorDialog.tsx
@@ -42,11 +42,21 @@ export function RoleEditorDialog({
   resources,
   onSave,
   roleDiffProps,
+  forceProcessingStatus = false,
 }: {
   open: boolean;
   onClose(): void;
   resources: ResourcesState;
   onSave(role: Partial<RoleWithYaml>): Promise<void>;
+  /**
+   * Forces this dialog to remain in the processing state while
+   * whatever required processing outside of this dialog finishes.
+   *
+   * eg: Clicking on a role label triggers rendering this dialog
+   * and fetching the role resource at the same time. The fetching
+   * can still be in progress.
+   */
+  forceProcessingStatus?: boolean;
 } & RolesProps) {
   const transitionRef = useRef<HTMLDivElement>(null);
   return (
@@ -63,6 +73,7 @@ export function RoleEditorDialog({
         resources={resources}
         onSave={onSave}
         roleDiffProps={roleDiffProps}
+        forceProcessingStatus={forceProcessingStatus}
       />
     </CSSTransition>
   );
@@ -74,26 +85,39 @@ const DialogInternal = forwardRef<
     onClose(): void;
     resources: ResourcesState;
     onSave(role: Partial<RoleWithYaml>): Promise<void>;
+    forceProcessingStatus?: boolean;
   } & RolesProps
->(({ onClose, resources, onSave, roleDiffProps }, ref) => {
-  return (
-    <Dialog
-      modalCss={() => modalCss}
-      disableEscapeKeyDown={false}
-      open={true}
-      modalRef={ref}
-      BackdropProps={{ className: 'backdrop' }}
-      className="dialog"
-    >
-      <RoleEditorAdapter
-        resources={resources}
-        onSave={onSave}
-        onCancel={onClose}
-        roleDiffProps={roleDiffProps}
-      />
-    </Dialog>
-  );
-});
+>(
+  (
+    {
+      onClose,
+      resources,
+      onSave,
+      roleDiffProps,
+      forceProcessingStatus = false,
+    },
+    ref
+  ) => {
+    return (
+      <Dialog
+        modalCss={() => modalCss}
+        disableEscapeKeyDown={false}
+        open={true}
+        modalRef={ref}
+        BackdropProps={{ className: 'backdrop' }}
+        className="dialog"
+      >
+        <RoleEditorAdapter
+          resources={resources}
+          onSave={onSave}
+          onCancel={onClose}
+          roleDiffProps={roleDiffProps}
+          forceProcessingStatus={forceProcessingStatus}
+        />
+      </Dialog>
+    );
+  }
+);
 
 const modalCss = css`
   & .dialog {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -84,10 +84,16 @@ export const ResourcesTab = memo(function ResourcesTab({
   isProcessing,
   validation,
   dispatch,
+  customDescription,
 }: SectionPropsWithDispatch<
   ResourceAccess[],
   ResourceAccessValidationResult[]
->) {
+> & {
+  /**
+   * Custom description describing this section.
+   */
+  customDescription?: React.ReactNode;
+}) {
   /** All resource access kinds except those that are already in the role. */
   const allowedResourceAccessKinds = allResourceAccessKinds.filter(k =>
     value.every(as => as.kind !== k)
@@ -98,9 +104,13 @@ export const ResourcesTab = memo(function ResourcesTab({
 
   return (
     <Flex flexDirection="column" gap={3}>
-      <SectionPadding>
-        Rules that allow connecting to resources controlled by Teleport
-      </SectionPadding>
+      {customDescription ? (
+        <>{customDescription}</>
+      ) : (
+        <SectionPadding>
+          Rules that allow connecting to resources controlled by Teleport
+        </SectionPadding>
+      )}
       {value.map((res, i) => {
         return (
           <ResourceAccessSection

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StatefulSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StatefulSection.tsx
@@ -76,7 +76,7 @@ export function StatefulSection<Model, ValidationResult>({
   );
 }
 
-const minimalRole = withDefaults({
+export const minimalRole = withDefaults({
   metadata: { name: 'foobar' },
   version: defaultRoleVersion,
 });

--- a/web/packages/teleport/src/components/useResources.ts
+++ b/web/packages/teleport/src/components/useResources.ts
@@ -20,13 +20,18 @@ import { useState } from 'react';
 
 import { Kind, Resource } from 'teleport/services/resources';
 
+type StateItem<T extends Kind> = {
+  status: EditingStatus;
+  item: Resource<T>;
+};
+
 export default function useResources<T extends Kind>(
   resources: Resource<T>[],
   templates: Templates<T>
 ) {
-  const [state, setState] = useState({
-    status: 'reading' as EditingStatus,
-    item: null as Resource<T>,
+  const [state, setState] = useState<StateItem<T>>({
+    status: 'empty',
+    item: null,
   });
 
   const create = (kind: T) => {
@@ -65,7 +70,7 @@ export default function useResources<T extends Kind>(
     });
   };
 
-  return { ...state, create, edit, disregard, remove };
+  return { ...state, create, edit, disregard, remove, setState };
 }
 
 export type State = ReturnType<typeof useResources>;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -314,9 +314,15 @@ const cfg = {
     userWithUsernamePath: '/v1/webapi/users/:username',
     createPrivilegeTokenPath: '/v1/webapi/users/privilege/token',
 
-    listRolesPath:
-      '/v1/webapi/roles?startKey=:startKey?&search=:search?&limit=:limit?',
-    rolePath: '/v1/webapi/roles/:name?',
+    role: {
+      create: '/v1/webapi/roles',
+      get: '/v1/webapi/roles/:name',
+      delete: '/v1/webapi/roles/:name',
+      update: '/v1/webapi/roles/:name',
+      list: '/v1/webapi/roles?startKey=:startKey?&search=:search?&limit=:limit?',
+      listWithoutQueryParam: '/v1/webapi/roles',
+    },
+
     presetRolesPath: '/v1/webapi/presetroles',
     githubConnectorsPath: '/v1/webapi/github/:name?',
     githubConnectorPath: '/v1/webapi/github/connector/:name',
@@ -1068,16 +1074,32 @@ const cfg = {
     return generatePath(cfg.api.trustedClustersPath, { name });
   },
 
-  getListRolesUrl(params?: UrlListRolesParams) {
-    return generatePath(cfg.api.listRolesPath, {
-      search: params?.search || undefined,
-      startKey: params?.startKey || undefined,
-      limit: params?.limit || undefined,
-    });
-  },
-
-  getRoleUrl(name?: string) {
-    return generatePath(cfg.api.rolePath, { name });
+  getRoleUrl(
+    req:
+      | {
+          action: 'get' | 'delete' | 'update';
+          name: string;
+        }
+      | { action: 'list'; params?: UrlListRolesParams }
+  ) {
+    const action = req.action;
+    switch (action) {
+      case 'get':
+        return generatePath(cfg.api.role.get, { name: req.name });
+      case 'delete':
+        return generatePath(cfg.api.role.delete, { name: req.name });
+      case 'update':
+        return generatePath(cfg.api.role.update, { name: req.name });
+      case 'list':
+        const params = req.params;
+        return generatePath(cfg.api.role.list, {
+          search: params?.search || undefined,
+          startKey: params?.startKey || undefined,
+          limit: params?.limit || undefined,
+        });
+      default:
+        action satisfies never;
+    }
   },
 
   getDiscoveryConfigUrl(clusterId: string) {

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -22,6 +22,8 @@ import api from 'teleport/services/api';
 import { ResourcesResponse, UnifiedResource } from '../agents';
 import auth, { MfaChallengeScope } from '../auth/auth';
 import { MfaChallengeResponse } from '../mfa';
+import { yamlService } from '../yaml';
+import { YamlSupportedResourceKind } from '../yaml/types';
 import {
   CreateOrOverwriteGitServer,
   DefaultAuthConnector,
@@ -29,6 +31,7 @@ import {
   makeResource,
   makeResourceList,
   Resource,
+  Role,
   RoleResource,
 } from './';
 import { makeUnifiedResource } from './makeUnifiedResource';
@@ -110,7 +113,7 @@ class ResourceService {
     items: RoleResource[];
     startKey: string;
   }> {
-    return await api.get(cfg.getListRolesUrl(params));
+    return await api.get(cfg.getRoleUrl({ action: 'list', params }));
   }
 
   fetchPresetRoles() {
@@ -119,11 +122,19 @@ class ResourceService {
       .then(res => makeResourceList<'role'>(res));
   }
 
+  /**
+   * @deprecated use standalone fetchRole function defined below this class
+   */
   async fetchRole(name: string): Promise<RoleResource> {
     return makeResource<'role'>(
-      await api.get(cfg.getRoleUrl(name), undefined, undefined, {
-        allowRoleNotFound: true,
-      })
+      await api.get(
+        cfg.getRoleUrl({ action: 'get', name }),
+        undefined,
+        undefined,
+        {
+          allowRoleNotFound: true,
+        }
+      )
     );
   }
 
@@ -136,7 +147,7 @@ class ResourceService {
   createRole(content: string, mfaResponse?: MfaChallengeResponse) {
     return api
       .post(
-        cfg.getRoleUrl(),
+        cfg.api.role.create,
         { content },
         undefined /* abort signal */,
         mfaResponse
@@ -156,9 +167,12 @@ class ResourceService {
       .then(res => makeResource<'trusted_cluster'>(res));
   }
 
+  /**
+   * @deprecated use standalone updateRole function defined below this class
+   */
   updateRole(name: string, content: string) {
     return api
-      .put(cfg.getRoleUrl(name), { content })
+      .put(cfg.getRoleUrl({ action: 'update', name }), { content })
       .then(res => makeResource<'role'>(res));
   }
 
@@ -179,7 +193,7 @@ class ResourceService {
   }
 
   deleteRole(name: string) {
-    return api.delete(cfg.getRoleUrl(name));
+    return api.delete(cfg.getRoleUrl({ action: 'delete', name }));
   }
 
   deleteGithubConnector(name: string) {
@@ -188,3 +202,46 @@ class ResourceService {
 }
 
 export default ResourceService;
+
+export async function fetchRole(
+  name: string,
+  signal?: AbortSignal
+): Promise<RoleResource> {
+  return makeResource<'role'>(
+    await api.get(cfg.getRoleUrl({ action: 'get', name }), signal, undefined, {
+      allowRoleNotFound: true,
+    })
+  );
+}
+
+export async function fetchRoleWithYamlParse(name: string): Promise<Role> {
+  const { content } = await fetchRole(name);
+  return yamlService.parse<Role>(YamlSupportedResourceKind.Role, {
+    yaml: content,
+  });
+}
+
+export async function updateRoleWithYamlConversion({
+  name,
+  role,
+}: {
+  name: string;
+  role: Role;
+}) {
+  const content = await yamlService.stringify(YamlSupportedResourceKind.Role, {
+    resource: role,
+  });
+  return updateRole({ name, content });
+}
+
+export async function updateRole({
+  name,
+  content,
+}: {
+  name: string;
+  content: string;
+}): Promise<RoleResource> {
+  return api
+    .put(cfg.getRoleUrl({ action: 'update', name }), { content })
+    .then(res => makeResource<'role'>(res));
+}


### PR DESCRIPTION
backport #56536 to branch/v18

manual because `fetchRoles` had a different signature (some other work wasn't backported)

tested role CRUD