### PR TITLE
[2] Mock testing for race condition when forwarding multiple ports to a single pod

### DIFF
--- a/fixtures/alpine/webserver.go
+++ b/fixtures/alpine/webserver.go
@@ -16,11 +16,22 @@
 
 package main
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, world!"))
 	})
-	http.ListenAndServe(":80", nil)
+
+	// Listen on five ports.
+	for p := 80; p < 85; p++ {
+		go func(port int) {
+			http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		}(p)
+	}
+	// Block indefinitely.
+	select {}
 }

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -183,6 +183,7 @@ func TestKube(t *testing.T) {
 	t.Run("Exec", suite.bind(testKubeExec))
 	t.Run("Deny", suite.bind(testKubeDeny))
 	t.Run("PortForward", suite.bind(testKubePortForward))
+	t.Run("PortForwardConcurrent", suite.bind(testKubePortForwardConcurrent))
 	t.Run("TransportProtocol", suite.bind(testKubeTransportProtocol))
 	t.Run("TrustedClustersClientCert", suite.bind(testKubeTrustedClustersClientCert))
 	t.Run("TrustedClustersSNI", suite.bind(testKubeTrustedClustersSNI))
@@ -591,6 +592,136 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 		)
 	}
 
+}
+
+// TestKubePortForwardConcurrent tests kubernetes
+// port forwarding with multiple ports to a single pod.
+func testKubePortForwardConcurrent(t *testing.T, suite *KubeSuite) {
+	t.Parallel()
+
+	tconf := suite.teleKubeConfig(Host)
+
+	teleport := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: helpers.Site,
+		HostID:      helpers.HostID,
+		NodeName:    Host,
+		Priv:        suite.priv,
+		Pub:         suite.pub,
+		Logger:      suite.log,
+	})
+
+	username := suite.me.Username
+	kubeGroups := []string{kube.TestImpersonationGroup}
+	role, err := types.NewRole("kubemaster", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{username},
+			KubeGroups: kubeGroups,
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: "pods", Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}, APIGroup: types.Wildcard,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	teleport.AddUserWithRole(username, role)
+
+	err = teleport.CreateEx(t, nil, tconf)
+	require.NoError(t, err)
+
+	err = teleport.Start()
+	require.NoError(t, err)
+	defer teleport.StopAll()
+
+	// set up kube configuration using proxy
+	_, proxyClientConfig, err := kube.ProxyClient(kube.ProxyConfig{
+		T:          teleport,
+		Username:   username,
+		KubeGroups: kubeGroups,
+	})
+	require.NoError(t, err)
+
+	// Define multiple ports for forwarding.
+	// Local ports are randomly selected by specifying 0.
+	forwarder, err := newPortForwarder(proxyClientConfig, kubePortForwardArgs{
+		ports:        []string{"0:80", "0:81", "0:82", "0:83", "0:84"},
+		podName:      testPod,
+		podNamespace: testNamespace,
+	})
+	require.NoError(t, err)
+
+	defer forwarder.Close()
+	forwarderCh := make(chan error, 1)
+	go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding")
+	case <-forwarder.readyC:
+	}
+
+	// Get local ports, which are randomly selected.
+	portPairs, err := forwarder.GetPorts()
+	require.NoError(t, err)
+	t.Logf("Ports forwarded %v", portPairs)
+
+	// Exercise each port forward for a single pod.
+	// It's fine that there isn't a response from each container port.
+	// It's understood that the container responds on a single remote port 80.
+	// The focus is on exercising multiple port forwards for concurrency testing.
+	g, groupCtx := errgroup.WithContext(t.Context())
+	for _, portPair := range portPairs {
+		portPair := portPair
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(groupCtx, 30*time.Second)
+			defer cancel()
+
+			url := fmt.Sprintf("http://localhost:%d", portPair.Local)
+			req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if errReq != nil {
+				return fmt.Errorf("http new request for port %v: %w", portPair, errReq)
+			}
+
+			resp, errDoReq := http.DefaultClient.Do(req)
+			if portPair.Remote == 80 {
+				// Expect port 80 to succeed. Container is listening.
+				if errDoReq != nil {
+					return fmt.Errorf("http GET on port %v: %w", portPair, errDoReq)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected http GET status %d on port %v", resp.StatusCode, portPair)
+				}
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			} else {
+				// Expect port != 80 to error EOF. Container is not listening.
+				if errDoReq == nil {
+					io.Copy(io.Discard, resp.Body)
+					resp.Body.Close()
+					return fmt.Errorf("expected io.EOF error on non-listening port %v", portPair)
+				}
+				if !errors.Is(errDoReq, io.EOF) {
+					// Response is expected to be nil. No need to close a response body.
+					return fmt.Errorf("non-listening port error (expected io.EOF): %w", errDoReq)
+				}
+			}
+
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	t.Log("Port forward closing")
+	close(forwarder.stopC)
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding to exit")
+	case err := <-forwarderCh:
+		require.NoError(t, err, "Port forwarding exited with an error")
+	}
 }
 
 // TestKubeTrustedClustersClientCert tests scenario with trusted clusters

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1813,21 +1813,11 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
-	var auditSentMu sync.Mutex
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster {
+		if !sess.isLocalKubernetesCluster || auditSent[addr] {
 			return
 		}
-
-		auditSentMu.Lock()
-		isAuditSent := auditSent[addr]
-		if !isAuditSent {
-			auditSent[addr] = true
-		}
-		auditSentMu.Unlock()
-		if isAuditSent {
-			return
-		}
+		auditSent[addr] = true
 
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1813,11 +1813,21 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
+	auditSentMu := sync.Mutex{}
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster || auditSent[addr] {
+		if !sess.isLocalKubernetesCluster {
 			return
 		}
-		auditSent[addr] = true
+
+		auditSentMu.Lock()
+		isAuditSent := auditSent[addr]
+		if !isAuditSent {
+			auditSent[addr] = true
+		}
+		auditSentMu.Unlock()
+		if isAuditSent {
+			return
+		}
 
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1813,21 +1813,11 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
-	auditSentMu := sync.Mutex{}
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster {
+		if !sess.isLocalKubernetesCluster || auditSent[addr] {
 			return
 		}
-
-		auditSentMu.Lock()
-		isAuditSent := auditSent[addr]
-		if !isAuditSent {
-			auditSent[addr] = true
-		}
-		auditSentMu.Unlock()
-		if isAuditSent {
-			return
-		}
+		auditSent[addr] = true
 
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -211,128 +210,6 @@ func TestPortForwardKubeService(t *testing.T) {
 				require.Equal(t, expected, string(p[:n]))
 			}
 		})
-	}
-}
-
-func TestPortForwardKubeServiceMultiPort(t *testing.T) {
-	t.Parallel()
-
-	kubeMock, err := testingkubemock.NewKubeAPIMock()
-	require.NoError(t, err)
-	t.Cleanup(func() { kubeMock.Close() })
-
-	// creates a Kubernetes service with a configured cluster pointing to mock api server
-	testCtx := SetupTestContext(
-		context.Background(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-		},
-	)
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	user, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		username,
-		RoleSpec{
-			Name:       roleName,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-		})
-
-	// generate a kube client with user certs for auth
-	_, config := testCtx.GenTestKubeClientTLSCert(
-		t,
-		user.GetName(),
-		kubeCluster,
-	)
-	require.NoError(t, err)
-
-	// Create multi-port forwarder
-	readyCh := make(chan struct{})
-	errCh := make(chan error)
-	stopCh := make(chan struct{})
-	t.Cleanup(func() { close(stopCh) })
-
-	fw := spdyMultiPortForwardClientBuilder(t, portForwardRequestConfig{
-		podName:      podName,
-		podNamespace: podNamespace,
-		restConfig:   config,
-		podPort:      80, // This is ignored in multi-port builder
-		stopCh:       stopCh,
-		readyCh:      readyCh,
-	})
-	t.Cleanup(fw.Close)
-
-	go func() {
-		defer close(errCh)
-		errCh <- trace.Wrap(fw.ForwardPorts())
-	}()
-
-	select {
-	case err := <-errCh:
-		t.Fatalf("Received error on errCh instead of ready signal: %v", err)
-	case <-readyCh:
-		// Port forwarding is ready
-		ports, err := fw.GetPorts()
-		require.NoError(t, err)
-		//require.Len(t, ports, 5) // We requested 5 ports
-
-		// Test EACH port to ensure they all work
-		var wg sync.WaitGroup
-		errors := make(chan error, len(ports))
-
-		for i, port := range ports {
-			wg.Add(1)
-			go func(idx int, p portforward.ForwardedPort) {
-				defer wg.Done()
-
-				// Add small delay to create concurrency
-				time.Sleep(time.Duration(idx*10) * time.Millisecond)
-
-				conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", p.Local))
-				if err != nil {
-					errors <- fmt.Errorf("port %d dial failed: %w", p.Local, err)
-					return
-				}
-				defer conn.Close()
-
-				testData := []byte(fmt.Sprintf("test-data-port-%d", idx))
-				_, err = conn.Write(testData)
-				if err != nil {
-					errors <- fmt.Errorf("port %d write failed: %w", p.Local, err)
-					return
-				}
-
-				// Set read timeout to avoid hanging
-				conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-
-				buf := make([]byte, 1024)
-				n, err := conn.Read(buf)
-				if err != nil {
-					errors <- fmt.Errorf("port %d read failed: %w", p.Local, err)
-					return
-				}
-
-				expected := fmt.Sprintf("%s%s%s", testingkubemock.PortForwardPayload, podName, string(testData))
-				if !strings.Contains(string(buf[:n]), expected) {
-					errors <- fmt.Errorf("port %d unexpected response: got %q, want substring %q",
-						p.Local, string(buf[:n]), expected)
-				}
-			}(i, port)
-		}
-
-		wg.Wait()
-		close(errors)
-
-		// Check for any errors
-		var allErrors []error
-		for err := range errors {
-			allErrors = append(allErrors, err)
-		}
-		require.Empty(t, allErrors, "Port forwarding errors: %v", allErrors)
 	}
 }
 

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -243,7 +243,7 @@ func spdyMultiPortForwardClientBuilder(t *testing.T, req portForwardRequestConfi
 	u, err := portforwardURL(req.podNamespace, req.podName, req.restConfig.Host, "")
 	require.NoError(t, err)
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, u)
-	const portCnt = 5
+	const portCnt = 100
 	port := 80
 	ports := make([]string, portCnt)
 	for idx := 0; idx < portCnt; idx++ {

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -213,6 +214,128 @@ func TestPortForwardKubeService(t *testing.T) {
 	}
 }
 
