### PR TITLE
Fix autoupdate canary sampling for the catch-all group

### DIFF
--- a/lib/auth/autoupdate_rollout.go
+++ b/lib/auth/autoupdate_rollout.go
@@ -54,14 +54,20 @@ func (a *Server) SampleAgentsFromAutoUpdateGroup(ctx context.Context, groupName 
 			return false
 		}
 
-		// If this is not the catch-all group, we can only check if the agent group is the right one.
-		if !isCatchAll {
+		// If the agent group matches, we keep it.
+		if handle.Hello().UpdaterInfo.UpdateGroup == groupName {
 			// No need to check for UpdaterInfo being nil, it would have been filtered
 			// out by filterHandler().
-			return handle.Hello().UpdaterInfo.UpdateGroup == groupName
+			return true
 		}
+
+		// If this is not the catch-all group, we filter the agent out
+		if !isCatchAll {
+			return false
+		}
+
 		// This is the catch-call group, it matches agents from every group not in groups.
-		_, ok := groupSet[groupName]
+		_, ok := groupSet[handle.Hello().UpdaterInfo.UpdateGroup]
 		// If the agent group is not in the group list, it falls into the catch-all.
 		return !ok
 	}

--- a/lib/auth/autoupdate_rollout_test.go
+++ b/lib/auth/autoupdate_rollout_test.go
@@ -125,7 +125,7 @@ func TestSampleAgentsFromGroup(t *testing.T) {
 	require.Less(t, conflicts, 4)
 
 	// Test execution: check that agents not belonging to any group are sampled whe requesting the catch-all group.
-	canariesCatchAll, err := auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testGroupName, sampleSize, []string{"group-a", testCatchAllGroupName})
+	canariesCatchAll, err := auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testCatchAllGroupName, sampleSize, []string{"group-a", testCatchAllGroupName})
 	require.NoError(t, err)
 	require.Len(t, canariesCatchAll, sampleSize)
 	canarySet = make(map[string]*autoupdatev1pb.Canary)
@@ -134,6 +134,15 @@ func TestSampleAgentsFromGroup(t *testing.T) {
 	}
 	require.Len(t, canarySet, sampleSize, "some canary got duplicated")
 
+	// Test execution: check that agents belonging to the catch-all group are sampled.
+	canariesCatchAll, err = auth.SampleAgentsFromAutoUpdateGroup(t.Context(), testGroupName, sampleSize, []string{"group-a", testGroupName})
+	require.NoError(t, err)
+	require.Len(t, canariesCatchAll, sampleSize)
+	canarySet = make(map[string]*autoupdatev1pb.Canary)
+	for _, canary := range canariesCatchAll {
+		canarySet[canary.UpdaterId] = canary
+	}
+	require.Len(t, canarySet, sampleSize, "some canary got duplicated")
 }
 
 func TestLookupAgentInInventory(t *testing.T) {


### PR DESCRIPTION
This PR fixes the catch-all group logic which had two bugs that were undetected because the test was wrong. I fixed the test and the code: now we are sampling agents that belong to the catch-all group.

For example: if we have 2 groups: ["group-a", "group-b"], before this change, agents belonging to "group-c" were seen as part of the catch-all group, but agents belonging to "group-b" were not.
