### PR TITLE
Gracefully handle NotFoundError for newly created singleton resources

### DIFF
--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -140,6 +140,10 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	var {{.VarName}}I {{.ProtoPackage}}.{{ if ne .IfaceName ""}}{{.IfaceName}}{{else}}{{.Name}}{{end}}
 	{{- end}}
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -147,12 +151,13 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		{{.VarName}}I, err = r.p.Client.{{.GetMethod}}(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(bErr), "{{.Kind}}"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading {{.Name}} (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "{{.Kind}}")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_access_list.go
+++ b/integrations/terraform/provider/resource_teleport_access_list.go
@@ -109,6 +109,7 @@ func (r resourceTeleportAccessList) Create(ctx context.Context, req tfsdk.Create
 		return
 	}
 		var accessListI = accessListResource
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -116,12 +117,13 @@ func (r resourceTeleportAccessList) Create(ctx context.Context, req tfsdk.Create
 		accessListI, err = r.p.Client.AccessListClient().GetAccessList(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(bErr), "access_list"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AccessList", trace.Wrap(err), "access_list"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading AccessList (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "access_list")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_app.go
+++ b/integrations/terraform/provider/resource_teleport_app.go
@@ -108,6 +108,7 @@ func (r resourceTeleportApp) Create(ctx context.Context, req tfsdk.CreateResourc
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var appI apitypes.Application
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportApp) Create(ctx context.Context, req tfsdk.CreateResourc
 		appI, err = r.p.Client.GetApp(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(bErr), "app"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Wrap(err), "app"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading App (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "app")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_auth_preference.go
+++ b/integrations/terraform/provider/resource_teleport_auth_preference.go
@@ -94,6 +94,10 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 
 	var authPreferenceI apitypes.AuthPreference
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -101,12 +105,13 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 		authPreferenceI, err = r.p.Client.GetAuthPreference(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(bErr), "cluster_auth_preference"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading AuthPreference (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "cluster_auth_preference")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -99,6 +99,10 @@ func (r resourceTeleportAutoUpdateConfig) Create(ctx context.Context, req tfsdk.
 	var autoUpdateConfigI *autoupdatev1.AutoUpdateConfig
 	
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -106,12 +110,13 @@ func (r resourceTeleportAutoUpdateConfig) Create(ctx context.Context, req tfsdk.
 		autoUpdateConfigI, err = r.p.Client.GetAutoUpdateConfig(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AutoUpdateConfig", trace.Wrap(bErr), "autoupdate_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AutoUpdateConfig", trace.Wrap(err), "autoupdate_config"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading AutoUpdateConfig (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "autoupdate_config")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -99,6 +99,10 @@ func (r resourceTeleportAutoUpdateVersion) Create(ctx context.Context, req tfsdk
 	var autoUpdateVersionI *autoupdatev1.AutoUpdateVersion
 	
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -106,12 +110,13 @@ func (r resourceTeleportAutoUpdateVersion) Create(ctx context.Context, req tfsdk
 		autoUpdateVersionI, err = r.p.Client.GetAutoUpdateVersion(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AutoUpdateVersion", trace.Wrap(bErr), "autoupdate_version"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading AutoUpdateVersion", trace.Wrap(err), "autoupdate_version"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading AutoUpdateVersion (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "autoupdate_version")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -94,6 +94,10 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 
 	var clusterNetworkingConfigI apitypes.ClusterNetworkingConfig
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -101,12 +105,13 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 		clusterNetworkingConfigI, err = r.p.Client.GetClusterNetworkingConfig(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(bErr), "cluster_networking_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading ClusterNetworkingConfig (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "cluster_networking_config")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_database.go
+++ b/integrations/terraform/provider/resource_teleport_database.go
@@ -108,6 +108,7 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var databaseI apitypes.Database
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportDatabase) Create(ctx context.Context, req tfsdk.CreateRe
 		databaseI, err = r.p.Client.GetDatabase(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(bErr), "db"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Wrap(err), "db"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Database (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "db")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_installer.go
+++ b/integrations/terraform/provider/resource_teleport_installer.go
@@ -108,6 +108,7 @@ func (r resourceTeleportInstaller) Create(ctx context.Context, req tfsdk.CreateR
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var installerI apitypes.Installer
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportInstaller) Create(ctx context.Context, req tfsdk.CreateR
 		installerI, err = r.p.Client.GetInstaller(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(bErr), "installer"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Wrap(err), "installer"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Installer (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "installer")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_login_rule.go
+++ b/integrations/terraform/provider/resource_teleport_login_rule.go
@@ -101,6 +101,7 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 		return
 	}
 		var loginRuleI *loginrulev1.LoginRule
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -108,12 +109,13 @@ func (r resourceTeleportLoginRule) Create(ctx context.Context, req tfsdk.CreateR
 		loginRuleI, err = r.p.Client.GetLoginRule(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(bErr), "login_rule"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading LoginRule", trace.Wrap(err), "login_rule"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading LoginRule (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "login_rule")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_provision_token.go
+++ b/integrations/terraform/provider/resource_teleport_provision_token.go
@@ -119,6 +119,7 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var provisionTokenI apitypes.ProvisionToken
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -126,12 +127,13 @@ func (r resourceTeleportProvisionToken) Create(ctx context.Context, req tfsdk.Cr
 		provisionTokenI, err = r.p.Client.GetToken(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(bErr), "token"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Wrap(err), "token"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading ProvisionToken (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "token")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_role.go
+++ b/integrations/terraform/provider/resource_teleport_role.go
@@ -108,6 +108,7 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var roleI apitypes.Role
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportRole) Create(ctx context.Context, req tfsdk.CreateResour
 		roleI, err = r.p.Client.GetRole(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(bErr), "role"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Wrap(err), "role"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading Role (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "role")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_saml_connector.go
+++ b/integrations/terraform/provider/resource_teleport_saml_connector.go
@@ -108,6 +108,7 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var samlConnectorI apitypes.SAMLConnector
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportSAMLConnector) Create(ctx context.Context, req tfsdk.Cre
 		samlConnectorI, err = r.p.Client.GetSAMLConnector(ctx, id, true)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(bErr), "saml"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Wrap(err), "saml"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading SAMLConnector (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "saml")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -99,6 +99,17 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 	for {
 		tries = tries + 1
 		sessionRecordingConfigI, err = r.p.Client.GetSessionRecordingConfig(ctx)
+		if trace.IsNotFound(err) {
+			if bErr := backoff.Do(ctx); bErr != nil {
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(bErr), "session_recording_config"))
+				return
+			}
+			if tries >= r.p.RetryConfig.MaxTries {
+				diagMessage := fmt.Sprintf("Error reading SessionRecordingConfig (tried %d times) - state outdated, please import resource", tries)
+				resp.Diagnostics.AddError(diagMessage, "session_recording_config")
+			}
+			continue
+		}
 		if err != nil {
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 			return

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -94,6 +94,10 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 
 	var sessionRecordingConfigI apitypes.SessionRecordingConfig
 
+	// Try getting the resource until it exists and is different than the previous ones.
+	// There are two types of singleton resources:
+	// - the ones who can deleted and return a trace.NotFoundErr
+	// - the ones who cannot be deleted, only reset. In this case, the resource revision is used to know if the change got applied.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -101,12 +105,13 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 		sessionRecordingConfigI, err = r.p.Client.GetSessionRecordingConfig(ctx)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(bErr), "session_recording_config"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading SessionRecordingConfig (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "session_recording_config")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/resource_teleport_trusted_cluster.go
@@ -108,6 +108,7 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var trustedClusterI apitypes.TrustedCluster
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportTrustedCluster) Create(ctx context.Context, req tfsdk.Cr
 		trustedClusterI, err = r.p.Client.GetTrustedCluster(ctx, id)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(bErr), "trusted_cluster"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Wrap(err), "trusted_cluster"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading TrustedCluster (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "trusted_cluster")
+				return
 			}
 			continue
 		}

--- a/integrations/terraform/provider/resource_teleport_user.go
+++ b/integrations/terraform/provider/resource_teleport_user.go
@@ -108,6 +108,7 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		
 	// Not really an inferface, just using the same name for easier templating.
 	var userI apitypes.User
+	// Try getting the resource until it exists.
 	tries := 0
 	backoff := backoff.NewDecorr(r.p.RetryConfig.Base, r.p.RetryConfig.Cap, clockwork.NewRealClock())
 	for {
@@ -115,12 +116,13 @@ func (r resourceTeleportUser) Create(ctx context.Context, req tfsdk.CreateResour
 		userI, err = r.p.Client.GetUser(ctx, id, false)
 		if trace.IsNotFound(err) {
 			if bErr := backoff.Do(ctx); bErr != nil {
-				resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(bErr), "user"))
+				resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Wrap(err), "user"))
 				return
 			}
 			if tries >= r.p.RetryConfig.MaxTries {
 				diagMessage := fmt.Sprintf("Error reading User (tried %d times) - state outdated, please import resource", tries)
 				resp.Diagnostics.AddError(diagMessage, "user")
+				return
 			}
 			continue
 		}


### PR DESCRIPTION
This PR fixes a race condition if TF faster than the Teleport cluster when creating singleton resources. Now instead of failing we backoff and retry, like we do for plural resources.

Changelog: Fix a race condition in the Teraform Provider potentially causing "does not exist" errors the following resources: `auth_preference`, `autoupdate_config`, `autoupdate_version`, `cluster_maintenance_config`, `cluster_network_config`, and `session_recording_config`
Changelog: Fix a Terraform provider bug causing resource creation to be retried more times than the MaxRetries setting.