### PR TITLE
Docs: AWS IAM Roles Anywhere integration and profile sync setup

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -342,6 +342,7 @@
     "awsic",
     "awskms",
     "awsoidc",
+    "awsra",
     "awsuser",
     "azblob",
     "azidentity",

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -1,27 +1,16 @@
 ---
-title: AWS Console and CLI access
-description: How to access AWS with Teleport.
+title: AWS Console and CLI access with Roles Anywhere
+description: How to use AWS IAM Roles Anywhere with Teleport for AWS Console and CLI access
 labels:
  - how-to
  - zero-trust
 ---
 
-<Admonition type="tip">
-You can access AWS APIs (e.g., CLI, SDKs) through Teleport using two methods:
-- using an Application Service which proxies and audits every AWS API request
-- using short-lived credentials stored in your local system
-Accessing the AWS Web Console works the same in both methods.
+Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI access.
+This allows you to take advantage of Teleport role-based access controls, just-in-time access requests and other zero-trust and identity governance capabilities to manage access to your AWS infrastructure.
 
-This guide focus on the second method, which is the recommend one.
-
-If you want to audit AWS API requests, then use the method[first method](aws-console.mdx).
-
-Access Requests, Access Lists and other RBAC access controls features work the same in both methods.
-</Admonition>
-
-You can protect the AWS Management Console and AWS APIs with Teleport.
-This allows you to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
-You can also configure Teleport to provide different levels of AWS access automatically when users authenticate using your single sign-on solution.
+If you're already using AWS IAM Roles Anywhere and looking to protect access to your AWS environment with Teleport, while ensuring full compatibility with all AWS API based tooling (such as CLI tools or terraform), this guide provides a recommended way for you to do that.
+If you're looking to provide AWS CLI access to your users with audit capture by going through Teleport proxy, or Roles Anywhere are not adopted at your organization, take a look at the guide for [agent-based AWS access](aws-console.mdx) instead.
 
 This guide will explain how to:
 
@@ -55,128 +44,128 @@ For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 ## Step 1/4. Configure AWS IAM Roles Anywhere integration
 
+Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listing page, and follow the guide after clicking on AWS CLI/Console Access tile.
+
+<details>
+  <summary>Manually configure the integration</summary>
+
+  You will create the following resources in AWS:
+
+  | Name                                 | Resource                        | Function                                                                                  |
+  |--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
+  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere Trust Anchor | Allow access from Teleport into AWS.                                                      |
+  | `TeleportRolesAnywhereProfileSync`   | IAM Role                        | Allows Teleport to iterate over AWS Roles Anywhere Profiles and import them as resources. |
+  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere Profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM Role.                             |
+
+  ### Create an IAM Roles Anywhere Trust Anchor
+
+  First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
+
+  1. Obtain the Teleport certificate by:
+    <Tabs>
+      <TabItem label="Via curl">
+      ```code
+      $ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
+      -----BEGIN CERTIFICATE-----
+      MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+      ...
+      -----END CERTIFICATE-----
+      ```
+      </TabItem>
+
+      <TabItem label="Via tctl">
+      ```code
+      $ tctl auth export --type awsra
+      -----BEGIN CERTIFICATE-----
+      MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+      ...
+      -----END CERTIFICATE-----
+      ```
+      </TabItem>
+    </Tabs>
+  1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
+    Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
+  1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
+
+  ### Set up Profile Sync
+
+  Next, you will create the required AWS resources to enable the Profile Sync.
+
+  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
+    Trust policy must include the Roles Anywhere service principal:
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "rolesanywhere.amazonaws.com"
+                },
+                "Action": [
+                    "sts:AssumeRole",
+                    "sts:SetSourceIdentity",
+                    "sts:TagSession"
+                ]
+            }
+        ]
+    }
+    ```
+  1. Copy the IAM Role ARN <Var name="Role ARN" />
+  1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "RolesAnywhereProfileSync",
+                "Effect": "Allow",
+                "Action": [
+                    "rolesanywhere:ListProfiles",
+                    "rolesanywhere:ListTagsForResource",
+                    "rolesanywhere:ImportCrl",
+                    "iam:GetRole"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+    ```
+
+  1. Now, navigate to the [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
+    Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
+  1. Copy the Profile ARN <Var name="Profile ARN" />
+
+  ### Create a Teleport AWS IAM Roles Anywhere integration
+  Now that the required AWS resources are created, you can create a Teleport AWS IAM Roles Anywhere integration.
+
+  1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
+    ```yaml
+    kind: integration
+    sub_kind: aws-ra
+    version: v1
+    metadata:
+      name: <Var name="Integration Name" />
+    spec:
+      aws_ra:
+        trust_anchor_arn: <Var name="Trust Anchor ARN" />
+        profile_sync_config:
+          enabled: true
+          profile_arn: <Var name="Profile ARN" />
+          role_arn: <Var name="Role ARN" />
+    ```
+
+  1. Create the integration with the following command:
+    ```code
+    $ tctl create -f roles-anywhere-integration.yaml
+    ```
+
+  Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS applications, every 5 minutes.
+</details>
+
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
-
-<Admonition type="note">
-Instead of doing this step manually, you can navigate to your Teleport Web UI,
-click on Enroll New Resource in Resources listing page,
-and follow the guide after clicking on the AWS CLI/Console Access tile.
-</Admonition>
-
-You will create the following resources in AWS:
-
-| Name                                 | Resource                        | Function                                                                                  |
-|--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
-| `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere Trust Anchor | Allow access from Teleport into AWS.                                                      |
-| `TeleportRolesAnywhereProfileSync`   | IAM Role                        | Allows Teleport to iterate over AWS Roles Anywhere Profiles and import them as resources. |
-| `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere Profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM Role.                             |
-
-### Create an IAM Roles Anywhere Trust Anchor
-
-First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
-
-1. Obtain the Teleport certificate by:
-  <Tabs>
-    <TabItem label="Via curl">
-    ```code
-    $ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
-    -----BEGIN CERTIFICATE-----
-    MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-    ...
-    -----END CERTIFICATE-----
-    ```
-    </TabItem>
-
-    <TabItem label="Via tctl">
-    ```code
-    $ tctl auth export --type awsra
-    -----BEGIN CERTIFICATE-----
-    MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-    ...
-    -----END CERTIFICATE-----
-    ```
-    </TabItem>
-  </Tabs>
-1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
-  Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
-1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
-
-### Set up Profile Sync
-
-Next, you will create the required AWS resources to enable the Profile Sync.
-
-1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
-  Trust policy must include the Roles Anywhere service principal:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Principal": {
-                  "Service": "rolesanywhere.amazonaws.com"
-              },
-              "Action": [
-                  "sts:AssumeRole",
-                  "sts:SetSourceIdentity",
-                  "sts:TagSession"
-              ]
-          }
-      ]
-  }
-  ```
-1. Copy the IAM Role ARN <Var name="Role ARN" />
-1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
-  ```json
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Sid": "RolesAnywhereProfileSync",
-              "Effect": "Allow",
-              "Action": [
-                  "rolesanywhere:ListProfiles",
-                  "rolesanywhere:ListTagsForResource",
-                  "rolesanywhere:ImportCrl",
-                  "iam:GetRole"
-              ],
-              "Resource": [
-                  "*"
-              ]
-          }
-      ]
-  }
-  ```
-
-1. Now, navigate to the [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
-  Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
-1. Copy the Profile ARN <Var name="Profile ARN" />
-
-### Create a Teleport AWS IAM Roles Anywhere integration
-Now that the required AWS resources are created, you can create a Teleport AWS IAM Roles Anywhere integration.
-
-1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
-  ```yaml
-  kind: integration
-  sub_kind: aws-ra
-  version: v1
-  metadata:
-    name: <Var name="Integration Name" />
-  spec:
-    aws_ra:
-      trust_anchor_arn: <Var name="Trust Anchor ARN" />
-      profile_sync_config:
-        enabled: true
-        profile_arn: <Var name="Profile ARN" />
-        role_arn: <Var name="Role ARN" />
-  ```
-
-1. Create the integration with the following command:
-  ```code
-  $ tctl create -f roles-anywhere-integration.yaml
-  ```
-
-Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS applications, every 5 minutes.
 
 ## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
 
@@ -212,7 +201,6 @@ If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this
   Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
   
   Copy the Profile ARN <Var name="Read Only Profile ARN" />.
-1. You should now see the `ExampleReadOnlyAccess` profile listed in your Teleport Web UI in the Resources page.
 
 ## Step 3/4. Set up access
 Now you need to grant your users access to the imported AWS profiles/roles.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -44,6 +44,8 @@ For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 ## Step 1/4. Configure AWS IAM Roles Anywhere integration
 
+In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
+
 Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listing page, and follow the guide after clicking on AWS CLI/Console Access tile.
 
 <details>
@@ -165,8 +167,6 @@ Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listi
   Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS applications, every 5 minutes.
 </details>
 
-In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
-
 ## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
 
 Now, you will create an example Profile and Role so that you can test the integration.
@@ -239,7 +239,7 @@ You will create a Teleport Role which will grant access to the `ExampleReadOnlyA
     </TabItem>
   </Tabs>
 
-Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide.mdx) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/).
+Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide.mdx) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/access-requests.mdx).
 
 ## Step 4/4. Access AWS resources
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -1,5 +1,5 @@
 ---
-title: AWS Console and CLI access with Roles Anywhere
+title: AWS Console and CLI Access with Roles Anywhere
 description: How to use AWS IAM Roles Anywhere with Teleport for AWS Console and CLI access
 labels:
  - how-to
@@ -7,7 +7,7 @@ labels:
 ---
 
 Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI access.
-This allows you to take advantage of Teleport role-based access controls, just-in-time access requests and other zero-trust and identity governance capabilities to manage access to your AWS infrastructure.
+This allows you to take advantage of Teleport role-based access controls, just-in-time Access Requests and other Teleport Zero Trust Access and Identity Governance capabilities to manage access to your AWS infrastructure.
 
 If you're already using AWS IAM Roles Anywhere and looking to protect access to your AWS environment with Teleport, while ensuring full compatibility with all AWS API based tooling (such as CLI tools or terraform), this guide provides a recommended way for you to do that.
 If you're looking to provide AWS CLI access to your users with audit capture by going through Teleport proxy, or Roles Anywhere are not adopted at your organization, take a look at the guide for [agent-based AWS access](aws-console.mdx) instead.
@@ -21,11 +21,12 @@ This guide will explain how to:
 
 ## How it works
 
-Teleport leverages AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM Roles.
+Teleport uses AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM roles.
 
 Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for authorized users and roles.
+No additional service is required, as it runs in the control plane (Proxy and Auth Services).
 
-For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere Profile.
+For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere profile.
 
 For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
@@ -35,9 +36,9 @@ For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 - (!docs/pages/includes/tctl.mdx!)
 - Permissions in AWS to:
