### PR TITLE
AccessList: Fix proto conversion when audit partially set

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -284,7 +284,7 @@ func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGran
 }
 
 func convertAuditToProto(audit accesslist.Audit) *accesslistv1.AccessListAudit {
-	if audit.Recurrence.Frequency == 0 && audit.NextAuditDate.IsZero() && audit.Notifications.Start == 0 {
+	if audit == (accesslist.Audit{}) {
 		return nil
 	}
 


### PR DESCRIPTION
I found it when I was testing `teleport_access_list_member` Terraform resource. When setting `day_of_month` to non-zero and `frequency` to zero, `day_of_month` was zeroed.

Backports:

- [ ] v18 included in https://github.com/gravitational/teleport/pull/57058
- [ ] v17