### PR TITLE
[tctl] Seperate config parsing from client init

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -66,8 +66,10 @@ func TestUpdate(t *testing.T) {
 
 	// Verify that the installed version is equal to requested one.
 	cmd := exec.CommandContext(ctx, tctlPath, "version")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
-	require.NoError(t, err)
+	require.NoError(t, err, stderr.String())
 
 	matches := pattern.FindStringSubmatch(string(out))
 	require.Len(t, matches, 2)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -181,7 +181,13 @@ func TryRun(ctx context.Context, commands []CLICommand, args []string) error {
 
 	cfg.Debug = ccf.Debug
 
-	clientFunc := commonclient.GetInitFunc(ccf, cfg)
+	clientConfig, err := tctlcfg.ApplyConfig(&ccf, cfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	clientFunc := commonclient.GetInitFunc(clientConfig)
+
 	// Execute whatever is selected.
 	for _, c := range commands {
 		match, err := c.TryRun(ctx, selectedCmd, clientFunc)


### PR DESCRIPTION
This change moves the tctl configuration parsing
to be done before running the selected command and not be part of client init. This means commands
that do not need a client can access the config
such as `tctl top` when using socket mode.