### PR TITLE
Validate `tls.mode` in static database configs

### DIFF
--- a/lib/service/servicecfg/database.go
+++ b/lib/service/servicecfg/database.go
@@ -19,6 +19,8 @@
 package servicecfg
 
 import (
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
@@ -114,6 +116,11 @@ func (d *Database) CheckAndSetDefaults() error {
 
 // ToDatabase converts Database to types.Database.
 func (d *Database) ToDatabase() (types.Database, error) {
+	tlsMode, err := d.TLS.Mode.ToProto()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return types.NewDatabaseV3(types.Metadata{
 		Name:        d.Name,
 		Description: d.Description,
@@ -125,7 +132,7 @@ func (d *Database) ToDatabase() (types.Database, error) {
 		TLS: types.DatabaseTLS{
 			CACert:              string(d.TLS.CACert),
 			ServerName:          d.TLS.ServerName,
-			Mode:                d.TLS.Mode.ToProto(),
+			Mode:                tlsMode,
 			TrustSystemCertPool: d.TLS.TrustSystemCertPool,
 		},
 		MySQL: types.MySQLOptions{

--- a/lib/service/servicecfg/tls.go
+++ b/lib/service/servicecfg/tls.go
@@ -36,32 +36,18 @@ const (
 	Insecure TLSMode = "insecure"
 )
 
-// AllTLSModes keeps all possible database TLS modes for easy access.
-var AllTLSModes = []TLSMode{VerifyFull, VerifyCA, Insecure}
-
-// CheckAndSetDefaults check if TLSMode holds a correct value. If the value is not set
-// VerifyFull is set as a default. BadParameter error is returned if value set is incorrect.
-func (m *TLSMode) CheckAndSetDefaults() error {
-	switch *m {
-	case "": // Use VerifyFull if not set.
-		*m = VerifyFull
-	case VerifyFull, VerifyCA, Insecure:
-		// Correct value, do nothing.
-	default:
-		return trace.BadParameter("provided incorrect TLSMode value. Correct values are: %v", AllTLSModes)
-	}
-
-	return nil
-}
-
 // ToProto returns a matching protobuf type or VerifyFull for empty value.
-func (m TLSMode) ToProto() types.DatabaseTLSMode {
+func (m TLSMode) ToProto() (types.DatabaseTLSMode, error) {
 	switch m {
 	case VerifyCA:
-		return types.DatabaseTLSMode_VERIFY_CA
+		return types.DatabaseTLSMode_VERIFY_CA, nil
 	case Insecure:
-		return types.DatabaseTLSMode_INSECURE
-	default: // VerifyFull
-		return types.DatabaseTLSMode_VERIFY_FULL
+		return types.DatabaseTLSMode_INSECURE, nil
+	case VerifyFull:
+		return types.DatabaseTLSMode_VERIFY_FULL, nil
+	case "": // default to verify-full.
+		return types.DatabaseTLSMode_VERIFY_FULL, nil
+	default:
+		return 0, trace.BadParameter("provided invalid TLS mode %q. Correct values are: %v", string(m), []TLSMode{VerifyFull, VerifyCA, Insecure})
 	}
 }

--- a/lib/service/servicecfg/tls_test.go
+++ b/lib/service/servicecfg/tls_test.go
@@ -1,0 +1,75 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package servicecfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestTLSModeToProto(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       TLSMode
+		want    types.DatabaseTLSMode
+		wantErr string
+	}{
+		{
+			name:    "verify CA",
+			m:       "verify-ca",
+			want:    types.DatabaseTLSMode_VERIFY_CA,
+			wantErr: "",
+		},
+		{
+			name:    "verify full",
+			m:       "verify-full",
+			want:    types.DatabaseTLSMode_VERIFY_FULL,
+			wantErr: "",
+		},
+		{
+			name:    "insecure",
+			m:       "insecure",
+			want:    types.DatabaseTLSMode_INSECURE,
+			wantErr: "",
+		},
+		{
+			name:    "empty string, use default",
+			m:       "",
+			want:    types.DatabaseTLSMode_VERIFY_FULL,
+			wantErr: "",
+		},
+		{
+			name:    "invalid",
+			m:       "invalid",
+			wantErr: `provided invalid TLS mode "invalid". Correct values are: [verify-full verify-ca insecure]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.m.ToProto()
+			require.Equal(t, tt.want, got)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rejects configurations with invalid `tls.mode` settings, for example:

```yaml
  - name: pg-invalid
    protocol: postgres
    uri: localhost:25432
    admin_user:
      name: postgres
    tls: 
      mode: invalid
```

This used to default to full validation instead, which could lead to quiet misconfigurations. This is a breaking change, so should only be released in the next major version.

changelog: Invalid `tls.mode` settings will now be rejected.