### PR TITLE
discovery: Fix boundary condition logging min tag AWS interval

### DIFF
--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -414,7 +414,7 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	// Configure the poll interval
 	tickerInterval := defaultPollInterval
 	if s.Config.Matchers.AccessGraph != nil {
-		if s.Config.Matchers.AccessGraph.PollInterval > defaultPollInterval {
+		if s.Config.Matchers.AccessGraph.PollInterval >= defaultPollInterval {
 			tickerInterval = s.Config.Matchers.AccessGraph.PollInterval
 		} else {
 			s.Log.WarnContext(ctx,


### PR DESCRIPTION
Fix a boundary condition causing a log message saying:

    Access graph service poll interval cannot be less than the default

when it has been configured with the default value (or left unconfigured
to automatically get the default value).

Just a little paper cut that had me looking for non-existent errors.
