### PR TITLE
[v17] discovery: Fix boundary condition logging min tag AWS interval

### DIFF
--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -373,7 +373,7 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	// Configure the poll interval
 	tickerInterval := defaultPollInterval
 	if s.Config.Matchers.AccessGraph != nil {
-		if s.Config.Matchers.AccessGraph.PollInterval > defaultPollInterval {
+		if s.Config.Matchers.AccessGraph.PollInterval >= defaultPollInterval {
 			tickerInterval = s.Config.Matchers.AccessGraph.PollInterval
 		} else {
 			s.Log.WarnContext(ctx,


### PR DESCRIPTION
Backport #57485 to branch/v17