### PR TITLE
[v18] Add `Resources` stream to generic storage services

### DIFF
--- a/lib/services/local/generic/generic.go
+++ b/lib/services/local/generic/generic.go
@@ -20,6 +20,7 @@ package generic
 
 import (
 	"context"
+	"iter"
 	"log/slog"
 	"strings"
 	"time"
@@ -194,6 +195,39 @@ func (s *Service[T]) GetResources(ctx context.Context) ([]T, error) {
 	return out, nil
 }
 
+// Resources returns a stream of resources within the range [startKey, endKey].
+// If both keys are empty, then the entire range is returned.
+func (s *Service[T]) Resources(ctx context.Context, startKey, endKey string) iter.Seq2[T, error] {
+	params := backend.ItemsParams{
+		StartKey: s.backendPrefix.AppendKey(backend.KeyFromString(startKey)),
+	}
+	if endKey == "" {
+		params.EndKey = backend.RangeEnd(s.backendPrefix.ExactKey())
+	} else {
+		params.EndKey = s.backendPrefix.AppendKey(backend.KeyFromString(endKey))
+	}
+	return func(yield func(T, error) bool) {
+		for item, err := range s.backend.Items(ctx, params) {
+			if err != nil {
+				var t T
+				yield(t, trace.Wrap(err))
+				return
+			}
+
+			resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision))
+			if err != nil {
+				// unmarshal errors are logged and skipped
+				slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
+				return
+			}
+
+			if !yield(resource, nil) {
+				return
+			}
+		}
+	}
+}
+
 // ListResources returns a paginated list of resources.
 func (s *Service[T]) ListResources(ctx context.Context, pageSize int, pageToken string) ([]T, string, error) {
 	resources, _, nextKey, err := s.listResourcesReturnNextResourceWithKey(ctx, pageSize, pageToken)
@@ -260,6 +294,8 @@ func (s *Service[T]) ListResourcesWithFilter(ctx context.Context, pageSize int, 
 
 		resource, err := s.unmarshalFunc(item.Value, services.WithRevision(item.Revision))
 		if err != nil {
+			// unmarshal errors are logged and skipped
+			slog.WarnContext(ctx, "skipping resource due to unmarshal error", "error", err, "key", logutils.StringerAttr(item.Key))
 			continue
 		}
 

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -202,6 +202,46 @@ func TestGenericCRUD(t *testing.T) {
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 	))
 
+	// Retrieve all resources from the stream
+	var streamedResources []*testResource
+	for r, err := range service.Resources(ctx, "", "") {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff(paginatedOut, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve all resources from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, r1.GetName(), r2.GetName()) {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff(paginatedOut, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve a single resource from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, r2.GetName(), "") {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff([]*testResource{r2}, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
+	// Retrieve a single resource from the stream
+	streamedResources = nil
+	for r, err := range service.Resources(ctx, "", r1.GetName()) {
+		require.NoError(t, err)
+		streamedResources = append(streamedResources, r)
+	}
+	require.Empty(t, cmp.Diff([]*testResource{r1}, streamedResources,
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+	))
+
 	// Fetch a specific service provider.
 	r, err := service.GetResource(ctx, r2.GetName())
 	require.NoError(t, err)

--- a/lib/services/local/plugin_static_credentials.go
+++ b/lib/services/local/plugin_static_credentials.go
@@ -76,13 +76,11 @@ func (p *PluginStaticCredentialsService) UpdatePluginStaticCredentials(ctx conte
 
 // GetPluginStaticCredentialsByLabels will get a list of plugin static credentials resource by matching labels.
 func (p *PluginStaticCredentialsService) GetPluginStaticCredentialsByLabels(ctx context.Context, labels map[string]string) ([]types.PluginStaticCredentials, error) {
-	creds, err := p.svc.GetResources(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	var foundCredentials []types.PluginStaticCredentials
-	for _, cred := range creds {
+	for cred, err := range p.svc.Resources(ctx, "", "") {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		if types.MatchLabels(cred, labels) {
 			foundCredentials = append(foundCredentials, cred)
 		}


### PR DESCRIPTION
Backport #55291 to branch/v18

Resolved `lib/services/local/generic/generic.go` manually: imports, the log warning statement in `ServiceWrapper.ListResourcesWithFilter`.

Required by https://github.com/gravitational/teleport/pull/57239.