### PR TITLE
[v18] Discover LDAP server via DNS

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2192,6 +2192,11 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 	}
 
+	locateServer := servicecfg.LocateServer{
+		Enabled: fc.WindowsDesktop.LDAP.LocateServer.Enabled,
+		Site:    fc.WindowsDesktop.LDAP.LocateServer.Site,
+	}
+
 	cfg.WindowsDesktop.LDAP = servicecfg.LDAPConfig{
 		Addr:               fc.WindowsDesktop.LDAP.Addr,
 		Username:           fc.WindowsDesktop.LDAP.Username,
@@ -2200,6 +2205,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		InsecureSkipVerify: fc.WindowsDesktop.LDAP.InsecureSkipVerify,
 		ServerName:         fc.WindowsDesktop.LDAP.ServerName,
 		CA:                 cert,
+		LocateServer:       locateServer,
 	}
 
 	cfg.WindowsDesktop.PKIDomain = fc.WindowsDesktop.PKIDomain

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2305,7 +2305,8 @@ func TestWindowsDesktopService(t *testing.T) {
 			mutate: func(fc *FileConfig) {
 				fc.WindowsDesktop.ADHosts = []string{"127.0.0.1:3389"}
 				fc.WindowsDesktop.LDAP = LDAPConfig{
-					Addr: "something",
+					Addr:   "something",
+					Domain: "example.com",
 				}
 			},
 		},
@@ -2349,7 +2350,8 @@ func TestWindowsDesktopService(t *testing.T) {
 					BaseDN: "something",
 				}
 				fc.WindowsDesktop.LDAP = LDAPConfig{
-					Addr: "something",
+					Addr:   "something",
+					Domain: "example.com",
 				}
 			},
 		},
