### PR TITLE
Delete deprecated HTTP endpoints

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -134,17 +134,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// trusted clusters
 	srv.POST("/:version/trustedclusters/validate", srv.WithAuth(srv.validateTrustedCluster))
 
-	// these endpoints are still in use by v17 agents since they cache
-	// KindNamespace
-	//
-	// TODO(espadolini): REMOVE IN v19
-	srv.GET("/:version/namespaces", srv.WithAuth(srv.getNamespaces))
-	srv.GET("/:version/namespaces/:namespace", srv.WithAuth(srv.getNamespace))
-
-	// cluster configuration
-	// TODO(noah): DELETE IN v19.0.0 - from v18 we switched to a gRPC equiv.
-	srv.GET("/:version/configuration/name", srv.WithAuth(srv.getClusterName))
-
 	// SSO validation handlers
 	srv.POST("/:version/github/requests/validate", srv.WithAuth(srv.validateGithubAuthCallback))
 
@@ -152,6 +141,9 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/reversetunnels", httpMigratedHandler)
 	srv.GET("/:version/reversetunnels", httpMigratedHandler)
 	srv.DELETE("/:version/reversetunnels/:domain", httpMigratedHandler)
+	srv.GET("/:version/namespaces", httpMigratedHandler)
+	srv.GET("/:version/namespaces/:namespace", httpMigratedHandler)
+	srv.GET("/:version/configuration/name", httpMigratedHandler)
 
 	if config.PluginRegistry != nil {
 		if err := config.PluginRegistry.RegisterAuthWebHandlers(&srv); err != nil {
@@ -502,45 +494,6 @@ func (s *APIServer) validateGithubAuthCallback(auth *ServerWithRoles, w http.Res
 		raw.HostSigners[i] = data
 	}
 	return &raw, nil
-}
-
-func (*APIServer) getNamespaces(*ServerWithRoles, http.ResponseWriter, *http.Request, httprouter.Params, string) (any, error) {
-	return []types.Namespace{{
-		Kind:    types.KindNamespace,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Name:      defaults.Namespace,
-			Namespace: defaults.Namespace,
-		},
-	}}, nil
-}
-
-func (*APIServer) getNamespace(_ *ServerWithRoles, _ http.ResponseWriter, _ *http.Request, p httprouter.Params, _ string) (any, error) {
-	name := p.ByName("namespace")
-	if !types.IsValidNamespace(name) {
-		return nil, trace.BadParameter("invalid namespace %q", name)
-	}
-	if name != defaults.Namespace {
-		return nil, trace.NotFound("namespace %q is not found", name)
-	}
-
-	return &types.Namespace{
-		Kind:    types.KindNamespace,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Name:      defaults.Namespace,
-			Namespace: defaults.Namespace,
-		},
-	}, nil
-}
-
-func (s *APIServer) getClusterName(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
-	cn, err := auth.GetClusterName(r.Context())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return rawMessage(services.MarshalClusterName(cn, services.WithVersion(version), services.PreserveRevision()))
 }
 
 type upsertTunnelConnectionRawReq struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4697,16 +4697,6 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	return a.authServer.DeleteRole(ctx, name)
 }
 
-// GetClusterName gets the name of the cluster.
-// TODO(noah): DELETE IN v19.0.0 - when the apiserver getClusterName method is also
-// deleted.
-func (a *ServerWithRoles) GetClusterName(ctx context.Context) (types.ClusterName, error) {
-	if err := a.authorizeAction(types.KindClusterName, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a.authServer.GetClusterName(ctx)
-}
-
 // GetAuthPreference gets cluster auth preference.
 func (a *ServerWithRoles) GetAuthPreference(ctx context.Context) (types.AuthPreference, error) {
 	if err := a.authorizeAction(types.KindClusterAuthPreference, types.VerbRead); err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3347,7 +3347,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	}
 	// add implicit roles to the set and build a checker
 	roleSet := services.NewRoleSet(parsedRoles...)
-	clusterName, err := a.GetClusterName(ctx)
+	clusterName, err := a.authServer.GetClusterName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -18,43 +18,5 @@
 
 package authclient
 
-import (
-	"context"
-	"net/url"
-
-	"github.com/gravitational/trace"
-
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/services"
-)
-
 // httpfallback.go holds endpoints that have been converted to gRPC
 // but still need http fallback logic in the old client.
-
-// GetClusterName returns a cluster name
-// TODO(noah): DELETE IN 19.0.0
-func (c *Client) GetClusterName(ctx context.Context) (types.ClusterName, error) {
-	cn, err := c.APIClient.GetClusterName(ctx)
-	if err == nil {
-		return cn, nil
-	}
-	if !trace.IsNotImplemented(err) {
-		return nil, trace.Wrap(err)
-	}
-	return c.getClusterName(ctx)
-}
-
-// getClusterName returns a cluster name
-func (c *HTTPClient) getClusterName(ctx context.Context) (types.ClusterName, error) {
-	out, err := c.Get(ctx, c.Endpoint("configuration", "name"), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	cn, err := services.UnmarshalClusterName(out.Bytes())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return cn, err
-}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -400,7 +400,7 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			clusterName, err := auth.GetClusterName(auth.CloseContext())
+			clusterName, err := auth.authServer.GetClusterName(auth.CloseContext())
 			if err != nil {
 				return trace.Wrap(err)
 			}


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/6394

Removes three HTTP endpoints that have been deprecated:

- `GET /:version/namespaces` GetNamespaces
- `GET /:version/namespaces/:namespace` GetNamespace
- `GET /:version/configuration/name` GetClusterName

These were either replaced with a gRPC equivalent or were no longer in use.