### PR TITLE
Add protobuf definitions for storing and retrieving session summaries

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -22,9 +22,9 @@ package summarizerv1
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	events "github.com/gravitational/teleport/api/types/events"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -620,7 +620,12 @@ type Summary struct {
 	// end events carry the most complete set of data that Teleport has about a
 	// given session. Used for checking access based on RBAC rule "where"
 	// filters.
-	SessionEndEvent *events.OneOf `protobuf:"bytes,7,opt,name=session_end_event,json=sessionEndEvent,proto3" json:"session_end_event,omitempty"`
+	//
+	// The event is stored in an unstructured form, as storing an instance of
+	// events.OneOf posed a number of technical challenges with JSON
+	// serialization as a subcomponent of this message. These challenges stem
+	// from the fact that audit events have gogoproto extensions.
+	SessionEndEvent *structpb.Struct `protobuf:"bytes,7,opt,name=session_end_event,json=sessionEndEvent,proto3" json:"session_end_event,omitempty"`
 	// ErrorMessage is an error message if the summarization failed. Available if
 	// the state is SUMMARY_STATE_ERROR.
 	ErrorMessage  string `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
@@ -700,7 +705,7 @@ func (x *Summary) GetModelName() string {
 	return ""
 }
 
-func (x *Summary) GetSessionEndEvent() *events.OneOf {
+func (x *Summary) GetSessionEndEvent() *structpb.Struct {
 	if x != nil {
 		return x.SessionEndEvent
 	}
@@ -718,7 +723,7 @@ var File_teleport_summarizer_v1_summarizer_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/summarizer/v1/summarizer.proto\x12\x16teleport.summarizer.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\x1a)teleport/legacy/types/events/events.proto\"\xd3\x01\n" +
+	"'teleport/summarizer/v1/summarizer.proto\x12\x16teleport.summarizer.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xd3\x01\n" +
 	"\x0eInferenceModel\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -751,7 +756,7 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x13InferencePolicySpec\x12\x14\n" +
 	"\x05kinds\x18\x01 \x03(\tR\x05kinds\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x16\n" +
-	"\x06filter\x18\x03 \x01(\tR\x06filter\"\x9b\x03\n" +
+	"\x06filter\x18\x03 \x01(\tR\x06filter\"\xa5\x03\n" +
 	"\aSummary\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12:\n" +
@@ -760,8 +765,8 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x15inference_finished_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x13inferenceFinishedAt\x12\x18\n" +
 	"\acontent\x18\x05 \x01(\tR\acontent\x12\x1d\n" +
 	"\n" +
-	"model_name\x18\x06 \x01(\tR\tmodelName\x129\n" +
-	"\x11session_end_event\x18\a \x01(\v2\r.events.OneOfR\x0fsessionEndEvent\x12#\n" +
+	"model_name\x18\x06 \x01(\tR\tmodelName\x12C\n" +
+	"\x11session_end_event\x18\a \x01(\v2\x17.google.protobuf.StructR\x0fsessionEndEvent\x12#\n" +
 	"\rerror_message\x18\b \x01(\tR\ferrorMessage*|\n" +
 	"\fSummaryState\x12\x1d\n" +
 	"\x19SUMMARY_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
@@ -795,7 +800,7 @@ var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
 	(*Summary)(nil),               // 8: teleport.summarizer.v1.Summary
 	(*v1.Metadata)(nil),           // 9: teleport.header.v1.Metadata
 	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
-	(*events.OneOf)(nil),          // 11: events.OneOf
+	(*structpb.Struct)(nil),       // 11: google.protobuf.Struct
 }
 var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
 	9,  // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
@@ -808,7 +813,7 @@ var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
 	0,  // 7: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
 	10, // 8: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
 	10, // 9: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
-	11, // 10: teleport.summarizer.v1.Summary.session_end_event:type_name -> events.OneOf
+	11, // 10: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
 	11, // [11:11] is the sub-list for method output_type
 	11, // [11:11] is the sub-list for method input_type
 	11, // [11:11] is the sub-list for extension type_name

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -22,8 +22,10 @@ package summarizerv1
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	events "github.com/gravitational/teleport/api/types/events"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -35,6 +37,59 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// SummaryState is the state of the summarization process.
+type SummaryState int32
+
+const (
+	SummaryState_SUMMARY_STATE_UNSPECIFIED SummaryState = 0
+	SummaryState_SUMMARY_STATE_PENDING     SummaryState = 1
+	SummaryState_SUMMARY_STATE_SUCCESS     SummaryState = 2
+	SummaryState_SUMMARY_STATE_ERROR       SummaryState = 3
+)
+
+// Enum value maps for SummaryState.
+var (
+	SummaryState_name = map[int32]string{
+		0: "SUMMARY_STATE_UNSPECIFIED",
+		1: "SUMMARY_STATE_PENDING",
+		2: "SUMMARY_STATE_SUCCESS",
+		3: "SUMMARY_STATE_ERROR",
+	}
+	SummaryState_value = map[string]int32{
+		"SUMMARY_STATE_UNSPECIFIED": 0,
+		"SUMMARY_STATE_PENDING":     1,
+		"SUMMARY_STATE_SUCCESS":     2,
+		"SUMMARY_STATE_ERROR":       3,
+	}
+)
+
+func (x SummaryState) Enum() *SummaryState {
+	p := new(SummaryState)
+	*p = x
+	return p
+}
+
+func (x SummaryState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SummaryState) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_summarizer_v1_summarizer_proto_enumTypes[0].Descriptor()
+}
+
+func (SummaryState) Type() protoreflect.EnumType {
+	return &file_teleport_summarizer_v1_summarizer_proto_enumTypes[0]
+}
+
+func (x SummaryState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SummaryState.Descriptor instead.
+func (SummaryState) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{0}
+}
 
 // InferenceModel resource specifies a session summarization inference model
 // configuration. It tells Teleport how to use a specific provider and model to
@@ -543,11 +598,124 @@ func (x *InferencePolicySpec) GetFilter() string {
 	return ""
 }
 
+// Summary represents a summary of a session recording. This format is used to
+// store the summaries in the session storage and return it with gRPC.
+type Summary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sessionId is an ID of the session whose recording got summarized.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// State is the state of the summarization process.
+	State SummaryState `protobuf:"varint,2,opt,name=state,proto3,enum=teleport.summarizer.v1.SummaryState" json:"state,omitempty"`
+	// InferenceStartedAt is the time when the summarization process started.
+	InferenceStartedAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=inference_started_at,json=inferenceStartedAt,proto3" json:"inference_started_at,omitempty"`
+	// InferenceFinishedAt is the time when the summarization process finished.
+	InferenceFinishedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=inference_finished_at,json=inferenceFinishedAt,proto3" json:"inference_finished_at,omitempty"`
+	// Content is the main text content of the summary. Available if the state is
+	// SUMMARY_STATE_SUCCESS.
+	Content string `protobuf:"bytes,5,opt,name=content,proto3" json:"content,omitempty"`
+	// ModelName is the name of the `InferenceModel` resource that was used to
+	// generate this summary.
+	ModelName string `protobuf:"bytes,6,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
+	// SessionEndEvent is the event that ended the summarized session.
+	SessionEndEvent *events.OneOf `protobuf:"bytes,7,opt,name=session_end_event,json=sessionEndEvent,proto3" json:"session_end_event,omitempty"`
+	// ErrorMessage is an error message if the summarization failed. Available if
+	// the state is SUMMARY_STATE_ERROR.
+	ErrorMessage  string `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Summary) Reset() {
+	*x = Summary{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Summary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Summary) ProtoMessage() {}
+
+func (x *Summary) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Summary.ProtoReflect.Descriptor instead.
+func (*Summary) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *Summary) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *Summary) GetState() SummaryState {
+	if x != nil {
+		return x.State
+	}
+	return SummaryState_SUMMARY_STATE_UNSPECIFIED
+}
+
+func (x *Summary) GetInferenceStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.InferenceStartedAt
+	}
+	return nil
+}
+
+func (x *Summary) GetInferenceFinishedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.InferenceFinishedAt
+	}
+	return nil
+}
+
+func (x *Summary) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+func (x *Summary) GetModelName() string {
+	if x != nil {
+		return x.ModelName
+	}
+	return ""
+}
+
+func (x *Summary) GetSessionEndEvent() *events.OneOf {
+	if x != nil {
+		return x.SessionEndEvent
+	}
+	return nil
+}
+
+func (x *Summary) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
 var File_teleport_summarizer_v1_summarizer_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/summarizer/v1/summarizer.proto\x12\x16teleport.summarizer.v1\x1a!teleport/header/v1/metadata.proto\"\xd3\x01\n" +
