### PR TITLE
Added "Allowed Tools" to "tsh mcp ls" and show a warning if no tools allowed

### DIFF
--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -228,23 +228,53 @@ func newMCPServerWithDetails(app types.Application, accessChecker services.Acces
 	return a
 }
 
+type mcpListRBACPrinter struct {
+	showFootnote bool
+}
+
+func (p *mcpListRBACPrinter) formatAllowedTools(mcpServer mcpServerWithDetails) string {
+	allowed := common.FormatAllowedEntities(mcpServer.Permissions.MCP.Tools.Allowed, mcpServer.Permissions.MCP.Tools.Denied)
+	if len(mcpServer.Permissions.MCP.Tools.Allowed) == 0 {
+		allowed += " [!]"
+		p.showFootnote = true
+	}
+	return allowed
+}
+
+func (p *mcpListRBACPrinter) maybePrintFootnote(w io.Writer) error {
+	if !p.showFootnote {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, `[!] Warning: you do not have access to any tools on the MCP server.
+Please contact your Teleport administrator to ensure your Teleport role has
+appropriate 'allow.mcp.tools' set. For details on MCP access RBAC, see:
+https://goteleport.com/docs/enroll-resources/mcp-access/rbac/
+`)
+	return trace.Wrap(err)
+}
+
 func printMCPServersInText(w io.Writer, mcpServers iter.Seq[mcpServerWithDetails]) error {
 	var rows [][]string
+	var rbacPrinter mcpListRBACPrinter
 	for mcpServer := range mcpServers {
 		rows = append(rows, []string{
 			mcpServer.GetName(),
 			mcpServer.GetDescription(),
 			types.GetMCPServerTransportType(mcpServer.GetURI()),
+			rbacPrinter.formatAllowedTools(mcpServer),
 			common.FormatLabels(mcpServer.GetAllLabels(), false),
 		})
 	}
-	t := asciitable.MakeTableWithTruncatedColumn([]string{"Name", "Description", "Type", "Labels"}, rows, "Labels")
-	_, err := fmt.Fprintln(w, t.AsBuffer().String())
-	return trace.Wrap(err)
+	t := asciitable.MakeTableWithTruncatedColumn([]string{"Name", "Description", "Type", "Allowed Tools", "Labels"}, rows, "Labels")
+	if _, err := fmt.Fprintln(w, t.AsBuffer().String()); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(rbacPrinter.maybePrintFootnote(w))
 }
 
 func printMCPServersInVerboseText(w io.Writer, mcpServers iter.Seq[mcpServerWithDetails]) error {
 	t := asciitable.MakeTable([]string{"Name", "Description", "Type", "Labels", "Command", "Args", "Allowed Tools"})
+	var rbacPrinter mcpListRBACPrinter
 	for mcpServer := range mcpServers {
 		mcpSpec := cmp.Or(mcpServer.GetMCP(), &types.MCP{})
 		t.AddRow([]string{
@@ -254,11 +284,13 @@ func printMCPServersInVerboseText(w io.Writer, mcpServers iter.Seq[mcpServerWith
 			common.FormatLabels(mcpServer.GetAllLabels(), true),
 			mcpSpec.Command,
 			strings.Join(mcpSpec.Args, " "),
-			common.FormatAllowedEntities(mcpServer.Permissions.MCP.Tools.Allowed, mcpServer.Permissions.MCP.Tools.Denied),
+			rbacPrinter.formatAllowedTools(mcpServer),
 		})
 	}
-	_, err := fmt.Fprintln(w, t.AsBuffer().String())
-	return trace.Wrap(err)
+	if _, err := fmt.Fprintln(w, t.AsBuffer().String()); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(rbacPrinter.maybePrintFootnote(w))
 }
 
 type mcpConfigCommand struct {

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -266,7 +266,7 @@ func printMCPServersInText(w io.Writer, mcpServers iter.Seq[mcpServerWithDetails
 		})
 	}
 	t := asciitable.MakeTableWithTruncatedColumn([]string{"Name", "Description", "Type", "Allowed Tools", "Labels"}, rows, "Labels")
-	if _, err := fmt.Fprintln(w, t.AsBuffer().String()); err != nil {
+	if _, err := fmt.Fprintln(w, t.String()); err != nil {
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(rbacPrinter.maybePrintFootnote(w))
@@ -287,7 +287,7 @@ func printMCPServersInVerboseText(w io.Writer, mcpServers iter.Seq[mcpServerWith
 			rbacPrinter.formatAllowedTools(mcpServer),
 		})
 	}
-	if _, err := fmt.Fprintln(w, t.AsBuffer().String()); err != nil {
+	if _, err := fmt.Fprintln(w, t.String()); err != nil {
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(rbacPrinter.maybePrintFootnote(w))

--- a/tool/tsh/common/testdata/Test_mcpListCommand/JSON_format.golden
+++ b/tool/tsh/common/testdata/Test_mcpListCommand/JSON_format.golden
@@ -1,0 +1,69 @@
+[
+  {
+    "kind": "app",
+    "sub_kind": "mcp",
+    "version": "v3",
+    "metadata": {
+      "name": "allow-read",
+      "description": "description",
+      "labels": {
+        "env": "dev"
+      }
+    },
+    "spec": {
+      "uri": "mcp+stdio://",
+      "insecure_skip_verify": false,
+      "mcp": {
+        "command": "test",
+        "args": [
+          "arg"
+        ],
+        "run_as_host_user": "test"
+      }
+    },
+    "permissions": {
+      "mcp": {
+        "tools": {
+          "allowed": [
+            "read_*"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "kind": "app",
+    "sub_kind": "mcp",
+    "version": "v3",
+    "metadata": {
+      "name": "deny-write",
+      "description": "description",
+      "labels": {
+        "env": "dev"
+      }
+    },
+    "spec": {
+      "uri": "mcp+stdio://",
+      "insecure_skip_verify": false,
+      "mcp": {
+        "command": "test",
+        "args": [
+          "arg"
+        ],
+        "run_as_host_user": "test"
+      }
+    },
+    "permissions": {
+      "mcp": {
+        "tools": {
+          "allowed": [
+            "*"
+          ],
+          "denied": [
+            "write_*"
+          ]
+        }
+      }
+    }
+  }
+]

--- a/tool/tsh/common/testdata/Test_mcpListCommand/YAML_format.golden
+++ b/tool/tsh/common/testdata/Test_mcpListCommand/YAML_format.golden
@@ -1,0 +1,45 @@
+- kind: app
+  metadata:
+    description: description
+    labels:
+      env: dev
+    name: allow-read
+  permissions:
+    mcp:
+      tools:
+        allowed:
+        - read_*
+  spec:
+    insecure_skip_verify: false
+    mcp:
+      args:
+      - arg
+      command: test
+      run_as_host_user: test
+    uri: mcp+stdio://
+  sub_kind: mcp
+  version: v3
+- kind: app
+  metadata:
+    description: description
+    labels:
+      env: dev
+    name: deny-write
+  permissions:
+    mcp:
+      tools:
+        allowed:
+        - '*'
+        denied:
+        - write_*
+  spec:
+    insecure_skip_verify: false
+    mcp:
+      args:
+      - arg
+      command: test
+      run_as_host_user: test
+    uri: mcp+stdio://
+  sub_kind: mcp
+  version: v3
+

--- a/tool/tsh/common/testdata/Test_mcpListCommand/text_format.golden
+++ b/tool/tsh/common/testdata/Test_mcpListCommand/text_format.golden
@@ -1,0 +1,5 @@
+Name       Description Type  Allowed Tools       Labels  
+---------- ----------- ----- ------------------- ------- 
+allow-read description stdio [read_*]            env=dev 
+deny-write description stdio [*], except: [wr... env=dev 
+

--- a/tool/tsh/common/testdata/Test_mcpListCommand/text_format_in_verbose.golden
+++ b/tool/tsh/common/testdata/Test_mcpListCommand/text_format_in_verbose.golden
@@ -1,0 +1,5 @@
+Name       Description Type  Labels  Command Args Allowed Tools          
+---------- ----------- ----- ------- ------- ---- ---------------------- 
+allow-read description stdio env=dev test    arg  [read_*]               
+deny-write description stdio env=dev test    arg  [*], except: [write_*] 
+

--- a/tool/tsh/common/testdata/Test_mcpListCommand/text_format_with_rbac_warning.golden
+++ b/tool/tsh/common/testdata/Test_mcpListCommand/text_format_with_rbac_warning.golden
@@ -1,0 +1,8 @@
+Name      Description Type  Allowed Tools Labels  
+--------- ----------- ----- ------------- ------- 
+no-access description stdio (none) [!]    env=dev 
+
+[!] Warning: you do not have access to any tools on the MCP server.
+Please contact your Teleport administrator to ensure your Teleport role has
+appropriate 'allow.mcp.tools' set. For details on MCP access RBAC, see:
+https://goteleport.com/docs/enroll-resources/mcp-access/rbac/


### PR DESCRIPTION
changelog: Added "Allowed Tools" to "tsh mcp ls" and show a warning if no tools allowed

warning example:
```
Name              Description                             Type  Allowed Tools Labels   
----------------- --------------------------------------- ----- ------------- -------- 
dev-files         Shared files for developers             stdio (none) [!]    team=dev 
everything        Everything MCP server                   stdio (none) [!]    env=dev  
teleport-mcp-demo A demo MCP server that shows current... stdio (none) [!]             

[!] Warning: you do not have access to any tools on the MCP server.
Please contact your Teleport administrator to ensure your Teleport role has
appropriate 'allow.mcp.tools' set. For details on MCP access RBAC, see:
https://goteleport.com/docs/enroll-resources/mcp-access/rbac/
```

no-warning example
```
$ tsh mcp ls
Name              Description                             Type  Allowed Tools Labels   
----------------- --------------------------------------- ----- ------------- -------- 
dev-files         Shared files for developers             stdio [*]           team=dev 
everything        Everything MCP server                   stdio [*]           env=dev  
teleport-mcp-demo A demo MCP server that shows current... stdio [*]                
```