### PR TITLE
docs: Fix Terraform syntax in SCIM docs

### DIFF
--- a/docs/pages/admin-guides/management/guides/scim/scim.mdx
+++ b/docs/pages/admin-guides/management/guides/scim/scim.mdx
@@ -43,7 +43,9 @@ and match `spec.title` to the name of `displayName` of  SCIM group that we be pr
 resource "teleport_access_list" "acl-group-requester" {
   header = {
     version = "v1"
-    name = "scim-group-requester"
+    metadata = {
+      name = "scim-group-requester"
+    }
   }
   spec = {
     title = "GroupRequester"


### PR DESCRIPTION
The current example in the docs is wrong and does not work:

```
╷
│ Error: Error reading AccessList
│ 
│   with teleport_access_list.acl-group-requester,
│   on access-list.tf line 1, in resource "teleport_access_list" "acl-group-requester":
│    1: resource "teleport_access_list" "acl-group-requester" {
│ 
│ Can not convert *accesslist.AccessList to AccessList: missing parameter
│ Name
╵
```

As per [fixture](https://github.com/gravitational/teleport/blob/457b3f49aa537160de61543752dfd9913644cba5/integrations/terraform/testlib/fixtures/access_list_0_create.tf) the `name` element should be nested under `metadata`.