### PR TITLE
Gracefully fail when cannot do client tools updates

### DIFF
--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -33,6 +33,7 @@ FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging /
 COPY --from=staging /opt/staging/root /
 COPY --from=staging /opt/staging/status /var/lib/dpkg/status.d
+ENV TELEPORT_TOOLS_VERSION=off
 # Attempt a graceful shutdown by default
 # See https://goteleport.com/docs/reference/signals/ for signal reference.
 STOPSIGNAL SIGQUIT

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -69,6 +69,12 @@ func newUpdater(toolsDir string) (*Updater, error) {
 // If they differ, the requested version is downloaded and extracted into the client tools directory,
 // the installation is recorded in the configuration file, and the tool is re-executed with the updated version.
 func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecArgs []string) error {
+	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
+	// so we don't try to read te user home directory, fail, and log warnings.
+	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled {
+		return nil
+	}
+
 	var err error
 	if currentProfileName == "" {
 		home := os.Getenv(types.HomeEnvVar)
@@ -84,12 +90,13 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 
 	toolsDir, err := Dir()
 	if err != nil {
-		slog.WarnContext(ctx, "Client tools update is disabled", "error", err)
+		slog.WarnContext(ctx, "Failed to detect the teleport home directory, client tools updates are disabled", "error", err)
 		return nil
 	}
 	updater, err := newUpdater(toolsDir)
 	if err != nil {
-		return trace.Wrap(err)
+		slog.WarnContext(ctx, "Failed to create the updater, client tools updates are disabled", "error", err)
+		return nil
 	}
 
 	slog.DebugContext(ctx, "Attempting to local update", "current_profile_name", currentProfileName)
@@ -117,14 +124,21 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 // the installed version is recorded in the configuration, and the tool is re-executed
 // with the updated version.
 func CheckAndUpdateRemote(ctx context.Context, currentProfileName string, insecure bool, reExecArgs []string) error {
+	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
+	// so we don't try to read te user home directory, fail, and log warnings.
+	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled {
+		return nil
+	}
+
 	toolsDir, err := Dir()
 	if err != nil {
-		slog.WarnContext(ctx, "Client tools update is disabled", "error", err)
+		slog.WarnContext(ctx, "Failed to detect the teleport home directory, client tools updates are disabled", "error", err)
 		return nil
 	}
 	updater, err := newUpdater(toolsDir)
 	if err != nil {
-		return trace.Wrap(err)
+		slog.WarnContext(ctx, "Failed to create the updater, client tools updates are disabled", "error", err)
+		return nil
 	}
 
 	slog.DebugContext(ctx, "Attempting to remote update", "current_profile_name", currentProfileName, "insecure", insecure)

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -102,7 +102,8 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 	slog.DebugContext(ctx, "Attempting to local update", "current_profile_name", currentProfileName)
 	resp, err := updater.CheckLocal(ctx, currentProfileName)
 	if err != nil {
-		return trace.Wrap(err)
+		slog.WarnContext(ctx, "Failed to check local teleport versions, client tools updates are disabled", "error", err)
+		return nil
 	}
 
 	if resp.ReExec {
@@ -144,7 +145,8 @@ func CheckAndUpdateRemote(ctx context.Context, currentProfileName string, insecu
 	slog.DebugContext(ctx, "Attempting to remote update", "current_profile_name", currentProfileName, "insecure", insecure)
 	resp, err := updater.CheckRemote(ctx, currentProfileName, insecure)
 	if err != nil {
-		return trace.Wrap(err)
+		slog.WarnContext(ctx, "Failed to check remote teleport versions, client tools updates are disabled", "error", err)
+		return nil
 	}
 
 	if !resp.Disabled && resp.ReExec {

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -52,6 +52,9 @@ import (
 const (
 	// teleportToolsVersionEnv is environment name for requesting specific version for update.
 	teleportToolsVersionEnv = "TELEPORT_TOOLS_VERSION"
+	// teleportToolsVersionEnvDisabled is a special value that disables teleport tools updates
+	// when assigned to the teleportToolsVersionEnv environment variable.
+	teleportToolsVersionEnvDisabled = "off"
 	// teleportToolsVersionReExecEnv is internal environment name for transferring original
 	// version to re-executed ones.
 	teleportToolsVersionReExecEnv = "TELEPORT_TOOLS_VERSION_REEXEC"
@@ -150,7 +153,7 @@ func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *Upd
 	requestedVersion := os.Getenv(teleportToolsVersionEnv)
 	switch requestedVersion {
 	// The user has turned off any form of automatic updates.
-	case "off":
+	case teleportToolsVersionEnvDisabled:
 		return &UpdateResponse{Version: "", ReExec: false}, nil
 	// Requested version already the same as client version.
 	case u.localVersion:
@@ -213,7 +216,7 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 	requestedVersion := os.Getenv(teleportToolsVersionEnv)
 	switch requestedVersion {
 	// The user has turned off any form of automatic updates.
-	case "off":
+	case teleportToolsVersionEnvDisabled:
 		return &UpdateResponse{Version: "", ReExec: false}, nil
 	// Requested version already the same as client version.
 	case u.localVersion:
@@ -427,7 +430,7 @@ func (u *Updater) Exec(ctx context.Context, toolsVersion string, args []string) 
 		if err := os.Unsetenv(teleportToolsVersionEnv); err != nil {
 			return 0, trace.Wrap(err)
 		}
-		env = append(env, teleportToolsVersionEnv+"=off")
+		env = append(env, teleportToolsVersionEnv+"="+teleportToolsVersionEnvDisabled)
 		slog.DebugContext(ctx, "Disable next re-execution")
 	}
 	env = append(env, fmt.Sprintf("%s=%s", teleportToolsVersionReExecEnv, u.localVersion))

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -113,7 +113,7 @@ func CheckToolVersion(toolPath string) (string, error) {
 	// Execute "{tsh, tctl} version" and pass in TELEPORT_TOOLS_VERSION=off to
 	// turn off all automatic updates code paths to prevent any recursion.
 	command := exec.CommandContext(ctx, toolPath, "version")
-	command.Env = []string{teleportToolsVersionEnv + "=off"}
+	command.Env = []string{teleportToolsVersionEnv + "=" + teleportToolsVersionEnvDisabled}
 	output, err := command.Output()
 	if err != nil {
 		slog.DebugContext(context.Background(), "failed to determine version",


### PR DESCRIPTION
This PR fixes a bug where client tools update fail to create/read `~/.tsh` and block the execution of tctl commands in container images. e.g.

```
kubectl exec -i deploy/teleport-auth -n cloud-gravitational-io-hugo-test-mu-18 -- tctl status
ERROR: mkdir /.tsh: read-only file system

command terminated with exit code 1
```

The PR does 3 changes:
- gracefully handle if we cannot create the home directory/check which version to use. Now we try to use the local binary (warn and disable client tools updates)
- handle the case where tools updates are explicitly disabled as early as possible. This prevents us from trying to read the user profile and log errors.
- set `TELEPORT_TOOLS_VERSION=off` in our docker container to prevent it from even thinking about updating client tools

Changelog: Fix a bug causing `tctl`/`tsh` to fail on read-only file systems.
Changelog: the `teleport-distroless` container image now disables client tools updates by default (when using tsh/tctl, you will always use the version from the image). You can enable them back by unsetting the `TELEPORT_TOOLS_VERSION` environment variable.