### PR TITLE
Mock testing for race condition when forwarding multiple ports to a single pod

### DIFF
--- a/fixtures/alpine/webserver.go
+++ b/fixtures/alpine/webserver.go
@@ -16,11 +16,22 @@
 
 package main
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, world!"))
 	})
-	http.ListenAndServe(":80", nil)
+
+	// Listen on five ports.
+	for p := 80; p < 85; p++ {
+		go func(port int) {
+			http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		}(p)
+	}
+	// Block indefinitely.
+	select {}
 }

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -183,6 +183,7 @@ func TestKube(t *testing.T) {
 	t.Run("Exec", suite.bind(testKubeExec))
 	t.Run("Deny", suite.bind(testKubeDeny))
 	t.Run("PortForward", suite.bind(testKubePortForward))
+	t.Run("PortForwardConcurrent", suite.bind(testKubePortForwardConcurrent))
 	t.Run("TransportProtocol", suite.bind(testKubeTransportProtocol))
 	t.Run("TrustedClustersClientCert", suite.bind(testKubeTrustedClustersClientCert))
 	t.Run("TrustedClustersSNI", suite.bind(testKubeTrustedClustersSNI))
@@ -591,6 +592,136 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 		)
 	}
 
+}
+
+// TestKubePortForwardConcurrent tests kubernetes
+// port forwarding with multiple ports to a single pod.
+func testKubePortForwardConcurrent(t *testing.T, suite *KubeSuite) {
+	t.Parallel()
+
+	tconf := suite.teleKubeConfig(Host)
+
+	teleport := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: helpers.Site,
+		HostID:      helpers.HostID,
+		NodeName:    Host,
+		Priv:        suite.priv,
+		Pub:         suite.pub,
+		Logger:      suite.log,
+	})
+
+	username := suite.me.Username
+	kubeGroups := []string{kube.TestImpersonationGroup}
+	role, err := types.NewRole("kubemaster", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{username},
+			KubeGroups: kubeGroups,
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: "pods", Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}, APIGroup: types.Wildcard,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	teleport.AddUserWithRole(username, role)
+
+	err = teleport.CreateEx(t, nil, tconf)
+	require.NoError(t, err)
+
+	err = teleport.Start()
+	require.NoError(t, err)
+	defer teleport.StopAll()
+
+	// set up kube configuration using proxy
+	_, proxyClientConfig, err := kube.ProxyClient(kube.ProxyConfig{
+		T:          teleport,
+		Username:   username,
+		KubeGroups: kubeGroups,
+	})
+	require.NoError(t, err)
+
+	// Define multiple ports for forwarding.
+	// Local ports are randomly selected by specifying 0.
+	forwarder, err := newPortForwarder(proxyClientConfig, kubePortForwardArgs{
+		ports:        []string{"0:80", "0:81", "0:82", "0:83", "0:84"},
+		podName:      testPod,
+		podNamespace: testNamespace,
+	})
+	require.NoError(t, err)
+
+	defer forwarder.Close()
+	forwarderCh := make(chan error, 1)
+	go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding")
+	case <-forwarder.readyC:
+	}
+
+	// Get local ports, which are randomly selected.
+	portPairs, err := forwarder.GetPorts()
+	require.NoError(t, err)
+	t.Logf("Ports forwarded %v", portPairs)
+
+	// Exercise each port forward for a single pod.
+	// It's fine that there isn't a response from each container port.
+	// It's understood that the container responds on a single remote port 80.
+	// The focus is on exercising multiple port forwards for concurrency testing.
+	g, groupCtx := errgroup.WithContext(t.Context())
+	for _, portPair := range portPairs {
+		portPair := portPair
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(groupCtx, 30*time.Second)
+			defer cancel()
+
+			url := fmt.Sprintf("http://localhost:%d", portPair.Local)
+			req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if errReq != nil {
+				return fmt.Errorf("http new request for port %v: %w", portPair, errReq)
+			}
+
+			resp, errDoReq := http.DefaultClient.Do(req)
+			if portPair.Remote == 80 {
+				// Expect port 80 to succeed. Container is listening.
+				if errDoReq != nil {
+					return fmt.Errorf("http GET on port %v: %w", portPair, errDoReq)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected http GET status %d on port %v", resp.StatusCode, portPair)
+				}
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			} else {
+				// Expect port != 80 to error EOF. Container is not listening.
+				if errDoReq == nil {
+					io.Copy(io.Discard, resp.Body)
+					resp.Body.Close()
+					return fmt.Errorf("expected io.EOF error on non-listening port %v", portPair)
+				}
+				if !errors.Is(errDoReq, io.EOF) {
+					// Response is expected to be nil. No need to close a response body.
+					return fmt.Errorf("non-listening port error (expected io.EOF): %w", errDoReq)
+				}
+			}
+
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	t.Log("Port forward closing")
+	close(forwarder.stopC)
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding to exit")
+	case err := <-forwarderCh:
+		require.NoError(t, err, "Port forwarding exited with an error")
+	}
 }
 
 // TestKubeTrustedClustersClientCert tests scenario with trusted clusters

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1813,21 +1813,11 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
-	var auditSentMu sync.Mutex
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster {
+		if !sess.isLocalKubernetesCluster || auditSent[addr] {
 			return
 		}
-
-		auditSentMu.Lock()
-		isAuditSent := auditSent[addr]
-		if !isAuditSent {
-			auditSent[addr] = true
-		}
-		auditSentMu.Unlock()
-		if isAuditSent {
-			return
-		}
+		auditSent[addr] = true
 
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"regexp"


### PR DESCRIPTION
An experimental draft branch.

- Rolled back auditSent mutex fix to enable testing
- Added table test with multiple ports. Based on original single port test. (`TestPortForwardKubeService`)
- Added new individual multi-port test which exercises all port forwards (`TestPortForwardKubeServiceMultiPort`)
- Revised KubeMockServer `portforward()` to support multiple ports

Related to:
- PR #57474.
- Issue #57242.