### PR TITLE
[v17] MWI: Fall back to registering without an existing auth client

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -286,14 +286,25 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	// If an explicit AuthClient has been provided, we want to go straight to
 	// using that rather than trying both proxy and auth dialing.
 	if params.AuthClient != nil {
-		slog.InfoContext(ctx, "Attempting registration with existing auth client.")
-		result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
+		// Test the auth client before assuming it will work - if the client is
+		// broken (expired certs, etc) we may need to attempt register without
+		// the existing client. For bots, this will probably produce a new bot
+		// instance, but in the case of expired certs, that's expected behavior,
+		// and acceptable otherwise - this would happen if the client was
+		// restarted.
+		_, err := params.AuthClient.Ping(ctx)
 		if err != nil {
-			slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
-			return nil, trace.Wrap(err)
+			slog.WarnContext(ctx, "An existing auth client was provided but could not be used", "error", err)
+		} else {
+			slog.InfoContext(ctx, "Attempting registration with existing auth client.")
+			result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
+			if err != nil {
+				slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
+				return nil, trace.Wrap(err)
+			}
+			slog.InfoContext(ctx, "Successfully registered with existing auth client.")
+			return result, nil
 		}
-		slog.InfoContext(ctx, "Successfully registered with existing auth client.")
-		return result, nil
 	}
 
 	type registerMethod struct {

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -286,25 +286,14 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	// If an explicit AuthClient has been provided, we want to go straight to
 	// using that rather than trying both proxy and auth dialing.
 	if params.AuthClient != nil {
-		// Test the auth client before assuming it will work - if the client is
-		// broken (expired certs, etc) we may need to attempt register without
-		// the existing client. For bots, this will probably produce a new bot
-		// instance, but in the case of expired certs, that's expected behavior,
-		// and acceptable otherwise - this would happen if the client was
-		// restarted.
-		_, err := params.AuthClient.Ping(ctx)
+		slog.InfoContext(ctx, "Attempting registration with existing auth client.")
+		result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
 		if err != nil {
-			slog.WarnContext(ctx, "An existing auth client was provided but could not be used", "error", err)
-		} else {
-			slog.InfoContext(ctx, "Attempting registration with existing auth client.")
-			result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
-			if err != nil {
-				slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
-				return nil, trace.Wrap(err)
-			}
-			slog.InfoContext(ctx, "Successfully registered with existing auth client.")
-			return result, nil
+			slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
+			return nil, trace.Wrap(err)
 		}
+		slog.InfoContext(ctx, "Successfully registered with existing auth client.")
+		return result, nil
 	}
 
 	type registerMethod struct {

--- a/lib/tbot/identity/identity_facade.go
+++ b/lib/tbot/identity/identity_facade.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
@@ -212,7 +211,7 @@ func (f *Facade) Expiry() (time.Time, bool) {
 	if len(f.identity.TLSCert.Certificate) == 0 {
 		return time.Time{}, false
 	}
-	cert, _, err := keys.X509Certificate(f.identity.TLSCert.Certificate[0])
+	cert, err := x509.ParseCertificate(f.identity.TLSCert.Certificate[0])
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -477,7 +477,9 @@ func renewIdentity(
 			"The bot identity appears to be expired and will not be used to "+
 				"authenticate the identity renewal. If it is possible to "+
 				"rejoin, a new bot instance will be issued. Ensure the "+
-				"certificate TTL and renewal interval are configured properly.",
+				"configured certificate TTL is long enough to accommodate "+
+				"your environment and that no external issues will prevent "+
+				"the bot from renewing its identity on schedule.",
 			"now", now,
 			"expiry", expiry,
 			"credential_lifetime", botCfg.CredentialLifetime,

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -470,15 +470,22 @@ func renewIdentity(
 		return newIdentity, nil
 	}
 
+	// Note: This simple expiration check is probably not the best possible
+	// solution to determine when to discard an existing identity: the client
+	// could have severe clock drift, or there could be non-expiry related
+	// reasons that an identity should be thrown out. We may improve this
+	// discard logic in the future if we determine we're still creating  excess
+	// bot instances.
 	now := time.Now()
 	if expiry, ok := facade.Expiry(); !ok || now.After(expiry) {
 		slog.WarnContext(
 			ctx,
 			"The bot identity appears to be expired and will not be used to "+
 				"authenticate the identity renewal. If it is possible to "+
-				"rejoin, a new bot instance will be issued. Ensure the "+
-				"configured certificate TTL is long enough to accommodate "+
-				"your environment and that no external issues will prevent "+
+				"rejoin, a new bot instance will be created. If this occurs "+
+				"repeatedly, ensure the local machine's clock is properly "+
+				"synchronized, the certificate TTL is adjusted to your "+
+				"environment, and that no external issues will prevent "+
 				"the bot from renewing its identity on schedule.",
 			"now", now,
 			"expiry", expiry,

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -423,20 +423,22 @@ func (s *identityService) unblockWaiters() {
 
 // renewIdentity attempts to renew an existing bot identity. "Renewal" in this
 // case means one of two things:
-//   1. If using an explicitly renewable identity (i.e. `token` joining),
-//      certificates will be renewed directly via Auth using the formal renewal
-//      process.
 //
-//      If the existing identity is expired, this will fail and cannot be
-//      recovered.
-//   2. For all other join methods, a "lightweight renewal" is performed. The
-//      existing client is used to authenticate the request and prove ownership
-//      of the existing bot instance ID, but otherwise the delegated joining
-//      ceremony is performed as usual.
+//  1. If using an explicitly renewable identity (i.e. `token` joining),
+//     certificates will be renewed directly via Auth using the formal renewal
+//     process.
 //
-//      If the existing identity appears to be expired (`time.Now()` >
-//      `NotAfter`), the existing auth client will be discarded and the bot will
-//      try to join without it. This will result in a new bot instance ID.
+//     If the existing identity is expired, this will fail and cannot be
+//     recovered.
+//
+//  2. For all other join methods, a "lightweight renewal" is performed. The
+//     existing client is used to authenticate the request and prove ownership
+//     of the existing bot instance ID, but otherwise the delegated joining
+//     ceremony is performed as usual.
+//
+//     If the existing identity appears to be expired (`time.Now()` >
+//     `NotAfter`), the existing auth client will be discarded and the bot will
+//     try to join without it. This will result in a new bot instance ID.
 func renewIdentity(
 	ctx context.Context,
 	log *slog.Logger,


### PR DESCRIPTION
Backport #56927 to branch/v17

changelog: Machine and Workload ID: The `tbot` client will now discard expired identities if needed during renewal to allow automatic recovery without restarting the process
