### PR TITLE
Minor autoupdate doc fixes

### DIFF
--- a/docs/pages/reference/cli/cli.mdx
+++ b/docs/pages/reference/cli/cli.mdx
@@ -7,9 +7,10 @@ labels:
  - platform-wide
 ---
 
-Teleport is made up of five CLI tools.
+Teleport is made up of six CLI tools.
 
 - [teleport](teleport.mdx): Supports the Teleport Infrastructure Identity Platform by starting and configuring various Teleport services.
+- [teleport-update](teleport-update.mdx): Installs and updates Teleport binaries.
 - [tsh](tsh.mdx): Allows end users to authenticate to Teleport and access resources in a cluster.
 - [tctl](tctl.mdx): Used to configure the Teleport Auth Service.
 - [tbot](tbot.mdx): Supports Machine ID, which provides short lived credentials to service accounts (e.g, a CI/CD server).
@@ -81,4 +82,3 @@ $ tsh ls --search=staging,mac
 # with key `env` equal to `staging` and key `os` equal to `mac`.
 $ tsh ls --query='labels["env"] == "staging" && equals(labels["os"], "mac")'
 ```
-

--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -122,7 +122,7 @@ Teleport cluster that agents use to determine when to check for upgrades.
 
 1. Add the role to your Teleport user:
 
-  (!docs/pages/includes/add-role-to-user.mdx role="cmc-editor"!)
+   (!docs/pages/includes/add-role-to-user.mdx role="cmc-editor"!)
 
 1. Create a cluster maintenance config in a file called `cmc.yaml`. The
    following example allows maintenance on Monday, Wednesday and Friday between
@@ -251,19 +251,19 @@ Server ID                            Hostname      Services Version Upgrader
    $ teleport version
    ```
 
-<details>
-<summary>Running the agent as a non-root user</summary>
+   <details>
+   <summary>Running the agent as a non-root user</summary>
 
-If you changed the agent user to run as non-root, create
-`/etc/teleport-upgrade.d/schedule` and grant ownership to your Teleport user:
+   If you changed the agent user to run as non-root, create
+   `/etc/teleport-upgrade.d/schedule` and grant ownership to your Teleport user:
 
-```code
-$ sudo mkdir -p /etc/teleport-upgrade.d/
-$ sudo touch /etc/teleport-upgrade.d/schedule
-$ sudo chown your-teleport-user /etc/teleport-upgrade.d/schedule
-```
+   ```code
+   $ sudo mkdir -p /etc/teleport-upgrade.d/
+   $ sudo touch /etc/teleport-upgrade.d/schedule
+   $ sudo chown your-teleport-user /etc/teleport-upgrade.d/schedule
+   ```
 
-</details>
+   </details>
 
 1. Verify that the upgrader can see your version endpoint by checking for
    upgrades:
@@ -411,4 +411,3 @@ until the next reconciliation, you can trigger an event.
    ```code
    $ sudo systemctl enable --now teleport-upgrade.timer
    ```
-


### PR DESCRIPTION
Fixes 2 docs issues with autoupdates:
- in managed updates v1 guide, the step counter was reset several times
- missing teleport-update reference link in CLI ref index