### PR TITLE
[v16] [buddy] chore: Accept 204 from FluentD responses

### DIFF
--- a/integrations/event-handler/fluentd_client.go
+++ b/integrations/event-handler/fluentd_client.go
@@ -129,7 +129,7 @@ func (f *FluentdClient) Send(ctx context.Context, url string, b []byte) error {
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode != http.StatusOK {
+	if r.StatusCode < 200 || r.StatusCode >= 300 {
 		return trace.Errorf("Failed to send event to fluentd (HTTP %v)", r.StatusCode)
 	}
 

--- a/integrations/event-handler/fluentd_client.go
+++ b/integrations/event-handler/fluentd_client.go
@@ -129,7 +129,7 @@ func (f *FluentdClient) Send(ctx context.Context, url string, b []byte) error {
 	}
 	defer r.Body.Close()
 
-	if r.StatusCode < 200 || r.StatusCode >= 300 {
+	if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
 		return trace.Errorf("Failed to send event to fluentd (HTTP %v)", r.StatusCode)
 	}
 


### PR DESCRIPTION
Backport #57581 to branch/v16

changelog: Teleport `event-handler` now accepts HTTP Status Code 204 from the recipient. This adds support for sending events to Grafana Alloy and newer Fluentd versions.
