### PR TITLE
Lock `mc` to light theme

### DIFF
--- a/web/packages/teleport/src/ThemeProvider.tsx
+++ b/web/packages/teleport/src/ThemeProvider.tsx
@@ -27,6 +27,8 @@ import { KeysEnum, storageService } from 'teleport/services/storageService';
 
 const customThemes = {
   bblp: bblpTheme,
+  // Lock mc to light theme, and flag it as a custom theme to disable the theme switcher.
+  mc: { ...lightTheme, isCustomTheme: true },
 };
 
 export const ThemeProvider = (props: { children?: ReactNode }) => {


### PR DESCRIPTION
Locks `mc` to light theme, corresponding `e` PR for context: https://github.com/gravitational/teleport.e/pull/6996