### PR TITLE
Mitigate stuck keys when taking a screenshot

### DIFF
--- a/web/packages/shared/components/DesktopSession/KeyboardHandler.tsx
+++ b/web/packages/shared/components/DesktopSession/KeyboardHandler.tsx
@@ -19,6 +19,7 @@
 import { getPlatform, Platform } from 'design/platform';
 import { ButtonState, SyncKeys, TdpClient } from 'shared/libs/tdp';
 
+import { StuckKeys } from './StuckKeys';
 import { Withholder } from './Withholder';
 
 /**
@@ -26,6 +27,7 @@ import { Withholder } from './Withholder';
  */
 export class KeyboardHandler {
   private withholder: Withholder = new Withholder();
+  private stuckKeys: StuckKeys = new StuckKeys();
   /**
    * Tracks whether the next keydown or keyup event should sync the
    * local toggle key state to the remote machine.
@@ -95,6 +97,12 @@ export class KeyboardHandler {
    */
   private finishHandlingKeyboardEvent(params: KeyboardEventParams): void {
     const { cli, e, state } = params;
+
+    // Monitor Meta and Shift keys to prevent stuck keys from MacOS screenshot.
+    if (KeyboardHandler.isMac) {
+      this.stuckKeys.handleKeyboardEvent(params);
+    }
+
     // Special handling for CapsLock on Mac.
     if (e.code === 'CapsLock' && KeyboardHandler.isMac) {
       // On Mac, every UP or DOWN given to us by the browser corresponds

--- a/web/packages/shared/components/DesktopSession/KeyboardHandler.tsx
+++ b/web/packages/shared/components/DesktopSession/KeyboardHandler.tsx
@@ -98,10 +98,8 @@ export class KeyboardHandler {
   private finishHandlingKeyboardEvent(params: KeyboardEventParams): void {
     const { cli, e, state } = params;
 
-    // Monitor Meta and Shift keys to prevent stuck keys from MacOS screenshot.
-    if (KeyboardHandler.isMac) {
-      this.stuckKeys.handleKeyboardEvent(params);
-    }
+    // Monitor Meta and Shift keys to prevent stuck keys
+    this.stuckKeys.handleKeyboardEvent(params);
 
     // Special handling for CapsLock on Mac.
     if (e.code === 'CapsLock' && KeyboardHandler.isMac) {

--- a/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
+++ b/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
@@ -22,7 +22,7 @@ import {
   TdpClient,
 } from 'shared/libs/tdp';
 
-import { StuckKeys } from './StuckKeys';
+import { StuckKeys, RELEASE_DELAY_MS } from './StuckKeys';
 
 jest.mock('teleport/lib/tdp', () => {
   const originalModule = jest.requireActual('shared/libs/tdp');
@@ -71,7 +71,7 @@ describe('StuckKeys', () => {
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS);
 
     expect(mockSendKeyboardInput).toHaveBeenCalledTimes(4);
 
@@ -99,7 +99,7 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS / 2);
 
     stuckKeys.handleKeyboardEvent({
       e: { key: 'Meta' } as KeyboardEvent,
@@ -107,7 +107,7 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS / 2);
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
   });
@@ -125,7 +125,7 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS / 2);
 
     stuckKeys.handleKeyboardEvent({
       e: { key: 'Shift' } as KeyboardEvent,
@@ -139,11 +139,11 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS / 2);
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS);
 
     expect(mockSendKeyboardInput).toHaveBeenCalledTimes(4);
   });
@@ -155,7 +155,7 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS);
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
   });
@@ -175,7 +175,7 @@ describe('StuckKeys', () => {
 
     stuckKeys.cancel();
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS);
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
   });
@@ -193,7 +193,7 @@ describe('StuckKeys', () => {
       cli: mockTdpClient,
     });
 
-    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS * 2);
+    jest.advanceTimersByTime(RELEASE_DELAY_MS * 2);
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
   });

