### PR TITLE
chore: Accept 204 from FluentD responses

### DIFF
--- a/integrations/event-handler/fluentd_client.go
+++ b/integrations/event-handler/fluentd_client.go
@@ -130,7 +130,7 @@ func (f *FluentdClient) Send(ctx context.Context, url string, b []byte) error {
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode < 200 || r.StatusCode >= 300 {
+	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
 		return trace.Errorf("Failed to send event to fluentd (HTTP %v)", r.StatusCode)
 	}
 

--- a/integrations/event-handler/fluentd_client.go
+++ b/integrations/event-handler/fluentd_client.go
@@ -130,7 +130,7 @@ func (f *FluentdClient) Send(ctx context.Context, url string, b []byte) error {
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode != http.StatusOK {
+	if r.StatusCode < 200 || r.StatusCode >= 300 {
 		return trace.Errorf("Failed to send event to fluentd (HTTP %v)", r.StatusCode)
 	}
 


### PR DESCRIPTION
# Problem

Many orgs already have logging infrastructure in place, but do not use FluentD. In this case, Teleport Audit Event Logging requires teams to install and manage FluentD in addition to existing infra.

# Solution

This relaxes the status code validation for FluentD responses, in order to allow other log aggregators to accept the event handlers requests.

The changes in this PR allow [Grafana Alloy](https://grafana.com/docs/alloy/latest/) to be used as a replacement for FluentD, by using the [loki.sources.api](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.api/) component and configuring the Teleport event handler to point `url` and `session-url` to Alloy's `/loki/api/v1/raw` endpoint.

This change should accommodate any Log Collectors that support raw JSON and emit 200 or 204 status codes.

Without these changes in place, logs get duplicated in our logging infra:

```
Stack Trace:
        github.com/gravitational/teleport/integrations/event-handler/fluentd_client.go:134 main.(*FluentdClient).Send
        github.com/gravitational/teleport/integrations/event-handler/app.go:116 main.(*App).SendEvent
        github.com/gravitational/teleport/integrations/event-handler/events_job.go:313 main.(*EventsJob).sendEvent
        github.com/gravitational/teleport/integrations/event-handler/events_job.go:288 main.(*EventsJob).handleEvent
        github.com/gravitational/teleport/integrations/event-handler/events_job.go:282 main.(*EventsJob).handleEventV2
        github.com/gravitational/teleport@v0.0.0/lib/events/export/date_exporter.go:599 github.com/gravitational/teleport/lib/events/export.(*DateExporter).exportEvents
        github.com/gravitational/teleport@v0.0.0/lib/events/export/date_exporter.go:456 github.com/gravitational/teleport/lib/events/export.(*DateExporter).processChunk
        github.com/gravitational/teleport@v0.0.0/lib/events/export/date_exporter.go:433 github.com/gravitational/teleport/lib/events/export.(*DateExporter).startProcessingChunk.func2
        runtime/asm_amd64.s:1700 runtime.goexit
User Message: Failed to send event to fluentd (HTTP 204)] attempts:5 event-handler/app.go:133
```