### PR TITLE
Add aws roles anywhere IAM enrollment view

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/Guide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/Guide.tsx
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Box, Link } from 'design';
+import {
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+
+const GuideReferenceLinks = {
+  AwsRolesAnywhere: {
+    title: 'AWS Roles Anywhere',
+    href: 'https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html',
+  },
+};
+
+export const Guide = ({ resourcesRoute }: { resourcesRoute: string }) => (
+  <Box>
+    <InfoTitle>How to Access Profiles as Resources</InfoTitle>
+    <InfoParagraph>
+      Teleport will periodically sync Roles Anywhere Profiles as AWS Access
+      applications. You can import all Profiles, or use a filter to only import
+      a subset of Profiles. You can access AWS by going to the{' '}
+      <Link href={resourcesRoute} target="_blank">
+        Resources page
+      </Link>{' '}
+      and select the Profile and IAM Role that you want to use. Other users can
+      use the Profile and IAM Role by requesting access to it.
+    </InfoParagraph>
+    <ReferenceLinks links={Object.values(GuideReferenceLinks)} />
+  </Box>
+);

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.story.tsx
@@ -1,0 +1,125 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+
+import { Info } from '@gravitational/design/src/Alert';
+import { CollapsibleInfoSection as CollapsibleInfoSectionComponent } from 'design/CollapsibleInfoSection';
+import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
+
+import cfg from 'teleport/config';
+import { IamIntegration } from 'teleport/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration';
+import { makeAwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
+
+export default {
+  title: 'Teleport/Integrations/Enroll/AwsConsole',
+};
+
+export const PageOneIamIntegration = () => (
+  <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()} path="">
+    <InfoGuidePanelProvider>
+      <MemoryRouter>
+        <CollapsibleInfoSectionComponent openLabel="Devs Instructions">
+          <Info
+            kind="info"
+            details={`(Devs) use any valid CloudShell output and click submit to see a success message, for instance:
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/bar
+arn:aws:iam::123456789012:role/baz`}
+          >
+            Step 3
+          </Info>
+          <Info
+            kind="success"
+            details="(Devs) step 1: use test as the integration name"
+          >
+            Case: Profiles
+          </Info>
+          <Info
+            kind="warning"
+            details="(Devs) step 1: use zero as the integration name"
+          >
+            Case: No Profiles
+          </Info>
+          <Info
+            kind="danger"
+            details="(Devs) step 1: use error as the integration name"
+          >
+            Case: Test error
+          </Info>
+        </CollapsibleInfoSectionComponent>
+        <IamIntegration />
+      </MemoryRouter>
+    </InfoGuidePanelProvider>
+  </MockAwsOidcStatusProvider>
+);
+PageOneIamIntegration.parameters = {
+  msw: {
+    handlers: [
+      http.post(cfg.getAwsRolesAnywherePingUrl('test'), () => {
+        return HttpResponse.json({
+          profileCount: 3,
+          accountID: 'fc2ef183-2ac0-4836-9d7d-ff873c99e733',
+          arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo',
+          userId: 'edd13a04-9956-4ef2-9ef5-7b0169e1cd5b',
+        });
+      }),
+      http.post(cfg.getAwsRolesAnywherePingUrl('zero'), () => {
+        return HttpResponse.json({
+          profileCount: 0,
+          accountID: 'fc2ef183-2ac0-4836-9d7d-ff873c99e733',
+          arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo',
+          userId: 'edd13a04-9956-4ef2-9ef5-7b0169e1cd5b',
+        });
+      }),
+      http.post(cfg.getAwsRolesAnywherePingUrl('error'), () => {
+        return HttpResponse.json(
+          {
+            message: 'some error message',
+          },
+          { status: 500 }
+        );
+      }),
+    ],
+  },
+};
+
+export const WithoutAccess = () => {
+  const acl = makeAcl({
+    integrations: {
+      ...defaultAccess,
+    },
+  });
+
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      path=""
+      customAcl={acl}
+    >
+      <InfoGuidePanelProvider>
+        <MemoryRouter>
+          <IamIntegration />
+        </MemoryRouter>
+      </InfoGuidePanelProvider>
+    </MockAwsOidcStatusProvider>
+  );
+};

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+
+import { render, userEvent } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport/index';
+import {
+  IamIntegration,
+  parseOutput,
+} from 'teleport/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration';
+import { makeAwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { integrationService } from 'teleport/services/integrations';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+test('flows through roles anywhere IAM setup', async () => {
+  const user = userEvent.setup();
+
+  const pingSpy = jest
+    .spyOn(integrationService, 'awsRolesAnywherePing')
+    .mockResolvedValue({} as any);
+
+  render(
+    <ContextProvider ctx={createTeleportContext()}>
+      <QueryClientProvider client={queryClient}>
+        <MockAwsOidcStatusProvider
+          value={makeAwsOidcStatusContextState()}
+          path=""
+        >
+          <IamIntegration />
+        </MockAwsOidcStatusProvider>
+      </QueryClientProvider>
+    </ContextProvider>
+  );
+
+  expect(
+    screen.getByText('Step 1: Name your Teleport Integration')
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText('Step 2: Create Roles Anywhere Trust Anchor')
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Next: Configure Access' })
+  ).toBeDisabled();
+
+  await user.type(
+    screen.getByLabelText('Integration Name'),
+    'some-integration-name'
+  );
+  await user.click(screen.getByRole('button', { name: 'Generate Command' }));
+
+  expect(
+    screen.getByText('Step 2: Create Roles Anywhere Trust Anchor')
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText('Step 3: Create and Sync the Integration Profile and Role')
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Test Configuration' })
+  ).toBeDisabled();
+  expect(
+    screen.getByRole('button', { name: 'Next: Configure Access' })
+  ).toBeDisabled();
+
+  await user.type(
+    screen.getByLabelText('Trust Anchor, Profile and Role ARNs'),
+    'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo\n' +
+      'arn:aws:rolesanywhere:eu-west-2:123456789012:profile/bar\n' +
+      'arn:aws:iam::123456789012:role/baz'
+  );
+
+  expect(
+    screen.getByRole('button', { name: 'Test Configuration' })
+  ).toBeEnabled();
+  await user.click(screen.getByRole('button', { name: 'Test Configuration' }));
+  expect(pingSpy).toHaveBeenCalledTimes(1);
+  expect(pingSpy).toHaveBeenCalledWith({
+    integrationName: 'some-integration-name',
+    syncProfileArn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:profile/bar',
+    syncRoleArn: 'arn:aws:iam::123456789012:role/baz',
+    trustAnchorArn:
+      'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo',
+  });
+
+  expect(
+    screen.getByRole('button', { name: 'Next: Configure Access' })
+  ).toBeEnabled();
+});
+
+describe('parseOutput', () => {
+  const excess = `
+  4. Create a Roles Anywhere Profile in AWS IAM for your Teleport cluster.
+CreateRolesAnywhereProfileProvider: {
+    "Name": "RAProfileFromCLI",
+    "RoleArns": [
+        "arn:aws:iam::123456789012:role/ra-role"
+    ],
+
+Copy and paste the following values to Teleport UI
+
+=================================================
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/ra-role
+=================================================
+
+2025-05-15T16:30:21.683+01:00 INFO  Success! operation:awsra-trust-anchor provisioning/operations.go:190
+`;
+  const topExcess = `
+
+=================================================
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/ra-role
+`;
+  const bottomExcess = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/ra-role
+=================================================
+`;
+  const perfect = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/ra-role
+`;
+  const empty = '';
+
+  const valid = {
+    trustAnchorArn:
+      'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000',
+    syncProfileArn:
+      'arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000',
+    syncRoleArn: 'arn:aws:iam::123456789012:role/ra-role',
+  };
+
+  test.each`
+    name                          | input           | expected
+    ${'valid excess copy'}        | ${excess}       | ${valid}
+    ${'valid excess top copy'}    | ${topExcess}    | ${valid}
+    ${'valid excess bottom copy'} | ${bottomExcess} | ${valid}
+    ${'valid perfect copy'}       | ${perfect}      | ${valid}
+    ${'invalid empty'}            | ${empty}        | ${undefined}
+  `(`parseOutput $name`, ({ input, expected }) => {
+    const values = parseOutput(input);
+    expect(values).toEqual(expected);
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
@@ -1,0 +1,412 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useMutation } from '@tanstack/react-query';
+import { ChangeEvent, ReactNode, useMemo, useState } from 'react';
+import { useHistory } from 'react-router';
+
+import {
+  Alert,
+  Box,
+  ButtonPrimary,
+  ButtonSecondary,
+  CardTile,
+  Flex,
+  H2,
+  Link,
+  Subtitle2,
+} from 'design';
+import { CollapsibleInfoSection } from 'design/CollapsibleInfoSection';
+import { Info, NewTab } from 'design/Icon';
+import FieldInput from 'shared/components/FieldInput';
+import { FieldTextArea } from 'shared/components/FieldTextArea';
+import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
+import Validation, { Validator } from 'shared/components/Validation';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import { FeatureBox } from 'teleport/components/Layout';
+import cfg from 'teleport/config';
+import { Guide } from 'teleport/Integrations/Enroll/AwsConsole/IamIntegration/Guide';
+import { validTrustAnchorInput } from 'teleport/Integrations/Enroll/AwsConsole/rules';
+import {
+  cloudShell,
+  rolesAnywhere,
+} from 'teleport/Integrations/Enroll/awsLinks';
+import {
+  AwsRolesAnywherePingResponse,
+  IntegrationKind,
+  integrationService,
+} from 'teleport/services/integrations';
+import useTeleport from 'teleport/useTeleport';
+
+enum Phase {
+  One, // enable step one
+  Two, // enable step two & three
+  Three, // step three is verified, enable proceed button
+}
+
+export function IamIntegration() {
+  const ctx = useTeleport();
+  const integrationsAccess = ctx.storeUser.getIntegrationsAccess();
+  const canEnroll = integrationsAccess.create;
+  const clusterId = ctx.storeUser.getClusterId();
+  const resourceRoute = cfg.getUnifiedResourcesRoute(clusterId);
+
+  const history = useHistory();
+  const [phase, setPhase] = useState(Phase.One);
+  const [alert, setAlert] = useState<ReactNode>();
+  const [scriptUrl, setScriptUrl] = useState<string>();
+  const [sync, setSync] = useState<string>();
+  const [output, setOutput] = useState<{
+    trustAnchorArn: string;
+    syncRoleArn: string;
+    syncProfileArn: string;
+  }>();
+
+  const [formState, setFormState] = useState({
+    // integrationName: the name of the AWS IAM Roles Anywhere Integration
+    // required by user, no default
+    integrationName: '',
+    // trustAnchor: the name of the Trust Anchor to be created
+    trustAnchorName: 'teleport-aws-roles-anywhere-trust-anchor',
+    // syncRole: the name of the IAM Role to be created
+    syncProfileName: 'teleport-aws-roles-anywhere-profile',
+    // syncProfile: the name of the IAM Roles Anywhere Profile to be created
+    syncRoleName: 'teleport-aws-roles-anywhere-role',
+  });
+
+  function generateCommand(validator: Validator) {
+    if (!validator.validate()) {
+      return;
+    }
+
+    setScriptUrl(
+      cfg.getAwsRolesAnywhereGenerateUrl(
+        formState.integrationName,
+        formState.trustAnchorName,
+        formState.syncRoleName,
+        formState.syncProfileName
+      )
+    );
+    setPhase(Phase.Two);
+  }
+
+  const manageAction = {
+    content: (
+      <>
+        Manage AWS Roles Anywhere Profiles{' '}
+        <NewTab size={18} ml={2} style={{ lineHeight: '22px' }} />
+      </>
+    ),
+    href: rolesAnywhere,
+  };
+
+  const testCfg = useMutation({
+    mutationFn: () => {
+      const inputs = parseOutput(sync);
+      // set output for final redirect
+      setOutput({
+        trustAnchorArn: inputs.trustAnchorArn,
+        syncProfileArn: inputs.syncProfileArn,
+        syncRoleArn: inputs.syncRoleArn,
+      });
+      return integrationService.awsRolesAnywherePing({
+        integrationName: formState.integrationName,
+        trustAnchorArn: inputs.trustAnchorArn,
+        syncRoleArn: inputs.syncRoleArn,
+        syncProfileArn: inputs.syncProfileArn,
+      });
+    },
+    onError: error => {
+      setAlert(
+        <Alert kind="danger" details={error.message}>
+          Error: {error.name}
+        </Alert>
+      );
+    },
+    onSuccess: (response: AwsRolesAnywherePingResponse) => {
+      if (response.profileCount > 0) {
+        setAlert(
+          <Alert kind="success" secondaryAction={manageAction}>
+            Success! AWS IAM Roles Anywhere Profiles found
+          </Alert>
+        );
+      } else {
+        setAlert(
+          <Alert
+            kind="warning"
+            secondaryAction={manageAction}
+            details={
+              'Create your first Profile to start accessing AWS from Teleport.'
+            }
+          >
+            Teleport didn&#39;t find any Profiles
+          </Alert>
+        );
+      }
+
+      setPhase(Phase.Three);
+    },
+  });
+
+  const validInput = useMemo(() => {
+    return validTrustAnchorInput(sync)().valid;
+  }, [sync]);
+
+  if (!canEnroll) {
+    return (
+      <FeatureBox>
+        <Alert kind="info" mt={4}>
+          You do not have permission to enroll integrations. Missing role
+          permissions: <code>integrations.create</code>
+        </Alert>
+      </FeatureBox>
+    );
+  }
+
+  return (
+    <>
+      <Flex mt={3} justifyContent="space-between" alignItems="center">
+        <H2>AWS CLI / Console Access</H2>
+        <InfoGuideButton
+          config={{
+            guide: <Guide resourcesRoute={resourceRoute} />,
+          }}
+        />
+      </Flex>
+      <Box>
+        Compatible with any CLI and AWS SDK-based tooling (such as Terraform and
+        AWS CLI). Teleport uses <strong>AWS IAM Roles Anywhere</strong> to
+        manage access and allows you to configure the right permissions for your
+        users.
+        <br />
+        Follow the below steps to create a Roles Anywhere Trust Anchor and
+        configure the required IAM Roles for synchronizing Profiles as Teleport
+        resources.
+      </Box>
+      <Alert
+        kind="neutral"
+        icon={Info}
+        mt={5}
+        secondaryAction={manageAction}
+        details={
+          'Create AWS Profiles and assign Roles to them in your AWS account. Teleport will allow you to import these Profiles as Resources.'
+        }
+      >
+        Prerequisites
+      </Alert>
+      <Validation>
+        {({ validator }) => (
+          <Flex flexDirection="column" gap={3}>
+            <CardTile>
+              <Flex flexDirection="column">
+                <H2>Step 1: Name your Teleport Integration</H2>
+                <Subtitle2>Give this integration a name.</Subtitle2>
+              </Flex>
+              <Flex flexDirection="column" gap={1} maxWidth={500}>
+                <FieldInput
+                  readonly={phase !== Phase.One}
+                  label="Integration Name"
+                  placeholder="teleport-aws-prod"
+                  rule={requiredField('Name is required')}
+                  value={formState.integrationName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    return setFormState(prev => ({
+                      ...prev,
+                      integrationName: e.target.value,
+                    }));
+                  }}
+                />
+              </Flex>
+              <CollapsibleInfoSection
+                openLabel="Optionally edit Trust Anchor, IAM Role and Profile Names"
+                closeLabel="Edit Trust Anchor, IAM Role and Profile Names"
+              >
+                <Flex flexDirection="column" gap={1} maxWidth={500}>
+                  <FieldInput
+                    readonly={phase !== Phase.One}
+                    label="Trust Anchor Name"
+                    placeholder=""
+                    value={formState.trustAnchorName}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      return setFormState(prev => ({
+                        ...prev,
+                        trustAnchorName: e.target.value,
+                      }));
+                    }}
+                  />
+                  <FieldInput
+                    readonly={phase !== Phase.One}
+                    label="AWS IAM Role Name *"
+                    placeholder=""
+                    value={formState.syncRoleName}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      return setFormState(prev => ({
+                        ...prev,
+                        syncRoleName: e.target.value,
+                      }));
+                    }}
+                  />
+                  <FieldInput
+                    readonly={phase !== Phase.One}
+                    label="Roles Anywhere Profile Name *"
+                    placeholder=""
+                    value={formState.syncProfileName}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      return setFormState(prev => ({
+                        ...prev,
+                        syncProfileName: e.target.value,
+                      }));
+                    }}
+                  />
+                </Flex>
+              </CollapsibleInfoSection>
+              <ButtonPrimary
+                width="200px"
+                disabled={phase !== Phase.One}
+                onClick={() => generateCommand(validator)}
+              >
+                Generate Command
+              </ButtonPrimary>
+            </CardTile>
+            {phase !== Phase.One && (
+              <>
+                <CardTile>
+                  <Flex flexDirection="column">
+                    <H2>Step 2: Create Roles Anywhere Trust Anchor</H2>
+                    <Subtitle2>
+                      Open{' '}
+                      <Link href={cloudShell} target="_blank">
+                        AWS CloudShell
+                      </Link>{' '}
+                      and copy and paste the command below. Upon executing in
+                      the AWS Shell the command will download and execute
+                      Teleport binary that configures Teleport as a IAM Roles
+                      Anywhere trusted entity. After running the script, copy
+                      the output and paste it in the field below.
+                    </Subtitle2>
+                  </Flex>
+                  <Box mb={2} mt={3}>
+                    <TextSelectCopyMulti
+                      lines={[
+                        {
+                          text: `bash -c "$(curl '${scriptUrl}')"`,
+                        },
+                      ]}
+                    />
+                  </Box>
+                </CardTile>
+                <CardTile>
+                  <Flex flexDirection="column">
+                    <H2>
+                      Step 3: Create and Sync the Integration Profile and Role
+                    </H2>
+                    <Subtitle2>
+                      Once the script above completes, copy and paste its output
+                      below.
+                    </Subtitle2>
+                    <Subtitle2>
+                      You can run the script again if you’ve already closed the
+                      window.
+                    </Subtitle2>
+                  </Flex>
+                  <FieldTextArea
+                    width="750px"
+                    value={sync}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      setSync(e.target.value);
+                    }}
+                    label="Trust Anchor, Profile and Role ARNs"
+                    placeholder={`:trust-anchor/\n:profile/\n:role/\n`}
+                    rule={validTrustAnchorInput}
+                  />
+                  <ButtonPrimary
+                    width="200px"
+                    onClick={() => testCfg.mutate()}
+                    disabled={!sync || phase !== Phase.Two || !validInput}
+                  >
+                    Test Configuration
+                  </ButtonPrimary>
+                  {alert && alert}
+                </CardTile>
+              </>
+            )}
+            <Flex gap={3}>
+              <ButtonPrimary
+                width="200px"
+                disabled={phase !== Phase.Three}
+                onClick={() =>
+                  history.push(
+                    cfg.getIntegrationEnrollRoute(
+                      IntegrationKind.AWSRa,
+                      'access'
+                    ),
+                    {
+                      integrationName: formState.integrationName,
+                      trustAnchorArn: output.trustAnchorArn,
+                      syncRoleArn: output.syncRoleArn,
+                      syncProfileArn: output.syncProfileArn,
+                    }
+                  )
+                }
+              >
+                Next: Configure Access
+              </ButtonPrimary>
+              <ButtonSecondary onClick={history.goBack} width="100px">
+                Back
+              </ButtonSecondary>
+            </Flex>
+          </Flex>
+        )}
+      </Validation>
+    </>
+  );
+}
+
+// The backend will use AWS validation to ensure the params are valid, we just want to get close at this point
+// Will remove dividing line if present, then ensures there are three inputs each starting with `arn:aws:`
+export function parseOutput(value: string): {
+  trustAnchorArn: string;
+  syncProfileArn: string;
+  syncRoleArn: string;
+} {
+  if (!value) {
+    return;
+  }
+
+  const lines = value.split('\n');
+  const trustAnchor = lines
+    .find(l => l.includes(':trust-anchor/'))
+    .replace(/"/g, '')
+    .trim();
+  const profile = lines
+    .find(l => l.includes(':profile/'))
+    .replace(/"/g, '')
+    .trim();
+  const role = lines
+    .find(l => l.includes(':role/'))
+    .replace(/"/g, '')
+    .trim();
+
+  return {
+    trustAnchorArn: trustAnchor,
+    syncProfileArn: profile,
+    syncRoleArn: role,
+  };
+}

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { IamIntegration } from './IamIntegration/IamIntegration';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/rules.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/rules.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { validTrustAnchorInput } from 'teleport/Integrations/Enroll/AwsConsole/rules';
+
+const excess = `
+  4. Create a Roles Anywhere Profile in AWS IAM for your Teleport cluster.
+CreateRolesAnywhereProfileProvider: {
+    "Name": "MarcoRAProfileFromCLI",
+    "RoleArns": [
+        "arn:aws:iam::123456789012:role/MarcoRARoleFromCLI"
+    ],
+
+Copy and paste the following values to Teleport UI
+
+=================================================
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+=================================================
+
+2025-05-15T16:30:21.683+01:00 INFO  Success! operation:awsra-trust-anchor provisioning/operations.go:190
+`;
+const topExcess = `
+
+=================================================
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+`;
+const bottomExcess = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+=================================================
+`;
+const perfect = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+`;
+const missingArn = `
+:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+`;
+const missingTrust = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:nottheanchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+`;
+const missingProfile = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:nottheprofile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
+`;
+const missingRole = `
+arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
+arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
+arn:aws:iam::123456789012:nottherole/MarcoRARoleFromCLI
+`;
+const missingAll = `
+foo
+bar
+baz
+`;
+
+test.each`
+  name                          | input             | valid    | message
+  ${'valid excess copy'}        | ${excess}         | ${true}  | ${undefined}
+  ${'valid excess top copy'}    | ${topExcess}      | ${true}  | ${undefined}
+  ${'valid excess bottom copy'} | ${bottomExcess}   | ${true}  | ${undefined}
+  ${'valid perfect copy'}       | ${perfect}        | ${true}  | ${undefined}
+  ${'invalid missing arn'}      | ${missingArn}     | ${false} | ${'Each line should start with arn:aws:, please double check the output'}
+  ${'invalid missing trust'}    | ${missingTrust}   | ${false} | ${'Output is missing trust anchor, please double check the output'}
+  ${'invalid missing profile'}  | ${missingProfile} | ${false} | ${'Output is missing profile, please double check the output'}
+  ${'invalid missing role'}     | ${missingRole}    | ${false} | ${'Output is missing role, please double check the output'}
+  ${'invalid missingAll'}       | ${missingAll}     | ${false} | ${'Each line should start with arn:aws:, please double check the output'}
+`(`parseOutput $name`, ({ input, valid, message }) => {
+  const validationResult = validTrustAnchorInput(input)();
+  expect(validationResult.valid).toBe(valid);
+  expect(validationResult.message).toBe(message);
+});

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/rules.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/rules.ts
@@ -1,0 +1,75 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ValidationResult } from 'shared/components/Validation/rules';
+
+/**
+ * Returns the validity of the trust anchor input including trust anchor, profile and role arns
+ *
+ * @remarks
+ * Loosely checks the inputs for validity; the API will do further validations using the aws package.
+ * Will return invalid if there are not three lines that begin with arn or if one of the following is missing: trust anchor, profile, role.
+ *
+ * @param value - The target to validate
+ * @returns () => {valid: boolean, message: string}
+ *
+ */
+export const validTrustAnchorInput =
+  (value: string) => (): ValidationResult => {
+    if (!value) {
+      return {
+        valid: true,
+      };
+    }
+
+    let lines = value.split('\n');
+    const startsWithArn = lines.filter(l => l.startsWith('arn:aws:'));
+    if (startsWithArn.length < 3) {
+      return {
+        valid: false,
+        message:
+          'Each line should start with arn:aws:, please double check the output',
+      };
+    }
+
+    const trustAnchor = lines.find(l => l.includes(':trust-anchor/'));
+    if (!trustAnchor) {
+      return {
+        valid: false,
+        message:
+          'Output is missing trust anchor, please double check the output',
+      };
+    }
+
+    const profile = lines.find(l => l.includes(':profile/'));
+    if (!profile) {
+      return {
+        valid: false,
+        message: 'Output is missing profile, please double check the output',
+      };
+    }
+    const role = lines.find(l => l.includes(':role/'));
+    if (!role) {
+      return {
+        valid: false,
+        message: 'Output is missing role, please double check the output',
+      };
+    }
+
+    return { valid: true };
+  };

--- a/web/packages/teleport/src/Integrations/Enroll/awsLinks.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/awsLinks.ts
@@ -1,0 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const cloudShell = 'https://console.aws.amazon.com/cloudshell/home';
+export const rolesAnywhere =
+  'https://console.aws.amazon.com/rolesanywhere/home';

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -28,19 +28,24 @@ import {
   AwsOidcStatusContextState,
 } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import { Acl } from 'teleport/services/user';
 
 export const MockAwsOidcStatusProvider = ({
   children,
   value,
   initialEntries,
   path,
+  customAcl,
 }: {
   children?: React.ReactNode;
   value: AwsOidcStatusContextState;
   path: string;
   initialEntries?: string[];
+  customAcl?: Acl;
 }) => {
-  const ctx = createTeleportContext();
+  const ctx = customAcl
+    ? createTeleportContext({ customAcl })
+    : createTeleportContext();
 
   return (
     <MemoryRouter initialEntries={initialEntries}>

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -218,6 +218,8 @@ const cfg = {
     integrationStatusResources:
       '/web/integrations/status/:type/:name/resources/:resourceKind',
     integrationEnroll: '/web/integrations/new/:type?/:subPage?',
+    integrationEnrollChild:
+      '/web/integrations/new/:type/:name/child/:subType/:subPage?',
     locks: '/web/locks',
     newLock: '/web/locks/new',
     requests: '/web/requests/:requestId?',
@@ -411,6 +413,12 @@ const cfg = {
       '/v1/webapi/sites/:clusterId/usertask?integration=:name?&state=:state?',
     userTaskPath: '/v1/webapi/sites/:clusterId/usertask/:name',
     resolveUserTaskPath: '/v1/webapi/sites/:clusterId/usertask/:name/state',
+
+    awsRolesAnywhere: {
+      generate:
+        '/v1/webapi/scripts/integrations/configure/awsra-trust-anchor.sh?integrationName=:integrationName?&trustAnchor=:trustAnchor?&syncRole=:syncRole?&syncProfile=:syncProfile',
+      ping: '/v1/webapi/sites/:clusterId/integrations/aws-ra/:integrationName/ping',
+    },
 
     thumbprintPath: '/v1/webapi/thumbprint',
     pingAwsOidcIntegrationPath:
@@ -1502,6 +1510,33 @@ const cfg = {
         ...params,
       })
     );
+  },
+
+  getAwsRolesAnywhereGenerateUrl(
+    integrationName: string,
+    trustAnchor: string,
+    syncRole: string,
+    syncProfile: string
+  ) {
+    const path = cfg.api.awsRolesAnywhere.generate;
+    return (
+      cfg.baseUrl +
+      generatePath(path, {
+        integrationName,
+        trustAnchor,
+        syncRole,
+        syncProfile,
+      })
+    );
+  },
+
+  getAwsRolesAnywherePingUrl(integrationName: string) {
+    const path = cfg.api.awsRolesAnywhere.ping;
+    const clusterId = cfg.proxyCluster;
+    return generatePath(path, {
+      clusterId,
+      integrationName,
+    });
   },
 
   getBotTokenUrl() {

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -38,6 +38,7 @@ import {
   AwsOidcPingRequest,
   AwsOidcPingResponse,
   AwsRdsDatabase,
+  AwsRolesAnywherePingResponse,
   CreateAwsAppAccessRequest,
   EnrollEksClustersRequest,
   EnrollEksClustersResponse,
@@ -542,6 +543,33 @@ export const integrationService = {
           title: resp.title,
           integration: resp.integration,
           lastStateChange: resp.lastStateChange,
+        };
+      });
+  },
+
+  awsRolesAnywherePing({
+    integrationName,
+    trustAnchorArn,
+    syncRoleArn,
+    syncProfileArn,
+  }: {
+    integrationName: string;
+    trustAnchorArn: string;
+    syncRoleArn: string;
+    syncProfileArn: string;
+  }): Promise<AwsRolesAnywherePingResponse> {
+    return api
+      .post(cfg.getAwsRolesAnywherePingUrl(integrationName), {
+        trustAnchorArn,
+        syncRoleArn,
+        syncProfileArn,
+      })
+      .then(json => {
+        return {
+          profileCount: json?.profileCount,
+          accountId: json?.accountID,
+          arn: json?.arn,
+          userId: json?.userId,
         };
       });
   },

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -77,6 +77,8 @@ export type IntegrationTemplate<
 // resource's subKind field.
 export enum IntegrationKind {
   AwsOidc = 'aws-oidc',
+  /* AWS Roles Anywhere */
+  AWSRa = 'aws-ra',
   AzureOidc = 'azure-oidc',
   ExternalAuditStorage = 'external-audit-storage',
   GitHub = 'github',
@@ -630,6 +632,30 @@ export type AWSOIDCDeployedDatabaseService = {
   validTeleportConfig: boolean;
   // matchingLabels are the labels that are used by the Teleport Database Service to know which databases it should proxy.
   matchingLabels: Label[];
+};
+
+/**
+ * AwsRolesAnywherePingResponse contains the result of the Ping request.
+ * This response contains meta information about the current state of the Integration.
+ */
+export type AwsRolesAnywherePingResponse = {
+  /**
+   * profileCount is the number of IAM Roles Anywhere Profiles that can be accessed by the Integration.
+   * Profiles that are disabled or don't have any IAM Role associated with them are not counted.
+   */
+  profileCount: number;
+  /**
+   * accountId number of the account that owns or contains the calling entity.
+   */
+  accountId: string;
+  /**
+   * arn associated with the calling entity.
+   */
+  arn: string;
+  /**
+   * userID is the unique identifier of the calling entity.
+   */
+  userId: string;
 };
 
 // awsRegionMap maps the AWS regions to it's region name


### PR DESCRIPTION
Adds the first page of the aws roles anywhere enrollment
* Is not routed yet

Follow up PR will route this into the aws roles anywhere enrollment flow with other steps.

<img width="1279" height="1293" alt="Screenshot 2025-08-06 at 2 08 38 PM" src="https://github.com/user-attachments/assets/d79aeacb-0e60-4d96-be01-0a5590f850fc" />

[Figma](https://www.figma.com/design/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?node-id=3314-59966&m=dev)

Supports https://github.com/gravitational/teleport/issues/53192