### PR TITLE
docs: Fix indent of "enabled" in SSH service reference

### DIFF
--- a/docs/pages/includes/config-reference/ssh-service.yaml
+++ b/docs/pages/includes/config-reference/ssh-service.yaml
@@ -1,6 +1,6 @@
 ssh_service:
-    # Turns 'ssh' role on. Default is true
-    enabled: true
+  # Turns 'ssh' role on. Default is true
+  enabled: true
 
   # IP and the port for SSH service to bind to.
   listen_addr: 0.0.0.0:3022


### PR DESCRIPTION
Fix the indent of the `enabled: true` line and its comment to match that
of the other lines in the config. It was indented an extra level.

---

Note: This does not require a backport to branch/v16 as the file on that
branch is all indented 4 chars so this line is correct. The indenting seems
to have been changed in #53473 perhaps as a side-effect when adding
a new block for `force_listen`.