### PR TITLE
fix: avoid panic when cloning nil values in cache

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1344,6 +1344,11 @@ func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[
 		getR, err := funcs.cacheGet(ctx, r.GetName())
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(r, getR, cmpOpts...))
+
+		// Make sure we get a NotFoundError (and not a panic) when the resource
+		// is not found.
+		_, err = funcs.cacheGet(ctx, "no-such-resource")
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	}
 
 	// update is optional as not every resource implements it

--- a/lib/cache/cluster_config.go
+++ b/lib/cache/cluster_config.go
@@ -80,7 +80,10 @@ func (c *Cache) GetClusterName(ctx context.Context) (types.ClusterName, error) {
 
 	if rg.ReadCache() {
 		name, err := rg.store.get(clusterNameDefaultIndex, types.MetaNameClusterName)
-		return name.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return name.Clone(), nil
 	}
 
 	cachedName, err := utils.FnCacheGet(ctx, c.fnCache, clusterConfigCacheKey{"name"}, func(ctx context.Context) (types.ClusterName, error) {
@@ -147,7 +150,10 @@ func (c *Cache) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditCo
 
 	if rg.ReadCache() {
 		cfg, err := rg.store.get(clusterAuditConfigNameIndex, types.MetaNameClusterAuditConfig)
-		return cfg.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return cfg.Clone(), nil
 	}
 
 	cachedCfg, err := utils.FnCacheGet(ctx, c.fnCache, clusterConfigCacheKey{"audit"}, func(ctx context.Context) (types.ClusterAuditConfig, error) {
@@ -210,7 +216,10 @@ func (c *Cache) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNe
 
 	if rg.ReadCache() {
 		cfg, err := rg.store.get(clusterNetworkingConfigNameIndex, types.MetaNameClusterNetworkingConfig)
-		return cfg.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return cfg.Clone(), nil
 	}
 
 	cachedCfg, err := utils.FnCacheGet(ctx, c.fnCache, clusterConfigCacheKey{"networking"}, func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
@@ -273,7 +282,10 @@ func (c *Cache) GetAuthPreference(ctx context.Context) (types.AuthPreference, er
 
 	if rg.ReadCache() {
 		cfg, err := rg.store.get(authPreferenceNameIndex, types.MetaNameClusterAuthPreference)
-		return cfg.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return cfg.Clone(), nil
 	}
 
 	cfg, err := c.Config.ClusterConfig.GetAuthPreference(ctx)
@@ -330,7 +342,10 @@ func (c *Cache) GetSessionRecordingConfig(ctx context.Context) (types.SessionRec
 
 	if rg.ReadCache() {
 		cfg, err := rg.store.get(sessionRecordingConfigNameIndex, types.MetaNameSessionRecordingConfig)
-		return cfg.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return cfg.Clone(), nil
 	}
 
 	cfg, err := c.Config.ClusterConfig.GetSessionRecordingConfig(ctx)

--- a/lib/cache/plugin_static_credentials_test.go
+++ b/lib/cache/plugin_static_credentials_test.go
@@ -55,6 +55,10 @@ func TestPluginStaticCredentials(t *testing.T) {
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
+				if len(creds) == 0 {
+					// testResources expects the getter to return a NotFound error for unknown names.
+					return nil, trace.NotFound("no plugin static credentials found")
+				}
 				if len(creds) != 1 {
 					return nil, trace.CompareFailed("expecting one creds for this test but got %v", len(creds))
 				}

--- a/lib/cache/tokens.go
+++ b/lib/cache/tokens.go
@@ -76,7 +76,10 @@ func (c *Cache) GetStaticTokens() (types.StaticTokens, error) {
 
 	if rg.ReadCache() {
 		st, err := rg.store.get(staticTokensNameIndex, types.MetaNameStaticTokens)
-		return st.Clone(), trace.Wrap(err)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return st.Clone(), nil
 	}
 
 	st, err := c.Config.ClusterConfig.GetStaticTokens()

--- a/lib/cache/tokens_test.go
+++ b/lib/cache/tokens_test.go
@@ -41,6 +41,11 @@ func TestStaticTokens(t *testing.T) {
 	p := newPackForAuth(t)
 	t.Cleanup(p.Close)
 
+	// Make sure we get a NotFoundError (and not a panic) when there are no
+	// static tokens.
+	_, err := p.cache.GetStaticTokens()
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
+
 	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{
 			{

--- a/lib/cache/user_group.go
+++ b/lib/cache/user_group.go
@@ -117,5 +117,8 @@ func (c *Cache) GetUserGroup(ctx context.Context, name string) (types.UserGroup,
 	}
 
 	group, err := rg.store.get(userGroupNameIndex, name)
-	return group.Clone(), trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return group.Clone(), nil
 }


### PR DESCRIPTION
Multiple of our current resource cache implementations may panic when trying to get a resource that is not found, when calling the `Clone()` method on a nil interface value. The pattern that hits this panic usually looks like:
```go
	group, err := rg.store.get(userGroupNameIndex, name)
	return group.Clone(), trace.Wrap(err)
```

In this PR I grepped for all lines matching `return .*Clone.*err` looking for unconditional Clone calls when there may be an error, and fixed them by returning early without calling Clone if the error is non-nil. I added test coverage that caught panics in the current user group and static token cache implementations.

changelog: fixed a panic that may occur when fetching non-existent resources from the cache