### PR TITLE
Fix flaky access list reminder notification test

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4681,6 +4681,23 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 		)
 	}
 
+	// Wait for cache to propagate the access lists before doing anything
+	require.Eventually(t, func() bool {
+		response, _, err := authServer.Cache.ListAccessLists(ctx, 50, "")
+		if err != nil {
+			return false
+		}
+		reviewableCount := 0
+		for _, al := range response {
+			if al.IsReviewable() {
+				reviewableCount++
+			}
+		}
+
+		// We should have 8 reviewable access lists
+		return reviewableCount >= 8
+	}, 10*time.Second, 100*time.Millisecond, "cache should contain all access lists")
+
 	// Run CreateAccessListReminderNotifications()
 	authServer.CreateAccessListReminderNotifications(ctx)
 


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/52808

Fixes flakiness from the access list reminder notification test, this is likely a timing issue in the CI environment due to latency (I was not able to reproduce locally) because we created the reminder notifications immediately after creating the access lists.