### PR TITLE
Access List: validate audit recurrence for non-reviewable access lists if set

### DIFF
--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -52,19 +52,23 @@ func validateAccessList(a *accesslist.AccessList) error {
 		return trace.BadParameter("owners are missing")
 	}
 
-	if a.IsReviewable() {
+	if a.IsReviewable() || a.Spec.Audit.Recurrence.Frequency != 0 {
 		switch a.Spec.Audit.Recurrence.Frequency {
 		case accesslist.OneMonth, accesslist.ThreeMonths, accesslist.SixMonths, accesslist.OneYear:
 		default:
 			return trace.BadParameter("audit recurrence frequency is an invalid value")
 		}
+	}
 
+	if a.IsReviewable() || a.Spec.Audit.Recurrence.DayOfMonth != 0 {
 		switch a.Spec.Audit.Recurrence.DayOfMonth {
 		case accesslist.FirstDayOfMonth, accesslist.FifteenthDayOfMonth, accesslist.LastDayOfMonth:
 		default:
 			return trace.BadParameter("audit recurrence day of month is an invalid value")
 		}
+	}
 
+	if a.IsReviewable() {
 		if a.Spec.Audit.NextAuditDate.IsZero() {
 			return trace.BadParameter("next audit date is not set")
 


### PR DESCRIPTION
This is not mission critical, but it's strange if the audit.reccurence is set in Terraform (e.g. when someone copy/pastes it) and then its values are set to 0, but only when they are invalid.

Backports:

- [ ] v18 included in https://github.com/gravitational/teleport/pull/57058
- [ ] v17