### PR TITLE
Remove the teleport.git variable

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -65,7 +65,6 @@
       "ca_pin": "sha256:abdc1245efgh5678abdc1245efgh5678abdc1245efgh5678abdc1245efgh5678"
     },
     "teleport": {
-      "git": "api/14.0.0-gd1e081e",
       "major_version": "19",
       "version": "19.0.0-dev",
       "url": "teleport.example.com",

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -29,7 +29,7 @@ Make sure the plugin is installed by running the following command:
 
 ```code
 $ docker run public.ecr.aws/gravitational/teleport-plugin-{{ name }}:(=teleport.plugin.version=) version
-teleport-{{ name }} v(=teleport.plugin.version=) git:teleport-{{ name }}-v(=teleport.plugin.version=)-(=teleport.git=) (=teleport.golang=)
+teleport-{{ name }} v(=teleport.plugin.version=) (=teleport.golang=)
 ```
 
 For a list of available tags, visit [Amazon ECR Public Gallery](https://gallery.ecr.aws/gravitational/teleport-plugin-{{ name }}).

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -108,12 +108,13 @@ $ sudo ./install
 After you download and install, all of the Teleport Enterprise binaries are
 installed in the `/usr/local/bin` directory. You can verify you have FIPS-compliant
 binaries installed by running the `teleport version` command and verifying that
-the `X:boringcrypto` library is listed. For example:
+the `X:boringcrypto` library is listed:
 
 ```code
 $ teleport version
-Teleport Enterprise (= teleport.version =) (= teleport.git =) (= teleport.golang =) X:boringcrypto
 ```
+
+The output should end with `X:boringcrypto`.
 
 If your Teleport cluster runs on AWS, the cluster can run in US-East or US-West regions for services
 with low or moderate impact levels. For services with a high impact level, the cluster must run


### PR DESCRIPTION
Closes #57170

This variable is long out of date, but is only used in two locations in the docs. Prevent us from having to maintain this variable by removing it.