@@ -2401,7 +2403,8 @@ func TestWindowsDesktopService(t *testing.T) {
 				fc.WindowsDesktop.ListenAddress = "0.0.0.0:3028"
 				fc.WindowsDesktop.ADHosts = []string{"127.0.0.1:3389"}
 				fc.WindowsDesktop.LDAP = LDAPConfig{
-					Addr: "something",
+					Addr:   "something",
+					Domain: "example.com",
 				}
 				fc.WindowsDesktop.HostLabels = []WindowsHostLabelRule{
 					{Match: ".*", Labels: map[string]string{"key": "value"}},

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2573,12 +2573,14 @@ func (wds *WindowsDesktopService) Check() error {
 		return host.AD
 	})
 
-	if hasAD && wds.LDAP.Addr == "" {
+	ldapConfigOK := wds.LDAP.Domain != "" && (wds.LDAP.Addr != "" || wds.LDAP.LocateServer.Enabled)
+
+	if hasAD && !ldapConfigOK {
 		return trace.BadParameter("if Active Directory hosts are specified in the windows_desktop_service, " +
 			"the ldap configuration must also be specified")
 	}
 
-	if wds.Discovery.BaseDN != "" && wds.LDAP.Addr == "" {
+	if (wds.Discovery.BaseDN != "" || len(wds.DiscoveryConfigs) > 0) && !ldapConfigOK {
 		return trace.BadParameter("if discovery is specified in the windows_desktop_service, " +
 			"ldap configuration must also be specified")
 	}
@@ -2609,10 +2611,22 @@ type WindowsHost struct {
 	AD bool `yaml:"ad"`
 }
 
+// LocateServer contains parameters for locating LDAP servers
+// from the AD Domain
+type LocateServer struct {
+	// Enabled will automatically locate the LDAP server using DNS SRV records.
+	// When enabled, Domain must be set, Addr will be ignored
+	// https://ldap.com/dns-srv-records-for-ldap/
+	Enabled bool `yaml:"enabled,omitempty"`
+	// Site is an LDAP site to locate servers from a specific logical site.
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/b645c125-a7da-4097-84a1-2fa7cea07714#gt_8abdc986-5679-42d9-ad76-b11eb5a0daba
+	Site string `yaml:"site,omitempty"`
+}
+
 // LDAPConfig is the LDAP connection parameters.
 type LDAPConfig struct {
 	// Addr is the host:port of the LDAP server (typically port 389).
-	Addr string `yaml:"addr"`
+	Addr string `yaml:"addr,omitempty"`
 	// Domain is the ActiveDirectory domain name.
 	Domain string `yaml:"domain"`
 	// Username for LDAP authentication.
@@ -2627,6 +2641,8 @@ type LDAPConfig struct {
 	DEREncodedCAFile string `yaml:"der_ca_file,omitempty"`
 	// PEMEncodedCACert is an optional PEM encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
 	PEMEncodedCACert string `yaml:"ldap_ca_cert,omitempty"`
+	// LocateServer is the config that enables LDAP server location using DNS SRV records.
+	LocateServer `yaml:"locate_server"`
 }
 
 // LDAPDiscoveryConfig is LDAP discovery configuration for windows desktop discovery service.

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/winpki"
 )
 
 func (process *TeleportProcess) initWindowsDesktopService() {
@@ -229,7 +228,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 			OnHeartbeat: process.OnHeartbeat(teleport.ComponentWindowsDesktop),
 		},
 		ShowDesktopWallpaper: cfg.WindowsDesktop.ShowDesktopWallpaper,
-		LDAPConfig:           winpki.LDAPConfig(cfg.WindowsDesktop.LDAP),
+		LDAPConfig:           cfg.WindowsDesktop.LDAP,
 		KDCAddr:              cfg.WindowsDesktop.KDCAddr,
 		PKIDomain:            cfg.WindowsDesktop.PKIDomain,
 		Discovery:            cfg.WindowsDesktop.Discovery,

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -24,6 +24,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -146,10 +148,22 @@ type HostLabelRule struct {
 	Labels map[string]string
 }
 
+type LocateServer struct {
+	// Enabled will automatically locate the LDAP server using DNS SRV records.
+	// When enabled, Domain must be set, Addr will be ignored
+	// https://ldap.com/dns-srv-records-for-ldap/
+	Enabled bool
+	// Site is an LDAP site to locate servers from a specific logical site.
+	Site string
+}
+
 // LDAPConfig is the LDAP connection parameters.
 type LDAPConfig struct {
 	// Addr is the address:port of the LDAP server (typically port 389).
 	Addr string
+	// LocateServer automatically locates the LDAP server using DNS SRV records.
+	// https://ldap.com/dns-srv-records-for-ldap/
+	LocateServer LocateServer
 	// Domain is the ActiveDirectory domain name.
 	Domain string
 	// Username for LDAP authentication.
@@ -162,4 +176,19 @@ type LDAPConfig struct {
 	ServerName string
 	// CA is an optional CA cert to be used for verification if InsecureSkipVerify is set to false.
 	CA *x509.Certificate
+}
+
+// CheckAndSetDefaults verifies this LDAPConfig
+func (cfg *LDAPConfig) CheckAndSetDefaults() error {
+	if cfg.Addr == "" && !cfg.LocateServer.Enabled {
+		return trace.BadParameter("Addr is required if locate_server is false in LDAPConfig")
+	}
+	if cfg.Domain == "" {
+		return trace.BadParameter("missing Domain in LDAPConfig")
+	}
+	if cfg.Username == "" {
+		return trace.BadParameter("missing Username in LDAPConfig")
+	}
+
+	return nil
 }

--- a/lib/srv/db/common/kerberos/kinit/ldap_test.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -119,66 +118,4 @@ func TestTLSConfigForLDAP(t *testing.T) {
 	require.Equal(t, "ldap.example.com", tlsConfig.ServerName)
 	require.NotEmpty(t, tlsConfig.Certificates)
 	require.NotNil(t, tlsConfig.RootCAs)
-}
-
-type mockLDAPClient struct {
-	searchWithPaging func(searchRequest *ldap.SearchRequest, pagingSize uint32) (*ldap.SearchResult, error)
-	ldap.Client
-}
-
-func (m *mockLDAPClient) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSize uint32) (*ldap.SearchResult, error) {
-	if m.searchWithPaging == nil {
-		return nil, trace.BadParameter("callback function searchWithPaging not set")
-	}
-	return m.searchWithPaging(searchRequest, pagingSize)
-}
-
-func TestGetActiveDirectorySID(t *testing.T) {
-	adConfig := types.AD{
-		KeytabFile:             "",
-		Krb5File:               "",
-		SPN:                    "",
-		Domain:                 "example.com",
-		LDAPCert:               fixtures.TLSCACertPEM,
-		KDCHostName:            "ldap.example.com",
-		LDAPServiceAccountName: "DOMAIN\\test-service-account",
-		LDAPServiceAccountSID:  "S-1-5-21-2191801808-3167526388-2669316733-1104",
-	}
-
-	connector, err := newLDAPConnector(slog.Default(), &mockAuthClient{}, adConfig)
-	require.NoError(t, err)
-
-	connector.dialLDAPServerFunc = func(ctx context.Context) (ldap.Client, error) {
-		return &mockLDAPClient{searchWithPaging: func(searchRequest *ldap.SearchRequest, pagingSize uint32) (*ldap.SearchResult, error) {
-			if searchRequest.BaseDN != "DC=example,DC=com" {
-				return nil, trace.BadParameter("unexpected value of base_dn")
-			}
-			if searchRequest.Filter != "(\u0026(sAMAccountType=805306368)(sAMAccountName=DOMAIN\\test-user))" {
-				return nil, trace.BadParameter("unexpected value of filter")
-			}
-			if len(searchRequest.Attributes) != 1 {
-				return nil, trace.BadParameter("unexpected number of search attributes")
-			}
-			if searchRequest.Attributes[0] != "objectSid" {
-				return nil, trace.BadParameter("unexpected value of search attribute")
-			}
-
-			const sidValue = "\u0001\u0005\u0000\u0000\u0000\u0000\u0000\u0005\u0015\u0000\u0000\u0000\ufffd=\ufffd\ufffd\ufffd\ufffd̼}\ufffd\u001a\ufffd\ufffd\u0001\u0000\u0000"
-
-			attr := ldap.NewEntryAttribute("objectSid", []string{sidValue})
-
-			return &ldap.SearchResult{
-				Entries: []*ldap.Entry{
-					{
-						DN:         "CN=test-user,CN=Users,DC=example,DC=com",
-						Attributes: []*ldap.EntryAttribute{attr},
-					},
-				},
-			}, nil
-		}}, nil
-	}
-
-	sid, err := connector.GetActiveDirectorySID(context.Background(), "DOMAIN\\test-user")
-	require.NoError(t, err)
-	require.Equal(t, "S-1-5-21-1035845615-4022190063-3220159935-3183472573", sid)
 }

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -66,20 +66,9 @@ const (
 
 	// attrDNSHostName is the DNS Host name of an LDAP object.
 	attrDNSHostName = "dNSHostName" // unusual capitalization is correct
-
-	// attrSAMAccountName is the SAM Account name of an LDAP object.
-	attrSAMAccountName = "sAMAccountName"
-
-	// attrSAMAccountType is the SAM Account type for an LDAP object.
-	attrSAMAccountType = "sAMAccountType"
 )
 
 const (
-	// AccountTypeUser is the SAM account type for user accounts.
-	// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccounttype
-	// (SAM_USER_OBJECT)
-	AccountTypeUser = "805306368"
-
 	// ClassComputer is the object class for computers in Active Directory.
 	ClassComputer = "computer"
 
@@ -149,15 +138,18 @@ func (s *WindowsService) ldapSearchFilter(additionalFilters []string) string {
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
 func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
-	// Check whether we've ever successfully initialized our LDAP client.
-	s.mu.Lock()
-	if !s.ldapInitialized {
-		s.cfg.Logger.DebugContext(s.closeCtx, "LDAP not ready, skipping discovery and attempting to reconnect")
-		s.mu.Unlock()
-		s.initializeLDAP()
+	tc, err := s.tlsConfigForLDAP()
+	if err != nil {
+		s.cfg.Logger.WarnContext(s.closeCtx, "could not request TLS certificate for LDAP discovery", "error", err)
 		return nil
 	}
-	s.mu.Unlock()
+
+	ldapClient, err := winpki.DialLDAP(s.closeCtx, s.getLDAPConfig(), tc)
+	if err != nil {
+		s.cfg.Logger.WarnContext(s.closeCtx, "could not dial LDAP server", "error", err)
+		return nil
+	}
+	defer ldapClient.Close()
 
 	result := make(map[string]types.WindowsDesktop)
 	for _, discoveryConfig := range s.cfg.Discovery {
@@ -168,18 +160,8 @@ func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
 		attrs = append(attrs, computerAttributes...)
 		attrs = append(attrs, discoveryConfig.LabelAttributes...)
 
-		entries, err := s.lc.ReadWithFilter(discoveryConfig.BaseDN, filter, attrs)
-		if trace.IsConnectionProblem(err) {
-			// If the connection was broken, re-initialize the LDAP client so that it's
-			// ready for the next reconcile loop. Return the last known set of desktops
-			// in this case, so that the reconciler doesn't delete the desktops it already
-			// knows about.
-			s.cfg.Logger.InfoContext(s.closeCtx, "LDAP connection error when searching for desktops, reinitializing client")
-			if err := s.initializeLDAP(); err != nil {
-				s.cfg.Logger.ErrorContext(s.closeCtx, "failed to reinitialize LDAP client, will retry on next reconcile", "error", err)
-			}
-			return s.lastDiscoveryResults
-		} else if err != nil {
+		entries, err := ldapClient.ReadWithFilter(discoveryConfig.BaseDN, filter, attrs)
+		if err != nil {
 			s.cfg.Logger.WarnContext(s.closeCtx, "could not discover Windows Desktops", "error", err)
 			return nil
 		}

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -48,7 +47,6 @@ import (
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/recorder"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -67,15 +65,6 @@ const (
 	// when resolving Windows Desktop hostnames
 	dnsDialTimeout = 5 * time.Second
 
-	// ldapDialTimeout is the timeout for dialing the LDAP server
-	// when making an initial connection
-	ldapDialTimeout = 15 * time.Second
-
-	// ldapRequestTimeout is the timeout for making LDAP requests.
-	// It is larger than the dial timeout because LDAP queries in large
-	// Active Directory environments may take longer to complete.
-	ldapRequestTimeout = 45 * time.Second
-
 	// windowsDesktopServiceCertTTL is the TTL for certificates issued to the
 	// Windows Desktop Service in order to authenticate with the LDAP server.
 	// It is set longer than the Windows certificates for users because it is
@@ -88,15 +77,6 @@ const (
 	// so the TTL is deliberately set to a small value to give enough time to establish
 	// a single session.
 	windowsUserCertTTL = 5 * time.Minute
-
-	// windowsDesktopServiceCertRetryInterval indicates how often to retry
-	// issuing an LDAP certificate if the operation fails.
-	windowsDesktopServiceCertRetryInterval = 10 * time.Minute
-
-	// ldapTimeoutRetryInterval indicates how often to retry LDAP initialization
-	// if it times out. It is set lower than windowsDesktopServiceCertRetryInterval
-	// because LDAP timeouts may indicate a temporary issue.
-	ldapTimeoutRetryInterval = 10 * time.Second
 )
 
 // computerAttributes are the attributes we fetch when discovering
@@ -123,12 +103,6 @@ type WindowsService struct {
 	middleware *auth.Middleware
 
 	ca *winpki.CertificateStoreClient
-	lc *winpki.LDAPClient
-
-	mu              sync.Mutex // mu protects the fields that follow
-	ldapConfigured  bool
-	ldapInitialized bool
-	ldapCertRenew   *time.Timer
 
 	// lastDisoveryResults stores the results of the most recent LDAP search
 	// when desktop discovery is enabled.
@@ -191,7 +165,7 @@ type WindowsServiceConfig struct {
 	ShowDesktopWallpaper bool
 	// LDAPConfig contains parameters for connecting to an LDAP server.
 	// LDAP functionality is disabled if Addr is empty.
-	winpki.LDAPConfig
+	servicecfg.LDAPConfig
 	// PKIDomain optionally configures a separate Active Directory domain
 	// for PKI operations. If empty, the domain from the LDAP config is used.
 	// This can be useful for cases where PKI is configured in a root domain
@@ -276,8 +250,8 @@ func (cfg *WindowsServiceConfig) CheckAndSetDefaults() error {
 	if err := cfg.Heartbeat.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-	if cfg.LDAPConfig.Addr != "" {
-		if err := cfg.LDAPConfig.Check(); err != nil {
+	if cfg.LDAPConfig.Addr != "" || cfg.LDAPConfig.LocateServer.Enabled {
+		if err := cfg.LDAPConfig.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -288,6 +262,10 @@ func (cfg *WindowsServiceConfig) CheckAndSetDefaults() error {
 	cfg.Logger = cmp.Or(cfg.Logger, slog.With(teleport.ComponentKey, teleport.ComponentWindowsDesktop))
 	cfg.Clock = cmp.Or(cfg.Clock, clockwork.NewRealClock())
 	cfg.ConnectedProxyGetter = cmp.Or(cfg.ConnectedProxyGetter, reversetunnel.NewConnectedProxyGetter())
+
+	if !cfg.LocateServer.Enabled && cfg.LocateServer.Site != "" {
+		cfg.Logger.WarnContext(context.Background(), "site is set, but locate_server is false. site will be ignored.")
+	}
 
 	return nil
 }
@@ -303,6 +281,17 @@ func (cfg *HeartbeatConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("HeartbeatConfig is missing OnHeartbeat")
 	}
 	return nil
+}
+
+func (s *WindowsService) getLDAPConfig() *winpki.LDAPConfig {
+	return &winpki.LDAPConfig{
+		Logger:       s.cfg.Logger,
+		Username:     s.cfg.LDAPConfig.Username,
+		SID:          s.cfg.LDAPConfig.SID,
+		Domain:       s.cfg.LDAPConfig.Domain,
+		Addr:         s.cfg.LDAPConfig.Addr,
+		LocateServer: winpki.LocateServer(s.cfg.LDAPConfig.LocateServer),
+	}
 }
 
 const insecureSkipVerifyWarning = "LDAP configuration specifies both a CA certificate and insecure_skip_verify. " +
@@ -361,7 +350,6 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 			AcceptedUsage: []string{teleport.UsageWindowsDesktopOnly},
 		},
 		dnsResolver: resolver,
-		lc:          winpki.NewLDAPClient(nil),
 		clusterName: clusterName.GetClusterName(),
 		closeCtx:    ctx,
 		close:       close,
@@ -377,18 +365,8 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		Domain:      cmp.Or(s.cfg.PKIDomain, s.cfg.Domain),
 		Logger:      slog.Default(),
 		ClusterName: s.clusterName,
-		LC:          s.lc,
+		LC:          s.getLDAPConfig(),
 	})
-
-	if s.cfg.LDAPConfig.Addr != "" {
-		s.ldapConfigured = true
-		// initialize LDAP - if this fails it will automatically schedule a retry.
-		// we don't want to return an error in this case, because failure to start
-		// the service brings down the entire Teleport process
-		if err := s.initializeLDAP(); err != nil {
-			s.cfg.Logger.ErrorContext(ctx, "initializing LDAP client, will retry", "error", err)
-		}
-	}
 
 	ok := false
 	defer func() {
@@ -419,58 +397,8 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		s.cfg.Logger.InfoContext(ctx, "desktop discovery via LDAP is disabled, set 'base_dn' to enable")
 	}
 
-	// if LDAP-based discovery is not enabled, but we have configured LDAP
-	// then it's important that we periodically try to use the LDAP connection
-	// to detect connection closure
-	if s.ldapConfigured && len(s.cfg.Discovery) == 0 {
-		s.startLDAPConnectionCheck(ctx)
-	}
-
 	ok = true
 	return s, nil
-}
-
-// startLDAPConnectionCheck starts a background process that
-// periodically reads from the LDAP connection in order to detect
-// connection closure, and reconnects if necessary.
-// This is useful when LDAP-based discovery is disabled, because without
-// discovery the connection goes idle and may be closed by the server.
-func (s *WindowsService) startLDAPConnectionCheck(ctx context.Context) {
-	s.cfg.Logger.DebugContext(ctx, "starting LDAP connection checker")
-	go func() {
-		t := s.cfg.Clock.NewTicker(5 * time.Minute)
-		defer t.Stop()
-
-		for {
-			select {
-			case <-t.Chan():
-				// First check if we have successfully initialized the LDAP client.
-				// If not, then do that now and return.
-				// (This mimics the check that is performed when LDAP discovery is enabled.)
-				s.mu.Lock()
-				if !s.ldapInitialized {
-					s.cfg.Logger.DebugContext(context.Background(), "LDAP not ready, attempting to reconnect")
-					s.mu.Unlock()
-					s.initializeLDAP()
-					return
-				}
-				s.mu.Unlock()
-
-				// If we have initialized the LDAP client, then try to use it to make sure we're still connected
-				// by attempting to read CAs in the NTAuth store (we know we have permissions to do so).
-				ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + winpki.DomainDN(s.cfg.LDAPConfig.Domain)
-				_, err := s.lc.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
-				if trace.IsConnectionProblem(err) {
-					s.cfg.Logger.DebugContext(ctx, "detected broken LDAP connection, will reconnect")
-					if err := s.initializeLDAP(); err != nil {
-						s.cfg.Logger.WarnContext(ctx, "failed to reconnect to LDAP", "error", err)
-					}
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
 }
 
 func (s *WindowsService) newSessionRecorder(recConfig types.SessionRecordingConfig, sessionID string) (libevents.SessionPreparerRecorder, error) {
@@ -540,81 +468,12 @@ func (s *WindowsService) tlsConfigForLDAP() (*tls.Config, error) {
 	return tc, nil
 }
 
-// initializeLDAP requests a TLS certificate from the auth server to be used for
-// authenticating with the LDAP server. If the certificate is obtained, and
-// authentication with the LDAP server succeeds, it schedules a renewal to take
-// place before the certificate expires. If we are unable to obtain a certificate
-// and authenticate with the LDAP server, then the operation will be automatically
-// retried.
-//
-// This method is safe for concurrent calls.
-func (s *WindowsService) initializeLDAP() error {
-	tc, err := s.tlsConfigForLDAP()
-	if trace.IsAccessDenied(err) && modules.GetModules().BuildType() == modules.BuildEnterprise {
-		s.cfg.Logger.WarnContext(context.Background(),
-			"Could not generate certificate for LDAPS. Ensure that the auth server is licensed for desktop access.")
-	}
-	if err != nil {
-		s.mu.Lock()
-		s.ldapInitialized = false
-		// in the case where we're not licensed for desktop access, we retry less frequently,
-		// since this is likely not an intermittent error that will resolve itself quickly
-		s.scheduleNextLDAPCertRenewalLocked(windowsDesktopServiceCertRetryInterval * 3)
-		s.mu.Unlock()
-		return trace.Wrap(err)
-	}
-
-	conn, err := ldap.DialURL(
-		"ldaps://"+s.cfg.Addr,
-		ldap.DialWithDialer(&net.Dialer{Timeout: ldapDialTimeout}),
-		ldap.DialWithTLSConfig(tc),
-	)
-	if err != nil {
-		s.mu.Lock()
-		s.ldapInitialized = false
-
-		// failures due to timeouts might be transient, so retry more frequently
-		retryAfter := windowsDesktopServiceCertRetryInterval
-		if errors.Is(err, context.DeadlineExceeded) {
-			retryAfter = ldapTimeoutRetryInterval
-		}
-
-		s.scheduleNextLDAPCertRenewalLocked(retryAfter)
-		s.mu.Unlock()
-		return trace.Wrap(err, "dial")
-	}
-
-	conn.SetTimeout(ldapRequestTimeout)
-	s.lc.SetClient(conn)
-
-	if err := s.ca.Update(s.closeCtx); err != nil {
-		return trace.Wrap(err)
-	}
-
-	s.mu.Lock()
-	s.ldapInitialized = true
-	s.scheduleNextLDAPCertRenewalLocked(windowsDesktopServiceCertTTL / 3)
-	s.mu.Unlock()
+// Close instructs the server to stop accepting new connections and abort all
+// established ones. Close does not wait for the connections to be finished.
+func (s *WindowsService) Close() error {
+	s.close()
 
 	return nil
-}
-
-// scheduleNextLDAPCertRenewalLocked schedules a renewal of our LDAP credentials
-// after some amount of time has elapsed. If an existing renewal is already
-// scheduled, it is canceled and this new one takes its place.
-//
-// The lock on s.mu MUST be held.
-func (s *WindowsService) scheduleNextLDAPCertRenewalLocked(after time.Duration) {
-	s.cfg.Logger.InfoContext(context.Background(), "scheduled next LDAP cert renewal", "duration", after)
-	if s.ldapCertRenew != nil {
-		s.ldapCertRenew.Reset(after)
-	} else {
-		s.ldapCertRenew = time.AfterFunc(after, func() {
-			if err := s.initializeLDAP(); err != nil {
-				s.cfg.Logger.ErrorContext(context.Background(), "couldn't renew certificate for LDAP auth", "error", err)
-			}
-		})
-	}
 }
 
 func (s *WindowsService) startServiceHeartbeat() error {
@@ -682,20 +541,6 @@ func (s *WindowsService) startStaticHostHeartbeat(host servicecfg.WindowsHost) e
 	return nil
 }
 
-// Close instructs the server to stop accepting new connections and abort all
-// established ones. Close does not wait for the connections to be finished.
-func (s *WindowsService) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.ldapCertRenew != nil {
-		s.ldapCertRenew.Stop()
-	}
-	s.close()
-	s.lc.Close()
-	return nil
-}
-
 // Serve starts serving TLS connections for plainLis. plainLis should be a TCP
 // listener and Serve will handle TLS internally.
 func (s *WindowsService) Serve(plainLis net.Listener) error {
@@ -723,20 +568,6 @@ func (s *WindowsService) Serve(plainLis net.Listener) error {
 	}
 }
 
-func (s *WindowsService) readyForConnections() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// If LDAP was not configured, we assume all hosts are non-AD
-	// and the server can accept connections right away.
-	if !s.ldapConfigured {
-		return true
-	}
-
-	// If LDAP was configured, then we need to wait for it to be initialized
-	// before accepting connections.
-	return s.ldapInitialized
-}
-
 // handleConnection handles TLS connections from a Teleport proxy.
 // It authenticates and authorizes the connection, and then begins
 // translating the TDP messages from the proxy into native RDP.
@@ -751,15 +582,6 @@ func (s *WindowsService) handleConnection(proxyConn *tls.Conn) {
 		if err := tdpConn.SendNotification(message, tdp.SeverityError); err != nil {
 			log.ErrorContext(context.Background(), "Failed to send TDP error message", "error", err)
 		}
-	}
-
-	// don't handle connections until the LDAP initialization retry loop has succeeded
-	// (it would fail anyway, but this presents a better error to the user)
-	if !s.readyForConnections() {
-		const msg = "This service cannot accept connections until LDAP initialization has completed."
-		log.ErrorContext(context.Background(), msg)
-		sendTDPError(msg)
-		return
 	}
 
 	// Check connection limits.
@@ -1272,34 +1094,23 @@ func timer() func() int64 {
 func (s *WindowsService) generateUserCert(ctx context.Context, username string, ttl time.Duration, desktop types.WindowsDesktop, createUsers bool, groups []string) (certDER, keyDER []byte, err error) {
 	var activeDirectorySID string
 	if !desktop.NonAD() {
-		// Find the user's SID
-		filter := winpki.CombineLDAPFilters([]string{
-			fmt.Sprintf("(%s=%s)", attrSAMAccountType, AccountTypeUser),
-			fmt.Sprintf("(%s=%s)", attrSAMAccountName, username),
-		})
-		s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username, "filter", filter)
-		domainDN := winpki.DomainDN(s.cfg.LDAPConfig.Domain)
+		tc, err := s.tlsConfigForLDAP()
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
 
-		entries, err := s.lc.ReadWithFilter(domainDN, filter, []string{winpki.AttrObjectSid})
-		// if LDAP-based desktop discovery is not enabled, there may not be enough
-		// traffic to keep the connection open. Attempt to open a new LDAP connection
-		// in this case.
-		if trace.IsConnectionProblem(err) {
-			s.initializeLDAP() // ignore error, this is a best effort attempt
-			entries, err = s.lc.ReadWithFilter(domainDN, filter, []string{winpki.AttrObjectSid})
-		}
+		ldapClient, err := winpki.DialLDAP(ctx, s.getLDAPConfig(), tc)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		if len(entries) == 0 {
-			return nil, nil, trace.NotFound("could not find Windows account %q", username)
-		} else if len(entries) > 1 {
-			s.cfg.Logger.WarnContext(ctx, "found multiple entries for user, taking the first", "username", username)
-		}
-		activeDirectorySID, err = winpki.ADSIDStringFromLDAPEntry(entries[0])
+		defer ldapClient.Close()
+
+		s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username)
+		activeDirectorySID, err = ldapClient.GetActiveDirectorySID(ctx, username)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
+
 		s.cfg.Logger.DebugContext(ctx, "Found objectSid Windows user", "username", username)
 	}
 	return s.generateCredentials(ctx, generateCredentialsRequest{

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -58,7 +58,7 @@ func TestConfigWildcardBaseDN(t *testing.T) {
 				BaseDN: "*",
 			},
 		},
-		LDAPConfig: winpki.LDAPConfig{
+		LDAPConfig: servicecfg.LDAPConfig{
 			Domain: "test.goteleport.com",
 		},
 	}

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -19,12 +19,16 @@
 package winpki
 
 import (
-	"crypto/x509"
+	"context"
+	"crypto/tls"
 	"encoding/base32"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net"
+	"os"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
@@ -33,11 +37,35 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+const (
+	// ldapDialTimeout is the timeout for dialing the LDAP server
+	// when making an initial connection
+	ldapDialTimeout = 15 * time.Second
+
+	// ldapRequestTimeout is the timeout for making LDAP requests.
+	// It is larger than the dial timeout because LDAP queries in large
+	// Active Directory environments may take longer to complete.
+	ldapRequestTimeout = 45 * time.Second
+)
+
+// LocateServer contains parameters for locating LDAP servers
+// from the AD Domain
+type LocateServer struct {
+	// Automatically locate the LDAP server using DNS SRV records.
+	// https://ldap.com/dns-srv-records-for-ldap/
+	Enabled bool
+	// Use LDAP site to locate servers from a specific logical site.
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/b645c125-a7da-4097-84a1-2fa7cea07714#gt_8abdc986-5679-42d9-ad76-b11eb5a0daba
+	Site string
+}
+
 // LDAPConfig contains parameters for connecting to an LDAP server.
 type LDAPConfig struct {
 	// Addr is the LDAP server address in the form host:port.
 	// Standard port is 636 for LDAPS.
 	Addr string
+	// LocateServer contains parameters for locating LDAP servers from the AD domain.
+	LocateServer LocateServer
 	// Domain is an Active Directory domain name, like "example.com".
 	Domain string
 	// Username is an LDAP username, like "EXAMPLE\Administrator", where
@@ -45,26 +73,38 @@ type LDAPConfig struct {
 	Username string
 	// SID is the SID for the user specified by Username.
 	SID string
-	// InsecureSkipVerify decides whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
-	InsecureSkipVerify bool
-	// ServerName is the name of the LDAP server for TLS.
-	ServerName string
-	// CA is an optional CA cert to be used for verification if InsecureSkipVerify is set to false.
-	CA *x509.Certificate
+	// Logger is the logger for the service.
+	Logger *slog.Logger
 }
 
-// Check verifies this LDAPConfig
-func (cfg LDAPConfig) Check() error {
-	if cfg.Addr == "" {
-		return trace.BadParameter("missing Addr in LDAPConfig")
+// LDAPClient is an LDAP client designed for Active Directory environments.
+// It uses mutual TLS for authentication, and has the ability to discover
+// LDAP servers from DNS if an explicit address is not provided.
+//
+// LDAPClient does not implement any form of credential refresh or certificate
+// rotation. It is no longer useful after its certificate expires.
+// For this reason, callers are encouraged to create clients on-demand rather
+// than keeping them open for long periods of time.
+type LDAPClient struct {
+	cfg  *LDAPConfig
+	conn *ldap.Conn
+}
+
+// DialLDAP creates a new LDAP client using the provided TLS config for client credentials.
+func DialLDAP(ctx context.Context, cfg *LDAPConfig, credentials *tls.Config) (*LDAPClient, error) {
+	conn, err := cfg.createConnection(ctx, credentials)
+	if err != nil {
+		return nil, trace.Wrap(err, "connecting to LDAP server")
 	}
-	if cfg.Domain == "" {
-		return trace.BadParameter("missing Domain in LDAPConfig")
-	}
-	if cfg.Username == "" {
-		return trace.BadParameter("missing Username in LDAPConfig")
-	}
-	return nil
+
+	return &LDAPClient{
+		cfg:  cfg,
+		conn: conn,
+	}, nil
+}
+
+func (l *LDAPClient) Close() error {
+	return l.conn.Close()
 }
 
 // DomainDN returns the distinguished name for an Active Directory Domain.
@@ -86,51 +126,22 @@ const (
 	AttrObjectSid = "objectSid"
 	// AttrObjectClass is the object class of an LDAP object
 	AttrObjectClass = "objectClass"
-)
 
-// classContainer is the object class for containers in Active Directory
-const classContainer = "container"
+	// AttrSAMAccountType is the SAM Account type for an LDAP object.
+	AttrSAMAccountType = "sAMAccountType"
+	// AccountTypeUser is the SAM account type for user accounts.
+	// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccounttype
+	// (SAM_USER_OBJECT)
+	AccountTypeUser = "805306368"
+
+	// AttrSAMAccountName is the SAM Account name of an LDAP object.
+	AttrSAMAccountName = "sAMAccountName"
+)
 
 // searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
 // so in most cases the 1000 search page size will result in the optimal amount of requests made to
 // LDAP server.
 const searchPageSize = 1000
-
-// LDAPClient is a windows LDAP client.
-//
-// It does not automatically detect when the underlying connection
-// is closed. Callers should check for trace.ConnectionProblem errors
-// and provide a new client with [SetClient].
-type LDAPClient struct {
-	mu     sync.Mutex
-	client ldap.Client
-}
-
-// NewLDAPClient returns new LDAPClient. Parameter client may be nil.
-func NewLDAPClient(client ldap.Client) *LDAPClient {
-	return &LDAPClient{
-		client: client,
-	}
-}
-
-// SetClient sets the underlying ldap.Client
-func (c *LDAPClient) SetClient(client ldap.Client) {
-	c.mu.Lock()
-	if c.client != nil {
-		c.client.Close()
-	}
-	c.client = client
-	c.mu.Unlock()
-}
-
-// Close closes the underlying ldap.Client
-func (c *LDAPClient) Close() {
-	c.mu.Lock()
-	if c.client != nil {
-		c.client.Close()
-	}
-	c.mu.Unlock()
-}
 
 // convertLDAPError attempts to convert LDAP error codes to their
 // equivalent trace errors.
@@ -143,9 +154,6 @@ func convertLDAPError(err error) error {
 	if errors.As(err, &ldapErr) {
 		switch ldapErr.ResultCode {
 		case ldap.ErrorNetwork:
-			// this one is especially important, because Teleport will
-			// try to re-establish the connection when a ConnectionProblem
-			// is detected
 			return trace.ConnectionProblem(err, "network error")
 		case ldap.LDAPResultOperationsError:
 			if strings.Contains(err.Error(), "successful bind must be completed") {
@@ -165,9 +173,35 @@ func convertLDAPError(err error) error {
 	return err
 }
 
+// GetActiveDirectorySID makes an LDAP query to retrieve the security identifier (SID)
+// for the specified Active Directory user.
+func (l *LDAPClient) GetActiveDirectorySID(ctx context.Context, username string) (string, error) {
+	filter := CombineLDAPFilters([]string{
+		fmt.Sprintf("(%s=%s)", AttrSAMAccountType, AccountTypeUser),
+		fmt.Sprintf("(%s=%s)", AttrSAMAccountName, username),
+	})
+
+	entries, err := l.ReadWithFilter(DomainDN(l.cfg.Domain), filter, []string{AttrObjectSid})
+	switch {
+	case err != nil:
+		return "", trace.Wrap(err)
+	case len(entries) == 0:
+		return "", trace.NotFound("could not find Windows account %q", username)
+	case len(entries) > 1:
+		l.cfg.Logger.WarnContext(ctx, "found multiple entries for user, taking the first", "user", username)
+	}
+
+	sid, err := ADSIDStringFromLDAPEntry(entries[0])
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return sid, nil
+}
+
 // ReadWithFilter searches the specified DN (and its children) using the specified LDAP filter.
 // See https://ldap.com/ldap-filters/ for more information on LDAP filter syntax.
-func (c *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([]*ldap.Entry, error) {
+func (l *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([]*ldap.Entry, error) {
 	req := ldap.NewSearchRequest(
 		dn,
 		ldap.ScopeWholeSubtree,
@@ -179,10 +213,8 @@ func (c *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([
 		attrs,
 		nil, // no Controls
 	)
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	res, err := c.client.SearchWithPaging(req, searchPageSize)
+	res, err := l.conn.SearchWithPaging(req, searchPageSize)
 	if err != nil {
 		return nil, trace.Wrap(convertLDAPError(err), "fetching LDAP object %q with filter %q", dn, filter)
 	}
@@ -198,8 +230,8 @@ func (c *LDAPClient) ReadWithFilter(dn string, filter string, attrs []string) ([
 // specific entry using ADSIEdit.msc.
 // You can find the list of all AD classes at
 // https://docs.microsoft.com/en-us/windows/win32/adschema/classes-all
-func (c *LDAPClient) Read(dn string, class string, attrs []string) ([]*ldap.Entry, error) {
-	return c.ReadWithFilter(dn, fmt.Sprintf("(%s=%s)", AttrObjectClass, class), attrs)
+func (l *LDAPClient) Read(dn string, class string, attrs []string) ([]*ldap.Entry, error) {
+	return l.ReadWithFilter(dn, fmt.Sprintf("(%s=%s)", AttrObjectClass, class), attrs)
 }
 
 // Create creates an LDAP entry at the given path, with the given class and
@@ -210,26 +242,23 @@ func (c *LDAPClient) Read(dn string, class string, attrs []string) ([]*ldap.Entr
 // attributes for similar entries using ADSIEdit.msc.
 // You can find the list of all AD classes at
 // https://docs.microsoft.com/en-us/windows/win32/adschema/classes-all
-func (c *LDAPClient) Create(dn string, class string, attrs map[string][]string) error {
+func (l *LDAPClient) Create(dn string, class string, attrs map[string][]string) error {
 	req := ldap.NewAddRequest(dn, nil)
 	for k, v := range attrs {
 		req.Attribute(k, v)
 	}
 	req.Attribute("objectClass", []string{class})
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.client.Add(req); err != nil {
+	if err := l.conn.Add(req); err != nil {
 		return trace.Wrap(convertLDAPError(err), "error creating LDAP object %q", dn)
 	}
 	return nil
 }
 
-// CreateContainer creates an LDAP container entry if
-// it doesn't already exist.
-func (c *LDAPClient) CreateContainer(dn string) error {
-	err := c.Create(dn, classContainer, nil)
+// CreateContainer creates an LDAP container entry if it doesn't already exist.
+func (l *LDAPClient) CreateContainer(ctx context.Context, dn string) error {
+	const classContainer = "container"
+	err := l.Create(dn, classContainer, nil /* attrs */)
 	// Ignore the error if container already exists.
 	if trace.IsAlreadyExists(err) {
 		return nil
@@ -246,16 +275,13 @@ func (c *LDAPClient) CreateContainer(dn string) error {
 //
 // You can browse LDAP on the Windows host to find attributes of existing
 // entries using ADSIEdit.msc.
-func (c *LDAPClient) Update(dn string, replaceAttrs map[string][]string) error {
+func (l *LDAPClient) Update(ctx context.Context, dn string, replaceAttrs map[string][]string) error {
 	req := ldap.NewModifyRequest(dn, nil)
 	for k, v := range replaceAttrs {
 		req.Replace(k, v)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.client.Modify(req); err != nil {
+	if err := l.conn.Modify(req); err != nil {
 		return trace.Wrap(convertLDAPError(err), "updating %q", dn)
 	}
 	return nil
@@ -296,4 +322,70 @@ func crlKeyName(caType types.CertAuthType) string {
 	default:
 		return "Teleport"
 	}
+}
+
+// createConnection dials an LDAP server using the provided TLS config.
+// The server is either obtained directly from the configuration or
+// discovered via DNS.
+func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Config) (*ldap.Conn, error) {
+	servers := []string{c.Addr}
+	dialer := net.Dialer{Timeout: ldapDialTimeout}
+
+	if c.LocateServer.Enabled {
+		dial := func(dialCtx context.Context, network, address string) (net.Conn, error) {
+			return dialer.DialContext(dialCtx, network, address)
+		}
+
+		// In development environments, the system's default resolver is unlikely to be
+		// able to resolve the Active Directory SRV records needed for server location,
+		// so we allow overriding the resolver.
+		if resolverAddr := os.Getenv("TELEPORT_LDAP_RESOLVER"); resolverAddr != "" {
+			c.Logger.DebugContext(ctx, "Using custom DNS resolver address", "address", resolverAddr)
+			// Check if resolver address has a port
+			host, port, err := net.SplitHostPort(resolverAddr)
+			if err != nil {
+				host = resolverAddr
+				port = "53"
+			}
+
+			customResolverAddr := net.JoinHostPort(host, port)
+			dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, customResolverAddr)
+			}
+		}
+
+		resolver := &net.Resolver{
+			PreferGo: true,
+			Dial:     dial,
+		}
+
+		var err error
+		if servers, err = locateLDAPServer(ctx, c.Domain, c.LocateServer.Site, resolver); err != nil {
+			return nil, trace.Wrap(err, "locating LDAP server")
+		}
+	}
+
+	if len(servers) == 0 {
+		return nil, trace.NotFound("no LDAP servers found for domain %q", c.Domain)
+	}
+
+	for _, server := range servers {
+		conn, err := ldap.DialURL(
+			"ldaps://"+server,
+			ldap.DialWithDialer(&dialer),
+			ldap.DialWithTLSConfig(ldapTLSConfig),
+		)
+
+		if err != nil {
+			// If the connection fails, try the next server
+			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
+			continue
+		}
+
+		c.Logger.DebugContext(ctx, "Connected to LDAP server", "server", server)
+		conn.SetTimeout(ldapRequestTimeout)
+		return conn, nil
+	}
+
+	return nil, trace.NotFound("no LDAP servers responded successfully for domain %q", c.Domain)
 }

--- a/lib/winpki/locate.go
+++ b/lib/winpki/locate.go
@@ -1,0 +1,74 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package winpki
+
+import (
+	"context"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/gravitational/trace"
+)
+
+// locateLDAPServer looks up the LDAP server in an Active Directory
+// environment by implementing the DNS-based discovery DC locator
+// process.
+//
+// See https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/dc-locator?tabs=dns-based-discovery
+func locateLDAPServer(ctx context.Context, domain string, site string, resolver *net.Resolver) ([]string, error) {
+	tryDomain := domain
+	if site != "" {
+		tryDomain = site + "._sites." + domain
+	}
+
+	_, records, err := resolver.LookupSRV(ctx, "ldap", "tcp", tryDomain)
+	if err != nil && site != "" {
+		// If the site lookup fails, try the domain directly.
+		_, records, err = resolver.LookupSRV(ctx, "ldap", "tcp", domain)
+	}
+
+	if err != nil {
+		return nil, trace.Wrap(err, "looking up SRV records for %v", domain)
+	}
+
+	// note: LookupSRV already returns records sorted by priority and takes in to account weights
+	var result []string
+	for _, record := range records {
+		addrs := []string{record.Target}
+
+		// In development environments, the hostnames returned from the SRV records are
+		// unlikely to resolve with the system resolver, so get an IP address now while
+		// we're using DNS from AD.
+		if resolve, _ := strconv.ParseBool(os.Getenv("TELEPORT_LDAP_RESOLVE_SERVER")); resolve {
+			var err error
+			addrs, err = resolver.LookupHost(ctx, record.Target)
+			if err != nil {
+				continue
+			}
+		}
+		for _, addr := range addrs {
+			// SRV records will likely return the insecure LDAP port,
+			// so we ignore it and hard code the LDAPS port.
+			result = append(result, net.JoinHostPort(addr, "636"))
+		}
+	}
+
+	return result, nil
+}

--- a/lib/winpki/locate.go
+++ b/lib/winpki/locate.go
@@ -21,8 +21,6 @@ package winpki
 import (
 	"context"
 	"net"
-	"os"
-	"strconv"
 
 	"github.com/gravitational/trace"
 )
@@ -51,23 +49,9 @@ func locateLDAPServer(ctx context.Context, domain string, site string, resolver 
 	// note: LookupSRV already returns records sorted by priority and takes in to account weights
 	var result []string
 	for _, record := range records {
-		addrs := []string{record.Target}
-
-		// In development environments, the hostnames returned from the SRV records are
-		// unlikely to resolve with the system resolver, so get an IP address now while
-		// we're using DNS from AD.
-		if resolve, _ := strconv.ParseBool(os.Getenv("TELEPORT_LDAP_RESOLVE_SERVER")); resolve {
-			var err error
-			addrs, err = resolver.LookupHost(ctx, record.Target)
-			if err != nil {
-				continue
-			}
-		}
-		for _, addr := range addrs {
-			// SRV records will likely return the insecure LDAP port,
-			// so we ignore it and hard code the LDAPS port.
-			result = append(result, net.JoinHostPort(addr, "636"))
-		}
+		// SRV records will likely return the insecure LDAP port,
+		// so we ignore it and hard code the LDAPS port.
+		result = append(result, net.JoinHostPort(record.Target, "636"))
 	}
 
 	return result, nil


### PR DESCRIPTION
Adds locate_server option for users to enable that allows Teleport to discover LDAP servers through SRV records, instead of the user having to specify a single LDAP server address.

Backports #55937
Backports #57106

changelog: Added auto discovery of LDAP servers through SRV records