### PR TITLE
refactor: Move ssh agent server helpers to `sshagent` package

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -61,7 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -141,7 +141,7 @@ func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 
 // CreateAgent creates a SSH agent with the passed in key ring that can be used
 // in tests. This is useful so tests don't clobber your system agent.
-func CreateAgent(keyRing *client.KeyRing) (*teleagent.AgentServer, string, string, error) {
+func CreateAgent(keyRing *client.KeyRing) (*sshagent.Server, string, string, error) {
 	// create a path to the unix socket
 	sockDirName := "int-test"
 	sockName := "agent.sock"
@@ -161,22 +161,22 @@ func CreateAgent(keyRing *client.KeyRing) (*teleagent.AgentServer, string, strin
 		return nil, "", "", trace.Wrap(err)
 	}
 
-	teleAgent := teleagent.NewServer(func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(keyring), nil
+	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
+		return sshagent.NopCloser(keyring), nil
 	})
 
 	// start the SSH agent
-	err = teleAgent.ListenUnixSocket(sockDirName, sockName, nil)
+	err = agentServer.ListenUnixSocket(sockDirName, sockName, nil)
 	if err != nil {
 		return nil, "", "", trace.Wrap(err)
 	}
-	go teleAgent.Serve()
+	go agentServer.Serve()
 
-	return teleAgent, teleAgent.Dir, teleAgent.Path, nil
+	return agentServer, agentServer.Dir, agentServer.Path, nil
 }
 
-func CloseAgent(teleAgent *teleagent.AgentServer, socketDirPath string) error {
-	err := teleAgent.Close()
+func CloseAgent(agent *sshagent.Server, socketDirPath string) error {
+	err := agent.Close()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -161,9 +161,7 @@ func CreateAgent(keyRing *client.KeyRing) (*sshagent.Server, string, string, err
 		return nil, "", "", trace.Wrap(err)
 	}
 
-	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
-		return sshagent.NopCloser(keyring), nil
-	})
+	agentServer := sshagent.NewServer(sshagent.NewStaticClientGetter(keyring))
 
 	// start the SSH agent
 	err = agentServer.ListenUnixSocket(sockDirName, sockName, nil)

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services/readonly"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -213,7 +213,7 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 // DialHost dials the node that matches the provided host, port and cluster. If no matching node
 // is found an error is returned. If more than one matching node is found and the cluster networking
 // configuration is not set to route to the most recent an error is returned.
-func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, clusterName string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter teleagent.Getter, signer agentless.SignerCreator) (_ net.Conn, err error) {
+func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, clusterName string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, signer agentless.SignerCreator) (_ net.Conn, err error) {
 	ctx, span := r.tracer.Start(
 		ctx,
 		"router/DialHost",

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services/readonly"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -716,7 +716,7 @@ func TestRouter_DialHost(t *testing.T) {
 		},
 	}
 
