### PR TITLE
(mock, nofix) race condition when forwarding multiple ports to a single pod

### DIFF
--- a/fixtures/alpine/webserver.go
+++ b/fixtures/alpine/webserver.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -25,13 +24,5 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, world!"))
 	})
-
-	// Listen on five ports.
-	for p := 80; p < 85; p++ {
-		go func(port int) {
-			http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
-		}(p)
-	}
-	// Block indefinitely.
-	select {}
+	http.ListenAndServe(":80", nil)
 }

--- a/fixtures/alpine/webserver.go
+++ b/fixtures/alpine/webserver.go
@@ -16,11 +16,22 @@
 
 package main
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello, world!"))
 	})
-	http.ListenAndServe(":80", nil)
+
+	// Listen on five ports.
+	for p := 80; p < 85; p++ {
+		go func(port int) {
+			http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		}(p)
+	}
+	// Block indefinitely.
+	select {}
 }

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -183,6 +183,7 @@ func TestKube(t *testing.T) {
 	t.Run("Exec", suite.bind(testKubeExec))
 	t.Run("Deny", suite.bind(testKubeDeny))
 	t.Run("PortForward", suite.bind(testKubePortForward))
+	t.Run("PortForwardConcurrent", suite.bind(testKubePortForwardConcurrent))
 	t.Run("TransportProtocol", suite.bind(testKubeTransportProtocol))
 	t.Run("TrustedClustersClientCert", suite.bind(testKubeTrustedClustersClientCert))
 	t.Run("TrustedClustersSNI", suite.bind(testKubeTrustedClustersSNI))
@@ -591,6 +592,136 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 		)
 	}
 
+}
+
+// TestKubePortForwardConcurrent tests kubernetes
+// port forwarding with multiple ports to a single pod.
+func testKubePortForwardConcurrent(t *testing.T, suite *KubeSuite) {
+	t.Parallel()
+
+	tconf := suite.teleKubeConfig(Host)
+
+	teleport := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: helpers.Site,
+		HostID:      helpers.HostID,
+		NodeName:    Host,
+		Priv:        suite.priv,
+		Pub:         suite.pub,
+		Logger:      suite.log,
+	})
+
+	username := suite.me.Username
+	kubeGroups := []string{kube.TestImpersonationGroup}
+	role, err := types.NewRole("kubemaster", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{username},
+			KubeGroups: kubeGroups,
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: "pods", Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}, APIGroup: types.Wildcard,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	teleport.AddUserWithRole(username, role)
+
+	err = teleport.CreateEx(t, nil, tconf)
+	require.NoError(t, err)
+
+	err = teleport.Start()
+	require.NoError(t, err)
+	defer teleport.StopAll()
+
+	// set up kube configuration using proxy
+	_, proxyClientConfig, err := kube.ProxyClient(kube.ProxyConfig{
+		T:          teleport,
+		Username:   username,
+		KubeGroups: kubeGroups,
+	})
+	require.NoError(t, err)
+
+	// Define multiple ports for forwarding.
+	// Local ports are randomly selected by specifying 0.
+	forwarder, err := newPortForwarder(proxyClientConfig, kubePortForwardArgs{
+		ports:        []string{"0:80", "0:81", "0:82", "0:83", "0:84"},
+		podName:      testPod,
+		podNamespace: testNamespace,
+	})
+	require.NoError(t, err)
+
+	defer forwarder.Close()
+	forwarderCh := make(chan error, 1)
+	go func() { forwarderCh <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding")
+	case <-forwarder.readyC:
+	}
+
+	// Get local ports, which are randomly selected.
+	portPairs, err := forwarder.GetPorts()
+	require.NoError(t, err)
+	t.Logf("Ports forwarded %v", portPairs)
+
+	// Exercise each port forward for a single pod.
+	// It's fine that there isn't a response from each container port.
+	// It's understood that the container responds on a single remote port 80.
+	// The focus is on exercising multiple port forwards for concurrency testing.
+	g, groupCtx := errgroup.WithContext(t.Context())
+	for _, portPair := range portPairs {
+		portPair := portPair
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(groupCtx, 30*time.Second)
+			defer cancel()
+
+			url := fmt.Sprintf("http://localhost:%d", portPair.Local)
+			req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if errReq != nil {
+				return fmt.Errorf("http new request for port %v: %w", portPair, errReq)
+			}
+
+			resp, errDoReq := http.DefaultClient.Do(req)
+			if portPair.Remote == 80 {
+				// Expect port 80 to succeed. Container is listening.
+				if errDoReq != nil {
+					return fmt.Errorf("http GET on port %v: %w", portPair, errDoReq)
+				}
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected http GET status %d on port %v", resp.StatusCode, portPair)
+				}
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			} else {
+				// Expect port != 80 to error EOF. Container is not listening.
+				if errDoReq == nil {
+					io.Copy(io.Discard, resp.Body)
+					resp.Body.Close()
+					return fmt.Errorf("expected io.EOF error on non-listening port %v", portPair)
+				}
+				if !errors.Is(errDoReq, io.EOF) {
+					// Response is expected to be nil. No need to close a response body.
+					return fmt.Errorf("non-listening port error (expected io.EOF): %w", errDoReq)
+				}
+			}
+
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	t.Log("Port forward closing")
+	close(forwarder.stopC)
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for port forwarding to exit")
+	case err := <-forwarderCh:
+		require.NoError(t, err, "Port forwarding exited with an error")
+	}
 }
 
 // TestKubeTrustedClustersClientCert tests scenario with trusted clusters

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1813,21 +1813,11 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
-	var auditSentMu sync.Mutex
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster {
+		if !sess.isLocalKubernetesCluster || auditSent[addr] {
 			return
 		}
-
-		auditSentMu.Lock()
-		isAuditSent := auditSent[addr]
-		if !isAuditSent {
-			auditSent[addr] = true
-		}
-		auditSentMu.Unlock()
-		if isAuditSent {
-			return
-		}
+		auditSent[addr] = true
 
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -892,7 +893,6 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 		}
 		upgrader := spdystream.NewResponseUpgraderWithPings(defaults.HighResPollingPeriod)
 		conn = upgrader.UpgradeResponse(w, req, httpStreamReceived(req.Context(), streamChan))
