### PR TITLE
docs: update policy references to identity security

### DIFF
--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -144,7 +144,7 @@ and access CloudTrail logs in the S3 bucket.
 ## Step 3/3. Set up Access Graph AWS Sync
 
 To initiate the setup wizard for configuring AWS Sync, access the Teleport UI,
-click the Policy sidebar button, and then click Integrations.
+click the Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "AWS". You'll be prompted
 to create a new Teleport AWS integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -144,7 +144,7 @@ and access CloudTrail logs in the S3 bucket.
 ## Step 3/3. Set up Access Graph AWS Sync
 
 To initiate the setup wizard for configuring AWS Sync, access the Teleport UI,
-click the Identity Security sidebar button, and then click Integrations.
+click the Teleport Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "AWS". You'll be prompted
 to create a new Teleport AWS integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -144,7 +144,7 @@ and access CloudTrail logs in the S3 bucket.
 ## Step 3/3. Set up Access Graph AWS Sync
 
 To initiate the setup wizard for configuring AWS Sync, access the Teleport UI,
-click the Teleport Identity Security sidebar button, and then click Integrations.
+click the Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "AWS". You'll be prompted
 to create a new Teleport AWS integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -83,7 +83,7 @@ The token will be used in the next step to configure the GitLab Sync integration
 ## Step 2/3. Set up Access Graph GitLab Sync
 
 To initiate the setup wizard for configuring Gitlab Sync, access the Teleport UI,
-click the Policy sidebar button, and then click Integrations.
+click the Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "Gitlab". You'll be prompted
 to create a new Teleport Gitlab integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -83,7 +83,7 @@ The token will be used in the next step to configure the GitLab Sync integration
 ## Step 2/3. Set up Access Graph GitLab Sync
 
 To initiate the setup wizard for configuring Gitlab Sync, access the Teleport UI,
-click the Identity Security sidebar button, and then click Integrations.
+click the Teleport Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "Gitlab". You'll be prompted
 to create a new Teleport Gitlab integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -83,7 +83,7 @@ The token will be used in the next step to configure the GitLab Sync integration
 ## Step 2/3. Set up Access Graph GitLab Sync
 
 To initiate the setup wizard for configuring Gitlab Sync, access the Teleport UI,
-click the Teleport Identity Security sidebar button, and then click Integrations.
+click the Identity Security sidebar button, and then click Integrations.
 
 Click the "Setup new integration" button, and then select "Gitlab". You'll be prompted
 to create a new Teleport Gitlab integration if you haven't configured one already.

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -48,7 +48,7 @@ The preset `editor` role has the required permissions by default.
 
 ## Set up a new integration
 
-On the left sidebar, click **Identity Security**. Click the connection icon labeled Integrations: 
+On the left sidebar, click **Teleport Identity Security**. Click the connection icon labeled Integrations: 
 ![Connection view](../../../img/access-graph/connection_view.png) 
 Select the "Set up new integration" button.
 

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -48,7 +48,7 @@ The preset `editor` role has the required permissions by default.
 
 ## Set up a new integration
 
-On the left sidebar, click **Teleport Identity Security**. Click the connection icon labeled Integrations: 
+On the left sidebar, click **Identity Security**. Click the connection icon labeled Integrations: 
 ![Connection view](../../../img/access-graph/connection_view.png) 
 Select the "Set up new integration" button.
 

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -48,7 +48,7 @@ The preset `editor` role has the required permissions by default.
 
 ## Set up a new integration
 
-On the left sidebar, click **Policy**. Click the connection icon labeled Integrations: 
+On the left sidebar, click **Identity Security**. Click the connection icon labeled Integrations: 
 ![Connection view](../../../img/access-graph/connection_view.png) 
 Select the "Set up new integration" button.
 

--- a/docs/pages/identity-security/teleport-policy.mdx
+++ b/docs/pages/identity-security/teleport-policy.mdx
@@ -22,7 +22,7 @@ Identity Security is a separately licensed product and is available to Teleport 
 Access Graph is a major capability of Identity Security that visually shows the relationships of
 policies of users, groups, and computing resources.
 
-To verify the availability of the Access Graph, ensure that the Policy icon is present in the navigation sidebar.
+To verify the availability of the Access Graph, ensure that the Teleport Security icon is present in the navigation sidebar.
 
 <Admonition type="note">
 Note: For managed Enterprise customers, Identity Security is enabled by default.

--- a/docs/pages/identity-security/teleport-policy.mdx
+++ b/docs/pages/identity-security/teleport-policy.mdx
@@ -22,7 +22,7 @@ Identity Security is a separately licensed product and is available to Teleport 
 Access Graph is a major capability of Identity Security that visually shows the relationships of
 policies of users, groups, and computing resources.
 
-To verify the availability of the Access Graph, ensure that the Teleport Security icon is present in the navigation sidebar.
+To verify the availability of the Access Graph, ensure that the Teleport Identity Security icon is present in the navigation sidebar.
 
 <Admonition type="note">
 Note: For managed Enterprise customers, Identity Security is enabled by default.

--- a/docs/pages/includes/policy/access-graph.mdx
+++ b/docs/pages/includes/policy/access-graph.mdx
@@ -2,4 +2,4 @@ Access Graph is a feature of the [Teleport Identity Security](https://goteleport
 Teleport Enterprise edition customers.
 
 To verify that Access Graph is set up correctly for your cluster, sign in to the Teleport Web UI, click the
-Policy sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.
+Identity Security sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.

--- a/docs/pages/includes/policy/access-graph.mdx
+++ b/docs/pages/includes/policy/access-graph.mdx
@@ -2,4 +2,4 @@ Access Graph is a feature of the [Teleport Identity Security](https://goteleport
 Teleport Enterprise edition customers.
 
 To verify that Access Graph is set up correctly for your cluster, sign in to the Teleport Web UI, click the
-Teleport Identity Security sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.
+Identity Security sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.

--- a/docs/pages/includes/policy/access-graph.mdx
+++ b/docs/pages/includes/policy/access-graph.mdx
@@ -2,4 +2,4 @@ Access Graph is a feature of the [Teleport Identity Security](https://goteleport
 Teleport Enterprise edition customers.
 
 To verify that Access Graph is set up correctly for your cluster, sign in to the Teleport Web UI, click the
-Identity Security sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.
+Teleport Identity Security sidebar button, and then the Browse menu item. Identities, resources, etc. should be listed.


### PR DESCRIPTION
The Policy Sidebar name was replaced with Identity Security. 

<img width="148" height="310" alt="image" src="https://github.com/user-attachments/assets/824f0ca5-c3cd-45e9-a69e-4b1b91fa645a" />

Updates #50411