### PR TITLE
[v17] Fix 25 Vale warnings

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -424,7 +424,7 @@ message AWS {
   ];
   // AccountID is the AWS account ID this database belongs to.
   string AccountID = 4 [(gogoproto.jsontag) = "account_id,omitempty"];
-  // ElastiCache contains AWS ElastiCache Redis specific metadata.
+  // ElastiCache contains Amazon ElastiCache Redis-specific metadata.
   ElastiCache ElastiCache = 5 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "elasticache,omitempty"
@@ -444,7 +444,7 @@ message AWS {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "rdsproxy,omitempty"
   ];
-  // RedshiftServerless contains AWS Redshift Serverless specific metadata.
+  // RedshiftServerless contains Amazon Redshift Serverless-specific metadata.
   RedshiftServerless RedshiftServerless = 9 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "redshift_serverless,omitempty"
@@ -470,7 +470,7 @@ message AWS {
   // SessionTags is a list of AWS STS session tags.
   map<string, string> SessionTags = 15 [(gogoproto.jsontag) = "session_tags,omitempty"];
 
-  // DocumentDB contains AWS DocumentDB specific metadata.
+  // DocumentDB contains Amazon DocumentDB-specific metadata.
   DocumentDB DocumentDB = 16 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "docdb,omitempty"
@@ -519,7 +519,7 @@ message RDSProxy {
   string ResourceID = 3 [(gogoproto.jsontag) = "resource_id,omitempty"];
 }
 
-// ElastiCache contains AWS ElastiCache Redis specific metadata.
+// ElastiCache contains Amazon ElastiCache Redis-specific metadata.
 message ElastiCache {
   // ReplicationGroupID is the Redis replication group ID.
   string ReplicationGroupID = 1 [(gogoproto.jsontag) = "replication_group_id,omitempty"];
@@ -543,7 +543,7 @@ message MemoryDB {
   string EndpointType = 4 [(gogoproto.jsontag) = "endpoint_type,omitempty"];
 }
 
-// RedshiftServerless contains AWS Redshift Serverless specific metadata.
+// RedshiftServerless contains Amazon Redshift Serverless-specific metadata.
 message RedshiftServerless {
   // WorkgroupName is the workgroup name.
   string WorkgroupName = 1 [(gogoproto.jsontag) = "workgroup_name,omitempty"];
@@ -563,7 +563,7 @@ message OpenSearch {
   string EndpointType = 3 [(gogoproto.jsontag) = "endpoint_type,omitempty"];
 }
 
-// DocumentDB contains AWS DocumentDB specific metadata.
+// DocumentDB contains Amazon DocumentDB-specific metadata.
 message DocumentDB {
   // ClusterID is the cluster identifier.
   string ClusterID = 1 [(gogoproto.jsontag) = "cluster_id,omitempty"];
@@ -2242,9 +2242,9 @@ message ClusterNetworkingConfigSpecV2 {
   // missed before the server disconnects the connection to the client.
   int64 KeepAliveCountMax = 3 [(gogoproto.jsontag) = "keep_alive_count_max"];
 
-  // SessionControlTimeout is the session control lease expiry and defines
-  // the upper limit of how long a node may be out of contact with the auth
-  // server before it begins terminating controlled sessions.
+  // SessionControlTimeout is the session control lease expiry and defines the
+  // upper limit of how long a node may be out of contact with the Auth Service
+  // before it begins terminating controlled sessions.
   int64 SessionControlTimeout = 4 [
     (gogoproto.jsontag) = "session_control_timeout",
     (gogoproto.casttype) = "Duration"

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -2029,7 +2029,7 @@ type AWS struct {
 	RDS RDS `protobuf:"bytes,3,opt,name=RDS,proto3" json:"rds,omitempty"`
 	// AccountID is the AWS account ID this database belongs to.
 	AccountID string `protobuf:"bytes,4,opt,name=AccountID,proto3" json:"account_id,omitempty"`
-	// ElastiCache contains AWS ElastiCache Redis specific metadata.
+	// ElastiCache contains Amazon ElastiCache Redis-specific metadata.
 	ElastiCache ElastiCache `protobuf:"bytes,5,opt,name=ElastiCache,proto3" json:"elasticache,omitempty"`
 	// SecretStore contains secret store configurations.
 	SecretStore SecretStore `protobuf:"bytes,6,opt,name=SecretStore,proto3" json:"secret_store,omitempty"`
@@ -2037,7 +2037,7 @@ type AWS struct {
 	MemoryDB MemoryDB `protobuf:"bytes,7,opt,name=MemoryDB,proto3" json:"memorydb,omitempty"`
 	// RDSProxy contains AWS Proxy specific metadata.
 	RDSProxy RDSProxy `protobuf:"bytes,8,opt,name=RDSProxy,proto3" json:"rdsproxy,omitempty"`
-	// RedshiftServerless contains AWS Redshift Serverless specific metadata.
+	// RedshiftServerless contains Amazon Redshift Serverless-specific metadata.
 	RedshiftServerless RedshiftServerless `protobuf:"bytes,9,opt,name=RedshiftServerless,proto3" json:"redshift_serverless,omitempty"`
 	// ExternalID is an optional AWS external ID used to enable assuming an AWS role across accounts.
 	ExternalID string `protobuf:"bytes,10,opt,name=ExternalID,proto3" json:"external_id,omitempty"`
@@ -2052,7 +2052,7 @@ type AWS struct {
 	IAMPolicyStatus IAMPolicyStatus `protobuf:"varint,14,opt,name=IAMPolicyStatus,proto3,enum=types.IAMPolicyStatus" json:"iam_policy_status"`
 	// SessionTags is a list of AWS STS session tags.
 	SessionTags map[string]string `protobuf:"bytes,15,rep,name=SessionTags,proto3" json:"session_tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// DocumentDB contains AWS DocumentDB specific metadata.
+	// DocumentDB contains Amazon DocumentDB-specific metadata.
 	DocumentDB           DocumentDB `protobuf:"bytes,16,opt,name=DocumentDB,proto3" json:"docdb,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
@@ -2278,7 +2278,7 @@ func (m *RDSProxy) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RDSProxy proto.InternalMessageInfo
 
-// ElastiCache contains AWS ElastiCache Redis specific metadata.
+// ElastiCache contains Amazon ElastiCache Redis-specific metadata.
 type ElastiCache struct {
 	// ReplicationGroupID is the Redis replication group ID.
 	ReplicationGroupID string `protobuf:"bytes,1,opt,name=ReplicationGroupID,proto3" json:"replication_group_id,omitempty"`
@@ -2374,7 +2374,7 @@ func (m *MemoryDB) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MemoryDB proto.InternalMessageInfo
 
-// RedshiftServerless contains AWS Redshift Serverless specific metadata.
+// RedshiftServerless contains Amazon Redshift Serverless-specific metadata.
 type RedshiftServerless struct {
 	// WorkgroupName is the workgroup name.
 	WorkgroupName string `protobuf:"bytes,1,opt,name=WorkgroupName,proto3" json:"workgroup_name,omitempty"`
@@ -2466,7 +2466,7 @@ func (m *OpenSearch) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_OpenSearch proto.InternalMessageInfo
 
-// DocumentDB contains AWS DocumentDB specific metadata.
+// DocumentDB contains Amazon DocumentDB-specific metadata.
 type DocumentDB struct {
 	// ClusterID is the cluster identifier.
 	ClusterID string `protobuf:"bytes,1,opt,name=ClusterID,proto3" json:"cluster_id,omitempty"`
@@ -6790,9 +6790,9 @@ type ClusterNetworkingConfigSpecV2 struct {
 	// KeepAliveCountMax is the number of keep-alive messages that can be
 	// missed before the server disconnects the connection to the client.
 	KeepAliveCountMax int64 `protobuf:"varint,3,opt,name=KeepAliveCountMax,proto3" json:"keep_alive_count_max"`
-	// SessionControlTimeout is the session control lease expiry and defines
-	// the upper limit of how long a node may be out of contact with the auth
-	// server before it begins terminating controlled sessions.
+	// SessionControlTimeout is the session control lease expiry and defines the
+	// upper limit of how long a node may be out of contact with the Auth Service
+	// before it begins terminating controlled sessions.
 	SessionControlTimeout Duration `protobuf:"varint,4,opt,name=SessionControlTimeout,proto3,casttype=Duration" json:"session_control_timeout"`
 	// ClientIdleTimeoutMessage is the message sent to the user when a connection times out.
 	ClientIdleTimeoutMessage string `protobuf:"bytes,5,opt,name=ClientIdleTimeoutMessage,proto3" json:"idle_timeout_message"`

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -12,8 +12,8 @@ labels:
 
 The Teleport Database Service proxies traffic between Teleport users and Azure
 Cache for Redis. When a user connects to the database via Teleport, the Database
-Service obtains an access token from Microsoft Entra ID (formerly Azure AD) and
-authenticates to Azure as a principal with permissions to manage the database.
+Service obtains an access token from Microsoft Entra ID and authenticates to
+Azure as a principal with permissions to manage the database.
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">

--- a/docs/pages/installation/helm.mdx
+++ b/docs/pages/installation/helm.mdx
@@ -12,7 +12,9 @@ and Access Request plugins.
 
 ## Installing Teleport as a cluster
 
-The [teleport-cluster](../reference/helm-reference/teleport-cluster.mdx) chart deploys the `teleport` daemon on Kubernetes with preset configurations for the Auth and Proxy Services and support for any Teleport service configuration.
+The [teleport-cluster](../reference/helm-reference/teleport-cluster.mdx) chart
+deploys the `teleport` daemon on Kubernetes with preset configurations for the
+Auth Service and Proxy Service and support for any Teleport service configuration.
 
 See the [Helm chart reference guide](../reference/helm-reference/teleport-cluster.mdx) or our [README](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/chart/teleport-cluster.mdx) on GitHub for available options and deployment examples.
 

--- a/docs/pages/installation/installation.mdx
+++ b/docs/pages/installation/installation.mdx
@@ -12,7 +12,7 @@ labels:
 Whether you are installing Teleport as a cluster or as an agent that talks to the cluster, the Teleport binary is the same. The difference is only in how you [configure it](../reference/config.mdx), which you will need to do after installation. Before choosing an installation method below, you should identify your particular use case. There are three:
 
 1. **Installing Teleport as a cluster:** Install a self-hosted Teleport cluster to provide secure, identity-based access to all your infrastructure. If you are running Teleport Enterprise Cloud, you will not need this use case, as the cluster is managed for you.
-2. **Installing Teleport as an agent:** Install a Teleport agent on your infrastructure resource to enroll it with your cluster for centralized access management.
+2. **Installing Teleport as an agent:** Install a Teleport Agent on your infrastructure resource to enroll it with your cluster for centralized access management.
 3. **Installing Teleport as a client:** For interacting with and managing your clusters via CLI and Teleport Connect.
 
 These use cases will be addressed in each platform page.

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1108,7 +1108,7 @@ $ tctl lock [<flags>]
 | `--server-id` | none | string | Target a specific node by name or UUID. |
 | `--mfa-device` | none | string | Target a specific MFA device by UUID. |
 | `--windows-desktop` | none | string | Target a specific Windows desktop by name. |
-| `--access-request` | none | string | Target a specific access request by ID. |
+| `--access-request` | none | string | Target a specific Access Request by ID. |
 | `--device` | none | string | Target a specific trusted device by ID. |
 | `--message` | none | string | Optional message explaining the reason for the lock. |
 | `--expires` | never | timestamp | When the lock should automatically expire (RFC3339). |

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -46,7 +46,7 @@ Optional:
 - `proxy_listener_mode` (Number) ProxyListenerMode is proxy listener mode used by Teleport Proxies. 0 is "separate"; 1 is "multiplex".
 - `proxy_ping_interval` (String) ProxyPingInterval defines in which interval the TLS routing ping message should be sent. This is applicable only when using ping-wrapped connections, regular TLS routing connections are not affected.
 - `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is "unambiguous_match"; 1 is "most_recent".
-- `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the auth server before it begins terminating controlled sessions.
+- `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the Auth Service before it begins terminating controlled sessions.
 - `ssh_dial_timeout` (String) SSHDialTimeout is a custom dial timeout used when establishing SSH connections. If not set, the default timeout of 30s will be used.
 - `tunnel_strategy` (Attributes) TunnelStrategyV1 determines the tunnel strategy used in the cluster. (see [below for nested schema](#nested-schema-for-spectunnel_strategy))
 - `web_idle_timeout` (String) WebIdleTimeout sets global cluster default setting for the web UI idle timeouts.

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -89,8 +89,8 @@ Optional:
 
 - `account_id` (String) AccountID is the AWS account ID this database belongs to.
 - `assume_role_arn` (String) AssumeRoleARN is an optional AWS role ARN to assume when accessing a database. Set this field and ExternalID to enable access across AWS accounts.
-- `docdb` (Attributes) DocumentDB contains AWS DocumentDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
-- `elasticache` (Attributes) ElastiCache contains AWS ElastiCache Redis specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
+- `docdb` (Attributes) DocumentDB contains Amazon DocumentDB-specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
+- `elasticache` (Attributes) ElastiCache contains Amazon ElastiCache Redis-specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
 - `external_id` (String) ExternalID is an optional AWS external ID used to enable assuming an AWS role across accounts.
 - `iam_policy_status` (Number) IAMPolicyStatus indicates whether the IAM Policy is configured properly for database access. If not, the user must update the AWS profile identity to allow access to the Database. Eg for an RDS Database: the underlying AWS profile allows for `rds-db:connect` for the Database.
 - `memorydb` (Attributes) MemoryDB contains AWS MemoryDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsmemorydb))
@@ -98,7 +98,7 @@ Optional:
 - `rds` (Attributes) RDS contains RDS specific metadata. (see [below for nested schema](#nested-schema-for-specawsrds))
 - `rdsproxy` (Attributes) RDSProxy contains AWS Proxy specific metadata. (see [below for nested schema](#nested-schema-for-specawsrdsproxy))
 - `redshift` (Attributes) Redshift contains Redshift specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift))
-- `redshift_serverless` (Attributes) RedshiftServerless contains AWS Redshift Serverless specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift_serverless))
+- `redshift_serverless` (Attributes) RedshiftServerless contains Amazon Redshift Serverless-specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift_serverless))
 - `region` (String) Region is a AWS cloud region.
 - `secret_store` (Attributes) SecretStore contains secret store configurations. (see [below for nested schema](#nested-schema-for-specawssecret_store))
 - `session_tags` (Map of String) SessionTags is a list of AWS STS session tags.

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -65,7 +65,7 @@ Optional:
 - `proxy_listener_mode` (Number) ProxyListenerMode is proxy listener mode used by Teleport Proxies. 0 is "separate"; 1 is "multiplex".
 - `proxy_ping_interval` (String) ProxyPingInterval defines in which interval the TLS routing ping message should be sent. This is applicable only when using ping-wrapped connections, regular TLS routing connections are not affected.
 - `routing_strategy` (Number) RoutingStrategy determines the strategy used to route to nodes. 0 is "unambiguous_match"; 1 is "most_recent".
-- `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the auth server before it begins terminating controlled sessions.
+- `session_control_timeout` (String) SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the Auth Service before it begins terminating controlled sessions.
 - `ssh_dial_timeout` (String) SSHDialTimeout is a custom dial timeout used when establishing SSH connections. If not set, the default timeout of 30s will be used.
 - `tunnel_strategy` (Attributes) TunnelStrategyV1 determines the tunnel strategy used in the cluster. (see [below for nested schema](#nested-schema-for-spectunnel_strategy))
 - `web_idle_timeout` (String) WebIdleTimeout sets global cluster default setting for the web UI idle timeouts.

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -109,8 +109,8 @@ Optional:
 
 - `account_id` (String) AccountID is the AWS account ID this database belongs to.
 - `assume_role_arn` (String) AssumeRoleARN is an optional AWS role ARN to assume when accessing a database. Set this field and ExternalID to enable access across AWS accounts.
-- `docdb` (Attributes) DocumentDB contains AWS DocumentDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
-- `elasticache` (Attributes) ElastiCache contains AWS ElastiCache Redis specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
+- `docdb` (Attributes) DocumentDB contains Amazon DocumentDB-specific metadata. (see [below for nested schema](#nested-schema-for-specawsdocdb))
+- `elasticache` (Attributes) ElastiCache contains Amazon ElastiCache Redis-specific metadata. (see [below for nested schema](#nested-schema-for-specawselasticache))
 - `external_id` (String) ExternalID is an optional AWS external ID used to enable assuming an AWS role across accounts.
 - `iam_policy_status` (Number) IAMPolicyStatus indicates whether the IAM Policy is configured properly for database access. If not, the user must update the AWS profile identity to allow access to the Database. Eg for an RDS Database: the underlying AWS profile allows for `rds-db:connect` for the Database.
 - `memorydb` (Attributes) MemoryDB contains AWS MemoryDB specific metadata. (see [below for nested schema](#nested-schema-for-specawsmemorydb))
@@ -118,7 +118,7 @@ Optional:
 - `rds` (Attributes) RDS contains RDS specific metadata. (see [below for nested schema](#nested-schema-for-specawsrds))
 - `rdsproxy` (Attributes) RDSProxy contains AWS Proxy specific metadata. (see [below for nested schema](#nested-schema-for-specawsrdsproxy))
 - `redshift` (Attributes) Redshift contains Redshift specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift))
-- `redshift_serverless` (Attributes) RedshiftServerless contains AWS Redshift Serverless specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift_serverless))
+- `redshift_serverless` (Attributes) RedshiftServerless contains Amazon Redshift Serverless-specific metadata. (see [below for nested schema](#nested-schema-for-specawsredshift_serverless))
 - `region` (String) Region is a AWS cloud region.
 - `secret_store` (Attributes) SecretStore contains secret store configurations. (see [below for nested schema](#nested-schema-for-specawssecret_store))
 - `session_tags` (Map of String) SessionTags is a list of AWS STS session tags.

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -166,10 +166,10 @@ Identity Governance Monthly Active Users (IG MAU) is the aggregate number of uni
 We aggregate IG MAU over each monthly period starting on the subscription start date and ending on each monthly anniversary thereafter.
 
 Identity Governance "active user" means a user having performed any of the following activities:
-- Submitting an access request
-- Reviewing an access request
-- Getting roles assigned during login through access list membership
-- Reviewing an access list
+- Submitting an Access Request
+- Reviewing an Access Request
+- Getting roles assigned during login through Access List membership
+- Reviewing an Access List
 - Logging in to a service provider application via Teleport SAML IdP
 
 IG MAU is calculated separately from standard MAU and represents users specifically engaging with Teleport's Identity Governance features. A user can contribute to both standard MAU and IG MAU billing metrics within the same period if they perform activities that qualify for both metrics.

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -197,7 +197,7 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 							}),
-							Description: "DocumentDB contains AWS DocumentDB specific metadata.",
+							Description: "DocumentDB contains Amazon DocumentDB-specific metadata.",
 							Optional:    true,
 						},
 						"elasticache": {
@@ -223,7 +223,7 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.ListType{ElemType: github_com_hashicorp_terraform_plugin_framework_types.StringType},
 								},
 							}),
-							Description: "ElastiCache contains AWS ElastiCache Redis specific metadata.",
+							Description: "ElastiCache contains Amazon ElastiCache Redis-specific metadata.",
 							Optional:    true,
 						},
 						"external_id": {
@@ -372,7 +372,7 @@ func GenSchemaDatabaseV3(ctx context.Context) (github_com_hashicorp_terraform_pl
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 							}),
-							Description: "RedshiftServerless contains AWS Redshift Serverless specific metadata.",
+							Description: "RedshiftServerless contains Amazon Redshift Serverless-specific metadata.",
 							Optional:    true,
 						},
 						"region": {
@@ -1161,7 +1161,7 @@ func GenSchemaClusterNetworkingConfigV2(ctx context.Context) (github_com_hashico
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.Int64Type,
 				},
 				"session_control_timeout": {
-					Description: "SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the auth server before it begins terminating controlled sessions.",
+					Description: "SessionControlTimeout is the session control lease expiry and defines the upper limit of how long a node may be out of contact with the Auth Service before it begins terminating controlled sessions.",
 					Optional:    true,
 					Type:        DurationType{},
 				},


### PR DESCRIPTION
Backports #56953

Fix capitalization and minor word usage, e.g., AWS product names.

Edit protos in order to fix Terraform and Kubernetes Operator reference docs.