### PR TITLE
Improve discovery bootstrap error messages

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/tracing/smithyoteltracing"
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel"
@@ -726,7 +727,7 @@ type unreachablePolicyTargetError struct {
 
 func (e unreachablePolicyTargetError) Error() string {
 	return fmt.Sprintf(
-		"%q is unreachable from %q",
+		"policy target %q is unreachable from assumed role %q",
 		e.target, e.from,
 	)
 }
@@ -811,11 +812,18 @@ func buildIAMARN(partitionID, accountID, resourceType, resource string) string {
 // which is necessary to attach policies to the identity.
 // Rather than returning errors about why it failed, this message suggests a
 // simple fix for the user to specify a role or user to attach policies to.
-func failedToResolveAssumeRoleARN(roleIdentity string) string {
-	return fmt.Sprintf("running with assumed-role credentials for %s, but "+
-		"policies cannot be attached to an assumed-role; "+
-		"provide the name or ARN of an IAM role (--attach-to-role) or user (--attach-to-user) to attach policies to",
-		roleIdentity)
+func failedToResolveAssumeRoleARN(roleIdentity string, missingPermissions bool) string {
+	solutions := []string{
+		"- provide the name or ARN of an IAM role (--attach-to-role) or user (--attach-to-user) to attach policies to",
+	}
+	if missingPermissions {
+		solutions = append(solutions, fmt.Sprintf("- ensure %s has the iam:GetRole permission", roleIdentity))
+	}
+	return fmt.Sprintf(
+		"could not resolve assumed-role %s to a full role ARN. To resolve, do one of the following:\n%s",
+		roleIdentity, strings.Join(solutions, "\n"),
+	)
+
 }
 
 // getRoleARNForAssumedRole attempts to resolve assumed-role credentials to
@@ -826,18 +834,21 @@ func getRoleARNForAssumedRole(iamClient iamClient, identity awslib.Identity) (aw
 	if iamClient == nil {
 		return nil, trace.BadParameter("missing iamClient")
 	}
-	failedToResolveAssumeRoleARN := failedToResolveAssumeRoleARN(identity.GetName())
-
 	out, err := iamClient.GetRole(context.Background(), &iam.GetRoleInput{
 		RoleName: aws.String(identity.GetName()),
 	})
 	if err != nil || out == nil || out.Role == nil || out.Role.Arn == nil {
-		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN)
+		var apiErr smithy.APIError
+		var missingPermissions bool
+		if errors.As(err, &apiErr) {
+			missingPermissions = apiErr.ErrorCode() == "AccessDenied"
+		}
+		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN(identity.GetName(), missingPermissions))
 	}
 
 	roleIdentity, err := awslib.IdentityFromArn(*out.Role.Arn)
 	if err != nil {
-		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN)
+		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN(identity.GetName(), false))
 	}
 	return roleIdentity, nil
 }


### PR DESCRIPTION
This change updates a few error messages in `teleport discovery bootstrap` to be more useful.