### PR TITLE
Fix kube port-forward to exit on pod removal

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -183,6 +183,7 @@ func TestKube(t *testing.T) {
 	t.Run("Exec", suite.bind(testKubeExec))
 	t.Run("Deny", suite.bind(testKubeDeny))
 	t.Run("PortForward", suite.bind(testKubePortForward))
+	t.Run("PortForwardPodDisconnect", suite.bind(testKubePortForwardPodDisconnect))
 	t.Run("TransportProtocol", suite.bind(testKubeTransportProtocol))
 	t.Run("TrustedClustersClientCert", suite.bind(testKubeTrustedClustersClientCert))
 	t.Run("TrustedClustersSNI", suite.bind(testKubeTrustedClustersSNI))
@@ -530,11 +531,11 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 		builder func(*rest.Config, kubePortForwardArgs) (*kubePortForwarder, error)
 	}{
 		{
-			name:    "SPDY portForwarder",
+			name:    "SPDY",
 			builder: newPortForwarder,
 		},
 		{
-			name:    "SPDY over Websocket portForwarder",
+			name:    "SPDY over Websocket",
 			builder: newPortForwarderSPDYOverWebsocket,
 		},
 	}
@@ -558,7 +559,9 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 				})
 				require.NoError(t, err)
 
+				// Forward local port to container port.
 				forwarderCh := make(chan error)
+				t.Cleanup(func() { forwarder.Close() })
 				go func() { forwarderCh <- forwarder.ForwardPorts() }()
 
 				select {
@@ -566,7 +569,6 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 					t.Fatalf("Timeout waiting for port forwarding.")
 				case <-forwarder.readyC:
 				}
-				t.Cleanup(func() {})
 
 				resp, err := http.Get(fmt.Sprintf("http://localhost:%v", localPort))
 				require.NoError(t, err)
@@ -587,6 +589,169 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 				err = impersonatingForwarder.ForwardPorts()
 				require.Error(t, err)
 				require.Regexp(t, ".*impersonation request has been denied.*|.*403 Forbidden.*", err.Error())
