### PR TITLE
Improve auto updates data model

### DIFF
--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -16,10 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { GetClusterVersionsResponse } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
+
 import Logger, { NullService } from 'teleterm/logger';
 
 import {
-  AutoUpdatesEnabled,
+  AutoUpdatesStatus,
   resolveAutoUpdatesStatus,
   shouldAutoDownload,
 } from './autoUpdatesStatus';
@@ -28,7 +30,15 @@ beforeAll(() => {
   Logger.init(new NullService());
 });
 
-test.each([
+test.each<{
+  title: string;
+  input: {
+    versionEnvVar: string;
+    managingClusterUri: string;
+    getClusterVersions: () => Promise<GetClusterVersionsResponse>;
+  };
+  expected: AutoUpdatesStatus;
+}>([
   {
     title: 'disabled when env var is "off"',
     input: {
@@ -42,6 +52,12 @@ test.each([
     expected: {
       enabled: false,
       reason: 'disabled-by-env-var',
+      options: {
+        managingClusterUri: '',
+        highestCompatibleVersion: '',
+        unreachableClusters: [],
+        clusters: [],
+      },
     },
   },
   {
@@ -57,14 +73,20 @@ test.each([
     expected: {
       enabled: true,
       version: '14.0.0',
-      source: { kind: 'env-var' },
+      source: 'env-var',
+      options: {
+        managingClusterUri: '',
+        highestCompatibleVersion: '',
+        unreachableClusters: [],
+        clusters: [],
+      },
     },
   },
   {
     title: 'disabled when no versions with auto-update enabled',
     input: {
       versionEnvVar: '',
-      managingClusterUri: '',
+      managingClusterUri: undefined,
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -80,16 +102,20 @@ test.each([
     expected: {
       enabled: false,
       reason: 'no-cluster-with-auto-update',
-      clusters: [
-        {
-          clusterUri: '/clusters/cluster-a',
-          toolsAutoUpdate: false,
-          toolsVersion: '14.0.0',
-          minToolsVersion: '13.0.0-aa',
-          otherCompatibleClusters: [],
-        },
-      ],
-      unreachableClusters: [],
+      options: {
+        managingClusterUri: undefined,
+        highestCompatibleVersion: undefined,
+        clusters: [
+          {
+            clusterUri: '/clusters/cluster-a',
+            toolsAutoUpdate: false,
+            toolsVersion: '14.0.0',
+            minToolsVersion: '13.0.0-aa',
+            otherCompatibleClusters: [],
+          },
+        ],
+        unreachableClusters: [],
+      },
     },
   },
   {
@@ -112,9 +138,10 @@ test.each([
     expected: {
       enabled: true,
       version: '14.0.0',
-      source: {
-        kind: 'managing-cluster',
-        clusterUri: '/clusters/cluster-a',
+      source: 'managing-cluster',
+      options: {
+        highestCompatibleVersion: '14.0.0',
+        managingClusterUri: '/clusters/cluster-a',
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -155,8 +182,10 @@ test.each([
     expected: {
       enabled: true,
       version: '14.0.0',
-      source: {
-        kind: 'most-compatible',
+      source: 'highest-compatible',
+      options: {
+        highestCompatibleVersion: '14.0.0',
+        managingClusterUri: undefined,
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -174,7 +203,6 @@ test.each([
           },
         ],
         unreachableClusters: [],
-        skippedManagingClusterUri: '',
       },
     },
   },
@@ -205,8 +233,10 @@ test.each([
     expected: {
       enabled: true,
       version: '14.2.0', // the newer version should be taken
-      source: {
-        kind: 'most-compatible',
+      source: 'highest-compatible',
+      options: {
+        highestCompatibleVersion: '14.2.0',
+        managingClusterUri: undefined,
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -224,7 +254,6 @@ test.each([
           },
         ],
         unreachableClusters: [],
-        skippedManagingClusterUri: '',
       },
     },
   },
@@ -255,8 +284,10 @@ test.each([
     expected: {
       enabled: true,
       version: '18.2.0', // From semver spec: pre-releases have lower precedence than a normal version.
-      source: {
-        kind: 'most-compatible',
+      source: 'highest-compatible',
+      options: {
+        highestCompatibleVersion: '18.2.0',
+        managingClusterUri: undefined,
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -274,7 +305,6 @@ test.each([
           },
         ],
         unreachableClusters: [],
-        skippedManagingClusterUri: '',
       },
     },
   },
@@ -305,8 +335,10 @@ test.each([
     expected: {
       enabled: true,
       version: '15.0.0',
-      source: {
-        kind: 'most-compatible',
+      source: 'highest-compatible',
+      options: {
+        highestCompatibleVersion: '15.0.0',
+        managingClusterUri: undefined,
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -324,13 +356,12 @@ test.each([
           },
         ],
         unreachableClusters: [],
-        skippedManagingClusterUri: '',
       },
     },
   },
   {
     title:
-      'resolving using most compatible version when cluster managing no longer has `toolsAutoUpdate` set to true',
+      'disabled when cluster managing updates no longer has `toolsAutoUpdate` set to true',
     input: {
       versionEnvVar: '',
       getClusterVersions: async () => ({
@@ -353,10 +384,11 @@ test.each([
       managingClusterUri: '/clusters/cluster-a',
     },
     expected: {
-      enabled: true,
-      version: '15.0.0',
-      source: {
-        kind: 'most-compatible',
+      enabled: false,
+      reason: 'managing-cluster-unable-to-manage',
+      options: {
+        highestCompatibleVersion: '15.0.0',
+        managingClusterUri: '/clusters/cluster-a',
         clusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -373,14 +405,12 @@ test.each([
             otherCompatibleClusters: ['/clusters/cluster-a'],
           },
         ],
-        skippedManagingClusterUri: '/clusters/cluster-a',
         unreachableClusters: [],
       },
     },
   },
   {
-    title:
-      'resolving using most compatible version when cluster managing updates is unreachable',
+    title: 'disabled when cluster managing updates is unreachable',
     input: {
       versionEnvVar: '',
       getClusterVersions: async () => ({
@@ -402,10 +432,11 @@ test.each([
       managingClusterUri: '/clusters/cluster-a',
     },
     expected: {
-      enabled: true,
-      version: '15.0.0',
-      source: {
-        kind: 'most-compatible',
+      enabled: false,
+      reason: 'managing-cluster-unable-to-manage',
+      options: {
+        highestCompatibleVersion: '15.0.0',
+        managingClusterUri: '/clusters/cluster-a',
         clusters: [
           {
             clusterUri: '/clusters/cluster-b',
@@ -415,7 +446,6 @@ test.each([
             otherCompatibleClusters: [],
           },
         ],
-        skippedManagingClusterUri: '/clusters/cluster-a',
         unreachableClusters: [
           {
             clusterUri: '/clusters/cluster-a',
@@ -458,30 +488,34 @@ test.each([
     expected: {
       enabled: false,
       reason: 'no-compatible-version',
-      clusters: [
-        {
-          clusterUri: '/clusters/cluster-a',
-          toolsAutoUpdate: false,
-          toolsVersion: '18.0.0',
-          minToolsVersion: '17.0.0-aa',
-          otherCompatibleClusters: [],
-        },
-        {
-          clusterUri: '/clusters/cluster-b',
-          toolsAutoUpdate: true,
-          toolsVersion: '16.0.0',
-          minToolsVersion: '15.0.0-aa',
-          otherCompatibleClusters: ['/clusters/cluster-c'],
-        },
-        {
-          clusterUri: '/clusters/cluster-c',
-          toolsAutoUpdate: true,
-          toolsVersion: '16.1.0',
-          minToolsVersion: '15.0.0-aa',
-          otherCompatibleClusters: ['/clusters/cluster-b'],
-        },
-      ],
-      unreachableClusters: [],
+      options: {
+        highestCompatibleVersion: undefined,
+        managingClusterUri: undefined,
+        clusters: [
+          {
+            clusterUri: '/clusters/cluster-a',
+            toolsAutoUpdate: false,
+            toolsVersion: '18.0.0',
+            minToolsVersion: '17.0.0-aa',
+            otherCompatibleClusters: [],
+          },
+          {
+            clusterUri: '/clusters/cluster-b',
+            toolsAutoUpdate: true,
+            toolsVersion: '16.0.0',
+            minToolsVersion: '15.0.0-aa',
+            otherCompatibleClusters: ['/clusters/cluster-c'],
+          },
+          {
+            clusterUri: '/clusters/cluster-c',
+            toolsAutoUpdate: true,
+            toolsVersion: '16.1.0',
+            minToolsVersion: '15.0.0-aa',
+            otherCompatibleClusters: ['/clusters/cluster-b'],
+          },
+        ],
+        unreachableClusters: [],
+      },
     },
   },
 ])('$title', async ({ input, expected }) => {
@@ -489,64 +523,30 @@ test.each([
   expect(result).toEqual(expected);
 });
 
-describe('should not auto download', () => {
-  test.each<{ title: string; input: AutoUpdatesEnabled }>([
-    {
-      title: 'when cluster previously managing updates was skipped',
-      input: {
-        enabled: true,
-        version: '15.0.0',
-        source: {
-          clusters: [
-            {
-              clusterUri: '/clusters/cluster-a',
-              minToolsVersion: '15.0.0-aa',
-              otherCompatibleClusters: ['/clusters/cluster-b'],
-              toolsAutoUpdate: false,
-              toolsVersion: '16.1.0',
-            },
-            {
-              clusterUri: '/clusters/cluster-b',
-              minToolsVersion: '15.0.0-aa',
-              otherCompatibleClusters: ['/clusters/cluster-a'],
-              toolsAutoUpdate: true,
-              toolsVersion: '16.1.0',
-            },
-          ],
-          skippedManagingClusterUri: '/clusters/cluster-b',
-          kind: 'most-compatible',
-          unreachableClusters: [],
+test('should not auto download when there is unreachable cluster in highest-compatible resolution', () => {
+  const result = shouldAutoDownload({
+    enabled: true,
+    version: '16.1.0',
+    source: 'highest-compatible',
+    options: {
+      highestCompatibleVersion: '16.1.0',
+      managingClusterUri: '',
+      clusters: [
+        {
+          clusterUri: '/clusters/cluster-b',
+          minToolsVersion: '15.0.0-aa',
+          otherCompatibleClusters: [],
+          toolsAutoUpdate: true,
+          toolsVersion: '16.1.0',
         },
-      },
-    },
-    {
-      title: 'when there is unreachable cluster',
-      input: {
-        enabled: true,
-        version: '16.1.0',
-        source: {
-          clusters: [
-            {
-              clusterUri: '/clusters/cluster-b',
-              minToolsVersion: '15.0.0-aa',
-              otherCompatibleClusters: [],
-              toolsAutoUpdate: true,
-              toolsVersion: '16.1.0',
-            },
-          ],
-          skippedManagingClusterUri: '/clusters/cluster-b',
-          kind: 'most-compatible',
-          unreachableClusters: [
-            {
-              clusterUri: '/clusters/cluster-a',
-              errorMessage: 'Something went wrong',
-            },
-          ],
+      ],
+      unreachableClusters: [
+        {
+          clusterUri: '/clusters/cluster-a',
+          errorMessage: 'Something went wrong',
         },
-      },
+      ],
     },
-  ])('$title', ({ input }) => {
-    const result = shouldAutoDownload(input);
-    expect(result).toBeFalsy();
   });
+  expect(result).toBeFalsy();
 });

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -376,7 +376,7 @@ test.each<{
             clusterUri: '/clusters/cluster-b',
             toolsVersion: '15.0.0',
             minToolsVersion: '14.0.0-aa',
-            toolsAutoUpdate: true,
+            toolsAutoUpdate: false,
           },
         ],
         unreachableClusters: [],
@@ -387,7 +387,7 @@ test.each<{
       enabled: false,
       reason: 'managing-cluster-unable-to-manage',
       options: {
-        highestCompatibleVersion: '15.0.0',
+        highestCompatibleVersion: undefined,
         managingClusterUri: '/clusters/cluster-a',
         clusters: [
           {
@@ -399,7 +399,7 @@ test.each<{
           },
           {
             clusterUri: '/clusters/cluster-b',
-            toolsAutoUpdate: true,
+            toolsAutoUpdate: false,
             toolsVersion: '15.0.0',
             minToolsVersion: '14.0.0-aa',
             otherCompatibleClusters: ['/clusters/cluster-a'],

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
@@ -109,14 +109,6 @@ function findVersionFromClusters(
   options: AutoUpdatesOptions
 ): AutoUpdatesStatus {
   const { managingClusterUri, clusters, highestCompatibleVersion } = options;
-  const autoUpdateCandidateClusters = clusters.filter(c => c.toolsAutoUpdate);
-  if (!autoUpdateCandidateClusters.length) {
-    return {
-      options,
-      enabled: false,
-      reason: 'no-cluster-with-auto-update',
-    };
-  }
 
   if (managingClusterUri) {
     const managingCluster = clusters.find(
@@ -139,6 +131,15 @@ function findVersionFromClusters(
       options,
       enabled: false,
       reason: 'managing-cluster-unable-to-manage',
+    };
+  }
+
+  const autoUpdateCandidateClusters = clusters.filter(c => c.toolsAutoUpdate);
+  if (!autoUpdateCandidateClusters.length) {
+    return {
+      options,
+      enabled: false,
+      reason: 'no-cluster-with-auto-update',
     };
   }
 
@@ -255,16 +256,16 @@ export interface AutoUpdatesDisabled {
   /**
    * Reason the updates are disabled:
    * `disabled-by-env-var` - `TELEPORT_TOOLS_VERSION` is 'off'.
-   * `no-cluster-with-auto-update` - there is no cluster that could manage updates.
    * `managing-cluster-unable-to-manage` - the manually selected managing cluster is either
    * unreachable or it has since disabled autoupdates.
+   * `no-cluster-with-auto-update` - there is no cluster that could manage updates.
    * `no-compatible-version` - there are clusters that could manage updates, but
    * they specify incompatible client tools versions.
    */
   reason:
     | 'disabled-by-env-var'
-    | 'no-cluster-with-auto-update'
     | 'managing-cluster-unable-to-manage'
+    | 'no-cluster-with-auto-update'
     | 'no-compatible-version';
   /**
    * Represents the options considered during the auto-update version resolution process.

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.ts
@@ -34,7 +34,7 @@ const logger = new Logger('resolveAutoUpdatesStatus');
  * The version is selected using the following precedence:
  * 1. `TELEPORT_TOOLS_VERSION` env var, if defined.
  * 2. `tools_version` from the cluster manually selected to manage updates, if selected.
- * 3. Most compatible version, if found.
+ * 3. Highest compatible version, if found.
  * 4. If there's no version at this point, stop auto updates.
  */
 export async function resolveAutoUpdatesStatus(sources: {
@@ -43,115 +43,136 @@ export async function resolveAutoUpdatesStatus(sources: {
   getClusterVersions(): Promise<GetClusterVersionsResponse>;
 }): Promise<AutoUpdatesStatus> {
   if (sources.versionEnvVar === 'off') {
-    return { enabled: false, reason: 'disabled-by-env-var' };
+    return {
+      enabled: false,
+      reason: 'disabled-by-env-var',
+      options: {
+        clusters: [],
+        unreachableClusters: [],
+        highestCompatibleVersion: '',
+        managingClusterUri: '',
+      },
+    };
   }
   if (sources.versionEnvVar) {
     return {
       enabled: true,
       version: sources.versionEnvVar,
-      source: { kind: 'env-var' },
+      source: 'env-var',
+      options: {
+        clusters: [],
+        unreachableClusters: [],
+        highestCompatibleVersion: '',
+        managingClusterUri: '',
+      },
     };
   }
 
   const clusterVersions = await sources.getClusterVersions();
-  return findVersionFromClusters({
-    clusterVersions,
+  const options = createAutoUpdateOptions({
     managingClusterUri: sources.managingClusterUri,
+    clusterVersions,
   });
+  return findVersionFromClusters(options);
+}
+
+function createAutoUpdateOptions(sources: {
+  managingClusterUri: string | undefined;
+  clusterVersions: GetClusterVersionsResponse;
+}): AutoUpdatesOptions {
+  const { reachableClusters, unreachableClusters } = sources.clusterVersions;
+  const clusters = makeClusters(reachableClusters);
+  const highestCompatibleVersion = findMostCompatibleToolsVersion(clusters);
+  // If the managing cluster doesn't exist, ignore it completely.
+  const managingClusterExists =
+    clusters.some(c => c.clusterUri === sources.managingClusterUri) ||
+    unreachableClusters.some(c => c.clusterUri === sources.managingClusterUri);
+
+  return {
+    clusters,
+    unreachableClusters,
+    highestCompatibleVersion,
+    managingClusterUri: managingClusterExists
+      ? sources.managingClusterUri
+      : undefined,
+  };
 }
 
 /**
  * Attempts to find tools version from a user-selected cluster or connected
  * clusters.
  */
-function findVersionFromClusters(sources: {
-  managingClusterUri: string | undefined;
-  clusterVersions: GetClusterVersionsResponse;
-}): AutoUpdatesStatus {
-  const { reachableClusters, unreachableClusters } = sources.clusterVersions;
-  const clusters = makeClusters(reachableClusters);
+function findVersionFromClusters(
+  options: AutoUpdatesOptions
+): AutoUpdatesStatus {
+  const { managingClusterUri, clusters, highestCompatibleVersion } = options;
   const autoUpdateCandidateClusters = clusters.filter(c => c.toolsAutoUpdate);
   if (!autoUpdateCandidateClusters.length) {
     return {
+      options,
       enabled: false,
       reason: 'no-cluster-with-auto-update',
-      clusters,
-      unreachableClusters,
     };
   }
 
-  const { managingClusterUri } = sources;
-  const managingCluster = clusters.find(
-    c => c.clusterUri === managingClusterUri
-  );
-
-  if (managingCluster?.toolsAutoUpdate) {
-    return {
-      enabled: true,
-      version: managingCluster.toolsVersion,
-      source: {
-        kind: 'managing-cluster',
-        clusters,
-        clusterUri: managingCluster.clusterUri,
-        unreachableClusters,
-      },
-    };
-  }
-
-  const managingClusterIsSkipped =
-    !!managingCluster ||
-    unreachableClusters.some(c => c.clusterUri === managingClusterUri);
-
-  if (managingClusterIsSkipped) {
-    logger.warn(
-      `Cluster ${managingClusterUri} managing updates is unreachable or not managing updates, continuing resolution with most compatible version.`
+  if (managingClusterUri) {
+    const managingCluster = clusters.find(
+      c => c.clusterUri === managingClusterUri
     );
+
+    if (managingCluster?.toolsAutoUpdate) {
+      return {
+        options,
+        enabled: true,
+        version: managingCluster.toolsVersion,
+        source: 'managing-cluster',
+      };
+    }
+
+    logger.warn(
+      `Cluster ${managingClusterUri} managing updates is unreachable or not managing updates.`
+    );
+    return {
+      options,
+      enabled: false,
+      reason: 'managing-cluster-unable-to-manage',
+    };
   }
 
-  const mostCompatibleVersion = findMostCompatibleToolsVersion(clusters);
-  if (mostCompatibleVersion) {
+  if (highestCompatibleVersion) {
     return {
+      options,
       enabled: true,
-      version: mostCompatibleVersion,
-      source: {
-        kind: 'most-compatible',
-        clusters,
-        unreachableClusters,
-        skippedManagingClusterUri: managingClusterIsSkipped
-          ? managingClusterUri
-          : '',
-      },
+      version: highestCompatibleVersion,
+      source: 'highest-compatible',
     };
   }
 
   return {
+    options,
     enabled: false,
     reason: 'no-compatible-version',
-    unreachableClusters,
-    clusters,
   };
 }
 
 /** When `false` is returned, the user will need to click 'Download' manually. */
 export function shouldAutoDownload(updatesStatus: AutoUpdatesEnabled): boolean {
-  const { kind } = updatesStatus.source;
-  switch (kind) {
+  const { source } = updatesStatus;
+  switch (source) {
     case 'env-var':
     case 'managing-cluster':
       return true;
-    case 'most-compatible':
+    case 'highest-compatible':
       return (
-        // Prevent auto-downloading in cases where the most-compatible approach had
+        // Prevent auto-downloading in cases where the highest-compatible approach had
         // to ignore some unreachable clusters.
-        // This can happen when a cluster that manages updates becomes temporarily unavailable
-        // – we don't want another cluster to suddenly take over managing updates.
-        updatesStatus.source.unreachableClusters.length === 0 &&
-        // Do not download the most compatible version automatically if the managing
-        // cluster is unreachable or has auto-updates disabled.
-        !updatesStatus.source.skippedManagingClusterUri
+        // This can happen when a cluster that automatically manages updates becomes
+        // temporarily unavailable – we don't want another cluster to suddenly
+        // take over managing updates.
+        updatesStatus.options.unreachableClusters.length === 0
       );
     default:
-      kind satisfies never;
+      source satisfies never;
   }
 }
 
@@ -206,69 +227,56 @@ function findMostCompatibleToolsVersion(
   }
 }
 
-export type AutoUpdatesEnabled = {
+export interface AutoUpdatesEnabled {
   enabled: true;
   version: string;
-  source:
-    | {
-        /** TELEPORT_TOOLS_VERSION configures app version. */
-        kind: 'env-var';
-      }
-    | {
-        /** Updates are auto by a specific cluster. */
-        kind: 'managing-cluster';
-        /** URI of the managing cluster. */
-        clusterUri: RootClusterUri;
-        /** Clusters considered during version resolution. */
-        clusters: Cluster[];
-        /** Clusters from which version information could not be retrieved. */
-        unreachableClusters: UnreachableCluster[];
-      }
-    | {
-        /** Updates determined by the most compatible clusters available. */
-        kind: 'most-compatible';
-        /** Clusters considered during version resolution. */
-        clusters: Cluster[];
-        /**
-         * Clusters from which version information could not be retrieved.
-         * If non-empty, the update is not automatically downloaded.
-         * */
-        unreachableClusters: UnreachableCluster[];
-        /**
-         * Indicates whether a cluster configured to manage updates is unreachable
-         * or not managing updates (toolsAutoUpdate: false).
-         */
-        skippedManagingClusterUri: string;
-      };
-};
+  /**
+   * Source of the update:
+   * - `env-var` - TELEPORT_TOOLS_VERSION configures app version.
+   * - `managing-cluster` - updates are managed by a manually configured cluster.
+   * - `highest-compatible` - updates are determined by the highest compatible version available.
+   */
+  source: 'env-var' | 'managing-cluster' | 'highest-compatible';
+  /**
+   * Represents the options considered during the auto-update version resolution process.
+   * If updates are configured via the environment variable, all fields will be empty or undefined.
+   */
+  options: AutoUpdatesOptions;
+}
 
-export type AutoUpdatesDisabled =
-  | {
-      enabled: false;
-      /** `TELEPORT_TOOLS_VERSION` is 'off'. */
-      reason: 'disabled-by-env-var';
-    }
-  | {
-      enabled: false;
-      /** There is no cluster that could manage updates. */
-      reason: 'no-cluster-with-auto-update';
-      /** Clusters considered during version resolution. */
-      clusters: Cluster[];
-      /** Clusters from which version information could not be retrieved. */
-      unreachableClusters: UnreachableCluster[];
-    }
-  | {
-      enabled: false;
-      /**
-       * There are clusters that could manage updates, but they specify
-       * incompatible client tools versions.
-       */
-      reason: 'no-compatible-version';
-      /** Clusters considered during version resolution. */
-      clusters: Cluster[];
-      /** Clusters from which version information could not be retrieved. */
-      unreachableClusters: UnreachableCluster[];
-    };
+export interface AutoUpdatesDisabled {
+  enabled: false;
+  /**
+   * Reason the updates are disabled:
+   * `disabled-by-env-var` - `TELEPORT_TOOLS_VERSION` is 'off'.
+   * `no-cluster-with-auto-update` - there is no cluster that could manage updates.
+   * `managing-cluster-unable-to-manage` - the manually selected managing cluster is either
+   * unreachable or stopped autoupdates.
+   * `no-compatible-version` - there are clusters that could manage updates, but
+   * they specify incompatible client tools versions.
+   */
+  reason:
+    | 'disabled-by-env-var'
+    | 'no-cluster-with-auto-update'
+    | 'managing-cluster-unable-to-manage'
+    | 'no-compatible-version';
+  /**
+   * Represents the options considered during the auto-update version resolution process.
+   * If updates are disabled via the environment variable, all fields will be empty or undefined.
+   */
+  options: AutoUpdatesOptions;
+}
+
+export interface AutoUpdatesOptions {
+  /** The highest version that is compatible with all other clusters. */
+  highestCompatibleVersion: string | undefined;
+  /** URI of a manually selected cluster to manage updates. */
+  managingClusterUri: string | undefined;
+  /** Clusters considered during version resolution. */
+  clusters: Cluster[];
+  /** Clusters from which version information could not be retrieved. */
+  unreachableClusters: UnreachableCluster[];
+}
 
 export type AutoUpdatesStatus = AutoUpdatesEnabled | AutoUpdatesDisabled;
 


### PR DESCRIPTION
Addresses https://github.com/gravitational/teleport/pull/57088#discussion_r2230629321

This PR updates the Connect auto-update model to avoid suggesting versions from other clusters, if a manually selected cluster is unreachable or no longer provides updates.
Users will now have to decide if they want to choose a different cluster, let Connect find the highest compatible version (if one is available), or wait for the cluster to provide updates again.
Additionally, `AutoUpdatesStatus` now always include the full set of options considered during the resolution (`highestCompatibleVersion`, `managingClusterUri`, `clusters`, `unreachableClusters`). Previously, there were included only in some cases. 