### PR TITLE
Prevent sending TDP messages in chunks during desktop sessions in Connect

### DIFF
--- a/api/utils/grpc/stream/stream.go
+++ b/api/utils/grpc/stream/stream.go
@@ -47,17 +47,46 @@ type ReadWriter struct {
 	wLock  sync.Mutex
 	rLock  sync.Mutex
 	rBytes []byte
+
+	options *Options
+}
+
+// Options is NewReadWriter config options.
+type Options struct {
+	// DisableChunking disables automatic splitting of data messages
+	// that exceed MaxChunkSize during writes.
+	// This is useful when the receiver does not support chunked reads.
+	DisableChunking bool
+}
+
+// Option allows setting options as functional arguments to NewReadWriter.
+type Option func(s *Options)
+
+// WithDisabledChunking	disables automatic splitting of data messages
+// that exceed MaxChunkSize during writes.
+// This is useful when the receiver does not support chunked reads.
+// Useful when the receiver doesn't support reading chunks.
+func WithDisabledChunking() Option {
+	return func(s *Options) {
+		s.DisableChunking = true
+	}
 }
 
 // NewReadWriter creates a new ReadWriter that leverages the provided
 // source to retrieve data from and write data to.
-func NewReadWriter(source Source) (*ReadWriter, error) {
+func NewReadWriter(source Source, opts ...Option) (*ReadWriter, error) {
 	if source == nil {
 		return nil, trace.BadParameter("parameter source required")
 	}
 
+	options := &Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	return &ReadWriter{
-		source: source,
+		source:  source,
+		options: options,
 	}, nil
 }
 
@@ -110,7 +139,7 @@ func (c *ReadWriter) Write(b []byte) (int, error) {
 	var sent int
 	for len(b) > 0 {
 		chunk := b
-		if len(chunk) > MaxChunkSize {
+		if !c.options.DisableChunking && len(chunk) > MaxChunkSize {
 			chunk = chunk[:MaxChunkSize]
 		}
 

--- a/api/utils/grpc/stream/stream.go
+++ b/api/utils/grpc/stream/stream.go
@@ -65,7 +65,6 @@ type Option func(s *Options)
 // WithDisabledChunking	disables automatic splitting of data messages
 // that exceed MaxChunkSize during writes.
 // This is useful when the receiver does not support chunked reads.
-// Useful when the receiver doesn't support reading chunks.
 func WithDisabledChunking() Option {
 	return func(s *Options) {
 		s.DisableChunking = true
@@ -131,7 +130,7 @@ func (c *ReadWriter) Read(b []byte) (n int, err error) {
 // the grpc stream. To prevent exhausting the stream all
 // sends on the stream are limited to be at most MaxChunkSize.
 // If the data exceeds the MaxChunkSize it will be sent in
-// batches.
+// batches. This behavior can be disabled by using WithDisabledChunking.
 func (c *ReadWriter) Write(b []byte) (int, error) {
 	c.wLock.Lock()
 	defer c.wLock.Unlock()

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -130,9 +130,12 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		return trace.Wrap(err)
 	}
 
-	downstreamRW, err := streamutils.NewReadWriter(&clientStream{
-		stream: stream,
-	})
+	downstreamRW, err := streamutils.NewReadWriter(
+		&clientStream{
+			stream: stream,
+		},
+		streamutils.WithDisabledChunking(),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/56921

Disables chunking TDP messages between tsh daemon and Electron, as described in https://github.com/gravitational/teleport/issues/56921#issuecomment-3101903793.
Clipboard data sent through this connection is limited to a maximum size of 1 MB, which is a restriction in the TDP message decoder. https://github.com/gravitational/teleport/blob/22ce46d00e1db2ff276e5bc459c40fc4c9d0d6f0/lib/srv/desktop/tdp/proto.go#L1791

changelog: Fixed a crash in Teleport Connect that could occur when copying large clipboard content during desktop sessions