### PR TITLE
Update form-data to 4.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4295,8 +4295,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   fs-extra@10.1.0:
@@ -10826,7 +10826,7 @@ snapshots:
       builder-util: 26.0.11
       builder-util-runtime: 9.3.1
       chalk: 4.1.2
-      form-data: 4.0.2
+      form-data: 4.0.4
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -11316,11 +11316,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   fs-extra@10.1.0:


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/security/dependabot/415

The issue is marked as "critical", so I wanted to address it ASAP even though we don't use the code that's vulnerable.

```
$ pnpm why -r form-data
Legend: production dependency, optional only, dev only

@gravitational/teleterm@1.0.0-dev web/packages/teleterm (PRIVATE)

devDependencies:
electron-builder 26.0.12
└─┬ app-builder-lib 26.0.12
  └─┬ electron-publish 26.0.11
    └── form-data 4.0.4
```

electron-publish uses form-data to [publish artifacts to Bitbucket](https://github.com/electron-userland/electron-builder/blob/e97982f06f81c53deb7ffebfec1b2b995b2cd290/packages/electron-publish/src/bitbucketPublisher.ts#L4).

This has to be backported to release branches since we always backport electron-builder updates.