+			},
+		)
+	}
+
+}
+
+// testKubePortForwardPodDisconnect tests Kubernetes port forwarding
+// with pod disconnection.
+func testKubePortForwardPodDisconnect(t *testing.T, suite *KubeSuite) {
+	tconf := suite.teleKubeConfig(Host)
+
+	teleport := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: helpers.Site,
+		HostID:      helpers.HostID,
+		NodeName:    Host,
+		Priv:        suite.priv,
+		Pub:         suite.pub,
+		Logger:      suite.log,
+	})
+
+	username := suite.me.Username
+	kubeGroups := []string{kube.TestImpersonationGroup}
+	role, err := types.NewRole("kubemaster", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{username},
+			KubeGroups: kubeGroups,
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: "pods", Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}, APIGroup: types.Wildcard,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	teleport.AddUserWithRole(username, role)
+
+	err = teleport.CreateEx(t, nil, tconf)
+	require.NoError(t, err)
+
+	err = teleport.Start()
+	require.NoError(t, err)
+	defer teleport.StopAll()
+
+	// set up kube configuration using proxy
+	_, proxyClientConfig, err := kube.ProxyClient(kube.ProxyConfig{
+		T:          teleport,
+		Username:   username,
+		KubeGroups: kubeGroups,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		builder func(*rest.Config, kubePortForwardArgs) (*kubePortForwarder, error)
+	}{
+		{
+			name:    "SPDY",
+			builder: newPortForwarder,
+		},
+		{
+			name:    "SPDY over Websocket",
+			builder: newPortForwarderSPDYOverWebsocket,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name,
+			func(t *testing.T) {
+				// TODO(rana): Improve k8s isolation per test.
+				// Each test can have an isolated k8s environment.
+				// The isolated environment may have it's own namespace, pods, etc.
+				// This would involve updating CI k8s RBAC (fixtures/ci-teleport-rbac/ci-teleport.yaml).
+				// Existing tests can be updated to use the an isolated k8s environment.
+				// Current k8s integration testing reuses a single k8s environment and pod across tests.
+				// Some tests which delete pods (this one), or require multiple pods would benefit
+				// from isolated k8s environments.
+				// In this test, with k8s isolation per test, pod creation would be moved
+				// from `t.Cleanup()` to test setup.
+				t.Cleanup(func() {
+					// Current CI RBAC allows only for a pod named "test-pod".
+					// Kube integration test suite uses a single instance of
+					// "test-pod" across multiple tests.
+					// Here we continue the use and maintenance of the single "test-pod" pod approach.
+					// On successful test, "test-pod" is deleted, and re-created for the next test.
+					pod := newPod(testNamespace, testPod)
+					if _, err := suite.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+						require.True(t, kubeerrors.IsAlreadyExists(err), "Failed to create test pod: %s.", err)
+					}
+
+					// Wait for pod to be running.
+					require.Eventually(t, func() bool {
+						rsp, err := suite.CoreV1().Pods(testNamespace).Get(context.Background(), testPod, metav1.GetOptions{})
+						if err != nil {
+							t.Logf("Get pod error: %s", err)
+							return false
+						}
+						if rsp.Status.Phase == v1.PodRunning {
+							return true
+						}
+						return false
+					}, 60*time.Second, 500*time.Millisecond)
+				})
+
+				// Setup port-forwarding configuration.
+				listener, err := net.Listen("tcp", "localhost:0")
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, listener.Close())
+				})
+				localPort := listener.Addr().(*net.TCPAddr).Port
+				forwarder, err := tt.builder(proxyClientConfig, kubePortForwardArgs{
+					ports:        []string{fmt.Sprintf("%d:80", localPort)},
+					podName:      testPod,
+					podNamespace: testNamespace,
+				})
+				require.NoError(t, err)
+
+				// Forward local port to container port.
+				forwarderCh := make(chan error, 1)
+				t.Cleanup(func() { forwarder.Close() })
+				go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
+				// Wait for port-forwarding to be ready.
+				select {
+				case <-time.After(5 * time.Second):
+					t.Fatal("Timed out waiting for port forward start")
+				case <-forwarder.readyC:
+				}
+
+				// Validate that port-forwarding is working.
+				resp, err := http.Get(fmt.Sprintf("http://localhost:%d", localPort))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				require.NoError(t, resp.Body.Close())
+
+				// Delete the pod.
+				err = suite.CoreV1().Pods(testNamespace).Delete(context.Background(), testPod, metav1.DeleteOptions{})
+				require.NoError(t, err)
+
+				// Wait for pod deletion.
+				require.Eventually(t, func() bool {
+					if _, err := suite.CoreV1().Pods(testNamespace).Get(context.Background(), testPod, metav1.GetOptions{}); err != nil {
+						return kubeerrors.IsNotFound(err)
+					}
+					return false
+				}, 60*time.Second, 500*time.Millisecond)
+
+				// Attempt an http GET after pod deletion.
+				// This enables error reporting from KubeAPI back to client.
+				//nolint:bodyclose // http response is expected to be nil and return an error
+				_, err = http.Get(fmt.Sprintf("http://localhost:%d", localPort))
+				require.Error(t, err)
+
+				// Wait for port-forwarding to exit.
+				select {
+				case <-time.After(5 * time.Second):
+					t.Fatal("Timed out waiting for port forward exit")
+				case err := <-forwarderCh:
+					require.Equal(t, err, portforward.ErrLostConnectionToPod)
+				}
 			},
 		)
 	}
@@ -832,8 +997,11 @@ loop:
 	})
 	require.NoError(t, err)
 
+	// Forward local port to container port.
 	forwarderCh := make(chan error)
+	t.Cleanup(func() { forwarder.Close() })
 	go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
 	defer func() {
 		require.NoError(t, <-forwarderCh, "Forward ports exited with error")
 	}()
@@ -1101,9 +1269,12 @@ loop:
 		podNamespace: pod.Namespace,
 	})
 	require.NoError(t, err)
-	forwarderCh := make(chan error)
 
+	// Forward local port to container port.
+	forwarderCh := make(chan error)
+	t.Cleanup(func() { forwarder.Close() })
 	go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
 	defer func() {
 		require.NoError(t, <-forwarderCh, "Forward ports exited with error")
 	}()