+	"'teleport/summarizer/v1/summarizer.proto\x12\x16teleport.summarizer.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\x1a)teleport/legacy/types/events/events.proto\"\xd3\x01\n" +
 	"\x0eInferenceModel\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -580,7 +748,23 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x13InferencePolicySpec\x12\x14\n" +
 	"\x05kinds\x18\x01 \x03(\tR\x05kinds\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x16\n" +
-	"\x06filter\x18\x03 \x01(\tR\x06filterBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x06filter\x18\x03 \x01(\tR\x06filter\"\x9b\x03\n" +
+	"\aSummary\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12:\n" +
+	"\x05state\x18\x02 \x01(\x0e2$.teleport.summarizer.v1.SummaryStateR\x05state\x12L\n" +
+	"\x14inference_started_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x12inferenceStartedAt\x12N\n" +
+	"\x15inference_finished_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x13inferenceFinishedAt\x12\x18\n" +
+	"\acontent\x18\x05 \x01(\tR\acontent\x12\x1d\n" +
+	"\n" +
+	"model_name\x18\x06 \x01(\tR\tmodelName\x129\n" +
+	"\x11session_end_event\x18\a \x01(\v2\r.events.OneOfR\x0fsessionEndEvent\x12#\n" +
+	"\rerror_message\x18\b \x01(\tR\ferrorMessage*|\n" +
+	"\fSummaryState\x12\x1d\n" +
+	"\x19SUMMARY_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15SUMMARY_STATE_PENDING\x10\x01\x12\x19\n" +
+	"\x15SUMMARY_STATE_SUCCESS\x10\x02\x12\x17\n" +
+	"\x13SUMMARY_STATE_ERROR\x10\x03BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_proto_rawDescOnce sync.Once
@@ -594,30 +778,39 @@ func file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP() []byte {
 	return file_teleport_summarizer_v1_summarizer_proto_rawDescData
 }
 
