### PR TITLE
Edit the Teleport Cloud architecture guide

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -98,6 +98,13 @@ notifications.
 
 ## Service Level Agreement
 
-Teleport Enterprise Cloud commits to an SLA of (=cloud.sla.monthly_percentage=) of monthly uptime,
+Teleport Cloud commits to an SLA of (=cloud.sla.monthly_percentage=) of monthly uptime,
 a maximum of (=cloud.sla.monthly_downtime=) of downtime per month. As we continue to invest in the
 cloud product and infrastructure, the SLA will be increased.
+
+In Teleport Cloud accounts that enable multi-region high availability, the SLA
+increases to 99.99%. 
+
+For more information on Teleport Cloud SLAs, see the [Teleport Enterprise
+Edition Pricing
+Guide](https://goteleport.com/api/files/teleport-pricing-guide.pdf) (PDF).


### PR DESCRIPTION
Closes #57135

Mention the multi-region HA SLA. Link to the pricing guide PDF, which contains more information about the SLA, so we can keep all information in a single place. While there's an exiting variable for the standard Cloud SLA, this is the only place we mention the mult-region HA SLA, so adding a variable is premature.