### PR TITLE
Add `ForRelay` cache and needed permissions

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -343,6 +343,33 @@ type ProxyAccessPoint interface {
 	accessPoint
 }
 
+// ReadRelayAccessPoint is a read only API interface to be used by a Relay
+// service.
+//
+// NOTE: This interface must be a subset of the [*cache.Cache] methods usable in the
+// cache configured by [cache.ForRelay].
+type ReadRelayAccessPoint interface {
+	io.Closer
+	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
+
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool) (types.CertAuthority, error)
+	GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error)
+
+	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
+
+	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
+
+	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+
+	GetRelayServer(ctx context.Context, name string) (*presencev1.RelayServer, error)
+
+	GetRole(ctx context.Context, name string) (types.Role, error)
+
+	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
+
+	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
+}
+
 // ReadRemoteProxyAccessPoint is a read only API interface implemented by a certificate authority (CA) to be
 // used by a teleport.ComponentProxy.
 //

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1097,8 +1097,36 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 					Namespaces: []string{
 						types.Wildcard,
 					},
+					NodeLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					AppLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					DatabaseLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					KubernetesLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
+					WindowsDesktopLabels: types.Labels{
+						types.Wildcard: {types.Wildcard},
+					},
 					Rules: []types.Rule{
-						// TODO(espadolini): define permissions for relay role
+						types.NewRule(types.KindAppServer, services.RO()),
+						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
+						types.NewRule(types.KindClusterAuthPreference, services.RO()),
+						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),
+						types.NewRule(types.KindDatabaseServer, services.RO()),
+						types.NewRule(types.KindEvent, services.RW()),
+						types.NewRule(types.KindKubeServer, services.RO()),
+						types.NewRule(types.KindLock, services.RO()),
+						types.NewRule(types.KindNode, services.RO()),
+						types.NewRule(types.KindRelayServer, services.RO()),
+						types.NewRule(types.KindRole, services.RO()),
+						types.NewRule(types.KindSessionRecordingConfig, services.RO()),
+						types.NewRule(types.KindUser, services.RO()),
+						types.NewRule(types.KindWindowsDesktop, services.RO()),
 					},
 				},
 			},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -276,6 +276,23 @@ func ForProxy(cfg Config) Config {
 	return cfg
 }
 
+// ForRelay sets up the given cache [Config] for use by the Relay cache.
+func ForRelay(cfg Config) Config {
+	cfg.target = "relay"
+	cfg.Watches = []types.WatchKind{
+		{Kind: types.KindCertAuthority, Filter: makeAllKnownCAsFilter().IntoMap()},
+		{Kind: types.KindClusterAuthPreference},
+		{Kind: types.KindClusterNetworkingConfig},
+		{Kind: types.KindNode},
+		{Kind: types.KindRelayServer},
+		{Kind: types.KindRole},
+		{Kind: types.KindSessionRecordingConfig},
+		{Kind: types.KindUser},
+	}
+	cfg.QueueSize = defaults.RelayQueueSize
+	return cfg
+}
+
 // ForRemoteProxy sets up watch configuration for remote proxies.
 func ForRemoteProxy(cfg Config) Config {
 	cfg.target = "remote-proxy"

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1736,6 +1736,7 @@ func TestSetupConfigFns(t *testing.T) {
 
 	setupFuncs := map[string]SetupConfigFn{
 		"ForProxy":          ForProxy,
+		"ForRelay":          ForRelay,
 		"ForRemoteProxy":    ForRemoteProxy,
 		"ForNode":           ForNode,
 		"ForKubernetes":     ForKubernetes,
@@ -1845,6 +1846,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 	cases := map[string]Config{
 		"ForAuth":        ForAuth(Config{}),
 		"ForProxy":       ForProxy(Config{}),
+		"ForRelay":       ForRelay(Config{}),
 		"ForRemoteProxy": ForRemoteProxy(Config{}),
 		"ForNode":        ForNode(Config{}),
 		"ForKubernetes":  ForKubernetes(Config{}),

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -339,6 +339,9 @@ const (
 	// ProxyQueueSize is proxy service queue size
 	ProxyQueueSize = 8192
 
+	// RelayQueueSize is the watcher queue size for the relay cache.
+	RelayQueueSize = 8192
+
 	// UnifiedResourcesQueueSize is the unified resource watcher queue size
 	UnifiedResourcesQueueSize = 8192
 

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -49,6 +49,14 @@ func (process *TeleportProcess) runRelayService() error {
 	}
 	defer conn.Close()
 
+	accessPoint, err := process.newLocalCacheForRelay(conn.Client, []string{teleport.ComponentRelay})
+	if err != nil {
+		return err
+	}
+
+	// TODO(espadolini): use the access point
+	_ = accessPoint
+
 	var relayServer atomic.Pointer[presencev1.RelayServer]
 	relayServer.Store(&presencev1.RelayServer{
 		Kind:    apitypes.KindRelayServer,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2995,6 +2995,20 @@ func (process *TeleportProcess) newLocalCacheForProxy(clt authclient.ClientI, ca
 	return authclient.NewProxyWrapper(clt, cache), nil
 }
 
+func (process *TeleportProcess) newLocalCacheForRelay(clt authclient.ClientI, cacheName []string) (authclient.ReadRelayAccessPoint, error) {
+	// if caching is disabled, return access point
+	if !process.Config.CachePolicy.Enabled {
+		return clt, nil
+	}
+
+	cache, err := process.NewLocalCache(clt, cache.ForRelay, cacheName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return cache, nil
+}
+
 // newLocalCacheForRemoteProxy returns new instance of access point configured for a remote proxy.
 func (process *TeleportProcess) newLocalCacheForRemoteProxy(clt authclient.ClientI, cacheName []string) (authclient.RemoteProxyAccessPoint, error) {
 	// if caching is disabled, return access point


### PR DESCRIPTION
This PR adds a cache definition for the Relay service and permissions for the Relay service to access all resource heartbeats, as well as relay server heartbeats (needed for peering) and a few other necessary bits for routing and general Teleport functions (routing connections needs to evaluate roles for the sake of idle time and connection counts, for example). The cache currently only caches nodes but it will be expanded in the future as the need arises, but this PR establishes slightly broader permissions to have better forwards compatibility.