### PR TITLE
Fix LDAP CRL publication

### DIFF
--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -192,3 +192,7 @@ func (cfg *LDAPConfig) CheckAndSetDefaults() error {
 
 	return nil
 }
+
+func (cfg *LDAPConfig) Enabled() bool {
+	return cfg.Addr != "" || cfg.LocateServer.Enabled
+}

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -241,6 +241,12 @@ func (s *WindowsService) lookupDesktop(ctx context.Context, hostname string) ([]
 	}
 
 	queryResolver := func(resolver *net.Resolver, resolverName string) chan []netip.Addr {
+		if resolver == nil {
+			ch := make(chan []netip.Addr)
+			close(ch)
+			return ch
+		}
+
 		ch := make(chan []netip.Addr, 1)
 		go func() {
 			tctx, cancel := context.WithTimeout(ctx, dnsQueryTimeout)


### PR DESCRIPTION
During development of #55937 we've lost ability to publish CRL at the start of the Windows Desktop Service.
This change brings it back

changelog: Fix CRL publication for Active Directory Windows desktop access