### PR TITLE
Additional packages for client tools and teleport-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1743,11 +1743,11 @@ pkg: | $(RELEASE_DIR)
 
 	@echo Combining teleport-bin-$(VERSION).pkg and tsh-$(VERSION).pkg into teleport-$(VERSION).pkg
 	productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/tctl*.pkg --package $(BUILDDIR)/teleport-bin*.pkg $(TELEPORT_PKG_UNSIGNED)
+	$(NOTARIZE_TELEPORT_PKG)
 
 	@echo Combining tsh-$(VERSION).pkg and tctl-$(VERSION).pkg into teleport-tools-$(VERSION).pkg
 	productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/tctl*.pkg $(TELEPORT_TOOLS_PKG_UNSIGNED)
-
-	$(NOTARIZE_TELEPORT_PKG)
+	$(NOTARIZE_TELEPORT_TOOLS_PKG)
 
 	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi
 

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ ARCH ?= $(GO_ENV_ARCH)
 
 FIPS ?=
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-bin
+RELEASE_TOOLS = teleport-tools-$(GITTAG)-$(OS)-$(ARCH)-bin
+RELEASE_UPDATE = teleport-update-$(GITTAG)-$(OS)-$(ARCH)-bin
 
 # If we're building inside the cross-compiling buildbox, include the
 # cross compilation definitions so we select the correct compilers and
@@ -251,6 +253,7 @@ BINS_darwin = teleport tctl tsh tbot fdpass-teleport
 BINS_windows = tsh tctl
 BINS = $(or $(BINS_$(OS)),$(BINS_default))
 BINARIES = $(addprefix $(BUILDDIR)/,$(BINS))
+UPDATE_BINARIES = $(addprefix $(BUILDDIR)/,teleport-update)
 
 # Joins elements of the list in arg 2 with the given separator.
 #   1. Element separator.
@@ -621,18 +624,37 @@ build-archive: | $(RELEASE_DIR)
 	rm -rf teleport
 	@echo "---> Created $(RELEASE).tar.gz."
 
+.PHONY: build-update-archive
+build-update-archive: | $(RELEASE_DIR)
+	@echo "---> Creating OSS update release archive."
+	mkdir -p teleport
+	cp -rf $(UPDATE_BINARIES) \
+		CHANGELOG.md \
+		build.assets/LICENSE-community \
+		teleport/
+	echo $(GITTAG) > teleport/VERSION
+	tar $(TAR_FLAGS) -c teleport | gzip -n > $(RELEASE_UPDATE).tar.gz
+	cp $(RELEASE_UPDATE).tar.gz $(RELEASE_DIR)
+	# linux-amd64 generates a centos7-compatible archive. Make a copy with the -centos7 label,
+	# for the releases page. We should probably drop that at some point.
+	$(if $(filter linux-amd64,$(OS)-$(ARCH)), \
+		cp $(RELEASE_UPDATE).tar.gz $(RELEASE_DIR)/$(subst amd64,amd64-centos7,$(RELEASE_UPDATE)).tar.gz \
+	)
+	rm -rf teleport
+	@echo "---> Created $(RELEASE_UPDATE).tar.gz."
+
 #
 # make release-unix - Produces binary release tarballs for both OSS and
 # Enterprise editions, containing teleport, tctl, tbot and tsh.
 #
 .PHONY: release-unix
-release-unix: clean full build-archive
+release-unix: clean full build-archive build-update-archive
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 
 # release-unix-preserving-webassets cleans just the build and not the UI
 # allowing webassets to be built in a prior step before building the release.
 .PHONY: release-unix-preserving-webassets
-release-unix-preserving-webassets: clean-build full build-archive
+release-unix-preserving-webassets: clean-build full build-archive build-update-archive
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 
 include darwin-signing.mk
@@ -1699,6 +1721,8 @@ endif
 .PHONY: pkg
 pkg: TELEPORT_PKG_UNSIGNED = $(BUILDDIR)/teleport-$(VERSION).unsigned.pkg
 pkg: TELEPORT_PKG_SIGNED = $(RELEASE_DIR)/teleport-$(VERSION).pkg