-  - create IAM Roles Anywhere Trust Anchor
-  - create IAM Roles Anywhere Profiles
-  - create IAM Roles
+  - create IAM Roles Anywhere trust anchor
+  - create IAM Roles Anywhere profiles
+  - create IAM roles
 - `aws` command line interface (CLI) tool in PATH. Read the AWS documentation to
   [install or update the latest version of the AWS
   CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
@@ -46,7 +47,7 @@ For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
-Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listing page, and follow the guide after clicking on AWS CLI/Console Access tile.
+Navigate to the Teleport Web UI, click on Enroll New Resource in the Resources listing page, and follow the guide after clicking on AWS CLI/Console Access tile.
 
 <details>
   <summary>Manually configure the integration</summary>
@@ -55,45 +56,31 @@ Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listi
 
   | Name                                 | Resource                        | Function                                                                                  |
   |--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
-  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere Trust Anchor | Allow access from Teleport into AWS.                                                      |
-  | `TeleportRolesAnywhereProfileSync`   | IAM Role                        | Allows Teleport to iterate over AWS Roles Anywhere Profiles and import them as resources. |
-  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere Profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM Role.                             |
+  | `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere trust anchor | Allow access from Teleport into AWS.                                                      |
+  | `TeleportRolesAnywhereProfileSync`   | IAM role                        | Allows Teleport to iterate over AWS Roles Anywhere profiles and import them as resources. |
+  | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM role.                             |
 
   ### Create an IAM Roles Anywhere Trust Anchor
 
   First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
 
-  1. Obtain the Teleport certificate by:
-    <Tabs>
-      <TabItem label="Via curl">
-      ```code
-      $ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
-      -----BEGIN CERTIFICATE-----
-      MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-      ...
-      -----END CERTIFICATE-----
-      ```
-      </TabItem>
-
-      <TabItem label="Via tctl">
-      ```code
-      $ tctl auth export --type awsra
-      -----BEGIN CERTIFICATE-----
-      MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-      ...
-      -----END CERTIFICATE-----
-      ```
-      </TabItem>
-    </Tabs>
+  1. Obtain the Teleport certificate:
+     ```code
+     $ tctl auth export --type awsra
+     -----BEGIN CERTIFICATE-----
+     MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+     ...
+     -----END CERTIFICATE-----
+     ```
   1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
     Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
   1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
 
   ### Set up Profile Sync
 
-  Next, you will create the required AWS resources to enable the Profile Sync.
+  Next, you will create the required AWS resources to enable the profile sync.
 
-  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
+  1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM role called `TeleportRolesAnywhereProfileSync`.
     Trust policy must include the Roles Anywhere service principal:
     ```json
     {
@@ -113,7 +100,7 @@ Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listi
         ]
     }
     ```
-  1. Copy the IAM Role ARN <Var name="Role ARN" />
+  1. Copy the IAM role ARN <Var name="Role ARN" />
   1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
     ```json
     {
@@ -164,16 +151,16 @@ Navigate to Teleport Web UI, click on Enroll New Resource in the Resources listi
     $ tctl create -f roles-anywhere-integration.yaml
     ```
 
-  Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS applications, every 5 minutes.
+  Teleport will now start syncing AWS IAM Roles Anywhere profiles as AWS applications, every 5 minutes.
 </details>
 
-## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
+## Step 2/4. Create an AWS IAM Roles Anywhere profile and assign IAM roles
 
-Now, you will create an example Profile and Role so that you can test the integration.
+Now, you will create an example profile and role so that you can test the integration.
 
-If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this step.
+If you are already leveraging AWS IAM Roles Anywhere profiles, you can skip this step.
 
-1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `ExampleReadOnlyAccess`.
+1. Navigate to [Create role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM role called `ExampleReadOnlyAccess`.
   Trust policy must include the Roles Anywhere service principal:
   ```json
   {
@@ -195,7 +182,7 @@ If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this
   ```
 
   Add the AWS-managed `ReadOnlyAccess` policy to the role.
-  Copy the Role ARN <Var name="Read Only Role ARN" />.
+  Copy the role ARN <Var name="Read Only Role ARN" />.
 
 1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `ExampleReadOnlyAccess`.
   Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
@@ -204,7 +191,7 @@ If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this
 
 ## Step 3/4. Set up access
 Now you need to grant your users access to the imported AWS profiles/roles.
-You will create a Teleport Role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM Role.
+You will create a Teleport role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM role.
 
   <Tabs>
     <TabItem label="Web UI">
@@ -214,6 +201,7 @@ You will create a Teleport Role which will grant access to the `ExampleReadOnlyA
     Next, add an Application Access entry, in the Resources section, with the following:
     - Labels: `teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'`
     - AWS Role ARNs: <Var name="Read Only Role ARN" />
+
     Proceed to the next steps and create the role.
     </TabItem>
 
@@ -248,8 +236,8 @@ Now that you have configured the Integration and set up the Role, users can acce
 ### Access AWS Management Console
 
 1. Visit the home page of the Teleport Web UI and click **Resources**.
-   If the Integration found any Profiles as expected, the Web UI will display the name of the Profile.
-   If you don't see any Profiles, see the [Troubleshooting](#troubleshooting) section.
+   If the Integration found any profiles as expected, the Web UI will display the name of the Profile.
+   If you don't see any profiles, see the [Troubleshooting](#troubleshooting) section.
 
 1. Click the **Launch** button for the AWS Console application, then click on the role you would like to assume when signing in to the AWS Console:
 
@@ -303,53 +291,54 @@ Setting the `AWS_PROFILE` environment variable is also an option.
 Read this section if you run into issues while following this guide.
 
 ### Missing Profiles in Resources page
-If you don't see the expected AWS Profiles in the Teleport Web UI, check the following:
+If you don't see the expected AWS profiles in the Teleport Web UI, check the following:
 
-1. **Profile Sync Configuration**
-  Ensure your the Profile Sync Configuration is enabled and the the `profile_name_filters` are set accordingly (set it to `*` if you want to import all the Profiles):
-  ```code
-  $ tctl get integration/<Var name="Integration Name" />
-  ...
-  spec:
-    aws_ra:
-      profile_sync_config:
-        enabled: true
-        profile_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
-        profile_name_filters:
-        - MarcoRA-*
-        role_arn: arn:aws:iam::123456789012:role/TeleportRolesAnywhereProfileSync
-      trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
-  ```
+1. Ensure the profile sync configuration is enabled and the `profile_name_filters` are set accordingly (set it to `*` if you want to import all the profiles):
 
-1. **Integration Status**
-  You can get the integration status summary by running the following command:
-  ```code
-  $ tctl get integration/<Var name="Integration Name" />
-  ...
-  status:
-    aws_ra:
-      last_profile_sync:
-        end_time: "2025-07-23T15:46:27.475629Z"
-        error_message: ""
-        start_time: "2025-07-23T15:46:26.334536Z"
-        status: SUCCESS
-        synced_profiles: 4
-  ```
-  Look for any error message you might have.
+   ```code
+   $ tctl get integration/<Var name="Integration Name" />
+   ...
+   spec:
+     aws_ra:
+       profile_sync_config:
+         enabled: true
+         profile_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
+         profile_name_filters:
+         - MarcoRA-*
+         role_arn: arn:aws:iam::123456789012:role/TeleportRolesAnywhereProfileSync
+       trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
+   ```
 
-1. **Missing permissions**
-  Ensure that your Teleport Role allows you access to all the expected Profiles.
-  AWS App resources have a specific label which you can use to control access: `teleport.dev/aws-roles-anywhere-profile-arn`.
-  Set it to `*` to allow access to all profiles, like so:
-  ```yaml
-  kind: role
-  spec:
-    allow:
-      app_labels:
-        'teleport.dev/aws-roles-anywhere-profile-arn': '*'
-  ```
+1. You can get the integration status summary by running the following command:
 
-## Next Steps
+   ```code
+   $ tctl get integration/<Var name="Integration Name" />
+   ...
+   status:
+     aws_ra:
+       last_profile_sync:
+         end_time: "2025-07-23T15:46:27.475629Z"
+         error_message: ""
+         start_time: "2025-07-23T15:46:26.334536Z"
+         status: SUCCESS
+         synced_profiles: 4
+   ```
+
+   Look for any error message you might have.
+
+1. Ensure that your Teleport role allows you access to all the expected profiles.
+   AWS app resources have a specific label which you can use to control access: `teleport.dev/aws-roles-anywhere-profile-arn`.
+   Set it to `*` to allow access to all profiles, like so:
+
+   ```yaml
+   kind: role
+   spec:
+     allow:
+       app_labels:
+         'teleport.dev/aws-roles-anywhere-profile-arn': '*'
+   ```
+
+## Next steps
 
 Now that you know how to set up Teleport to protect access to the AWS Management Console and APIs, you can tailor your setup to the needs of your organization.
 
@@ -367,8 +356,8 @@ If you define a Teleport role to mention the `{{external.aws_role_arns}}` variab
 
 See the [Access Controls Reference](../../../reference/access-controls/roles.mdx) for all of the variables and functions you can use in the `aws_role_arns` field.
 
-### Create Roles to grant access to specific Profile and IAM Roles
+### Create Roles to grant access to a specific profile and IAM roles
 
-You can create multiple Teleport Roles to grant access to the Profiles and IAM Roles for each Profile.
+You can create multiple Teleport roles to grant access to the profiles and IAM roles for each Profile.
 
 See [Role Access Requests](../../../identity-governance/access-requests/role-requests.mdx) to learn more about creating Roles and how to access them using Access Requests.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: AWS Console and CLI access via AWS IAM Roles Anywhere
-description: How to access AWS with Teleport via AWS IAM Roles Anywhere.
+title: AWS Console and CLI access
+description: How to access AWS with Teleport.
 labels:
  - how-to
  - zero-trust
@@ -99,7 +99,7 @@ First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Telep
 Next, you will create the required AWS resources to enable the Profile Sync.
 
 1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
-   Trust policy must include the Roles Anywhere service principal:
+  Trust policy must include the Roles Anywhere service principal:
   ```json
   {
       "Version": "2012-10-17",
@@ -118,7 +118,6 @@ Next, you will create the required AWS resources to enable the Profile Sync.
       ]
   }
   ```
-
 1. Copy the IAM Role ARN <Var name="Role ARN" />
 1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
   ```json
@@ -143,7 +142,7 @@ Next, you will create the required AWS resources to enable the Profile Sync.
   ```
 
 1. Now, navigate to the [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
-Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
+  Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
 1. Copy the Profile ARN <Var name="Profile ARN" />
 
 ### Create a Teleport AWS IAM Roles Anywhere integration
@@ -179,7 +178,7 @@ Now, you will create an example Profile and Role so that you can test the integr
 If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this step.
 
 1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `ExampleReadOnlyAccess`.
-Trust policy must include the Roles Anywhere service principal:
+  Trust policy must include the Roles Anywhere service principal:
   ```json
   {
       "Version": "2012-10-17",
@@ -199,14 +198,13 @@ Trust policy must include the Roles Anywhere service principal:
   }
   ```
 
-Add the AWS-managed `ReadOnlyAccess` policy to the role.
-Copy the Role ARN <Var name="Read Only Role ARN" />.
+  Add the AWS-managed `ReadOnlyAccess` policy to the role.
+  Copy the Role ARN <Var name="Read Only Role ARN" />.
 
 1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `ExampleReadOnlyAccess`.
-Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
-
-Copy the Profile ARN <Var name="Read Only Profile ARN" />.
-
+  Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
+  
+  Copy the Profile ARN <Var name="Read Only Profile ARN" />.
 1. You should now see the `ExampleReadOnlyAccess` profile listed in your Teleport Web UI in the Resources page.
 
 ## Step 3/4. Set up access
@@ -246,7 +244,7 @@ You will create a Teleport Role which will grant access to the `ExampleReadOnlyA
     </TabItem>
   </Tabs>
 
-Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide/) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/).
+Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide.mdx) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/).
 
 ## Step 4/4. Access AWS resources
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -1,6 +1,6 @@
 ---
-title: Access AWS With Teleport
-description: How to access AWS with Teleport.
+title: AWS Console and CLI access via AWS IAM Roles Anywhere
+description: How to access AWS with Teleport via AWS IAM Roles Anywhere.
 labels:
  - how-to
  - zero-trust
@@ -10,11 +10,17 @@ You can protect the AWS Management Console and AWS APIs with Teleport.
 This makes it possible to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
 You can also configure Teleport to provide different levels of AWS access automatically when users authenticate using your single sign-on solution.
 
+<Admonition type="note">
+When compared with the [AWS Console and CLI access](aws-console.mdx) method,
+this guide does not require a Teleport Agent to be installed and provides 100% compatibility with AWS SDK based tools.
+However, it does not record the requests in Teleport's audit logs, only that a session was started by a given user.
+</Admonition>
+
 This guide will explain how to:
 
-- Access the AWS Management Console through Teleport.
-- Access the AWS Command Line Interface (CLI) through Teleport.
-- Access applications using AWS SDKs through Teleport.
+- Access the AWS Management Console
+- Access the AWS Command Line Interface (CLI)
+- Access applications using AWS SDKs
 
 ## How it works
 
@@ -81,9 +87,8 @@ In this section, you will create an IAM Roles Anywhere Trust Anchor which trusts
     ```
     </TabItem>
   </Tabs>
-
 1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
-Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
+  Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
 1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
 
 ### Set up Profile Sync
@@ -121,10 +126,10 @@ This section will create the required AWS resources to enable the Profile Sync.
               "Sid": "RolesAnywhereProfileSync",
               "Effect": "Allow",
               "Action": [
-            "rolesanywhere:ListProfiles",
-            "rolesanywhere:ListTagsForResource",
-            "rolesanywhere:ImportCrl",
-            "iam:GetRole"
+                  "rolesanywhere:ListProfiles",
+                  "rolesanywhere:ListTagsForResource",
+                  "rolesanywhere:ImportCrl",
+                  "iam:GetRole"
               ],
               "Resource": [
                   "*"
@@ -163,20 +168,6 @@ Now that the required AWS resources are created, you can create a Teleport AWS I
   ```
 
 Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS application resources, every 5 minutes.
-
-You can get the sync summary by running the following command:
-  ```code
-  $ tctl get integration/<Var name="Integration Name" />
-  ...
-  status:
-    aws_ra:
-      last_profile_sync:
-        end_time: "2025-07-23T15:46:27.475629Z"
-        error_message: ""
-        start_time: "2025-07-23T15:46:26.334536Z"
-        status: SUCCESS
-        synced_profiles: 4
-  ```
 
 ## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
 
@@ -226,9 +217,9 @@ In this section, you'll create a Teleport Role which will grant access to the `E
     name: aws-ro-access
   spec:
     allow:
-    app_labels:
-      'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
-    aws_role_arns:
+      app_labels:
+        'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
+      aws_role_arns:
       - <Var name="Read Only Role ARN" />
   ```
 
@@ -274,7 +265,7 @@ Example AWS CLI commands:
     AWS_PROFILE=example-read-only-access aws s3 ls
 ```
 
-#### Access AWS using AWS cli
+#### Access AWS using AWS CLI
 You can now access all your AWS resources from the command line using the `aws` command line tool.
 
 You need to pass the `--profile` flag or export the `AWS_PROFILE` environment variable with the name of the profile you created earlier.
@@ -301,4 +292,72 @@ Instead of always setting the AWS Profile in your commands/scripts/configuration
 $ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access --set-as-default-profile
 ```
 
-Now, you will be able to run any AWS cli or AWS SDK based tool (including terraform) without any additional change.
+Now, you will be able to run any AWS CLI or AWS SDK based tool (including terraform) without any additional change.
+
+## Troubleshooting
+
+Read this section if you run into issues while following this guide.
+
+### Missing Profiles in Resources page
+If you don't see the expected AWS Profiles in the Teleport Web UI, check the following:
+
+1. **Profile Sync Configuration**
+  Ensure your the Profile Sync Configuration is enabled and the the `profile_name_filters` are set accordingly (set it to `*` if you want to import all the Profiles):
+  ```code
+  $ tctl get integration/<Var name="Integration Name" />
+  ...
+  spec:
+    aws_ra:
+      profile_sync_config:
+        enabled: true
+        profile_arn: arn:aws:rolesanywhere:eu-west-2:278576220453:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
+        profile_name_filters:
+        - MarcoRA-*
+        role_arn: arn:aws:iam::278576220453:role/marcolocal-teleport-aws-roles-anywhere-role
+      trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:278576220453:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
+  ```
+
+1. **Integration Status**
+  You can get the integration status summary by running the following command:
+  ```code
+  $ tctl get integration/<Var name="Integration Name" />
+  ...
+  status:
+    aws_ra:
+      last_profile_sync:
+        end_time: "2025-07-23T15:46:27.475629Z"
+        error_message: ""
+        start_time: "2025-07-23T15:46:26.334536Z"
+        status: SUCCESS
+        synced_profiles: 4
+  ```
+  Look for any error message you might have.
+
+1. **Missing permissions**
+  Ensure that your Teleport Role allows you access to all the expected Profiles.
+  AWS App resources have a specific label which you can use to control access: `teleport.dev/aws-roles-anywhere-profile-arn`.
+  Set it to `*` to allow access to all profiles.
+
+## Next Steps
+
+Now that you know how to set up Teleport to protect access to the AWS Management Console and APIs, you can tailor your setup to the needs of your organization.
+
+### Refine your AWS IAM role mapping
+
+The `aws_role_arns` field supports template variables so they can be populated dynamically when a user authenticates to Teleport.
+
+For example, you can configure your identity provider to define a SAML attribute or OIDC claim called `aws_role_arns`, then use this field to list each user's permitted AWS role ARNs on your IdP.
+If you define a Teleport role to mention the `{{external.aws_role_arns}}` variable, the Auth Service will fill in the user's permitted ARNs based on data from the IdP:
+
+```yaml
+    aws_role_arns:
+    - {{external.aws_role_arns}}
+```
+
+See the [Access Controls Reference](../../../reference/access-controls/roles.mdx) for all of the variables and functions you can use in the `aws_role_arns` field.
+
+### Create Roles to grant access to specific Profile and IAM Roles
+
+You can create multiple Teleport Roles to grant access to the Profiles and IAM Roles for each Profile.
+
+See [Role Access Requests](../../../identity-governance/access-requests/role-requests.mdx) to learn more about creating Roles and how to access them using Access Requests.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -7,30 +7,31 @@ labels:
 ---
 
 You can protect the AWS Management Console and AWS APIs with Teleport.
-This makes it possible to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
+This allows you to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
 You can also configure Teleport to provide different levels of AWS access automatically when users authenticate using your single sign-on solution.
 
-<Admonition type="note">
-When compared with the [AWS Console and CLI access](aws-console.mdx) method,
-this guide does not require a Teleport Agent to be installed and provides 100% compatibility with AWS SDK based tools.
+<Admonition type="tip">
+When compared with the [AWS Console and CLI access via Teleport Agent](aws-console.mdx) method,
+this guide does not require a Teleport Agent to be installed and provides 100% compatibility with AWS SDK based tools (e.g., terraform).
 However, it does not record the requests in Teleport's audit logs, only that a session was started by a given user.
 </Admonition>
 
 This guide will explain how to:
 
+- Configure AWS Console and CLI access with Teleport using Roles Anywhere
 - Access the AWS Management Console
 - Access the AWS Command Line Interface (CLI)
 - Access applications using AWS SDKs
 
 ## How it works
 
-In this setup, Teleport provides credentials for the user to assume one or more target IAM Roles.
-Teleport users access the AWS Management Console and APIs through the Teleport Web UI and AWS CLI or other AWS tools.
+Teleport leverages AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM Roles.
 
-Teleport checks the user's RBAC permissions when generating credentials, to ensure only authorized users get access and only to the authorized IAM Role.
+Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for authorized users and roles.
 
-Teleport uses AWS IAM Roles Anywhere to issue temporary credentials to users.
-AWS IAM Roles Anywhere Profiles will appear as Teleport AWS Application resources in the Web UI and users can access their roles through the Web UI or CLI.
+For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere Profile.
+
+For CLI and SDK based access, you must use `tsh` to obtain the credentials
 
 ## Prerequisites
 
@@ -50,7 +51,9 @@ AWS IAM Roles Anywhere Profiles will appear as Teleport AWS Application resource
 In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
 
 <Admonition type="note">
-Instead of doing this step manually, you can navigate to your Teleport Web UI, click on Enroll New Resource in Resources listing page, and follow the guide after clicking in AWS CLI/Console Access tile.
+Instead of doing this step manually, you can navigate to your Teleport Web UI,
+click on Enroll New Resource in Resources listing page,
+and follow the guide after clicking on the AWS CLI/Console Access tile.
 </Admonition>
 
 You will create the following resources in AWS:
@@ -63,7 +66,7 @@ You will create the following resources in AWS:
 
 ### Create an IAM Roles Anywhere Trust Anchor
 
-In this section, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
+First, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
 
 1. Obtain the Teleport certificate by:
   <Tabs>
@@ -93,7 +96,7 @@ In this section, you will create an IAM Roles Anywhere Trust Anchor which trusts
 
 ### Set up Profile Sync
 
-This section will create the required AWS resources to enable the Profile Sync.
+Next, you will create the required AWS resources to enable the Profile Sync.
 
 1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
    Trust policy must include the Roles Anywhere service principal:
@@ -167,11 +170,11 @@ Now that the required AWS resources are created, you can create a Teleport AWS I
   $ tctl create -f roles-anywhere-integration.yaml
   ```
 
-Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS application resources, every 5 minutes.
+Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS applications, every 5 minutes.
 
 ## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
 
-In this step, you will create an example Profile and Role so that you can test the integration.
+Now, you will create an example Profile and Role so that you can test the integration.
 
 If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this step.
 
@@ -206,29 +209,44 @@ Copy the Profile ARN <Var name="Read Only Profile ARN" />.
 
 1. You should now see the `ExampleReadOnlyAccess` profile listed in your Teleport Web UI in the Resources page.
 
-## Step 3/4. Set up Access
-In this section, you'll create a Teleport Role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM Role.
+## Step 3/4. Set up access
+Now you need to grant your users access to the imported AWS profiles/roles.
+You will create a Teleport Role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM Role.
 
-1. Create a file named `example-read-only-access-role.yaml` with the following contents:
-  ```yaml
-  kind: role
-  version: v8
-  metadata:
-    name: aws-ro-access
-  spec:
-    allow:
-      app_labels:
-        'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
-      aws_role_arns:
-      - <Var name="Read Only Role ARN" />
-  ```
+  <Tabs>
+    <TabItem label="Web UI">
+    Open your Teleport cluster Web UI, select the "Zero Trust Access" and then "Roles".
 
-1. Create the role with the following command:
-  ```code
-  $ tctl create -f example-read-only-access-role.yaml
-  ```
+    Click the "Create New Role" button, set the role name to `aws-ro-access`.
+    Next, add an Application Access entry, in the Resources section, with the following:
+    - Labels: `teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'`
+    - AWS Role ARNs: <Var name="Read Only Role ARN" />
+    Proceed to the next steps and create the role.
+    </TabItem>
 
-1. Assign the Role to the users you want to allow access. You can also assign it to an Access List or use it in conjunction with Access Requests.
+    <TabItem label="Via tctl">
+      1. Create a file named `example-read-only-access-role.yaml` with the following contents:
+        ```yaml
+        kind: role
+        version: v8
+        metadata:
+          name: aws-ro-access
+        spec:
+          allow:
+            app_labels:
+              'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
+            aws_role_arns:
+            - <Var name="Read Only Role ARN" />
+        ```
+
+      1. Create the role with the following command:
+        ```code
+        $ tctl create -f example-read-only-access-role.yaml
+        ```
+    </TabItem>
+  </Tabs>
+
+Assign the Role to the users you want to allow access. You can also assign it to an [Access List](../../../identity-governance/access-lists/guide/) or use it in conjunction with [Access Requests](../../../identity-governance/access-requests/).
 
 ## Step 4/4. Access AWS resources
 
@@ -238,6 +256,7 @@ Now that you have configured the Integration and set up the Role, users can acce
 
 1. Visit the home page of the Teleport Web UI and click **Resources**.
    If the Integration found any Profiles as expected, the Web UI will display the name of the Profile.
+   If you don't see any Profiles, see the [Troubleshooting](#troubleshooting) section.
 
 1. Click the **Launch** button for the AWS Console application, then click on the role you would like to assume when signing in to the AWS Console:
 
@@ -286,14 +305,6 @@ provider "aws" {
 
 Setting the `AWS_PROFILE` environment variable is also an option.
 
-#### Set the default profile
-Instead of always setting the AWS Profile in your commands/scripts/configurations, when logging in, you can set it to be the default AWS configuration profile.
-```code
-$ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access --set-as-default-profile
-```
-
-Now, you will be able to run any AWS CLI or AWS SDK based tool (including terraform) without any additional change.
-
 ## Troubleshooting
 
 Read this section if you run into issues while following this guide.
@@ -310,11 +321,11 @@ If you don't see the expected AWS Profiles in the Teleport Web UI, check the fol
     aws_ra:
       profile_sync_config:
         enabled: true
-        profile_arn: arn:aws:rolesanywhere:eu-west-2:278576220453:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
+        profile_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:profile/5c659b8f-7ca3-48ef-a1aa-14c9c93506ee
         profile_name_filters:
         - MarcoRA-*
-        role_arn: arn:aws:iam::278576220453:role/marcolocal-teleport-aws-roles-anywhere-role
-      trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:278576220453:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
+        role_arn: arn:aws:iam::123456789012:role/TeleportRolesAnywhereProfileSync
+      trust_anchor_arn: arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/69a0c3f8-3157-49b2-85dd-75bdef828a68
   ```
 
 1. **Integration Status**
@@ -336,7 +347,14 @@ If you don't see the expected AWS Profiles in the Teleport Web UI, check the fol
 1. **Missing permissions**
   Ensure that your Teleport Role allows you access to all the expected Profiles.
   AWS App resources have a specific label which you can use to control access: `teleport.dev/aws-roles-anywhere-profile-arn`.
-  Set it to `*` to allow access to all profiles.
+  Set it to `*` to allow access to all profiles, like so:
+  ```yaml
+  kind: role
+  spec:
+    allow:
+      app_labels:
+        'teleport.dev/aws-roles-anywhere-profile-arn': '*'
+  ```
 
 ## Next Steps
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -1,0 +1,305 @@
+---
+title: Access AWS With Teleport
+description: How to access AWS with Teleport.
+labels:
+ - how-to
+ - zero-trust
+---
+
+You can protect the AWS Management Console and AWS APIs with Teleport.
+This makes it possible to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
+You can also configure Teleport to provide different levels of AWS access automatically when users authenticate using your single sign-on solution.
+
+This guide will explain how to:
+
+- Access the AWS Management Console through Teleport.
+- Access the AWS Command Line Interface (CLI) through Teleport.
+- Access applications using AWS SDKs through Teleport.
+
+## How it works
+
+In this setup, Teleport provides credentials for the user to assume one or more target IAM Roles.
+Teleport users access the AWS Management Console and APIs through the Teleport Web UI and AWS CLI or other AWS tools.
+
+Teleport checks the user's RBAC permissions when generating credentials, to ensure only authorized users get access and only to the authorized IAM Role.
+
+Teleport uses AWS IAM Roles Anywhere to issue temporary credentials to users.
+AWS IAM Roles Anywhere Profiles will appear as Teleport AWS Application resources in the Web UI and users can access their roles through the Web UI or CLI.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- (!docs/pages/includes/tctl.mdx!)
+- Permissions in AWS to:
+  - create IAM Roles Anywhere Trust Anchor
+  - create IAM Roles Anywhere Profiles
+  - create IAM Roles
+- `aws` command line interface (CLI) tool in PATH. Read the AWS documentation to
+  [install or update the latest version of the AWS
+  CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+
+## Step 1/4. Configure AWS IAM Roles Anywhere integration
+
+In this section, you will configure AWS IAM resources to allow Teleport to issue AWS credentials.
+
+<Admonition type="note">
+Instead of doing this step manually, you can navigate to your Teleport Web UI, click on Enroll New Resource in Resources listing page, and follow the guide after clicking in AWS CLI/Console Access tile.
+</Admonition>
+
+You will create the following resources in AWS:
+
+| Name                                 | Resource                        | Function                                                                                  |
+|--------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|
+| `TeleportRolesAnywhereIntegrationCA` | IAM Roles Anywhere Trust Anchor | Allow access from Teleport into AWS.                                                      |
+| `TeleportRolesAnywhereProfileSync`   | IAM Role                        | Allows Teleport to iterate over AWS Roles Anywhere Profiles and import them as resources. |
+| `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere Profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM Role.                             |
+
+### Create an IAM Roles Anywhere Trust Anchor which trusts Teleport
+
+In this section, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
+
+1. Obtain the Teleport's certificate by:
+<Tabs>
+<TabItem label="Via curl">
+```code
+$ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
+-----BEGIN CERTIFICATE-----
+MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+...
+-----END CERTIFICATE-----
+```
+</TabItem>
+
+<TabItem label="Via tctl">
+```code
+$ tctl auth export --type awsra
+-----BEGIN CERTIFICATE-----
+MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+...
+-----END CERTIFICATE-----
+```
+</TabItem>
+</Tabs>
+
+1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
+Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
+1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
+
+### Create an IAM Role and IAM Roles Anywhere Profile to sync AWS Roles Anywhere Profiles
+
+1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
+   Trust policy must include the Roles Anywhere service principal:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "rolesanywhere.amazonaws.com"
+            },
+            "Action": [
+                "sts:AssumeRole",
+                "sts:SetSourceIdentity",
+                "sts:TagSession"
+            ]
+        }
+    ]
+}
+```
+
+1. Copy the IAM Role ARN <Var name="Role ARN" />
+1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "RolesAnywhereProfileSync",
+            "Effect": "Allow",
+            "Action": [
+			    "rolesanywhere:ListProfiles",
+			    "rolesanywhere:ListTagsForResource",
+			    "rolesanywhere:ImportCrl",
+			    "iam:GetRole"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+```
+
+1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
+Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
+1. Copy the Profile ARN <Var name="Profile ARN" />
+
+#### Create a Teleport AWS IAM Roles Anywhere integration
+Now that the required AWS resources are created, you can create a Teleport AWS IAM Roles Anywhere integration.
+
+1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
+```yaml
+kind: integration
+sub_kind: aws-ra
+version: v1
+metadata:
+  name: <Var name="Integration Name" />
+spec:
+  aws_ra:
+    trust_anchor_arn: <Var name="Trust Anchor ARN" />
+    profile_sync_config:
+      enabled: true
+      profile_arn: <Var name="Profile ARN" />
+      role_arn: <Var name="Role ARN" />
+```
+
+1. Create the integration with the following command:
+```code
+$ tctl create -f roles-anywhere-integration.yaml
+```
+
+Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS application resources, every 5 minutes.
+
+You can get the sync summary by running the following command:
+```code
+$ tctl get integration/<Var name="Integration Name" />
+...
+status:
+  aws_ra:
+    last_profile_sync:
+      end_time: "2025-07-23T15:46:27.475629Z"
+      error_message: ""
+      start_time: "2025-07-23T15:46:26.334536Z"
+      status: SUCCESS
+      synced_profiles: 4
+```
+
+## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
+
+In this step, you will create an example Profile and Role so that you can test the integration.
+
+If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this step.
+
+1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `ExampleReadOnlyAccess`.
+Trust policy must include the Roles Anywhere service principal:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "rolesanywhere.amazonaws.com"
+            },
+            "Action": [
+                "sts:AssumeRole",
+                "sts:SetSourceIdentity",
+                "sts:TagSession"
+            ]
+        }
+    ]
+}
+```
+
+Add the AWS-managed `ReadOnlyAccess` policy to the role.
+Copy the Role ARN <Var name="Read Only Role ARN" />.
+
+1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `ExampleReadOnlyAccess`.
+Add the role created in the last step (`ExampleReadOnlyAccess`) and create the Profile.
+
+Copy the Profile ARN <Var name="Read Only Profile ARN" />.
+
+1. You should now see the `ExampleReadOnlyAccess` profile listed in your Teleport Web UI in the Resources page.
+
+## Step 3/4. Set up Access
+
+### Create Teleport Role that gives access to a Profile/Roles combination
+
+In this section, you'll create a Teleport Role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM Role.
+
+1. Create a file named `example-read-only-access-role.yaml` with the following contents:
+```yaml
+kind: role
+version: v8
+metadata:
+  name: aws-ro-access
+spec:
+  allow:
+  app_labels:
+    'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
+  aws_role_arns:
+    - <Var name="Read Only Role ARN" />
+```
+
+1. Create the role with the following command:
+```code
+$ tctl create -f example-read-only-access-role.yaml
+```
+
+1. Assign the Role to the users you want to allow access. You can also assign it to an Access List or use it in conjunction with Access Requests.
+
+## Step 4/4. Access AWS resources
+
+Now that you have configured the Integration and set up the Role, users can access AWS resources through Teleport.
+
+### Access AWS Management Console
+
+1. Visit the home page of the Teleport Web UI and click **Resources**.
+   If the Integration found any Profiles as expected, the Web UI will display the name of the Profile.
+
+1. Click the **Launch** button for the AWS Console application, then click on the role you would like to assume when signing in to the AWS Console:
+
+   ![IAM role selector](../../../../img/application-access/iam-role-selector.png)
+
+1. You will get redirected to the AWS Management Console, signed in with the selected role.
+   You should see your Teleport user name as a federated login assigned to `ExampleReadOnlyRole` in the top-right corner of the AWS Console:
+
+   ![Federated login](../../../../img/application-access/federated-login@2x.png)
+
+### Access AWS using AWS CLI or other AWS SDK based tools
+
+#### Obtain the credentials
+On your desktop, log into the AWS App Profile that was synced:
+
+```code
+$ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access
+Logged into AWS app "example-read-only-access".
+
+Your IAM role:
+    arn:aws:iam::123456789012:role/ExampleReadOnlyAccess
+
+Example AWS CLI commands:
+    aws --profile example-read-only-access s3 ls
+    AWS_PROFILE=example-read-only-access aws s3 ls
+```
+
+#### Access AWS using AWS cli
+You can now access all your AWS resources from the command line using the `aws` command line tool.
+
+You need to pass the `--profile` flag or export the `AWS_PROFILE` environment variable with the name of the profile you created earlier.
+
+```code
+$ aws --profile example-read-only-access s3 ls
+...
+```
+
+#### Access AWS from Terraform
+Using Terraform requires you to set the profile in the provider.
+```hcl
+provider "aws" {
+  profile = "example-read-only-access"
+  // ...
+}
+```
+
+Setting the `AWS_PROFILE` environment variable is also an option.
+
+#### Set the default profile
+Instead of always setting the AWS Profile in your commands/scripts/configurations, when logging in, you can set it to be the default AWS configuration profile.
+```code
+$ tsh apps login --aws-role arn:aws:iam::278576220453:role/ExampleReadOnlyAccess example-read-only-access --set-as-default-profile
+```
+
+Now, you will be able to run any AWS cli or AWS SDK based tool (including terraform) without any additional change.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -6,15 +6,22 @@ labels:
  - zero-trust
 ---
 
+<Admonition type="tip">
+You can access AWS APIs (e.g., CLI, SDKs) through Teleport using two methods:
+- using an Application Service which proxies and audits every AWS API request
+- using short-lived credentials stored in your local system
+Accessing the AWS Web Console works the same in both methods.
+
+This guide focus on the second method, which is the recommend one.
+
+If you want to audit AWS API requests, then use the method[first method](aws-console.mdx).
+
+Access Requests, Access Lists and other RBAC access controls features work the same in both methods.
+</Admonition>
+
 You can protect the AWS Management Console and AWS APIs with Teleport.
 This allows you to manage access to AWS infrastructure with Teleport features like Access Requests, Access Lists, and identity locking.
 You can also configure Teleport to provide different levels of AWS access automatically when users authenticate using your single sign-on solution.
-
-<Admonition type="tip">
-When compared with the [AWS Console and CLI access via Teleport Agent](aws-console.mdx) method,
-this guide does not require a Teleport Agent to be installed and provides 100% compatibility with AWS SDK based tools (e.g., terraform).
-However, it does not record the requests in Teleport's audit logs, only that a session was started by a given user.
-</Admonition>
 
 This guide will explain how to:
 
@@ -31,7 +38,7 @@ Access is managed through Teleport's RBAC policies, ensuring credentials are onl
 
 For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere Profile.
 
-For CLI and SDK based access, you must use `tsh` to obtain the credentials
+For CLI and SDK based access, you must use `tsh` to obtain AWS credentials.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-without-agent.mdx
@@ -55,126 +55,128 @@ You will create the following resources in AWS:
 | `TeleportRolesAnywhereProfileSync`   | IAM Role                        | Allows Teleport to iterate over AWS Roles Anywhere Profiles and import them as resources. |
 | `TeleportRolesAnywhereProfileSync`   | IAM Roles Anywhere Profile      | Allows access to `TeleportRolesAnywhereProfileSync` IAM Role.                             |
 
-### Create an IAM Roles Anywhere Trust Anchor which trusts Teleport
+### Create an IAM Roles Anywhere Trust Anchor
 
 In this section, you will create an IAM Roles Anywhere Trust Anchor which trusts the Teleport's AWS Roles Anywhere CA.
 
-1. Obtain the Teleport's certificate by:
-<Tabs>
-<TabItem label="Via curl">
-```code
-$ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
------BEGIN CERTIFICATE-----
-MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-...
------END CERTIFICATE-----
-```
-</TabItem>
+1. Obtain the Teleport certificate by:
+  <Tabs>
+    <TabItem label="Via curl">
+    ```code
+    $ curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=awsra'
+    -----BEGIN CERTIFICATE-----
+    MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+    ...
+    -----END CERTIFICATE-----
+    ```
+    </TabItem>
 
-<TabItem label="Via tctl">
-```code
-$ tctl auth export --type awsra
------BEGIN CERTIFICATE-----
-MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
-...
------END CERTIFICATE-----
-```
-</TabItem>
-</Tabs>
+    <TabItem label="Via tctl">
+    ```code
+    $ tctl auth export --type awsra
+    -----BEGIN CERTIFICATE-----
+    MIIDqjCCApKgAwIBAgIQMIK8/WiQ/rUOrjlmB0IHVTANBgkqhkiG9w0BAQsFADBv
+    ...
+    -----END CERTIFICATE-----
+    ```
+    </TabItem>
+  </Tabs>
 
 1. Navigate to [Create a trust anchor](https://console.aws.amazon.com/rolesanywhere/home/trust-anchors/create) page.
 Name the trust anchor `TeleportRolesAnywhereIntegrationCA` and add the Teleport's `awsra` CA certificate you obtained in the previous step as an External certificate bundle.
 1. Copy the Trust Anchor ARN <Var name="Trust Anchor ARN" />
 
-### Create an IAM Role and IAM Roles Anywhere Profile to sync AWS Roles Anywhere Profiles
+### Set up Profile Sync
+
+This section will create the required AWS resources to enable the Profile Sync.
 
 1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `TeleportRolesAnywhereProfileSync`.
    Trust policy must include the Roles Anywhere service principal:
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "rolesanywhere.amazonaws.com"
-            },
-            "Action": [
-                "sts:AssumeRole",
-                "sts:SetSourceIdentity",
-                "sts:TagSession"
-            ]
-        }
-    ]
-}
-```
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Principal": {
+                  "Service": "rolesanywhere.amazonaws.com"
+              },
+              "Action": [
+                  "sts:AssumeRole",
+                  "sts:SetSourceIdentity",
+                  "sts:TagSession"
+              ]
+          }
+      ]
+  }
+  ```
 
 1. Copy the IAM Role ARN <Var name="Role ARN" />
 1. Navigate to the [TeleportRolesAnywhereProfileSync Role](https://console.aws.amazon.com/iam/home?#/roles/details/TeleportRolesAnywhereProfileSync) and create a new inline policy:
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "RolesAnywhereProfileSync",
-            "Effect": "Allow",
-            "Action": [
-			    "rolesanywhere:ListProfiles",
-			    "rolesanywhere:ListTagsForResource",
-			    "rolesanywhere:ImportCrl",
-			    "iam:GetRole"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-```
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "RolesAnywhereProfileSync",
+              "Effect": "Allow",
+              "Action": [
+            "rolesanywhere:ListProfiles",
+            "rolesanywhere:ListTagsForResource",
+            "rolesanywhere:ImportCrl",
+            "iam:GetRole"
+              ],
+              "Resource": [
+                  "*"
+              ]
+          }
+      ]
+  }
+  ```
 
-1. Now, navigate to [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
+1. Now, navigate to the [Create a Profile](https://console.aws.amazon.com/rolesanywhere/home/profiles/create) page and name it `TeleportRolesAnywhereProfileSync`.
 Add the role created in the last step (`TeleportRolesAnywhereProfileSync`) and create the Profile.
 1. Copy the Profile ARN <Var name="Profile ARN" />
 
-#### Create a Teleport AWS IAM Roles Anywhere integration
+### Create a Teleport AWS IAM Roles Anywhere integration
 Now that the required AWS resources are created, you can create a Teleport AWS IAM Roles Anywhere integration.
 
 1. Write the following contents to a file called `roles-anywhere-integration.yaml`:
-```yaml
-kind: integration
-sub_kind: aws-ra
-version: v1
-metadata:
-  name: <Var name="Integration Name" />
-spec:
-  aws_ra:
-    trust_anchor_arn: <Var name="Trust Anchor ARN" />
-    profile_sync_config:
-      enabled: true
-      profile_arn: <Var name="Profile ARN" />
-      role_arn: <Var name="Role ARN" />
-```
+  ```yaml
+  kind: integration
+  sub_kind: aws-ra
+  version: v1
+  metadata:
+    name: <Var name="Integration Name" />
+  spec:
+    aws_ra:
+      trust_anchor_arn: <Var name="Trust Anchor ARN" />
+      profile_sync_config:
+        enabled: true
+        profile_arn: <Var name="Profile ARN" />
+        role_arn: <Var name="Role ARN" />
+  ```
 
 1. Create the integration with the following command:
-```code
-$ tctl create -f roles-anywhere-integration.yaml
-```
+  ```code
+  $ tctl create -f roles-anywhere-integration.yaml
+  ```
 
 Teleport will now start syncing AWS IAM Roles Anywhere Profiles as AWS application resources, every 5 minutes.
 
 You can get the sync summary by running the following command:
-```code
-$ tctl get integration/<Var name="Integration Name" />
-...
-status:
-  aws_ra:
-    last_profile_sync:
-      end_time: "2025-07-23T15:46:27.475629Z"
-      error_message: ""
-      start_time: "2025-07-23T15:46:26.334536Z"
-      status: SUCCESS
-      synced_profiles: 4
-```
+  ```code
+  $ tctl get integration/<Var name="Integration Name" />
+  ...
+  status:
+    aws_ra:
+      last_profile_sync:
+        end_time: "2025-07-23T15:46:27.475629Z"
+        error_message: ""
+        start_time: "2025-07-23T15:46:26.334536Z"
+        status: SUCCESS
+        synced_profiles: 4
+  ```
 
 ## Step 2/4. Create an AWS IAM Roles Anywhere Profile and assign IAM Roles
 
@@ -184,24 +186,24 @@ If you are already leveraging AWS IAM Roles Anywhere Profiles, you can skip this
 
 1. Navigate to [Create Role](https://console.aws.amazon.com/iam/home?#/roles/create) and create a new IAM Role called `ExampleReadOnlyAccess`.
 Trust policy must include the Roles Anywhere service principal:
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "rolesanywhere.amazonaws.com"
-            },
-            "Action": [
-                "sts:AssumeRole",
-                "sts:SetSourceIdentity",
-                "sts:TagSession"
-            ]
-        }
-    ]
-}
-```
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Principal": {
+                  "Service": "rolesanywhere.amazonaws.com"
+              },
+              "Action": [
+                  "sts:AssumeRole",
+                  "sts:SetSourceIdentity",
+                  "sts:TagSession"
+              ]
+          }
+      ]
+  }
+  ```
 
 Add the AWS-managed `ReadOnlyAccess` policy to the role.
 Copy the Role ARN <Var name="Read Only Role ARN" />.
@@ -214,29 +216,26 @@ Copy the Profile ARN <Var name="Read Only Profile ARN" />.
 1. You should now see the `ExampleReadOnlyAccess` profile listed in your Teleport Web UI in the Resources page.
 
 ## Step 3/4. Set up Access
-
-### Create Teleport Role that gives access to a Profile/Roles combination
-
 In this section, you'll create a Teleport Role which will grant access to the `ExampleReadOnlyAccess` Profile and associated IAM Role.
 
 1. Create a file named `example-read-only-access-role.yaml` with the following contents:
-```yaml
-kind: role
-version: v8
-metadata:
-  name: aws-ro-access
-spec:
-  allow:
-  app_labels:
-    'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
-  aws_role_arns:
-    - <Var name="Read Only Role ARN" />
-```
+  ```yaml
+  kind: role
+  version: v8
+  metadata:
+    name: aws-ro-access
+  spec:
+    allow:
+    app_labels:
+      'teleport.dev/aws-roles-anywhere-profile-arn': '<Var name="Read Only Profile ARN" />'
+    aws_role_arns:
+      - <Var name="Read Only Role ARN" />
+  ```
 
 1. Create the role with the following command:
-```code
-$ tctl create -f example-read-only-access-role.yaml
-```
+  ```code
+  $ tctl create -f example-read-only-access-role.yaml
+  ```
 
 1. Assign the Role to the users you want to allow access. You can also assign it to an Access List or use it in conjunction with Access Requests.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -12,10 +12,9 @@ like Access Requests, Access Lists, and identity locking. You can also configure
 Teleport to provide different levels of AWS access automatically when users
 authenticate using your single sign-on solution.
 
-<Admonition type="note">
-When compared with the [AWS Console and CLI access via AWS IAM Roles Anywhere](aws-console-without-agent.mdx) method,
+<Admonition type="tip">
+When compared with the [AWS Console and CLI access](aws-console-without-agent.mdx) method,
 this guide requires a Teleport Agent to be installed and records the requests in Teleport's audit logs for API calls.
-However, it requires the installation and configuration of a Teleport Agent.
 </Admonition>
 
 This guide will explain how to:

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -12,6 +12,12 @@ like Access Requests, Access Lists, and identity locking. You can also configure
 Teleport to provide different levels of AWS access automatically when users
 authenticate using your single sign-on solution.
 
+<Admonition type="note">
+When compared with the [AWS Console and CLI access via AWS IAM Roles Anywhere](aws-console-without-agent.mdx) method,
+this guide requires a Teleport Agent to be installed and records the requests in Teleport's audit logs for API calls.
+However, it requires the installation and configuration of a Teleport Agent.
+</Admonition>
+
 This guide will explain how to:
 
 - Access the AWS Management Console through Teleport.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -7,16 +7,8 @@ labels:
 ---
 
 <Admonition type="tip">
-You can access AWS APIs (e.g., CLI, SDKs) through Teleport using two methods:
-- using an Application Service which proxies and audits every AWS API request
-- using short-lived credentials stored in your local system
-Accessing the AWS Web Console works the same in both methods.
-
-This guide focus on the first method and should be used when you need to audit every request made from the CLI.
-
-If you don't have that requirement, we recommend that you use the [second method](aws-console-without-agent.mdx).
-
-Access Requests, Access Lists and other RBAC access controls features work the same in both methods.
+If you're using AWS IAM Roles Anywhere, see the [corresponding guide](aws-console-roles-anywhere.mdx) that provides
+the recommended way to manage access to AWS Console and CLI-based tooling.
 </Admonition>
 
 You can protect the AWS Management Console and AWS APIs with Teleport. This

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -6,16 +6,24 @@ labels:
  - zero-trust
 ---
 
+<Admonition type="tip">
+You can access AWS APIs (e.g., CLI, SDKs) through Teleport using two methods:
+- using an Application Service which proxies and audits every AWS API request
+- using short-lived credentials stored in your local system
+Accessing the AWS Web Console works the same in both methods.
+
+This guide focus on the first method and should be used when you need to audit every request made from the CLI.
+
+If you don't have that requirement, we recommend that you use the [second method](aws-console-without-agent.mdx).
+
+Access Requests, Access Lists and other RBAC access controls features work the same in both methods.
+</Admonition>
+
 You can protect the AWS Management Console and AWS APIs with Teleport. This
 makes it possible to manage access to AWS infrastructure with Teleport features
 like Access Requests, Access Lists, and identity locking. You can also configure
 Teleport to provide different levels of AWS access automatically when users
 authenticate using your single sign-on solution.
-
-<Admonition type="tip">
-When compared with the [AWS Console and CLI access](aws-console-without-agent.mdx) method,
-this guide requires a Teleport Agent to be installed and records the requests in Teleport's audit logs for API calls.
-</Admonition>
 
 This guide will explain how to:
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -18,7 +18,7 @@ longstanding admin accounts to target.
 Learn how to protect your cloud provider APIs with Teleport:
 
 - [AWS Console and CLI application](aws-console.mdx)
-- [AWS Console and CLI application (without a teleport agent)](aws-console-without-agent.mdx)
+- [AWS Console and CLI application (without a Teleport Agent)](aws-console-without-agent.mdx)
 - [Azure CLI applications](azure.mdx)
 - [Azure CLI applications (AKS with Workload ID deployment)](azure-aks-workload-id.mdx)
 - [Google Cloud CLI applications](google-cloud.mdx)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -17,8 +17,8 @@ longstanding admin accounts to target.
 
 Learn how to protect your cloud provider APIs with Teleport:
 
-- [AWS Console and CLI application](aws-console.mdx)
-- [AWS Console and CLI application (without a Teleport Agent)](aws-console-without-agent.mdx)
+- [AWS Console and CLI access](aws-console.mdx)
+- [AWS Console and CLI access via AWS IAM Roles Anywhere](aws-console-without-agent.mdx)
 - [Azure CLI applications](azure.mdx)
 - [Azure CLI applications (AKS with Workload ID deployment)](azure-aks-workload-id.mdx)
 - [Google Cloud CLI applications](google-cloud.mdx)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -17,8 +17,8 @@ longstanding admin accounts to target.
 
 Learn how to protect your cloud provider APIs with Teleport:
 
+- [AWS Console and CLI access](aws-console-roles-anywhere.mdx)
 - [AWS Console and CLI access via Teleport Agent](aws-console.mdx)
-- [AWS Console and CLI access](aws-console-without-agent.mdx)
 - [Azure CLI applications](azure.mdx)
 - [Azure CLI applications (AKS with Workload ID deployment)](azure-aks-workload-id.mdx)
 - [Google Cloud CLI applications](google-cloud.mdx)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -17,7 +17,8 @@ longstanding admin accounts to target.
 
 Learn how to protect your cloud provider APIs with Teleport:
 
-- [AWS (console and CLI applications)](aws-console.mdx)
+- [AWS Console and CLI application](aws-console.mdx)
+- [AWS Console and CLI application (without a teleport agent)](aws-console-without-agent.mdx)
 - [Azure CLI applications](azure.mdx)
 - [Azure CLI applications (AKS with Workload ID deployment)](azure-aks-workload-id.mdx)
 - [Google Cloud CLI applications](google-cloud.mdx)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -17,8 +17,8 @@ longstanding admin accounts to target.
 
 Learn how to protect your cloud provider APIs with Teleport:
 
-- [AWS Console and CLI access](aws-console.mdx)
-- [AWS Console and CLI access via AWS IAM Roles Anywhere](aws-console-without-agent.mdx)
+- [AWS Console and CLI access via Teleport Agent](aws-console.mdx)
+- [AWS Console and CLI access](aws-console-without-agent.mdx)
 - [Azure CLI applications](azure.mdx)
 - [Azure CLI applications (AKS with Workload ID deployment)](azure-aks-workload-id.mdx)
 - [Google Cloud CLI applications](google-cloud.mdx)


### PR DESCRIPTION
This PR adds the required docs for the AWS IAM Roles Anywhere integration.
It includes:
- integration set up (set up trust anchor in AWS)
- profile sync set up
- how to grant access
- how to use from the end-user point of view