### PR TITLE
chore: remove buf local plugin config

### DIFF
--- a/buf-legacy.yaml
+++ b/buf-legacy.yaml
@@ -21,7 +21,6 @@ lint:
     # - COMMENT_MESSAGE
     - COMMENT_RPC
     - COMMENT_SERVICE
-    - PAGINATION_REQUIRED
   except:
     # MINIMAL
     - PACKAGE_DIRECTORY_MATCH
@@ -36,12 +35,3 @@ lint:
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_REQUEST_STANDARD_NAME
     - RPC_RESPONSE_STANDARD_NAME
-plugins:
-  - plugin:
-      - env
-      - GOWORK=off
-      - go
-      - -C
-      - ./build.assets/tooling
-      - run
-      - ./cmd/buf-plugin-linters

--- a/buf.yaml
+++ b/buf.yaml
@@ -17,7 +17,6 @@ lint:
     - COMMENT_RPC
     - COMMENT_SERVICE
     - PACKAGE_NO_IMPORT_CYCLE
-    - PAGINATION_REQUIRED
     - UNARY_RPC
   except:
     - FIELD_NOT_REQUIRED
@@ -84,13 +83,3 @@ breaking:
   ignore:
     # TODO(codingllama): Remove ignore once the PDP API is stable.
     - api/proto/teleport/decision/v1alpha1
-
-plugins:
-  - plugin:
-      - env
-      - GOWORK=off
-      - go
-      - -C
-      - ./build.assets/tooling
-      - run
-      - ./cmd/buf-plugin-linters


### PR DESCRIPTION
This breaks the CI flows for backport linter
runs for breaking changes as buf expects the plugin locally which is not present.

Disable the configuration to unblock.