### PR TITLE
Install `wasm32` target in MacOS workflow

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Configure Rust Toolchain
         run: |
           rustup override set ${{ env.RUST_VERSION }}
+          rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: make ensure-wasm-deps


### PR DESCRIPTION
This is preparation for changes in https://github.com/gravitational/teleport/pull/57304