--- a/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
+++ b/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  ButtonState,
+  selectDirectoryInBrowser,
+  TdpClient,
+} from 'shared/libs/tdp';
+
+import { StuckKeys } from './StuckKeys';
+
+jest.mock('teleport/lib/tdp', () => {
+  const originalModule = jest.requireActual('shared/libs/tdp');
+  return {
+    ...originalModule,
+    TdpClient: jest.fn().mockImplementation(() => {
+      return {
+        connect: jest.fn().mockResolvedValue(undefined),
+        sendKeyboardInput: jest.fn(),
+      };
+    }),
+  };
+});
+
+describe('StuckKeys', () => {
+  jest.useFakeTimers();
+  let stuckKeys: StuckKeys;
+  let mockTdpClient: TdpClient;
+  let mockSendKeyboardInput: jest.Mock;
+
+  beforeEach(() => {
+    stuckKeys = new StuckKeys();
+    mockTdpClient = new TdpClient(() => null, selectDirectoryInBrowser);
+    mockSendKeyboardInput = jest.fn();
+    (mockTdpClient.sendKeyboardInput as jest.Mock) = mockSendKeyboardInput;
+  });
+
+  afterEach(() => {
+    stuckKeys.cancel();
+    mockSendKeyboardInput.mockClear();
+    jest.clearAllTimers();
+  });
+
+  it('releases Meta and Shift keys after timeout when both are pressed', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+
+    expect(mockSendKeyboardInput).toHaveBeenCalledTimes(4);
+
+    const callArgs = mockSendKeyboardInput.mock.calls.map(call => call);
+    expect(callArgs).toEqual(
+      expect.arrayContaining([
+        ['MetaLeft', ButtonState.UP],
+        ['MetaRight', ButtonState.UP],
+        ['ShiftLeft', ButtonState.UP],
+        ['ShiftRight', ButtonState.UP],
+      ])
+    );
+  });
+
+  it('does not release keys if one is released before the timeout', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.UP,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+  });
+
+  it('resets the timeout when keys are pressed again', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.UP,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS / 2);
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+
+    expect(mockSendKeyboardInput).toHaveBeenCalledTimes(4);
+  });
+
+  it('ignores unmonitored keys', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'A' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+  });
+
+  it('cancels all timeouts and resets states when cancel is called', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.cancel();
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS);
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
+++ b/web/packages/shared/components/DesktopSession/StuckKeys.test.ts
@@ -179,4 +179,22 @@ describe('StuckKeys', () => {
 
     expect(mockSendKeyboardInput).not.toHaveBeenCalled();
   });
+
+  it('does not release shift when used with regular keys after timeout', () => {
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'Shift' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    stuckKeys.handleKeyboardEvent({
+      e: { key: 'A' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: mockTdpClient,
+    });
+
+    jest.advanceTimersByTime(stuckKeys.RELEASE_DELAY_MS * 2);
+
+    expect(mockSendKeyboardInput).not.toHaveBeenCalled();
+  });
 });

