### PR TITLE
Web: tweak table style

### DIFF
--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -349,7 +349,7 @@ function ServersideTable<T>({
   return (
     <>
       <StyledPanel>
-        {serversideProps?.serversideSearchPanel}
+        <Box width="100%">{serversideProps?.serversideSearchPanel}</Box>
         {(showTopPager || showBothPager) && (
           <ServerSidePager
             nextPage={nextPage}


### PR DESCRIPTION
If serversideSearchPanel prop is not provided, keep the top pager buttons right aligned with bottom pager (which is right aligned).


before:
<img width="965" height="156" alt="image" src="https://github.com/user-attachments/assets/a63c8941-f990-4e2d-bb74-91050901df4f" />


after:
<img width="964" height="198" alt="image" src="https://github.com/user-attachments/assets/2c6703cd-361e-44e3-8d05-c4f0ef2f1475" />
