### PR TITLE
[v17] docs: Fix indent of "enabled" in SSH service reference

### DIFF
--- a/docs/pages/includes/config-reference/ssh-service.yaml
+++ b/docs/pages/includes/config-reference/ssh-service.yaml
@@ -1,6 +1,6 @@
 ssh_service:
-    # Turns 'ssh' role on. Default is true
-    enabled: true
+  # Turns 'ssh' role on. Default is true
+  enabled: true
 
   # IP and the port for SSH service to bind to.
   listen_addr: 0.0.0.0:3022


### PR DESCRIPTION
Backport #57489 to branch/v17