-var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_teleport_summarizer_v1_summarizer_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
-	(*InferenceModel)(nil),      // 0: teleport.summarizer.v1.InferenceModel
-	(*InferenceModelSpec)(nil),  // 1: teleport.summarizer.v1.InferenceModelSpec
-	(*OpenAIProvider)(nil),      // 2: teleport.summarizer.v1.OpenAIProvider
-	(*InferenceSecret)(nil),     // 3: teleport.summarizer.v1.InferenceSecret
-	(*InferenceSecretSpec)(nil), // 4: teleport.summarizer.v1.InferenceSecretSpec
-	(*InferencePolicy)(nil),     // 5: teleport.summarizer.v1.InferencePolicy
-	(*InferencePolicySpec)(nil), // 6: teleport.summarizer.v1.InferencePolicySpec
-	(*v1.Metadata)(nil),         // 7: teleport.header.v1.Metadata
+	(SummaryState)(0),             // 0: teleport.summarizer.v1.SummaryState
+	(*InferenceModel)(nil),        // 1: teleport.summarizer.v1.InferenceModel
+	(*InferenceModelSpec)(nil),    // 2: teleport.summarizer.v1.InferenceModelSpec
+	(*OpenAIProvider)(nil),        // 3: teleport.summarizer.v1.OpenAIProvider
+	(*InferenceSecret)(nil),       // 4: teleport.summarizer.v1.InferenceSecret
+	(*InferenceSecretSpec)(nil),   // 5: teleport.summarizer.v1.InferenceSecretSpec
+	(*InferencePolicy)(nil),       // 6: teleport.summarizer.v1.InferencePolicy
+	(*InferencePolicySpec)(nil),   // 7: teleport.summarizer.v1.InferencePolicySpec
+	(*Summary)(nil),               // 8: teleport.summarizer.v1.Summary
+	(*v1.Metadata)(nil),           // 9: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
+	(*events.OneOf)(nil),          // 11: events.OneOf
 }
 var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
-	7, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
-	1, // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
-	2, // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
-	7, // 3: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
-	4, // 4: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	7, // 5: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
-	6, // 6: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	9,  // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
+	2,  // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
+	3,  // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
+	9,  // 3: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
+	5,  // 4: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	9,  // 5: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
+	7,  // 6: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
+	0,  // 7: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
+	10, // 8: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
+	10, // 9: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
+	11, // 10: teleport.summarizer.v1.Summary.session_end_event:type_name -> events.OneOf
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_proto_init() }
@@ -633,13 +826,14 @@ func file_teleport_summarizer_v1_summarizer_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   7,
+			NumEnums:      1,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_teleport_summarizer_v1_summarizer_proto_goTypes,
 		DependencyIndexes: file_teleport_summarizer_v1_summarizer_proto_depIdxs,