+pkg: TELEPORT_TOOLS_PKG_UNSIGNED = $(BUILDDIR)/teleport-tools-$(VERSION).unsigned.pkg
+pkg: TELEPORT_TOOLS_PKG_SIGNED = $(RELEASE_DIR)/teleport-tools-$(VERSION).pkg
 pkg: | $(RELEASE_DIR)
 	mkdir -p $(BUILDDIR)/
 
@@ -1719,6 +1743,10 @@ pkg: | $(RELEASE_DIR)
 
 	@echo Combining teleport-bin-$(VERSION).pkg and tsh-$(VERSION).pkg into teleport-$(VERSION).pkg
 	productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/tctl*.pkg --package $(BUILDDIR)/teleport-bin*.pkg $(TELEPORT_PKG_UNSIGNED)
+
+	@echo Combining tsh-$(VERSION).pkg and tctl-$(VERSION).pkg into teleport-tools-$(VERSION).pkg
+	productbuild --package $(BUILDDIR)/tsh*.pkg --package $(BUILDDIR)/tctl*.pkg $(TELEPORT_TOOLS_PKG_UNSIGNED)
+
 	$(NOTARIZE_TELEPORT_PKG)
 
 	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -305,9 +305,6 @@ if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
     mv -v ${TAR_PATH}/examples/systemd/post-install ${PACKAGE_TEMPDIR}
     mv -v ${TAR_PATH}/examples/systemd/before-remove ${PACKAGE_TEMPDIR}
 
-    # create versions folder
-    mkdir -p ${PACKAGE_TEMPDIR}/buildroot${LINUX_DATA_DIR}/versions
-
     # /var/lib/teleport
     # shellcheck disable=SC2174
     mkdir -p -m0700 ${PACKAGE_TEMPDIR}/buildroot${LINUX_DATA_DIR}

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -119,6 +119,10 @@ endef
 NOTARIZE_TELEPORT_PKG = $(if $(SHOULD_NOTARIZE),$(notarize_teleport_pkg),$(not_notarizing_cmd))
 define notarize_teleport_pkg
 	$(call notarize_pkg,$(TELEPORT_PKG_UNSIGNED),$(TELEPORT_PKG_SIGNED))
+endef
+
+NOTARIZE_TELEPORT_TOOLS_PKG = $(if $(SHOULD_NOTARIZE),$(notarize_teleport_tools_pkg),$(not_notarizing_cmd))
+define notarize_teleport_tools_pkg
 	$(call notarize_pkg,$(TELEPORT_TOOLS_PKG_UNSIGNED),$(TELEPORT_TOOLS_PKG_SIGNED))
 endef
 

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -119,6 +119,7 @@ endef
 NOTARIZE_TELEPORT_PKG = $(if $(SHOULD_NOTARIZE),$(notarize_teleport_pkg),$(not_notarizing_cmd))
 define notarize_teleport_pkg
 	$(call notarize_pkg,$(TELEPORT_PKG_UNSIGNED),$(TELEPORT_PKG_SIGNED))
+	$(call notarize_pkg,$(TELEPORT_TOOLS_PKG_UNSIGNED),$(TELEPORT_TOOLS_PKG_SIGNED))
 endef
 
 define notarize_app_bundle


### PR DESCRIPTION
This PR adds additional package for `tsh` and `tctl` only on macOS to reduce the download size for client tools managed updates.

Also added separated package with `teleport-update` single binary, required to make managed updates the only way to install and run Teleport: https://github.com/gravitational/cloud/issues/14225

example build: 
- https://cdn.cloud.gravitational.io/teleport-update-v19.0.0-dev.vapopov.4-linux-arm64-bin.tar.gz (15Mb)
- https://cdn.cloud.gravitational.io/teleport-tools-19.0.0-dev.vapopov.4.pkg (120Mb)

tag-build: https://github.com/gravitational/teleport.e/actions/runs/16773124444
tag-publish: https://github.com/gravitational/teleport.e/actions/runs/16782424106