### PR TITLE
Integrate app updater with UI

### DIFF
--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -147,6 +147,7 @@ func (s *Service) GetDownloadBaseUrl(_ context.Context, _ *api.GetDownloadBaseUr
 func resolveBaseURL() (string, error) {
 	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
 	if envBaseURL != "" {
+		// TODO(gzdunek): Validate if it's correct URL.
 		return envBaseURL, nil
 	}
 

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -96,7 +96,7 @@ func (s *Service) GetClusterVersions(ctx context.Context, _ *api.GetClusterVersi
 				mu.Lock()
 				unreachableClusters = append(unreachableClusters, &api.UnreachableCluster{
 					ClusterUri:   cluster.URI.String(),
-					ErrorMessage: err.Error(),
+					ErrorMessage: pingErr.Error(),
 				})
 				mu.Unlock()
 				return nil

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -178,6 +178,9 @@ export class MockMainProcessClient implements MainProcessClient {
     return '';
   }
 
+  supportsAppUpdates() {
+    return true;
+  }
   async changeAppUpdatesManagingCluster() {}
   async maybeRemoveAppUpdatesManagingCluster() {}
   async checkForAppUpdates() {}

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -179,6 +179,7 @@ export class MockMainProcessClient implements MainProcessClient {
   }
 
   async changeAppUpdatesManagingCluster() {}
+  async maybeRemoveAppUpdatesManagingCluster() {}
   async checkForAppUpdates() {}
   async downloadAppUpdate() {}
   async cancelAppUpdateDownload() {}

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -177,6 +177,22 @@ export class MockMainProcessClient implements MainProcessClient {
   async selectDirectoryForDesktopSession() {
     return '';
   }
+
+  async changeAppUpdatesManagingCluster() {}
+  async checkForAppUpdates() {}
+  async downloadAppUpdate() {}
+  async cancelAppUpdateDownload() {}
+  async quitAndInstallAppUpdate() {}
+  subscribeToAppUpdateEvents(): {
+    cleanup: () => void;
+  } {
+    return { cleanup: () => undefined };
+  }
+  subscribeToOpenAppUpdateDialog(): {
+    cleanup: () => void;
+  } {
+    return { cleanup: () => undefined };
+  }
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/ipcSerializer.ts
+++ b/web/packages/teleterm/src/mainProcess/ipcSerializer.ts
@@ -1,0 +1,43 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type SerializedError = {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+};
+
+/** Serializes an Error into a plain object for transport through Electron IPC. */
+export function serializeError(error: Error): SerializedError {
+  return {
+    name: error.name,
+    message: error.message,
+    cause: error.cause,
+    stack: error.stack,
+  };
+}
+
+/** Deserializes a plain object back into an Error instance. */
+export function deserializeError(serialized: SerializedError): Error {
+  const error = new Error(serialized.message);
+  error.name = serialized.name;
+  error.cause = serialized.cause;
+  error.stack = serialized.stack;
+  return error;
+}

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -648,6 +648,10 @@ export default class MainProcess {
       }
     );
 
+    ipcMain.on(MainProcessIpc.SupportsAppUpdates, event => {
+      event.returnValue = this.appUpdater.supportsUpdates();
+    });
+
     ipcMain.handle(MainProcessIpc.CheckForAppUpdates, () =>
       this.appUpdater.checkForUpdates()
     );

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -704,7 +704,28 @@ export default class MainProcess {
         };
 
     const macTemplate: MenuItemConstructorOptions[] = [
-      { role: 'appMenu' },
+      {
+        role: 'appMenu',
+        submenu: [
+          { role: 'about' },
+          {
+            label: 'Check for Updates…',
+            click: () => {
+              this.windowsManager
+                .getWindow()
+                .webContents.send(RendererIpc.OpenAppUpdateDialog);
+            },
+          },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
       { role: 'editMenu' },
       viewMenuTemplate,
       {

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -185,8 +185,8 @@ export default class MainProcess {
 
   async dispose(): Promise<void> {
     this.windowsManager.dispose();
-    this.appUpdater.dispose();
     await Promise.all([
+      this.appUpdater.dispose(),
       // sending usage events on tshd shutdown has 10-seconds timeout
       terminateWithTimeout(this.tshdProcess, 10_000, () => {
         this.gracefullyKillTshdProcess();

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -83,6 +83,7 @@ import {
   removeAgentDirectory,
   type CreateAgentConfigFileArgs,
 } from './createAgentConfigFile';
+import { serializeError } from './ipcSerializer';
 import { ResolveError, resolveNetworkAddress } from './resolveNetworkAddress';
 import { terminateWithTimeout } from './terminateWithTimeout';
 import { WindowsManager } from './windowsManager';
@@ -163,6 +164,9 @@ export default class MainProcess {
       getClusterVersions,
       getDownloadBaseUrl,
       event => {
+        if (event.kind === 'error') {
+          event.error = serializeError(event.error);
+        }
         this.windowsManager
           .getWindow()
           .webContents.send(RendererIpc.AppUpdateEvent, event);

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -658,6 +658,16 @@ export default class MainProcess {
       ) => this.appUpdater.changeManagingCluster(args.clusterUri)
     );
 
+    ipcMain.handle(
+      MainProcessIpc.MaybeRemoveAppUpdatesManagingCluster,
+      (
+        event,
+        args: {
+          clusterUri: RootClusterUri;
+        }
+      ) => this.appUpdater.maybeRemoveManagingCluster(args.clusterUri)
+    );
+
     ipcMain.handle(MainProcessIpc.DownloadAppUpdate, () =>
       this.appUpdater.download()
     );

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -201,6 +201,9 @@ export default function createMainProcessClient(): MainProcessClient {
         args
       );
     },
+    supportsAppUpdates() {
+      return ipcRenderer.sendSync(MainProcessIpc.SupportsAppUpdates);
+    },
     checkForAppUpdates() {
       return ipcRenderer.invoke(MainProcessIpc.CheckForAppUpdates);
     },

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -222,6 +222,14 @@ export default function createMainProcessClient(): MainProcessClient {
         }
       );
     },
+    maybeRemoveAppUpdatesManagingCluster(clusterUri) {
+      return ipcRenderer.invoke(
+        MainProcessIpc.MaybeRemoveAppUpdatesManagingCluster,
+        {
+          clusterUri,
+        }
+      );
+    },
     subscribeToAppUpdateEvents: listener => {
       const ipcListener = (_, updateEvent: AppUpdateEvent) => {
         // Deserialize the error.

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -18,8 +18,6 @@
 
 import { ipcRenderer } from 'electron';
 
-import { ensureError } from 'shared/utils/error';
-
 import { CreateAgentConfigFileArgs } from 'teleterm/mainProcess/createAgentConfigFile';
 import { AppUpdateEvent } from 'teleterm/services/appUpdater';
 import { createFileStorageClient } from 'teleterm/services/fileStorage';
@@ -28,6 +26,7 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 import { createConfigServiceClient } from '../services/config';
 import { openTabContextMenu } from './contextMenus/tabContextMenu';
 import { openTerminalContextMenu } from './contextMenus/terminalContextMenu';
+import { deserializeError } from './ipcSerializer';
 import {
   AgentProcessState,
   ChildProcessAddresses,
@@ -232,9 +231,8 @@ export default function createMainProcessClient(): MainProcessClient {
     },
     subscribeToAppUpdateEvents: listener => {
       const ipcListener = (_, updateEvent: AppUpdateEvent) => {
-        // Deserialize the error.
         if (updateEvent.kind === 'error') {
-          updateEvent.error = ensureError(updateEvent.error);
+          updateEvent.error = deserializeError(updateEvent.error);
         }
         listener(updateEvent);
       };

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -237,5 +237,12 @@ export default function createMainProcessClient(): MainProcessClient {
           ipcRenderer.removeListener(RendererIpc.AppUpdateEvent, ipcListener),
       };
     },
+    subscribeToOpenAppUpdateDialog: listener => {
+      ipcRenderer.addListener(RendererIpc.OpenAppUpdateDialog, listener);
+      return {
+        cleanup: () =>
+          ipcRenderer.removeListener(RendererIpc.OpenAppUpdateDialog, listener),
+      };
+    },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -213,6 +213,7 @@ export type MainProcessClient = {
   maybeRemoveAppUpdatesManagingCluster(
     clusterUri: RootClusterUri
   ): Promise<void>;
+  supportsAppUpdates(): boolean;
   checkForAppUpdates(): Promise<void>;
   downloadAppUpdate(): Promise<void>;
   cancelAppUpdateDownload(): Promise<void>;
@@ -347,6 +348,7 @@ export enum MainProcessIpc {
   QuiteAndInstallAppUpdate = 'main-process-quit-and-install-app-update',
   ChangeAppUpdatesManagingCluster = 'main-process-change-app-updates-managing-cluster',
   MaybeRemoveAppUpdatesManagingCluster = 'main-process-maybe-remove-app-updates-managing-cluster',
+  SupportsAppUpdates = 'main-process-supports-app-updates',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -210,6 +210,9 @@ export type MainProcessClient = {
   changeAppUpdatesManagingCluster(
     clusterUri: RootClusterUri | undefined
   ): Promise<void>;
+  maybeRemoveAppUpdatesManagingCluster(
+    clusterUri: RootClusterUri
+  ): Promise<void>;
   checkForAppUpdates(): Promise<void>;
   downloadAppUpdate(): Promise<void>;
   cancelAppUpdateDownload(): Promise<void>;
@@ -343,6 +346,7 @@ export enum MainProcessIpc {
   CancelAppUpdateDownload = 'main-process-cancel-app-update-download',
   QuiteAndInstallAppUpdate = 'main-process-quit-and-install-app-update',
   ChangeAppUpdatesManagingCluster = 'main-process-change-app-updates-managing-cluster',
+  MaybeRemoveAppUpdatesManagingCluster = 'main-process-maybe-remove-app-updates-managing-cluster',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -18,6 +18,7 @@
 
 import { DeepLinkParseResult } from 'teleterm/deepLinks';
 import { CreateAgentConfigFileArgs } from 'teleterm/mainProcess/createAgentConfigFile';
+import { AppUpdateEvent } from 'teleterm/services/appUpdater';
 import { FileStorage } from 'teleterm/services/fileStorage';
 import { Document } from 'teleterm/ui/services/workspacesService';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -206,6 +207,16 @@ export type MainProcessClient = {
     desktopUri: string;
     login: string;
   }): Promise<string>;
+  changeAppUpdatesManagingCluster(
+    clusterUri: RootClusterUri | undefined
+  ): Promise<void>;
+  checkForAppUpdates(): Promise<void>;
+  downloadAppUpdate(): Promise<void>;
+  cancelAppUpdateDownload(): Promise<void>;
+  quitAndInstallAppUpdate(): Promise<void>;
+  subscribeToAppUpdateEvents(listener: (args: AppUpdateEvent) => void): {
+    cleanup: () => void;
+  };
 };
 
 export type ChildProcessAddresses = {
@@ -311,6 +322,7 @@ export enum RendererIpc {
   NativeThemeUpdate = 'renderer-native-theme-update',
   ConnectMyComputerAgentUpdate = 'renderer-connect-my-computer-agent-update',
   DeepLinkLaunch = 'renderer-deep-link-launch',
+  AppUpdateEvent = 'renderer-app-update-event',
 }
 
 export enum MainProcessIpc {
@@ -322,6 +334,11 @@ export enum MainProcessIpc {
   SaveTextToFile = 'main-process-save-text-to-file',
   ForceFocusWindow = 'main-process-force-focus-window',
   SelectDirectoryForDesktopSession = 'main-process-select-directory-for-desktop-session',
+  CheckForAppUpdates = 'main-process-check-for-app-updates',
+  DownloadAppUpdate = 'main-process-download-app-update',
+  CancelAppUpdateDownload = 'main-process-cancel-app-update-download',
+  QuiteAndInstallAppUpdate = 'main-process-quit-and-install-app-update',
+  ChangeAppUpdatesManagingCluster = 'main-process-change-app-updates-managing-cluster',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -217,6 +217,9 @@ export type MainProcessClient = {
   subscribeToAppUpdateEvents(listener: (args: AppUpdateEvent) => void): {
     cleanup: () => void;
   };
+  subscribeToOpenAppUpdateDialog(listener: () => void): {
+    cleanup: () => void;
+  };
 };
 
 export type ChildProcessAddresses = {
@@ -322,6 +325,7 @@ export enum RendererIpc {
   NativeThemeUpdate = 'renderer-native-theme-update',
   ConnectMyComputerAgentUpdate = 'renderer-connect-my-computer-agent-update',
   DeepLinkLaunch = 'renderer-deep-link-launch',
+  OpenAppUpdateDialog = 'renderer-open-app-update-dialog',
   AppUpdateEvent = 'renderer-app-update-event',
 }
 

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { MacUpdater } from 'electron-updater';
+
+import type { GetClusterVersionsResponse } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
+import { wait } from 'shared/utils/wait';
+
+import Logger, { NullService } from 'teleterm/logger';
+
+import { AppUpdateEvent, AppUpdater, AppUpdaterStorage } from './appUpdater';
+
+const mockedAppVersion = '15.0.0';
+
+jest.mock('electron', () => ({
+  app: {
+    // Should be false to avoid removing real Squirrel directory in `dispose`.
+    isPackaged: false,
+    getVersion: () => mockedAppVersion,
+  },
+  autoUpdater: { on: () => {} },
+}));
+
+beforeAll(() => {
+  Logger.init(new NullService());
+
+  // Mock fetching checksum.
+  // Creates hash from the passed URL.
+  global.fetch = jest.fn(async url => ({
+    ok: true,
+    text: async () =>
+      `${createHash('sha-512').update(url).digest('hex')}  Teleport Connect-17.5.4-mac.zip`,
+  })) as jest.Mock;
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+function makeUpdaterStorage(
+  initialValue: { managingClusterUri?: string } = {}
+): AppUpdaterStorage {
+  return {
+    get: () => initialValue,
+    put: newValue => (initialValue = newValue),
+  };
+}
+
+// MacUpdater with mocked download and install features.
+class MockedMacUpdater extends MacUpdater {
+  constructor() {
+    super(undefined, {
+      appUpdateConfigPath: __dirname,
+      baseCachePath: __dirname,
+      isPackaged: false,
+      userDataPath: '',
+      onQuit(): void {},
+      quit(): void {},
+      relaunch(): void {},
+      version: mockedAppVersion,
+      whenReady: () => Promise.resolve(),
+      name: 'Teleport Connect',
+    });
+    // Prevents electron-updater from creating .updaterId file.
+    this.stagingUserIdPromise.value = Promise.resolve(
+      '153432a8-93de-577c-a76a-3a042f1d7580'
+    );
+  }
+
+  protected override async doDownloadUpdate(): Promise<string[]> {
+    // Simulate download.
+    await wait(10);
+    this.dispatchUpdateDownloaded({
+      ...this.updateInfoAndProvider.info,
+      downloadedFile: 'some-update',
+    });
+    return ['some-update'];
+  }
+
+  override quitAndInstall() {}
+}
+
+function setUpAppUpdater(options: {
+  clusters: GetClusterVersionsResponse;
+  storage?: AppUpdaterStorage;
+}) {
+  const clusterGetter = async () => {
+    return options.clusters;
+  };
+
+  const nativeUpdater = new MockedMacUpdater();
+
+  const checkForUpdatesSpy = jest.spyOn(nativeUpdater, 'checkForUpdates');
+  const downloadUpdateSpy = jest.spyOn(nativeUpdater, 'downloadUpdate');
+  let lastEvent: { value?: AppUpdateEvent } = {};
+  const appUpdater = new AppUpdater(
+    options.storage || makeUpdaterStorage(),
+    clusterGetter,
+    async () => 'https://cdn.teleport.dev',
+    event => {
+      lastEvent.value = event;
+    },
+    nativeUpdater
+  );
+
+  return {
+    appUpdater,
+    nativeUpdater,
+    checkForUpdatesSpy,
+    downloadUpdateSpy,
+    lastEvent,
+  };
+}
+
+test('auto-downloads update when all clusters are reachable', async () => {
+  const setup = setUpAppUpdater({
+    clusters: {
+      reachableClusters: [
+        {
+          clusterUri: '/clusters/foo',
+          toolsAutoUpdate: true,
+          toolsVersion: '18.0.0',
+          minToolsVersion: '17.0.0-aa',
+        },
+      ],
+      unreachableClusters: [],
+    },
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-available',
+      autoDownload: true,
+    })
+  );
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(1);
+
+  await setup.downloadUpdateSpy.mock.results[0].value;
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-downloaded',
+    })
+  );
+});
+
+test('does not auto-download update when there are unreachable clusters', async () => {
+  const setup = setUpAppUpdater({
+    clusters: {
+      reachableClusters: [
+        {
+          clusterUri: '/clusters/foo',
+          toolsAutoUpdate: true,
+          toolsVersion: '18.0.0',
+          minToolsVersion: '17.0.0-aa',
+        },
+      ],
+      unreachableClusters: [
+        {
+          clusterUri: '/clusters/bar',
+          errorMessage: 'Network issue',
+        },
+      ],
+    },
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-available',
+      autoDownload: false,
+    })
+  );
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(0);
+});
+
+test('does not auto-download update when all clusters are reachable and noAutoDownload is set', async () => {
+  const setup = setUpAppUpdater({
+    clusters: {
+      reachableClusters: [
+        {
+          clusterUri: '/clusters/foo',
+          toolsAutoUpdate: true,
+          toolsVersion: '18.0.0',
+          minToolsVersion: '17.0.0-aa',
+        },
+      ],
+      unreachableClusters: [],
+    },
+  });
+
+  await setup.appUpdater.checkForUpdates({ noAutoDownload: true });
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-available',
+      autoDownload: false,
+    })
+  );
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(0);
+});
+
+test('discards previous update if a new one is found that should not auto-download', async () => {
+  const clusters = {
+    reachableClusters: [
+      {
+        clusterUri: '/clusters/foo',
+        toolsAutoUpdate: true,
+        toolsVersion: '18.0.0',
+        minToolsVersion: '17.0.0-aa',
+      },
+    ],
+    unreachableClusters: [],
+  };
+
+  const setup = setUpAppUpdater({
+    clusters,
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(1);
+  await setup.downloadUpdateSpy.mock.results[0].value;
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-downloaded',
+      update: expect.objectContaining({
+        version: '18.0.0',
+      }),
+    })
+  );
+
+  clusters.reachableClusters = [
+    {
+      clusterUri: '/clusters/foo',
+      toolsAutoUpdate: true,
+      toolsVersion: '18.0.0',
+      minToolsVersion: '17.0.0-aa',
+    },
+
+    // This cluster is on newer version, so it will be providing updates.
+    {
+      clusterUri: '/clusters/bar',
+      toolsAutoUpdate: true,
+      toolsVersion: '18.0.1',
+      minToolsVersion: '17.0.0-aa',
+    },
+  ];
+  await setup.appUpdater.checkForUpdates({ noAutoDownload: true });
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(1);
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      autoDownload: false,
+      kind: 'update-available',
+      update: expect.objectContaining({
+        version: '18.0.1',
+      }),
+    })
+  );
+  await setup.appUpdater.dispose();
+  // Check if the app is set to discard the first downloaded update on close.
+  expect(setup.nativeUpdater.autoInstallOnAppQuit).toBeFalsy();
+});
+
+test('discards previous update if the latest check returns no update', async () => {
+  const clusters = {
+    reachableClusters: [
+      {
+        clusterUri: '/clusters/foo',
+        toolsAutoUpdate: true,
+        toolsVersion: '18.0.0',
+        minToolsVersion: '17.0.0-aa',
+      },
+    ],
+    unreachableClusters: [],
+  };
+
+  const setup = setUpAppUpdater({
+    clusters,
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(1);
+  await setup.downloadUpdateSpy.mock.results[0].value;
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-downloaded',
+      update: expect.objectContaining({
+        version: '18.0.0',
+      }),
+    })
+  );
+
+  clusters.reachableClusters = [];
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(1);
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-not-available',
+    })
+  );
+  await setup.appUpdater.dispose();
+  // Check if the app is set to discard the first downloaded update on close.
+  expect(setup.nativeUpdater.autoInstallOnAppQuit).toBeFalsy();
+});

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -24,9 +24,12 @@ import process from 'process';
 import { app } from 'electron';
 import {
   autoUpdater,
+  DebUpdater,
   MacUpdater,
   AppUpdater as NativeUpdater,
+  NsisUpdater,
   ProgressInfo,
+  RpmUpdater,
   UpdateCheckResult,
   UpdateInfo,
 } from 'electron-updater';
@@ -124,6 +127,20 @@ export class AppUpdater {
   }
 
   /**
+   * Determines whether updates are supported for the current distribution.
+   * Note: Updating `.tar.gz` archives is not supported, but `electron-updater`
+   * incorrectly treats them as AppImage packages.
+   */
+  supportsUpdates(): boolean {
+    return (
+      this.nativeUpdater instanceof MacUpdater ||
+      this.nativeUpdater instanceof NsisUpdater ||
+      this.nativeUpdater instanceof DebUpdater ||
+      this.nativeUpdater instanceof RpmUpdater
+    );
+  }
+
+  /**
    * Checks for app updates.
    *
    * This method enhances the standard autoUpdater.checkForUpdates() by adding
@@ -166,6 +183,10 @@ export class AppUpdater {
       hasRetried?: boolean;
     } = {}
   ): Promise<void> {
+    if (!this.supportsUpdates()) {
+      return;
+    }
+
     this.forceNoAutoDownload = opts.noAutoDownload;
 
     const result = await this.nativeUpdater.checkForUpdates();

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -232,8 +232,8 @@ export class AppUpdater {
     // into a broken state where it becomes unresponsive.
     // To avoid this, we instead close the network connections to abort
     // the current download.
+    await autoUpdater.netSession.closeAllConnections();
     try {
-      await autoUpdater.netSession.closeAllConnections();
       await this.downloadPromise;
       return false;
     } catch {

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -397,15 +397,9 @@ function registerEventHandlers(
     if (error.message.includes('net::ERR_ABORTED')) {
       error = new AbortError('Update download was canceled');
     }
-    const serializedError = {
-      name: error.name,
-      message: error.message,
-      cause: error.cause,
-      stack: error.stack,
-    };
     emit({
       kind: 'error',
-      error: serializedError,
+      error,
       update: updateInfo,
       autoUpdatesStatus: getAutoUpdatesStatus() as AutoUpdatesEnabled,
     });

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -213,13 +213,14 @@ export class AppUpdater {
     }
 
     if (
-      this.shouldAutoDownload() ||
-      // This can occur if the user manually downloads an update
-      // and then triggers another check for updates.
-      // Since the update is already downloaded, the updater should transition
-      // to the `update-downloaded` state automatically.
-      // The update file will be read from the local cache.
-      this.isUpdateDownloaded
+      result.isUpdateAvailable &&
+      (this.shouldAutoDownload() ||
+        // This can occur if the user manually downloads an update
+        // and then triggers another check for updates.
+        // Since the update is already downloaded, the updater should transition
+        // to the `update-downloaded` state automatically.
+        // The update file will be read from the local cache.
+        this.isUpdateDownloaded)
     ) {
       void this.download();
       return;

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -145,6 +145,7 @@ export class AppUpdater {
     try {
       await this.checkForUpdatesPromise;
     } catch (error) {
+      // The error from autoUpdater.checkForUpdates is surfaced to the UI through error event.
       this.logger.error('Failed to check for updates.', error);
     } finally {
       this.checkForUpdatesPromise = undefined;
@@ -211,6 +212,7 @@ export class AppUpdater {
       await this.downloadPromise;
       this.isUpdateDownloaded = true;
     } catch (error) {
+      // The error from autoUpdater.download is surfaced to the UI through error event.
       this.logger.error('Failed to download update.', error);
     } finally {
       this.downloadPromise = undefined;

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -128,8 +128,10 @@ export class AppUpdater {
    * - It allows update checks during an ongoing download process.
    * If a new update is found (or no update is available), the current download
    * is canceled.
-   * - If an update is checked after a download has completed, the updater
-   * automatically transitions to the `update-downloaded` state.
+   * - If downloading the update requires user confirmation, but the update has
+   * already been downloaded, checking for updates will transition the updater
+   * to the `update-downloaded` state (instead of staying in `update-available`
+   * state).
    */
   async checkForUpdates(
     options: { noAutoDownload?: boolean } = {}

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -314,35 +314,37 @@ export class AppUpdater {
    * no new updates.
    */
   private async preventInstallingOutdatedUpdates(): Promise<void> {
-    if (!this.isUpdateDownloaded) {
-      // Workaround for Windows and Linux.
-      autoUpdater.autoInstallOnAppQuit = false;
+    if (this.isUpdateDownloaded) {
+      return;
+    }
 
-      // macOS-specific workaround:
-      // On macOS, electron-updater downloads the update file and, if
-      // `autoUpdater.autoInstallOnAppQuit` is true, passes it to the native Electron
-      // autoUpdater via a local server. The update is then handed off to the Squirrel
-      // framework for installation (either on demand or after quitting the app).
-      // Unfortunately, once Squirrel gets the update, it is always installed
-      // on quit, regardless of the `autoInstallOnAppQuit` value.
-      // The only workaround I've found is to manually delete the ShipItState.plist
-      // file so Squirrel cannot apply the update.
-      // The downloaded update will be overwritten with the next update.
-      if (autoUpdater instanceof MacUpdater && app.isPackaged) {
-        const squirrelMacPath = path.join(
-          os.homedir(),
-          'Library',
-          'Caches',
-          'gravitational.teleport.connect.ShipIt',
-          'ShipItState.plist'
-        );
-        try {
-          await rm(squirrelMacPath, {
-            force: true,
-          });
-        } catch (error) {
-          this.logger.error(error);
-        }
+    // Workaround for Windows and Linux.
+    autoUpdater.autoInstallOnAppQuit = false;
+
+    // macOS-specific workaround:
+    // On macOS, electron-updater downloads the update file and, if
+    // `autoUpdater.autoInstallOnAppQuit` is true, passes it to the native Electron
+    // autoUpdater via a local server. The update is then handed off to the Squirrel
+    // framework for installation (either on demand or after quitting the app).
+    // Unfortunately, once Squirrel gets the update, it is always installed
+    // on quit, regardless of the `autoInstallOnAppQuit` value.
+    // The only workaround I've found is to manually delete the ShipItState.plist
+    // file so Squirrel cannot apply the update.
+    // The downloaded update will be overwritten with the next update.
+    if (autoUpdater instanceof MacUpdater && app.isPackaged) {
+      const squirrelPlistFilePath = path.join(
+        os.homedir(),
+        'Library',
+        'Caches',
+        'gravitational.teleport.connect.ShipIt',
+        'ShipItState.plist'
+      );
+      try {
+        await rm(squirrelPlistFilePath, {
+          force: true,
+        });
+      } catch (error) {
+        this.logger.error(error);
       }
     }
   }

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -16,12 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import process from 'process';
 
+import { app } from 'electron';
 import {
   autoUpdater,
   AppUpdater as ElectronAppUpdater,
+  MacUpdater,
   ProgressInfo,
+  UpdateCheckResult,
   UpdateInfo,
 } from 'electron-updater';
 import { ProviderRuntimeOptions } from 'electron-updater/out/providers/Provider';
@@ -30,6 +36,7 @@ import type { GetClusterVersionsResponse } from 'gen-proto-ts/teleport/lib/telet
 import { AbortError } from 'shared/utils/error';
 
 import Logger from 'teleterm/logger';
+import { RootClusterUri } from 'teleterm/ui/uri';
 
 import {
   AutoUpdatesEnabled,
@@ -48,11 +55,16 @@ export class AppUpdater {
   private readonly logger = new Logger('AppUpdater');
   private readonly unregisterEventHandlers: () => void;
   private autoUpdatesStatus: AutoUpdatesStatus | undefined;
+  private updateCheckResult: UpdateCheckResult | undefined;
+  private checkForUpdatesPromise: Promise<void> | undefined;
+  private downloadPromise: Promise<string[]> | undefined;
+  private isUpdateDownloaded = false;
 
   constructor(
-    private storage: AppUpdaterStorage,
-    private getClusterVersions: () => Promise<GetClusterVersionsResponse>,
-    getDownloadBaseUrl: () => Promise<string>
+    private readonly storage: AppUpdaterStorage,
+    private readonly getClusterVersions: () => Promise<GetClusterVersionsResponse>,
+    readonly getDownloadBaseUrl: () => Promise<string>,
+    private readonly emit: (event: AppUpdateEvent) => void
   ) {
     const getClientToolsVersion: ClientToolsVersionGetter = async () => {
       await this.refreshAutoUpdatesStatus();
@@ -81,6 +93,12 @@ export class AppUpdater {
 
     autoUpdater.logger = this.logger;
     autoUpdater.allowDowngrade = true;
+    autoUpdater.autoDownload = false;
+    // Must be set to true before any download starts.
+    // electron-updater registers a listener to install the update when
+    // the app quits, after the download has completed.
+    // It can be then set to false, it the update shouldn't be installed
+    // (except macOS).
     autoUpdater.autoInstallOnAppQuit = true;
     // Enables checking for updates and downloading them in dev mode.
     // It makes testing this feature easier.
@@ -89,13 +107,200 @@ export class AppUpdater {
     autoUpdater.forceDevUpdateConfig = true;
 
     this.unregisterEventHandlers = registerEventHandlers(
-      () => {}, //TODO: send the events to the window.
-      () => this.autoUpdatesStatus
+      this.emit,
+      () => this.autoUpdatesStatus,
+      () => this.shouldAutoDownload()
     );
+
+    // Workaround to prevent installing outdated updates.
+    // electron-updater lacks support for this: once an update is downloaded,
+    // it will be installed on quit—even if subsequent update checks report
+    // no new updates.
+    app.on('will-quit', () => {
+      if (!this.isUpdateDownloaded) {
+        // Workaround for Windows and Linux.
+        autoUpdater.autoInstallOnAppQuit = false;
+
+        // macOS-specific workaround:
+        // On macOS, electron-updater downloads the update file and, if
+        // `autoUpdater.autoInstallOnAppQuit` is true, passes it to the native Electron
+        // autoUpdater via a local server. The update is then handed off to the Squirrel
+        // framework for installation (either on demand or after quitting the app).
+        // Unfortunately, once Squirrel gets the update, it is always installed
+        // on quit, regardless of the `autoInstallOnAppQuit` value.
+        // The only workaround I've found is to manually delete the entire Squirrel
+        // update directory for Connect.
+        if (autoUpdater instanceof MacUpdater && app.isPackaged) {
+          const squirrelMacPath = path.join(
+            os.homedir(),
+            'Library',
+            'Caches',
+            'gravitational.teleport.connect.ShipIt'
+          );
+          try {
+            rmSync(squirrelMacPath, {
+              recursive: true,
+              force: true,
+              maxRetries: 2,
+            });
+          } catch {
+            /* empty */
+          }
+        }
+      }
+    });
   }
 
   dispose(): void {
     this.unregisterEventHandlers();
+  }
+
+  /**
+   * Checks for app updates.
+   *
+   * This method enhances the standard autoUpdater.checkForUpdates() by adding
+   * the following behaviors:
+   * - It allows update checks during an ongoing download process.
+   * If a new update is found (or no update is available), the current download
+   * is canceled.
+   * - If an update is checked after a download has completed, the updater
+   * automatically transitions to the `update-downloaded` state.
+   */
+  async checkForUpdates(): Promise<void> {
+    if (this.checkForUpdatesPromise) {
+      this.logger.info('Check for updates already in progress.');
+      return this.checkForUpdatesPromise;
+    }
+
+    this.checkForUpdatesPromise = this.doCheckForUpdates();
+    try {
+      await this.checkForUpdatesPromise;
+    } catch (error) {
+      this.logger.error('Failed to check for updates.', error);
+    } finally {
+      this.checkForUpdatesPromise = undefined;
+    }
+  }
+
+  /** Not safe for concurrent use. */
+  private async doCheckForUpdates(
+    opts: {
+      /**
+       * Whether this is a retry attempt.
+       * Used as a guard to prevent infinite loops.
+       */
+      hasRetried?: boolean;
+    } = {}
+  ): Promise<void> {
+    const result = await autoUpdater.checkForUpdates();
+
+    const newSha = result.updateInfo?.files[0]?.sha512;
+    const oldSha = this.updateCheckResult?.updateInfo.files[0]?.sha512;
+    const isSameUpdate = newSha && oldSha && newSha === oldSha;
+
+    this.updateCheckResult = result;
+
+    const updateUnavailable = !result.isUpdateAvailable;
+    const updateChanged = !isSameUpdate;
+
+    let downloadCanceled = false;
+    if (updateUnavailable || updateChanged) {
+      downloadCanceled = await this.cancelDownload();
+    }
+
+    if (
+      this.shouldAutoDownload() ||
+      // This can occur if the user manually downloads an update
+      // and then triggers another check for updates.
+      // Since the update is already downloaded, the updater should transition
+      // to the `update-downloaded` state automatically.
+      // The update file will be read from the local cache.
+      this.isUpdateDownloaded
+    ) {
+      void this.download();
+      return;
+    }
+
+    // Retry to refresh the state so that the UI won't be showing
+    // a cancellation error.
+    if (downloadCanceled && !opts.hasRetried) {
+      await this.doCheckForUpdates({ hasRetried: true });
+    }
+  }
+
+  /** Starts download. */
+  async download(): Promise<string[]> {
+    if (this.downloadPromise) {
+      this.logger.info('Download already in progress.');
+      return this.downloadPromise;
+    }
+
+    this.downloadPromise = autoUpdater.downloadUpdate();
+    try {
+      await this.downloadPromise;
+      this.isUpdateDownloaded = true;
+    } catch (error) {
+      this.logger.error('Failed to download update.', error);
+    } finally {
+      this.downloadPromise = undefined;
+    }
+  }
+
+  /** Cancels download. Returns true if aborted the network request. */
+  async cancelDownload(): Promise<boolean> {
+    if (!this.downloadPromise) {
+      this.isUpdateDownloaded = false;
+      return false;
+    }
+
+    // Due to a bug in electron-updater, we can't cancel downloads using cancellation
+    // token passed to autoUpdater.download().
+    // Repeatedly starting and canceling downloads causes the updater to go
+    // into a broken state where it becomes unresponsive.
+    // To avoid this, we instead close the network connections to abort
+    // the current download.
+    try {
+      await autoUpdater.netSession.closeAllConnections();
+      await this.downloadPromise;
+      return false;
+    } catch {
+      return true;
+    } finally {
+      this.isUpdateDownloaded = false;
+    }
+  }
+
+  /**
+   * Sets given cluster as managing app version.
+   * When `undefined` is passed, the managing cluster is cleared.
+   *
+   * Immediately cancels an in-progress download and then checks for updates.
+   */
+  async changeManagingCluster(
+    clusterUri: RootClusterUri | undefined
+  ): Promise<void> {
+    this.storage.put({ managingClusterUri: clusterUri });
+    await this.cancelDownload();
+    await this.checkForUpdates();
+  }
+
+  /**
+   * Restarts the app and installs the update after it has been downloaded.
+   * It should only be called after update-downloaded has been emitted.
+   */
+  quitAndInstall(): void {
+    try {
+      autoUpdater.quitAndInstall();
+    } catch (error) {
+      this.logger.error('Failed to quit and install update', error);
+    }
+  }
+
+  private shouldAutoDownload(): boolean {
+    return (
+      this.autoUpdatesStatus?.enabled &&
+      shouldAutoDownload(this.autoUpdatesStatus)
+    );
   }
 
   private async refreshAutoUpdatesStatus(): Promise<void> {
@@ -107,9 +312,6 @@ export class AppUpdater {
       managingClusterUri,
       getClusterVersions: this.getClusterVersions,
     });
-    if (this.autoUpdatesStatus.enabled) {
-      autoUpdater.autoDownload = shouldAutoDownload(this.autoUpdatesStatus);
-    }
     this.logger.info('Resolved auto updates status', this.autoUpdatesStatus);
   }
 }
@@ -126,14 +328,14 @@ export interface AppUpdaterStorage<
 
 function registerEventHandlers(
   emit: (event: AppUpdateEvent) => void,
-  getAutoUpdatesStatus: () => AutoUpdatesStatus
+  getAutoUpdatesStatus: () => AutoUpdatesStatus,
+  getAutoDownload: () => boolean
 ): () => void {
   // updateInfo becomes defined when an update is available (see onUpdateAvailable).
   // It is later attached to other events, like 'download-progress' or 'error'.
   let updateInfo: UpdateInfo | undefined;
 
   const onCheckingForUpdate = () => {
-    updateInfo = undefined;
     emit({
       kind: 'checking-for-update',
       autoUpdatesStatus: getAutoUpdatesStatus(),
@@ -144,30 +346,30 @@ function registerEventHandlers(
     emit({
       kind: 'update-available',
       update,
-      autoDownload: autoUpdater.autoDownload,
+      autoDownload: getAutoDownload(),
       autoUpdatesStatus: getAutoUpdatesStatus() as AutoUpdatesEnabled,
     });
   };
-  const onUpdateNotAvailable = () =>
+  const onUpdateNotAvailable = () => {
+    updateInfo = undefined;
     emit({
       kind: 'update-not-available',
       autoUpdatesStatus: getAutoUpdatesStatus(),
     });
-  const onUpdateCancelled = (update: UpdateInfo) => {
-    emit({
-      kind: 'error',
-      error: new AbortError('Update download was canceled'),
-      update,
-      autoUpdatesStatus: getAutoUpdatesStatus() as AutoUpdatesEnabled,
-    });
   };
   const onError = (error: Error) => {
-    // Functions can't be sent through IPC.
-    delete error.toString;
-
+    if (error.message.includes('net::ERR_ABORTED')) {
+      error = new AbortError('Update download was canceled');
+    }
+    const serializedError = {
+      name: error.name,
+      message: error.message,
+      cause: error.cause,
+      stack: error.stack,
+    };
     emit({
       kind: 'error',
-      error: error,
+      error: serializedError,
       update: updateInfo,
       autoUpdatesStatus: getAutoUpdatesStatus() as AutoUpdatesEnabled,
     });
@@ -189,7 +391,6 @@ function registerEventHandlers(
   autoUpdater.on('checking-for-update', onCheckingForUpdate);
   autoUpdater.on('update-available', onUpdateAvailable);
   autoUpdater.on('update-not-available', onUpdateNotAvailable);
-  autoUpdater.on('update-cancelled', onUpdateCancelled);
   autoUpdater.on('error', onError);
   autoUpdater.on('download-progress', onDownloadProgress);
   autoUpdater.on('update-downloaded', onUpdateDownloaded);
@@ -198,7 +399,6 @@ function registerEventHandlers(
     autoUpdater.off('checking-for-update', onCheckingForUpdate);
     autoUpdater.off('update-available', onUpdateAvailable);
     autoUpdater.off('update-not-available', onUpdateNotAvailable);
-    autoUpdater.off('update-cancelled', onUpdateCancelled);
     autoUpdater.off('error', onError);
     autoUpdater.off('download-progress', onDownloadProgress);
     autoUpdater.off('update-downloaded', onUpdateDownloaded);

--- a/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
+++ b/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
@@ -68,7 +68,7 @@ export class ClientToolsUpdateProvider extends Provider<UpdateInfo> {
     }
 
     const { baseUrl, version } = clientTools;
-    const fileUrl = `https://${baseUrl}/${makeDownloadFilename(this.nativeUpdater, version)}`;
+    const fileUrl = `${baseUrl}/${makeDownloadFilename(this.nativeUpdater, version)}`;
     const sha512 = await fetchChecksum(fileUrl);
 
     return {
@@ -138,7 +138,8 @@ async function fetchChecksum(fileUrl: string): Promise<string> {
       `Could not retrieve checksum from "${response.url}" (${response.status} ${response.statusText}).`
     );
   }
-  const checksumText = await response.text();
+  // Trim the response which ends with a new line.
+  const checksumText = (await response.text()).trim();
   if (!CHECKSUM_FORMAT.test(checksumText)) {
     throw new Error(`Invalid checksum format ${checksumText}`);
   }

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -21,6 +21,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { AppInitializer } from 'teleterm/ui/AppInitializer';
+import { AppUpdaterContextProvider } from 'teleterm/ui/AppUpdater';
 
 import AppContext from './appContext';
 import AppContextProvider from './appContextProvider';
@@ -41,17 +42,19 @@ export const App: React.FC<{
       <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
-            <ResourcesContextProvider>
-              <ConnectionsContextProvider>
-                <VnetContextProvider>
-                  <ThemeProvider>
-                    <DeepLinks launchDeepLink={launchDeepLink} />
+            <AppUpdaterContextProvider>
+              <ResourcesContextProvider>
+                <ConnectionsContextProvider>
+                  <VnetContextProvider>
+                    <ThemeProvider>
+                      <DeepLinks launchDeepLink={launchDeepLink} />
 
-                    <AppInitializer />
-                  </ThemeProvider>
-                </VnetContextProvider>
-              </ConnectionsContextProvider>
-            </ResourcesContextProvider>
+                      <AppInitializer />
+                    </ThemeProvider>
+                  </VnetContextProvider>
+                </ConnectionsContextProvider>
+              </ResourcesContextProvider>
+            </AppUpdaterContextProvider>
           </AppContextProvider>
         </DndProvider>
       </StyledApp>

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdaterContext.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdaterContext.tsx
@@ -1,0 +1,74 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { type AppUpdateEvent } from 'teleterm/services/appUpdater';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+
+interface AppUpdaterContext {
+  updateEvent: AppUpdateEvent;
+}
+
+const AppUpdaterContext = createContext<AppUpdaterContext>(null);
+
+export function AppUpdaterContextProvider(props: PropsWithChildren) {
+  const appContext = useAppContext();
+  const [updateEvent, setUpdateEvent] = useState<AppUpdateEvent>({
+    kind: 'checking-for-update',
+  });
+
+  useEffect(() => {
+    const { cleanup } =
+      appContext.mainProcessClient.subscribeToAppUpdateEvents(setUpdateEvent);
+
+    return cleanup;
+  }, [appContext]);
+
+  const value = useMemo(
+    () => ({
+      updateEvent,
+    }),
+    [updateEvent]
+  );
+
+  return (
+    <AppUpdaterContext.Provider value={value}>
+      {props.children}
+    </AppUpdaterContext.Provider>
+  );
+}
+
+export const useAppUpdaterContext = () => {
+  const context = useContext(AppUpdaterContext);
+
+  if (!context) {
+    throw new Error(
+      'useAppUpdaterContext must be used within an AppUpdaterContext'
+    );
+  }
+
+  return context;
+};

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
 import {
   Alert,
@@ -89,6 +89,7 @@ export function DetailsView({
         onDownload={onDownload}
         onCancelDownload={onCancelDownload}
         onInstall={onInstall}
+        key={JSON.stringify(updateEvent)}
       />
     </Stack>
   );
@@ -109,6 +110,7 @@ function UpdaterState({
   onCancelDownload(): void;
   onInstall(): void;
 }) {
+  const [downloadStarted, setDownloadStarted] = useState(false);
   switch (event.kind) {
     case 'checking-for-update':
       return (
@@ -126,12 +128,18 @@ function UpdaterState({
       return (
         <Stack gap={3} width="100%">
           <AvailableUpdate update={event.update} platform={platform} />
-          {event.autoDownload ? (
+          {event.autoDownload || downloadStarted ? (
             <ButtonSecondary disabled block>
               Starting Download…
             </ButtonSecondary>
           ) : (
-            <ButtonSecondary block onClick={onDownload}>
+            <ButtonSecondary
+              block
+              onClick={() => {
+                setDownloadStarted(true);
+                onDownload();
+              }}
+            >
               Download
             </ButtonSecondary>
           )}

--- a/web/packages/teleterm/src/ui/AppUpdater/index.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/index.ts
@@ -18,3 +18,4 @@
 
 export * from './DetailsView';
 export * from './WidgetView';
+export * from './AppUpdaterContext';

--- a/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -18,6 +18,7 @@
 
 import { useAsync } from 'shared/hooks/useAsync';
 
+import { useLogger } from 'teleterm/ui/hooks/useLogger';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { useAppContext } from '../appContextProvider';
@@ -28,11 +29,15 @@ export function useClusterLogout({
   clusterUri: RootClusterUri;
 }) {
   const ctx = useAppContext();
+  const logger = useLogger('useClusterLogout');
   const [{ status, statusText }, removeCluster] = useAsync(async () => {
     await ctx.clustersService.logout(clusterUri);
-    await ctx.mainProcessClient.maybeRemoveAppUpdatesManagingCluster(
-      clusterUri
-    );
+    // This function checks for updates, do not wait for it.
+    ctx.mainProcessClient
+      .maybeRemoveAppUpdatesManagingCluster(clusterUri)
+      .catch(err => {
+        logger.error('Failed to remove managing cluster', err);
+      });
 
     if (ctx.workspacesService.getRootClusterUri() === clusterUri) {
       const [firstConnectedWorkspace] =

--- a/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -30,6 +30,9 @@ export function useClusterLogout({
   const ctx = useAppContext();
   const [{ status, statusText }, removeCluster] = useAsync(async () => {
     await ctx.clustersService.logout(clusterUri);
+    await ctx.mainProcessClient.maybeRemoveAppUpdatesManagingCluster(
+      clusterUri
+    );
 
     if (ctx.workspacesService.getRootClusterUri() === clusterUri) {
       const [firstConnectedWorkspace] =

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -28,6 +28,7 @@ import { ClusterLogout } from '../ClusterLogout';
 import { ResourceSearchErrors } from '../Search/ResourceSearchErrors';
 import { assertUnreachable } from '../utils';
 import { ConfigureSSHClients } from '../Vnet/ConfigureSSHClients';
+import { AppUpdates } from './modals/AppUpdates';
 import { ChangeAccessRequestKind } from './modals/ChangeAccessRequestKind';
 import { AskPin, ChangePin, OverwriteSlot, Touch } from './modals/HardwareKeys';
 import { ReAuthenticate } from './modals/ReAuthenticate';
@@ -292,6 +293,9 @@ function renderDialog({
           host={dialog.host}
         />
       );
+    }
+    case 'app-updates': {
+      return <AppUpdates hidden={hidden} onClose={() => handleClose()} />;
     }
 
     default: {

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
@@ -1,0 +1,88 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useMemo } from 'react';
+
+import { ButtonIcon, H2 } from 'design';
+import DialogConfirmation, {
+  DialogContent,
+  DialogHeader,
+} from 'design/DialogConfirmation';
+import { Cross } from 'design/Icon';
+
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { DetailsView, useAppUpdaterContext } from 'teleterm/ui/AppUpdater';
+
+export function AppUpdates(props: { hidden?: boolean; onClose(): void }) {
+  const appContext = useAppContext();
+  const { updateEvent } = useAppUpdaterContext();
+
+  const {
+    checkForAppUpdates,
+    downloadAppUpdate,
+    cancelAppUpdateDownload,
+    quitAndInstallAppUpdate,
+    changeAppUpdatesManagingCluster,
+  } = appContext.mainProcessClient;
+
+  useEffect(() => {
+    void checkForAppUpdates();
+  }, [checkForAppUpdates]);
+
+  const platform = useMemo(() => {
+    return appContext.mainProcessClient.getRuntimeSettings().platform;
+  }, [appContext.mainProcessClient]);
+
+  return (
+    <DialogConfirmation
+      open={!props.hidden}
+      keepInDOMAfterClose
+      onClose={props.onClose}
+      dialogCss={() => ({
+        maxWidth: '420px',
+        width: '100%',
+      })}
+    >
+      <DialogHeader justifyContent="space-between" mb={4} alignItems="baseline">
+        <H2>App Updates</H2>
+        <ButtonIcon
+          type="button"
+          onClick={props.onClose}
+          color="text.slightlyMuted"
+        >
+          <Cross size="medium" />
+        </ButtonIcon>
+      </DialogHeader>
+
+      <DialogContent mb={0}>
+        <DetailsView
+          platform={platform}
+          updateEvent={updateEvent}
+          clusterGetter={appContext.clustersService}
+          onCancelDownload={() => void cancelAppUpdateDownload()}
+          onDownload={() => void downloadAppUpdate()}
+          onCheckForUpdates={() => void checkForAppUpdates()}
+          onInstall={() => void quitAndInstallAppUpdate()}
+          changeManagingCluster={clusterUri =>
+            void changeAppUpdatesManagingCluster(clusterUri)
+          }
+        />
+      </DialogContent>
+    </DialogConfirmation>
+  );
+}

--- a/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { Popover } from 'design';
 import * as icons from 'design/Icon';
@@ -45,6 +45,10 @@ function useMenuItems(): MenuItem[] {
 
   const { platform } = mainProcessClient.getRuntimeSettings();
   const isDarwin = platform === 'darwin';
+
+  const supportsAppUpdates = useMemo(() => {
+    return mainProcessClient.supportsAppUpdates();
+  }, [mainProcessClient]);
 
   const menuItems: (MenuItem & { isVisible: boolean })[] = [
     {
@@ -84,7 +88,7 @@ function useMenuItems(): MenuItem[] {
     },
     {
       title: 'Check for updates…',
-      isVisible: true,
+      isVisible: supportsAppUpdates,
       Icon: icons.Application,
       onNavigate: () => {
         appUpdaterContext.openDialog();

--- a/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
@@ -22,6 +22,7 @@ import { Popover } from 'design';
 import * as icons from 'design/Icon';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useAppUpdaterContext } from 'teleterm/ui/AppUpdater';
 import { useWorkspaceServiceState } from 'teleterm/ui/services/workspacesService';
 import { useNewTabOpener } from 'teleterm/ui/TabHost';
 import { TopBarButton } from 'teleterm/ui/TopBar/TopBarButton';
@@ -30,6 +31,7 @@ import { Menu, MenuItem, MenuListItem } from '../components/Menu';
 
 function useMenuItems(): MenuItem[] {
   const ctx = useAppContext();
+  const appUpdaterContext = useAppUpdaterContext();
   const { workspacesService, mainProcessClient, notificationsService } = ctx;
   useWorkspaceServiceState();
   const documentsService =
@@ -78,6 +80,14 @@ function useMenuItems(): MenuItem[] {
       Icon: icons.Unlink,
       onNavigate: () => {
         ctx.commandLauncher.executeCommand('tsh-uninstall', undefined);
+      },
+    },
+    {
+      title: 'Check for updates…',
+      isVisible: true,
+      Icon: icons.Application,
+      onNavigate: () => {
+        appUpdaterContext.openDialog();
       },
     },
   ];

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -310,6 +310,10 @@ export interface DialogConfigureSSHClients {
   host?: string;
 }
 
+export interface DialogAppUpdate {
+  kind: 'app-updates';
+}
+
 export type Dialog =
   | DialogClusterConnect
   | DialogClusterLogout
@@ -324,4 +328,5 @@ export type Dialog =
   | DialogHardwareKeyPin
   | DialogHardwareKeyTouch
   | DialogHardwareKeyPinChange
-  | DialogHardwareKeySlotOverwrite;
+  | DialogHardwareKeySlotOverwrite
+  | DialogAppUpdate;


### PR DESCRIPTION
Part 5 of https://github.com/gravitational/teleport/issues/50948. [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0144-client-tools-updates.md#teleport-connect-automatic-updates-added-on-2025-07-10-by-gzdunek).

This PR adds a dialog to check for updates and integrates it with the updater service (the widget will be added in the next PR).

This first commit is most important one. It implements updater methods that will be used by the UI. Unfortunately, I found some bugs in `electron-updater`, so I had to add extra logic to resolve them. I've left comments in `AppUpdater.ts` to explain what wasn't working and how those issues were addressed. If anything is unclear, please let me know.

While testing, I also realized that the UI in the multi-cluster scenario may be too complex when we show errors/warning about unreachable clusters (although it seemed fine in Storybook to me). I'll address this separately by reducing alerts and making inline errors more prominent.

### How to test it (on macOS)
I prepared two dev builds with different versions (`19.0.0-dev.connect.updates.1` and `19.0.0-dev.connect.updates.2`) to test the updates.
1. Globally set the base URL env var: `launchctl setenv TELEPORT_CDN_BASE_URL https://cdn.cloud.gravitational.io`.
2. Set your cluster client tools version: `tctl autoupdate client-tools target 19.0.0-dev.connect.updates.2`.
3. Download `19.0.0-dev.connect.updates.1` build from https://cdn.cloud.gravitational.io/Teleport%20Connect-19.0.0-dev.connect.updates.1.dmg.
4. Move the app to Applications and start it -> App menu -> Check for updates.