### PR TITLE
[v18] allow teleport-update to configure Teleport SSH SELinux module

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -83,6 +84,9 @@ type UpdateSpec struct {
 	Enabled bool `yaml:"enabled"`
 	// Pinned controls whether the active_version is pinned.
 	Pinned bool `yaml:"pinned"`
+	// SELinuxSSH controls whether an SELinux module will be installed to
+	// constrain Teleport SSH.
+	SELinuxSSH bool `yaml:"selinux_ssh,omitempty"`
 }
 
 // UpdateStatus describes the status field in update.yaml.
@@ -238,6 +242,12 @@ func updateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
 	}
 	if override.Pinned {
 		spec.Pinned = true
+	}
+	if override.SELinuxSSHChanged {
+		spec.SELinuxSSH = override.SELinuxSSH
+	}
+	if spec.SELinuxSSH && runtime.GOOS != "linux" {
+		return trace.BadParameter("SELinux is only supported on Linux")
 	}
 	return nil
 }

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -27,6 +27,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -35,10 +36,13 @@ import (
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/autoupdate"
 	"github.com/gravitational/teleport/lib/config/systemd"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/selinux"
 	libutils "github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/versioncontrol"
 )
 
 // Base paths for constructing namespaced directories.
@@ -116,6 +120,10 @@ ExecStart=-/bin/echo "The teleport-upgrade script has been disabled by teleport-
 	needrestartConfTemplate = `$nrconf{override_rc}{qr(^{{replace .TeleportService "." "\\."}})} = 0;
 `
 )
