### PR TITLE
Supporting changes for summarizer tests in e/

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/auth/summarizer"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -85,10 +86,16 @@ type AuthServerConfig struct {
 	// ClusterNetworkingConfig allows a test to change the default
 	// networking configuration.
 	ClusterNetworkingConfig types.ClusterNetworkingConfig
+	// UploadHandler allows a test to set its own upload handler. This setting is
+	// propagated to AuditLog, but only if they are not customized here.
+	UploadHandler events.MultipartHandler
 	// Streamer allows a test to set its own session recording streamer.
 	Streamer events.Streamer
 	// AuditLog allows a test to configure its own audit log.
 	AuditLog events.AuditLogSessionStreamer
+	// SessionSummarizerProvider allows a test to configure its own session
+	// summarizer provider.
+	SessionSummarizerProvider *summarizer.SessionSummarizerProvider
 	// TraceClient allows a test to configure the trace client
 	TraceClient otlptrace.Client
 	// AuthPreferenceSpec is custom initial AuthPreference spec for the test.
@@ -261,7 +268,11 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	// Wrap backend in sanitizer like in production.
 	srv.Backend = backend.NewSanitizer(b)
 
-	uploadHandler := eventstest.NewMemoryUploader()
+	uploadHandler := cfg.UploadHandler
+	if uploadHandler == nil {
+		uploadHandler = eventstest.NewMemoryUploader()
+	}
+
 	if cfg.AuditLog != nil {
 		srv.AuditLog = cfg.AuditLog
 	} else {
@@ -305,24 +316,25 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	}
 
 	srv.AuthServer, err = auth.NewServer(&auth.InitConfig{
-		DataDir:                cfg.Dir,
-		Backend:                srv.Backend,
-		VersionStorage:         NewFakeTeleportVersion(),
-		Authority:              authority.NewWithClock(cfg.Clock),
-		Access:                 access,
-		Identity:               identity,
-		AuditLog:               srv.AuditLog,
-		Streamer:               cfg.Streamer,
-		SkipPeriodicOperations: true,
-		Emitter:                emitter,
-		TraceClient:            cfg.TraceClient,
-		Clock:                  cfg.Clock,
-		ClusterName:            clusterName,
-		HostUUID:               uuid.New().String(),
-		AccessLists:            accessLists,
-		FIPS:                   cfg.FIPS,
-		KeyStoreConfig:         cfg.KeystoreConfig,
-		MultipartHandler:       uploadHandler,
+		DataDir:                   cfg.Dir,
+		Backend:                   srv.Backend,
+		VersionStorage:            NewFakeTeleportVersion(),
+		Authority:                 authority.NewWithClock(cfg.Clock),
+		Access:                    access,
+		Identity:                  identity,
+		AuditLog:                  srv.AuditLog,
+		Streamer:                  cfg.Streamer,
+		SkipPeriodicOperations:    true,
+		Emitter:                   emitter,
+		TraceClient:               cfg.TraceClient,
+		Clock:                     cfg.Clock,
+		ClusterName:               clusterName,
+		HostUUID:                  uuid.New().String(),
+		AccessLists:               accessLists,
+		FIPS:                      cfg.FIPS,
+		KeyStoreConfig:            cfg.KeystoreConfig,
+		MultipartHandler:          uploadHandler,
+		SessionSummarizerProvider: cfg.SessionSummarizerProvider,
 	},
 		WithClock(cfg.Clock),
 		// Reduce auth.Server bcrypt costs when testing.

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -131,6 +131,9 @@ func (cfg *AuthServerConfig) CheckAndSetDefaults() error {
 			SecondFactor: constants.SecondFactorOff,
 		}
 	}
+	if cfg.UploadHandler == nil {
+		cfg.UploadHandler = eventstest.NewMemoryUploader()
+	}
 	return nil
 }
 
@@ -268,11 +271,6 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	// Wrap backend in sanitizer like in production.
 	srv.Backend = backend.NewSanitizer(b)
 
-	uploadHandler := cfg.UploadHandler
-	if uploadHandler == nil {
-		uploadHandler = eventstest.NewMemoryUploader()
-	}
-
 	if cfg.AuditLog != nil {
 		srv.AuditLog = cfg.AuditLog
 	} else {
@@ -280,7 +278,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 			DataDir:       cfg.Dir,
 			ServerID:      cfg.ClusterName,
 			Clock:         cfg.Clock,
-			UploadHandler: uploadHandler,
+			UploadHandler: cfg.UploadHandler,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -333,7 +331,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		AccessLists:               accessLists,
 		FIPS:                      cfg.FIPS,
 		KeyStoreConfig:            cfg.KeystoreConfig,
-		MultipartHandler:          uploadHandler,
+		MultipartHandler:          cfg.UploadHandler,
 		SessionSummarizerProvider: cfg.SessionSummarizerProvider,
 	},
 		WithClock(cfg.Clock),