--- a/web/packages/shared/components/DesktopSession/StuckKeys.tsx
+++ b/web/packages/shared/components/DesktopSession/StuckKeys.tsx
@@ -1,0 +1,189 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ButtonState, TdpClient } from 'shared/libs/tdp';
+
+import { KeyboardEventParams } from './KeyboardHandler';
+
+interface KeyState {
+  down: boolean;
+}
+
+/**
+ * KeyCombo represents a combination of keys that are pressed together to
+ * trigger shortcuts. It tracks the keys, their states, and manages timeouts
+ * for releasing them.
+ */
+class KeyCombo {
+  keys: Set<string>;
+  timeout?: NodeJS.Timeout;
+  keyStates: Map<string, KeyState>;
+
+  /**
+   * Creates a new KeyCombo instance.
+   *
+   * @param keys - Array of key names to track as a combination (e.g., ['Meta', 'Shift'])
+   * @param keyStates - Reference to the parent StuckKeys' key states map to track down/up state
+   */
+  constructor(keys: string[], keyStates: Map<string, KeyState>) {
+    this.keys = new Set(keys);
+    this.timeout = undefined;
+    this.keyStates = keyStates;
+  }
+
+  /**
+   * Checks if all keys in the combo are currently pressed down.
+   */
+  isActive(): boolean {
+    return Array.from(this.keys).every(key => this.keyStates.get(key)?.down);
+  }
+
+  /**
+   * Releases the keys in the combo by sending keyup events to the TDP client
+   * and updating global key state.
+   */
+  release(cli: TdpClient): void {
+    // For reach key in the key combo
+    this.keys.forEach(key => {
+      // Get the key code for the key and send a keyup event
+      this.getKeyCode(key).forEach(keyCode => {
+        cli.sendKeyboardInput(keyCode, ButtonState.UP);
+      });
+
+      // Update the key state to indicate it's no longer down
+      if (this.keyStates.has(key)) {
+        this.keyStates.get(key)!.down = false;
+      }
+    });
+
+    this.timeout = undefined;
+  }
+
+  /**
+   * Cancels the combo by clearing the timeout.
+   */
+  cancel(): void {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+  }
+
+  /**
+   * Returns the key codes for a given key.
+   * For example, 'Meta' returns ['MetaLeft', 'MetaRight'].
+   */
+  private getKeyCode(key: string): string[] {
+    switch (key) {
+      case 'Meta':
+        return ['MetaLeft', 'MetaRight'];
+      case 'Shift':
+        return ['ShiftLeft', 'ShiftRight'];
+      default:
+        return [key];
+    }
+  }
+}
+
+/**
+ * StuckKeys tracks key states and automatically sends keyup events after a timeout
+ * for potentially stuck keys. This prevents issues where the remote system thinks
+ * modifier keys are still pressed when they're not.
+ *
+ * This addresses the issue of Meta and Shift keys getting "stuck" when users
+ * take a screenshot with Meta+Shift+[3 | 4 | 5] on macOS. When macOS steals focus during
+ * screenshot capture, the browser does not receive keyup events for these keys.
+ * It also doesn't trigger blur, focusout, or visibilitychange events. This class
+ * can be extended to handle other key combinations that may get stuck.
+ */
+export class StuckKeys {
+  /**
+   * Keys to monitor
+   */
+  private keyStates = new Map<string, KeyState>();
+
+  /**
+   * Key combinations to check for stuck state
+   */
+  private keyCombos: KeyCombo[] = [];
+
+  /**
+   * Timeout period (ms) after which we assume keys are stuck and auto-release them
+   */
+  public readonly RELEASE_DELAY_MS = 1000;
+
+  constructor() {
+    // All of the keys we want to track the state of.
+    ['Meta', 'Shift'].forEach(key => {
+      this.keyStates.set(key, { down: false });
+    });
+
+    // Initialize key combinations to monitor for stuck keys.
+    this.keyCombos.push(new KeyCombo(['Meta', 'Shift'], this.keyStates));
+  }
+
+  /**
+   * Process keyboard events and manage potential stuck keys.
+   *
+   * This function only sends key up events for keys that may
+   * be stuck, it will not forward any other keys to the server,
+   * so make sure they're handled by the KeyboardHandler.
+   */
+  public handleKeyboardEvent(params: KeyboardEventParams) {
+    const { e, state, cli } = params;
+    const key = e.key;
+
+    // Exit early if the key is not one we need to monitor
+    if (!this.keyStates.has(key)) {
+      return;
+    }
+
+    // Update key state
+    this.keyStates.get(key)!.down = state === ButtonState.DOWN;
+
+    // Check all key combinations to see if any are active
+    this.keyCombos.forEach(combo => {
+      if (combo.keys.has(key)) {
+        this.handleComboState(combo, cli);
+      }
+    });
+  }
+
+  private handleComboState(combo: KeyCombo, cli: TdpClient) {
+    // Clear the timeout if it exists because key state has changed
+    if (combo.timeout) {
+      clearTimeout(combo.timeout);
+      combo.timeout = undefined;
+    }
+
+    // If the combo is active, set a timeout to release it
+    if (combo.isActive()) {
+      combo.timeout = setTimeout(() => {
+        combo.release(cli);
+      }, this.RELEASE_DELAY_MS);
+    }
+  }
+
+  // Add cancel function to clear timeouts and reset key states
+  public cancel() {
+    this.keyCombos.forEach(combo => {
+      combo.cancel();
+    });
+    this.keyStates.forEach(state => (state.down = false));
+  }
+}

--- a/web/packages/shared/components/DesktopSession/StuckKeys.tsx
+++ b/web/packages/shared/components/DesktopSession/StuckKeys.tsx
@@ -31,7 +31,7 @@ interface KeyState {
  */
 class KeyCombo {
   keys: Set<string>;
-  timeout?: NodeJS.Timeout;
+  timeout?: number;
   keyStates: Map<string, KeyState>;
 
   /**
@@ -79,7 +79,7 @@ class KeyCombo {
    */
   cancel(): void {
     if (this.timeout) {
-      clearTimeout(this.timeout);
+      window.clearTimeout(this.timeout);
       this.timeout = undefined;
     }
   }
@@ -167,13 +167,12 @@ export class StuckKeys {
   private handleComboState(combo: KeyCombo, cli: TdpClient) {
     // Clear the timeout if it exists because key state has changed
     if (combo.timeout) {
-      clearTimeout(combo.timeout);
-      combo.timeout = undefined;
+      combo.cancel();
     }
 
     // If the combo is active, set a timeout to release it
     if (combo.isActive()) {
-      combo.timeout = setTimeout(() => {
+      combo.timeout = window.setTimeout(() => {
         combo.release(cli);
       }, this.RELEASE_DELAY_MS);
     }


### PR DESCRIPTION
Users are seeing stuck keys when the host OS takes focus away from the browser. One such report can be found [here](https://github.com/gravitational/teleport/issues/54725).

From testing taking a screenshot on Mac (Cmd+Shift+5), the OS takes focus and absorbs the Cmd and Shift key up events.
We already have an `onFocusOut` method that fixes similar problems with state keys, but for some reason the MacOS screenshot tool doesn't trigger blur, focusout, or visibilitychange events.

As an attempt to fix this issue, I added a `StuckKeys` class that tracks key combinations that the user activates. If the keys haven't been released after a certain amount of time, currently one second, the class will send key up events for that key combo.

changelog: Add mitigation for stuck keys when taking a screenshot during a desktop access session.