### PR TITLE
Edit the guide to enrolling Amazon Redis caches

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
@@ -9,6 +9,8 @@ labels:
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache for Redis and Valkey" dbConfigure="with IAM authentication"!)
 
+Teleport does not support enrolling Amazon ElastiCache Serverless.
+
 ## How it works
 
 (!docs/pages/includes/database-access/aws-redis-how-it-works.mdx dbType="Amazon ElastiCache for Redis and Valkey"!)


### PR DESCRIPTION
Closes #57015

Indicate that ElastiCache Serverless is not currently supported.