### PR TITLE
Add testing symbol inspection to lint step

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -164,6 +164,9 @@ jobs:
       - name: Check if go generated files are up to date
         run: make go-generate-up-to-date
 
+      - name: Check if testing symbols are included in binaries
+        run: make lint-testing-symbols
+
   lint-rust:
     name: Lint (Rust)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Any changes to Go code in CI now inspect the dependency tree for testing symbols in production binaries by leveraging https://github.com/loov/goda. A new make target `lint-testing-symbols` has been added which uses `goda reach` on the tool directory to anaylze whether the testing or github.com/stretchr/testify packages are imported either directly or transitively.

Until https://github.com/gravitational/teleport/issues/51023 is resolved there are a few exlucsions supplied to `goda reach` to permit the step to pass. The intent is to prevent any new avenues in which testing symbols are added while we eliminate the current ways testing sybmols show up in binaries.

Updates https://github.com/gravitational/teleport/issues/51023.