### PR TITLE
tctl: support getting and deleting relay_server items

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -297,6 +297,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindInferenceSecret, nil
 	case types.KindInferencePolicy, "inference_policies":
 		return types.KindInferencePolicy, nil
+	case types.KindRelayServer, types.KindRelayServer + "s":
+		return types.KindRelayServer, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -2369,6 +2369,11 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		fmt.Printf("AutoUpdateAgentRollout has been deleted\n")
 	case types.KindHealthCheckConfig:
 		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
+	case types.KindRelayServer:
+		if err := client.DeleteRelayServer(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("relay_server %+q has been deleted\n", rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -3719,6 +3724,22 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 		}
 		return &scopedRoleAssignmentCollection{items: items}, nil
+	case types.KindRelayServer:
+		if rc.ref.Name != "" {
+			rs, err := client.GetRelayServer(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return namedResourceCollection{types.ProtoResource153ToLegacy(rs)}, nil
+		}
+		var c namedResourceCollection
+		for rs, err := range clientutils.Resources(ctx, client.ListRelayServers) {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			c = append(c, types.ProtoResource153ToLegacy(rs))
+		}
+		return c, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
This PR adds support for `tctl get relay_server(/<hostid>)` and `tctl rm relay_server/<hostid>`, and crystallizes the user-visible representation of `relay_server` v1 (i.e. `teleport.presence.v1.RelayServer`) to be the protojson encoding of the message (yamled as necessary).

No support for `tctl create` or `tctl edit` is implemented, deliberately (these resources should only exist as a result of inventory heartbeating, listing and deletion are for troubleshooting and cleaning up).