### PR TITLE
Add the DocsHeader component to the docs homepage

### DIFF
--- a/docs/pages/includes/homepage/docs-header.mdx
+++ b/docs/pages/includes/homepage/docs-header.mdx
@@ -1,3 +1,18 @@
 import DocsHeader, { DocsHeaderProps } from "@site/src/components/Pages/Homepage/DocsHeader";
 
-<DocsHeader />
+<DocsHeader
+  quickActions={[
+    { 
+      label: "Enroll Kubernetes cluster", 
+      href: "./enroll-resources/kubernetes-access/getting-started/" 
+    },
+    { 
+      label: "Set up SSO with GitHub", 
+      href: "./zero-trust-access/sso/github-sso/" 
+    },
+    { 
+      label: "Set up Slack Access Request Plugin", 
+      href: "./identity-governance/access-request-plugins/ssh-approval-slack/" 
+    }
+  ]}
+/>

--- a/docs/pages/includes/homepage/docs-header.mdx
+++ b/docs/pages/includes/homepage/docs-header.mdx
@@ -1,0 +1,3 @@
+import DocsHeader, { DocsHeaderProps } from "@site/src/components/Pages/Homepage/DocsHeader";
+
+<DocsHeader />

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -3,11 +3,13 @@ h1: Introduction to Teleport
 title: "The Teleport Infrastructure Identity Platform"
 description: Read an overview of the Teleport Access Platform. Learn how to implement Zero Trust Security across all your infrastructure for enhanced protection and streamlined access control.
 tocDepth: 3
-remove_table_of_contents: true
+template: "landing-page"
 labels:
  - get-started
  - platform-wide
 ---
+
+(!docs/pages/includes/homepage/docs-header.mdx!)
 
 Teleport is the easiest, most secure way to access and protect all your infrastructure.
 


### PR DESCRIPTION
This PR adds the DocsHeader component to the docs homepage according to the new design.

⚠️ Waiting on [gravitational/docs-website#267](https://github.com/gravitational/docs-website/pull/267) to be merged first.