### PR TITLE
[v16] gha(docs-amplify): update amplify preview to v0.0.2

### DIFF
--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -23,8 +23,8 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Create Amplify preview environment
-      uses: gravitational/shared-workflows/tools/amplify-preview@c46b731e6f7e2c50024454965c6097a72f866734 # tools/amplify-preview/v0.0.1
-      continue-on-error: true
+      uses: gravitational/shared-workflows/tools/amplify-preview@664e788d45a7f56935cf63094b4fb52a41b12015 # tools/amplify-preview/v0.0.2
+      id: amplify_preview
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
         create_branches: "true"
@@ -37,6 +37,7 @@ jobs:
         ERR_TITLE: Teleport Docs preview build failed
         ERR_MESSAGE: >-
           Please refer to the following documentation for help: https://www.notion.so/goteleport/How-to-Amplify-deployments-162fdd3830be8096ba72efa1a49ee7bc?pvs=4
+          Execution info: ${{ steps.amplify_preview.outputs.amplify_app_id }} ${{ steps.amplify_preview.outputs.amplify_branch_name }} ${{ steps.amplify_preview.outputs.amplify_job_id }}
       run: |
         echo ::error title=$ERR_TITLE::$ERR_MESSAGE
         exit 1


### PR DESCRIPTION
### Summary

This updates `amplify-preview` action (https://github.com/gravitational/shared-workflows/pull/311) to improve following areas:
- Better failure message now includes execution info. This info can be copied and used to fetch build log
- Remove `continue-on-error`, error message will be printed without it because `if: failure()`


### Testing

Failing job example: https://github.com/gravitational/docs-website/actions/runs/16122341243/job/45491022486

Backports #56497