### PR TITLE
docs: update mcp link to docs on homepage

### DIFF
--- a/docs/pages/includes/homepage/products.mdx
+++ b/docs/pages/includes/homepage/products.mdx
@@ -26,7 +26,7 @@ import ISSvg from "@site/src/components/Icon/teleport-svg/identity-security.svg"
         {
           title: 'Secure MCP (Protect the Vibes)',
           description: 'Secure MCP integration with granular audit trail',
-          href: 'https://goteleport.com/use-cases/secure-model-context-protocol/'
+          href: './connect-your-client/model-context-protocol/'
         },
         {
           title: 'Role-Based Access Control (RBAC)',


### PR DESCRIPTION
Fixes #57471

Update link to docs from marketing site.