### PR TITLE
[v16][buddy] Add `--listen` and `--insecure-listen-anywhere` flags to `proxy db`

### DIFF
--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/db/dbcmd"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -171,9 +172,22 @@ func onProxyCommandDB(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	if cf.LocalProxyAddr != "" && cf.LocalProxyPort != "" {
+		return trace.BadParameter("either the address or port for the local proxy can be specified, not both")
+	}
 	addr := "localhost:0"
 	randomPort := true
-	if cf.LocalProxyPort != "" {
+	if cf.LocalProxyAddr != "" {
+		host, _, err := net.SplitHostPort(cf.LocalProxyAddr)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !cf.InsecureListenAnywhere && !apiutils.IsLoopback(host) {
+			return trace.BadParameter("only loopback addresses are allowed for listener without --insecure-listen-anywhere switch, got %q", cf.LocalProxyAddr)
+		}
+		randomPort = false
+		addr = cf.LocalProxyAddr
+	} else if cf.LocalProxyPort != "" {
 		randomPort = false
 		addr = fmt.Sprintf("127.0.0.1:%s", cf.LocalProxyPort)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -425,6 +425,10 @@ type CLIConf struct {
 	// GlobalTshConfigPath is a path to global TSH config. Can be overridden with TELEPORT_GLOBAL_TSH_CONFIG.
 	GlobalTshConfigPath string
 
+	// InsecureListenAnywhere, when set, allows local proxy listener to use any address other than loopback addresses (127/8).
+	InsecureListenAnywhere bool
+	// LocalProxyAddr is an address used by local proxy listener.
+	LocalProxyAddr string
 	// LocalProxyPort is a port used by local proxy listener.
 	LocalProxyPort string
 	// LocalProxyTunnel specifies whether local proxy will open auth'd tunnel.
@@ -935,9 +939,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	proxySSH.Flag("relogin", "Permit performing an authentication attempt on a failed command").Default("true").BoolVar(&cf.Relogin)
 	proxyDB := proxy.Command("db", "Start local TLS proxy for database connections when using Teleport in single-port mode.")
 	// don't require <db> positional argument, user can select with --labels/--query alone.
-	proxyDB.Arg("db", "The name of the database to start local proxy for").StringVar(&cf.DatabaseService)
-	proxyDB.Flag("port", "Specifies the source port used by proxy db listener").Short('p').StringVar(&cf.LocalProxyPort)
-	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate").BoolVar(&cf.LocalProxyTunnel)
+	proxyDB.Arg("db", "The name of the database to start local proxy for.").StringVar(&cf.DatabaseService)
+	proxyDB.Flag("insecure-listen-anywhere", "Allows the local proxy to listen on any address without restrictions. WARNING: this will expose unsecured listener to anyone in the network. Only use when network access is otherwise restricted.").BoolVar(&cf.InsecureListenAnywhere)
+	proxyDB.Flag("listen", "Specifies the source address used by proxy db listener. Mutually exclusive with --port.").StringVar(&cf.LocalProxyAddr)
+	proxyDB.Flag("port", "Specifies the source port used by proxy db listener.").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyDB.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate.").BoolVar(&cf.LocalProxyTunnel)
 	proxyDB.Flag("db-user", "Database user to log in as.").Short('u').StringVar(&cf.DatabaseUser)
 	proxyDB.Flag("db-name", "Database name to log in to.").Short('n').StringVar(&cf.DatabaseName)
 	proxyDB.Flag("db-roles", "List of comma separate database roles to use for auto-provisioned user.").Short('r').StringVar(&cf.DatabaseRoles)


### PR DESCRIPTION
backport of #56419 to branch/v16

Changelog: Adds `--listen` flag to `tsh proxy db` for setting local listener address