+		EnumInfos:         file_teleport_summarizer_v1_summarizer_proto_enumTypes,
 		MessageInfos:      file_teleport_summarizer_v1_summarizer_proto_msgTypes,
 	}.Build()
 	File_teleport_summarizer_v1_summarizer_proto = out.File

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -610,13 +610,16 @@ type Summary struct {
 	InferenceStartedAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=inference_started_at,json=inferenceStartedAt,proto3" json:"inference_started_at,omitempty"`
 	// InferenceFinishedAt is the time when the summarization process finished.
 	InferenceFinishedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=inference_finished_at,json=inferenceFinishedAt,proto3" json:"inference_finished_at,omitempty"`
-	// Content is the main text content of the summary. Available if the state is
-	// SUMMARY_STATE_SUCCESS.
+	// Content is the main text content of the summary, stored in Markdown
+	// format. Available if the state is SUMMARY_STATE_SUCCESS.
 	Content string `protobuf:"bytes,5,opt,name=content,proto3" json:"content,omitempty"`
 	// ModelName is the name of the `InferenceModel` resource that was used to
 	// generate this summary.
 	ModelName string `protobuf:"bytes,6,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
-	// SessionEndEvent is the event that ended the summarized session.
+	// SessionEndEvent is the event that ended the summarized session. Session
+	// end events carry the most complete set of data that Teleport has about a
+	// given session. Used for checking access based on RBAC rule "where"
+	// filters.
 	SessionEndEvent *events.OneOf `protobuf:"bytes,7,opt,name=session_end_event,json=sessionEndEvent,proto3" json:"session_end_event,omitempty"`
 	// ErrorMessage is an error message if the summarization failed. Available if
 	// the state is SUMMARY_STATE_ERROR.

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service.pb.go
@@ -1736,6 +1736,98 @@ func (x *ListInferencePoliciesResponse) GetNextPageToken() string {
 	return ""
 }
 
+// GetSummaryRequest is a request for retrieving a session recording summary.
+type GetSummaryRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SessionId is the ID of the session whose summary is being requested.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSummaryRequest) Reset() {
+	*x = GetSummaryRequest{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSummaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSummaryRequest) ProtoMessage() {}
+
+func (x *GetSummaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSummaryRequest.ProtoReflect.Descriptor instead.
+func (*GetSummaryRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *GetSummaryRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// GetSummaryResponse is a response to retrieving a session recording summary.
+type GetSummaryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Summary is the session recording summary.
+	Summary       *Summary `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSummaryResponse) Reset() {
+	*x = GetSummaryResponse{}
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSummaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSummaryResponse) ProtoMessage() {}
+
+func (x *GetSummaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSummaryResponse.ProtoReflect.Descriptor instead.
+func (*GetSummaryResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *GetSummaryResponse) GetSummary() *Summary {
+	if x != nil {
+		return x.Summary
+	}
+	return nil
+}
+
 var File_teleport_summarizer_v1_summarizer_service_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
@@ -1818,7 +1910,12 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\"\x8c\x01\n" +
 	"\x1dListInferencePoliciesResponse\x12C\n" +
 	"\bpolicies\x18\x01 \x03(\v2'.teleport.summarizer.v1.InferencePolicyR\bpolicies\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\xda\x12\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"2\n" +
+	"\x11GetSummaryRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"O\n" +
+	"\x12GetSummaryResponse\x129\n" +
+	"\asummary\x18\x01 \x01(\v2\x1f.teleport.summarizer.v1.SummaryR\asummary2\xbf\x13\n" +
 	"\x11SummarizerService\x12\x81\x01\n" +
 	"\x14CreateInferenceModel\x123.teleport.summarizer.v1.CreateInferenceModelRequest\x1a4.teleport.summarizer.v1.CreateInferenceModelResponse\x12x\n" +
 	"\x11GetInferenceModel\x120.teleport.summarizer.v1.GetInferenceModelRequest\x1a1.teleport.summarizer.v1.GetInferenceModelResponse\x12\x81\x01\n" +
@@ -1837,7 +1934,9 @@ const file_teleport_summarizer_v1_summarizer_service_proto_rawDesc = "" +
 	"\x15UpdateInferencePolicy\x124.teleport.summarizer.v1.UpdateInferencePolicyRequest\x1a5.teleport.summarizer.v1.UpdateInferencePolicyResponse\x12\x84\x01\n" +
 	"\x15UpsertInferencePolicy\x124.teleport.summarizer.v1.UpsertInferencePolicyRequest\x1a5.teleport.summarizer.v1.UpsertInferencePolicyResponse\x12\x84\x01\n" +
 	"\x15DeleteInferencePolicy\x124.teleport.summarizer.v1.DeleteInferencePolicyRequest\x1a5.teleport.summarizer.v1.DeleteInferencePolicyResponse\x12\x84\x01\n" +
-	"\x15ListInferencePolicies\x124.teleport.summarizer.v1.ListInferencePoliciesRequest\x1a5.teleport.summarizer.v1.ListInferencePoliciesResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x15ListInferencePolicies\x124.teleport.summarizer.v1.ListInferencePoliciesRequest\x1a5.teleport.summarizer.v1.ListInferencePoliciesResponse\x12c\n" +
+	"\n" +
+	"GetSummary\x12).teleport.summarizer.v1.GetSummaryRequest\x1a*.teleport.summarizer.v1.GetSummaryResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_service_proto_rawDescOnce sync.Once
@@ -1851,7 +1950,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_rawDescGZIP() []byte {
 	return file_teleport_summarizer_v1_summarizer_service_proto_rawDescData
 }
 
-var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_teleport_summarizer_v1_summarizer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*CreateInferenceModelRequest)(nil),   // 0: teleport.summarizer.v1.CreateInferenceModelRequest
 	(*CreateInferenceModelResponse)(nil),  // 1: teleport.summarizer.v1.CreateInferenceModelResponse
