### PR TITLE
Add depguard for `golang.org/x/net/context`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,6 +163,8 @@ linters:
               desc: use "github.com/gravitational/teleport/lib/msgraph" instead
             - pkg: github.com/cloudflare/cfssl
               desc: use "crypto" or "x/crypto" instead
+            - pkg: "golang.org/x/net/context"
+              desc: use "context" instead
         oidc:
           deny:
             - pkg: github.com/coreos/go-oidc


### PR DESCRIPTION
My IDE auto-imported `golang.org/x/net/context`. While I haven't seen this happen before or reproduced it, I figured a depguard might as well be added to avoid the issue, and the weird linting errors Tim and I had to debug to realize it had happened.