### PR TITLE
Remove db name requirement for mysql connect dialog

### DIFF
--- a/web/packages/shared/services/databases/databases.ts
+++ b/web/packages/shared/services/databases/databases.ts
@@ -131,3 +131,32 @@ export const formatDatabaseInfo = (type: DbType, protocol: DbProtocol) => {
 };
 
 export type DatabaseInfo = ReturnType<typeof formatDatabaseInfo>;
+
+export type DbNameRequirement = 'unsupported' | 'optional' | 'required';
+
+const dbNameRequirementsByProtocol: Record<DbProtocol, DbNameRequirement> = {
+  mongodb: 'required',
+  oracle: 'required',
+  postgres: 'required',
+  spanner: 'required',
+  sqlserver: 'required',
+
+  cassandra: 'unsupported',
+  clickhouse: 'unsupported',
+  'clickhouse-http': 'unsupported',
+  dynamodb: 'unsupported',
+  elasticsearch: 'unsupported',
+  opensearch: 'unsupported',
+  redis: 'unsupported',
+
+  cockroachdb: 'optional',
+  mysql: 'optional',
+  snowflake: 'optional',
+};
+
+export const getDbNameRequirement = (
+  protocol: DbProtocol
+): DbNameRequirement => {
+  // default to 'optional'
+  return dbNameRequirementsByProtocol[protocol] ?? 'optional';
+};

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -34,6 +34,7 @@ import { Option } from 'shared/components/Select';
 import Validation from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { useAsync } from 'shared/hooks/useAsync';
+import { getDbNameRequirement } from 'shared/services/databases';
 
 import { useTeleport } from 'teleport';
 import { DbConnectData } from 'teleport/lib/term/tty';