@@ -1889,76 +1988,82 @@ var file_teleport_summarizer_v1_summarizer_service_proto_goTypes = []any{
 	(*DeleteInferencePolicyResponse)(nil), // 33: teleport.summarizer.v1.DeleteInferencePolicyResponse
 	(*ListInferencePoliciesRequest)(nil),  // 34: teleport.summarizer.v1.ListInferencePoliciesRequest
 	(*ListInferencePoliciesResponse)(nil), // 35: teleport.summarizer.v1.ListInferencePoliciesResponse
-	(*InferenceModel)(nil),                // 36: teleport.summarizer.v1.InferenceModel
-	(*InferenceSecret)(nil),               // 37: teleport.summarizer.v1.InferenceSecret
-	(*InferencePolicy)(nil),               // 38: teleport.summarizer.v1.InferencePolicy
+	(*GetSummaryRequest)(nil),             // 36: teleport.summarizer.v1.GetSummaryRequest
+	(*GetSummaryResponse)(nil),            // 37: teleport.summarizer.v1.GetSummaryResponse
+	(*InferenceModel)(nil),                // 38: teleport.summarizer.v1.InferenceModel
+	(*InferenceSecret)(nil),               // 39: teleport.summarizer.v1.InferenceSecret
+	(*InferencePolicy)(nil),               // 40: teleport.summarizer.v1.InferencePolicy
+	(*Summary)(nil),                       // 41: teleport.summarizer.v1.Summary
 }
 var file_teleport_summarizer_v1_summarizer_service_proto_depIdxs = []int32{
-	36, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
-	36, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
-	37, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
-	37, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
-	38, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
-	38, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
-	0,  // 24: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
-	2,  // 25: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
-	4,  // 26: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
-	6,  // 27: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
-	8,  // 28: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
-	10, // 29: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
-	12, // 30: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
-	14, // 31: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
-	16, // 32: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
-	18, // 33: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
-	20, // 34: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
-	22, // 35: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
-	24, // 36: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
-	26, // 37: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
-	28, // 38: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
-	30, // 39: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
-	32, // 40: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
-	34, // 41: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
-	1,  // 42: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
-	3,  // 43: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
-	5,  // 44: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
-	7,  // 45: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
-	9,  // 46: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
-	11, // 47: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
-	13, // 48: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
-	15, // 49: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
-	17, // 50: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
-	19, // 51: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
-	21, // 52: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
-	23, // 53: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
-	25, // 54: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
-	27, // 55: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
-	29, // 56: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
-	31, // 57: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
-	33, // 58: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
-	35, // 59: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
-	42, // [42:60] is the sub-list for method output_type
-	24, // [24:42] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	38, // 0: teleport.summarizer.v1.CreateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 1: teleport.summarizer.v1.CreateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 2: teleport.summarizer.v1.GetInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 3: teleport.summarizer.v1.UpdateInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 4: teleport.summarizer.v1.UpdateInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 5: teleport.summarizer.v1.UpsertInferenceModelRequest.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 6: teleport.summarizer.v1.UpsertInferenceModelResponse.model:type_name -> teleport.summarizer.v1.InferenceModel
+	38, // 7: teleport.summarizer.v1.ListInferenceModelsResponse.models:type_name -> teleport.summarizer.v1.InferenceModel
+	39, // 8: teleport.summarizer.v1.CreateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 9: teleport.summarizer.v1.CreateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 10: teleport.summarizer.v1.GetInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 11: teleport.summarizer.v1.UpdateInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 12: teleport.summarizer.v1.UpdateInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 13: teleport.summarizer.v1.UpsertInferenceSecretRequest.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 14: teleport.summarizer.v1.UpsertInferenceSecretResponse.secret:type_name -> teleport.summarizer.v1.InferenceSecret
+	39, // 15: teleport.summarizer.v1.ListInferenceSecretsResponse.secrets:type_name -> teleport.summarizer.v1.InferenceSecret
+	40, // 16: teleport.summarizer.v1.CreateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 17: teleport.summarizer.v1.CreateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 18: teleport.summarizer.v1.GetInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 19: teleport.summarizer.v1.UpdateInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 20: teleport.summarizer.v1.UpdateInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 21: teleport.summarizer.v1.UpsertInferencePolicyRequest.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 22: teleport.summarizer.v1.UpsertInferencePolicyResponse.policy:type_name -> teleport.summarizer.v1.InferencePolicy
+	40, // 23: teleport.summarizer.v1.ListInferencePoliciesResponse.policies:type_name -> teleport.summarizer.v1.InferencePolicy
+	41, // 24: teleport.summarizer.v1.GetSummaryResponse.summary:type_name -> teleport.summarizer.v1.Summary
+	0,  // 25: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:input_type -> teleport.summarizer.v1.CreateInferenceModelRequest
+	2,  // 26: teleport.summarizer.v1.SummarizerService.GetInferenceModel:input_type -> teleport.summarizer.v1.GetInferenceModelRequest
+	4,  // 27: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:input_type -> teleport.summarizer.v1.UpdateInferenceModelRequest
+	6,  // 28: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:input_type -> teleport.summarizer.v1.UpsertInferenceModelRequest
+	8,  // 29: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:input_type -> teleport.summarizer.v1.DeleteInferenceModelRequest
+	10, // 30: teleport.summarizer.v1.SummarizerService.ListInferenceModels:input_type -> teleport.summarizer.v1.ListInferenceModelsRequest
+	12, // 31: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:input_type -> teleport.summarizer.v1.CreateInferenceSecretRequest
+	14, // 32: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:input_type -> teleport.summarizer.v1.GetInferenceSecretRequest
+	16, // 33: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:input_type -> teleport.summarizer.v1.UpdateInferenceSecretRequest
+	18, // 34: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:input_type -> teleport.summarizer.v1.UpsertInferenceSecretRequest
+	20, // 35: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:input_type -> teleport.summarizer.v1.DeleteInferenceSecretRequest
+	22, // 36: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:input_type -> teleport.summarizer.v1.ListInferenceSecretsRequest
+	24, // 37: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:input_type -> teleport.summarizer.v1.CreateInferencePolicyRequest
+	26, // 38: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:input_type -> teleport.summarizer.v1.GetInferencePolicyRequest
+	28, // 39: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:input_type -> teleport.summarizer.v1.UpdateInferencePolicyRequest
+	30, // 40: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:input_type -> teleport.summarizer.v1.UpsertInferencePolicyRequest
+	32, // 41: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:input_type -> teleport.summarizer.v1.DeleteInferencePolicyRequest
+	34, // 42: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:input_type -> teleport.summarizer.v1.ListInferencePoliciesRequest
+	36, // 43: teleport.summarizer.v1.SummarizerService.GetSummary:input_type -> teleport.summarizer.v1.GetSummaryRequest
+	1,  // 44: teleport.summarizer.v1.SummarizerService.CreateInferenceModel:output_type -> teleport.summarizer.v1.CreateInferenceModelResponse
+	3,  // 45: teleport.summarizer.v1.SummarizerService.GetInferenceModel:output_type -> teleport.summarizer.v1.GetInferenceModelResponse
+	5,  // 46: teleport.summarizer.v1.SummarizerService.UpdateInferenceModel:output_type -> teleport.summarizer.v1.UpdateInferenceModelResponse
+	7,  // 47: teleport.summarizer.v1.SummarizerService.UpsertInferenceModel:output_type -> teleport.summarizer.v1.UpsertInferenceModelResponse
+	9,  // 48: teleport.summarizer.v1.SummarizerService.DeleteInferenceModel:output_type -> teleport.summarizer.v1.DeleteInferenceModelResponse
+	11, // 49: teleport.summarizer.v1.SummarizerService.ListInferenceModels:output_type -> teleport.summarizer.v1.ListInferenceModelsResponse
+	13, // 50: teleport.summarizer.v1.SummarizerService.CreateInferenceSecret:output_type -> teleport.summarizer.v1.CreateInferenceSecretResponse
+	15, // 51: teleport.summarizer.v1.SummarizerService.GetInferenceSecret:output_type -> teleport.summarizer.v1.GetInferenceSecretResponse
+	17, // 52: teleport.summarizer.v1.SummarizerService.UpdateInferenceSecret:output_type -> teleport.summarizer.v1.UpdateInferenceSecretResponse
+	19, // 53: teleport.summarizer.v1.SummarizerService.UpsertInferenceSecret:output_type -> teleport.summarizer.v1.UpsertInferenceSecretResponse
+	21, // 54: teleport.summarizer.v1.SummarizerService.DeleteInferenceSecret:output_type -> teleport.summarizer.v1.DeleteInferenceSecretResponse
+	23, // 55: teleport.summarizer.v1.SummarizerService.ListInferenceSecrets:output_type -> teleport.summarizer.v1.ListInferenceSecretsResponse
+	25, // 56: teleport.summarizer.v1.SummarizerService.CreateInferencePolicy:output_type -> teleport.summarizer.v1.CreateInferencePolicyResponse
+	27, // 57: teleport.summarizer.v1.SummarizerService.GetInferencePolicy:output_type -> teleport.summarizer.v1.GetInferencePolicyResponse
+	29, // 58: teleport.summarizer.v1.SummarizerService.UpdateInferencePolicy:output_type -> teleport.summarizer.v1.UpdateInferencePolicyResponse
+	31, // 59: teleport.summarizer.v1.SummarizerService.UpsertInferencePolicy:output_type -> teleport.summarizer.v1.UpsertInferencePolicyResponse
+	33, // 60: teleport.summarizer.v1.SummarizerService.DeleteInferencePolicy:output_type -> teleport.summarizer.v1.DeleteInferencePolicyResponse
+	35, // 61: teleport.summarizer.v1.SummarizerService.ListInferencePolicies:output_type -> teleport.summarizer.v1.ListInferencePoliciesResponse
+	37, // 62: teleport.summarizer.v1.SummarizerService.GetSummary:output_type -> teleport.summarizer.v1.GetSummaryResponse
+	44, // [44:63] is the sub-list for method output_type
+	25, // [25:44] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_service_proto_init() }
@@ -1973,7 +2078,7 @@ func file_teleport_summarizer_v1_summarizer_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer_service_grpc.pb.go
@@ -51,6 +51,7 @@ const (
 	SummarizerService_UpsertInferencePolicy_FullMethodName = "/teleport.summarizer.v1.SummarizerService/UpsertInferencePolicy"
 	SummarizerService_DeleteInferencePolicy_FullMethodName = "/teleport.summarizer.v1.SummarizerService/DeleteInferencePolicy"
 	SummarizerService_ListInferencePolicies_FullMethodName = "/teleport.summarizer.v1.SummarizerService/ListInferencePolicies"
+	SummarizerService_GetSummary_FullMethodName            = "/teleport.summarizer.v1.SummarizerService/GetSummary"
 )
 
 // SummarizerServiceClient is the client API for SummarizerService service.
@@ -100,6 +101,9 @@ type SummarizerServiceClient interface {
 	DeleteInferencePolicy(ctx context.Context, in *DeleteInferencePolicyRequest, opts ...grpc.CallOption) (*DeleteInferencePolicyResponse, error)
 	// ListInferencePolicies lists all InferencePolicies that match the request.
 	ListInferencePolicies(ctx context.Context, in *ListInferencePoliciesRequest, opts ...grpc.CallOption) (*ListInferencePoliciesResponse, error)
+	// GetSummary retrieves the inference result for a session, which
+	// contains the session summary.
+	GetSummary(ctx context.Context, in *GetSummaryRequest, opts ...grpc.CallOption) (*GetSummaryResponse, error)
 }
 
 type summarizerServiceClient struct {
@@ -290,6 +294,16 @@ func (c *summarizerServiceClient) ListInferencePolicies(ctx context.Context, in 
 	return out, nil
 }
 
+func (c *summarizerServiceClient) GetSummary(ctx context.Context, in *GetSummaryRequest, opts ...grpc.CallOption) (*GetSummaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSummaryResponse)
+	err := c.cc.Invoke(ctx, SummarizerService_GetSummary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SummarizerServiceServer is the server API for SummarizerService service.
 // All implementations must embed UnimplementedSummarizerServiceServer
 // for forward compatibility.
@@ -337,6 +351,9 @@ type SummarizerServiceServer interface {
 	DeleteInferencePolicy(context.Context, *DeleteInferencePolicyRequest) (*DeleteInferencePolicyResponse, error)
 	// ListInferencePolicies lists all InferencePolicies that match the request.
 	ListInferencePolicies(context.Context, *ListInferencePoliciesRequest) (*ListInferencePoliciesResponse, error)
+	// GetSummary retrieves the inference result for a session, which
+	// contains the session summary.
+	GetSummary(context.Context, *GetSummaryRequest) (*GetSummaryResponse, error)
 	mustEmbedUnimplementedSummarizerServiceServer()
 }
 
@@ -400,6 +417,9 @@ func (UnimplementedSummarizerServiceServer) DeleteInferencePolicy(context.Contex
 }
 func (UnimplementedSummarizerServiceServer) ListInferencePolicies(context.Context, *ListInferencePoliciesRequest) (*ListInferencePoliciesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListInferencePolicies not implemented")
+}
+func (UnimplementedSummarizerServiceServer) GetSummary(context.Context, *GetSummaryRequest) (*GetSummaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetSummary not implemented")
 }
 func (UnimplementedSummarizerServiceServer) mustEmbedUnimplementedSummarizerServiceServer() {}
 func (UnimplementedSummarizerServiceServer) testEmbeddedByValue()                           {}
@@ -746,6 +766,24 @@ func _SummarizerService_ListInferencePolicies_Handler(srv interface{}, ctx conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SummarizerService_GetSummary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSummaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SummarizerServiceServer).GetSummary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SummarizerService_GetSummary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SummarizerServiceServer).GetSummary(ctx, req.(*GetSummaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SummarizerService_ServiceDesc is the grpc.ServiceDesc for SummarizerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -824,6 +862,10 @@ var SummarizerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListInferencePolicies",
 			Handler:    _SummarizerService_ListInferencePolicies_Handler,
+		},
+		{
+			MethodName: "GetSummary",
+			Handler:    _SummarizerService_GetSummary_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -16,9 +16,9 @@ syntax = "proto3";
 
 package teleport.summarizer.v1;
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/metadata.proto";
-import "teleport/legacy/types/events/events.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1";
 
@@ -139,7 +139,12 @@ message Summary {
   // end events carry the most complete set of data that Teleport has about a
   // given session. Used for checking access based on RBAC rule "where"
   // filters.
-  events.OneOf session_end_event = 7;
+  //
+  // The event is stored in an unstructured form, as storing an instance of
+  // events.OneOf posed a number of technical challenges with JSON
+  // serialization as a subcomponent of this message. These challenges stem
+  // from the fact that audit events have gogoproto extensions.
+  google.protobuf.Struct session_end_event = 7;
   // ErrorMessage is an error message if the summarization failed. Available if
   // the state is SUMMARY_STATE_ERROR.
   string error_message = 8;

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -16,7 +16,9 @@ syntax = "proto3";
 
 package teleport.summarizer.v1;
 
+import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/metadata.proto";
+import "teleport/legacy/types/events/events.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1";
 
@@ -106,4 +108,36 @@ message InferencePolicySpec {
   // to select sessions for summarization. If it's empty, all sessions that
   // match the list of kinds will be summarized using this model.
   string filter = 3;
+}
+
+// SummaryState is the state of the summarization process.
+enum SummaryState {
+  SUMMARY_STATE_UNSPECIFIED = 0;
+  SUMMARY_STATE_PENDING = 1;
+  SUMMARY_STATE_SUCCESS = 2;
+  SUMMARY_STATE_ERROR = 3;
+}
+
+// Summary represents a summary of a session recording. This format is used to
+// store the summaries in the session storage and return it with gRPC.
+message Summary {
+  // sessionId is an ID of the session whose recording got summarized.
+  string session_id = 1;
+  // State is the state of the summarization process.
+  SummaryState state = 2;
+  // InferenceStartedAt is the time when the summarization process started.
+  google.protobuf.Timestamp inference_started_at = 3;
+  // InferenceFinishedAt is the time when the summarization process finished.
+  google.protobuf.Timestamp inference_finished_at = 4;
+  // Content is the main text content of the summary. Available if the state is
+  // SUMMARY_STATE_SUCCESS.
+  string content = 5;
+  // ModelName is the name of the `InferenceModel` resource that was used to
+  // generate this summary.
+  string model_name = 6;
+  // SessionEndEvent is the event that ended the summarized session.
+  events.OneOf session_end_event = 7;
+  // ErrorMessage is an error message if the summarization failed. Available if
+  // the state is SUMMARY_STATE_ERROR.
+  string error_message = 8;
 }

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -129,13 +129,16 @@ message Summary {
   google.protobuf.Timestamp inference_started_at = 3;
   // InferenceFinishedAt is the time when the summarization process finished.
   google.protobuf.Timestamp inference_finished_at = 4;
-  // Content is the main text content of the summary. Available if the state is
-  // SUMMARY_STATE_SUCCESS.
+  // Content is the main text content of the summary, stored in Markdown
+  // format. Available if the state is SUMMARY_STATE_SUCCESS.
   string content = 5;
   // ModelName is the name of the `InferenceModel` resource that was used to
   // generate this summary.
   string model_name = 6;
-  // SessionEndEvent is the event that ended the summarized session.
+  // SessionEndEvent is the event that ended the summarized session. Session
+  // end events carry the most complete set of data that Teleport has about a
+  // given session. Used for checking access based on RBAC rule "where"
+  // filters.
   events.OneOf session_end_event = 7;
   // ErrorMessage is an error message if the summarization failed. Available if
   // the state is SUMMARY_STATE_ERROR.

--- a/api/proto/teleport/summarizer/v1/summarizer_service.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer_service.proto
@@ -65,6 +65,10 @@ service SummarizerService {
   rpc DeleteInferencePolicy(DeleteInferencePolicyRequest) returns (DeleteInferencePolicyResponse);
   // ListInferencePolicies lists all InferencePolicies that match the request.
   rpc ListInferencePolicies(ListInferencePoliciesRequest) returns (ListInferencePoliciesResponse);
+
+  // GetSummary retrieves the inference result for a session, which
+  // contains the session summary.
+  rpc GetSummary(GetSummaryRequest) returns (GetSummaryResponse);
 }
 
 // Summarization inference models
@@ -308,4 +312,16 @@ message ListInferencePoliciesResponse {
   // NextPageToken is the token to retrieve the next page of results, or empty
   // if there are no more results in the list.
   string next_page_token = 2;
+}
+
+// GetSummaryRequest is a request for retrieving a session recording summary.
+message GetSummaryRequest {
+  // SessionId is the ID of the session whose summary is being requested.
+  string session_id = 1;
+}
+
+// GetSummaryResponse is a response to retrieving a session recording summary.
+message GetSummaryResponse {
+  // Summary is the session recording summary.
+  Summary summary = 1;
 }


### PR DESCRIPTION
These will be consumed by `tctl`, `tsh`, and the Web proxy.

RFD: https://github.com/gravitational/teleport.e/blob/master/rfd/0026e-ai-session-summaries.md
Contributes to https://github.com/gravitational/teleport/issues/47083
Blocks https://github.com/gravitational/teleport.e/pull/7015