### PR TITLE
Tweak MWI docs intro page language

### DIFF
--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -5,7 +5,7 @@ labels:
  - mwi
 ---
 
-Teleport Machine & Workload Identity offers two complementary sets of functionality for non-human entities in your infrastructure:
+Teleport Machine & Workload Identity offers two complementary sets of capabilities for non-human entities in your infrastructure:
 
 - **Zero Trust Access for machines**: 
 Enables machines (like CI/CD pipelines) to securely authenticate with your Teleport cluster to access protected resources and configure the cluster itself.

--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -5,7 +5,7 @@ labels:
  - mwi
 ---
 
-Teleport Zero Trust Access & Flexible Workload Identity offers two complementary types of identity for non-human entities in your infrastructure:
+Teleport Machine & Workload Identity offers two complementary sets of functionality for non-human entities in your infrastructure:
 
 - **Zero Trust Access for machines**: 
 Enables machines (like CI/CD pipelines) to securely authenticate with your Teleport cluster to access protected resources and configure the cluster itself.


### PR DESCRIPTION
Slightly tweaks the language in the introduction of the MWI docs:

- Replaces one use of "Zero Trust Access & Flexible Workload Identity" with "Machine & Workload Identity" which seems to be a better fit within the following context.
- Replaces "types of identity" with "sets of functionality" since "Zero Trust Access for machines" isn't specifically a type of identity.