### PR TITLE
Fix CRL backfill

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -795,7 +795,7 @@ func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthI
 		}
 
 		if cert.KeyUsage&x509.KeyUsageCRLSign == 0 {
-			asrv.logger.WarnContext(ctx, "Certificate authority can't sign CRLs, some Active Directory integrations will not work", "ca_type", caID.Type)
+			asrv.logger.WarnContext(ctx, "Certificate authority can't sign CRLs, some Active Directory integrations will require a CA rotation", "ca_type", caID.Type)
 			continue
 		}
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -785,15 +785,24 @@ func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthI
 		}
 		certBytes, signer, err := asrv.keyStore.GetTLSCertAndSigner(ctx, ca)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			asrv.logger.WarnContext(ctx, "Couldn't get CA certificate", "ca_type", caID.Type, "error", err)
+			continue
 		}
 		cert, err := tlsca.ParseCertificatePEM(certBytes)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			asrv.logger.WarnContext(ctx, "Couldn't parse CA certificate", "ca_type", caID.Type, "error", err)
+			continue
 		}
+
+		if cert.KeyUsage&x509.KeyUsageCRLSign == 0 {
+			asrv.logger.WarnContext(ctx, "Certificate authority can't sign CRLs, some Active Directory integrations will not work", "ca_type", caID.Type)
+			continue
+		}
+
 		crl, err := keystore.GenerateCRL(cert, signer)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			asrv.logger.WarnContext(ctx, "Failed to generate CRL", "ca_type", caID.Type, "error", err)
+			continue
 		}
 		kp.CRL = crl
 		updated = true


### PR DESCRIPTION
This change fixes CRL backfill for long-standing clusters, which lacks CRL signing purpose in their CAs' certificates.
We will log warning instead of crashing in such case.

changelog: Fixed an issue backfilling CRLs during startup for long-standing clusters.