-
 	}
 
 	if conn == nil {
@@ -900,36 +900,107 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 		return nil, err
 	}
 	defer conn.Close()
-	var (
-		data      httpstream.Stream
-		errStream httpstream.Stream
-	)
+
+	// Create a context for managing goroutines.
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	// Wait for all active port forwards to complete before returning.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	type portStream struct {
+		data       httpstream.Stream
+		error      httpstream.Stream
+		processing bool // Prevent duplicate handlers
+	}
+
+	portStreams := make(map[string]*portStream)
+	var streamsMu sync.Mutex
 
 	for {
 		select {
+		case <-ctx.Done():
+			s.log.InfoContext(ctx, "Context canceled, stopping stream processing")
+			return nil, nil
 		case <-conn.CloseChan():
+			s.log.InfoContext(ctx, "Connection closed")
 			return nil, nil
 		case stream := <-streamChan:
+			port := stream.Headers().Get(portHeader)
+			if port == "" {
+				s.log.WarnContext(ctx, "Received stream without port header")
+				continue
+			}
+
+			streamsMu.Lock()
+			if _, ok := portStreams[port]; !ok {
+				portStreams[port] = &portStream{}
+			}
+
+			ps := portStreams[port]
+
 			switch stream.Headers().Get(StreamType) {
 			case StreamTypeError:
-				errStream = stream
+				ps.error = stream
 			case StreamTypeData:
-				data = stream
+				ps.data = stream
+			default:
+				s.log.WarnContext(ctx, "Unknown stream type", "type", stream.Headers().Get(StreamType))
 			}
-		}
-		if errStream != nil && data != nil {
-			break
-		}
-	}
 
-	buf := make([]byte, 1024)
-	n, err := data.Read(buf)
-	if err != nil {
-		errStream.Write([]byte(err.Error()))
-		return nil, nil
+			// Check whether port is ready to process.
+			if ps.data != nil && ps.error != nil && !ps.processing {
+				ps.processing = true
+
+				// Process each port in a separate goroutine for concurrency testing.
+				wg.Add(1)
+				go func(portNum string, dataStream, errorStream httpstream.Stream) {
+					defer wg.Done()
+					defer dataStream.Close()
+					defer errorStream.Close()
+
+					// Check context canceled.
+					select {
+					case <-ctx.Done():
+						s.log.InfoContext(ctx, "Port forward canceled", "port", portNum)
+						return
+					default:
+					}
+
+					// Read from source.
+					buf := make([]byte, 1024)
+					n, readErr := dataStream.Read(buf)
+					if readErr != nil {
+						// EOF is expected when a client closes a connection.
+						if !errors.Is(readErr, io.EOF) {
+							s.log.ErrorContext(ctx, "Read error", "port", portNum, "error", readErr)
+							if _, writeErr := errorStream.Write([]byte(readErr.Error())); writeErr != nil {
+								s.log.ErrorContext(ctx, "Unable to write error", "error", writeErr)
+							}
+						}
+						return
+					}
+
+					// Add a random delay to increase chances of race condition.
+					time.Sleep(time.Duration(rand.IntN(10)) * time.Millisecond)
+
+					// Write to target.
+					_, writeErr := fmt.Fprint(dataStream, PortForwardPayload, p.ByName("name"), string(buf[:n]))
+					if writeErr != nil {
+						s.log.ErrorContext(ctx, "Unable to write response", "error", writeErr)
+						if _, errWriteErr := errorStream.Write([]byte(writeErr.Error())); errWriteErr != nil {
+							s.log.ErrorContext(ctx, "Unable to write error", "error", errWriteErr)
+						}
+					}
+
+					s.log.InfoContext(ctx, "Port forward completed", "port", portNum)
+				}(port, ps.data, ps.error)
+
+			}
+			streamsMu.Unlock()
+		}
 	}
-	fmt.Fprint(data, PortForwardPayload, p.ByName("name"), string(buf[:n]))
-	return nil, nil
 }
 
 // httpStreamReceived is the httpstream.NewStreamHandler for port


### PR DESCRIPTION
An experimental draft branch.

- Rolled back auditSent mutex fix to validate mock testing
- Added mock test  `TestPortForwardKubeServiceMultiPort`
- Revised kube mock server `portforward` function to process streams in goroutines
- Removed kube integration test
- Restored container webserver to listen on a single port

Relates to:
- PR #57474
- Issue #57242