### PR TITLE
Add `expires` support to tokens provisioned via the k8s operator

### DIFF
--- a/integrations/operator/apis/resources/constants.go
+++ b/integrations/operator/apis/resources/constants.go
@@ -21,4 +21,5 @@ package resources
 const (
 	GroupName      = "resources.teleport.dev"
 	DescriptionKey = "description"
+	ExpiresKey     = "expires"
 )


### PR DESCRIPTION
Tokens provisioned via the k8s operator cannot define an expiration time, because the schema for the Teleport resource requires that this be specified under `metadata.expires`. Kubernetes does not allow additional fields under `metadata`, so I've added support for this via an annotation. This matches the pattern used for `description` on several other resources.

Here's an example of a k8s resource with an expiration set:
```yaml
apiVersion: resources.teleport.dev/v2
kind: TeleportProvisionToken
metadata:
  name: abcd123-insecure-do-not-use-this
  annotations:
    expires: "2023-11-24T21:45:40.104524Z"
spec:
  join_method: token
  roles:
    - Discovery
    - App
```

Here is the Teleport resource that it will produce:
```yaml
kind: token
version: v2
metadata:
  expires: "2023-11-24T21:45:40.104524Z"
  name: abcd123-insecure-do-not-use-this
spec:
  join_method: token
  roles:
    - Discovery
    - App
```

If `metadata.annotations.expires` is unset or syntactically invalid, then `metadata.expires` will be unset on the Teleport token resource.

Fixes https://github.com/gravitational/teleport/issues/49925.

Changelog: Added support for specifying token expiration for tokens provisioned via the Kubernetes operator.