### PR TITLE
Fix unlink package for every version w/ and w/o `teleport-update`

### DIFF
--- a/examples/systemd/before-remove
+++ b/examples/systemd/before-remove
@@ -4,9 +4,48 @@
 
 set -eu
 
-if [ $# -ge 1 ] && [ "$1" = "1" ]; then
-  echo "Skipping symlink removal as this is a package upgrade."
-else
+version_le() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+}
+
+unlink() {
   echo "Removing symlinks from Teleport system paths..."
-  /opt/teleport/system/bin/teleport-update unlink-package || true
-fi
+  /opt/teleport/system/bin/teleport-update unlink-package
+}
+
+case "$1" in
+  1)
+    echo "Skipping symlink removal as this is a package upgrade."
+    ;;
+  remove|0)
+    unlink || true
+    ;;
+  purge)
+    ;;
+  upgrade)
+    target_version="$2"
+    if [[ -n "$target_version" ]]; then
+      major="${target_version%%.*}"
+      case "$major" in
+        17)
+          version_le "$target_version" "17.2.9" && unlink || true
+          ;;
+        16)
+          version_le "$target_version" "16.4.29" && unlink || true
+          ;;
+        15)
+          version_le "$target_version" "15.4.33" && unlink || true
+          ;;
+        *)
+          echo "Skipping symlink removal for version $target_version."
+          ;;
+      esac
+    fi
+    ;;
+  failed-upgrade)
+    echo "Upgrade failed — skipping symlink removal."
+    ;;
+  *)
+    unlink || true
+    ;;
+esac

