### PR TITLE
AWS Roles Anywhere: improve logging when proxy is missing

### DIFF
--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -166,29 +166,8 @@ func RunAWSRolesAnywherProfileSyncer(ctx context.Context, params AWSRolesAnywher
 	}
 
 	for {
-		integrations, err := integrationsWithProfileSyncEnabled(ctx, params.Cache)
-		if err != nil {
+		if err := runProfileSyncerIteration(ctx, params); err != nil {
 			return trace.Wrap(err)
-		}
-
-		proxyPublicAddr, err := fetchProxyPublicAddr(params.Cache)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		for _, integration := range integrations {
-			syncSummary := syncProfileForIntegration(ctx, params, integration, proxyPublicAddr)
-			if syncSummary.setupError != nil {
-				// Only log the error if there was a set up error (eg, invalid sync configuration, missing permissions, ...).
-				// Profile specific errors (eg, invalid application url) were already logged.
-				params.Logger.WarnContext(ctx, "failed to sync AWS Roles Anywhere Profiles for integration", "error", err)
-			}
-
-			integration = updateIntegrationStatus(integration, syncSummary)
-
-			if _, err := params.StatusReporter.UpdateIntegration(ctx, integration); err != nil {
-				params.Logger.ErrorContext(ctx, "failed to update integration status", "integration", integration.GetName(), "error", err)
-			}
 		}
 
 		select {
@@ -198,6 +177,44 @@ func RunAWSRolesAnywherProfileSyncer(ctx context.Context, params AWSRolesAnywher
 		case <-params.Clock.After(params.SyncPollInterval):
 		}
 	}
+}
+
+func runProfileSyncerIteration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams) error {
+	integrations, err := integrationsWithProfileSyncEnabled(ctx, params.Cache)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if len(integrations) == 0 {
+		return nil
+	}
+
+	proxyPublicAddr, err := fetchProxyPublicAddr(params.Cache)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			params.Logger.WarnContext(ctx, "AWS IAM Roles Anywhere Profile Syncer requires a Proxy which isn't available yet. It will retry again later.")
+			return nil
+		}
+
+		return trace.Wrap(err)
+	}
+
+	for _, integration := range integrations {
+		syncSummary := syncProfileForIntegration(ctx, params, integration, proxyPublicAddr)
+		if syncSummary.setupError != nil {
+			// Only log the error if there was a set up error (eg, invalid sync configuration, missing permissions, ...).
+			// Profile specific errors (eg, invalid application url) were already logged.
+			params.Logger.WarnContext(ctx, "failed to sync AWS Roles Anywhere Profiles for integration", "error", syncSummary.setupError)
+		}
+
+		integration = updateIntegrationStatus(integration, syncSummary)
+
+		if _, err := params.StatusReporter.UpdateIntegration(ctx, integration); err != nil {
+			params.Logger.ErrorContext(ctx, "failed to update integration status", "integration", integration.GetName(), "error", err)
+		}
+	}
+
+	return nil
 }
 
 func updateIntegrationStatus(integration types.Integration, syncSummary *syncSummary) types.Integration {


### PR DESCRIPTION
It might happen that the Auth Service is running but no Proxy is yet available.

Prev, it would print a stack trace indicating the error of no proxy being available.
However, the Proxy should come up quickly unless there's a worse problem with the cluster.

Now, instead of a stack trace we just log a message saying that no proxy is available but the system will retry again.
Another subtle change, is that we do an early return if there's no AWS Roles Anywhere integrations with profile sync enabled.

After:
```logs
2025-07-23T10:23:35.984+01:00 WARN [PROC:1]    AWS IAM Roles Anywhere Profile Syncer requires a Proxy which isn't available yet. It will retry again later. pid:5819.1 process:aws-roles-anywhere.profile-sync awsra/profile_syncer.go:199
```