@@ -121,34 +122,45 @@ function ConnectForm(props: {
     props.onConnect({
       serviceName: props.db.name,
       protocol: props.db.protocol,
-      dbName: selectedName.value,
+      dbName: selectedName?.value,
       dbUser: selectedUser.value,
       dbRoles: selectedRoles?.map(role => role.value),
     });
   };
 
+  const dbNameReq = getDbNameRequirement(props.db.protocol);
   return (
     <Validation>
       {({ validator }) => (
         <form>
           <DialogContent flex="0 0 auto">
+            {dbNameReq !== 'unsupported' && (
+              <ConnectionField
+                // if db name is optional, then RBAC is not enforcing a db name, so they can input whatever they want
+                allowCreatableSelect={
+                  dbNameHasWildcard || dbNameReq === 'optional'
+                }
+                label="Database name"
+                menuPosition="fixed"
+                onChange={option => setSelectedName(option as Option)}
+                value={selectedName}
+                options={dbNamesOpts}
+                creatableOptions={{
+                  formatCreateLabel: (userInput: string) =>
+                    `Use "${userInput}" database name`,
+                  toolTipContent:
+                    'You can type in the select box to use a custom database name instead of the available options.',
+                }}
+                isClearable={dbNameReq === 'optional'}
+                rule={
+                  dbNameReq === 'required'
+                    ? requiredField('Database name is required')
+                    : undefined
+                }
+              />
+            )}
             <ConnectionField
-              hasWildcard={dbNameHasWildcard}
-              label="Database name"
-              menuPosition="fixed"
-              onChange={option => setSelectedName(option as Option)}
-              value={selectedName}
-              options={dbNamesOpts}
-              creatableOptions={{
-                formatCreateLabel: userInput =>
-                  `Use "${userInput}" database name`,
-                toolTipContent:
-                  'You can type in the select box to use a custom database name instead of the available options.',
-              }}
-              rule={requiredField('Database name is required')}
-            />
-            <ConnectionField
-              hasWildcard={dbUserHasWildcard}
+              allowCreatableSelect={dbUserHasWildcard}
               label="Database user"
               menuPosition="fixed"
               onChange={option => setSelectedUser(option as Option)}
@@ -170,7 +182,7 @@ function ConnectForm(props: {
             />
             {(dbRolesOpts?.length > 0 || dbRoleHasWildcard) && (
               <ConnectionField
-                hasWildcard={dbRoleHasWildcard}
+                allowCreatableSelect={dbRoleHasWildcard}
                 label="Database roles"
                 menuPosition="fixed"
                 isMulti={true}
@@ -217,11 +229,11 @@ function ConnectForm(props: {
 }
 
 function ConnectionField({
-  hasWildcard,
+  allowCreatableSelect,
   creatableOptions = {},
   ...commonOptions
 }) {
-  return hasWildcard ? (
+  return allowCreatableSelect ? (
     <FieldSelectCreatable {...commonOptions} {...creatableOptions} />
   ) : (
     <FieldSelect {...commonOptions} />

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
@@ -54,6 +54,79 @@ export const Connect = () => {
   return <DocumentDbWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />;
 };
 
+export const ConnectWithEmptyDatabaseName = () => {
+  const { ctx, consoleCtx } = getContexts(
+    Promise.resolve({
+      agents: [
+        {
+          kind: 'db',
+          name: 'mydb',
+          description: '',
+          type: '',
+          protocol: 'mysql',
+          labels: [],
+          names: ['users', 'orders'],
+          users: ['alice', 'bob'],
+          roles: ['reader', 'all'],
+          hostname: '',
+          supportsInteractive: true,
+        },
+      ],
+    })
+  );
+
+  return <DocumentDbWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />;
+};
+
+export const ConnectWithoutAllowedDatabaseNames = () => {
+  const { ctx, consoleCtx } = getContexts(
+    Promise.resolve({
+      agents: [
+        {
+          kind: 'db',
+          name: 'mydb',
+          description: '',
+          type: '',
+          protocol: 'mysql',
+          labels: [],
+          users: ['alice', 'bob'],
+          roles: ['reader', 'all'],
+          hostname: '',
+          supportsInteractive: true,
+        },
+      ],
+    })
+  );
+
+  return <DocumentDbWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />;
+};
+
+export const ConnectWithDatabaseNamesUnsupported = () => {
+  const { ctx, consoleCtx } = getContexts(
+    Promise.resolve({
+      agents: [
+        {
+          kind: 'db',
+          name: 'mydb',
+          description: '',
+          type: '',
+          // as of writing, we don't even have a Cassandra web client, but we
+          // should test that protocols without database name support render
+          // without an input for database name.
+          protocol: 'cassandra',
+          labels: [],
+          users: ['alice', 'bob'],
+          roles: ['reader', 'all'],
+          hostname: '',
+          supportsInteractive: true,
+        },
+      ],
+    })
+  );
+
+  return <DocumentDbWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />;
+};
+
 export const ConnectWithoutRoles = () => {
   const { ctx, consoleCtx } = getContexts(
     Promise.resolve({

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
@@ -35,7 +35,8 @@ import { NewTab as NewTabIcon } from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { TextSelectCopy } from 'shared/components/TextSelectCopy';
 import { getDatabaseIconName } from 'shared/components/UnifiedResources/shared/viewItemsFactory';
-import { DbProtocol } from 'shared/services/databases';
+import { DbProtocol, getDbNameRequirement } from 'shared/services/databases';
+import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
 import cfg from 'teleport/config';
 import { generateTshLoginCommand, openNewTab } from 'teleport/lib/util';
@@ -56,32 +57,22 @@ export default function ConnectDialog({
     dbProtocol == 'dynamodb' || dbProtocol == 'clickhouse-http'
       ? 'proxy db --tunnel'
       : 'db connect';
-
   // Adjust `--db-name` flag based on db protocol, as it's required for
   // some, optional for some, and unsupported by some.
+  const dbNameReq = getDbNameRequirement(dbProtocol);
   let dbNameFlag: string;
-  switch (dbProtocol) {
-    case 'postgres':
-    case 'sqlserver':
-    case 'oracle':
-    case 'mongodb':
-    case 'spanner':
-      // Required
+  switch (dbNameReq) {
+    case 'required':
       dbNameFlag = ' --db-name=<name>';
       break;
-    case 'cassandra':
-    case 'clickhouse':
-    case 'clickhouse-http':
-    case 'dynamodb':
-    case 'opensearch':
-    case 'elasticsearch':
-    case 'redis':
-      // No flag
+    case 'unsupported':
       dbNameFlag = '';
       break;
-    default:
-      // Default to optional
+    case 'optional':
       dbNameFlag = ' [--db-name=<name>]';
+      break;
+    default:
+      assertUnreachable(dbNameReq);
   }
 
   const onConnect = () => {


### PR DESCRIPTION
This PR makes the database name input optional for the MySQL web UI REPL.

I also added a helper to avoid duplicating the logic and made the database name input render conditionally while I was at it, so that databases which don't support a database name won't even render it as an input option (if we ever add support for such databases in the web ui).

Stacked on top of another PR so people can test it out if they want to:
- https://github.com/gravitational/teleport/pull/57169


https://github.com/user-attachments/assets/e9562dbc-3e26-4b5e-ac9c-d27c021e3d74

