### PR TITLE
ui: differentiate desktop certs on the audit log page

### DIFF
--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1381,8 +1381,11 @@ export const formatters: Formatters = {
   [eventCodes.CERTIFICATE_CREATED]: {
     type: 'cert.create',
     desc: 'Certificate Issued',
-    format: ({ cert_type, identity: { user } }) => {
+    format: ({ cert_type, identity: { user, usage } }) => {
       if (cert_type === 'user') {
+        if (usage?.includes('usage:windows_desktop')) {
+          return `Windows desktop certificate issued for user [${user}]`;
+        }
         return `User certificate issued for [${user}]`;
       }
       return `Certificate of type [${cert_type}] issued for [${user}]`;

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1292,7 +1292,7 @@ export type RawEvents = {
     typeof eventCodes.CERTIFICATE_CREATED,
     {
       cert_type: 'user';
-      identity: { user: string };
+      identity: { user: string; usage?: string[] };
     }
   >;
   [eventCodes.UPGRADE_WINDOW_UPDATED]: RawEvent<


### PR DESCRIPTION
Desktop access uses Teleport's user CA to issue certificates, so the cert.create event in the audit log renders the same for desktop certificates as for user logins.

In the future, we should probably use a different audit event entirely for when desktop certs are issued, since there's some Windows-specific metadata in the cert that should probably be captured in the audit log.

For now, we change the title of the event in the audit log table to it's easier to spot the difference between login certs and desktop certs.

Changelog: make it easier to identify Windows desktop certificate issuance on the audit log page.