### PR TITLE
Make LockWatcher forward deleted lock to subscribers

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1070,6 +1070,10 @@ func (p *lockCollector) processEventsAndUpdateCurrent(ctx context.Context, event
 
 		switch event.Type {
 		case types.OpDelete:
+			lockName := event.Resource.GetName()
+			if lock, ok := p.current[lockName]; ok {
+				event.Resource = lock
+			}
 			delete(p.current, event.Resource.GetName())
 			eventsToEmit = append(eventsToEmit, event)
 		case types.OpPut:

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -290,6 +290,7 @@ func TestLockWatcher(t *testing.T) {
 	case event := <-sub.Events():
 		require.Equal(t, types.OpDelete, event.Type)
 		require.Equal(t, event.Resource.GetName(), lock.GetName())
+		require.IsType(t, (*types.LockV2)(nil), event.Resource)
 	case <-sub.Done():
 		t.Fatal("Lock watcher subscription has unexpectedly exited.")
 	case <-time.After(2 * time.Second):


### PR DESCRIPTION
This change makes the `services.LockWatcher` forward its own cached copy of a lock to its subscribers on a delete event, rather than the truncated Resource Header that usually accompanies a delete.

The motivating example for this change is the AWS Identity Center integration. When a lock is deleted, the IC integration needs to know the lock target(s) in order to trigger a permission assignment recalculation and possible update for the affected resources, and it can't get this information from the vestigial Resource Header.

The `LockWatcher` already contains a lock-ID-to-lock-resource mapping internally, so having it supply its copy of the deleted lock resource to its subscribers seemed the most straightforward way to get that lock info to the IC integration.