+func TestPortForwardKubeServiceMultiPort(t *testing.T) {
+	t.Parallel()
+
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	// creates a Kubernetes service with a configured cluster pointing to mock api server
+	testCtx := SetupTestContext(
+		context.Background(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		},
+	)
+	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	user, _ := testCtx.CreateUserAndRole(
+		testCtx.Context,
+		t,
+		username,
+		RoleSpec{
+			Name:       roleName,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+		})
+
+	// generate a kube client with user certs for auth
+	_, config := testCtx.GenTestKubeClientTLSCert(
+		t,
+		user.GetName(),
+		kubeCluster,
+	)
+	require.NoError(t, err)
+
+	// Create multi-port forwarder
+	readyCh := make(chan struct{})
+	errCh := make(chan error)
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+
+	fw := spdyMultiPortForwardClientBuilder(t, portForwardRequestConfig{
+		podName:      podName,
+		podNamespace: podNamespace,
+		restConfig:   config,
+		podPort:      80, // This is ignored in multi-port builder
+		stopCh:       stopCh,
+		readyCh:      readyCh,
+	})
+	t.Cleanup(fw.Close)
+
+	go func() {
+		defer close(errCh)
+		errCh <- trace.Wrap(fw.ForwardPorts())
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Received error on errCh instead of ready signal: %v", err)
+	case <-readyCh:
+		// Port forwarding is ready
+		ports, err := fw.GetPorts()
+		require.NoError(t, err)
+		//require.Len(t, ports, 5) // We requested 5 ports
+
+		// Test EACH port to ensure they all work
+		var wg sync.WaitGroup
+		errors := make(chan error, len(ports))
+
+		for i, port := range ports {
+			wg.Add(1)
+			go func(idx int, p portforward.ForwardedPort) {
+				defer wg.Done()
+
+				// Add small delay to create concurrency
+				time.Sleep(time.Duration(idx*10) * time.Millisecond)
+
+				conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", p.Local))
+				if err != nil {
+					errors <- fmt.Errorf("port %d dial failed: %w", p.Local, err)
+					return
+				}
+				defer conn.Close()
+
+				testData := []byte(fmt.Sprintf("test-data-port-%d", idx))
+				_, err = conn.Write(testData)
+				if err != nil {
+					errors <- fmt.Errorf("port %d write failed: %w", p.Local, err)
+					return
+				}
+
+				// Set read timeout to avoid hanging
+				conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+				buf := make([]byte, 1024)
+				n, err := conn.Read(buf)
+				if err != nil {
+					errors <- fmt.Errorf("port %d read failed: %w", p.Local, err)
+					return
+				}
+
+				expected := fmt.Sprintf("%s%s%s", testingkubemock.PortForwardPayload, podName, string(testData))
+				if !strings.Contains(string(buf[:n]), expected) {
+					errors <- fmt.Errorf("port %d unexpected response: got %q, want substring %q",
+						p.Local, string(buf[:n]), expected)
+				}
+			}(i, port)
+		}
+
+		wg.Wait()
+		close(errors)
+
+		// Check for any errors
+		var allErrors []error
+		for err := range errors {
+			allErrors = append(allErrors, err)
+		}
+		require.Empty(t, allErrors, "Port forwarding errors: %v", allErrors)
+	}
+}
+
 func portforwardURL(namespace, podName string, host string, query string) (*url.URL, error) {
 	u, err := url.Parse(host)
 	if err != nil {
@@ -250,7 +373,6 @@ func spdyMultiPortForwardClientBuilder(t *testing.T, req portForwardRequestConfi
 		ports[idx] = fmt.Sprintf("0:%d", port)
 		port++
 	}
-	//ports := []string{"0:80", "0:81", "0:82", "0:83", "0:84"}
 	fw, err := portforward.New(dialer, ports, req.stopCh, req.readyCh, os.Stdout, os.Stdin)
 	require.NoError(t, err)
 	return fw

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -243,7 +243,7 @@ func spdyMultiPortForwardClientBuilder(t *testing.T, req portForwardRequestConfi
 	u, err := portforwardURL(req.podNamespace, req.podName, req.restConfig.Host, "")
 	require.NoError(t, err)
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, u)
-	const portCnt = 100
+	const portCnt = 5
 	port := 80
 	ports := make([]string, portCnt)
 	for idx := 0; idx < portCnt; idx++ {

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -976,6 +977,9 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 						}
 						return
 					}
+
+					// Add small delay to increase chance of race conditions
+					time.Sleep(time.Duration(rand.IntN(10)) * time.Millisecond)
 
 					// Write to target.
 					_, writeErr := fmt.Fprint(dataStream, PortForwardPayload, p.ByName("name"), string(buf[:n]))

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -958,10 +958,10 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 				go func(portNum string, dataStream, errorStream httpstream.Stream) {
 					defer wg.Done()
 
-					// Check context cancelled.
+					// Check context canceled.
 					select {
 					case <-ctx.Done():
-						s.log.InfoContext(ctx, "Port forward cancelled", "port", portNum)
+						s.log.InfoContext(ctx, "Port forward canceled", "port", portNum)
 						return
 					default:
 					}

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -847,8 +847,6 @@ func (s *KubeMockServer) selfSubjectAccessReviews(w http.ResponseWriter, req *ht
 
 // portforward supports SPDY protocols only. Teleport always uses SPDY when
 // portforwarding to upstreams even if the original request is WebSocket.
-// kube_mock.go
-
 func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	if s.portforwardError != nil {
 		s.writeResponseError(w, nil, s.portforwardError)
@@ -903,7 +901,7 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 	}
 	defer conn.Close()
 
-	// Use the request's context to manage goroutine lifecycle without a premature timeout.
+	// Create a context for managing goroutines.
 	ctx, cancel := context.WithCancel(req.Context())
 	defer cancel()
 


### PR DESCRIPTION
An experimental draft branch.

- Rolled back auditSent mutex fix to enable testing
- Added new individual multi-port test which exercises all port forwards (TestPortForwardKubeServiceMultiPort)
- Revised KubeMockServer portforward() to support multiple ports

Relates to:
- PR #57474
- Issue #57242