### PR TITLE
Refactor reversetunnelclient.Tunnel interface

### DIFF
--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -378,10 +378,10 @@ func (p *DatabasePack) setupUsersAndRoles(t *testing.T) {
 
 func (p *DatabasePack) WaitForLeaf(t *testing.T) {
 	helpers.WaitForProxyCount(p.Leaf.Cluster, p.Root.Cluster.Secrets.SiteName, 1)
-	site, err := p.Root.Cluster.Tunnel.GetSite(p.Leaf.Cluster.Secrets.SiteName)
+	cluster, err := p.Root.Cluster.Tunnel.Cluster(t.Context(), p.Leaf.Cluster.Secrets.SiteName)
 	require.NoError(t, err)
 
-	accessPoint, err := site.CachingAccessPoint()
+	accessPoint, err := cluster.CachingAccessPoint()
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -457,18 +457,18 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 // GetSiteAPI is a helper which returns an API endpoint to a site with
 // a given name. i endpoint implements HTTP-over-SSH access to the
 // site's auth server.
-func (i *TeleInstance) GetSiteAPI(siteName string) authclient.ClientI {
-	siteTunnel, err := i.Tunnel.GetSite(siteName)
+func (i *TeleInstance) GetSiteAPI(clusterName string) authclient.ClientI {
+	cluster, err := i.Tunnel.Cluster(context.Background(), clusterName)
 	if err != nil {
-		i.Log.WarnContext(context.Background(), "failed to get site", "error", err, "site", siteName)
+		i.Log.WarnContext(context.Background(), "failed to get site", "error", err, "cluster", clusterName)
 		return nil
 	}
-	siteAPI, err := siteTunnel.GetClient()
+	clusterClient, err := cluster.GetClient()
 	if err != nil {
-		i.Log.WarnContext(context.Background(), "failed to get site client", "error", err, "site", siteName)
+		i.Log.WarnContext(context.Background(), "failed to get site client", "error", err, "cluster", clusterName)
 		return nil
 	}
-	return siteAPI
+	return clusterClient
 }
 
 // Create creates a new instance of Teleport which trusts a list of other clusters (other
@@ -1882,20 +1882,20 @@ func (i *TeleInstance) StopAll() error {
 // WaitForNodeCount waits for a certain number of nodes in the provided cluster
 // to be visible to the Proxy. This should be called prior to any client dialing
 // of nodes to be sure that the node is registered and routable.
-func (i *TeleInstance) WaitForNodeCount(ctx context.Context, cluster string, count int) error {
+func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string, count int) error {
 	const (
 		deadline     = time.Second * 30
 		iterWaitTime = time.Second
 	)
 
 	err := retryutils.RetryStaticFor(deadline, iterWaitTime, func() error {
-		site, err := i.Tunnel.GetSite(cluster)
+		cluster, err := i.Tunnel.Cluster(ctx, clusterName)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
 		// Validate that the site cache contains the expected count.
-		accessPoint, err := site.CachingAccessPoint()
+		accessPoint, err := cluster.CachingAccessPoint()
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1909,7 +1909,7 @@ func (i *TeleInstance) WaitForNodeCount(ctx context.Context, cluster string, cou
 		}
 
 		// Validate that the site watcher contains the expected count.
-		watcher, err := site.NodeWatcher()
+		watcher, err := cluster.NodeWatcher()
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -130,11 +130,11 @@ func TryUpsertTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 }
 
 func WaitForClusters(tun reversetunnelclient.Server, expected int) func() bool {
-	// GetSites will always return the local site
+	// Clusters will always return the local site
 	expected++
 
 	return func() (ok bool) {
-		clusters, err := tun.GetSites()
+		clusters, err := tun.Clusters(context.Background())
 		if err != nil {
 			return false
 		}
@@ -161,8 +161,9 @@ func WaitForClusters(tun reversetunnelclient.Server, expected int) func() bool {
 
 // WaitForActiveTunnelConnections waits for remote cluster to report a minimum number of active connections
 func WaitForActiveTunnelConnections(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, expectedCount int) {
+	ctx := t.Context()
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		cluster, err := tunnel.GetSite(clusterName)
+		cluster, err := tunnel.Cluster(ctx, clusterName)
 		if !assert.NoError(t, err, "site not found") {
 			return
 		}

--- a/lib/desktop/conn.go
+++ b/lib/desktop/conn.go
@@ -34,9 +34,8 @@ type ConnectionConfig struct {
 	Log *slog.Logger
 	// DesktopsGetter is responsible for getting desktops and desktop services.
 	DesktopsGetter DesktopsGetter
-	// Site represents a remote teleport site that can be accessed via
-	// a teleport tunnel or directly by proxy.
-	Site reversetunnelclient.Cluster
+	// Cluster represents a Teleport cluster that the desktop is connected to.
+	Cluster reversetunnelclient.Cluster
 	// ClientSrcAddr is the original observed client address.
 	ClientSrcAddr net.Addr
 	// ClientDstAddr is the original client's destination address.
@@ -104,7 +103,7 @@ func tryConnect(ctx context.Context, desktopServiceID string, config *Connection
 		return nil, "", trace.NotFound("could not find windows desktop service %s: %v", desktopServiceID, err)
 	}
 
-	conn, err = config.Site.DialTCP(reversetunnelclient.DialParams{
+	conn, err = config.Cluster.DialTCP(reversetunnelclient.DialParams{
 		From:                  config.ClientSrcAddr,
 		To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: service.GetAddr()},
 		ConnType:              types.WindowsDesktopTunnel,

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -319,7 +319,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	testCtx.KubeProxy, err = proxy.NewTLSServer(proxy.TLSServerConfig{
 		ForwarderConfig: proxy.ForwarderConfig{
 			ReverseTunnelSrv: &reversetunnelclient.FakeServer{
-				Clusters: []reversetunnelclient.Cluster{
+				FakeClusters: []reversetunnelclient.Cluster{
 					&fakeCluster{
 						FakeCluster: reversetunnelclient.NewFakeCluster(testCtx.ClusterName, client),
 						idToAddr: map[string]string{

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1215,7 +1215,7 @@ type mockRevTunnel struct {
 	sites map[string]reversetunnelclient.Cluster
 }
 
-func (t mockRevTunnel) GetSite(name string) (reversetunnelclient.Cluster, error) {
+func (t mockRevTunnel) Cluster(_ context.Context, name string) (reversetunnelclient.Cluster, error) {
 	s, ok := t.sites[name]
 	if !ok {
 		return nil, trace.NotFound("remote site %q not found", name)
@@ -1223,7 +1223,7 @@ func (t mockRevTunnel) GetSite(name string) (reversetunnelclient.Cluster, error)
 	return s, nil
 }
 
-func (t mockRevTunnel) GetSites() ([]reversetunnelclient.Cluster, error) {
+func (t mockRevTunnel) Clusters(context.Context) ([]reversetunnelclient.Cluster, error) {
 	var sites []reversetunnelclient.Cluster
 	for _, s := range t.sites {
 		sites = append(sites, s)

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -234,7 +234,7 @@ func (f *Forwarder) remoteClusterDialer(clusterName string) dialContextFunc {
 		)
 		defer span.End()
 
-		targetCluster, err := f.cfg.ReverseTunnelSrv.GetSite(clusterName)
+		targetCluster, err := f.cfg.ReverseTunnelSrv.Cluster(ctx, clusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -309,7 +309,7 @@ func (f *Forwarder) localClusterDialer(kubeClusterName string, opts ...contextDi
 		// Use the local reversetunnel.Site which knows how to dial by serverID
 		// (for "kubernetes_service" connected over a tunnel) and falls back to
 		// direct dial if needed.
-		localCluster, err := f.cfg.ReverseTunnelSrv.GetSite(f.cfg.ClusterName)
+		localCluster, err := f.cfg.ReverseTunnelSrv.Cluster(ctx, f.cfg.ClusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -110,7 +110,7 @@ type fakeReverseTunnel struct {
 	t    *testing.T
 }
 
-func (f *fakeReverseTunnel) GetSite(_ string) (reversetunnelclient.Cluster, error) {
+func (f *fakeReverseTunnel) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
 	return &fakeRemoteSiteTunnel{
 		want: f.want,
 		t:    f.t,

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -319,7 +319,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	testCtx.KubeProxy, err = NewTLSServer(TLSServerConfig{
 		ForwarderConfig: ForwarderConfig{
 			ReverseTunnelSrv: &reversetunnelclient.FakeServer{
-				Clusters: []reversetunnelclient.Cluster{
+				FakeClusters: []reversetunnelclient.Cluster{
 					&fakeCluster{
 						FakeCluster: reversetunnelclient.NewFakeCluster(testCtx.ClusterName, client),
 						idToAddr: map[string]string{

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -106,10 +106,10 @@ func (c *ProxiedMetricConn) Close() error {
 type serverResolverFn = func(ctx context.Context, host, port string, cluster cluster) (types.Server, error)
 type windowsDesktopServiceConnectorFn = func(ctx context.Context, config *desktop.ConnectionConfig) (conn net.Conn, version string, err error)
 
-// SiteGetter provides access to connected local or remote clusters.
-type SiteGetter interface {
-	// GetSite returns the cluster matching the provided clusterName
-	GetSite(clusterName string) (reversetunnelclient.Cluster, error)
+// ClusterGetter provides access to connected local or remote clusters.
+type ClusterGetter interface {
+	// Cluster returns the cluster matching the provided clusterName
+	Cluster(ctx context.Context, clusterName string) (reversetunnelclient.Cluster, error)
 }
 
 // LocalAccessPoint provides access to remote cluster resources
@@ -127,8 +127,8 @@ type RouterConfig struct {
 	ClusterName string
 	// LocalAccessPoint is the proxy cache
 	LocalAccessPoint LocalAccessPoint
-	// SiteGetter allows looking up clusters
-	SiteGetter SiteGetter
+	// ClusterGetter allows looking up clusters
+	ClusterGetter ClusterGetter
 	// TracerProvider allows tracers to be created
 	TracerProvider oteltrace.TracerProvider
 	// Log is an optional logger. A default logger will be created if not set.
@@ -150,7 +150,7 @@ func (c *RouterConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("LocalAccessPoint must be provided")
 	}
 
-	if c.SiteGetter == nil {
+	if c.ClusterGetter == nil {
 		return trace.BadParameter("SiteGetter must be provided")
 	}
 
@@ -179,7 +179,7 @@ type Router struct {
 	clusterName                    string
 	localAccessPoint               LocalAccessPoint
 	localCluster                   reversetunnelclient.Cluster
-	siteGetter                     SiteGetter
+	clusterGetter                  ClusterGetter
 	tracer                         oteltrace.Tracer
 	log                            *slog.Logger
 	serverResolver                 serverResolverFn
@@ -193,7 +193,7 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	localCluster, err := cfg.SiteGetter.GetSite(cfg.ClusterName)
+	localCluster, err := cfg.ClusterGetter.Cluster(context.Background(), cfg.ClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -202,7 +202,7 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 		clusterName:                    cfg.ClusterName,
 		localAccessPoint:               cfg.LocalAccessPoint,
 		localCluster:                   localCluster,
-		siteGetter:                     cfg.SiteGetter,
+		clusterGetter:                  cfg.ClusterGetter,
 		tracer:                         cfg.TracerProvider.Tracer("Router"),
 		log:                            cfg.Logger,
 		serverResolver:                 cfg.serverResolver,
@@ -359,7 +359,7 @@ func (r *Router) DialWindowsDesktop(ctx context.Context, clientSrcAddr, clientDs
 	serviceConn, _, err := r.windowsDesktopServiceConnector(ctx, &desktop.ConnectionConfig{
 		Log:            r.log,
 		DesktopsGetter: accessPoint,
-		Site:           cluster,
+		Cluster:        cluster,
 		ClientSrcAddr:  clientSrcAddr,
 		ClientDstAddr:  clientDstAddr,
 		ClusterName:    clusterName,
@@ -424,7 +424,7 @@ func (r *Router) getRemoteCluster(ctx context.Context, clusterName string, clust
 	)
 	defer span.End()
 
-	cluster, err := r.siteGetter.GetSite(clusterName)
+	cluster, err := r.clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, utils.OpaqueAccessDenied(err)
 	}
@@ -621,7 +621,7 @@ func (r *Router) DialSite(ctx context.Context, clusterName string, clientSrcAddr
 	}
 
 	// lookup the cluster and dial its auth server
-	cluster, err := r.siteGetter.GetSite(clusterName)
+	cluster, err := r.clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -640,7 +640,7 @@ func (r *Router) GetSiteClient(ctx context.Context, clusterName string) (authcli
 		return r.localCluster.GetClient()
 	}
 
-	cluster, err := r.siteGetter.GetSite(clusterName)
+	cluster, err := r.clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -627,14 +627,13 @@ func TestCheckedPrefixWriter(t *testing.T) {
 	})
 }
 
-type fakeTunnel struct {
-	reversetunnelclient.Tunnel
-
+type fakeClusterGetter struct {
+	ClusterGetter
 	cluster reversetunnelclient.Cluster
 	err     error
 }
 
-func (t fakeTunnel) GetSite(cluster string) (reversetunnelclient.Cluster, error) {
+func (t fakeClusterGetter) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
 	return t.cluster, t.err
 }
 
@@ -662,14 +661,6 @@ func (r testRemoteSite) GetClient() (authclient.ClientI, error) {
 
 func (r testRemoteSite) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
 	return nil, nil
-}
-
-type fakeSiteGetter struct {
-	cluster reversetunnelclient.Cluster
-}
-
-func (s fakeSiteGetter) GetSite(clusterName string) (reversetunnelclient.Cluster, error) {
-	return s.cluster, nil
 }
 
 type fakeConn struct {
@@ -747,9 +738,9 @@ func TestRouter_DialHost(t *testing.T) {
 		{
 			name: "failure looking up cluster",
 			router: Router{
-				clusterName: "leaf",
-				siteGetter:  fakeTunnel{err: trace.NotFound("unknown cluster")},
-				tracer:      tracing.NoopTracer("test"),
+				clusterName:   "leaf",
+				clusterGetter: fakeClusterGetter{err: trace.NotFound("unknown cluster")},
+				tracer:        tracing.NoopTracer("test"),
 			},
 			assertion: func(t *testing.T, params reversetunnelclient.DialParams, conn net.Conn, err error) {
 				require.Error(t, err)
@@ -794,7 +785,7 @@ func TestRouter_DialHost(t *testing.T) {
 			router: Router{
 				clusterName:    "test",
 				localCluster:   &testRemoteSite{conn: fakeConn{}},
-				siteGetter:     &fakeSiteGetter{cluster: &testRemoteSite{conn: fakeConn{}}},
+				clusterGetter:  &fakeClusterGetter{cluster: &testRemoteSite{conn: fakeConn{}}},
 				tracer:         tracing.NoopTracer("test"),
 				serverResolver: serverResolver(agentlessSrv, nil),
 			},
@@ -814,7 +805,7 @@ func TestRouter_DialHost(t *testing.T) {
 			router: Router{
 				clusterName:    "test",
 				localCluster:   &testRemoteSite{conn: fakeConn{}},
-				siteGetter:     &fakeSiteGetter{cluster: &testRemoteSite{conn: fakeConn{}}},
+				clusterGetter:  &fakeClusterGetter{cluster: &testRemoteSite{conn: fakeConn{}}},
 				tracer:         tracing.NoopTracer("test"),
 				serverResolver: serverResolver(agentlessEC2ICESrv, nil),
 			},
@@ -854,7 +845,7 @@ func TestRouter_DialSite(t *testing.T) {
 		name      string
 		cluster   string
 		localSite testRemoteSite
-		tunnel    fakeTunnel
+		tunnel    fakeClusterGetter
 		assertion func(t *testing.T, conn net.Conn, err error)
 	}{
 		{
@@ -888,7 +879,7 @@ func TestRouter_DialSite(t *testing.T) {
 		{
 			name:    "failure to dial remote site",
 			cluster: "leaf",
-			tunnel: fakeTunnel{
+			tunnel: fakeClusterGetter{
 				cluster: &testRemoteSite{err: trace.ConnectionProblem(context.DeadlineExceeded, "connection refused")},
 			},
 			assertion: func(t *testing.T, conn net.Conn, err error) {
@@ -900,7 +891,7 @@ func TestRouter_DialSite(t *testing.T) {
 		{
 			name:    "unknown cluster",
 			cluster: "fake",
-			tunnel: fakeTunnel{
+			tunnel: fakeClusterGetter{
 				err: trace.NotFound("unknown cluster"),
 			},
 			assertion: func(t *testing.T, conn net.Conn, err error) {
@@ -912,7 +903,7 @@ func TestRouter_DialSite(t *testing.T) {
 		{
 			name:    "successfully  dial remote site",
 			cluster: "leaf",
-			tunnel: fakeTunnel{
+			tunnel: fakeClusterGetter{
 				cluster: &testRemoteSite{conn: fakeConn{}},
 			},
 			assertion: func(t *testing.T, conn net.Conn, err error) {
@@ -927,10 +918,10 @@ func TestRouter_DialSite(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			router := Router{
-				clusterName:  cluster,
-				localCluster: &tt.localSite,
-				siteGetter:   tt.tunnel,
-				tracer:       tracing.NoopTracer(cluster),
+				clusterName:   cluster,
+				localCluster:  &tt.localSite,
+				clusterGetter: tt.tunnel,
+				tracer:        tracing.NoopTracer(cluster),
 			}
 
 			conn, err := router.DialSite(ctx, tt.cluster, nil, nil)
@@ -950,9 +941,9 @@ func TestRouter_DialWindowsDesktop(t *testing.T) {
 		{
 			name: "failure looking up cluster",
 			router: Router{
-				clusterName: "leaf",
-				siteGetter:  fakeTunnel{err: trace.NotFound("unknown cluster")},
-				tracer:      tracing.NoopTracer("test"),
+				clusterName:   "leaf",
+				clusterGetter: fakeClusterGetter{err: trace.NotFound("unknown cluster")},
+				tracer:        tracing.NoopTracer("test"),
 			},
 			assertion: func(t *testing.T, conn net.Conn, err error) {
 				require.Error(t, err)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -469,7 +469,7 @@ func (s *server) periodicFunctions() {
 // fetchClusterPeers pulls back all proxies that have registered themselves
 // (created a services.TunnelConnection) in the backend and compares them to
 // what was found in the previous iteration and updates the in-memory cluster
-// peer map. This map is used later by GetSite(s) to return either local or
+// peer map. This map is used later by Cluster(s) to return either local or
 // remote site, or if no match, a cluster peer.
 func (s *server) fetchClusterPeers() error {
 	conns, err := s.LocalAccessPoint.GetAllTunnelConnections()
@@ -1067,7 +1067,7 @@ func (s *server) upsertRemoteCluster(conn net.Conn, sshConn *ssh.ServerConn) (*r
 	return site, remoteConn, nil
 }
 
-func (s *server) GetSites() ([]reversetunnelclient.Cluster, error) {
+func (s *server) Clusters(context.Context) ([]reversetunnelclient.Cluster, error) {
 	s.RLock()
 	defer s.RUnlock()
 	out := make([]reversetunnelclient.Cluster, 0, len(s.remoteSites)+len(s.clusterPeers)+1)
@@ -1096,15 +1096,15 @@ func (s *server) getRemoteClusters() []*remoteSite {
 	return out
 }
 
-// GetSite returns a RemoteSite. The first attempt is to find and return a
-// remote site and that is what is returned if a remote agent has
+// Cluster returns the Cluster with the matching name. The first attempt
+// is to find and return a remote site and that is what is returned if a remote agent has
 // connected to this proxy. Next we loop over local sites and try and try and
 // return a local site. If that fails, we return a cluster peer. This happens
 // when you hit proxy that has never had an agent connect to it. If you end up
 // with a cluster peer your best bet is to wait until the agent has discovered
 // all proxies behind a load balancer. Note, the cluster peer is a
 // services.TunnelConnection that was created by another proxy.
-func (s *server) GetSite(name string) (reversetunnelclient.Cluster, error) {
+func (s *server) Cluster(_ context.Context, name string) (reversetunnelclient.Cluster, error) {
 	s.RLock()
 	defer s.RUnlock()
 	if s.localSite.GetName() == name {

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -105,11 +105,6 @@ func (params DialParams) String() string {
 	return fmt.Sprintf("from: %q to: %q", params.From, to)
 }
 
-// RemoteSite is an alis to allow migrating to Cluster without breaking builds.
-// Deprecated: Use Cluster instead
-// TODO(tross): Delete when all references are converted to Cluster.
-type RemoteSite = Cluster
-
 // Cluster represents a teleport cluster, either root or leaf,
 // that can be accessed via teleport tunnel or directly by proxy.
 type Cluster interface {
@@ -147,19 +142,18 @@ type Cluster interface {
 	io.Closer
 }
 
-// Tunnel provides access to connected local or remote clusters
-// using unified interface.
-type Tunnel interface {
-	// GetSites returns a list of connected clusters
-	GetSites() ([]Cluster, error)
-	// GetSite returns cluster this node belongs to
-	GetSite(domainName string) (Cluster, error)
+// ClusterGetter allows retrieving connected [Cluster].
+type ClusterGetter interface {
+	// Clusters returns all connected clusters
+	Clusters(ctx context.Context) ([]Cluster, error)
+	// Cluster returns the cluster matching the provided name or a trace.NotFoundError.
+	Cluster(ctx context.Context, clusterName string) (Cluster, error)
 }
 
 // Server is a TCP/IP SSH server which listens on an SSH endpoint and remote/local
 // cluster connect and register with it.
 type Server interface {
-	Tunnel
+	ClusterGetter
 	// Start starts server
 	Start() error
 	// Close closes server's operations immediately

--- a/lib/reversetunnelclient/api_with_roles.go
+++ b/lib/reversetunnelclient/api_with_roles.go
@@ -28,38 +28,38 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ClusterGetter is an interface that defines GetRemoteCluster method
-type ClusterGetter interface {
+// RemoteClusterGetter is an interface that defines GetRemoteCluster method
+type RemoteClusterGetter interface {
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(ctx context.Context, clusterName string) (types.RemoteCluster, error)
 }
 
-// NewTunnelWithRoles returns new authorizing tunnel
-func NewTunnelWithRoles(tunnel Tunnel, localCluster string, clusterAccessChecker func(types.RemoteCluster) error, access ClusterGetter) *TunnelWithRoles {
-	return &TunnelWithRoles{
-		tunnel:               tunnel,
+// NewClusterGetterWithRoles returns new ClusterGetter wrapper that authorizes
+// access to queried clusters.
+func NewClusterGetterWithRoles(clusterGetter ClusterGetter, localCluster string, clusterAccessChecker func(types.RemoteCluster) error, remoteClusterGetter RemoteClusterGetter) *ClusterGetterWithRoles {
+	return &ClusterGetterWithRoles{
+		clusterGetter:        clusterGetter,
 		localCluster:         localCluster,
 		clusterAccessChecker: clusterAccessChecker,
-		access:               access,
+		remoteClusterGetter:  remoteClusterGetter,
 	}
 }
 
-// TunnelWithRoles authorizes requests
-type TunnelWithRoles struct {
-	tunnel Tunnel
+// ClusterGetterWithRoles authorizes requests
+type ClusterGetterWithRoles struct {
+	clusterGetter ClusterGetter
 
 	localCluster string
 
 	// clusterAccessChecker is used to check RBAC permissions.
 	clusterAccessChecker func(types.RemoteCluster) error
 
-	access ClusterGetter
+	remoteClusterGetter RemoteClusterGetter
 }
 
-// GetSites returns a list of connected remote sites
-func (t *TunnelWithRoles) GetSites() ([]Cluster, error) {
-	ctx := context.TODO()
-	clusters, err := t.tunnel.GetSites()
+// Clusters returns all connected Teleport clusters.
+func (t *ClusterGetterWithRoles) Clusters(ctx context.Context) ([]Cluster, error) {
+	clusters, err := t.clusterGetter.Clusters(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -69,7 +69,7 @@ func (t *TunnelWithRoles) GetSites() ([]Cluster, error) {
 			out = append(out, cluster)
 			continue
 		}
-		rc, err := t.access.GetRemoteCluster(ctx, cluster.GetName())
+		rc, err := t.remoteClusterGetter.GetRemoteCluster(ctx, cluster.GetName())
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return nil, trace.Wrap(err)
@@ -88,17 +88,16 @@ func (t *TunnelWithRoles) GetSites() ([]Cluster, error) {
 	return out, nil
 }
 
-// GetSite returns remote site this node belongs to
-func (t *TunnelWithRoles) GetSite(clusterName string) (Cluster, error) {
-	ctx := context.TODO()
-	cluster, err := t.tunnel.GetSite(clusterName)
+// Cluster returns a cluster matching the provided clusterName
+func (t *ClusterGetterWithRoles) Cluster(ctx context.Context, clusterName string) (Cluster, error) {
+	cluster, err := t.clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, utils.OpaqueAccessDenied(err)
 	}
 	if t.localCluster == cluster.GetName() {
 		return cluster, nil
 	}
-	rc, err := t.access.GetRemoteCluster(ctx, clusterName)
+	rc, err := t.remoteClusterGetter.GetRemoteCluster(ctx, clusterName)
 	if err != nil {
 		return nil, utils.OpaqueAccessDenied(err)
 	}

--- a/lib/reversetunnelclient/fake.go
+++ b/lib/reversetunnelclient/fake.go
@@ -19,6 +19,7 @@
 package reversetunnelclient
 
 import (
+	"context"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -31,18 +32,18 @@ import (
 // FakeServer is a fake Server implementation used in tests.
 type FakeServer struct {
 	Server
-	// Clusters is a list of clusters registered via this fake reverse tunnel.
-	Clusters []Cluster
+	// FakeClusters is a list of clusters registered via this fake reverse tunnel.
+	FakeClusters []Cluster
 }
 
-// GetSites returns all available clusters.
-func (s *FakeServer) GetSites() ([]Cluster, error) {
-	return s.Clusters, nil
+// Clusters returns all available clusters.
+func (s *FakeServer) Clusters(context.Context) ([]Cluster, error) {
+	return s.FakeClusters, nil
 }
 
-// GetSite returns the cluster by name.
-func (s *FakeServer) GetSite(name string) (Cluster, error) {
-	for _, cluster := range s.Clusters {
+// Cluster returns the cluster by name.
+func (s *FakeServer) Cluster(_ context.Context, name string) (Cluster, error) {
+	for _, cluster := range s.FakeClusters {
 		if cluster.GetName() == name {
 			return cluster, nil
 		}

--- a/lib/reversetunnelclient/peer.go
+++ b/lib/reversetunnelclient/peer.go
@@ -17,6 +17,7 @@
 package reversetunnelclient
 
 import (
+	"context"
 	"net"
 
 	"github.com/gravitational/trace"
@@ -33,9 +34,9 @@ func (f PeerDialerFunc) Dial(clusterName string, request peerdial.DialParams) (n
 }
 
 // NewPeerDialer implements [peerdial.Dialer] for a reverse tunnel server.
-func NewPeerDialer(server Tunnel) PeerDialerFunc {
+func NewPeerDialer(clusterGetter ClusterGetter) PeerDialerFunc {
 	return func(clusterName string, request peerdial.DialParams) (net.Conn, error) {
-		site, err := server.GetSite(clusterName)
+		site, err := clusterGetter.Cluster(context.TODO(), clusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/service/acme.go
+++ b/lib/service/acme.go
@@ -36,8 +36,8 @@ type hostPolicyCheckerConfig struct {
 	publicAddrs []utils.NetAddr
 	// clt is used to get the list of registered applications
 	clt app.Getter
-	// tun is a reverse tunnel
-	tun reversetunnelclient.Tunnel
+	// clusterGetter is used to retrieve connected Teleport clusters.
+	clusterGetter reversetunnelclient.ClusterGetter
 	// clusterName is a name of this cluster
 	clusterName string
 }
@@ -60,7 +60,7 @@ func (h *hostPolicyChecker) checkHost(ctx context.Context, host string) error {
 		return nil
 	}
 
-	_, _, err := app.ResolveFQDN(ctx, h.cfg.clt, h.cfg.tun, h.dnsNames, host)
+	_, _, err := app.ResolveFQDN(ctx, h.cfg.clt, h.cfg.clusterGetter, h.dnsNames, host)
 	if err == nil {
 		return nil
 	}
@@ -91,8 +91,8 @@ func (h *hostPolicyCheckerConfig) CheckAndSetDefaults() ([]string, error) {
 		return nil, trace.BadParameter("missing parameter clt")
 	}
 
-	if h.tun == nil {
-		return nil, trace.BadParameter("missing parameter tun")
+	if h.clusterGetter == nil {
+		return nil, trace.BadParameter("missing parameter clusterGetter")
 	}
 
 	dnsNames := make([]string, 0, len(h.publicAddrs))

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4969,7 +4969,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		router, err := proxy.NewRouter(proxy.RouterConfig{
 			ClusterName:      clusterName,
 			LocalAccessPoint: accessPoint,
-			SiteGetter:       tsrv,
+			ClusterGetter:    tsrv,
 			TracerProvider:   process.TracingProvider,
 			Logger:           process.logger.With(teleport.ComponentKey, "router"),
 		})
@@ -5947,10 +5947,10 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 			return nil, trace.ConvertSystemError(err)
 		}
 		hostChecker, err := newHostPolicyChecker(hostPolicyCheckerConfig{
-			publicAddrs: process.Config.Proxy.PublicAddrs,
-			clt:         conn.Client,
-			tun:         tsrv,
-			clusterName: conn.ClusterName(),
+			publicAddrs:   process.Config.Proxy.PublicAddrs,
+			clt:           conn.Client,
+			clusterGetter: tsrv,
+			clusterName:   conn.ClusterName(),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/srv/alpnproxy/auth/auth_proxy.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy.go
@@ -38,29 +38,29 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-type sitesGetter interface {
-	GetSites() ([]reversetunnelclient.Cluster, error)
+type ClusterGetter interface {
+	Cluster(context.Context, string) (reversetunnelclient.Cluster, error)
 }
 
 // NewAuthProxyDialerService create new instance of AuthProxyDialerService.
-func NewAuthProxyDialerService(reverseTunnelServer sitesGetter, localClusterName string, authServers []string, proxySigner multiplexer.PROXYHeaderSigner, tracer oteltrace.Tracer) *AuthProxyDialerService {
+func NewAuthProxyDialerService(clusterGetter ClusterGetter, localClusterName string, authServers []string, proxySigner multiplexer.PROXYHeaderSigner, tracer oteltrace.Tracer) *AuthProxyDialerService {
 	return &AuthProxyDialerService{
-		reverseTunnelServer: reverseTunnelServer,
-		localClusterName:    localClusterName,
-		authServers:         authServers,
-		proxySigner:         proxySigner,
-		tracer:              tracer,
+		clusterGetter:    clusterGetter,
+		localClusterName: localClusterName,
+		authServers:      authServers,
+		proxySigner:      proxySigner,
+		tracer:           tracer,
 	}
 }
 
 // AuthProxyDialerService allows dialing local/remote auth service base on SNI value encoded as destination auth
 // cluster name and ALPN set to teleport-auth protocol.
 type AuthProxyDialerService struct {
-	reverseTunnelServer sitesGetter
-	localClusterName    string
-	authServers         []string
-	proxySigner         multiplexer.PROXYHeaderSigner
-	tracer              oteltrace.Tracer
+	clusterGetter    ClusterGetter
+	localClusterName string
+	authServers      []string
+	proxySigner      multiplexer.PROXYHeaderSigner
+	tracer           oteltrace.Tracer
 }
 
 func (s *AuthProxyDialerService) HandleConnection(ctx context.Context, conn net.Conn, connInfo alpnproxy.ConnectionInfo) error {
@@ -102,7 +102,7 @@ func (s *AuthProxyDialerService) dialAuthServer(ctx context.Context, clusterName
 	if clusterNameFromSNI == s.localClusterName {
 		return s.dialLocalAuthServer(ctx, clientSrcAddr, clientDstAddr)
 	}
-	if s.reverseTunnelServer != nil {
+	if s.clusterGetter != nil {
 		return s.dialRemoteAuthServer(ctx, clusterNameFromSNI, clientSrcAddr, clientDstAddr)
 	}
 	return nil, trace.NotFound("auth server for %q cluster name not found", clusterNameFromSNI)
@@ -160,21 +160,17 @@ func (s *AuthProxyDialerService) dialRemoteAuthServer(ctx context.Context, clust
 		))
 	defer span.End()
 
-	sites, err := s.reverseTunnelServer.GetSites()
+	cluster, err := s.clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	for _, site := range sites {
-		if site.GetName() != clusterName {
-			continue
-		}
-		conn, err := site.DialAuthServer(reversetunnelclient.DialParams{From: clientSrcAddr, OriginalClientDstAddr: clientDstAddr})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return conn, nil
+
+	conn, err := cluster.DialAuthServer(reversetunnelclient.DialParams{From: clientSrcAddr, OriginalClientDstAddr: clientDstAddr})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return nil, trace.NotFound("cluster name %q not found", clusterName)
+
+	return conn, nil
 }
 
 func (s *AuthProxyDialerService) proxyConn(ctx context.Context, upstreamConn, downstreamConn net.Conn) error {

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2384,7 +2384,7 @@ func setupTestContext(ctx context.Context, t testing.TB, withDatabases ...withDa
 	testCtx.fakeCluster = reversetunnelclient.NewFakeCluster(testCtx.clusterName, proxyAuthClient)
 	t.Cleanup(func() { require.NoError(t, testCtx.fakeCluster.Close()) })
 	tunnel := &reversetunnelclient.FakeServer{
-		Clusters: []reversetunnelclient.Cluster{
+		FakeClusters: []reversetunnelclient.Cluster{
 			testCtx.fakeCluster,
 		},
 	}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -518,7 +518,7 @@ func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utils.TLSConn, para
 	if params.ClientIP != "" {
 		identity.LoginIP = params.ClientIP
 	}
-	cluster, err := s.cfg.Tunnel.GetSite(identity.RouteToCluster)
+	cluster, err := s.cfg.Tunnel.Cluster(ctx, identity.RouteToCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -173,13 +173,13 @@ func newProxySubsys(ctx context.Context, serverContext *srv.ServerContext, srv *
 		)
 		req.clusterName = serverContext.Identity.RouteToCluster
 	}
-	if req.clusterName != "" && srv.proxyTun != nil {
-		checker, err := srv.tunnelWithAccessChecker(serverContext)
+	if req.clusterName != "" && srv.proxyClusterGetter != nil {
+		checker, err := srv.clusterGetterWithAccessChecker(serverContext)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		if _, err := checker.GetSite(req.clusterName); err != nil {
+		if _, err := checker.Cluster(ctx, req.clusterName); err != nil {
 			return nil, trace.BadParameter("invalid format for proxy request: unknown cluster %q", req.clusterName)
 		}
 	}

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -54,19 +54,19 @@ func (t *proxySitesSubsys) Wait() error {
 // service.Site structures, and writes it serialized as JSON back to the SSH client
 func (t *proxySitesSubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, serverContext *srv.ServerContext) error {
 	t.srv.logger.DebugContext(ctx, "starting proxysites subsystem", "server_context", serverContext)
-	checker, err := t.srv.tunnelWithAccessChecker(serverContext)
+	checker, err := t.srv.clusterGetterWithAccessChecker(serverContext)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	remoteSites, err := checker.GetSites()
+	clusters, err := checker.Clusters(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// build an arary of services.Site structures:
-	retval := make([]types.Site, 0, len(remoteSites))
-	for _, s := range remoteSites {
+	retval := make([]types.Site, 0, len(clusters))
+	for _, s := range clusters {
 		retval = append(retval, types.Site{
 			Name:          s.GetName(),
 			Status:        s.GetStatus(),

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -101,10 +101,10 @@ type Server struct {
 	// cloudLabels are the labels imported from a cloud provider.
 	cloudLabels labels.Importer
 
-	proxyMode        bool
-	proxyTun         reversetunnelclient.Tunnel
-	proxyAccessPoint authclient.ReadProxyAccessPoint
-	peerAddr         string
+	proxyMode          bool
+	proxyClusterGetter reversetunnelclient.ClusterGetter
+	proxyAccessPoint   authclient.ReadProxyAccessPoint
+	peerAddr           string
 
 	advertiseAddr   *utils.NetAddr
 	proxyPublicAddr utils.NetAddr
@@ -467,13 +467,13 @@ func SetRotationGetter(getter services.RotationGetter) ServerOption {
 }
 
 // SetProxyMode starts this server in SSH proxying mode
-func SetProxyMode(peerAddr string, tsrv reversetunnelclient.Tunnel, ap authclient.ReadProxyAccessPoint, router *proxy.Router) ServerOption {
+func SetProxyMode(peerAddr string, clusterGetter reversetunnelclient.ClusterGetter, ap authclient.ReadProxyAccessPoint, router *proxy.Router) ServerOption {
 	return func(s *Server) error {
 		// always set proxy mode to true,
 		// because in some tests reverse tunnel is disabled,
 		// but proxy is still used without it.
 		s.proxyMode = true
-		s.proxyTun = tsrv
+		s.proxyClusterGetter = clusterGetter
 		s.proxyAccessPoint = ap
 		s.peerAddr = peerAddr
 		s.router = router
@@ -928,13 +928,13 @@ func (s *Server) getNamespace() string {
 	return types.ProcessNamespace(s.namespace)
 }
 
-func (s *Server) tunnelWithAccessChecker(ctx *srv.ServerContext) (reversetunnelclient.Tunnel, error) {
+func (s *Server) clusterGetterWithAccessChecker(ctx *srv.ServerContext) (reversetunnelclient.ClusterGetter, error) {
 	clusterName, err := s.GetAccessPoint().GetClusterName(s.ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return reversetunnelclient.NewTunnelWithRoles(s.proxyTun, clusterName.GetClusterName(), ctx.Identity.UnstableClusterAccessChecker, s.proxyAccessPoint), nil
+	return reversetunnelclient.NewClusterGetterWithRoles(s.proxyClusterGetter, clusterName.GetClusterName(), ctx.Identity.UnstableClusterAccessChecker, s.proxyAccessPoint), nil
 }
 
 // startAuthorizedKeysManager starts the authorized keys manager.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1823,7 +1823,7 @@ func TestProxyRoundRobin(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:      f.testSrv.ClusterName(),
 		LocalAccessPoint: proxyClient,
-		SiteGetter:       reverseTunnelServer,
+		ClusterGetter:    reverseTunnelServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)
@@ -1969,7 +1969,7 @@ func TestProxyDirectAccess(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:      f.testSrv.ClusterName(),
 		LocalAccessPoint: proxyClient,
-		SiteGetter:       reverseTunnelServer,
+		ClusterGetter:    reverseTunnelServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)
@@ -2667,7 +2667,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 		router, err := libproxy.NewRouter(libproxy.RouterConfig{
 			ClusterName:      f.testSrv.ClusterName(),
 			LocalAccessPoint: proxyClient,
-			SiteGetter:       reverseTunnelServer,
+			ClusterGetter:    reverseTunnelServer,
 			TracerProvider:   tracing.NoopProvider(),
 		})
 		require.NoError(t, err)
@@ -2933,7 +2933,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:      f.testSrv.ClusterName(),
 		LocalAccessPoint: proxyClient,
-		SiteGetter:       reverseTunnelServer,
+		ClusterGetter:    reverseTunnelServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)
@@ -3375,7 +3375,7 @@ func TestHostUserCreationProxy(t *testing.T) {
 	router, err := libproxy.NewRouter(libproxy.RouterConfig{
 		ClusterName:      f.testSrv.ClusterName(),
 		LocalAccessPoint: proxyClient,
-		SiteGetter:       reverseTunnelServer,
+		ClusterGetter:    reverseTunnelServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -457,7 +457,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:      s.server.ClusterName(),
 		LocalAccessPoint: s.proxyClient,
-		SiteGetter:       revTunServer,
+		ClusterGetter:    revTunServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)
@@ -3416,18 +3416,18 @@ func TestSearchClusterEvents(t *testing.T) {
 func TestGetClusterDetails(t *testing.T) {
 	t.Parallel()
 	s := newWebSuite(t)
-	site, err := s.proxyTunnel.GetSite(s.server.ClusterName())
+	cluster, err := s.proxyTunnel.Cluster(t.Context(), s.server.ClusterName())
 	require.NoError(t, err)
-	require.NotNil(t, site)
+	require.NotNil(t, cluster)
 
-	cluster, err := webui.GetClusterDetails(s.ctx, site)
+	clusterDetails, err := webui.GetClusterDetails(s.ctx, cluster)
 	require.NoError(t, err)
-	require.Equal(t, s.server.ClusterName(), cluster.Name)
-	require.Equal(t, teleport.Version, cluster.ProxyVersion)
-	require.Equal(t, fmt.Sprintf("%v:%v", s.server.ClusterName(), defaults.HTTPListenPort), cluster.PublicURL)
-	require.Equal(t, teleport.RemoteClusterStatusOnline, cluster.Status)
-	require.NotNil(t, cluster.LastConnected)
-	require.Equal(t, teleport.Version, cluster.AuthVersion)
+	require.Equal(t, s.server.ClusterName(), clusterDetails.Name)
+	require.Equal(t, teleport.Version, clusterDetails.ProxyVersion)
+	require.Equal(t, fmt.Sprintf("%v:%v", s.server.ClusterName(), defaults.HTTPListenPort), clusterDetails.PublicURL)
+	require.Equal(t, teleport.RemoteClusterStatusOnline, clusterDetails.Status)
+	require.NotNil(t, clusterDetails.LastConnected)
+	require.Equal(t, teleport.Version, clusterDetails.AuthVersion)
 }
 
 func TestTokenGeneration(t *testing.T) {
@@ -8380,7 +8380,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	router, err := proxy.NewRouter(proxy.RouterConfig{
 		ClusterName:      clustername,
 		LocalAccessPoint: client,
-		SiteGetter:       revTunServer,
+		ClusterGetter:    revTunServer,
 		TracerProvider:   tracing.NoopProvider(),
 	})
 	require.NoError(t, err)

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -329,7 +329,7 @@ func TestMatchApplicationServers(t *testing.T) {
 	expectedContent := "Hello application"
 	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
 	tunnel := &reversetunnelclient.FakeServer{
-		Clusters: []reversetunnelclient.Cluster{
+		FakeClusters: []reversetunnelclient.Cluster{
 			fakeCluster,
 		},
 	}
@@ -419,14 +419,14 @@ func TestHealthCheckAppServer(t *testing.T) {
 			authClient.appServers = tc.appServersFunc(t, fakeCluster)
 
 			tunnel := &reversetunnelclient.FakeServer{
-				Clusters: []reversetunnelclient.Cluster{fakeCluster},
+				FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
 			}
 
 			appHandler, err := NewHandler(ctx, &HandlerConfig{
 				Clock:                 fakeClock,
 				AuthClient:            authClient,
 				AccessPoint:           authClient,
-				ProxyClient:           tunnel,
+				ClusterGetter:         tunnel,
 				CipherSuites:          utils.DefaultCipherSuites(),
 				IntegrationAppHandler: &mockIntegrationAppHandler{},
 			})
@@ -443,12 +443,12 @@ type testServer struct {
 	serverURL *url.URL
 }
 
-func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.ClientI, proxyClient reversetunnelclient.Tunnel) *testServer {
+func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.ClientI, clusterGetter reversetunnelclient.ClusterGetter) *testServer {
 	appHandler, err := NewHandler(context.Background(), &HandlerConfig{
 		Clock:                 clock,
 		AuthClient:            authClient,
 		AccessPoint:           authClient,
-		ProxyClient:           proxyClient,
+		ClusterGetter:         clusterGetter,
 		CipherSuites:          utils.DefaultCipherSuites(),
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
 	})
@@ -831,8 +831,8 @@ func TestHandlerAuthenticate(t *testing.T) {
 		Clock:       fakeClock,
 		AuthClient:  authClient,
 		AccessPoint: authClient,
-		ProxyClient: &reversetunnelclient.FakeServer{
-			Clusters: []reversetunnelclient.Cluster{fakeCluster},
+		ClusterGetter: &reversetunnelclient.FakeServer{
+			FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
 		},
 		CipherSuites:          utils.DefaultCipherSuites(),
 		IntegrationAppHandler: &mockIntegrationAppHandler{},

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -76,7 +76,7 @@ func TestMatchHealthy(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			match := MatchHealthy(&mockProxyClient{
+			match := MatchHealthy(&mockClusterGetter{
 				cluster: &mockCluster{
 					dialErr: test.dialErr,
 				},
@@ -111,12 +111,12 @@ func mustNewAppServer(t *testing.T, origin string) func() types.AppServer {
 	}
 }
 
-type mockProxyClient struct {
-	reversetunnelclient.Tunnel
+type mockClusterGetter struct {
+	reversetunnelclient.ClusterGetter
 	cluster *mockCluster
 }
 
-func (p *mockProxyClient) GetSite(_ string) (reversetunnelclient.Cluster, error) {
+func (p *mockClusterGetter) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
 	return p.cluster, nil
 }
 

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -56,7 +56,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 
 	// Query the cluster this application is running in to find the public
 	// address and cluster name pair which will be encoded into the certificate.
-	clusterClient, err := h.c.ProxyClient.GetSite(identity.RouteToApp.ClusterName)
+	clusterClient, err := h.c.ClusterGetter.Cluster(ctx, identity.RouteToApp.ClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -68,7 +68,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 	servers, err := MatchUnshuffled(
 		ctx,
 		accessPoint,
-		appServerMatcher(h.c.ProxyClient, identity.RouteToApp.PublicAddr, identity.RouteToApp.ClusterName),
+		appServerMatcher(h.c.ClusterGetter, identity.RouteToApp.PublicAddr, identity.RouteToApp.ClusterName),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -86,7 +86,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 	transport, err := newTransport(&transportConfig{
 		log:                   h.logger,
 		clock:                 h.c.Clock,
-		proxyClient:           h.c.ProxyClient,
+		clusterGetter:         h.c.ClusterGetter,
 		accessPoint:           h.c.AccessPoint,
 		cipherSuites:          h.c.CipherSuites,
 		identity:              identity,
@@ -125,7 +125,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 
 // appServerMatcher returns a Matcher function used to find which AppServer can
 // handle the application requests.
-func appServerMatcher(proxyClient reversetunnelclient.Tunnel, publicAddr string, clusterName string) Matcher {
+func appServerMatcher(clusterGetter reversetunnelclient.ClusterGetter, publicAddr string, clusterName string) Matcher {
 	// Match healthy and PublicAddr servers. Having a list of only healthy
 	// servers helps the transport fail before the request is forwarded to a
 	// server (in cases where there are no healthy servers). This process might
@@ -135,6 +135,6 @@ func appServerMatcher(proxyClient reversetunnelclient.Tunnel, publicAddr string,
 		MatchPublicAddr(publicAddr),
 		// NOTE: Try to leave this matcher as the last one to dial only the
 		// application servers that match the requested application.
-		MatchHealthy(proxyClient, clusterName),
+		MatchHealthy(clusterGetter, clusterName),
 	)
 }

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -85,8 +85,8 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 			identity:    identity,
 			servers:     []types.AppServer{server},
 
-			cipherSuites: utils.DefaultCipherSuites(),
-			proxyClient:  &mockProxyClient{},
+			cipherSuites:  utils.DefaultCipherSuites(),
+			clusterGetter: &mockClusterGetter{},
 			accessPoint: &mockAuthClient{
 				caKey:       caKey,
 				caCert:      caCert,
@@ -218,20 +218,20 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 }
 
 type fakeTunnel struct {
-	reversetunnelclient.Tunnel
+	reversetunnelclient.ClusterGetter
 
 	fakeCluster *reversetunnelclient.FakeCluster
 	err         error
 }
 
-func (f fakeTunnel) GetSite(domainName string) (reversetunnelclient.Cluster, error) {
+func (f fakeTunnel) Cluster(context.Context, string) (reversetunnelclient.Cluster, error) {
 	return f.fakeCluster, f.err
 }
 
 func TestTransport_DialContextNoServersAvailable(t *testing.T) {
 	tp := transport{
 		c: &transportConfig{
-			proxyClient: fakeTunnel{
+			clusterGetter: fakeTunnel{
 				err: trace.ConnectionProblem(errors.New(reversetunnelclient.NoApplicationTunnel), ""),
 			},
 			identity: &tlsca.Identity{},
@@ -305,9 +305,9 @@ func Test_transport_rewriteRequest(t *testing.T) {
 				AzureIdentity: "azure-identity",
 			},
 		},
-		servers:      []types.AppServer{azureAppServer},
-		cipherSuites: utils.DefaultCipherSuites(),
-		proxyClient:  &mockProxyClient{},
+		servers:       []types.AppServer{azureAppServer},
+		cipherSuites:  utils.DefaultCipherSuites(),
+		clusterGetter: &mockClusterGetter{},
 		accessPoint: &mockAuthClient{
 			caKey:       caKey,
 			caCert:      caCert,
@@ -481,9 +481,9 @@ func Test_transport_with_integration(t *testing.T) {
 				AWSRoleARN:  "MyAWSRole",
 			},
 		},
-		servers:      []types.AppServer{awsAppServer},
-		cipherSuites: utils.DefaultCipherSuites(),
-		proxyClient:  &mockProxyClient{},
+		servers:       []types.AppServer{awsAppServer},
+		cipherSuites:  utils.DefaultCipherSuites(),
+		clusterGetter: &mockClusterGetter{},
 		accessPoint: &mockAuthClient{
 			caKey:       caKey,
 			caCert:      caCert,

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -282,8 +282,8 @@ func (h *Handler) resolveApp(ctx context.Context, scx *SessionContext, params Re
 
 // resolveAppByName will take an application name and cluster name and exactly resolves
 // the application and the server on which it is running.
-func (h *Handler) resolveAppByName(ctx context.Context, proxy reversetunnelclient.Tunnel, appName string, clusterName string) (types.AppServer, string, error) {
-	clusterClient, err := proxy.GetSite(clusterName)
+func (h *Handler) resolveAppByName(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, appName string, clusterName string) (types.AppServer, string, error) {
+	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -307,8 +307,8 @@ func (h *Handler) resolveAppByName(ctx context.Context, proxy reversetunnelclien
 
 // resolveDirect takes a public address and cluster name and exactly resolves
 // the application and the server on which it is running.
-func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnelclient.Tunnel, publicAddr string, clusterName string) (types.AppServer, string, error) {
-	clusterClient, err := proxy.GetSite(clusterName)
+func (h *Handler) resolveDirect(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, publicAddr string, clusterName string) (types.AppServer, string, error) {
+	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -332,8 +332,8 @@ func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnelclient.T
 
 // resolveFQDN makes a best effort attempt to resolve FQDN to an application
 // running within a root or leaf cluster.
-func (h *Handler) resolveFQDN(ctx context.Context, clt app.Getter, proxy reversetunnelclient.Tunnel, fqdn string) (types.AppServer, string, error) {
-	return app.ResolveFQDN(ctx, clt, proxy, h.proxyDNSNames(), fqdn)
+func (h *Handler) resolveFQDN(ctx context.Context, clt app.Getter, clusterGetter reversetunnelclient.ClusterGetter, fqdn string) (types.AppServer, string, error) {
+	return app.ResolveFQDN(ctx, clt, clusterGetter, h.proxyDNSNames(), fqdn)
 }
 
 // proxyDNSName is a DNS name the HTTP proxy is available at, where

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -190,7 +190,7 @@ func (h *Handler) createDesktopConnection(
 	serviceConn, version, err := desktop.ConnectToWindowsService(ctx, &desktop.ConnectionConfig{
 		Log:            log,
 		DesktopsGetter: clt,
-		Site:           cluster,
+		Cluster:        cluster,
 		ClientSrcAddr:  clientSrcAddr,
 		ClientDstAddr:  clientDstAddr,
 		DesktopName:    desktopName,

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -148,14 +148,14 @@ func sendMessage(ws *websocket.Conn, msgType sessionRecordingMessageType, data i
 }
 
 func (h *Handler) getSessionRecordingThumbnail(
-	w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite,
+	w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, cluster reversetunnelclient.Cluster,
 ) (any, error) {
 	sessionId := p.ByName("session_id")
 	if sessionId == "" {
 		return nil, trace.BadParameter("session_id is required")
 	}
 
-	clt, err := sctx.GetUserClient(r.Context(), site)
+	clt, err := sctx.GetUserClient(r.Context(), cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
The interface has been renamed from Tunnel to ClusterGetter and its methods were change from GetSite(s) to Cluster(s).

Updates https://github.com/gravitational/teleport/issues/19164.