### PR TITLE
[teleport-update] Reliably detect update.yaml after soft reloads

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -59,6 +59,16 @@ type UpdateConfig struct {
 	Status UpdateStatus `yaml:"status"`
 }
 
+// Copy an UpdateConfig. Pointers are not copied.
+func (cfg *UpdateConfig) Copy() *UpdateConfig {
+	if cfg == nil {
+		return nil
+	}
+	// All pointer fields use immutable values.
+	// This may need additional logic if changes.
+	return toPtr(*cfg)
+}
+
 // UpdateSpec describes the spec field in update.yaml.
 type UpdateSpec struct {
 	// Proxy address

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -48,6 +48,7 @@ const (
 )
 
 // UpdateConfig describes the update.yaml file schema.
+// Pointer values should be replaced and not mutated, see Copy.
 type UpdateConfig struct {
 	// Version of the configuration file
 	Version string `yaml:"version"`
@@ -62,14 +63,13 @@ type UpdateConfig struct {
 // Copy an UpdateConfig. Pointers are not copied.
 func (cfg *UpdateConfig) Copy() *UpdateConfig {
 	if cfg == nil {
-		return nil
+		return &UpdateConfig{}
 	}
-	// All pointer fields use immutable values.
-	// This may need additional logic if changes.
 	return toPtr(*cfg)
 }
 
 // UpdateSpec describes the spec field in update.yaml.
+// Pointer values should be replaced and not mutated, see Copy.
 type UpdateSpec struct {
 	// Proxy address
 	Proxy string `yaml:"proxy"`
@@ -86,6 +86,7 @@ type UpdateSpec struct {
 }
 
 // UpdateStatus describes the status field in update.yaml.
+// Pointer values should be replaced and not mutated, see Copy.
 type UpdateStatus struct {
 	// IDFile is the path to a temporary file containing the updater ID.
 	IDFile string `yaml:"id_file,omitempty"`

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -209,7 +209,7 @@ func writeConfig(filename string, cfg *UpdateConfig) error {
 	}))
 }
 
-func validateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
+func updateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
 	if override.Proxy != "" {
 		spec.Proxy = override.Proxy
 	}

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -223,7 +223,7 @@ func TestValidateConfigSpec(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateConfigSpec(&tt.config, OverrideConfig{UpdateSpec: tt.override})
+			err := updateConfigSpec(&tt.config, OverrideConfig{UpdateSpec: tt.override})
 			if tt.errMatch != "" {
 				require.ErrorContains(t, err, tt.errMatch)
 				return

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -171,6 +171,10 @@ func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string
 		return nil, trace.Wrap(err, "reading config file %s", configPath)
 	}
 
+	// Note that only IDFile may be read from Status on the initial HELLO.
+	// Any fields set after the agent starts (e.g., active version) will be
+	// outdated until the agent is confirmed healthy.
+
 	info.UpdateGroup = cfg.Spec.Group
 	if info.UpdateGroup == "" {
 		info.UpdateGroup = defaultSetting

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -25,7 +25,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -33,10 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-const (
-	installDirEnvVar       = "TELEPORT_UPDATE_INSTALL_DIR"
-	updateConfigFileEnvVar = "TELEPORT_UPDATE_CONFIG_FILE"
-)
+const updateConfigFileEnvVar = "TELEPORT_UPDATE_CONFIG_FILE"
 
 // IsManagedByUpdater returns true if the local Teleport binary is managed by teleport-update.
 // Note that true may be returned even if auto-updates is disabled or the version is pinned.
@@ -54,64 +50,20 @@ func IsManagedByUpdater() (bool, error) {
 	if err != nil {
 		return false, trace.Wrap(err, "cannot find Teleport binary")
 	}
-	installDir := os.Getenv(installDirEnvVar)
-	if installDir == "" {
-		installDir = defaultInstallDir
+	// Consider all installations that have an update.yaml file to be
+	// managed by teleport-update (the "binary" updater).
+	p := findParentMatching(teleportPath, versionsDirName, 4)
+	if p == "" {
+		return false, nil
 	}
-	// Check if current binary is under the updater-managed path.
-	managed, err := hasParentDir(teleportPath, installDir)
+	_, err = os.Stat(filepath.Join(p, updateConfigName))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	if !managed {
-		return false, nil
-	}
-	// Return false if the binary is under the updater-managed path, but in the system prefix reserved for the package.
-	system, err := hasParentDir(teleportPath, packageSystemDir)
-	return !system, trace.Wrap(err)
-}
-
-// IsManagedAndDefault returns true if the local Teleport binary is both managed by teleport-update
-// and the default installation (with teleport.service as the unit file name).
-// The binary is considered managed and default if it lives within /opt/teleport/default.
-func IsManagedAndDefault() (bool, error) {
-	systemd, err := hasSystemD()
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	if !systemd {
-		return false, nil
-	}
-	teleportPath, err := os.Executable()
-	if err != nil {
-		return false, trace.Wrap(err, "cannot find Teleport binary")
-	}
-	installDir := os.Getenv(installDirEnvVar)
-	if installDir == "" {
-		installDir = defaultInstallDir
-	}
-	isDefault, err := hasParentDir(teleportPath, filepath.Join(installDir, defaultNamespace))
-	return isDefault, trace.Wrap(err)
-}
-
-// hasParentDir returns true if dir is any parent directory of parent.
-// hasParentDir does not resolve symlinks, and requires that files be represented the same way in dir and parent.
-func hasParentDir(dir, parent string) (bool, error) {
-	// Note that os.Stat + os.SameFile would be more reliable,
-	// but does not work well for arbitrarily nested subdirectories.
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return false, trace.Wrap(err, "cannot get absolute path for directory %s", dir)
-	}
-	absParent, err := filepath.Abs(parent)
-	if err != nil {
-		return false, trace.Wrap(err, "cannot get absolute path for parent directory %s", dir)
-	}
-	sep := string(filepath.Separator)
-	if !strings.HasSuffix(absParent, sep) {
-		absParent += sep
-	}
-	return strings.HasPrefix(absDir, absParent), nil
+	return true, nil
 }
 
 // ErrUnstableExecutable is returned by StableExecutable when no stable path can be found.
@@ -170,15 +122,37 @@ func stablePathForBinary(origPath, defaultPath string) (string, error) {
 
 // findParentMatching returns the directory above name, if name is at rpos.
 // Otherwise, it returns empty string.
-func findParentMatching(dir, name string, rpos int) string {
+func findParentMatching(path, parent string, rpos int) string {
+	if parent == "" {
+		return ""
+	}
 	var base string
 	for range rpos {
-		dir, base = filepath.Split(filepath.Clean(dir))
+		path, base = filepath.Split(filepath.Clean(path))
 	}
-	if base == name {
-		return dir
+	if base == parent {
+		return filepath.Clean(path)
 	}
 	return ""
+}
+
+// findConfigFile returns the path to the Teleport installation's update.yaml file.
+func findConfigFile() (string, error) {
+	// Note that if the install dir or install suffix changes before the installation
+	// is hard restarted, this path will be incorrect.
+	configPath := os.Getenv(updateConfigFileEnvVar)
+	if configPath != "" {
+		return configPath, nil
+	}
+	teleportPath, err := os.Executable()
+	if err != nil {
+		return "", trace.Wrap(err, "cannot find Teleport binary")
+	}
+	p := findParentMatching(teleportPath, versionsDirName, 4)
+	if p == "" {
+		return "", trace.Errorf("installation not managed by updater")
+	}
+	return filepath.Join(p, updateConfigName), nil
 }
 
 // ReadHelloUpdaterInfo reads the updater config and generates a proto.UpdaterV2Info
@@ -188,11 +162,10 @@ func findParentMatching(dir, name string, rpos int) string {
 func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string) (*types.UpdaterV2Info, error) {
 	info := &types.UpdaterV2Info{}
 
-	configPath := os.Getenv(updateConfigFileEnvVar)
-	if configPath == "" {
-		return nil, trace.Errorf("config file not specified")
+	configPath, err := findConfigFile()
+	if err != nil {
+		return nil, trace.Wrap(err, "config file not specified")
 	}
-
 	cfg, err := readConfig(configPath)
 	if err != nil {
 		return nil, trace.Wrap(err, "reading config file %s", configPath)

--- a/lib/autoupdate/agent/integrations_test.go
+++ b/lib/autoupdate/agent/integrations_test.go
@@ -27,86 +27,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHasParentDir(t *testing.T) {
+func TestFindParentMatching(t *testing.T) {
 	tests := []struct {
-		name       string
-		path       string
-		parent     string
-		wantResult bool
+		name   string
+		path   string
+		parent string
+		rpos   int
+		result string
 	}{
 		{
-			name:       "Has valid parent directory",
-			path:       "/opt/teleport/dir/test",
-			parent:     "/opt/teleport",
-			wantResult: true,
+			name:   "Has valid parent directory",
+			path:   "/opt/teleport/default/versions/v1.2.3/bin/teleport",
+			parent: "versions",
+			rpos:   4,
+			result: "/opt/teleport/default",
 		},
 		{
-			name:       "Has valid parent directory with slash",
-			path:       "/opt/teleport/dir/test",
-			parent:     "/opt/teleport/",
-			wantResult: true,
+			name:   "Parent too close",
+			path:   "/opt/teleport/default/versions/bin/teleport",
+			parent: "versions",
+			rpos:   4,
 		},
 		{
-			name:       "Parent directory is root",
-			path:       "/opt/teleport/dir",
-			parent:     "/",
-			wantResult: true,
+			name:   "Parent too far",
+			path:   "/opt/teleport/default/versions/v1.2.3/extra/bin/teleport",
+			parent: "versions",
+			rpos:   4,
 		},
 		{
-			name:       "Parent is the same as the path",
-			path:       "/opt/teleport/dir",
-			parent:     "/opt/teleport/dir",
-			wantResult: false,
+			name:   "Parent missing",
+			path:   "/opt/teleport/default/version/v1.2.3/bin/teleport",
+			parent: "versions",
+			rpos:   4,
 		},
 		{
-			name:       "Parent the same as the path but without slash",
-			path:       "/opt/teleport/dir/",
-			parent:     "/opt/teleport/dir",
-			wantResult: false,
+			name:   "Parent at root",
+			path:   "/versions/v1.2.3/bin/teleport",
+			parent: "versions",
+			rpos:   4,
+			result: "/",
 		},
 		{
-			name:       "Parent the same as the path but with slash",
-			path:       "/opt/teleport/dir",
-			parent:     "/opt/teleport/dir/",
-			wantResult: false,
+			name:   "Position past root",
+			path:   "/v1.2.3/bin/teleport",
+			parent: "versions",
+			rpos:   4,
 		},
 		{
-			name:       "Parent is substring of the path",
-			path:       "/opt/teleport/dir-place",
-			parent:     "/opt/teleport/dir",
-			wantResult: false,
+			name: "Empty",
 		},
 		{
-			name:       "Parent is in path",
-			path:       "/opt/teleport",
-			parent:     "/opt/teleport/dir",
-			wantResult: false,
+			name:   "Empty path",
+			parent: "versions",
+			rpos:   4,
 		},
 		{
-			name:       "Empty parent",
-			path:       "/opt/teleport/dir",
-			parent:     "",
-			wantResult: false,
-		},
-		{
-			name:       "Empty path",
-			path:       "",
-			parent:     "/opt/teleport",
-			wantResult: false,
-		},
-		{
-			name:       "Both empty",
-			path:       "",
-			parent:     "",
-			wantResult: false,
+			name:   "Empty parent",
+			path:   "/v1.2.3/bin/teleport",
+			parent: "",
+			rpos:   4,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := hasParentDir(tt.path, tt.parent)
-			require.NoError(t, err)
-			require.Equal(t, tt.wantResult, result)
+			result := findParentMatching(tt.path, tt.parent, tt.rpos)
+			require.Equal(t, tt.result, result)
 		})
 	}
 }

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/setup_fails.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/setup_fails.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: ""
+    path: ""
+    enabled: false
+    pinned: false
+status:
+    active:
+        version: ""

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -440,7 +440,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 		defer func() {
 			if err != nil {
 				if err := os.Remove(u.UpdateConfigFile); err != nil {
-					u.Log.WarnContext(ctx, "Failed to remove stale configuration.", "path", u.UpdateConfigFile)
+					u.Log.ErrorContext(ctx, "Failed to remove invalid partial configuration.", "path", u.UpdateConfigFile, errorKey, err)
 				}
 			}
 		}()

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -386,6 +386,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 	if err != nil {
 		return trace.Wrap(err, "failed to read %s", updateConfigName)
 	}
+	origCfg := cfg.Copy()
 	// Set the desired state.
 	if err := updateConfigSpec(&cfg.Spec, override); err != nil {
 		return trace.Wrap(err)
@@ -430,21 +431,20 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 		u.Log.InfoContext(ctx, "Initiating installation.", targetKey, target, activeKey, active)
 	}
 
-	// If update.yaml does not exist, write it before attempting to install.
+	// Write update.yaml before attempting to install.
 	// This ensures that update.yaml always exists when the agent is started and sends HELLO.
-	// The written file does not contain any versions, only the desired configuration.
-	if _, statErr := os.Stat(u.UpdateConfigFile); errors.Is(statErr, fs.ErrNotExist) {
-		if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
-			return trace.Wrap(err, "failed to write %s", updateConfigName)
-		}
-		defer func() {
-			if err != nil {
-				if err := os.Remove(u.UpdateConfigFile); err != nil {
-					u.Log.ErrorContext(ctx, "Failed to remove invalid partial configuration.", "path", u.UpdateConfigFile, errorKey, err)
-				}
-			}
-		}()
+	// The written file does not contain updated versions, only the desired configuration.
+	// It is reverted if the installation fails to start, so that configuration is not persisted.
+	if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
+		return trace.Wrap(err, "failed to write %s", updateConfigName)
 	}
+	defer func() {
+		if err != nil {
+			if err := writeConfig(u.UpdateConfigFile, origCfg); err != nil {
+				u.Log.ErrorContext(ctx, "Failed to revert invalid partial configuration.", "path", u.UpdateConfigFile, errorKey, err)
+			}
+		}
+	}()
 
 	if err := u.update(ctx, cfg, target, override.AllowOverwrite, resp.AGPL); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1818,12 +1818,6 @@ func TestUpdater_Install(t *testing.T) {
 			require.Equal(t, tt.setupCalls, setupCalls)
 			require.Equal(t, tt.restarted, restarted)
 
-			if tt.cfg == nil && err != nil {
-				_, err := os.Stat(cfgPath)
-				require.Error(t, err)
-				return
-			}
-
 			data, err := os.ReadFile(cfgPath)
 			require.NoError(t, err)
 			data = blankTestAddr(data)


### PR DESCRIPTION
This PR addresses an issue where Teleport agents that are soft-reloaded (not restarted) after being converted to Managed Updates v2 may not accurately report their group to the auth server. It also fixes an issue where Teleport agents with custom install directories (hidden flag) are not detected as being managed by Managed Updates v2 until they are restarted.

These issues occur because the Teleport systemd drop-in file adds environment variables that only apply on a hard restart. The environment variables are currently used by the agent to determine where update.yaml lives. This PR modifies the detection logic to look for `../../../versions/update.yaml` relative to the binary, which is a hard-coded path within the installation directory.

---

changelog: teleport-update: more reliably detect update.yaml in agent logic

RFD: https://github.com/gravitational/teleport/pull/47126
Goal: https://github.com/gravitational/cloud/issues/13207 (internal)