### PR TITLE
Fix Alt+Click in desktop sessions

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -49,7 +49,7 @@ import {
 } from 'shared/libs/tdp';
 import { TdpError } from 'shared/libs/tdp/client';
 
-import { KeyboardHandler } from './KeyboardHandler';
+import { InputHandler } from './InputHandler';
 import TopBar from './TopBar';
 import useDesktopSession, {
   clipboardSharingMessage,
@@ -109,9 +109,9 @@ export function DesktopSession({
   const [tdpConnectionStatus, setTdpConnectionStatus] =
     useState<TdpConnectionStatus>({ status: '' });
 
-  const keyboardHandler = useRef(new KeyboardHandler());
+  const inputHandler = useRef(new InputHandler());
   useEffect(() => {
-    return () => keyboardHandler.current.dispose();
+    return () => inputHandler.current.dispose();
   }, []);
 
   const [
@@ -243,7 +243,7 @@ export function DesktopSession({
   }, [client, shouldConnect, keyboardLayout]);
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    keyboardHandler.current.handleKeyboardEvent({
+    inputHandler.current.handleInputEvent({
       cli: client,
       e: e.nativeEvent,
       state: ButtonState.DOWN,
@@ -262,7 +262,7 @@ export function DesktopSession({
   }
 
   function handleKeyUp(e: React.KeyboardEvent) {
-    keyboardHandler.current.handleKeyboardEvent({
+    inputHandler.current.handleInputEvent({
       cli: client,
       e: e.nativeEvent,
       state: ButtonState.UP,
@@ -270,7 +270,7 @@ export function DesktopSession({
   }
 
   function handleBlur() {
-    keyboardHandler.current.onFocusOut();
+    inputHandler.current.onFocusOut();
   }
 
   function handleMouseMove(e: React.MouseEvent) {
@@ -281,9 +281,11 @@ export function DesktopSession({
   }
 
   function handleMouseDown(e: React.MouseEvent) {
-    if (e.button === 0 || e.button === 1 || e.button === 2) {
-      client.sendMouseButton(e.button, ButtonState.DOWN);
-    }
+    inputHandler.current.handleInputEvent({
+      cli: client,
+      e: e.nativeEvent,
+      state: ButtonState.DOWN,
+    });
 
     // Opportunistically sync local clipboard to remote while
     // transient user activation is in effect.
@@ -292,9 +294,11 @@ export function DesktopSession({
   }
 
   function handleMouseUp(e: React.MouseEvent) {
-    if (e.button === 0 || e.button === 1 || e.button === 2) {
-      client.sendMouseButton(e.button, ButtonState.UP);
-    }
+    inputHandler.current.handleInputEvent({
+      cli: client,
+      e: e.nativeEvent,
+      state: ButtonState.UP,
+    });
   }
 
   function handleMouseWheel(e: WheelEvent) {

--- a/web/packages/shared/components/DesktopSession/Withholder.test.ts
+++ b/web/packages/shared/components/DesktopSession/Withholder.test.ts
@@ -59,7 +59,7 @@ describe('withholder', () => {
       state: ButtonState.DOWN,
       cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
-    withholder.handleKeyboardEvent(params, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(params, mockHandleKeyboardEvent);
     expect(mockHandleKeyboardEvent).toHaveBeenCalledWith(params);
   });
 
@@ -82,12 +82,12 @@ describe('withholder', () => {
       cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
-    withholder.handleKeyboardEvent(metaDown, mockHandleKeyboardEvent);
-    withholder.handleKeyboardEvent(metaUp, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(metaDown, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(metaUp, mockHandleKeyboardEvent);
 
     expect(mockHandleKeyboardEvent).not.toHaveBeenCalled();
 
-    withholder.handleKeyboardEvent(enterDown, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(enterDown, mockHandleKeyboardEvent);
 
     expect(mockHandleKeyboardEvent).toHaveBeenCalledTimes(3);
     expect(mockHandleKeyboardEvent).toHaveBeenNthCalledWith(1, metaDown);
@@ -107,8 +107,8 @@ describe('withholder', () => {
       cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
 
-    withholder.handleKeyboardEvent(metaParams, mockHandleKeyboardEvent);
-    withholder.handleKeyboardEvent(altParams, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(metaParams, mockHandleKeyboardEvent);
+    withholder.handleInputEvent(altParams, mockHandleKeyboardEvent);
 
     expect(mockHandleKeyboardEvent).not.toHaveBeenCalled();
 
@@ -125,13 +125,32 @@ describe('withholder', () => {
       state: ButtonState.UP,
       cli: new TdpClient(() => null, selectDirectoryInBrowser),
     };
-    withholder.handleKeyboardEvent(metaParams, mockHandleKeyboardEvent);
-    expect((withholder as any).withheldKeys).toHaveLength(1);
+    withholder.handleInputEvent(metaParams, mockHandleKeyboardEvent);
+    expect((withholder as any).withheldInputs).toHaveLength(1);
 
     withholder.cancel();
     jest.advanceTimersByTime(10);
 
     expect(mockHandleKeyboardEvent).not.toHaveBeenCalled();
-    expect((withholder as any).withheldKeys).toHaveLength(0);
+    expect((withholder as any).withheldInputs).toHaveLength(0);
+  });
+
+  it('flushes keys on mouse event', () => {
+    const metaParams = {
+      e: { key: 'Meta' } as KeyboardEvent,
+      state: ButtonState.DOWN,
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
+    };
+    withholder.handleInputEvent(metaParams, mockHandleKeyboardEvent);
+
+    const mouseEvent = {
+      e: { button: 0 } as MouseEvent,
+      state: ButtonState.DOWN,
+      cli: new TdpClient(() => null, selectDirectoryInBrowser),
+    };
+    withholder.handleInputEvent(mouseEvent, mockHandleKeyboardEvent);
+
+    expect(mockHandleKeyboardEvent).toHaveBeenCalledWith(metaParams);
+    expect(mockHandleKeyboardEvent).toHaveBeenCalledWith(mouseEvent);
   });
 });


### PR DESCRIPTION
This PR fixes #50725, where a user couldn't Alt+Click.

This was being blocked by the `Withholder` class that withholds the `Alt` key until another key is pressed to avoid stuck keys. To fix this issue, I modified `Withholder` to also handle mouse events so that when a click is registered it flushes any held keys to the remote desktop.

Before:
Notice that after finish selecting each line and release `Alt`, the VSCode menu items at the top left are underlined showing that `Alt` is only sent to the client after I release it.
https://github.com/user-attachments/assets/873e31b8-07e5-4fde-8285-c9149c4cb384

After:
I start holding `Alt` after selecting the first line, but it isn't sent to the remote desktop until I click on the second line. This shows that `Withholder` logic is maintained until another event comes in.
https://github.com/user-attachments/assets/5fbd091f-044d-43a1-8867-bc046da09931

changelog: Fix Alt+Click not being registered in remote desktop sessions.