### PR TITLE
FIx potential PATH issue in discovery script

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -59,11 +59,12 @@ var (
 			"\n\n",
 		),
 	)
+	// Note: if we add namespacing support, we will need to edit this script to use the namespaced full path
 	configureTeleport = `
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport ` + strings.Join(argsList, " ") + " $@"
+sudo /usr/local/bin/teleport ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -49,7 +49,7 @@ rm "$TEMP_INSTALLER_SCRIPT"
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+sudo /usr/local/bin/teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {


### PR DESCRIPTION
Fix a PATH issue on certain distros with the discovery script.

Depending on the distro, teleport might not be in the sudoer PATH, which causes the script to fail.

Example failure:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 14  209M   14 29.5M    0     0  34.5M      0  0:00:06 --:--:--  0:00:06 34.5M
 28  209M   28 58.9M    0     0  35.0M      0  0:00:05  0:00:01  0:00:04 35.0M
 46  209M   46 98.1M    0     0  34.0M      0  0:00:06  0:00:02  0:00:04 34.0M
 60  209M   60  127M    0     0  35.0M      0  0:00:05  0:00:03  0:00:02 35.0M
 79  209M   79  166M    0     0  34.4M      0  0:00:06  0:00:04  0:00:02 34.4M
 93  209M   93  196M    0     0  34.6M      0  0:00:06  0:00:05  0:00:01 34.6M
100  209M  100  209M    0     0  34.6M      0  0:00:06  0:00:06 --:--:-- 34.5M
2025-07-29T19:31:39.371Z INFO [UPDATER]   Initiating installation. target_version:17.5.6+Enterprise active_version:17.5.6+Enterprise agent/updater.go:409
2025-07-29T19:31:39.377Z INFO [UPDATER]   Version already present. version:17.5.6+Enterprise agent/installer.go:144
2025-07-29T19:31:39.377Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2025-07-29T19:31:39.379Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2025-07-29T19:31:39.379Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2025-07-29T19:31:39.422Z INFO [UPDATER]   [stdout] Teleport v17.5.6 git:v17.5.6-0-g708cd9e go1.23.11 agent/logger.go:69
2025-07-29T19:31:39.424Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2025-07-29T19:31:39.474Z INFO [UPDATER]   [stdout] Teleport v17.5.6 git:v17.5.6-0-g708cd9e go1.23.11 agent/logger.go:69
2025-07-29T19:31:39.477Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2025-07-29T19:31:39.610Z INFO [UPDATER]   [stdout] Teleport Enterprise v17.5.6 git:v17.5.6-0-g708cd9e go1.23.11 agent/logger.go:69
2025-07-29T19:31:39.616Z INFO [UPDATER]   Validating binary name:teleport-update agent/validate.go:68
2025-07-29T19:31:39.637Z INFO [UPDATER]   [stdout] Teleport v17.5.6 git:v17.5.6-0-g708cd9e go1.23.11 agent/logger.go:69
2025-07-29T19:31:39.638Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2025-07-29T19:31:39.714Z INFO [UPDATER]   [stdout] Teleport v17.5.6 git:v17.5.6-0-g708cd9e go1.23.11 agent/logger.go:69
2025-07-29T19:31:39.718Z INFO [UPDATER]   Executing new teleport-update binary to update configuration. agent/updater.go:174
2025-07-29T19:31:39.857Z INFO [UPDATER]   Systemd configuration synced. unit:teleport-update.timer agent/process.go:366
2025-07-29T19:31:39.947Z INFO [UPDATER]   Systemd service enabled. unit:teleport-update.timer now:true agent/process.go:387
2025-07-29T19:31:39.951Z INFO [UPDATER]   [stderr] Failed to execute operation: No such file or directory agent/logger.go:69
2025-07-29T19:31:39.951Z INFO [UPDATER]   Non-zero exit code or error running systemctl. args:[disable teleport-upgrade.timer] code:1 agent/process.go:524
2025-07-29T19:31:39.955Z INFO [UPDATER]   Finished executing new teleport-update binary. agent/updater.go:176
2025-07-29T19:31:39.955Z INFO [UPDATER]   Target version successfully validated. target_version:17.5.6+Enterprise agent/updater.go:1034
2025-07-29T19:31:39.957Z INFO [UPDATER]   Configuration updated. agent/updater.go:430
2025-07-29T19:31:39.958Z WARN [UPDATER]   Remember to use systemctl to enable and start Teleport. agent/updater.go:1099
sudo: teleport: command not found
failed to run commands: exit status 1
```


Changelog: Fix a bug in the default discovery script that can happen discovering instances whose PATH doesn't contain `/usr/local/bin`.