### PR TITLE
MWI: Add note about bound keypair joining only supporting bots

### DIFF
--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -278,13 +278,17 @@ New Machine & Workload Identity bot deployments should consider upgrading to the
 ### Bound Keypair: `bound_keypair`
 
 Bound Keypair tokens are an alternative to
-[secret-based join methods](#secret-based-join-methods) that improve security
-and flexibility. They are best used on platforms with persistent storage, but
-can be configured for use in nearly any environment.
+[secret-based join methods](#secret-based-join-methods) for Machine and Workload
+ID bots that improve security and flexibility. They are best used on platforms
+with persistent storage, but can be configured for use in nearly any
+environment.
 
 This join method is recommended for on-prem environments
 [without TPMs](#trusted-platform-module-tpm) or cloud platforms
 without a specialized [delegated join method](#delegated-join-methods).
+
+At this time, `bound_keypair` can only be used to join Machine and Workload ID
+bots, and cannot be used to join other Teleport agent types.
 
 (!docs/pages/includes/provision-token/bound-keypair-spec.mdx!)
 

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -288,7 +288,8 @@ This join method is recommended for on-prem environments
 without a specialized [delegated join method](#delegated-join-methods).
 
 At this time, `bound_keypair` can only be used to join Machine and Workload ID
-bots, and cannot be used to join other Teleport agent types.
+bots, and cannot be used to join other Teleport agent types, including
+infrastructure proxies and the `teleport-kube-agent` Helm chart.
 
 (!docs/pages/includes/provision-token/bound-keypair-spec.mdx!)
 

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -288,8 +288,7 @@ This join method is recommended for on-prem environments
 without a specialized [delegated join method](#delegated-join-methods).
 
 At this time, `bound_keypair` can only be used to join Machine and Workload ID
-bots, and cannot be used to join other Teleport agent types, including
-infrastructure proxies and the `teleport-kube-agent` Helm chart.
+bots, and cannot be used to join other Teleport agent types.
 
 (!docs/pages/includes/provision-token/bound-keypair-spec.mdx!)
 

--- a/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
@@ -20,6 +20,9 @@ Specifically, this join method:
 <Admonition type="tip" title="Preview Note">
 Bound Keypair Joining is available in v18.1.0 and is intended to replace `token`
 joining as the default recommended join method in Teleport v19.0.0.
+
+At this time, Bound Keypair Joining can only be used to join Machine ID bots and
+cannot be used to join other Teleport agent types.
 </Admonition>
 
 ## Use cases

--- a/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
@@ -21,8 +21,9 @@ Specifically, this join method:
 Bound Keypair Joining is available in v18.1.0 and is intended to replace `token`
 joining as the default recommended join method in Teleport v19.0.0.
 
-At this time, Bound Keypair Joining can only be used to join Machine ID bots and
-cannot be used to join other Teleport agent types.
+At this time, Bound Keypair Joining can only be used to join Machine and
+Workload ID bots and cannot be used to join other Teleport agent types,
+including infrastructure proxies and the `teleport-kube-agent` Helm chart.
 </Admonition>
 
 ## Use cases

--- a/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-id/bound-keypair/bound-keypair.mdx
@@ -22,8 +22,7 @@ Bound Keypair Joining is available in v18.1.0 and is intended to replace `token`
 joining as the default recommended join method in Teleport v19.0.0.
 
 At this time, Bound Keypair Joining can only be used to join Machine and
-Workload ID bots and cannot be used to join other Teleport agent types,
-including infrastructure proxies and the `teleport-kube-agent` Helm chart.
+Workload ID bots and cannot be used to join other Teleport agent types.
 </Admonition>
 
 ## Use cases


### PR DESCRIPTION
Bound keypair joining only supports bots right now, so this adds a note about this limitation in the overview page and join method reference.