### PR TITLE
docs: Add a terraform example for `login_rule.traits_expression`

### DIFF
--- a/docs/pages/reference/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/login_rule.mdx
@@ -30,6 +30,8 @@ resource "teleport_login_rule" "example" {
 
   version  = "v1"
   priority = 0
+
+  # Either traits_map or traits_expression must be provided, but not both.
   traits_map = {
     "logins" = {
       values = [
@@ -43,6 +45,12 @@ resource "teleport_login_rule" "example" {
       ]
     }
   }
+  #   # This traits_expression is functionally equivalent to the traits_map above.
+  #   traits_expression = <<EOF
+  # dict(
+  #   pair("logins", union(external.logins, external.username))
+  #   pair("groups", external.groups))
+  # EOF
 }
 ```
 

--- a/integrations/terraform/examples/resources/teleport_login_rule/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_login_rule/resource.tf
@@ -10,6 +10,8 @@ resource "teleport_login_rule" "example" {
 
   version  = "v1"
   priority = 0
+
+  # Either traits_map or traits_expression must be provided, but not both.
   traits_map = {
     "logins" = {
       values = [
@@ -23,4 +25,10 @@ resource "teleport_login_rule" "example" {
       ]
     }
   }
+  #   # This traits_expression is functionally equivalent to the traits_map above.
+  #   traits_expression = <<EOF
+  # dict(
+  #   pair("logins", union(external.logins, external.username))
+  #   pair("groups", external.groups))
+  # EOF
 }


### PR DESCRIPTION
Without an example, it was unclear how to get `traits_expression` working with terraform.