-	agentGetter := func() (teleagent.Agent, error) {
+	agentGetter := func() (sshagent.Client, error) {
 		return nil, nil
 	}
 	createSigner := func(_ context.Context, _ agentless.LocalAccessPoint, _ agentless.CertGenerator) (ssh.Signer, error) {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv/forward"
 	"github.com/gravitational/teleport/lib/srv/git"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 	proxyutils "github.com/gravitational/teleport/lib/utils/proxy"
@@ -412,7 +412,7 @@ func (s *localSite) dialAndForward(params reversetunnelclient.DialParams) (_ net
 	)
 
 	// request user agent connection if a SSH user agent is set
-	var userAgent teleagent.Agent
+	var userAgent sshagent.Client
 	if params.GetUserAgent != nil {
 		ua, err := params.GetUserAgent()
 		if err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv/forward"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -856,7 +856,7 @@ func (s *remoteSite) dialAndForward(params reversetunnelclient.DialParams) (_ ne
 	)
 
 	// request user agent connection if a SSH user agent is set
-	var userAgent teleagent.Agent
+	var userAgent sshagent.Client
 	if params.GetUserAgent != nil {
 		ua, err := params.GetUserAgent()
 		if err != nil {

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 )
 
 // ConnectedProxyGetter provides the ability to retrieve which proxy instances
@@ -52,7 +52,7 @@ type DialParams struct {
 
 	// GetUserAgent gets an SSH agent for use in connecting to the remote host. Used by the
 	// forwarding proxy.
-	GetUserAgent teleagent.Getter
+	GetUserAgent sshagent.ClientGetter
 
 	// IsAgentlessNode indicates whether the Node is an OpenSSH Node.
 	// This includes Nodes whose sub kind is OpenSSH and OpenSSHEICE.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -53,9 +53,9 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
-	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -111,7 +111,7 @@ type Server struct {
 	identityContext srv.IdentityContext
 
 	// userAgent is the SSH user agent that was forwarded to the proxy.
-	userAgent teleagent.Agent
+	userAgent sshagent.Client
 
 	// agentlessSigner is used for client authentication when no SSH
 	// user agent is provided, ie when connecting to agentless nodes.
@@ -197,7 +197,7 @@ type ServerConfig struct {
 	// of the server being connected to, whether it is the local cluster or a
 	// remote cluster.
 	TargetClusterAccessPoint srv.AccessPoint
-	UserAgent                teleagent.Agent
+	UserAgent                sshagent.Client
 	TargetConn               net.Conn
 	SrcAddr                  net.Addr
 	DstAddr                  net.Addr

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -44,9 +44,9 @@ import (
 	"github.com/gravitational/teleport"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshutils/networking"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
-	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils/host"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
@@ -315,18 +315,18 @@ func testAgentForward(ctx context.Context, t *testing.T, proc *networking.Proces
 	err = keyring.Add(testKey)
 	require.NoError(t, err)
 
-	teleAgent := teleagent.NewServer(func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(keyring), nil
+	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
+		return sshagent.NopCloser(keyring), nil
 	})
 
 	// Forward the agent over the networking process.
 	listener, err := proc.ListenAgent(ctx)
 	require.NoError(t, err)
-	teleAgent.SetListener(listener)
+	agentServer.SetListener(listener)
 
-	go teleAgent.Serve()
+	go agentServer.Serve()
 	t.Cleanup(func() {
-		teleAgent.Close()
+		agentServer.Close()
 	})
 
 	agentConn, err := net.Dial(listener.Addr().Network(), listener.Addr().String())

--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -315,9 +315,7 @@ func testAgentForward(ctx context.Context, t *testing.T, proc *networking.Proces
 	err = keyring.Add(testKey)
 	require.NoError(t, err)
 
-	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
-		return sshagent.NopCloser(keyring), nil
-	})
+	agentServer := sshagent.NewServer(sshagent.NewStaticClientGetter(keyring))
 
 	// Forward the agent over the networking process.
 	listener, err := proc.ListenAgent(ctx)

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -251,7 +252,9 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 
 	signer := agentless.SignerFromSSHIdentity(identity.UnmappedIdentity, authClient, t.clusterName, identity.TeleportUser)
 
-	aGetter := t.ctx.StartAgentChannel
+	aGetter := func() (sshagent.Client, error) {
+		return t.ctx.StartAgentChannel()
+	}
 	conn, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.UnstableClusterAccessChecker, aGetter, signer)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1852,7 +1852,9 @@ func (s *Server) serveAgent(ctx context.Context, scx *srv.ServerContext) error {
 
 	// start an agent server on a unix socket.  each incoming connection
 	// will result in a separate agent request.
-	agentServer := sshagent.NewServer(scx.Parent().StartAgentChannel)
+	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
+		return scx.Parent().StartAgentChannel()
+	})
 	agentServer.SetListener(listener)
 	scx.Parent().AddCloser(agentServer)
 	scx.Parent().SetEnv(teleport.SSHAuthSock, listener.Addr().String())

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -66,10 +66,10 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/ingress"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/networking"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
-	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 )
@@ -1852,7 +1852,7 @@ func (s *Server) serveAgent(ctx context.Context, scx *srv.ServerContext) error {
 
 	// start an agent server on a unix socket.  each incoming connection
 	// will result in a separate agent request.
-	agentServer := teleagent.NewServer(scx.Parent().StartAgentChannel)
+	agentServer := sshagent.NewServer(scx.Parent().StartAgentChannel)
 	agentServer.SetListener(listener)
 	scx.Parent().AddCloser(agentServer)
 	scx.Parent().SetEnv(teleport.SSHAuthSock, listener.Addr().String())

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -99,9 +99,7 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 
 	if c.agentGetterFn == nil {
 		c.agentGetterFn = func(rw io.ReadWriter) sshagent.ClientGetter {
-			return func() (sshagent.Client, error) {
-				return sshagent.NopCloser(agent.NewClient(rw)), nil
-			}
+			return sshagent.NewStaticClientGetter(agent.NewClient(rw))
 		}
 	}
 

--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -40,7 +40,7 @@ import (
 	streamutils "github.com/gravitational/teleport/api/utils/grpc/stream"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -48,7 +48,7 @@ import (
 // Dialer is the interface that groups basic dialing methods.
 type Dialer interface {
 	DialSite(ctx context.Context, cluster string, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error)
-	DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter teleagent.Getter, singer agentless.SignerCreator) (net.Conn, error)
+	DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (net.Conn, error)
 	DialWindowsDesktop(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, desktopName, cluster string, clusterAccessChecker func(types.RemoteCluster) error) (net.Conn, error)
 }
 
@@ -76,7 +76,7 @@ type ServerConfig struct {
 	LocalAddr net.Addr
 
 	// agentGetterFn used by tests to serve the agent directly
-	agentGetterFn func(rw io.ReadWriter) teleagent.Getter
+	agentGetterFn func(rw io.ReadWriter) sshagent.ClientGetter
 
 	// authzContextFn used by tests to inject an access checker
 	authzContextFn func(info credentials.AuthInfo) (*authz.Context, error)
@@ -98,9 +98,9 @@ func (c *ServerConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.agentGetterFn == nil {
-		c.agentGetterFn = func(rw io.ReadWriter) teleagent.Getter {
-			return func() (teleagent.Agent, error) {
-				return teleagent.NopCloser(agent.NewClient(rw)), nil
+		c.agentGetterFn = func(rw io.ReadWriter) sshagent.ClientGetter {
+			return func() (sshagent.Client, error) {
+				return sshagent.NopCloser(agent.NewClient(rw)), nil
 			}
 		}
 	}

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -120,7 +120,7 @@ func (f fakeDialer) DialSite(ctx context.Context, clusterName string, clientSrcA
 	return conn, nil
 }
 
-func (f fakeDialer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter teleagent.Getter, singer agentless.SignerCreator) (_ net.Conn, err error) {
+func (f fakeDialer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
 	key := fmt.Sprintf("%s.%s.%s", host, port, cluster)
 	conn, ok := f.hostConns[key]
 	if !ok {
@@ -576,8 +576,8 @@ func TestService_ProxySSH(t *testing.T) {
 		Logger:            logtest.NewLogger(),
 		LocalAddr:         utils.MustParseAddr("127.0.0.1:4242"),
 		ConnectionMonitor: fakeMonitor{},
-		agentGetterFn: func(rw io.ReadWriter) teleagent.Getter {
-			return func() (teleagent.Agent, error) {
+		agentGetterFn: func(rw io.ReadWriter) sshagent.ClientGetter {
+			return func() (sshagent.Client, error) {
 				srw, ok := rw.(*streamutils.ReadWriter)
 				if !ok {
 					return nil, trace.BadParameter("rw must be a streamutils.ReadWriter")
@@ -954,7 +954,7 @@ func (s *sshServer) DialSite(ctx context.Context, clusterName string, clientSrcA
 // nil and is of type testAgent, then the server will serve its keyring
 // over the underlying [streamutils.ReadWriter] so that tests can exercise
 // ssh agent multiplexing.
-func (s *sshServer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter teleagent.Getter, singer agentless.SignerCreator) (_ net.Conn, err error) {
+func (s *sshServer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
 	conn, err := s.dial()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/sshagent/server.go
+++ b/lib/sshagent/server.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package teleagent
+package sshagent
 
 import (
 	"context"
@@ -36,56 +36,32 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-// TODO(Joerger): Move this file to lib/sshagent and replace
-// similar types.
-
-// Agent extends the agent.ExtendedAgent interface.
-// APIs which accept this interface promise to
-// call `Close()` when they are done using the
-// supplied agent.
-type Agent interface {
-	agent.ExtendedAgent
-	io.Closer
+// TODO(Joerger): Remove in favor of NewStaticClientGetter
+func NopCloser(std agent.ExtendedAgent) Client {
+	return NewStaticClient(std)
 }
 
-// nopCloser wraps an agent.Agent in the extended
-// Agent interface by adding a NOP closer.
-type nopCloser struct {
-	agent.ExtendedAgent
-}
-
-func (n nopCloser) Close() error { return nil }
-
-// NopCloser wraps an agent.Agent with a NOP closer, allowing it
-// to be passed to APIs which expect the extended agent interface.
-func NopCloser(std agent.ExtendedAgent) Agent {
-	return nopCloser{std}
-}
-
-// Getter is a function used to get an agent instance.
-type Getter func() (Agent, error)
-
-// AgentServer is implementation of SSH agent server
-type AgentServer struct {
-	getAgent Getter
+// Server is an SSH agent server implementation.
+type Server struct {
+	getAgent ClientGetter
 	listener net.Listener
 	Path     string
 	Dir      string
 }
 
-// NewServer returns new instance of agent server
-func NewServer(getter Getter) *AgentServer {
-	return &AgentServer{getAgent: getter}
+// NewServer returns a new [Server].
+func NewServer(agentClient ClientGetter) *Server {
+	return &Server{getAgent: agentClient}
 }
 
-func (a *AgentServer) SetListener(l net.Listener) {
+func (a *Server) SetListener(l net.Listener) {
 	a.listener = l
 	a.Path = l.Addr().String()
 	a.Dir = filepath.Dir(a.Path)
 }
 
 // ListenUnixSocket starts listening on a new unix socket.
-func (a *AgentServer) ListenUnixSocket(sockDir, sockName string, _ *user.User) error {
+func (a *Server) ListenUnixSocket(sockDir, sockName string, _ *user.User) error {
 	// Create a temp directory to hold the agent socket.
 	sockDir, err := os.MkdirTemp(os.TempDir(), sockDir+"-")
 	if err != nil {
@@ -104,7 +80,7 @@ func (a *AgentServer) ListenUnixSocket(sockDir, sockName string, _ *user.User) e
 }
 
 // Serve starts serving on the listener, assumes that Listen was called before
-func (a *AgentServer) Serve() error {
+func (a *Server) Serve() error {
 	if a.listener == nil {
 		return trace.BadParameter("Serve needs a Listen call first")
 	}
@@ -157,18 +133,8 @@ func (a *AgentServer) Serve() error {
 	}
 }
 
-// ListenAndServe is similar http.ListenAndServe
-func (a *AgentServer) ListenAndServe(addr utils.NetAddr) error {
-	l, err := net.Listen(addr.AddrNetwork, addr.Addr)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	a.listener = l
-	return a.Serve()
-}
-
 // Close closes listener and stops serving agent
-func (a *AgentServer) Close() error {
+func (a *Server) Close() error {
 	var errors []error
 	if a.listener != nil {
 		slog.DebugContext(context.Background(), "AgentServer is closing",

--- a/lib/sshagent/server.go
+++ b/lib/sshagent/server.go
@@ -36,11 +36,6 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-// TODO(Joerger): Remove in favor of NewStaticClientGetter
-func NopCloser(std agent.ExtendedAgent) Client {
-	return NewStaticClient(std)
-}
-
 // Server is an SSH agent server implementation.
 type Server struct {
 	getAgent ClientGetter

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -31,8 +31,8 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshutils/networking"
-	"github.com/gravitational/teleport/lib/teleagent"
 )
 
 // ConnectionContext manages connection-level state.
@@ -114,7 +114,7 @@ func NewConnectionContext(ctx context.Context, nconn net.Conn, sconn *ssh.Server
 	return ctx, ccx
 }
 
-// agentChannel implements the extended teleteleagent.Agent interface,
+// agentChannel implements the extended telesshagent.AgentCloser interface,
 // allowing the underlying ssh.Channel to be closed when the agent
 // is no longer needed.
 type agentChannel struct {
@@ -159,7 +159,7 @@ func (c *ConnectionContext) SetSessionID(sessionID rsession.ID) {
 // StartAgentChannel sets up a new agent forwarding channel against this connection.  The channel
 // is automatically closed when either ConnectionContext, or the supplied context.Context
 // gets canceled.
-func (c *ConnectionContext) StartAgentChannel() (teleagent.Agent, error) {
+func (c *ConnectionContext) StartAgentChannel() (sshagent.Client, error) {
 	// refuse to start an agent if forwardAgent has not yet been set.
 	if !c.GetForwardAgent() {
 		return nil, trace.AccessDenied("agent forwarding has not been requested")

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -31,7 +31,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 
 	rsession "github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshutils/networking"
 )
 
@@ -114,16 +113,16 @@ func NewConnectionContext(ctx context.Context, nconn net.Conn, sconn *ssh.Server
 	return ctx, ccx
 }
 
-// agentChannel implements the extended telesshagent.AgentCloser interface,
+// AgentChannel implements the extended telesshagent.AgentCloser interface,
 // allowing the underlying ssh.Channel to be closed when the agent
 // is no longer needed.
-type agentChannel struct {
+type AgentChannel struct {
 	agent.ExtendedAgent
 	ch ssh.Channel
 }
 
 // Close closes the agent channel.
-func (a *agentChannel) Close() error {
+func (a *AgentChannel) Close() error {
 	// For graceful teardown, close the write part of the channel first. This
 	// will send "EOF" packet (type 96) to the other side which will drain and
 	// close the channel.
@@ -159,7 +158,7 @@ func (c *ConnectionContext) SetSessionID(sessionID rsession.ID) {
 // StartAgentChannel sets up a new agent forwarding channel against this connection.  The channel
 // is automatically closed when either ConnectionContext, or the supplied context.Context
 // gets canceled.
-func (c *ConnectionContext) StartAgentChannel() (sshagent.Client, error) {
+func (c *ConnectionContext) StartAgentChannel() (*AgentChannel, error) {
 	// refuse to start an agent if forwardAgent has not yet been set.
 	if !c.GetForwardAgent() {
 		return nil, trace.AccessDenied("agent forwarding has not been requested")
@@ -170,7 +169,7 @@ func (c *ConnectionContext) StartAgentChannel() (sshagent.Client, error) {
 		return nil, trace.Wrap(err)
 	}
 	go ssh.DiscardRequests(reqC)
-	return &agentChannel{
+	return &AgentChannel{
 		ExtendedAgent: agent.NewClient(ch),
 		ch:            ch,
 	}, nil

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -113,9 +113,9 @@ func NewConnectionContext(ctx context.Context, nconn net.Conn, sconn *ssh.Server
 	return ctx, ccx
 }
 
-// AgentChannel implements the extended telesshagent.AgentCloser interface,
-// allowing the underlying ssh.Channel to be closed when the agent
-// is no longer needed.
+// AgentChannel implements the [agent.ExtendedAgent] and [io.Closer]
+// interfaces, allowing the underlying ssh.Channel to be closed when
+// the agent is no longer needed.
 type AgentChannel struct {
 	agent.ExtendedAgent
 	ch ssh.Channel

--- a/lib/sshutils/ctx_test.go
+++ b/lib/sshutils/ctx_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAgentChannelClose(t *testing.T) {
-	aChannel := agentChannel{
+	aChannel := AgentChannel{
 		ch: &mockChannel{
 			ReadWriter: fakeReaderWriter{},
 		},

--- a/lib/teleagent/alias.go
+++ b/lib/teleagent/alias.go
@@ -1,0 +1,33 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package teleagent
+
+import (
+	"github.com/gravitational/teleport/lib/sshagent"
+)
+
+// TODO(Joerger): Remove this file once no longer needed by /e
+type (
+	Agent = sshagent.Client
+)
+
+var (
+	NopCloser = sshagent.NewStaticClient
+	NewServer = sshagent.NewServer
+)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -171,9 +171,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		return nil, trace.Wrap(err)
 	}
 
-	getAgent := func() (sshagent.Client, error) {
-		return sshagent.NopCloser(tc.LocalAgent()), nil
-	}
+	getAgent := sshagent.NewStaticClientGetter(tc.LocalAgent())
 
 	cert, err := sctx.GetSSHCertificate()
 	if err != nil {

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -39,9 +39,9 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
-	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -171,9 +171,10 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		return nil, trace.Wrap(err)
 	}
 
-	getAgent := func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(tc.LocalAgent()), nil
+	getAgent := func() (sshagent.Client, error) {
+		return sshagent.NopCloser(tc.LocalAgent()), nil
 	}
+
 	cert, err := sctx.GetSSHCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -61,8 +61,8 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/sshca"
-	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/diagnostics/latency"
 	"github.com/gravitational/teleport/lib/web/terminal"
@@ -669,7 +669,7 @@ func newMFACeremony(stream *terminal.WSStream, createAuthenticateChallenge mfa.C
 	}
 }
 
-type connectWithMFAFn = func(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter, signer agentless.SignerCreator) (*client.NodeClient, error)
+type connectWithMFAFn = func(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
 
 // connectToHost establishes a connection to the target host. To reduce connection
 // latency if per session mfa is required, connections are tried with the existing
@@ -685,9 +685,10 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 		return nil, trace.Wrap(err)
 	}
 
-	getAgent := func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(tc.LocalAgent()), nil
+	getAgent := func() (sshagent.Client, error) {
+		return sshagent.NopCloser(tc.LocalAgent()), nil
 	}
+
 	cert, err := t.ctx.GetSSHCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -899,7 +900,7 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 
 // connectToNode attempts to connect to the host with the already
 // provisioned certs for the user.
-func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
 	conn, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
 	if err != nil {
 		t.logger.WarnContext(ctx, "Unable to stream terminal - failed to dial host", "error", err)
@@ -952,7 +953,7 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, 
 
 // connectToNodeWithMFA attempts to perform the mfa ceremony and then dial the
 // host with the retrieved single use certs.
-func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
 	// perform mfa ceremony and retrieve new certs
 	authMethods, err := t.issueSessionMFACerts(ctx, tc, t.stream.WSStream)
 	if err != nil {
@@ -964,7 +965,7 @@ func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws terminal.
 
 // connectToNodeWithMFABase attempts to dial the host with the provided auth
 // methods.
-func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter, signer agentless.SignerCreator, authMethods []ssh.AuthMethod) (*client.NodeClient, error) {
+func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator, authMethods []ssh.AuthMethod) (*client.NodeClient, error) {
 	sshConfig := &ssh.ClientConfig{
 		User:            tc.HostLogin,
 		Auth:            authMethods,

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -685,10 +685,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 		return nil, trace.Wrap(err)
 	}
 
-	getAgent := func() (sshagent.Client, error) {
-		return sshagent.NopCloser(tc.LocalAgent()), nil
-	}
-
+	getAgent := sshagent.NewStaticClientGetter(tc.LocalAgent())
 	cert, err := t.ctx.GetSSHCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -69,7 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -985,21 +985,21 @@ func createAgent(t *testing.T) (agent.ExtendedAgent, string) {
 	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
 	require.True(t, ok)
 
-	teleAgent := teleagent.NewServer(func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(keyring), nil
+	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
+		return sshagent.NopCloser(keyring), nil
 	})
 
 	// Start the SSH agent.
-	err := teleAgent.ListenUnixSocket(sockDir, sockName, nil)
+	err := agentServer.ListenUnixSocket(sockDir, sockName, nil)
 	require.NoError(t, err)
-	go teleAgent.Serve()
+	go agentServer.Serve()
 	t.Cleanup(func() {
-		teleAgent.Close()
+		agentServer.Close()
 	})
 
-	t.Setenv(teleport.SSHAuthSock, teleAgent.Path)
+	t.Setenv(teleport.SSHAuthSock, agentServer.Path)
 
-	return keyring, teleAgent.Path
+	return keyring, agentServer.Path
 }
 
 func disableAgent(t *testing.T) {

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -985,9 +985,7 @@ func createAgent(t *testing.T) (agent.ExtendedAgent, string) {
 	keyring, ok := agent.NewKeyring().(agent.ExtendedAgent)
 	require.True(t, ok)
 
-	agentServer := sshagent.NewServer(func() (sshagent.Client, error) {
-		return sshagent.NopCloser(keyring), nil
-	})
+	agentServer := sshagent.NewServer(sshagent.NewStaticClientGetter(keyring))
 
 	// Start the SSH agent.
 	err := agentServer.ListenUnixSocket(sockDir, sockName, nil)


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/57243, I added a new `lib/sshagent` package with client logic. This PR moves `lib/teleagent`'s SSH agent server logic into the package in order to have a more accurate package name and make use of shared interfaces (ClientGetter).

e PR: https://github.com/gravitational/teleport.e/pull/6983