### PR TITLE
Update AccessList.Spec.Type docs

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -412,9 +412,9 @@ type AccessListSpec struct {
 	Title string `protobuf:"bytes,8,opt,name=title,proto3" json:"title,omitempty"`
 	// owner_grants describes the access granted by owners to this Access List.
 	OwnerGrants *AccessListGrants `protobuf:"bytes,11,opt,name=owner_grants,json=ownerGrants,proto3" json:"owner_grants,omitempty"`
-	// type can be currently "dynamic" (the default if empty string) which denotes a regular Access
-	// List, "scim" which represents an Access List created from SCIM group or "static" for Access
-	// Lists managed by IaC tools.
+	// type can be an empty string which denotes a regular Access List, "scim" which represents
+	// an Access List created from SCIM group or "static" for Access Lists managed by IaC
+	// tools.
 	Type          string `protobuf:"bytes,12,opt,name=type,proto3" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -72,9 +72,9 @@ message AccessListSpec {
   // owner_grants describes the access granted by owners to this Access List.
   AccessListGrants owner_grants = 11;
 
-  // type can be currently "dynamic" (the default if empty string) which denotes a regular Access
-  // List, "scim" which represents an Access List created from SCIM group or "static" for Access
-  // Lists managed by IaC tools.
+  // type can be an empty string which denotes a regular Access List, "scim" which represents
+  // an Access List created from SCIM group or "static" for Access Lists managed by IaC
+  // tools.
   string type = 12;
 }
 

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -141,9 +141,9 @@ type AccessList struct {
 
 // Spec is the specification for an access list.
 type Spec struct {
-	// Type can be currently "dynamic" (the default if empty string) which denotes a regular
-	// Access List, "scim" which represents an Access List created from SCIM group or "static"
-	// for Access Lists managed by IaC tools.
+	// Type can be an empty string which denotes a regular Access List, "scim" which represents
+	// an Access List created from SCIM group or "static" for Access Lists managed by IaC
+	// tools.
 	Type Type `json:"type" yaml:"type"`
 
 	// Title is a plaintext short description of the access list.

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -37,7 +37,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |owners|[][object](#specowners-items)|owners is a list of owners of the Access List.|
 |ownership_requires|[object](#specownership_requires)|ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list.|
 |title|string|title is a plaintext short description of the Access List.|
-|type|string|type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.|
+|type|string|type can be an empty string which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.|
 
 ### spec.audit
 

--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -65,7 +65,7 @@ Optional:
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
-- `type` (String) type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
+- `type` (String) type can be an empty string which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
 
 ### Nested Schema for `spec.audit`
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -110,7 +110,7 @@ Optional:
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
-- `type` (String) type can be currently "dynamic" (the default if empty string) which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
+- `type` (String) type can be an empty string which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
 
 ### Nested Schema for `spec.audit`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_accesslists.yaml
@@ -191,10 +191,9 @@ spec:
                   List.
                 type: string
               type:
-                description: type can be currently "dynamic" (the default if empty
-                  string) which denotes a regular Access List, "scim" which represents
-                  an Access List created from SCIM group or "static" for Access Lists
-                  managed by IaC tools.
+                description: type can be an empty string which denotes a regular Access
+                  List, "scim" which represents an Access List created from SCIM group
+                  or "static" for Access Lists managed by IaC tools.
                 type: string
             type: object
           status:

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -119,9 +119,9 @@ export interface AccessListSpec {
      */
     ownerGrants?: AccessListGrants;
     /**
-     * type can be currently "dynamic" (the default if empty string) which denotes a regular Access
-     * List, "scim" which represents an Access List created from SCIM group or "static" for Access
-     * Lists managed by IaC tools.
+     * type can be an empty string which denotes a regular Access List, "scim" which represents
+     * an Access List created from SCIM group or "static" for Access Lists managed by IaC
+     * tools.
      *
      * @generated from protobuf field: string type = 12;
      */

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_accesslists.yaml
@@ -191,10 +191,9 @@ spec:
                   List.
                 type: string
               type:
-                description: type can be currently "dynamic" (the default if empty
-                  string) which denotes a regular Access List, "scim" which represents
-                  an Access List created from SCIM group or "static" for Access Lists
-                  managed by IaC tools.
+                description: type can be an empty string which denotes a regular Access
+                  List, "scim" which represents an Access List created from SCIM group
+                  or "static" for Access Lists managed by IaC tools.
                 type: string
             type: object
           status:

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -298,7 +298,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},
 				"type": {
-					Description: "type can be currently \"dynamic\" (the default if empty string) which denotes a regular Access List, \"scim\" which represents an Access List created from SCIM group or \"static\" for Access Lists managed by IaC tools.",
+					Description: "type can be an empty string which denotes a regular Access List, \"scim\" which represents an Access List created from SCIM group or \"static\" for Access Lists managed by IaC tools.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				},


### PR DESCRIPTION
This is to declutter https://github.com/gravitational/teleport/pull/56999.

The only change here is a doc update on the proto field in `api/proto/teleport/accesslist/v1/accesslist.proto` and internal struct filed in `api/types/accesslist/accesslist.go`. All the rest is generated.

Backports:

- [ ] v18 included in https://github.com/gravitational/teleport/pull/57058
- [ ] v17