### PR TITLE
Fix case in icon import, re-run `pnpm process-icons`

### DIFF
--- a/web/packages/design/src/ResourceIcon/assets/windows-dark.svg
+++ b/web/packages/design/src/ResourceIcon/assets/windows-dark.svg
@@ -1,10 +1,1 @@
-<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_6706_29760)">
-<path d="M29.5089 37.9911V66.1597L0 62.0917V37.9911H29.5089ZM29.5089 5.84031V34.3551H0V9.90831L29.5089 5.84031ZM72 37.9911V72L32.7545 66.5917V37.9911H72ZM72 0V34.3551H32.7545V5.40831L72 0Z" fill="#0DADEA"/>
-</g>
-<defs>
-<clipPath id="clip0_6706_29760">
-<rect width="72" height="72" fill="white"/>
-</clipPath>
-</defs>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" fill="none" viewBox="0 0 72 72"><g clip-path="url(#clip0_6706_29760)"><path fill="#0dadea" d="M29.509 37.991V66.16L0 62.092v-24.1zm0-32.15v28.514H0V9.908zM72 37.99V72l-39.245-5.408v-28.6zM72 0v34.355H32.755V5.408z"/></g><defs><clipPath id="clip0_6706_29760"><path fill="#fff" d="M0 0h72v72H0z"/></clipPath></defs></svg>

--- a/web/packages/design/src/ResourceIcon/assets/windows-light.svg
+++ b/web/packages/design/src/ResourceIcon/assets/windows-light.svg
@@ -1,10 +1,1 @@
-<svg width="72" height="72" viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_6706_29761)">
-<path d="M29.5089 37.9911V66.1597L0 62.0917V37.9911H29.5089ZM29.5089 5.84031V34.3551H0V9.90831L29.5089 5.84031ZM72 37.9911V72L32.7545 66.5917V37.9911H72ZM72 0V34.3551H32.7545V5.40831L72 0Z" fill="#0078D4"/>
-</g>
-<defs>
-<clipPath id="clip0_6706_29761">
-<rect width="72" height="72" fill="white"/>
-</clipPath>
-</defs>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" fill="none" viewBox="0 0 72 72"><g clip-path="url(#clip0_6706_29761)"><path fill="#0078d4" d="M29.509 37.991V66.16L0 62.092v-24.1zm0-32.15v28.514H0V9.908zM72 37.99V72l-39.245-5.408v-28.6zM72 0v34.355H32.755V5.408z"/></g><defs><clipPath id="clip0_6706_29761"><path fill="#fff" d="M0 0h72v72H0z"/></clipPath></defs></svg>

--- a/web/packages/design/src/ResourceIcon/icons.ts
+++ b/web/packages/design/src/ResourceIcon/icons.ts
@@ -192,7 +192,7 @@ import maxioLight from './assets/maxio-light.svg?no-inline';
 import mcpCursorDark from './assets/mcpcursor-dark.svg';
 import mcpCursorLight from './assets/mcpcursor-dark.svg';
 import mcpVscode from './assets/mcpvscode.svg';
-import mcpVscodeInsiders from './assets/mcpVscodeinsiders.svg';
+import mcpVscodeInsiders from './assets/mcpvscodeinsiders.svg';
 import metabase from './assets/metabase.svg?no-inline';
 import microsoft from './assets/microsoft.svg?no-inline';
 import microsoftexcel from './assets/microsoftexcel.svg?no-inline';


### PR DESCRIPTION
This currently blocks the build on master and v18. I fixed the import, re-run `pnpm process-icons` and then verified with Storybook that all three icons still render properly. I verified that the fix works by running `pnpm build-ui-oss` in a Linux VM on master and then on this branch.

This wasn't spotted because the filesystem on macOS is case-insensitive. https://github.com/gravitational/teleport/issues/45056 would have prevented the problem with the icon import from being merged.