### PR TITLE
fix teleport-update labeling itself when installing SELinux SSH module

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -383,6 +383,7 @@ func tgzExtractPaths(ent bool) []utils.ExtractPath {
 		{Src: path.Join(prefix, "examples/systemd/teleport.service"), Dst: filepath.Join(serviceDir, serviceName), DirMode: systemDirMode},
 		{Src: path.Join(prefix, "examples"), Skip: true, DirMode: systemDirMode},
 		{Src: path.Join(prefix, "install"), Skip: true, DirMode: systemDirMode},
+		{Src: path.Join(prefix, "install-selinux.sh"), Skip: true, DirMode: systemDirMode},
 		{Src: path.Join(prefix, "README.md"), Dst: "share/README.md", DirMode: systemDirMode},
 		{Src: path.Join(prefix, "CHANGELOG.md"), Dst: "share/CHANGELOG.md", DirMode: systemDirMode},
 		{Src: path.Join(prefix, "VERSION"), Dst: "share/VERSION", DirMode: systemDirMode},

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -246,7 +246,7 @@ func (ns *Namespace) Init() (lockFile string, err error) {
 // Afterwords, Setup reloads systemd and enables the timer with --now.
 func (ns *Namespace) Setup(ctx context.Context, path string, rev Revision, installSELinux bool) error {
 	if installSELinux {
-		if err := ns.installSELinux(ctx); err != nil {
+		if err := ns.installSELinux(ctx, rev); err != nil {
 			ns.log.WarnContext(ctx, "Failed to install SELinux module.", errorKey, err)
 		}
 	} else {
@@ -307,14 +307,15 @@ func (ns *Namespace) Setup(ctx context.Context, path string, rev Revision, insta
 	return nil
 }
 
-func (ns *Namespace) installSELinux(ctx context.Context) error {
+func (ns *Namespace) installSELinux(ctx context.Context, rev Revision) error {
 	ns.log.InfoContext(ctx, "Installing SELinux module.")
 
 	if err := ns.checkSELinux(ctx, true); err != nil {
 		return trace.Wrap(err)
 	}
 
-	fileCtxs, err := selinux.FileContexts(ns.dataDir, ns.configFile)
+	binaryPath := filepath.Join(ns.Dir(), versionsDirName, rev.Dir(), "bin", "teleport")
+	fileCtxs, err := selinux.FileContexts(ns.dataDir, ns.configFile, binaryPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -35,6 +35,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -190,9 +191,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 				SetupVersionEnvVar+"="+rev.Version,
 				SetupFlagsEnvVar+"="+strings.Join(rev.Flags.Strings(), "\n"),
 			)
-			if enableSELinux {
-				cmd.Env = append(cmd.Env, SetupSELinuxSSHEnvVar+"=true")
-			}
+			cmd.Env = append(cmd.Env, SetupSELinuxSSHEnvVar+"="+strconv.FormatBool(enableSELinux))
 			cfg.Log.InfoContext(ctx, "Executing new teleport-update binary to update configuration.")
 			defer cfg.Log.InfoContext(ctx, "Finished executing new teleport-update binary.")
 			return trace.Wrap(cmd.Run())

--- a/lib/selinux/selinux_others.go
+++ b/lib/selinux/selinux_others.go
@@ -34,7 +34,7 @@ func ModuleSource() string {
 }
 
 // FileContexts returns file contexts for the SELinux SSH module.
-func FileContexts(dataDir, configPath string) (string, error) {
+func FileContexts(dataDir, configPath, execPathOverride string) (string, error) {
 	return "", trace.Errorf(errPlatformNotSupportedMsg)
 }
 

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -187,7 +187,8 @@ func Run(args []string) int {
 		Envar(autoupdate.SetupVersionEnvVar).StringVar(&ccfg.ForceVersion)
 	setupCmd.Flag("flag", "Use the provided flags to generate configuration files.").
 		Envar(autoupdate.SetupFlagsEnvVar).StringsVar(&ccfg.ForceFlags)
-	setupCmd.Flag("selinux-ssh", "Install the SELinux module for Teleport SSH.").Hidden().BoolVar(&ccfg.SELinuxSSH)
+	setupCmd.Flag("selinux-ssh", "Install the SELinux module for Teleport SSH.").
+		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).BoolVar(&ccfg.SELinuxSSH)
 
 	statusCmd := app.Command("status", "Show Teleport agent auto-update status.")
 	statusCmd.Flag("err-if-should-update-now",

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1157,7 +1157,7 @@ func onSELinuxFileContexts(configPath string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fileContexts, err := selinux.FileContexts(cfg.DataDir, configPath)
+	fileContexts, err := selinux.FileContexts(cfg.DataDir, configPath, "")
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
I changed the file context logic in #55307 to simplify labeling the Teleport binary so that `os.Executable` is used to get the exact path, but didn't consider that this wouldn't work when `teleport-update` is calls the function. 

Also allows the `selinux-ssh` flag to be set by an env var when the `setup` subcommand is passed, and skips extracting the SELinux install script as it's not needed.