### PR TITLE
[v18] Fix printing empty usage and terminate CLI for parsing global flags

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -296,7 +296,9 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 }
 
 // InitHiddenCLIParser initializes a `kingpin.Application` that does not terminate the application
-// or write any usage information to os.Stdout.
+// or write any usage information to os.Stdout. Can be used in scenarios where multiple `kingpin.Application`
+// instances are needed without interfering with subsequent parsing. Usage output is completely suppressed,
+// and the default global `--help` flag is ignored to prevent the application from exiting.
 func InitHiddenCLIParser() (app *kingpin.Application) {
 	app = kingpin.New("", "")
 	app.UsageWriter(io.Discard)

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -295,6 +295,16 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 	return app.UsageTemplate(createUsageTemplate())
 }
 
+// InitHiddenCLIParser initializes a `kingpin.Application` that does not terminate the application
+// or write any usage information to os.Stdout.
+func InitHiddenCLIParser() (app *kingpin.Application) {
+	app = kingpin.New("", "")
+	app.UsageWriter(io.Discard)
+	app.Terminate(func(i int) {})
+
+	return app
+}
+
 // createUsageTemplate creates an usage template for kingpin applications.
 func createUsageTemplate(opts ...func(*usageTemplateOptions)) string {
 	opt := &usageTemplateOptions{

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -825,10 +825,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// All other commands and flags may change between versions, so full parsing
 	// should be performed only after managed updates are applied.
 	var proxyArg string
-	muApp := utils.InitCLIParser("tsh", "")
+	muApp := utils.InitHiddenCLIParser()
 	muApp.Flag("proxy", "Teleport proxy address").Envar(proxyEnvVar).Hidden().StringVar(&proxyArg)
 	muApp.Flag("check-update", "Check for availability of managed update.").Envar(toolsCheckUpdateEnvVar).Hidden().BoolVar(&cf.checkManagedUpdates)
-
 	if _, err := muApp.Parse(utils.FilterArguments(args, muApp.Model())); err != nil {
 		slog.WarnContext(ctx, "can't identify current profile", "error", err)
 	}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -474,13 +474,13 @@ func TestDefaultPrintUsage(t *testing.T) {
 	ctx := context.Background()
 
 	cmd := exec.CommandContext(ctx, testExecutable, "version", "--help")
-	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv), "TELEPORT_TOOLS_VERSION=off"}
 	flagOutput, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 	require.Contains(t, string(flagOutput), "Print the tsh client and Proxy server versions for the current context")
 
 	cmd = exec.CommandContext(ctx, testExecutable, "help", "version")
-	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv), "TELEPORT_TOOLS_VERSION=off"}
 	commandOutput, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 	require.Equal(t, string(flagOutput), string(commandOutput))

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -463,6 +463,29 @@ func TestNoEnvVars(t *testing.T) {
 	require.NoError(t, trace.NewAggregate(err, ctx.Err()))
 }
 
+// TestDefaultPrintUsage verifies that the main `kingpin.Application` parser has not been
+// previously terminated, and that it correctly prints the usage message when using the
+// global `--help` flag or the `help` command, and both are identical.
+func TestDefaultPrintUsage(t *testing.T) {
+	t.Parallel()
+	testExecutable, err := os.Executable()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, testExecutable, "version", "--help")
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+	flagOutput, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Contains(t, string(flagOutput), "Print the tsh client and Proxy server versions for the current context")
+
+	cmd = exec.CommandContext(ctx, testExecutable, "help", "version")
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+	commandOutput, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, string(flagOutput), string(commandOutput))
+}
+
 func TestFailedLogin(t *testing.T) {
 	t.Parallel()
 	tmpHomePath := t.TempDir()


### PR DESCRIPTION
Backport #57401 to branch/v18

changelog: Fixed usage print for global `--help` flag
