### PR TITLE
[tctl/top] Refactor keymaps into common module

### DIFF
--- a/tool/tctl/common/top/model.go
+++ b/tool/tctl/common/top/model.go
@@ -34,6 +34,7 @@ import (
 	"github.com/guptarohit/asciigraph"
 
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/tool/tctl/common/top/tui/keymap"
 )
 
 // topModel is a [tea.Model] implementation which
@@ -95,22 +96,22 @@ func (m *topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height - v
 		m.width = msg.Width - h
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
+		switch {
+		case key.Matches(msg, keymap.Keymap.Quit):
 			return m, tea.Quit
-		case "1":
+		case key.Matches(msg, keymap.Keymap.Common):
 			m.selected = 0
-		case "2":
+		case key.Matches(msg, keymap.Keymap.Backend):
 			m.selected = 1
-		case "3":
+		case key.Matches(msg, keymap.Keymap.Cache):
 			m.selected = 2
-		case "4":
+		case key.Matches(msg, keymap.Keymap.Watcher):
 			m.selected = 3
-		case "5":
+		case key.Matches(msg, keymap.Keymap.Audit):
 			m.selected = 4
-		case "right":
+		case key.Matches(msg, keymap.Keymap.Right):
 			m.selected = min(m.selected+1, len(tabs)-1)
-		case "left":
+		case key.Matches(msg, keymap.Keymap.Left):
 			m.selected = max(m.selected-1, 0)
 		}
 	case *Report:
@@ -194,7 +195,7 @@ func (m *topModel) footerView() string {
 		Inline(true).
 		Width(35).
 		Align(lipgloss.Center).
-		Render(m.help.View(helpKeys))
+		Render(m.help.View(keymap.Keymap))
 
 	center := lipgloss.NewStyle().
 		Inline(true).
@@ -558,41 +559,7 @@ func tabView(selectedTab int) string {
 	return output
 }
 
-// keyMap is used to display the help text at
-// the bottom of the screen.
-type keyMap struct {
-	quit  key.Binding
-	right key.Binding
-	left  key.Binding
-}
-
-func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.left, k.right, k.quit}
-}
-
-func (k keyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{
-		{k.left, k.right},
-		{k.quit},
-	}
-}
-
 var (
-	helpKeys = keyMap{
-		quit: key.NewBinding(
-			key.WithKeys("q", "esc", "ctrl+c"),
-			key.WithHelp("q", "quit"),
-		),
-		left: key.NewBinding(
-			key.WithKeys("left", "esc"),
-			key.WithHelp("left", "previous"),
-		),
-		right: key.NewBinding(
-			key.WithKeys("right"),
-			key.WithHelp("right", "next"),
-		),
-	}
-
 	statusBarStyle = lipgloss.NewStyle()
 
 	separator = lipgloss.NewStyle().

--- a/tool/tctl/common/top/tui/keymap.go
+++ b/tool/tctl/common/top/tui/keymap.go
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package keymap
+package tui
 
 import "github.com/charmbracelet/bubbles/key"
 
-type keyMap struct {
+type KeyMap struct {
 	Quit  key.Binding
 	Right key.Binding
 	Left  key.Binding
@@ -31,43 +31,11 @@ type keyMap struct {
 	Audit   key.Binding
 }
 
-var (
-	Keymap = keyMap{
-		Quit: key.NewBinding(
-			key.WithKeys("q", "ctrl+c"),
-			key.WithHelp("q", "quit"),
-		),
-		Left: key.NewBinding(
-			key.WithKeys("left", "esc", "shift+tab", "h"),
-			key.WithHelp("←", "previous"),
-		),
-		Right: key.NewBinding(
-			key.WithKeys("right", "tab", "l"),
-			key.WithHelp("→", "next"),
-		),
-		Common: key.NewBinding(
-			key.WithKeys("1"), key.WithHelp("1", "common"),
-		),
-		Backend: key.NewBinding(
-			key.WithKeys("2"), key.WithHelp("2", "backend"),
-		),
-		Cache: key.NewBinding(
-			key.WithKeys("3"), key.WithHelp("3", "cache"),
-		),
-		Watcher: key.NewBinding(
-			key.WithKeys("4"), key.WithHelp("4", "watcher"),
-		),
-		Audit: key.NewBinding(
-			key.WithKeys("5"), key.WithHelp("5", "audit"),
-		),
-	}
-)
-
-func (k keyMap) ShortHelp() []key.Binding {
+func (k KeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{k.Left, k.Right, k.Quit}
 }
 
-func (k keyMap) FullHelp() [][]key.Binding {
+func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Left, k.Right},
 		{k.Quit},

--- a/tool/tctl/common/top/tui/keymap/keymap.go
+++ b/tool/tctl/common/top/tui/keymap/keymap.go
@@ -1,0 +1,59 @@
+package keymap
+
+import "github.com/charmbracelet/bubbles/key"
+
+type keyMap struct {
+	Quit  key.Binding
+	Right key.Binding
+	Left  key.Binding
+
+	// Tabs
+	Common  key.Binding
+	Backend key.Binding
+	Cache   key.Binding
+	Watcher key.Binding
+	Audit   key.Binding
+}
+
+var (
+	Keymap = keyMap{
+		Quit: key.NewBinding(
+			key.WithKeys("q", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+		Left: key.NewBinding(
+			key.WithKeys("left", "esc", "shift+tab", "h"),
+			key.WithHelp("←", "previous"),
+		),
+		Right: key.NewBinding(
+			key.WithKeys("right", "tab", "l"),
+			key.WithHelp("→", "next"),
+		),
+		Common: key.NewBinding(
+			key.WithKeys("1"), key.WithHelp("1", "common"),
+		),
+		Backend: key.NewBinding(
+			key.WithKeys("2"), key.WithHelp("2", "backend"),
+		),
+		Cache: key.NewBinding(
+			key.WithKeys("3"), key.WithHelp("3", "cache"),
+		),
+		Watcher: key.NewBinding(
+			key.WithKeys("4"), key.WithHelp("4", "watcher"),
+		),
+		Audit: key.NewBinding(
+			key.WithKeys("5"), key.WithHelp("5", "audit"),
+		),
+	}
+)
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Left, k.Right, k.Quit}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Left, k.Right},
+		{k.Quit},
+	}
+}

--- a/tool/tctl/common/top/tui/keymap/keymap.go
+++ b/tool/tctl/common/top/tui/keymap/keymap.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package keymap
 
 import "github.com/charmbracelet/bubbles/key"


### PR DESCRIPTION
This clean up commit moves the keymappings into
a common module which will make adding nested models which reuse keybinds easier. It also now makes use of `key.Matches` on key messages to ensure the keybinds do not drift between the help struct and the implemention.

Towards: #56944