### PR TITLE
Database MCP server to support CockroachDB databases

### DIFF
--- a/lib/client/db/postgres/mcp/mcp.go
+++ b/lib/client/db/postgres/mcp/mcp.go
@@ -82,7 +82,7 @@ func NewServer(ctx context.Context, cfg *dbmcp.NewServerConfig) (dbmcp.Server, e
 //
 // Teleport differentiates CockroachDB and PostgreSQL as different protocols but
 // uses the same db engine under the hood. Here we use the same PostgreSQL
-// MCP server implementation as well just provides a slightly different tool
+// MCP server implementation as well, except for a slightly different tool
 // name and description.
 func NewServerForCockroachDB(ctx context.Context, cfg *dbmcp.NewServerConfig) (dbmcp.Server, error) {
 	return newServer(ctx, queryToolForCockroachDB, cfg)

--- a/lib/client/db/postgres/mcp/mcp.go
+++ b/lib/client/db/postgres/mcp/mcp.go
@@ -46,6 +46,20 @@ var queryTool = mcp.NewTool(dbmcp.ToolName(defaults.ProtocolPostgres, "query"),
 	),
 )
 
+// queryToolForCockroachDB is same as queryTool but promotes CockroachDB instead
+// of PostgreSQL.
+var queryToolForCockroachDB = mcp.NewTool(dbmcp.ToolName(defaults.ProtocolCockroachDB, "query"),
+	mcp.WithDescription("Execute SQL query against CockroachDB database connected using Teleport"),
+	mcp.WithString(queryToolDatabaseParam,
+		mcp.Required(),
+		mcp.Description("Teleport database resource URI where the query will be executed"),
+	),
+	mcp.WithString(queryToolQueryParam,
+		mcp.Required(),
+		mcp.Description("CockroachDB SQL query to execute"),
+	),
+)
+
 type database struct {
 	*dbmcp.Database
 	pool *pgxpool.Pool
@@ -60,8 +74,22 @@ type Server struct {
 // NewServer initializes a PostgreSQL MCP server, creating the database
 // configurations and registering Server tools into the root server.
 func NewServer(ctx context.Context, cfg *dbmcp.NewServerConfig) (dbmcp.Server, error) {
-	s := &Server{logger: cfg.Logger, databases: make(map[string]*database)}
+	return newServer(ctx, queryTool, cfg)
+}
 
+// NewServerForCockroachDB initializes a CockroachDB MCP server, creating the
+// database configurations and registering Server tools into the root server.
+//
+// Teleport differentiates CockroachDB and PostgreSQL as different protocols but
+// uses the same db engine under the hood. Here we use the same PostgreSQL
+// MCP server implementation as well just provides a slightly different tool
+// name and description.
+func NewServerForCockroachDB(ctx context.Context, cfg *dbmcp.NewServerConfig) (dbmcp.Server, error) {
+	return newServer(ctx, queryToolForCockroachDB, cfg)
+}
+
+func newServer(ctx context.Context, queryTool mcp.Tool, cfg *dbmcp.NewServerConfig) (*Server, error) {
+	s := &Server{logger: cfg.Logger, databases: make(map[string]*database)}
 	for _, db := range cfg.Databases {
 		if db.DatabaseUser == "" || db.DatabaseName == "" {
 			return nil, trace.BadParameter("database %q is missing the username and database name", db.DB.GetName())

--- a/lib/player/player.go
+++ b/lib/player/player.go
@@ -498,7 +498,8 @@ func (p *Player) translateEvent(evt events.AuditEvent) (translatedEvent events.A
 
 // databaseTranslators maps database protocol event translators.
 var databaseTranslators = map[string]newSessionPrintTranslatorFunc{
-	defaults.ProtocolPostgres: func() sessionPrintTranslator { return db.NewPostgresTranslator() },
+	defaults.ProtocolPostgres:    func() sessionPrintTranslator { return db.NewPostgresTranslator() },
+	defaults.ProtocolCockroachDB: func() sessionPrintTranslator { return db.NewPostgresTranslator() },
 }
 
 // SupportedDatabaseProtocols a list of database protocols supported by the

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1162,7 +1162,8 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 
 	if cfg.DatabaseREPLRegistry == nil {
 		cfg.DatabaseREPLRegistry = dbrepl.NewREPLGetter(map[string]dbrepl.REPLNewFunc{
-			defaults.ProtocolPostgres: pgrepl.New,
+			defaults.ProtocolPostgres:    pgrepl.New,
+			defaults.ProtocolCockroachDB: pgrepl.New,
 		})
 	}
 

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -392,7 +392,8 @@ func (m *mcpDBConfigCommand) addDatabaseToConfig(config claudeConfig, dbURI mcp.
 var (
 	// defaultDBMCPRegistry is the default database access MCP servers registry.
 	defaultDBMCPRegistry = map[string]dbmcp.NewServerFunc{
-		defaults.ProtocolPostgres: pgmcp.NewServer,
+		defaults.ProtocolPostgres:    pgmcp.NewServer,
+		defaults.ProtocolCockroachDB: pgmcp.NewServerForCockroachDB,
 	}
 )
 

--- a/tool/tsh/common/mcp_db_test.go
+++ b/tool/tsh/common/mcp_db_test.go
@@ -48,8 +48,8 @@ func TestMCPDBCommand(t *testing.T) {
 	connector := mockConnector(t)
 	alice, err := types.NewUser("alice@example.com")
 	require.NoError(t, err)
-	alice.SetDatabaseUsers([]string{"postgres"})
-	alice.SetDatabaseNames([]string{"postgres"})
+	alice.SetDatabaseUsers([]string{"postgres", "root"})
+	alice.SetDatabaseNames([]string{"postgres", "defaultdb"})
 	alice.SetRoles([]string{"access"})
 
 	authProcess := testserver.MakeTestServer(
@@ -69,6 +69,11 @@ func TestMCPDBCommand(t *testing.T) {
 					Name:     "postgres2",
 					Protocol: defaults.ProtocolPostgres,
 					URI:      "external-pg:5432",
+				},
+				{
+					Name:     "cockroach",
+					Protocol: defaults.ProtocolCockroachDB,
+					URI:      "external-cockroach:5432",
 				},
 				{
 					Name:     "mysql-local",
@@ -104,13 +109,29 @@ func TestMCPDBCommand(t *testing.T) {
 			"start",
 			"teleport://clusters/root/databases/postgres1?dbUser=postgres&dbName=postgres",
 			"teleport://clusters/root/databases/postgres2?dbUser=postgres&dbName=postgres",
+			"teleport://clusters/root/databases/cockroach?dbUser=root&dbName=defaultdb",
 		}, setHomePath(tmpHomePath), func(c *CLIConf) error {
 			c.overrideStdin = stdin
 			c.OverrideStdout = stdout
 			// MCP server logs are going to be discarded.
 			c.overrideStderr = io.Discard
+
+			// Fake a query tool for each database.
+			addDBQueryTool := func(protocol string, nsc *dbmcp.NewServerConfig) {
+				nsc.RootServer.AddTool(
+					mcp.NewTool(dbmcp.ToolName(protocol, "query")),
+					func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+						return nil, trace.NotImplemented("not implemented")
+					},
+				)
+			}
 			c.databaseMCPRegistryOverride = map[string]dbmcp.NewServerFunc{
 				defaults.ProtocolPostgres: func(ctx context.Context, nsc *dbmcp.NewServerConfig) (dbmcp.Server, error) {
+					addDBQueryTool(defaults.ProtocolPostgres, nsc)
+					return &testDatabaseMCP{}, nil
+				},
+				defaults.ProtocolCockroachDB: func(ctx context.Context, nsc *dbmcp.NewServerConfig) (dbmcp.Server, error) {
+					addDBQueryTool(defaults.ProtocolCockroachDB, nsc)
 					return &testDatabaseMCP{}, nil
 				},
 			}
@@ -134,7 +155,19 @@ func TestMCPDBCommand(t *testing.T) {
 		require.NoError(collect, clt.Ping(t.Context()))
 	}, time.Second, 100*time.Millisecond)
 
-	// Stop the MCP server command and wait until it is finshed.
+	tools, err := clt.ListTools(t.Context(), mcp.ListToolsRequest{})
+	require.NoError(t, err)
+	var toolNames []string
+	for _, tool := range tools.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	require.ElementsMatch(t, []string{
+		"teleport_list_databases",
+		"teleport_postgres_query",
+		"teleport_cockroachdb_query",
+	}, toolNames)
+
+	// Stop the MCP server command and wait until it is finished.
 	cancel()
 	select {
 	case err := <-executionCh:


### PR DESCRIPTION
changelog: Database MCP server now supports CockroachDB databases
changelog: Added support for CockroachDB Web Access and interactive CockroachDB session playback

<img width="317" height="187" alt="Screenshot 2025-08-01 at 1 52 31 PM" src="https://github.com/user-attachments/assets/7d2a3062-6a1c-457d-9bf7-9e124895561c" />
<img width="764" height="627" alt="Screenshot 2025-08-01 at 1 53 17 PM" src="https://github.com/user-attachments/assets/f40d4885-62d9-4cc1-8d45-ef8057037896" />
