### PR TITLE
Fix Admonition

### DIFF
--- a/docs/pages/admin-guides/management/guides/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/admin-guides/management/guides/aws-iam-identity-center/using-aws-cli.mdx
@@ -86,7 +86,7 @@ which tells the AWS tools to use SSO authentication when the profile is active.
 
 Again you can do this either via an `aws configure` wizard, or editing your `/.aws/config` file directly.
 
-<Admonition>
+<Admonition type="info">
 You can create as many profiles as you like, so repeat this step for as many AWS
 Account / Permission Set pairs that you need.
 </Admonition>


### PR DESCRIPTION
Add a type, which is a required parameter, in order to prevent a warning in the build logs.