### PR TITLE
Disallow new uses of gogoproto jsonpb

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,10 +174,10 @@ linters:
                 migrated away from jsonpb, but it should not be used by new
                 code. If you need to encode and decode a gogoproto-generated
                 message in protobuf json, use
-                google.golang.org/protobuf/google.golang.org/protobuf/encoding/protojson
-                together with google.golang.org/protobuf/protoadapt instead, or,
-                better yet, see if you can move the code generation for that
-                message to the modern protoc-gen-go.
+                google.golang.org/protobuf/encoding/protojson together with
+                google.golang.org/protobuf/protoadapt instead, or, better yet,
+                see if you can move the code generation for that message to the
+                modern protoc-gen-go.
         oidc:
           deny:
             - pkg: github.com/coreos/go-oidc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,8 +163,21 @@ linters:
               desc: use "github.com/gravitational/teleport/lib/msgraph" instead
             - pkg: github.com/cloudflare/cfssl
               desc: use "crypto" or "x/crypto" instead
-            - pkg: "golang.org/x/net/context"
+            - pkg: golang.org/x/net/context
               desc: use "context" instead
+            - pkg: github.com/gogo/protobuf/jsonpb
+              desc: gogoproto jsonpb has inconsistent interactions with any
+                message that directly or indirectly makes use of
+                gogoproto.casttype, and will happily violate the protobuf json
+                encoding spec in those situations. It should only be used for
+                existing marshaling and unmarshaling that can't easily be
+                migrated away from jsonpb, but it should not be used by new
+                code. If you need to encode and decode a gogoproto-generated
+                message in protobuf json, use
+                google.golang.org/protobuf/google.golang.org/protobuf/encoding/protojson
+                together with google.golang.org/protobuf/protoadapt instead, or,
+                better yet, see if you can move the code generation for that
+                message to the modern protoc-gen-go.
         oidc:
           deny:
             - pkg: github.com/coreos/go-oidc
@@ -317,7 +330,7 @@ linters:
         - pattern: ^protojson\.Unmarshal$
           msg: use protojson.UnmarshalOptions and consider enabling DiscardUnknown
         - pattern: ^jsonpb\.(?:Unmarshal|UnmarshalString|UnmarshalNext)$
-          msg: use jsonpb.Unmarshaler and consider enabling AllowUnknownFields
+          msg: use protojson if possible, or use jsonpb.Unmarshaler and consider enabling AllowUnknownFields
     misspell:
       locale: US
     nolintlint:

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/api/types/events/struct.go
+++ b/api/types/events/struct.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 )

--- a/api/types/mfa.go
+++ b/api/types/mfa.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"

--- a/api/utils/keys/hardwarekey/attestation.go
+++ b/api/utils/keys/hardwarekey/attestation.go
@@ -17,7 +17,7 @@ package hardwarekey
 import (
 	"bytes"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	attestationv1 "github.com/gravitational/teleport/api/gen/proto/go/attestation/v1"

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"

--- a/lib/services/plugins.go
+++ b/lib/services/plugins.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -34,7 +34,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
 	"github.com/pkg/sftp"
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
The jsonpb package from gogoproto violates the protobuf json spec by calling any custom `MarshalJSON` implementation for fields that make use of the `gogoproto.casttype` option (quite a few, in our codebase), as well as calling custom marshaling for standard library types such as `time.Duration` even in situations where it wouldn't be appropriate.

This issue was thankfully noticed because `types.JamfSpecV1` has an `int64` field with casttype set to `github.com/gravitational/teleport/api/types.Duration`, which has custom marshaling (which is used by `jsonpb.Marshal`) and custom unmarshaling (which is not used by `jsonpb.Unmarshal`), so any roundtrip with a non-zero `sync_delay` field results in an error because marshaling writes out the duration as a duration string, but unmarshaling (rightfully) expects a number. Other uses of casttype with `time.Duration` (for example, in `types.OIDCAuthRequest`) roundtrip correctly through marshal/unmarshal because the protobuf json spec is violated in the same way in both directions.

This PR adds an entry to the depguard linter configuration to prevent the use of gogoproto jsonpb, as well as linter exceptions for all current uses of jsonpb.