--- a/lib/events/eventstest/generate.go
+++ b/lib/events/eventstest/generate.go
@@ -50,6 +50,8 @@ type SessionParams struct {
 	SessionID string
 	// ClusterName is an optional originating cluster name
 	ClusterName string
+	// UserName is name of the user interacting with the session
+	UserName string
 }
 
 // SetDefaults sets parameters defaults
@@ -70,12 +72,20 @@ func (p *SessionParams) SetDefaults() {
 			p.PrintData[i] = strings.Repeat("hello", int(i%177+1))
 		}
 	}
+	if p.UserName == "" {
+		p.UserName = "alice@example.com"
+	}
 }
 
 // GenerateTestSession generates test session events starting with session start
 // event, adds printEvents events and returns the result.
 func GenerateTestSession(params SessionParams) []apievents.AuditEvent {
 	params.SetDefaults()
+	connectionMetadata := apievents.ConnectionMetadata{
+		LocalAddr:  "127.0.0.1:3022",
+		RemoteAddr: "[::1]:37718",
+		Protocol:   events.EventProtocolSSH,
+	}
 	sessionStart := apievents.SessionStart{
 		Metadata: apievents.Metadata{
 			Index:       0,
@@ -100,14 +110,11 @@ func GenerateTestSession(params SessionParams) []apievents.AuditEvent {
 			SessionID: params.SessionID,
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:  "bob@example.com",
+			User:  params.UserName,
 			Login: "bob",
 		},
-		ConnectionMetadata: apievents.ConnectionMetadata{
-			LocalAddr:  "127.0.0.1:3022",
-			RemoteAddr: "[::1]:37718",
-		},
-		TerminalSize: "80:25",
+		ConnectionMetadata: connectionMetadata,
+		TerminalSize:       "80:25",
 	}
 
 	sessionEnd := apievents.SessionEnd{
@@ -127,13 +134,14 @@ func GenerateTestSession(params SessionParams) []apievents.AuditEvent {
 			SessionID: params.SessionID,
 		},
 		UserMetadata: apievents.UserMetadata{
-			User: "alice@example.com",
+			User: params.UserName,
 		},
-		EnhancedRecording: true,
-		Interactive:       true,
-		Participants:      []string{"alice@example.com"},
-		StartTime:         params.Clock.Now().UTC(),
-		EndTime:           params.Clock.Now().UTC().Add(3*time.Hour + time.Second + 7*time.Millisecond),
+		ConnectionMetadata: connectionMetadata,
+		EnhancedRecording:  true,
+		Interactive:        true,
+		Participants:       []string{params.UserName},
+		StartTime:          params.Clock.Now().UTC(),
+		EndTime:            params.Clock.Now().UTC().Add(3*time.Hour + time.Second + 7*time.Millisecond),
 	}
 
 	genEvents := []apievents.AuditEvent{&sessionStart}
@@ -179,6 +187,8 @@ type DBSessionParams struct {
 	SessionID string
 	// ClusterName is an optional originating cluster name
 	ClusterName string
+	// UserName is name of the user interacting with the session
+	UserName string
 }
 
 // SetDefaults sets parameters defaults
@@ -196,6 +206,9 @@ func (p *DBSessionParams) SetDefaults() {
 	if p.SessionID == "" {
 		p.SessionID = uuid.New().String()
 	}
+	if p.UserName == "" {
+		p.UserName = "bob@example.com"
+	}
 }
 
 // GenerateTestDBSession generates test database session events starting with
@@ -206,7 +219,7 @@ func GenerateTestDBSession(params DBSessionParams) []apievents.AuditEvent {
 	startTime := params.Clock.Now().UTC()
 	endTime := startTime.Add(time.Minute)
 	userMetadata := apievents.UserMetadata{
-		User:     "bob@example.com",
+		User:     params.UserName,
 		UserKind: apievents.UserKind_USER_KIND_HUMAN,
 	}
 	sessionMetadata := apievents.SessionMetadata{
@@ -269,7 +282,7 @@ func GenerateTestDBSession(params DBSessionParams) []apievents.AuditEvent {
 	for i := range params.Queries {
 		query := &apievents.DatabaseSessionQuery{
 			Metadata: apievents.Metadata{
-				Index:       i * 2,
+				Index:       i*2 + 1,
 				Type:        events.DatabaseSessionQueryEvent,
 				ID:          uuid.New().String(),
 				Code:        events.DatabaseSessionQueryCode,
@@ -287,7 +300,7 @@ func GenerateTestDBSession(params DBSessionParams) []apievents.AuditEvent {
 
 		result := &apievents.DatabaseSessionCommandResult{
 			Metadata: apievents.Metadata{
-				Index:       i*2 + 1,
+				Index:       i*2 + 2,
 				Type:        events.DatabaseSessionCommandResultEvent,
 				ID:          uuid.New().String(),
 				Code:        events.DatabaseSessionCommandResultCode,


### PR DESCRIPTION
- Allow callers of GenerateTestSession to specify actual print data
- Allow specifying the upload handler and summarizer provider in the test auth server config
- Allow specifying user name in generated fake session data
- Fix the SSH fake session data to include the protocol
- Fix event indices in the database fake session data

This is required for some enterprise unit tests from an upcoming PR.