### PR TITLE
[v18] FIx potential PATH issue in discovery script

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -59,11 +59,12 @@ var (
 			"\n\n",
 		),
 	)
+	// Note: if we add namespacing support, we will need to edit this script to use the namespaced full path
 	configureTeleport = `
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport ` + strings.Join(argsList, " ") + " $@"
+sudo /usr/local/bin/teleport ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -49,7 +49,7 @@ rm "$TEMP_INSTALLER_SCRIPT"
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+sudo /usr/local/bin/teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {


### PR DESCRIPTION
Backport #57522 to branch/v18

changelog: Fixed a bug in the default discovery script that can happen discovering instances whose PATH doesn't contain `/usr/local/bin`.
