### PR TITLE
Set packageImportMethod to clone-or-copy for pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,7 @@ peerDependencyRules:
     - electron-builder-squirrel-windows
 # shellEmulator enables cross-platform scripting, allowing POSIX-style shell variables to work on Windows.
 shellEmulator: true
+# packageImportMethod avoids an issue building the web UI in docker on mac. It does not seem to
+# affect performance outside of docker.
+# https://github.com/gravitational/teleport/issues/46019
+packageImportMethod: clone-or-copy


### PR DESCRIPTION
Setting the pnpm `packageImportMethod` to `clone-or-copy` has resolved
issues I've consistently had trying to build the web UI using a docker
container which I have needed to do to test buildboxes.

Random files are reported as `ENOENT: no such file or directory` when
building the web UI. The linked issue and related items have more
detail.

Note: This does not address the issue of the location of `.pnmp_store`
mentioned in the issue.

Issue: https://github.com/gravitational/teleport/issues/46019
