### PR TITLE
Add missing handling for recording encryption configs and keys

### DIFF
--- a/api/gen/proto/go/teleport/recordingencryption/v1/recording_encryption.pb.go
+++ b/api/gen/proto/go/teleport/recordingencryption/v1/recording_encryption.pb.go
@@ -37,36 +37,29 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// WrappedKey wraps the private key of a recording encryption key pair using a
-// separate asymmetric keypair.
-type WrappedKey struct {
+// A key pair used with age to wrap and unwrap file keys for session recording encryption.
+type KeyPair struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// RecordingEncryptionPair is the asymmetric keypair used with age to encrypt
-	// and decrypt filekeys. The private key is encrypted using the KeyEncryptionPair's
-	// public key and has to be decrypted before recording decryption operations can
-	// be fulfilled.
-	RecordingEncryptionPair *types.EncryptionKeyPair `protobuf:"bytes,1,opt,name=recording_encryption_pair,json=recordingEncryptionPair,proto3" json:"recording_encryption_pair,omitempty"`
-	// KeyEncryptionPair is the asymmetric keypair used to wrap (encrypt) the
-	// RecordingEncryptionPair's private key.
-	KeyEncryptionPair *types.EncryptionKeyPair `protobuf:"bytes,2,opt,name=key_encryption_pair,json=keyEncryptionPair,proto3" json:"key_encryption_pair,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// A key pair used with age to wrap and unwrap file keys for session recording encryption.
+	KeyPair       *types.EncryptionKeyPair `protobuf:"bytes,1,opt,name=key_pair,json=keyPair,proto3" json:"key_pair,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *WrappedKey) Reset() {
-	*x = WrappedKey{}
+func (x *KeyPair) Reset() {
+	*x = KeyPair{}
 	mi := &file_teleport_recordingencryption_v1_recording_encryption_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *WrappedKey) String() string {
+func (x *KeyPair) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*WrappedKey) ProtoMessage() {}
+func (*KeyPair) ProtoMessage() {}
 
-func (x *WrappedKey) ProtoReflect() protoreflect.Message {
+func (x *KeyPair) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_recordingencryption_v1_recording_encryption_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -78,21 +71,14 @@ func (x *WrappedKey) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use WrappedKey.ProtoReflect.Descriptor instead.
-func (*WrappedKey) Descriptor() ([]byte, []int) {
+// Deprecated: Use KeyPair.ProtoReflect.Descriptor instead.
+func (*KeyPair) Descriptor() ([]byte, []int) {
 	return file_teleport_recordingencryption_v1_recording_encryption_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *WrappedKey) GetRecordingEncryptionPair() *types.EncryptionKeyPair {
+func (x *KeyPair) GetKeyPair() *types.EncryptionKeyPair {
 	if x != nil {
-		return x.RecordingEncryptionPair
-	}
-	return nil
-}
-
-func (x *WrappedKey) GetKeyEncryptionPair() *types.EncryptionKeyPair {
-	if x != nil {
-		return x.KeyEncryptionPair
+		return x.KeyPair
 	}
 	return nil
 }
@@ -100,13 +86,13 @@ func (x *WrappedKey) GetKeyEncryptionPair() *types.EncryptionKeyPair {
 // RecordingEncryptionSpec contains the active key set for encrypted session recording.
 type RecordingEncryptionSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// AciveKeys is a list of active, wrapped X25519 keypairs. The unique set of RecordingEncryptionPair
-	// public keys are used as recipients during age encryption of session recordings. This
-	// allows any active private key to be used during decryption which guards against recordings
-	// being inaccessible to auth servers waiting for their key to rotate.
-	ActiveKeys    []*WrappedKey `protobuf:"bytes,1,rep,name=active_keys,json=activeKeys,proto3" json:"active_keys,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// A list of active key pairs used for session recording encryption. The unique set of
+	// active public keys are used as recipients during age encryption. This allows any
+	// active private key to be used during decryption which guards against recordings being
+	// inaccessible to auth servers waiting for key rotation.
+	ActiveKeyPairs []*KeyPair `protobuf:"bytes,2,rep,name=active_key_pairs,json=activeKeyPairs,proto3" json:"active_key_pairs,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RecordingEncryptionSpec) Reset() {
@@ -139,9 +125,9 @@ func (*RecordingEncryptionSpec) Descriptor() ([]byte, []int) {
 	return file_teleport_recordingencryption_v1_recording_encryption_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *RecordingEncryptionSpec) GetActiveKeys() []*WrappedKey {
+func (x *RecordingEncryptionSpec) GetActiveKeyPairs() []*KeyPair {
 	if x != nil {
-		return x.ActiveKeys
+		return x.ActiveKeyPairs
 	}
 	return nil
 }
@@ -272,14 +258,11 @@ var File_teleport_recordingencryption_v1_recording_encryption_proto protoreflect
 
 const file_teleport_recordingencryption_v1_recording_encryption_proto_rawDesc = "" +
 	"\n" +
-	":teleport/recordingencryption/v1/recording_encryption.proto\x12\x1fteleport.recordingencryption.v1\x1a!teleport/header/v1/metadata.proto\x1a!teleport/legacy/types/types.proto\"\xac\x01\n" +
-	"\n" +
-	"WrappedKey\x12T\n" +
-	"\x19recording_encryption_pair\x18\x01 \x01(\v2\x18.types.EncryptionKeyPairR\x17recordingEncryptionPair\x12H\n" +
-	"\x13key_encryption_pair\x18\x02 \x01(\v2\x18.types.EncryptionKeyPairR\x11keyEncryptionPair\"g\n" +
-	"\x17RecordingEncryptionSpec\x12L\n" +
-	"\vactive_keys\x18\x01 \x03(\v2+.teleport.recordingencryption.v1.WrappedKeyR\n" +
-	"activeKeys\"\x1b\n" +
+	":teleport/recordingencryption/v1/recording_encryption.proto\x12\x1fteleport.recordingencryption.v1\x1a!teleport/header/v1/metadata.proto\x1a!teleport/legacy/types/types.proto\">\n" +
+	"\aKeyPair\x123\n" +
+	"\bkey_pair\x18\x01 \x01(\v2\x18.types.EncryptionKeyPairR\akeyPair\"\x80\x01\n" +
+	"\x17RecordingEncryptionSpec\x12R\n" +
+	"\x10active_key_pairs\x18\x02 \x03(\v2(.teleport.recordingencryption.v1.KeyPairR\x0eactiveKeyPairsJ\x04\b\x01\x10\x02R\vactive_keys\"\x1b\n" +
 	"\x19RecordingEncryptionStatus\"\xba\x02\n" +
 	"\x13RecordingEncryption\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
@@ -303,7 +286,7 @@ func file_teleport_recordingencryption_v1_recording_encryption_proto_rawDescGZIP
 
 var file_teleport_recordingencryption_v1_recording_encryption_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_teleport_recordingencryption_v1_recording_encryption_proto_goTypes = []any{
-	(*WrappedKey)(nil),                // 0: teleport.recordingencryption.v1.WrappedKey
+	(*KeyPair)(nil),                   // 0: teleport.recordingencryption.v1.KeyPair
 	(*RecordingEncryptionSpec)(nil),   // 1: teleport.recordingencryption.v1.RecordingEncryptionSpec
 	(*RecordingEncryptionStatus)(nil), // 2: teleport.recordingencryption.v1.RecordingEncryptionStatus
 	(*RecordingEncryption)(nil),       // 3: teleport.recordingencryption.v1.RecordingEncryption
@@ -311,17 +294,16 @@ var file_teleport_recordingencryption_v1_recording_encryption_proto_goTypes = []
 	(*v1.Metadata)(nil),               // 5: teleport.header.v1.Metadata
 }
 var file_teleport_recordingencryption_v1_recording_encryption_proto_depIdxs = []int32{
-	4, // 0: teleport.recordingencryption.v1.WrappedKey.recording_encryption_pair:type_name -> types.EncryptionKeyPair
-	4, // 1: teleport.recordingencryption.v1.WrappedKey.key_encryption_pair:type_name -> types.EncryptionKeyPair
-	0, // 2: teleport.recordingencryption.v1.RecordingEncryptionSpec.active_keys:type_name -> teleport.recordingencryption.v1.WrappedKey
-	5, // 3: teleport.recordingencryption.v1.RecordingEncryption.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 4: teleport.recordingencryption.v1.RecordingEncryption.spec:type_name -> teleport.recordingencryption.v1.RecordingEncryptionSpec
-	2, // 5: teleport.recordingencryption.v1.RecordingEncryption.status:type_name -> teleport.recordingencryption.v1.RecordingEncryptionStatus
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	4, // 0: teleport.recordingencryption.v1.KeyPair.key_pair:type_name -> types.EncryptionKeyPair
+	0, // 1: teleport.recordingencryption.v1.RecordingEncryptionSpec.active_key_pairs:type_name -> teleport.recordingencryption.v1.KeyPair
+	5, // 2: teleport.recordingencryption.v1.RecordingEncryption.metadata:type_name -> teleport.header.v1.Metadata
+	1, // 3: teleport.recordingencryption.v1.RecordingEncryption.spec:type_name -> teleport.recordingencryption.v1.RecordingEncryptionSpec
+	2, // 4: teleport.recordingencryption.v1.RecordingEncryption.status:type_name -> teleport.recordingencryption.v1.RecordingEncryptionStatus
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_recordingencryption_v1_recording_encryption_proto_init() }

--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -1269,9 +1269,9 @@ message EncryptionKeyPair {
   uint32 hash = 4 [(gogoproto.jsontag) = "hash,omitempty"];
 }
 
-// AgeEncryptionKey is a Bech32 encoded age X25519 public key.
+// A public key to be used as a recipient during age encryption of session recordings.
 message AgeEncryptionKey {
-  // PublicKey is a Bech32 encoded age X25519 public key.
+  // A PEM encoded public key used for key wrapping during age encryption. Expected to be RSA 4096.
   bytes public_key = 1 [(gogoproto.jsontag) = "public_key"];
 }
 

--- a/api/proto/teleport/recordingencryption/v1/recording_encryption.proto
+++ b/api/proto/teleport/recordingencryption/v1/recording_encryption.proto
@@ -21,26 +21,22 @@ import "teleport/legacy/types/types.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1;recordingencryptionv1";
 
-// WrappedKey wraps the private key of a recording encryption key pair using a
-// separate asymmetric keypair.
-message WrappedKey {
-  // RecordingEncryptionPair is the asymmetric keypair used with age to encrypt
-  // and decrypt filekeys. The private key is encrypted using the KeyEncryptionPair's
-  // public key and has to be decrypted before recording decryption operations can
-  // be fulfilled.
-  types.EncryptionKeyPair recording_encryption_pair = 1;
-  // KeyEncryptionPair is the asymmetric keypair used to wrap (encrypt) the
-  // RecordingEncryptionPair's private key.
-  types.EncryptionKeyPair key_encryption_pair = 2;
+// A key pair used with age to wrap and unwrap file keys for session recording encryption.
+message KeyPair {
+  // A key pair used with age to wrap and unwrap file keys for session recording encryption.
+  types.EncryptionKeyPair key_pair = 1;
 }
 
 // RecordingEncryptionSpec contains the active key set for encrypted session recording.
 message RecordingEncryptionSpec {
-  // AciveKeys is a list of active, wrapped X25519 keypairs. The unique set of RecordingEncryptionPair
-  // public keys are used as recipients during age encryption of session recordings. This
-  // allows any active private key to be used during decryption which guards against recordings
-  // being inaccessible to auth servers waiting for their key to rotate.
-  repeated WrappedKey active_keys = 1;
+  reserved 1; // active_keys
+  reserved "active_keys";
+
+  // A list of active key pairs used for session recording encryption. The unique set of
+  // active public keys are used as recipients during age encryption. This allows any
+  // active private key to be used during decryption which guards against recordings being
+  // inaccessible to auth servers waiting for key rotation.
+  repeated KeyPair active_key_pairs = 2;
 }
 
 // RecordingEncryptionStatus contains the status of the RecordingEncryption resource.

--- a/api/types/sessionrecording.go
+++ b/api/types/sessionrecording.go
@@ -59,6 +59,7 @@ type SessionRecordingConfig interface {
 
 	// Clone returns a copy of the resource.
 	Clone() SessionRecordingConfig
+
 	// CheckAndSetDefaults verifies the constraints for a SessionRecordingConfig
 	CheckAndSetDefaults() error
 }

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -4413,9 +4413,9 @@ func (m *EncryptionKeyPair) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_EncryptionKeyPair proto.InternalMessageInfo
 
-// AgeEncryptionKey is a Bech32 encoded age X25519 public key.
+// A public key to be used as a recipient during age encryption of session recordings.
 type AgeEncryptionKey struct {
-	// PublicKey is a Bech32 encoded age X25519 public key.
+	// A PEM encoded public key used for key wrapping during age encryption. Expected to be RSA 4096.
 	PublicKey            []byte   `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
@@ -89,5 +89,5 @@ Optional:
 
 Optional:
 
-- `public_key` (String) PublicKey is a Bech32 encoded age X25519 public key.
+- `public_key` (String) A PEM encoded public key used for key wrapping during age encryption. Expected to be RSA 4096.
 

--- a/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
@@ -111,4 +111,4 @@ Optional:
 
 Optional:
 
-- `public_key` (String) PublicKey is a Bech32 encoded age X25519 public key.
+- `public_key` (String) A PEM encoded public key used for key wrapping during age encryption. Expected to be RSA 4096.

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -2157,7 +2157,7 @@ func GenSchemaSessionRecordingConfigV2(ctx context.Context) (github_com_hashicor
 		"status": {
 			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"encryption_keys": {
 				Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"public_key": {
-					Description: "PublicKey is a Bech32 encoded age X25519 public key.",
+					Description: "A PEM encoded public key used for key wrapping during age encryption. Expected to be RSA 4096.",
 					Optional:    true,
 					Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 				}}),

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -738,7 +738,7 @@ func (s *Service) CreateSessionRecordingConfig(ctx context.Context, cfg types.Se
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
-	if err := services.ValidateSessionRecordingConfig(cfg); err != nil {
+	if err := services.ValidateSessionRecordingConfig(cfg, s.signatureAlgorithmSuiteParams.FIPS, s.signatureAlgorithmSuiteParams.Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -776,9 +776,10 @@ func (s *Service) UpdateSessionRecordingConfig(ctx context.Context, req *cluster
 
 	req.SessionRecordingConfig.SetOrigin(types.OriginDynamic)
 
-	if err := services.ValidateSessionRecordingConfig(req.SessionRecordingConfig); err != nil {
+	if err := services.ValidateSessionRecordingConfig(req.SessionRecordingConfig, s.signatureAlgorithmSuiteParams.FIPS, s.signatureAlgorithmSuiteParams.Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	updated, err := s.backend.UpdateSessionRecordingConfig(ctx, req.SessionRecordingConfig)
 
 	if err := s.emitter.EmitAuditEvent(ctx, &apievents.SessionRecordingConfigUpdate{
@@ -825,9 +826,10 @@ func (s *Service) UpsertSessionRecordingConfig(ctx context.Context, req *cluster
 
 	req.SessionRecordingConfig.SetOrigin(types.OriginDynamic)
 
-	if err := services.ValidateSessionRecordingConfig(req.SessionRecordingConfig); err != nil {
+	if err := services.ValidateSessionRecordingConfig(req.SessionRecordingConfig, s.signatureAlgorithmSuiteParams.FIPS, s.signatureAlgorithmSuiteParams.Cloud); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	upserted, err := s.backend.UpsertSessionRecordingConfig(ctx, req.SessionRecordingConfig)
 
 	if err := s.emitter.EmitAuditEvent(ctx, &apievents.SessionRecordingConfigUpdate{

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -222,13 +222,17 @@ func TestBackends(t *testing.T) {
 				publicKeys[i] = signer.Public()
 			}
 
+			// generate an encryption key that should not be cleaned up
+			encryptionKey, decrypter, hash, err := backend.generateDecrypter(ctx, cryptosuites.RSA4096)
+			require.NoError(t, err)
+
 			// AWS KMS keystore will not delete any keys created in the past 5
 			// minutes.
 			pack.clock.Advance(6 * time.Minute)
 
 			// say that only the first key is in use, delete the rest
 			usedKeys := [][]byte{rawPrivateKeys[0]}
-			err := backend.deleteUnusedKeys(ctx, usedKeys)
+			err = backend.deleteUnusedKeys(ctx, usedKeys)
 			require.NoError(t, err, trace.DebugReport(err))
 
 			// make sure the first key is still good
@@ -236,6 +240,23 @@ func TestBackends(t *testing.T) {
 			require.NoError(t, err)
 			_, err = signer.Sign(rand.Reader, messageHash[:], crypto.SHA256)
 			require.NoError(t, err)
+
+			// make sure the encryption key is still good
+			plaintext := "test message"
+			pubKey, ok := decrypter.Public().(*rsa.PublicKey)
+			require.True(t, ok, "expected *rsa.PublicKey, got %T", decrypter.Public())
+
+			cipher, err := rsa.EncryptOAEP(hash.New(), rand.Reader, pubKey, []byte(plaintext), nil)
+			require.NoError(t, err)
+
+			decrypter, err = backend.getDecrypter(ctx, encryptionKey, decrypter.Public(), hash)
+			require.NoError(t, err)
+
+			decrypted, err := decrypter.Decrypt(rand.Reader, cipher, &rsa.OAEPOptions{
+				Hash: hash,
+			})
+			require.NoError(t, err)
+			require.Equal(t, plaintext, string(decrypted))
 
 			// make sure all other keys are deleted
 			for i := 1; i < numKeys; i++ {

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -44,6 +44,10 @@ import (
 
 var pkcs11Prefix = []byte("pkcs11:")
 
+const (
+	recordingEncryptionHostID = "teleport_recording_encryption"
+)
+
 type pkcs11KeyStore struct {
 	ctx       *crypto11.Context
 	hostUUID  string
@@ -198,6 +202,7 @@ func (p *pkcs11KeyStore) generateDecrypter(ctx context.Context, alg cryptosuites
 		return nil, nil, p.oaepHash, trace.Wrap(err)
 	}
 
+	id.HostID = recordingEncryptionHostID
 	rawTeleportID, err := id.marshal()
 	if err != nil {
 		return nil, nil, p.oaepHash, trace.Wrap(err)
@@ -210,7 +215,7 @@ func (p *pkcs11KeyStore) generateDecrypter(ctx context.Context, alg cryptosuites
 
 	p.log.InfoContext(ctx, "Creating new HSM keypair.", "id", id, "algorithm", logutils.StringerAttr(alg))
 
-	label := []byte(p.hostUUID)
+	label := []byte(id.HostID)
 	switch alg {
 	case cryptosuites.RSA4096:
 		decrypter, err := p.generateRSA4096(rawPKCS11ID, label)
@@ -329,6 +334,10 @@ func (p *pkcs11KeyStore) findDecryptersByLabel(ctx context.Context, label *types
 	return decrypters, nil
 }
 
+func (p *pkcs11KeyStore) checkAccessibleHostID(hostID string) bool {
+	return hostID == recordingEncryptionHostID || hostID == p.hostUUID
+}
+
 func (p *pkcs11KeyStore) getSignerWithoutPublicKey(ctx context.Context, rawKey []byte) (crypto.Signer, error) {
 	if t := keyType(rawKey); t != types.PrivateKeyType_PKCS11 {
 		return nil, trace.BadParameter("pkcs11KeyStore cannot get signer for key type %s", t.String())
@@ -337,14 +346,14 @@ func (p *pkcs11KeyStore) getSignerWithoutPublicKey(ctx context.Context, rawKey [
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if keyID.HostID != p.hostUUID {
+	if !p.checkAccessibleHostID(keyID.HostID) {
 		return nil, trace.NotFound("given pkcs11 key is for host: %q, but this host is: %q", keyID.HostID, p.hostUUID)
 	}
 	pkcs11ID, err := keyID.pkcs11Key(p.isYubiHSM)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	signer, err := p.ctx.FindKeyPair(pkcs11ID, []byte(p.hostUUID))
+	signer, err := p.ctx.FindKeyPair(pkcs11ID, []byte(keyID.HostID))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -367,7 +376,7 @@ func (p *pkcs11KeyStore) canUseKey(ctx context.Context, raw []byte, keyType type
 		return false, trace.Wrap(err)
 	}
 
-	return keyID.HostID == p.hostUUID, nil
+	return p.checkAccessibleHostID(keyID.HostID), nil
 }
 
 // deleteKey deletes the given key from the HSM
@@ -376,7 +385,7 @@ func (p *pkcs11KeyStore) deleteKey(_ context.Context, rawKey []byte) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if keyID.HostID != p.hostUUID {
+	if !p.checkAccessibleHostID(keyID.HostID) {
 		return trace.NotFound("pkcs11 key is for different host")
 	}
 	pkcs11ID, err := keyID.pkcs11Key(p.isYubiHSM)
@@ -413,7 +422,7 @@ func (p *pkcs11KeyStore) deleteUnusedKeys(ctx context.Context, activeKeys [][]by
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if keyID.HostID != p.hostUUID {
+		if !p.checkAccessibleHostID(keyID.HostID) {
 			// This key was labeled with a foreign host UUID, it is likely not
 			// present on the attached HSM and definitely will not be returned
 			// by FindKeyPairs below which queries by host UUID.

--- a/lib/cache/recording_encryption_test.go
+++ b/lib/cache/recording_encryption_test.go
@@ -35,7 +35,7 @@ func newRecordingEncryption() *recordingencryptionv1.RecordingEncryption {
 			Name: types.MetaNameRecordingEncryption,
 		},
 		Spec: &recordingencryptionv1.RecordingEncryptionSpec{
-			ActiveKeys: nil,
+			ActiveKeyPairs: nil,
 		},
 	}
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2592,6 +2592,10 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 				!cfg.Auth.SessionRecordingConfig.GetProxyChecksHostKeys() {
 				return trace.BadParameter("non-FIPS compliant proxy settings: \"proxy_checks_host_keys\" must be true")
 			}
+
+			if err := services.ValidateSessionRecordingConfig(cfg.Auth.SessionRecordingConfig, clf.FIPS, modules.GetModules().Features().Cloud); err != nil {
+				return trace.Wrap(err)
+			}
 		}
 	}
 

--- a/lib/services/local/recording_encryption_test.go
+++ b/lib/services/local/recording_encryption_test.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"crypto"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,7 +38,7 @@ func TestRecordingEncryption(t *testing.T) {
 
 	initialEncryption := pb.RecordingEncryption{
 		Spec: &pb.RecordingEncryptionSpec{
-			ActiveKeys: nil,
+			ActiveKeyPairs: nil,
 		},
 	}
 
@@ -53,33 +52,28 @@ func TestRecordingEncryption(t *testing.T) {
 	encryption, err := service.GetRecordingEncryption(ctx)
 	require.NoError(t, err)
 
-	require.Empty(t, created.Spec.ActiveKeys)
-	require.Empty(t, encryption.Spec.ActiveKeys)
+	require.Empty(t, created.Spec.ActiveKeyPairs)
+	require.Empty(t, encryption.Spec.ActiveKeyPairs)
 
-	encryption.Spec.ActiveKeys = []*pb.WrappedKey{
+	encryption.Spec.ActiveKeyPairs = []*pb.KeyPair{
 		{
-			RecordingEncryptionPair: &types.EncryptionKeyPair{
+			KeyPair: &types.EncryptionKeyPair{
 				PrivateKey: []byte("recording encryption private"),
 				PublicKey:  []byte("recording encryption public"),
 				Hash:       0,
-			},
-			KeyEncryptionPair: &types.EncryptionKeyPair{
-				PrivateKey: []byte("key encryption private"),
-				PublicKey:  []byte("key encryption public"),
-				Hash:       uint32(crypto.SHA256),
 			},
 		},
 	}
 
 	updated, err := service.UpdateRecordingEncryption(ctx, encryption)
 	require.NoError(t, err)
-	require.Len(t, updated.Spec.ActiveKeys, 1)
-	require.EqualExportedValues(t, encryption.Spec.ActiveKeys[0], updated.Spec.ActiveKeys[0])
+	require.Len(t, updated.Spec.ActiveKeyPairs, 1)
+	require.EqualExportedValues(t, encryption.Spec.ActiveKeyPairs[0], updated.Spec.ActiveKeyPairs[0])
 
 	encryption, err = service.GetRecordingEncryption(ctx)
 	require.NoError(t, err)
-	require.Len(t, encryption.Spec.ActiveKeys, 1)
-	require.EqualExportedValues(t, updated.Spec.ActiveKeys[0], encryption.Spec.ActiveKeys[0])
+	require.Len(t, encryption.Spec.ActiveKeyPairs, 1)
+	require.EqualExportedValues(t, updated.Spec.ActiveKeyPairs[0], encryption.Spec.ActiveKeyPairs[0])
 
 	err = service.DeleteRecordingEncryption(ctx)
 	require.NoError(t, err)

--- a/lib/services/sessionrecording.go
+++ b/lib/services/sessionrecording.go
@@ -97,8 +97,11 @@ const (
 	KeyTypeSoftware = "software"
 )
 
+var errRecordingEncryptionWithFIPS = &trace.BadParameterError{Message: `non-FIPS compliant session recording setting: "encryption" must not be enabled`}
+var errManualKeyManagementInCloud = &trace.BadParameterError{Message: `"manual_key_management" configuration is unsupported in Teleport Cloud`}
+
 // ValidateSessionRecordingConfig checks that the state of a [SessionRecordingConfig] meets constraints.
-func ValidateSessionRecordingConfig(cfg types.SessionRecordingConfig) error {
+func ValidateSessionRecordingConfig(cfg types.SessionRecordingConfig, fips, cloud bool) error {
 	if !slices.Contains(types.SessionRecordingModes, cfg.GetMode()) {
 		return trace.BadParameter("session recording mode must be one of %v; got %q", strings.Join(types.SessionRecordingModes, ","), cfg.GetMode())
 	}
@@ -108,9 +111,17 @@ func ValidateSessionRecordingConfig(cfg types.SessionRecordingConfig) error {
 		return nil
 	}
 
+	if fips && encryptionCfg.Enabled {
+		return trace.Wrap(errRecordingEncryptionWithFIPS)
+	}
+
 	manualKeyManagement := encryptionCfg.ManualKeyManagement
 	if manualKeyManagement == nil || !manualKeyManagement.Enabled {
 		return nil
+	}
+
+	if cloud {
+		return trace.Wrap(errManualKeyManagementInCloud)
 	}
 
 	if len(manualKeyManagement.ActiveKeys) == 0 {

--- a/lib/services/sessionrecording_test.go
+++ b/lib/services/sessionrecording_test.go
@@ -31,6 +31,9 @@ func TestValidateSessionRecordingConfig(t *testing.T) {
 	cases := []struct {
 		name      string
 		spec      types.SessionRecordingConfigSpecV2
+		params    types.SignatureAlgorithmSuiteParams
+		cloud     bool
+		fips      bool
 		expectErr error
 	}{
 		{
@@ -38,6 +41,8 @@ func TestValidateSessionRecordingConfig(t *testing.T) {
 			spec: types.SessionRecordingConfigSpecV2{
 				Mode: "node",
 			},
+			fips:      true,
+			cloud:     true,
 			expectErr: nil,
 		},
 		{
@@ -75,6 +80,31 @@ func TestValidateSessionRecordingConfig(t *testing.T) {
 				Mode: "invalid",
 			},
 			expectErr: trace.BadParameter("session recording mode must be one of %v; got %q", strings.Join(types.SessionRecordingModes, ","), "invalid"),
+		},
+		{
+			name: "invalid config: encryption with FIPS",
+			spec: types.SessionRecordingConfigSpecV2{
+				Mode: "node",
+				Encryption: &types.SessionRecordingEncryptionConfig{
+					Enabled: true,
+				},
+			},
+			fips:      true,
+			expectErr: trace.BadParameter("non-FIPS compliant session recording setting"),
+		},
+		{
+			name: "invalid config: manual encryption in cloud",
+			spec: types.SessionRecordingConfigSpecV2{
+				Mode: "node",
+				Encryption: &types.SessionRecordingEncryptionConfig{
+					Enabled: true,
+					ManualKeyManagement: &types.ManualKeyManagementConfig{
+						Enabled: true,
+					},
+				},
+			},
+			cloud:     true,
+			expectErr: trace.BadParameter(`"manual_key_management" configuration is unsupported in Teleport Cloud`),
 		},
 		{
 			name: "invalid config: manual encryption without active keys",
@@ -137,7 +167,7 @@ func TestValidateSessionRecordingConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := services.ValidateSessionRecordingConfig(&types.SessionRecordingConfigV2{Spec: c.spec})
+			err := services.ValidateSessionRecordingConfig(&types.SessionRecordingConfigV2{Spec: c.spec}, c.fips, c.cloud)
 			if c.expectErr == nil {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
This PR adds a few missing pieces to recording encryption:
- Use alternate labels/tags for encryption keys so they aren't automatically removed while still in use
- Prevent cloud tenants from using `manual_key_management`
- Prevent recording encryption in FIPS mode