### PR TITLE
Add OTP fallback for SSHAgentMFAWebSessionLogin

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3880,7 +3880,7 @@ func (tc *TeleportClient) directLoginWeb(ctx context.Context, secondFactorType c
 	}
 
 	// authenticate via the web api
-	clt, session, err := SSHAgentLoginWeb(ctx, SSHLoginDirect{
+	clt, session, err := sshAgentLoginWeb(ctx, SSHLoginDirect{
 		SSHLogin: sshLogin,
 		User:     tc.Username,
 		Password: password,
@@ -3901,7 +3901,7 @@ func (tc *TeleportClient) mfaLocalLoginWeb(ctx context.Context, keyRing *KeyRing
 		return nil, nil, trace.Wrap(err)
 	}
 
-	clt, session, err := SSHAgentMFAWebSessionLogin(ctx, SSHLoginMFA{
+	clt, session, err := sshAgentMFAWebSessionLogin(ctx, SSHLoginMFA{
 		SSHLogin:             sshLogin,
 		User:                 tc.Username,
 		Password:             password,

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -888,7 +888,7 @@ func SSHAgentMFAWebSessionLogin(ctx context.Context, login SSHLoginMFA) (*WebCli
 	// Convert back from auth gRPC proto response.
 	switch r := mfaResp.Response.(type) {
 	case *proto.MFAAuthenticateResponse_TOTP:
-		// Only TOTP is configured fallback on direct login
+		// If TOTP is configured we have to fallback on direct login
 		return sshAgentLoginWebCreateSession(ctx, clt, SSHLoginDirect{
 			User:     login.User,
 			Password: login.Password,

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -858,8 +858,8 @@ func sshAgentLoginWebCreateSession(ctx context.Context, clt *WebClient, login SS
 	return clt, session, nil
 }
 
-// SSHAgentLoginWeb is used by tsh to fetch local user credentials via the web api.
-func SSHAgentLoginWeb(ctx context.Context, login SSHLoginDirect) (*WebClient, types.WebSession, error) {
+// sshAgentLoginWeb is used by tsh to fetch local user credentials via the web api.
+func sshAgentLoginWeb(ctx context.Context, login SSHLoginDirect) (*WebClient, types.WebSession, error) {
 	clt, _, err := initClient(login.ProxyAddr, login.Insecure, login.Pool, login.ExtraHeaders)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -868,10 +868,10 @@ func SSHAgentLoginWeb(ctx context.Context, login SSHLoginDirect) (*WebClient, ty
 	return sshAgentLoginWebCreateSession(ctx, clt, login)
 }
 
-// SSHAgentMFAWebSessionLogin requests a MFA challenge via the proxy web api.
+// sshAgentMFAWebSessionLogin requests a MFA challenge via the proxy web api.
 // If the credentials are valid, the proxy will return a challenge. We then
 // prompt the user to provide 2nd factor and pass the response to the proxy.
-func SSHAgentMFAWebSessionLogin(ctx context.Context, login SSHLoginMFA) (*WebClient, types.WebSession, error) {
+func sshAgentMFAWebSessionLogin(ctx context.Context, login SSHLoginMFA) (*WebClient, types.WebSession, error) {
 	clt, _, err := initClient(login.ProxyAddr, login.Insecure, login.Pool, login.ExtraHeaders)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -897,7 +897,7 @@ func SSHAgentMFAWebSessionLogin(ctx context.Context, login SSHLoginMFA) (*WebCli
 	case *proto.MFAAuthenticateResponse_Webauthn:
 		challengeResp.WebauthnAssertionResponse = wantypes.CredentialAssertionResponseFromProto(r.Webauthn)
 	default:
-		return nil, nil, trace.NotImplemented("unsupported MFA challenge for web session login")
+		return nil, nil, trace.NotImplemented("unsupported MFA challenge for web session login (%T)", r)
 	}
 
 	loginRespJSON, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "finishsession"), challengeResp)

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -897,7 +897,7 @@ func SSHAgentMFAWebSessionLogin(ctx context.Context, login SSHLoginMFA) (*WebCli
 	case *proto.MFAAuthenticateResponse_Webauthn:
 		challengeResp.WebauthnAssertionResponse = wantypes.CredentialAssertionResponseFromProto(r.Webauthn)
 	default:
-		// No challenge was sent, so we send back just username/password.
+		return nil, nil, trace.NotImplemented("unsupported MFA challenge for web session login")
 	}
 
 	loginRespJSON, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "finishsession"), challengeResp)


### PR DESCRIPTION
In the case Teleport `second_factor` is set to `on`, it is possible for a user to only have OTP configured. Prior to this commit this would result in a auth fail as the created challenge only supported TOTP.

Server side would recieve an incomplete `AuthenticateWebUserRequest` object, which fails validation via `CheckAndSetDefaults` and as such only a failed login audit event was emitted with no additional logs.

This mode of failure can be reproduced with
`tsh bench -d web sessions --auth=local`.

changelog: Fixed fallback for web login when second factor is set to `on` but only OTP is configured.