+
+// standard Makefile included in 'selinux-policy-devel' RPM package
+// used to build SELinux modules
+const selinuxMakefile = "/usr/share/selinux/devel/Makefile"
 
 type confParams struct {
 	TeleportService   string
@@ -236,7 +244,17 @@ func (ns *Namespace) Init() (lockFile string, err error) {
 
 // Setup installs service and timer files for the teleport-update binary.
 // Afterwords, Setup reloads systemd and enables the timer with --now.
-func (ns *Namespace) Setup(ctx context.Context, path string, rev Revision) error {
+func (ns *Namespace) Setup(ctx context.Context, path string, rev Revision, installSELinux bool) error {
+	if installSELinux {
+		if err := ns.installSELinux(ctx); err != nil {
+			ns.log.WarnContext(ctx, "Failed to install SELinux module.", errorKey, err)
+		}
+	} else {
+		if err := ns.removeSELinux(ctx); err != nil {
+			ns.log.WarnContext(ctx, "Failed to remove SELinux module.", errorKey, err)
+		}
+	}
+
 	if ok, err := hasSystemD(); err == nil && !ok {
 		ns.log.WarnContext(ctx, "Systemd is not running, skipping updater installation.")
 		return nil
@@ -285,12 +303,185 @@ func (ns *Namespace) Setup(ctx context.Context, path string, rev Revision) error
 			}
 		}
 	}
+
+	return nil
+}
+
+func (ns *Namespace) installSELinux(ctx context.Context) error {
+	ns.log.InfoContext(ctx, "Installing SELinux module.")
+
+	if err := ns.checkSELinux(ctx, true); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fileCtxs, err := selinux.FileContexts(ns.dataDir, ns.configFile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "selinux-*")
+	if err != nil {
+		return trace.Wrap(err, "failed to create temporary directory")
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = os.WriteFile(filepath.Join(tempDir, "teleport_ssh.fc"), []byte(fileCtxs), 0440)
+	if err != nil {
+		return trace.Wrap(err, "failed to write module source file")
+	}
+
+	err = os.WriteFile(filepath.Join(tempDir, "teleport_ssh.te"), []byte(selinux.ModuleSource()), 0440)
+	if err != nil {
+		return trace.Wrap(err, "failed to write module source file")
+	}
+
+	cmd := localExec{
+		Dir:      tempDir,
+		Log:      ns.log,
+		ErrLevel: slog.LevelDebug,
+		OutLevel: slog.LevelDebug,
+	}
+
+	// Build and install the module, then ensure files are properly labeled.
+	_, err = cmd.Run(ctx, "make", "-f", selinuxMakefile, "teleport_ssh.pp")
+	if err != nil {
+		return trace.Wrap(err, "failed to build module")
+	}
+
+	_, err = cmd.Run(ctx, "semodule", "-i", "teleport_ssh.pp")
+	if err != nil {
+		return trace.Wrap(err, "failed to install module")
+	}
+
+	if err := ns.createAndLabelDirs(ctx, cmd); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (ns *Namespace) createAndLabelDirs(ctx context.Context, cmd localExec) error {
+	// Create the teleport-upgrade and data dirs ahead of time so we
+	// can ensure they exist when we label them.
+	if err := os.MkdirAll(versioncontrol.UnitConfigDir, defaults.DirectoryPermissions); err != nil {
+		ns.log.WarnContext(ctx, "Failed to create teleport-upgrade directory.", errorKey, err)
+	}
+	if err := os.MkdirAll(ns.dataDir, teleport.PrivateDirMode); err != nil {
+		ns.log.WarnContext(ctx, "Failed to create teleport data directory.", errorKey, err)
+	}
+
+	dirsToLabel := []string{
+		filepath.Clean(ns.installDir),
+		ns.dataDir,
+		versioncontrol.UnitConfigDir,
+	}
+	// Create an empty teleport.yaml config file if it doesn't exist, and
+	// only attempt to label it if it exists.
+	if libutils.FileExists(ns.configFile) {
+		dirsToLabel = append(dirsToLabel, filepath.Dir(ns.configFile))
+	} else {
+		confFile, err := os.OpenFile(ns.configFile, os.O_RDONLY|os.O_CREATE|os.O_EXCL, 0o640)
+		if err != nil {
+			ns.log.WarnContext(ctx, "Failed to create teleport.yaml.", errorKey, err, "path", ns.configFile)
+			ns.log.WarnContext(ctx, "You will likely need to create teleport.yaml and re-run 'sudo teleport-update enable' for Teleport SSH to work correctly with SELinux.")
+		} else {
+			confFile.Close()
+			dirsToLabel = append(dirsToLabel, filepath.Dir(ns.configFile))
+			ns.log.WarnContext(ctx, "Created an empty teleport.yaml.", "path", ns.configFile)
+			ns.log.WarnContext(ctx, "If you move or copy another file onto this file you will likely need to re-run 'sudo teleport-update enable' for Teleport SSH to work correctly with SELinux.")
+		}
+	}
+
+	labelArgs := append([]string{"-rv"}, dirsToLabel...)
+	_, err := cmd.Run(ctx, "restorecon", labelArgs...)
+	if err != nil {
+		return trace.Wrap(err, "failed to restore file contexts")
+	}
+
+	return nil
+}
+
+func (ns *Namespace) removeSELinux(ctx context.Context) error {
+	installed, err := selinux.ModuleInstalled()
+	if err != nil {
+		return trace.Wrap(err, "failed to check if SELinux module is installed")
+	}
+	if !installed {
+		ns.log.DebugContext(ctx, "SELinux module is not installed.")
+		return nil
+	}
+
+	ns.log.InfoContext(ctx, "Removing SELinux module.")
+
+	if err := ns.checkSELinux(ctx, false); err != nil {
+		return trace.Wrap(err)
+	}
+
+	cmd := localExec{
+		Log:      ns.log,
+		ErrLevel: slog.LevelDebug,
+		OutLevel: slog.LevelDebug,
+	}
+
+	removeOutput, err := cmd.Output(ctx, "semodule", "-r", "teleport_ssh")
+	if err != nil {
+		// If the module is not installed, return without an error.
+		if bytes.Contains(removeOutput, []byte("(No such file or directory).")) {
+			return nil
+		}
+		return trace.Wrap(err, "failed to remove module")
+	}
+
+	_, err = cmd.Run(ctx, "restorecon", "-rv", filepath.Clean(ns.installDir), ns.dataDir, filepath.Dir(ns.configFile))
+	if err != nil {
+		return trace.Wrap(err, "failed to restore file contexts")
+	}
+
+	return nil
+}
+
+func (ns *Namespace) checkSELinux(ctx context.Context, installing bool) error {
+	// Ensure necessary files and binaries exist for building a module and
+	// inform the user what packages need to be installed if they can't be
+	// found.
+	if installing {
+		_, err := exec.LookPath("make")
+		if err != nil {
+			ns.log.ErrorContext(ctx, "Failed to find 'make', you may need to install the 'make' package.")
+			return trace.Wrap(err)
+		}
+		if !libutils.FileExists(selinuxMakefile) {
+			ns.log.ErrorContext(ctx, "Failed to find the SELinux Makefile, you may need to install the 'selinux-policy-devel' package.")
+			return trace.NotFound("failed to find %s", selinuxMakefile)
+		}
+	}
+	_, err := exec.LookPath("semodule")
+	if err != nil {
+		ns.log.ErrorContext(ctx, "Failed to find 'semodule', you may need to install the 'policycoreutils' package.")
+		return trace.Wrap(err)
+	}
+	_, err = exec.LookPath("restorecon")
+	if err != nil {
+		ns.log.ErrorContext(ctx, "Failed to find 'restorecon', you may need to install the 'policycoreutils' package.")
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 
 // Teardown removes all traces of the auto-updater, including its configuration.
 // Teardown does not verify that the removed files were created by teleport-update.
 func (ns *Namespace) Teardown(ctx context.Context) error {
+	modInstalled, err := selinux.ModuleInstalled()
+	if err != nil {
+		return trace.Wrap(err, "failed to check if SELinux module is installed")
+	}
+	if modInstalled {
+		if err := ns.removeSELinux(ctx); err != nil {
+			ns.log.WarnContext(ctx, "Failed to remove SELinux module.", errorKey, err)
+		}
+	}
+
 	if ok, err := hasSystemD(); err == nil && !ok {
 		ns.log.WarnContext(ctx, "Systemd is not running, skipping updater removal.")
 		if err := os.RemoveAll(ns.Dir()); err != nil {

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/install_selinux_from_file.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/install_selinux_from_file.golden
@@ -1,0 +1,14 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    path: /usr/local/bin
+    enabled: false
+    pinned: false
+    selinux_ssh: true
+status:
+    id_file: updater-id-file
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/install_selinux_from_user.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/install_selinux_from_user.golden
@@ -1,0 +1,14 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    path: /usr/local/bin
+    enabled: false
+    pinned: false
+    selinux_ssh: true
+status:
+    id_file: updater-id-file
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -840,12 +840,12 @@ func TestUpdater_Update(t *testing.T) {
 				},
 			}
 			var restarted bool
-			updater.ReexecSetup = func(_ context.Context, path string, rev Revision, reload bool) error {
+			updater.ReexecSetup = func(_ context.Context, path string, rev Revision, _ bool, reload bool) error {
 				restarted = reload
 				setupCalls++
 				return tt.setupErr
 			}
-			updater.SetupNamespace = func(_ context.Context, path string, rev Revision) error {
+			updater.SetupNamespace = func(_ context.Context, path string, rev Revision, _ bool) error {
 				revertSetupCalls++
 				return nil
 			}
@@ -1429,6 +1429,8 @@ func TestUpdater_Install(t *testing.T) {
 		reloadCalls       int
 		revertCalls       int
 		setupCalls        int
+		selinuxInstalls   int
+		selinuxRemovals   int
 		restarted         bool
 		errMatch          string
 	}{
@@ -1644,6 +1646,7 @@ func TestUpdater_Install(t *testing.T) {
 			revertCalls:       1,
 			setupCalls:        1,
 			reloadCalls:       1,
+			selinuxRemovals:   1,
 			restarted:         true,
 			errMatch:          "setup error",
 		},
@@ -1664,6 +1667,7 @@ func TestUpdater_Install(t *testing.T) {
 			requestGroup:      "default",
 			revertCalls:       1,
 			setupCalls:        1,
+			selinuxRemovals:   1,
 			errMatch:          "setup error",
 		},
 		{
@@ -1687,6 +1691,54 @@ func TestUpdater_Install(t *testing.T) {
 			linkedRevision:    NewRevision("16.3.0", 0),
 			requestGroup:      "default",
 			setupCalls:        1,
+			restarted:         true,
+		},
+		{
+			name: "install selinux from file",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					SELinuxSSH: true,
+				},
+				Status: UpdateStatus{
+					Active: NewRevision("old-version", 0),
+				},
+			},
+
+			installedRevision: NewRevision("16.3.0", 0),
+			installedBaseURL:  autoupdate.DefaultBaseURL,
+			linkedRevision:    NewRevision("16.3.0", 0),
+			requestGroup:      "default",
+			setupCalls:        1,
+			selinuxInstalls:   1,
+			restarted:         true,
+		},
+		{
+			name: "install selinux from user",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					SELinuxSSH: false,
+				},
+				Status: UpdateStatus{
+					Active: NewRevision("old-version", 0),
+				},
+			},
+			userCfg: OverrideConfig{
+				UpdateSpec: UpdateSpec{
+					SELinuxSSH: true,
+				},
+				SELinuxSSHChanged: true,
+			},
+
+			installedRevision: NewRevision("16.3.0", 0),
+			installedBaseURL:  autoupdate.DefaultBaseURL,
+			linkedRevision:    NewRevision("16.3.0", 0),
+			requestGroup:      "default",
+			setupCalls:        1,
+			selinuxInstalls:   1,
 			restarted:         true,
 		},
 	}
@@ -1752,6 +1804,8 @@ func TestUpdater_Install(t *testing.T) {
 				reloadCalls       int
 				setupCalls        int
 				revertSetupCalls  int
+				selinuxInstalls   int
+				selinuxRemovals   int
 			)
 			updater.Installer = &testInstaller{
 				FuncInstall: func(_ context.Context, rev Revision, baseURL string, force bool) error {
@@ -1793,13 +1847,21 @@ func TestUpdater_Install(t *testing.T) {
 				},
 			}
 			var restarted bool
-			updater.ReexecSetup = func(_ context.Context, path string, rev Revision, reload bool) error {
+			updater.ReexecSetup = func(_ context.Context, path string, rev Revision, installSELinux bool, reload bool) error {
 				setupCalls++
+				if installSELinux {
+					selinuxInstalls++
+				}
 				restarted = reload
 				return tt.setupErr
 			}
-			updater.SetupNamespace = func(_ context.Context, path string, rev Revision) error {
+			updater.SetupNamespace = func(_ context.Context, path string, rev Revision, installSELinux bool) error {
 				revertSetupCalls++
+				if installSELinux {
+					selinuxInstalls++
+				} else {
+					selinuxRemovals++
+				}
 				return nil
 			}
 
@@ -1821,6 +1883,8 @@ func TestUpdater_Install(t *testing.T) {
 			require.Equal(t, tt.revertCalls, revertSetupCalls)
 			require.Equal(t, tt.revertCalls, revertFuncCalls)
 			require.Equal(t, tt.setupCalls, setupCalls)
+			require.Equal(t, tt.selinuxInstalls, selinuxInstalls)
+			require.Equal(t, tt.selinuxRemovals, selinuxRemovals)
 			require.Equal(t, tt.restarted, restarted)
 
 			data, err := os.ReadFile(cfgPath)
@@ -1892,12 +1956,15 @@ func TestUpdater_Setup(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		restart    bool
-		present    bool
-		setupErr   error
-		presentErr error
-		reloadErr  error
+		name           string
+		cfg            *UpdateConfig // nil -> file not present
+		restart        bool
+		present        bool
+		installSELinux bool
+		removeSELinux  bool
+		setupErr       error
+		presentErr     error
+		reloadErr      error
 
 		errMatch string
 	}{
@@ -1966,11 +2033,65 @@ func TestUpdater_Setup(t *testing.T) {
 			reloadErr: errors.New("some error"),
 			errMatch:  "some error",
 		},
+		{
+			name:           "install selinux",
+			installSELinux: true,
+			restart:        false,
+			present:        true,
+		},
+		{
+			name: "install selinux false in file",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					SELinuxSSH: false,
+				},
+			},
+			installSELinux: true,
+			restart:        false,
+			present:        true,
+		},
+		{
+			name: "remove selinux",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					SELinuxSSH: true,
+				},
+			},
+			installSELinux: false,
+			removeSELinux:  true,
+			restart:        false,
+			present:        true,
+		},
+		{
+			name: "selinux no-op",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					SELinuxSSH: false,
+				},
+			},
+			installSELinux: false,
+			removeSELinux:  false,
+			restart:        false,
+			present:        true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ns := &Namespace{}
+			dir := t.TempDir()
+			ns := &Namespace{
+				installDir: dir,
+			}
+			_, err := ns.Init()
+			require.NoError(t, err)
+			cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{}, ns)
 			require.NoError(t, err)
 
@@ -1982,8 +2103,9 @@ func TestUpdater_Setup(t *testing.T) {
 					return tt.present, tt.presentErr
 				},
 			}
-			updater.SetupNamespace = func(_ context.Context, path string, rev Revision) error {
+			updater.SetupNamespace = func(_ context.Context, path string, rev Revision, installSELinux bool) error {
 				require.Equal(t, "test", path)
+				require.Equal(t, tt.installSELinux, installSELinux)
 				return tt.setupErr
 			}
 			updater.WriteTeleportService = func(_ context.Context, path string, rev Revision) error {
@@ -1992,8 +2114,16 @@ func TestUpdater_Setup(t *testing.T) {
 				return tt.setupErr
 			}
 
+			// Create config file only if provided in test case
+			if tt.cfg != nil {
+				b, err := yaml.Marshal(tt.cfg)
+				require.NoError(t, err)
+				err = os.WriteFile(cfgPath, b, 0600)
+				require.NoError(t, err)
+			}
+
 			ctx := context.Background()
-			err = updater.Setup(ctx, "test", Revision{Version: "version"}, tt.restart)
+			err = updater.Setup(ctx, "test", Revision{Version: "version"}, tt.installSELinux, tt.restart)
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)

--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -165,7 +165,7 @@ func CheckConfiguration(ensureEnforced bool, logger *slog.Logger) error {
 	}
 
 	if !installed {
-		return trace.Errorf("the SSH SELinux module %s is not installed", moduleName)
+		return trace.NotFound("the SSH SELinux module %s is not installed", moduleName)
 	}
 	if disabled {
 		return trace.Errorf("the SSH SELinux module %s is disabled", moduleName)
@@ -215,6 +215,22 @@ func diagnoseWrongDomain(procCtx *selinuxContext, logger *slog.Logger) error {
 	}
 
 	return fallbackErr
+}
+
+// ModuleInstalled returns true if the SSH SELinux module is installed.
+func ModuleInstalled() (bool, error) {
+	selinuxType, err := readConfig(selinuxTypeTag)
+	if err != nil {
+		return false, trace.Wrap(err, "failed to find SELinux type")
+	}
+
+	modulesDir := filepath.Join(selinuxRoot, selinuxType, "active/modules")
+	installed, _, _, err := moduleStatus(modulesDir)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return installed, nil
 }
 
 func moduleStatus(modulesDir string) (installed bool, disabled bool, permissive bool, err error) {

--- a/lib/selinux/selinux_others.go
+++ b/lib/selinux/selinux_others.go
@@ -44,6 +44,11 @@ func CheckConfiguration(ensureEnforced bool, logger *slog.Logger) error {
 	return trace.Errorf(errPlatformNotSupportedMsg)
 }
 
+// ModuleInstalled returns true if the SSH SELinux module is installed.
+func ModuleInstalled() (bool, error) {
+	return false, trace.Errorf(errPlatformNotSupportedMsg)
+}
+
 // UserContext returns the SELinux context that should be used when
 // creating processes as a certain user.
 func UserContext(login string) (string, error) {

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -137,6 +137,8 @@ func Run(args []string) int {
 		Hidden().BoolVar(&ccfg.SelfSetup)
 	enableCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
 		Hidden().StringVar(&ccfg.Path)
+	enableCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
+		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 
 	disableCmd := app.Command("disable", "Disable agent managed updates. Does not affect the active installation of Teleport.")
 
@@ -159,6 +161,8 @@ func Run(args []string) int {
 		Hidden().BoolVar(&ccfg.SelfSetup)
 	pinCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
 		Hidden().StringVar(&ccfg.Path)
+	pinCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
+		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 
 	unpinCmd := app.Command("unpin", "Unpin the current version, allowing it to be updated.")
 
@@ -183,6 +187,7 @@ func Run(args []string) int {
 		Envar(autoupdate.SetupVersionEnvVar).StringVar(&ccfg.ForceVersion)
 	setupCmd.Flag("flag", "Use the provided flags to generate configuration files.").
 		Envar(autoupdate.SetupFlagsEnvVar).StringsVar(&ccfg.ForceFlags)
+	setupCmd.Flag("selinux-ssh", "Install the SELinux module for Teleport SSH.").Hidden().BoolVar(&ccfg.SELinuxSSH)
 
 	statusCmd := app.Command("status", "Show Teleport agent auto-update status.")
 	statusCmd.Flag("err-if-should-update-now",
@@ -478,7 +483,7 @@ func cmdSetup(ctx context.Context, ccfg *cliConfig) error {
 	}
 	flags := common.NewInstallFlagsFromStrings(ccfg.ForceFlags)
 	rev := autoupdate.NewRevision(ccfg.ForceVersion, flags)
-	err = updater.Setup(ctx, ccfg.Path, rev, ccfg.Reload)
+	err = updater.Setup(ctx, ccfg.Path, rev, ccfg.SELinuxSSH, ccfg.Reload)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/54108.

changelog: add SSH SELinux module management to teleport-update