### PR TITLE
ci: Manually install wasm dependencies in lint-ui

### DIFF
--- a/.github/workflows/lint-ui-bypass.yaml
+++ b/.github/workflows/lint-ui-bypass.yaml
@@ -14,6 +14,7 @@ run-name: Lint UI - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/lint-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
@@ -25,6 +26,7 @@ on:
       - 'tsconfig.node.json'
   merge_group:
     paths-ignore:
+      - '.github/workflows/lint-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -4,6 +4,7 @@ run-name: Lint UI - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths:
+      - '.github/workflows/lint-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
@@ -15,6 +16,7 @@ on:
       - 'tsconfig.node.json'
   merge_group:
     paths:
+      - '.github/workflows/lint-ui.yaml'
       - 'web/**'
       - 'gen/proto/js/**'
       - 'gen/proto/ts/**'
@@ -42,6 +44,9 @@ jobs:
       - name: Install JS dependencies
         run: |
           pnpm install --frozen-lockfile
+
+      - name: Install WASM deps
+        run: make ensure-wasm-deps
 
       - name: Build WASM
         run: pnpm build-wasm


### PR DESCRIPTION
Use `make ensure-wasm-deps` to install wasm-pack and wasm-bindgen as
wasm-pack often fails to build wasm-bindgen due to it not using
`--locked`. If we pre-install the correct versions, wasm-pack does not
try to build wasm-bindgen.

Make sure the workflow runs if the workflow itself is changed.
