### PR TITLE
Add aws roles anywhere profiles enrollment view

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.story.tsx
@@ -1,0 +1,184 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+
+import { Info } from 'design/Alert';
+import { CollapsibleInfoSection as CollapsibleInfoSectionComponent } from 'design/CollapsibleInfoSection';
+import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
+
+import cfg from 'teleport/config';
+import { Access } from 'teleport/Integrations/Enroll/AwsConsole/Access/Access';
+import { makeAwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { IntegrationKind } from 'teleport/services/integrations';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
+
+export default {
+  title: 'Teleport/Integrations/Enroll/AwsConsole/ConfigureAccess',
+};
+
+const raName = 'test-ra';
+
+const initialEntries = [
+  {
+    pathname: cfg.getIntegrationEnrollRoute(IntegrationKind.AWSRa, 'access'),
+    state: {
+      integrationName: raName,
+      trustAnchorArn: 'trust-anchor-arn',
+      syncRoleArn: 'sync-role-arn',
+      syncProfileArn: 'sync-profile-arn',
+    },
+  },
+];
+
+export const NoProfiles = () => (
+  <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()} path="">
+    <InfoGuidePanelProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Access />
+      </MemoryRouter>
+    </InfoGuidePanelProvider>
+  </MockAwsOidcStatusProvider>
+);
+NoProfiles.parameters = {
+  msw: {
+    handlers: [
+      http.post(cfg.getAwsRolesAnywhereProfilesUrl(raName), () => {
+        return HttpResponse.json({
+          profiles: [],
+        });
+      }),
+    ],
+  },
+};
+
+export const WithProfiles = () => (
+  <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()} path="">
+    <InfoGuidePanelProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <CollapsibleInfoSectionComponent openLabel="Devs Instructions">
+          <Info
+            kind="info"
+            details="(Devs) Success is a redirect that is not yet implemented, that is not mocked here"
+          >
+            Case: Success
+          </Info>
+          <Info
+            kind="danger"
+            details="(Devs) Add a label with `baz` and submit to see filter error formatting"
+          >
+            Case: Test error
+          </Info>
+        </CollapsibleInfoSectionComponent>
+        <Access />
+      </MemoryRouter>
+    </InfoGuidePanelProvider>
+  </MockAwsOidcStatusProvider>
+);
+WithProfiles.parameters = {
+  msw: {
+    handlers: [
+      http.post(cfg.getAwsRolesAnywhereProfilesUrl(raName), () => {
+        return HttpResponse.json({
+          profiles: [
+            {
+              arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo',
+              enabled: true,
+              name: raName,
+              acceptRoleSessionName: false,
+              tags: [{ foo: 'bar' }, { baz: 'qux' }, { TagA: 1 }],
+              roles: ['RoleA', 'RoleC'],
+            },
+            {
+              arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/bar',
+              enabled: true,
+              name: raName,
+              acceptRoleSessionName: false,
+              tags: [{ foo2: 'bar2' }, { baz2: 'qux2' }, { TagA: 2 }],
+              roles: ['RoleB', 'RoleB'],
+            },
+          ],
+        });
+      }),
+      http.post(cfg.getIntegrationsUrl(), () => {
+        return HttpResponse.json(
+          {
+            error: { message: 'Filter baz invalid.' },
+          },
+          { status: 400 }
+        );
+      }),
+    ],
+  },
+};
+
+export const WithoutAccess = () => {
+  const acl = makeAcl({
+    integrations: {
+      ...defaultAccess,
+    },
+  });
+
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      path=""
+      customAcl={acl}
+    >
+      <InfoGuidePanelProvider>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Access />
+        </MemoryRouter>
+      </InfoGuidePanelProvider>
+    </MockAwsOidcStatusProvider>
+  );
+};
+
+const missingState = [
+  {
+    pathname: cfg.getIntegrationEnrollRoute(IntegrationKind.AWSRa, 'access'),
+    state: {
+      integrationName: raName,
+      syncRoleArn: 'sync-role-arn',
+      syncProfileArn: 'sync-profile-arn',
+    },
+  },
+];
+
+export const MissingState = () => (
+  <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()} path="">
+    <InfoGuidePanelProvider>
+      <MemoryRouter initialEntries={missingState}>
+        <Access />
+      </MemoryRouter>
+    </InfoGuidePanelProvider>
+  </MockAwsOidcStatusProvider>
+);
+MissingState.parameters = {
+  msw: {
+    handlers: [
+      http.post(cfg.getAwsRolesAnywhereProfilesUrl(raName), () => {
+        return HttpResponse.json({
+          profiles: [],
+        });
+      }),
+    ],
+  },
+};

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { fireEvent, render, userEvent } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport/index';
+import { Access } from 'teleport/Integrations/Enroll/AwsConsole/Access/Access';
+import { makeAwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { integrationService } from 'teleport/services/integrations';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const initialEntries = [
+  {
+    state: {
+      integrationName: 'test',
+      trustAnchorArn: 'trust-anchor-arn',
+      syncRoleArn: 'sync-role-arn',
+      syncProfileArn: 'sync-profile-arn',
+    },
+  },
+];
+
+test('flows through profiles configuration', async () => {
+  const user = userEvent.setup();
+
+  jest.spyOn(integrationService, 'awsRolesAnywhereProfiles').mockResolvedValue({
+    profiles: [
+      {
+        arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/foo',
+        enabled: true,
+        name: 'test',
+        acceptRoleSessionName: false,
+        tags: ['foo:bar', 'baz:qux', 'TagA:1'],
+        roles: ['RoleA', 'RoleC'],
+      },
+      {
+        arn: 'arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/bar',
+        enabled: true,
+        name: 'test',
+        acceptRoleSessionName: false,
+        tags: ['foo2:bar2', 'baz2:qux2', 'TagA:2'],
+        roles: ['RoleB', 'RoleB'],
+      },
+    ],
+  } as any);
+  const createSpy = jest
+    .spyOn(integrationService, 'createIntegration')
+    .mockResolvedValue({} as any);
+
+  render(
+    <ContextProvider ctx={createTeleportContext()}>
+      <QueryClientProvider client={queryClient}>
+        <MockAwsOidcStatusProvider
+          value={makeAwsOidcStatusContextState()}
+          path=""
+        >
+          <MemoryRouter initialEntries={initialEntries}>
+            <Access />
+          </MemoryRouter>
+        </MockAwsOidcStatusProvider>
+      </QueryClientProvider>
+    </ContextProvider>
+  );
+
+  await screen.findByText('Import All Profiles');
+  expect(screen.getByText('Configure Access')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Enable Sync' })).toBeEnabled();
+  expect(screen.queryByText('Filter by Profile Name')).not.toBeInTheDocument();
+  expect(screen.getByTestId('toggle')).toBeEnabled();
+  await user.click(screen.getByTestId('toggle'));
+  expect(screen.getByText('Filter by Profile Name')).toBeInTheDocument();
+
+  await user.type(screen.getByLabelText('Filter by Profile Name'), 'test-*');
+  fireEvent.keyDown(screen.getByLabelText('Filter by Profile Name'), {
+    key: 'Enter',
+  });
+  await user.click(screen.getByRole('button', { name: 'Enable Sync' }));
+
+  expect(createSpy).toHaveBeenCalledTimes(1);
+  expect(createSpy).toHaveBeenCalledWith({
+    awsRa: {
+      profileSyncConfig: {
+        enabled: true,
+        profileAcceptsRoleSessionName: false,
+        profileArn: 'sync-profile-arn',
+        profileNameFilters: ['test-*'],
+        roleArn: 'sync-role-arn',
+      },
+      trustAnchorArn: 'trust-anchor-arn',
+    },
+    name: 'test',
+    subKind: 'aws-ra',
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Access.tsx
@@ -1,0 +1,256 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router';
+
+import { CardTile, ResourceIcon } from 'design';
+import * as Alerts from 'design/Alert';
+import { Alert } from 'design/Alert';
+import Box from 'design/Box';
+import { ButtonBorder, ButtonPrimary, ButtonSecondary } from 'design/Button';
+import Flex from 'design/Flex';
+import { Indicator } from 'design/Indicator';
+import { H2, H3, P2 } from 'design/Text';
+import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide';
+
+import { FeatureBox } from 'teleport/components/Layout';
+import cfg from 'teleport/config';
+import { Guide } from 'teleport/Integrations/Enroll/AwsConsole/Access/Guide';
+import { Profiles } from 'teleport/Integrations/Enroll/AwsConsole/Access/Profiles';
+import { ProfilesFilterOption } from 'teleport/Integrations/Enroll/AwsConsole/Access/ProfilesFilter';
+import { rolesAnywhereCreateProfile } from 'teleport/Integrations/Enroll/awsLinks';
+import { ApiError } from 'teleport/services/api/parseError';
+import {
+  IntegrationKind,
+  integrationService,
+} from 'teleport/services/integrations';
+import useTeleport from 'teleport/useTeleport';
+
+export function Access() {
+  const ctx = useTeleport();
+  const integrationsAccess = ctx.storeUser.getIntegrationsAccess();
+  const canEnroll = integrationsAccess.create;
+  const clusterId = ctx.storeUser.getClusterId();
+  const resourceRoute = cfg.getUnifiedResourcesRoute(clusterId);
+
+  const history = useHistory();
+  const location = useLocation<{
+    integrationName?: string;
+    trustAnchorArn?: string;
+    syncRoleArn?: string;
+    syncProfileArn?: string;
+  }>();
+
+  const {
+    integrationName = '',
+    trustAnchorArn = '',
+    syncRoleArn = '',
+    syncProfileArn = '',
+  } = location.state;
+  const [syncAll, setSyncAll] = useState(true);
+  const [filters, setFilters] = useState<ProfilesFilterOption[]>([]);
+
+  // todo (michellescripts) list profiles as written today fails
+  //   meeting with marcoandredinis next week to correct
+  const { status, error, data, isFetching, refetch } = useQuery({
+    enabled: canEnroll,
+    queryKey: ['profiles', filters],
+    gcTime: 0,
+    queryFn: () =>
+      integrationService.awsRolesAnywhereProfiles({
+        integrationName: integrationName,
+        filters,
+      }),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000, // Cached pages are valid for 30 seconds
+  });
+
+  // todo (michellescripts) create as written today fails
+  //   meeting with marcoandredinis next week to correct
+  const submitSync = useMutation({
+    mutationFn: () =>
+      integrationService
+        .createIntegration({
+          name: integrationName,
+          subKind: IntegrationKind.AWSRa,
+          awsRa: {
+            trustAnchorArn: trustAnchorArn,
+            profileSyncConfig: {
+              enabled: true, // must be true for creation
+              profileArn: syncProfileArn,
+              profileAcceptsRoleSessionName: false, // not necessary for creation
+              roleArn: syncRoleArn,
+              profileNameFilters:
+                filters.length > 0 ? filters.map(f => f.value) : ['*'],
+            },
+          },
+        })
+        .then(data => data),
+    onSuccess: () => {
+      //   todo (michellescripts) redirect to success view in follow up PR
+    },
+    onError: (e: ApiError) => {
+      // Set validity on invalid filter based on API error
+      const messages = e.messages.join(' ');
+      const next = filters.map(f => {
+        if (e.message.includes(f.value) || messages.includes(f.value)) {
+          return {
+            ...f,
+            invalid: true,
+          };
+        } else {
+          return f;
+        }
+      });
+
+      setFilters(next);
+    },
+  });
+
+  useEffect(() => {
+    // clear filters on syncAll
+    if (syncAll) {
+      setFilters([]);
+    }
+  }, [syncAll]);
+
+  if (!canEnroll) {
+    return (
+      <FeatureBox>
+        <Alert kind="info" mt={4}>
+          You do not have permission to enroll integrations. Missing role
+          permissions: <code>integrations.create</code>
+        </Alert>
+      </FeatureBox>
+    );
+  }
+
+  if (!integrationName || !trustAnchorArn || !syncRoleArn || !syncProfileArn) {
+    return (
+      <FeatureBox>
+        <Alert kind="info" mt={4}>
+          Missing form data, please go back and restart enrollment.
+        </Alert>
+        <ButtonPrimary
+          onClick={() =>
+            history.push(
+              cfg.getIntegrationEnrollRoute(
+                IntegrationKind.AWSRa,
+                'integration'
+              )
+            )
+          }
+          width="100px"
+        >
+          Back
+        </ButtonPrimary>
+      </FeatureBox>
+    );
+  }
+
+  const nothingToSync =
+    status === 'success' && (!data.profiles || data.profiles.length === 0);
+  return (
+    <>
+      <Flex mt={3} justifyContent="space-between" alignItems="center">
+        <H2>Configure Access</H2>
+        <InfoGuideButton
+          config={{
+            guide: <Guide resourcesRoute={resourceRoute} />,
+          }}
+        />
+      </Flex>
+      <P2 mb={3}>
+        Import and synchronize AWS IAM Roles Anywhere Profiles into Teleport.
+        Imported Profiles will be available as Resources with each Role
+        available as an account.
+      </P2>
+      {status === 'error' && (
+        <Alerts.Danger details={error.message}>
+          Error: {error.name}
+        </Alerts.Danger>
+      )}
+      {status === 'pending' && (
+        <Box data-testid="loading" textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      )}
+      {nothingToSync && <ProfilesEmptyState />}
+      {status === 'success' && data.profiles.length > 0 && (
+        <Profiles
+          data={data.profiles}
+          fetchStatus={isFetching ? 'loading' : ''}
+          filters={filters}
+          setFilters={setFilters}
+          refetch={refetch}
+          syncAll={syncAll}
+          setSyncAll={setSyncAll}
+        />
+      )}
+      {submitSync.error && (
+        <Alerts.Danger details={submitSync.error?.message} mt={2}>
+          Error: {submitSync.error.name}
+        </Alerts.Danger>
+      )}
+      <Flex gap={3} mt={3}>
+        <ButtonPrimary
+          width="200px"
+          onClick={() => submitSync.mutate()}
+          disabled={nothingToSync}
+        >
+          Enable Sync
+        </ButtonPrimary>
+        <ButtonSecondary
+          onClick={() =>
+            history.push(
+              cfg.getIntegrationEnrollRoute(
+                IntegrationKind.AWSRa,
+                'integration'
+              )
+            )
+          }
+          width="100px"
+        >
+          Back
+        </ButtonSecondary>
+      </Flex>
+    </>
+  );
+}
+
+function ProfilesEmptyState() {
+  return (
+    <CardTile alignItems="center" gap={4}>
+      <ResourceIcon name="awsidentityandaccessmanagementiam" width="164px" />
+      <Flex flexDirection="column" alignItems="center">
+        <H3 mb={1}>No AWS IAM Roles Anywhere Profiles Found</H3>
+        <P2>Create AWS IAM Roles Anywhere Profiles in your AWS console</P2>
+      </Flex>
+      <Flex gap={3}>
+        <ButtonPrimary as="a" target="blank" href={rolesAnywhereCreateProfile}>
+          Create AWS Roles Anywhere Profiles
+        </ButtonPrimary>
+        <ButtonBorder intent="primary">
+          Refresh AWS Roles Anywhere Profiles
+        </ButtonBorder>
+      </Flex>
+    </CardTile>
+  );
+}

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Guide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Guide.tsx
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Box, Link } from 'design';
+import {
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+
+const GuideReferenceLinks = {
+  AwsRolesAnywhere: {
+    title: 'AWS Roles Anywhere',
+    href: 'https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html',
+  },
+};
+
+export const Guide = ({ resourcesRoute }: { resourcesRoute: string }) => (
+  <Box>
+    <InfoTitle>How to Access Profiles as Resources</InfoTitle>
+    <InfoParagraph>
+      Teleport will periodically sync Roles Anywhere Profiles as AWS Access
+      applications. You can import all Profiles, or use a filter to only import
+      a subset of Profiles. You can access AWS by going to the{' '}
+      <Link href={resourcesRoute} target="_blank">
+        Resources page
+      </Link>{' '}
+      and select the Profile and IAM Role that you want to use. Other users can
+      use the Profile and IAM Role by requesting access to it.
+    </InfoParagraph>
+    <ReferenceLinks links={Object.values(GuideReferenceLinks)} />
+  </Box>
+);

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Profiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/Profiles.tsx
@@ -1,0 +1,111 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Dispatch, SetStateAction } from 'react';
+
+import { ButtonPrimary } from 'design/Button';
+import { CardTile } from 'design/CardTile';
+import { FetchingConfig } from 'design/DataTable/types';
+import Flex from 'design/Flex';
+import * as Icons from 'design/Icon';
+import { H3, P1, P2 } from 'design/Text';
+import { Toggle } from 'design/Toggle';
+import Validation from 'shared/components/Validation';
+
+import { rolesAnywhereCreateProfile } from 'teleport/Integrations/Enroll/awsLinks';
+import { RolesAnywhereProfile } from 'teleport/services/integrations';
+
+import { ProfilesFilter, ProfilesFilterOption } from './ProfilesFilter';
+import { ProfilesTable } from './ProfilesTable';
+
+export function Profiles({
+  data,
+  fetchStatus,
+  filters,
+  setFilters,
+  onFetchNext,
+  onFetchPrev,
+  refetch,
+  syncAll,
+  setSyncAll,
+}: {
+  data: RolesAnywhereProfile[];
+  filters: ProfilesFilterOption[];
+  setFilters: Dispatch<SetStateAction<ProfilesFilterOption[]>>;
+  refetch: () => void;
+  syncAll: boolean;
+  setSyncAll: Dispatch<SetStateAction<boolean>>;
+} & Omit<FetchingConfig, 'onFetchMore'>) {
+  return (
+    <Validation>
+      <CardTile backgroundColor="levels.elevated">
+        <Flex justifyContent="space-between">
+          <Flex flexDirection="column">
+            <H3>Sync IAM Profiles with Teleport as Resources</H3>
+            <P2>
+              You will be able to see the imported profiles on the Resources
+              Page
+            </P2>
+          </Flex>
+          <Flex alignItems="center" gap={3}>
+            <ButtonPrimary
+              gap={2}
+              fill="minimal"
+              intent="neutral"
+              size="small"
+              onClick={refetch}
+            >
+              <Icons.Refresh size="small" />
+              Refresh
+            </ButtonPrimary>
+            <ButtonPrimary
+              gap={2}
+              intent="neutral"
+              size="small"
+              as="a"
+              target="blank"
+              href={rolesAnywhereCreateProfile}
+            >
+              Create AWS Roles Anywhere Profiles
+              <Icons.NewTab size="small" />
+            </ButtonPrimary>
+            <Flex gap={1}>
+              <Toggle
+                isToggled={syncAll}
+                onToggle={() => {
+                  setSyncAll(!syncAll);
+                }}
+                size="large"
+              />
+              <P1>Import All Profiles</P1>
+            </Flex>
+          </Flex>
+        </Flex>
+        {!syncAll && (
+          <ProfilesFilter filters={filters} setFilters={setFilters} />
+        )}
+        <ProfilesTable
+          data={data}
+          fetchStatus={fetchStatus}
+          onFetchNext={onFetchNext}
+          onFetchPrev={onFetchPrev}
+        />
+      </CardTile>
+    </Validation>
+  );
+}

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/ProfilesFilter.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/ProfilesFilter.tsx
@@ -1,0 +1,100 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Dispatch, SetStateAction } from 'react';
+import { components } from 'react-select';
+import { useTheme } from 'styled-components';
+
+import Box from 'design/Box';
+import Flex from 'design/Flex';
+import { P1 } from 'design/Text';
+import { Theme } from 'design/theme/themes/types';
+import { FieldSelectCreatable } from 'shared/components/FieldSelect';
+import { CustomSelectComponentProps, Option } from 'shared/components/Select';
+
+export type ProfilesFilterOption = Option & { invalid: boolean };
+
+export function ProfilesFilter({
+  filters,
+  setFilters,
+}: {
+  filters: ProfilesFilterOption[];
+  setFilters: Dispatch<SetStateAction<ProfilesFilterOption[]>>;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Flex alignItems="center" gap={2}>
+      <Box width="540px">
+        <FieldSelectCreatable
+          ariaLabel={`input-profiles`}
+          autoFocus={true}
+          placeholder="* – Type a filter to restrict matches"
+          isMulti
+          isClearable
+          isSearchable
+          options={filters}
+          onChange={(o: ProfilesFilterOption[]) => setFilters(o)}
+          value={filters || []}
+          noOptionsMessage={() => null}
+          label="Filter by Profile Name"
+          helperText="Regex and glob supported. Defaults to all(*) if no filters are defined"
+          formatCreateLabel={userInput => `Apply filter: ${userInput}`}
+          stylesConfig={filterCreateCss(theme)}
+          components={{
+            MultiValueContainer,
+            Menu: () => null,
+            DropdownIndicator: () => null,
+          }}
+          customProps={{
+            lastFilter:
+              filters?.length > 1 ? filters[filters.length - 1].value : '',
+          }}
+        />
+      </Box>
+    </Flex>
+  );
+}
+
+const filterCreateCss = (theme: Theme) => ({
+  multiValue: (base, state) => {
+    const errorState = state.data.invalid
+      ? { border: `1px solid ${theme.colors.interactive.solid.danger.default}` }
+      : undefined;
+
+    return {
+      ...base,
+      ...errorState,
+    };
+  },
+});
+
+const MultiValueContainer = (
+  props: CustomSelectComponentProps<{ lastFilter: string }, Option>
+) => {
+  const lastFilter = props.selectProps.customProps.lastFilter;
+  const currFilter = props.data.value;
+
+  const isLastFilter = lastFilter === currFilter;
+  return (
+    <>
+      <components.MultiValueContainer {...props} />
+      {lastFilter && !isLastFilter && <P1 fontSize={0}>OR</P1>}
+    </>
+  );
+};

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/ProfilesTable.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Access/ProfilesTable.tsx
@@ -1,0 +1,164 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import Table, { Cell, LabelCell } from 'design/DataTable';
+import { ClientSidePager } from 'design/DataTable/Pager';
+import { StyledTable } from 'design/DataTable/StyledTable';
+import { FetchingConfig, PagedTableProps } from 'design/DataTable/types';
+import Flex from 'design/Flex';
+import * as Icons from 'design/Icon';
+import { Check } from 'design/Icon';
+import { P2 } from 'design/Text';
+
+import { RolesAnywhereProfile } from 'teleport/services/integrations';
+
+export function ProfilesTable({
+  data,
+  fetchStatus,
+  onFetchNext,
+  onFetchPrev,
+}: {
+  data: RolesAnywhereProfile[];
+} & Omit<FetchingConfig, 'onFetchMore'>) {
+  return (
+    <Table
+      data={data}
+      columns={[
+        {
+          altKey: 'selected',
+          headerText: '',
+          render: row =>
+            data?.includes(row) ? (
+              <Cell width="50px">
+                <Check size="small" color="success.main" />
+              </Cell>
+            ) : (
+              <Cell width="50px" />
+            ),
+        },
+        {
+          key: 'name',
+          headerText: 'Profile Name',
+        },
+        {
+          key: 'tags',
+          headerText: 'Tags',
+          render: row => <LabelCell data={row.tags} />,
+        },
+        {
+          key: 'roles',
+          headerText: 'IAM Roles',
+          render: row => <Cell>{row.roles.join(', ')}</Cell>,
+        },
+      ]}
+      emptyText="No Profiles Found"
+      pagination={{ pageSize: 20, CustomTable }}
+      fetching={{
+        fetchStatus,
+        onFetchNext,
+        onFetchPrev,
+        disableLoadingIndicator: true,
+      }}
+    />
+  );
+}
+
+function CustomTable<T>({
+  nextPage,
+  prevPage,
+  data,
+  pagination,
+  renderHeaders,
+  renderBody,
+}: PagedTableProps<T>) {
+  const { paginatedData, currentPage } = pagination;
+
+  return (
+    <>
+      <TableWrapper>
+        <CustomerStyledTable>
+          {renderHeaders()}
+          {renderBody(paginatedData[currentPage])}
+        </CustomerStyledTable>
+      </TableWrapper>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Flex gap={1}>
+          <Icons.Info color="text.muted" />
+          <P2 color="text.muted">
+            New and matching AWS Roles Anywhere Profiles created in the AWS
+            Console will be automatically synced with Teleport.
+          </P2>
+        </Flex>
+        <Flex>
+          <ClientSidePager
+            nextPage={nextPage}
+            prevPage={prevPage}
+            data={data}
+            {...pagination}
+          />
+        </Flex>
+      </Flex>
+    </>
+  );
+}
+
+const TableWrapper = styled.div(
+  props => `
+      border-bottom: 1px solid ${props.theme.colors.interactive.tonal.neutral[0]};
+      overflow-y: auto;
+      max-height: 330px;
+`
+);
+
+const CustomerStyledTable = styled(StyledTable)(
+  props => `
+
+   background-color: inherit;
+   border-collapse: separate;
+
+  tbody > tr > td, thead > tr > th {
+    font-size: ${props.theme.fontSizes[2]}px;
+    font-weight: 300;
+  }
+
+  thead > tr > th {
+    font-weight: bold;
+    border-bottom: 1px solid ${props.theme.colors.interactive.tonal.neutral[0]};
+    text-transform: none;
+    padding: ${props.theme.space[2]}px 0;
+    top: 0;
+    position: sticky;
+    z-index: 1;
+    opacity: 1;
+  }
+
+  tbody > tr > td {
+    padding: ${props.theme.space[3]}px 0;
+  }
+
+  tbody > tr {
+    background-color: ${props.theme.colors.levels.surface};
+    border: none;
+    
+    transition: all 150ms;
+    position: relative;
+  }
+`
+);

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.story.tsx
@@ -19,7 +19,7 @@
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 
-import { Info } from '@gravitational/design/src/Alert';
+import { Info } from 'design/Alert';
 import { CollapsibleInfoSection as CollapsibleInfoSectionComponent } from 'design/CollapsibleInfoSection';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
@@ -30,10 +30,10 @@ import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/
 import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
 
 export default {
-  title: 'Teleport/Integrations/Enroll/AwsConsole',
+  title: 'Teleport/Integrations/Enroll/AwsConsole/IamIntegration',
 };
 
-export const PageOneIamIntegration = () => (
+export const Loaded = () => (
   <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()} path="">
     <InfoGuidePanelProvider>
       <MemoryRouter>
@@ -71,7 +71,7 @@ arn:aws:iam::123456789012:role/baz`}
     </InfoGuidePanelProvider>
   </MockAwsOidcStatusProvider>
 );
-PageOneIamIntegration.parameters = {
+Loaded.parameters = {
   msw: {
     handlers: [
       http.post(cfg.getAwsRolesAnywherePingUrl('test'), () => {

--- a/web/packages/teleport/src/Integrations/Enroll/awsLinks.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/awsLinks.ts
@@ -19,3 +19,5 @@
 export const cloudShell = 'https://console.aws.amazon.com/cloudshell/home';
 export const rolesAnywhere =
   'https://console.aws.amazon.com/rolesanywhere/home';
+export const rolesAnywhereCreateProfile =
+  'https://console.aws.amazon.com/rolesanywhere/home/profiles/create';

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -418,6 +418,8 @@ const cfg = {
       generate:
         '/v1/webapi/scripts/integrations/configure/awsra-trust-anchor.sh?integrationName=:integrationName?&trustAnchor=:trustAnchor?&syncRole=:syncRole?&syncProfile=:syncProfile',
       ping: '/v1/webapi/sites/:clusterId/integrations/aws-ra/:integrationName/ping',
+      profiles:
+        '/v1/webapi/sites/:clusterId/integrations/aws-ra/:integrationName/listprofiles',
     },
 
     thumbprintPath: '/v1/webapi/thumbprint',
@@ -1532,6 +1534,15 @@ const cfg = {
 
   getAwsRolesAnywherePingUrl(integrationName: string) {
     const path = cfg.api.awsRolesAnywhere.ping;
+    const clusterId = cfg.proxyCluster;
+    return generatePath(path, {
+      clusterId,
+      integrationName,
+    });
+  },
+
+  getAwsRolesAnywhereProfilesUrl(integrationName: string) {
+    const path = cfg.api.awsRolesAnywhere.profiles;
     const clusterId = cfg.proxyCluster;
     return generatePath(path, {
       clusterId,

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -17,6 +17,7 @@
  */
 
 import cfg from 'teleport/config';
+import { ProfilesFilterOption } from 'teleport/Integrations/Enroll/AwsConsole/Access/ProfilesFilter';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
 import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
 import api from 'teleport/services/api';
@@ -62,8 +63,10 @@ import {
   ListAwsSubnetsResponse,
   ListEksClustersRequest,
   ListEksClustersResponse,
+  ListRolesAnywhereProfilesResponse,
   RdsEngineIdentifier,
   Regions,
+  RolesAnywhereProfile,
   SecurityGroup,
   SecurityGroupRule,
   Subnet,
@@ -573,6 +576,29 @@ export const integrationService = {
         };
       });
   },
+
+  awsRolesAnywhereProfiles(
+    variables: {
+      integrationName: string;
+      filters?: ProfilesFilterOption[];
+    },
+    signal?: AbortSignal
+  ): Promise<ListRolesAnywhereProfilesResponse> {
+    const { integrationName, filters } = variables;
+    const path = cfg.getAwsRolesAnywhereProfilesUrl(integrationName);
+
+    return api
+      .post(
+        path,
+        {
+          filters: filters?.length > 0 ? filters.map(f => f.value) : ['*'],
+        },
+        signal
+      )
+      .then(data => ({
+        profiles: data?.profiles?.map(profile => makeProfile(profile)) ?? [],
+      }));
+  },
 };
 
 function makeDatabaseServices(json: any): AWSOIDCDeployedDatabaseService[] {
@@ -695,5 +721,30 @@ function makeAwsSubnets(json: any): Subnet {
     name,
     id,
     availabilityZone: availability_zone,
+  };
+}
+
+function makeProfile(json: any): RolesAnywhereProfile {
+  json = json ?? {};
+
+  const { arn, enabled, name, acceptRoleSessionName, tags, roles } = json;
+
+  let arr: string[] = [];
+  if (tags != undefined && tags.length > 0) {
+    const parsedObject: { [key: string]: string } = JSON.parse(
+      JSON.stringify(tags[0])
+    );
+    Object.entries(parsedObject).forEach(entry => {
+      arr.push(entry.join(':'));
+    });
+  }
+
+  return {
+    arn,
+    enabled,
+    name,
+    acceptRoleSessionName,
+    tags: arr,
+    roles,
   };
 }

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -121,6 +121,49 @@ export type IntegrationSpecAwsOidc = {
   audience?: IntegrationAudience;
 };
 
+export type IntegrationSpecAwsRa = {
+  trustAnchorArn: string;
+  profileSyncConfig: AwsRolesAnywhereProfileSyncConfig;
+};
+/**
+ * AwsRolesAnywhereProfileSyncConfig contains the configuration for the AWS Roles Anywhere Profile sync.
+ * This is used to sync AWS Roles Anywhere profiles as application servers.
+ */
+type AwsRolesAnywhereProfileSyncConfig = {
+  /**
+   * Enabled is set to true if this integration should sync profiles as application servers.
+   */
+  enabled: boolean;
+  /**
+   * ProfileARN is the ARN of the Roles Anywhere Profile used to generate credentials to access the AWS APIs.
+   */
+  profileArn: string;
+  /**
+   * ProfileAcceptsRoleSessionName indicates whether the profile accepts a custom Role Session name.
+   */
+  profileAcceptsRoleSessionName: boolean;
+  /**
+   * RoleARN is the ARN of the IAM Role to assume when accessing the AWS APIs.
+   */
+  roleArn: string;
+  /**
+   * ProfileNameFilters is a list of filters applied to the profile name.
+   * Only matching profiles will be synchronized as application servers.
+   * If empty, no filtering is applied.
+   *
+   * Filters can be globs, for example,
+   *
+   *	profile*
+   *	*name*
+   *
+   * Or regexes if they're prefixed and suffixed with ^ and $, for example:
+   *
+   *	^profile.*$
+   *	^.*name.*$
+   */
+  profileNameFilters: string[];
+};
+
 export type IntegrationAwsOidc = IntegrationTemplate<
   'integration',
   IntegrationKind.AwsOidc,
@@ -397,9 +440,16 @@ type IntegrationCreateAwsOidcRequest = {
   awsoidc: IntegrationSpecAwsOidc;
 };
 
+type IntegrationCreateAwsRaRequest = {
+  name: string;
+  subKind: IntegrationKind.AWSRa;
+  awsRa: IntegrationSpecAwsRa;
+};
+
 export type IntegrationCreateRequest =
   | IntegrationCreateAwsOidcRequest
-  | IntegrationCreateGitHubRequest;
+  | IntegrationCreateGitHubRequest
+  | IntegrationCreateAwsRaRequest;
 
 export type IntegrationListResponse = {
   items: Integration[];
@@ -656,6 +706,46 @@ export type AwsRolesAnywherePingResponse = {
    * userID is the unique identifier of the calling entity.
    */
   userId: string;
+};
+
+/**
+ * ListRolesAnywhereProfilesResponse contains the response for the ListRolesAnywhereProfiles operation.
+ */
+export type ListRolesAnywhereProfilesResponse = {
+  /**
+   * Profiles is a list of AWS Roles Anywhere Profiles.
+   */
+  profiles: RolesAnywhereProfile[];
+};
+
+/**
+ * RolesAnywhereProfile represents an AWS Roles Anywhere Profile.
+ */
+export type RolesAnywhereProfile = {
+  /**
+   * The AWS Roles Anywhere Profile ARN.
+   */
+  arn: string;
+  /**
+   * Whether the AWS Roles Anywhere Profile is enabled.
+   */
+  enabled: boolean;
+  /**
+   * The name of the AWS Roles Anywhere Profile.
+   */
+  name: string;
+  /**
+   * Whether the profile accepts role session names.
+   */
+  acceptRoleSessionName: boolean;
+  /**
+   * The tags associated with the AWS Roles Anywhere Profile.
+   */
+  tags: string[];
+  /**
+   * The roles accessible from this AWS Roles Anywhere Profile.
+   */
+  roles: string[];
 };
 
 // awsRegionMap maps the AWS regions to it's region name


### PR DESCRIPTION
Adds the second page of the aws roles anywhere enrollment
* Is not routed yet
* List Profiles requires more full stack work to work correctly, meeting with Marco next week to fix (see todo)
* Create requires more full stack work to work correctly, meeting with Marco next week to fix (see todo)
  * For now, both are mocked as written for storybook

Follow up PR will route this into the aws roles anywhere enrollment flow with other steps.
<img width="1959" height="562" alt="Screenshot 2025-08-07 at 2 21 36 PM" src="https://github.com/user-attachments/assets/60a57558-0ab3-4bb3-907e-87ed457fdb33" />

[Figma](https://www.figma.com/design/uLevdNsEnIvvLDSZ9sQqXM/Discover-Access?node-id=3314-59966&m=dev)

Supports https://github.com/gravitational/teleport/issues/53192