### PR TITLE
[tctl/top] Fix tctl top not parsing teleport config

### DIFF
--- a/tool/tctl/common/top/command.go
+++ b/tool/tctl/common/top/command.go
@@ -94,10 +94,17 @@ func (c *Command) newMetricsClient(ctx context.Context) (string, MetricsClient, 
 }
 
 // TryRun attempts to run subcommands.
-func (c *Command) TryRun(ctx context.Context, cmd string, _ commonclient.InitFunc) (match bool, err error) {
+func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
 	if cmd != c.top.FullCommand() {
 		return false, nil
 	}
+
+	// Call clientFunc to init `c.config`
+	_, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return true, trace.Wrap(err)
+	}
+	closeFn(ctx)
 
 	addr, metricsClient, err := c.newMetricsClient(ctx)
 	if err != nil {


### PR DESCRIPTION
The configuration file is parsed during `InitFunc` call, since `top` does not make use of the client this was previously omitted leading to default data dir location in the config. This fix allows custom locations for the debug unix socket.

changelog: Fix tctl top not parsing teleport config