--- a/examples/systemd/before-remove
+++ b/examples/systemd/before-remove
@@ -5,7 +5,7 @@
 set -eu
 
 version_le() {
-  if command -v dpkg &>/dev/null; then
+  if command -v dpkg >/dev/null 2>&1; then
     dpkg --compare-versions "$1" le "$2"
   else
     [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]

--- a/examples/systemd/before-remove
+++ b/examples/systemd/before-remove
@@ -5,7 +5,11 @@
 set -eu
 
 version_le() {
-  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+  if command -v dpkg &>/dev/null; then
+    dpkg --compare-versions "$1" le "$2"
+  else
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+  fi
 }
 
 unlink() {
@@ -24,6 +28,13 @@ case "$1" in
     ;;
   upgrade)
     target_version="$2"
+    # We need to compare versions by their major version to determine whether
+    # a package unlink is required. Starting with versions 17.3.0, 16.5.0, and 15.5.0,
+    # the package structure changed — all Teleport binaries were moved to the `/opt/teleport`
+    # directory. After installation, symlinks are created in `/usr/local/bin`, and all
+    # symlinks are managed by `teleport-update`.
+    # When downgrading to an older version that does not use `teleport-update`,
+    # these symlinks must be removed by `teleport-update unlink-package` before installation.
     if [[ -n "$target_version" ]]; then
       major="${target_version%%.*}"
       case "$major" in


### PR DESCRIPTION
In this PR added version check for `before-remove` script execution for upgrade and downgrade after introducing `teleport-update` and moving binaries to new location `/opt/teleport`.

<details>
<summary>deb installation example logs</summary>

## 18.1.0-dev.vapopov.3 -> 17.5.5
```
root@7621b6cb4def:/go/teleport# dpkg -i teleport_18.1.0-dev.vapopov.3_arm64.deb
(Reading database ... 17574 files and directories currently installed.)
Preparing to unpack teleport_18.1.0-dev.vapopov.3_arm64.deb ...
Skipping symlink removal for version 18.1.0-dev.vapopov.3.
Unpacking teleport (18.1.0-dev.vapopov.3) over (18.1.0-dev.vapopov.3) ...
Setting up teleport (18.1.0-dev.vapopov.3) ...
Teleport system symlinks creation...
2025-07-30T10:15:36.091Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:15:36.092Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:15:36.092Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:15:36.109Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:15:36.110Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:15:36.140Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:15:36.141Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:15:36.185Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:15:36.188Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:15:36.195Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:15:36.196Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:15:36.231Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:15:36.304Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:15:36.308Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258
root@7621b6cb4def:/go/teleport# dpkg -i teleport_17.5.5_arm64.deb
dpkg: warning: downgrading teleport from 18.1.0-dev.vapopov.3 to 17.5.5
(Reading database ... 17574 files and directories currently installed.)
Preparing to unpack teleport_17.5.5_arm64.deb ...
Unpacking teleport (17.5.5) over (18.1.0-dev.vapopov.3) ...
Setting up teleport (17.5.5) ...
Teleport system symlinks creation...
2025-07-30T10:16:09.963Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:16:09.964Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:16:09.964Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:16:09.987Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:16:09.988Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:16:10.013Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:16:10.014Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:16:10.063Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:16:10.065Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:16:10.073Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:16:10.074Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:16:10.111Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:16:10.173Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:16:10.177Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1203
```

## 18.1.0-dev.vapopov.3 -> 17.2.9
```
root@7621b6cb4def:/go/teleport# dpkg -i teleport_18.1.0-dev.vapopov.3_arm64.deb
dpkg -i teleport_17.2.9_arm64.deb
Selecting previously unselected package teleport.
(Reading database ... 17556 files and directories currently installed.)
Preparing to unpack teleport_18.1.0-dev.vapopov.3_arm64.deb ...
Unpacking teleport (18.1.0-dev.vapopov.3) ...
Setting up teleport (18.1.0-dev.vapopov.3) ...
Teleport system symlinks creation...
2025-07-30T10:25:11.554Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:25:11.555Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:25:11.555Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:25:11.572Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:25:11.573Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:25:11.596Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:25:11.598Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:25:11.638Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:25:11.640Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:25:11.646Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:25:11.647Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:25:11.678Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:25:11.728Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:25:11.732Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258
dpkg: warning: downgrading teleport from 18.1.0-dev.vapopov.3 to 17.2.9
(Reading database ... 17574 files and directories currently installed.)
Preparing to unpack teleport_17.2.9_arm64.deb ...
Removing symlinks from Teleport system paths...
2025-07-30T10:25:11.762Z WARN [UPDATER]   Removed binary link, but skipping removal of custom service that does not match the binary. service:teleport.service binary:teleport agent/installer.go:780
2025-07-30T10:25:11.812Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:25:11.812Z INFO [UPDATER]   Successfully unlinked system package installation. agent/updater.go:1273
Unpacking teleport (17.2.9) over (18.1.0-dev.vapopov.3) ...
dpkg: warning: unable to delete old directory '/opt/teleport': Directory not empty
dpkg: warning: unable to delete old directory '/opt': Directory not empty
Setting up teleport (17.2.9) ...
```

## 18.1.0-dev.vapopov.3 install -> remove
```
root@7621b6cb4def:/go/teleport# dpkg -i teleport_18.1.0-dev.vapopov.3_arm64.deb
Selecting previously unselected package teleport.
(Reading database ... 17556 files and directories currently installed.)
Preparing to unpack teleport_18.1.0-dev.vapopov.3_arm64.deb ...
Unpacking teleport (18.1.0-dev.vapopov.3) ...
Setting up teleport (18.1.0-dev.vapopov.3) ...
Teleport system symlinks creation...
2025-07-30T10:22:25.630Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:22:25.631Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:22:25.631Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:22:25.650Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:22:25.652Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:22:25.675Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:22:25.676Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:22:25.723Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:22:25.725Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:22:25.731Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:22:25.732Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:22:25.763Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:22:25.812Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:22:25.815Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258
root@7621b6cb4def:/go/teleport# dpkg -r teleport
(Reading database ... 17574 files and directories currently installed.)
Removing teleport (18.1.0-dev.vapopov.3) ...
Removing symlinks from Teleport system paths...
2025-07-30T10:22:32.476Z WARN [UPDATER]   Removed binary link, but skipping removal of custom service that does not match the binary. service:teleport.service binary:teleport agent/installer.go:780
2025-07-30T10:22:32.545Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:22:32.545Z INFO [UPDATER]   Successfully unlinked system package installation. agent/updater.go:1273
dpkg: warning: while removing teleport, directory '/var/lib/teleport' not empty so not removed
dpkg: warning: while removing teleport, directory '/opt/teleport' not empty so not removed
```

</details>


<details>
<summary>yum installation example logs</summary>

## 18.1.0-dev.vapopov.3 -> 17.5.5
```
[root@3b712c71b962 teleport]# yum install -y ./teleport-18.1.0-dev.vapopov.3-1.arm64.rpm
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:23:06 ago on Wed Jul 30 10:05:03 2025.
Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                        Architecture                                  Version                                                        Repository                                          Size
======================================================================================================================================================================================================================
Installing:
 teleport                                       aarch64                                       18.1.0_dev.vapopov.3-1                                         @commandline                                       183 M

Transaction Summary
======================================================================================================================================================================================================================
Install  1 Package

Total size: 183 M
Installed size: 734 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Installing       : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Teleport system symlinks creation...
2025-07-30T10:28:13.760Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:28:13.761Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:28:13.761Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:28:13.791Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:28:13.793Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:28:13.819Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:28:13.820Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:28:13.920Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:28:13.922Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:28:13.945Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:28:13.946Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:28:13.982Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:28:14.029Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:28:14.031Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258

  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Installed products updated.

Installed:
  teleport-18.1.0_dev.vapopov.3-1.aarch64

Complete!
[root@3b712c71b962 teleport]# yum install -y ./teleport-17.5.5-1.arm64.rpm
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:23:43 ago on Wed Jul 30 10:05:03 2025.
Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                            Architecture                                      Version                                            Repository                                              Size
======================================================================================================================================================================================================================
Downgrading:
 teleport                                           aarch64                                           17.5.5-1                                           @commandline                                           180 M

Transaction Summary
======================================================================================================================================================================================================================
Downgrade  1 Package

Total size: 180 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Downgrading      : teleport-17.5.5-1.aarch64                                                                                                                                                                    1/2
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
Skipping symlink removal as this is a package upgrade.

  Cleanup          : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
  Running scriptlet: teleport-17.5.5-1.aarch64                                                                                                                                                                    2/2
Teleport system symlinks creation...
2025-07-30T10:28:52.729Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:28:52.730Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:28:52.730Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:28:52.821Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:28:52.822Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:28:52.849Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:28:52.851Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:28:52.915Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:28:52.918Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:28:52.927Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:28:52.927Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:28:52.962Z INFO [UPDATER]   [stdout] Teleport v17.5.5 git:v17.5.5-0-gd87af52 go1.23.11 agent/logger.go:69
2025-07-30T10:28:52.988Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:28:52.989Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1203

  Verifying        : teleport-17.5.5-1.aarch64                                                                                                                                                                    1/2
  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
Installed products updated.

Downgraded:
  teleport-17.5.5-1.aarch64

Complete!
```

## 18.1.0-dev.vapopov.3 -> 17.2.9
```
[root@3b712c71b962 teleport]# yum install -y ./teleport-18.1.0-dev.vapopov.3-1.arm64.rpm
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:26:01 ago on Wed Jul 30 10:05:03 2025.
Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                        Architecture                                  Version                                                        Repository                                          Size
======================================================================================================================================================================================================================
Installing:
 teleport                                       aarch64                                       18.1.0_dev.vapopov.3-1                                         @commandline                                       183 M

Transaction Summary
======================================================================================================================================================================================================================
Install  1 Package

Total size: 183 M
Installed size: 734 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test

Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Installing       : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Teleport system symlinks creation...
2025-07-30T10:31:08.679Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:31:08.680Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:31:08.680Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:31:08.703Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:31:08.704Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:31:08.736Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:31:08.739Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:31:08.801Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:31:08.919Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:31:08.927Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:31:08.928Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:31:08.970Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:31:08.991Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:31:08.993Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258

  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Installed products updated.

Installed:
  teleport-18.1.0_dev.vapopov.3-1.aarch64

Complete!
[root@3b712c71b962 teleport]# yum install -y ./teleport-17.2.9-1.arm64.rpm
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:26:06 ago on Wed Jul 30 10:05:03 2025.
Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                            Architecture                                      Version                                            Repository                                              Size
======================================================================================================================================================================================================================
Downgrading:
 teleport                                           aarch64                                           17.2.9-1                                           @commandline                                           155 M

Transaction Summary
======================================================================================================================================================================================================================
Downgrade  1 Package

Total size: 155 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Downgrading      : teleport-17.2.9-1.aarch64                                                                                                                                                                    1/2
  Running scriptlet: teleport-17.2.9-1.aarch64                                                                                                                                                                    1/2
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
Skipping symlink removal as this is a package upgrade.

  Cleanup          : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
  Verifying        : teleport-17.2.9-1.aarch64                                                                                                                                                                    1/2
  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
Installed products updated.

Downgraded:
  teleport-17.2.9-1.aarch64

Complete!
```

## 18.1.0-dev.vapopov.3 install -> remove
```
[root@3b712c71b962 teleport]# yum install -y ./teleport-18.1.0-dev.vapopov.3-1.arm64.rpm
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:28:02 ago on Wed Jul 30 10:05:03 2025.
Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                        Architecture                                  Version                                                        Repository                                          Size
======================================================================================================================================================================================================================
Upgrading:
 teleport                                       aarch64                                       18.1.0_dev.vapopov.3-1                                         @commandline                                       183 M

Transaction Summary
======================================================================================================================================================================================================================
Upgrade  1 Package

Total size: 183 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test

Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Upgrading        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/2
  Cleanup          : teleport-17.2.9-1.aarch64                                                                                                                                                                    2/2
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      2/2
Teleport system symlinks creation...
2025-07-30T10:33:09.288Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-30T10:33:09.288Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-30T10:33:09.288Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-30T10:33:09.308Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:33:09.309Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-30T10:33:09.335Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:33:09.337Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-30T10:33:09.386Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:33:09.389Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-30T10:33:09.396Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:33:09.397Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-30T10:33:09.428Z INFO [UPDATER]   [stdout] Teleport v18.1.0-dev.vapopov.3 git:v18.1.0-dev.vapopov.3-0-g065615f go1.24.5 agent/logger.go:74
2025-07-30T10:33:09.455Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:33:09.457Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:1258

  Running scriptlet: teleport-17.2.9-1.aarch64                                                                                                                                                                    2/2
  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/2
  Verifying        : teleport-17.2.9-1.aarch64                                                                                                                                                                    2/2
Installed products updated.

Upgraded:
  teleport-18.1.0_dev.vapopov.3-1.aarch64

Complete!
[root@3b712c71b962 teleport]# yum remove -y teleport
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Dependencies resolved.
======================================================================================================================================================================================================================
 Package                                        Architecture                                  Version                                                       Repository                                           Size
======================================================================================================================================================================================================================
Removing:
 teleport                                       aarch64                                       18.1.0_dev.vapopov.3-1                                        @@commandline                                       734 M

Transaction Summary
======================================================================================================================================================================================================================
Remove  1 Package

Freed space: 734 M
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                              1/1
  Running scriptlet: teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Removing symlinks from Teleport system paths...
2025-07-30T10:33:09.725Z WARN [UPDATER]   Removed binary link, but skipping removal of custom service that does not match the binary. service:teleport.service binary:teleport agent/installer.go:780
2025-07-30T10:33:09.747Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:366
2025-07-30T10:33:09.747Z INFO [UPDATER]   Successfully unlinked system package installation. agent/updater.go:1273

  Erasing          : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
  Verifying        : teleport-18.1.0_dev.vapopov.3-1.aarch64                                                                                                                                                      1/1
Installed products updated.

Removed:
  teleport-18.1.0_dev.vapopov.3-1.aarch64

Complete!
```

</details>


tag-build: https://github.com/gravitational/teleport.e/actions/runs/16589887976
tag-publish: https://github.com/gravitational/teleport.e/actions/runs/16593390909
changelog: Fixed unlink-package during upgrade/downgrade 