### PR TITLE
Add Vale to the Lint (Docs) workflow

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -142,6 +142,26 @@ jobs:
         working-directory: 'docs'
         run: yarn markdown-lint
 
+      - name: Check out vale
+        uses: actions/checkout@v4
+        with:
+          repository: 'errata-ai/vale'
+          path: 'vale'
+
+      - name: Download vale
+        working-directory: 'vale'
+        env: 
+          GH_TOKEN: ${{ github.token }}
+          VALE_VERSION: 3.12.0
+        run: |
+          gh release download v${VALE_VERSION} --pattern="*Linux_64-bit*"
+          tar -xvf vale_${VALE_VERSION}_Linux_64-bit.tar.gz
+
+      - name: Check docs style
+        working-directory: 'docs/content/current'
+        run:
+          ${GITHUB_WORKSPACE}/vale/vale --config docs/.vale.ini docs/pages
+
       - name: Test the docs build
         working-directory: docs
         run: yarn build

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -142,25 +142,23 @@ jobs:
         working-directory: 'docs'
         run: yarn markdown-lint
 
-      - name: Check out vale
-        uses: actions/checkout@v4
-        with:
-          repository: 'errata-ai/vale'
-          path: 'vale'
-
       - name: Download vale
-        working-directory: 'vale'
         env: 
           GH_TOKEN: ${{ github.token }}
           VALE_VERSION: 3.12.0
+          # The sha256 checksum must be changed based on the downloaded package
+          # when you update the Vale version.
+          VALE_SHA256SUM: 3f4ea05cd1f2291b660ecf11a77cbb6b544b0f3b780604ad183f63285611321b
         run: |
-          gh release download v${VALE_VERSION} --pattern="*Linux_64-bit*"
+          VALE_FILENAME="vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          gh release download v${VALE_VERSION} --repo="errata-ai/vale" --pattern=${VALE_FILENAME}
+          sha256sum --check <<<"${VALE_SHA256SUM}  ${VALE_FILENAME}"
           tar -xvf vale_${VALE_VERSION}_Linux_64-bit.tar.gz
 
       - name: Check docs style
         working-directory: 'docs/content/current'
         run:
-          ${GITHUB_WORKSPACE}/vale/vale --config docs/.vale.ini docs/pages
+          ${GITHUB_WORKSPACE}/vale --config docs/.vale.ini docs/pages
 
       - name: Test the docs build
         working-directory: docs

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -157,7 +157,8 @@ jobs:
 
       - name: Check docs style
         working-directory: 'docs/content/current'
-        run:
+        run: |
+          echo "Running Vale style checks. For information about ignoring Vale rules, see: https://vale.sh/docs/formats/mdx#comments"
           "${GITHUB_WORKSPACE}/vale" --config docs/.vale.ini docs/pages
 
       - name: Test the docs build

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -151,14 +151,14 @@ jobs:
           VALE_SHA256SUM: 3f4ea05cd1f2291b660ecf11a77cbb6b544b0f3b780604ad183f63285611321b
         run: |
           VALE_FILENAME="vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
-          gh release download v${VALE_VERSION} --repo="errata-ai/vale" --pattern=${VALE_FILENAME}
+          gh release download "v${VALE_VERSION}" --repo="errata-ai/vale" --pattern="${VALE_FILENAME}"
           sha256sum --check <<<"${VALE_SHA256SUM}  ${VALE_FILENAME}"
-          tar -xvf vale_${VALE_VERSION}_Linux_64-bit.tar.gz
+          tar -xvf "vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
 
       - name: Check docs style
         working-directory: 'docs/content/current'
         run:
-          ${GITHUB_WORKSPACE}/vale --config docs/.vale.ini docs/pages
+          "${GITHUB_WORKSPACE}/vale" --config docs/.vale.ini docs/pages
 
       - name: Test the docs build
         working-directory: docs


### PR DESCRIPTION
Install and run Vale in the Lint (Docs) workflow in order to ensure that the documentation has a consistent style. This approach downloads a release from the Vale GitHub repository, extracts a precompiled binary, and runs it on all docs files. It assumes that all Vale warnings and errors are already resolved, so that any new ones would have been introduced by the target pull request.

This is an alternative to using reviewdog, which was behind a security incident (see #53162 for context). While reviewdog can inspect the diff introduced by a PR and limit its checks to changed lines, this change does not require reliance on an insecure dependency.