### PR TITLE
Complete cryptosuitestest migration

### DIFF
--- a/lib/cryptosuites/cryptosuitestest/precompute.go
+++ b/lib/cryptosuites/cryptosuitestest/precompute.go
@@ -25,7 +25,7 @@ import (
 	internalrsa "github.com/gravitational/teleport/lib/cryptosuites/internal/rsa"
 )
 
-// PrecomputeRSATestKeys may be called from TestMain to set this package into a
+// PrecomputeRSAKeys may be called from TestMain to set this package into a
 // mode where it will precompute a fixed number of RSA keys and reuse them to
 // save on CPU usage.
 func PrecomputeRSAKeys(ctx context.Context) {

--- a/lib/cryptosuites/internal/rsa/rsa.go
+++ b/lib/cryptosuites/internal/rsa/rsa.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rsa"
 	"log/slog"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -84,58 +83,11 @@ func precomputeKeys() {
 	}
 }
 
-func precomputeTestKeys() {
-	generatedTestKeys := generateTestKeys()
-	keysToReuse := make([]*rsa.PrivateKey, 0, testKeysNumber)
-	for range testKeysNumber {
-		k := <-generatedTestKeys
-		PrecomputedKeys <- k
-		keysToReuse = append(keysToReuse, k)
-	}
-	for {
-		for _, k := range keysToReuse {
-			PrecomputedKeys <- k
-		}
-	}
-}
-
-// testKeysNumber is the number of RSA keys generated in tests.
-const testKeysNumber = 25
-
-func generateTestKeys() <-chan *rsa.PrivateKey {
-	generatedTestKeys := make(chan *rsa.PrivateKey, testKeysNumber)
-	for range testKeysNumber {
-		// Generate each key in a separate goroutine to take advantage of
-		// multiple cores if possible.
-		go func() {
-			private, err := generateRSAPrivateKey(constants.RSAKeySize)
-			if err != nil {
-				// Use only in tests. Safe to panic.
-				panic(err)
-			}
-			generatedTestKeys <- private
-		}()
-	}
-	return generatedTestKeys
-}
-
 // PrecomputeKeys sets this package into a mode where a small backlog of keys are
 // computed in advance. This should only be enabled if large spikes in key computation
 // are expected (e.g. in auth/proxy services). Safe to double-call.
 func PrecomputeKeys() {
 	StartPrecomputeOnce.Do(func() {
 		go precomputeKeys()
-	})
-}
-
-// PrecomputeTestKeys generates a fixed number of RSA keys and reuses them to
-// reduce CPU usage. This method should only be in tests. Safe to call multiple
-// times. This function takes *testing.M so it can only be used from TestMain in
-// tests.
-// Deprecated: prefer using cyptosuitestest.PrecomputeRSAKeys instead
-// TODO(tross): Delete once references in teleport.e are gone.
-func PrecomputeTestKeys(_ *testing.M) {
-	StartPrecomputeOnce.Do(func() {
-		go precomputeTestKeys()
 	})
 }

--- a/lib/cryptosuites/precompute.go
+++ b/lib/cryptosuites/precompute.go
@@ -17,8 +17,6 @@
 package cryptosuites
 
 import (
-	"testing"
-
 	"github.com/gravitational/teleport/lib/cryptosuites/internal/rsa"
 )
 
@@ -28,13 +26,4 @@ import (
 // is configured). Safe to double-call.
 func PrecomputeRSAKeys() {
 	rsa.PrecomputeKeys()
-}
-
-// PrecomputeRSATestKeys may be called from TestMain to set this package into a
-// mode where it will precompute a fixed number of RSA keys and reuse them to
-// save on CPU usage.
-// Deprecated: prefer using cryptosuitestest.PrecomputeRSAKeys
-// TODO(tross): Delete once teleport.e no longer references it.
-func PrecomputeRSATestKeys(m *testing.M) {
-	rsa.PrecomputeTestKeys(m)
 }


### PR DESCRIPTION
Now that https://github.com/gravitational/teleport.e/pull/6950 has landed the deprecated key pre-generation functions can be removed since they are no longer used.

Updates #51023.