### PR TITLE
[v16] Reduce Connect subprocesses entitlements to just allow-jit

### DIFF
--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -109,6 +109,9 @@ module.exports = {
     notarize: true,
     hardenedRuntime: true,
     gatekeeperAssess: false,
+    // Use the same entitlements for Electron subprocesses (e.g., renderer, GPU)
+    // as those defined for the main app.
+    entitlementsInherit: 'build_resources/entitlements.mac.plist',
     // If CONNECT_TSH_APP_PATH is provided, we assume that tsh.app is already signed.
     signIgnore: env.CONNECT_TSH_APP_PATH && ['tsh.app'],
     icon: 'build_resources/icon-mac.png',


### PR DESCRIPTION
Backport #56983 to branch/v16

changelog: Removed unnecessary macOS entitlements from Teleport Connect subprocesses 
