### PR TITLE
[v16] Set packageImportMethod to clone-or-copy for pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,7 @@ peerDependencyRules:
     # This dep is needed only when using Squirrel.Windows as an installer in electron-build which we
     # don't use. https://www.electron.build/squirrel-windows.html
     - electron-builder-squirrel-windows
+# packageImportMethod avoids an issue building the web UI in docker on mac. It does not seem to
+# affect performance outside of docker.
+# https://github.com/gravitational/teleport/issues/46019
+packageImportMethod: clone-or-copy


### PR DESCRIPTION
Setting the pnpm `packageImportMethod` to `clone-or-copy` has resolved
issues I've consistently had trying to build the web UI using a docker
container which I have needed to do to test buildboxes.

Random files are reported as `ENOENT: no such file or directory` when
building the web UI. The linked issue and related items have more
detail.

Backport: https://github.com/gravitational/teleport/pull/57296

---

Manually backported due to conflicts as v16 does not have the
`shellEmulator` setting.