--- a/lib/kube/proxy/portforward_spdy.go
+++ b/lib/kube/proxy/portforward_spdy.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -199,7 +200,12 @@ func (h *portForwardProxy) forwardStreamPair(p *httpStreamPair, remotePort int64
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := utils.ProxyConn(h.context, p.errorStream, targetErrorStream); err != nil {
+		// Close the target error stream to indicate no more writes.
+		if err := targetErrorStream.Close(); err != nil {
+			h.logger.DebugContext(h.context, "Unable to close target error stream", "error", err)
+		}
+		// Enables error propagation from Kube API server to kubectl client.
+		if _, err := io.Copy(p.errorStream, targetErrorStream); err != nil {
 			h.logger.DebugContext(h.context, "Unable to proxy portforward error-stream", "error", err)
 		}
 	}()
@@ -297,6 +303,8 @@ func (h *portForwardProxy) requestID(stream httpstream.Stream) (string, error) {
 // when the httpstream.Connection is closed.
 func (h *portForwardProxy) run() {
 	h.logger.DebugContext(h.context, "Waiting for port forward streams")
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	for {
 		select {
 		case <-h.context.Done():
@@ -304,6 +312,9 @@ func (h *portForwardProxy) run() {
 			return
 		case <-h.sourceConn.CloseChan():
 			h.logger.DebugContext(h.context, "Upgraded connection closed")
+			return
+		case <-h.targetConn.CloseChan():
+			h.logger.DebugContext(h.context, "Target connection closed")
 			return
 		case stream := <-h.streamChan:
 			requestID, err := h.requestID(stream)
@@ -323,7 +334,11 @@ func (h *portForwardProxy) run() {
 				err := trace.BadParameter("error processing stream for request %s: %v", requestID, err)
 				p.sendErr(err)
 			} else if complete {
-				go h.portForward(p)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					h.portForward(p)
+				}()
 			}
 		}
 	}

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -20,6 +20,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -139,7 +140,13 @@ func TestPortForwardKubeService(t *testing.T) {
 			readyCh := make(chan struct{})
 			// errCh receives a single error from ForwardPorts goroutine.
 			errCh := make(chan error)
-			t.Cleanup(func() { require.NoError(t, <-errCh) })
+			t.Cleanup(func() {
+				// ErrLostConnectionToPod is an expected error.
+				// Server allowed to communicate error to client.
+				if err := <-errCh; !errors.Is(err, portforward.ErrLostConnectionToPod) {
+					require.NoError(t, err)
+				}
+			})
 			// stopCh control the port forwarding lifecycle. When it gets closed the
 			// port forward will terminate.
 			stopCh := make(chan struct{})
@@ -523,7 +530,13 @@ func TestPortForwardUnderlyingProtocol(t *testing.T) {
 			readyCh := make(chan struct{})
 			// errCh receives a single error from ForwardPorts goroutine.
 			errCh := make(chan error)
-			t.Cleanup(func() { require.NoError(t, <-errCh) })
+			t.Cleanup(func() {
+				// ErrLostConnectionToPod is an expected error.
+				// Server allowed to communicate error to client.
+				if err := <-errCh; !errors.Is(err, portforward.ErrLostConnectionToPod) {
+					require.NoError(t, err)
+				}
+			})
 			// stopCh control the port forwarding lifecycle. When it gets closed the
 			// port forward will terminate.
 			stopCh := make(chan struct{})


### PR DESCRIPTION
Fixes #54814

`kubectl port-forward` now exits when a pod disconnects. 

This addresses `kubectl` user expectations that the Teleport Kubernetes proxy behave transparently, and identical to direct-to-Kubernetes. Previously `kubectl` over Teleport port-forwarding would remain open indefinitely even though no pods were available. That behavior was different from the `kubectl` direct-to-Kubernetes experience.

In this PR:
- Changed error stream copying to uni-directional (target -> source) in SPDY and WebSocket `forwardStreamPair()` functions
- Added `WaitGroup` to SPDY `run()` enabling all port-forward streams to fully complete before returning
- Added an integration test for Kubernetes port-forwarding with pod disconnection
- Updated existing port-forward integration tests to allow and expect `ErrLostConnectionToPod`

## Manual Bug Reproduction

The bug was manually reproduced using `kubectl` direct-to-Kubernetes, and `kubectl` over Teleport.

### Bug Behavior (Teleport) 

Observing the bug with `kubectl` and Teleport.

Here we see the `kubectl port-forward` process *running* after all pods are removed.

```bash
> tsh logout
Credentials expired for proxy "localhost:3080", skipping...
Logged out all users from all proxies.

> k delete all --all
service "kubernetes" deleted
deployment.apps "test-web" deleted
replicaset.apps "test-web-6875846678" deleted

> tsh login --proxy=localhost:3080
Enter password for Teleport user rana.ian:
Enter an OTP code from a device:

> Profile URL:        https://localhost:3080
  Logged in as:       rana.ian
  Cluster:            kube-test-cluster
  Roles:              access, editor, kube-admin
  Kubernetes:         enabled
  Kubernetes groups:  system:masters
  Valid until:        2025-07-22 23:47:05 -0700 PDT [valid for 12h0m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

> tsh kube login colima
Logged into Kubernetes cluster "colima". Try 'kubectl version' to test the connection.

> kubectl create deployment test-web --image=nginx
deployment.apps/test-web created

> kubectl wait --for=condition=ready pod -l app=test-web
pod/test-web-6875846678-pk8kd condition met

> kubectl port-forward deployment/test-web 8080:80 &
PF_PID=$!
[1] 18578

> Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
kubectl scale deployment test-web --replicas=0
deployment.apps/test-web scaled

> sleep 5

> curl --max-time 2 http://localhost:8080
Handling connection for 8080
curl: (52) Empty reply from server

> ps -p $PF_PID > /dev/null && echo "❌ BUG: kubectl still running"
❌ BUG: kubectl still running

> kill $PF_PID
[1]  + terminated  kubectl port-forward deployment/test-web 8080:80 
```

### Expected Behavior (Direct k8s)

Observing `kubectl` behavior when directly connected to Kubernetes (no Teleport).

Here we see the `kubectl port-forward` process *exits* after all pods are removed.

```bash
> tsh logout
Logged out all users from all proxies.

> k delete all --all
service "kubernetes" deleted
deployment.apps "test-web" deleted

> kubectl config use-context colima
Switched to context "colima".

> kubectl create deployment test-web --image=nginx
deployment.apps/test-web created

> kubectl wait --for=condition=ready pod -l app=test-web
pod/test-web-6875846678-jx8cn condition met

> kubectl port-forward deployment/test-web 8080:80 &
DIRECT_PID=$!
[1] 19650

> Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80
kubectl scale deployment test-web --replicas=0
deployment.apps/test-web scaled

> sleep 5

> curl --max-time 2 http://localhost:8080
Handling connection for 8080
E0722 11:59:15.648965   19650 portforward.go:424] "Unhandled Error" err="an error occurred forwarding 8080 -> 80: error forwarding port 80 to pod d085c4246eb130a7fd585cda71cf69d4a90a6156b8cf659bcc0a4adeca7d66f5, uid : network namespace for sandbox \"d085c4246eb130a7fd585cda71cf69d4a90a6156b8cf659bcc0a4adeca7d66f5\" is closed"
curl: (52) Empty reply from server
error: lost connection to pod
[1]  + exit 1     kubectl port-forward deployment/test-web 8080:80    

> ps -p $DIRECT_PID > /dev/null || echo "✓ EXPECTED: kubectl exited"
✓ EXPECTED: kubectl exited
```

### Fix Behavior (Teleport) 

Observing the fix with `kubectl` and Teleport.

Here we see the `kubectl port-forward` process *exits* after all pods are removed.

```bash
> tsh logout
All users logged out.

> kubectl delete deployment test-web
Error from server (NotFound): deployments.apps "test-web" not found

> tsh login --proxy=localhost:3080
Enter password for Teleport user rana.ian:
Enter an OTP code from a device:
> Profile URL:        https://localhost:3080
  Logged in as:       rana.ian
  Cluster:            teleport-laptop
  Roles:              access, editor, kube-admin
  Kubernetes:         enabled
  Kubernetes groups:  system:masters
  Valid until:        2025-07-26 00:30:19 -0700 PDT [valid for 12h0m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

> tsh kube login colima
Logged into Kubernetes cluster "colima". Try 'kubectl version' to test the connection.

> kubectl create deployment test-web --image=nginx
deployment.apps/test-web created

> kubectl wait --for=condition=ready pod -l app=test-web
pod/test-web-6875846678-ds94t condition met

> kubectl port-forward deployment/test-web 8080:80 & PF_PID=$!
[1] 34723
> Forwarding from 127.0.0.1:8080 -> 80
Forwarding from [::1]:8080 -> 80

> kubectl scale deployment test-web --replicas=0
deployment.apps/test-web scaled

> sleep 5

> curl --max-time 2 http://localhost:8080
Handling connection for 8080
E0725 12:32:31.608718   34723 portforward.go:424] "Unhandled Error" err="an error occurred forwarding 8080 -> 80: error forwarding port 80 to pod f3382c71de162fc90a1c696de37bc0a6473813f8e6776e356046b25b5bb8b5b8, uid : network namespace for sandbox \"f3382c71de162fc90a1c696de37bc0a6473813f8e6776e356046b25b5bb8b5b8\" is closed"
curl: (52) Empty reply error: lost connection to pod
from server
[1]  + exit 1     kubectl port-forward deployment/test-web 8080:80

> ps -p $PF_PID > /dev/null && echo "❌ BUG: kubectl still running" || echo "✓ Fixed: kubectl exited"
✓ Fixed: kubectl exited
```

Changelog: Kubernetes Access: `kubectl port-forward` now exits cleanly when backend pods are removed