### PR TITLE
[v16] Fix domain name examples in docs

### DIFF
--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -16,7 +16,7 @@
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 
   # Provide your Teleport domain to query the latest compatible Teleport version
-  $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+  $ export TELEPORT_DOMAIN=<Var name="teleport.example.com" />
   $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
 
   # Update the repo and install Teleport and the Teleport updater
@@ -38,7 +38,7 @@
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
 
   # Provide your Teleport domain to query the latest compatible Teleport version
-  $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+  $ export TELEPORT_DOMAIN=<Var name="teleport.example.com" />
   $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
 
   # Install Teleport and the Teleport updater
@@ -59,7 +59,7 @@
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-yum.repo")"
 
   # Provide your Teleport domain to query the latest compatible Teleport version
-  $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+  $ export TELEPORT_DOMAIN=<Var name="teleport.example.com" />
   $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
   
   # Install Teleport and the Teleport updater
@@ -80,7 +80,7 @@
   $ sudo zypper addrepo --refresh --repo $(rpm --eval "https://zypper.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport-zypper.repo")
 
   # Provide your Teleport domain to query the latest compatible Teleport version
-  $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+  $ export TELEPORT_DOMAIN=<Var name="teleport.example.com" />
   $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
   
   # Install Teleport and the Teleport updater

--- a/docs/pages/includes/install-linux-enterprise.mdx
+++ b/docs/pages/includes/install-linux-enterprise.mdx
@@ -13,14 +13,14 @@ Install Teleport on your Linux server:
    with the updater:
 
    ```code
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="teleport.example.com" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
    ```
    
    Otherwise, get the version of your Teleport cluster:
    
    ```code 
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="teleport.example.com" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/ping | jq -r '.server_version')"
    ```
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -29,14 +29,14 @@ On *older Teleport versions*:
    with the updater:
 
    ```code
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="teleport.example.com:443" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
    ```
 
    Otherwise, get the version of your Teleport cluster:
 
    ```code
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="teleport.example.com:443" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/ping | jq -r '.server_version')"
    ```
 

--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -39,7 +39,7 @@ url = "https://fluentd.example.com:8888/test.log"
 session-url = "https://fluentd.example.com:8888/session"
 
 [teleport]
-addr = "example.teleport.com:443"
+addr = "teleport.example.com:443"
 identity = "identity"
 ```
 
@@ -79,7 +79,7 @@ eventHandler:
   skipSessionTypes: []
 
 teleport:
-  address: "example.teleport.com:443"
+  address: "teleport.example.com:443"
   identitySecretName: teleport-event-handler-identity
   identitySecretPath: identity
 


### PR DESCRIPTION
Backports #56938

Closes #56814

Some docs pages unintentionally use `example.teleport.com` in domain name examples when they should have used `teleport.example.com`. Replace incorrect example domains with the correct domain.

This change is based on a docs-wide `find` and `sed` command to change `example.teleport.com` to `teleport.example.com`.