### PR TITLE
Add e/lib/idp/saml/testenv to known test packages depguard rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -176,6 +176,7 @@ linters:
             - '!**/e/lib/aws/identitycenter/test/**'
             - '!**/e/lib/devicetrust/testenv/**'
             - '!**/e/lib/jamf/testenv/**'
+            - '!**/e/lib/idp/saml/testenv/**'
             - '!**/e/lib/operatortest/**'
             - '!**/e/tests/**'
           deny:


### PR DESCRIPTION
This is required to allow the test package to import other test packages from the OSS repo.