### PR TITLE
Use both old and new CDP location in certs

### DIFF
--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -98,8 +98,9 @@ func (a *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 	// by the client because the CDP is based on the identity of the issuer, which is
 	// necessary in order to support clusters with multiple issuing certs (HSMs).
 	if req.CRLDomain != "" {
-		cdp := winpki.CRLDistributionPoint(req.CRLDomain, types.UserCA, tlsCA, true)
-		certReq.CRLDistributionPoints = []string{cdp}
+		cdpOld := winpki.CRLDistributionPoint(req.CRLDomain, types.UserCA, tlsCA, false)
+		cdpNew := winpki.CRLDistributionPoint(req.CRLDomain, types.UserCA, tlsCA, true)
+		certReq.CRLDistributionPoints = []string{cdpOld, cdpNew}
 	} else if req.CRLEndpoint != "" {
 		// legacy clients will specify CRL endpoint instead of CRL domain
 		// DELETE IN v21 (zmb3)

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -308,6 +308,10 @@ func CRLDistributionPoint(activeDirectoryDomain string, caType types.CertAuthTyp
 		id := base32.HexEncoding.EncodeToString(issuer.Cert.SubjectKeyId)
 		name = id + "_" + name
 	}
+	return crlDistributionPoint(name, activeDirectoryDomain, caType)
+}
+
+func crlDistributionPoint(name string, activeDirectoryDomain string, caType types.CertAuthType) string {
 	crlDN := CRLDN(name, activeDirectoryDomain, caType)
 	return fmt.Sprintf("ldap:///%s?certificateRevocationList?base?objectClass=cRLDistributionPoint", crlDN)
 }


### PR DESCRIPTION
Depending on update order of components it might happen that Windows Desktop Service will not push CRLs to new location in LDAP (that happens if you update WDS before any auth).
After auth is updated it starts to include only new location in certs which causes CRL validation errors.
With this change auth will include both old and new location in cert as any successful check is sufficient to get past validation.

changelog: Fix CRL validation errors after upgrade