### PR TITLE
Allow ignoring errors in `tctl workload-identity x509-issuer-overrides sign-csrs`

### DIFF
--- a/docs/pages/reference/workload-identity/issuer-override.mdx
+++ b/docs/pages/reference/workload-identity/issuer-override.mdx
@@ -58,6 +58,8 @@ SERIALNUMBER=234567890123456789012345678901234567890,CN=clustername,O=clusternam
 
 Use of this command requires `create` permissions for the `workload_identity_x509_issuer_override_csr` resource kind in one of the roles associated with the identity running the command.
 
+In clusters that make use of Hardware Security Modules (HSMs) it's possible that no single Teleport Auth Service instance is capable of generating signatures for all the keys that make up the SPIFFE certificate authority at once. In such situations, it's possible to use the `--force` option with the `sign-csrs` command on each machine running the Auth Service, to gather CSRs for keys managed by the different HSMs.
+
 ## Using `tctl` to create a `workload_identity_x509_issuer_override` from certificate chain PEM files
 
 The `tctl workload-identity x509-issuer-overrides create` command can be used to build a `workload_identity_x509_issuer_override` resource out of one or more PEM files containing a certificate chain each, and to create or forcibly overwrite an existing resource in the cluster. The command will check that the first certificates in the specified chains have different public keys, and that they match 1:1 with the trusted X.509 certificates in the SPIFFE certificate authority in the Teleport cluster.


### PR DESCRIPTION
The `tctl workload-identity x509-issuer-overrides sign-csrs` command currently stops, with no output, at the first encountered error, including errors such as "no usable TLS key pairs found" returned if one of the keys used by a trusted issuer in the SPIFFE certificate authority is not usable by the Auth Service that happened to serve the `teleport.workloadidentity.v1.X509OverridesService/SignX509IssuerCSR` request. This is a fairly common situation when a Teleport cluster is configured to use hardware HSMs that don't share keys (as opposed to most cloud KMS which allow the use of keys by all Auth Service instances at once).

This PR adds a `--force` option that makes it so that `tctl` will display the error returned by the `SignX509IssuerCSR` call in lieu of the respective CSR, so in clusters that make use of HSMs it's possible to run the `sign-csrs` command on all the machines running the Auth Service and then assemble a complete list of CSRs. It's also possible (but we won't recommend it, which is why it's not documented) to just keep retrying the command remotely until the load balancer happens to steer the connection to all the distinct Auth Service instances.

In addition, this PR fixes an oversight in the `sign-csrs` implementation: we currently display each CSR in a PEM block prefixed by the subject of the CSR in string form, even if the subject was left blank due to the choice of sign mode. This PR changes that so we always display the subject of the original issuer instead, before either the error or the PEM block with the CSR.

changelog: added `--force` option to `tctl workload-identity x509-issuer-overrides sign-csrs` to allow displaying the output of partial failures, intended for use in clusters that make use of HSMs