### PR TITLE
[v18] Complete logtest migration

### DIFF
--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 /*
@@ -207,7 +207,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 			Cache:             serverClient,
 			StatusReporter:    serverClient,
 			AppServerUpserter: serverClient,
-			Logger:            utils.NewSlogLoggerForTests(),
+			Logger:            logtest.NewLogger(),
 			createSession:     mockCreateSession,
 		}
 	}

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -41,11 +41,12 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
 
 func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1245,7 +1245,7 @@ func TestBotSSHMultiplexer(t *testing.T) {
 func TestBotJoiningURI(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	log := utils.NewSlogLoggerForTests()
+	log := logtest.NewLogger()
 
 	process := testenv.MakeTestServer(
 		t,

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,8 +30,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
-	"testing"
 	"unicode"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -134,38 +131,6 @@ func InitLogger(purpose LoggingPurpose, level slog.Level, opts ...LoggerOption) 
 		OSLogSubsystem: o.osLogSubsystem,
 	})
 	return logger, trace.Wrap(err)
-}
-
-var initTestLoggerOnce = sync.Once{}
-
-// InitLoggerForTests initializes the standard logger for tests.
-// Deprecated: prefer using logtest.InitLogger
-// TODO(tross): remove after enterprise references are updated.
-func InitLoggerForTests() {
-	initTestLoggerOnce.Do(func() {
-		if !flag.Parsed() {
-			// Parse flags to check testing.Verbose().
-			flag.Parse()
-		}
-
-		if !testing.Verbose() {
-			slog.SetDefault(slog.New(slog.DiscardHandler))
-			return
-		}
-
-		logutils.Initialize(logutils.Config{
-			Severity: slog.LevelDebug.String(),
-			Format:   LogFormatJSON,
-		})
-	})
-}
-
-// NewSlogLoggerForTests creates a new slog logger for test environments.
-// Deprecated: prefer using logtest.NewLogger
-// TODO(tross): remove after enterprise references are updated.
-func NewSlogLoggerForTests() *slog.Logger {
-	InitLoggerForTests()
-	return slog.Default()
 }
 
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -32,10 +32,11 @@ import (
 
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
-	InitLoggerForTests()
+	logtest.InitLogger(testing.Verbose)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Now that e includes https://github.com/gravitational/teleport.e/pull/6915 utils.InitLoggerForTests and utils.NewSlogLoggerForTests can be removed. This also converts a few other uses of InitLoggerForTests that slipped in between https://github.com/gravitational/teleport/pull/56822 and this change.

Updates #51023.