### PR TITLE
Connect: Update link to Device Trust docs

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -149,13 +149,14 @@ function DeviceTrustMessage(props: { status: DeviceTrustStatus }) {
         <>
           <ShieldWarning color="warning.main" size="small" mb="2px" />
           <P3>
-            Full access requires a trusted device.{' '}
+            Full access requires a trusted device. Learn how to{' '}
             <Link
-              href="https://goteleport.com/docs/admin-guides/access-controls/device-trust/guide/#step-22-enroll-device"
+              href="https://goteleport.com/docs/identity-governance/device-trust/device-management/#create-a-device-enrollment-token"
               target="_blank"
             >
-              Learn how to enroll your device.
+              enroll your device
             </Link>
+            .
           </P3>
         </>
       );


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="468" height="286" alt="before" src="https://github.com/user-attachments/assets/ccddb1d0-8986-483f-bb1d-7615e70dee2d" /> | <img width="468" height="286" alt="after" src="https://github.com/user-attachments/assets/54acf98b-08e0-4648-b0e8-657cd381287b" /> |

Before this change, the link pointed to [a step from the getting started guide](https://goteleport.com/docs/admin-guides/access-controls/device-trust/guide/#step-22-enroll-device). This guide is meant for the practitioner so that they can quickly enroll a device into the cluster. A regular user will typically lack the privileges required to run `tsh device enroll --current-device`, so instead they should use [an enrollment token](https://goteleport.com/docs/identity-governance/device-trust/device-management/#create-a-device-enrollment-token).

Another scenario in which a user can see this view in Connect is when the cluster has [auto-enrollment](https://github.com/gravitational/teleport.e/blob/master/rfd/0007e-device-trust-mdm-integration.md#automatic-enrollment) enabled. In that scenario, the device should get enrolled on the first login. If it didn't happen and the user sees the link to the docs, it means that auto-enrollment failed, likely because the current device didn't match any device in the inventory of the cluster, the device profile from the MDM failed to match data reported by tsh, or the device wasn't reverted back to the not enrolled state before being given to another user. In that situation, the best approach would be for the admin to inspect the logs and determine the exact problem with auto-enrollment, but the admin can still issue an enrollment token for the user as a workaround.