### PR TITLE
Fix AccessListMember proto conversion for zero timestamps

### DIFF
--- a/api/types/accesslist/convert/v1/member.go
+++ b/api/types/accesslist/convert/v1/member.go
@@ -18,11 +18,11 @@ package v1
 
 import (
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	headerv1 "github.com/gravitational/teleport/api/types/header/convert/v1"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 type MemberOption func(*accesslist.AccessListMember)
@@ -40,8 +40,8 @@ func FromMemberProto(msg *accesslistv1.Member, opts ...MemberOption) (*accesslis
 	member, err := accesslist.NewAccessListMember(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), accesslist.AccessListMemberSpec{
 		AccessList: msg.GetSpec().GetAccessList(),
 		Name:       msg.GetSpec().GetName(),
-		Joined:     msg.GetSpec().GetJoined().AsTime(),
-		Expires:    msg.GetSpec().GetExpires().AsTime(),
+		Joined:     utils.TimeFromProto(msg.GetSpec().GetJoined()),
+		Expires:    utils.TimeFromProto(msg.GetSpec().GetExpires()),
 		Reason:     msg.GetSpec().GetReason(),
 		AddedBy:    msg.GetSpec().GetAddedBy(),
 		// Set it to empty as default.
@@ -90,8 +90,8 @@ func ToMemberProto(member *accesslist.AccessListMember) *accesslistv1.Member {
 		Spec: &accesslistv1.MemberSpec{
 			AccessList:       member.Spec.AccessList,
 			Name:             member.Spec.Name,
-			Joined:           timestamppb.New(member.Spec.Joined),
-			Expires:          timestamppb.New(member.Spec.Expires),
+			Joined:           utils.TimeIntoProto(member.Spec.Joined),
+			Expires:          utils.TimeIntoProto(member.Spec.Expires),
 			Reason:           member.Spec.Reason,
 			AddedBy:          member.Spec.AddedBy,
 			IneligibleStatus: ineligibleStatus,

--- a/api/utils/time.go
+++ b/api/utils/time.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // UTC converts time to UTC timezone
@@ -40,4 +42,29 @@ const HumanTimeFormatString = "Mon Jan _2 15:04 UTC"
 // HumanTimeFormat formats time as recognized by humans
 func HumanTimeFormat(d time.Time) string {
 	return d.Format(HumanTimeFormatString)
+}
+
+// TimeFromProto converts a protobuf Timestamp to a Go time.Time, preserving
+// the zero value across the conversion boundary (standard go/proto timestamp
+// conversion doesn't preserve "zeroness").
+func TimeFromProto(t *timestamppb.Timestamp) time.Time {
+	// use the zero time to represent the nil timestamp. note that this is conceptually distinct
+	// from using t.GetSeconds() == 0 && t.GetNanos() == 0. a timstampb that happens to be created
+	// targeting the unix epoch isn't necessarily equivalent to a zero go timestamp, since the zero
+	// value for the go timestamp isn't the unix epoch.
+	if t == nil || (t.GetSeconds() == 0 && t.GetNanos() == 0) {
+		return time.Time{}
+	}
+
+	return t.AsTime()
+}
+
+// TimeIntoProto converts a Go time.Time to a protobuf Timestamp, preserving
+// the zero value across the conversion boundary (standard go/proto timestamp
+// conversion doesn't preserve "zeroness").
+func TimeIntoProto(t time.Time) *timestamppb.Timestamp {
+	if t.IsZero() {
+		return nil
+	}
+	return timestamppb.New(t)
 }


### PR DESCRIPTION
Otherwise access_list_member.spec.expires is set to 1970-01-01 if not set in terraform manifests causing members to be expired.