### PR TITLE
Show update widget in login dialog

### DIFF
--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -61,6 +61,7 @@ export function StepSlider<Flows>(props: Props<Flows>) {
     defaultStepIndex = 0,
     tDuration = 500,
     wrapping = false,
+    className,
     // extraProps are the props required by our step components defined in our flows.
     ...extraProps
   } = props;
@@ -274,7 +275,7 @@ export function StepSlider<Flows>(props: Props<Flows>) {
   const transitionRef = keyToNodeRef.current.get(key);
 
   return (
-    <Box ref={rootRef} style={rootStyle}>
+    <Box ref={rootRef} style={rootStyle} className={className}>
       {preMount && <HiddenBox>{$preContent}</HiddenBox>}
       <Wrap className={animationDirectionPrefix} tDuration={tDuration}>
         <TransitionGroup component={null}>
@@ -420,6 +421,8 @@ type Props<Flows> =
          * one and backwards from the first one to the last one.
          */
         wrapping?: boolean;
+        /** Allows styling of the container element. */
+        className?: string;
       } & ExtraProps // Extra props that are passed to each step component. Each step of each flow needs to accept the same set of extra props.
     : any;
 

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -291,7 +291,15 @@ function WidgetAndDetails(storyProps: StoryProps) {
 
   return (
     <Flex rowGap={7} columnGap={10} flexWrap="wrap">
-      <Stack gap={4} maxWidth="432px">
+      <Stack
+        gap={4}
+        maxWidth="432px"
+        css={`
+          > * {
+            width: 100%;
+          }
+        `}
+      >
         <Stack height={textHeight}>
           <H3>Widget View</H3>
           <P2>The component is rendered in the login form.</P2>

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -291,15 +291,7 @@ function WidgetAndDetails(storyProps: StoryProps) {
 
   return (
     <Flex rowGap={7} columnGap={10} flexWrap="wrap">
-      <Stack
-        gap={4}
-        maxWidth="432px"
-        css={`
-          > * {
-            width: 100%;
-          }
-        `}
-      >
+      <Stack gap={4} maxWidth="432px" alignItems="stretch">
         <Stack height={textHeight}>
           <H3>Widget View</H3>
           <P2>The component is rendered in the login form.</P2>

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -18,7 +18,15 @@
 
 import { ComponentType } from 'react';
 
-import { ButtonPrimary, ButtonSecondary, Flex, P3, Stack, Text } from 'design';
+import {
+  ButtonBorder,
+  ButtonPrimary,
+  ButtonSecondary,
+  Flex,
+  P3,
+  Stack,
+  Text,
+} from 'design';
 import { Alert } from 'design/Alert';
 import { Info } from 'design/Icon';
 import { IconProps } from 'design/Icon/Icon';
@@ -78,11 +86,13 @@ export function WidgetView({
       <Alert
         kind="danger"
         mb={0}
-        details={issueRequiringAttention}
-        secondaryAction={{
-          content: 'Resolve',
-          onClick: onMore,
-        }}
+        details={
+          <Stack gap={2}>
+            {issueRequiringAttention}
+            {/*TODO(gzdunek): Allow Alert to show buttons at the bottom. */}
+            <ButtonBorder onClick={onMore}>Resolve</ButtonBorder>
+          </Stack>
+        }
       >
         App updates are disabled
       </Alert>
@@ -95,12 +105,14 @@ export function WidgetView({
       <Alert
         kind="danger"
         mb={0}
-        details={updateEvent.error.message}
-        secondaryAction={{
-          content: 'More',
-          onClick: onMore,
-        }}
         {...rest}
+        details={
+          <Stack gap={2}>
+            {updateEvent.error.message}
+            {/*TODO(gzdunek): Allow Alert to show buttons at the bottom. */}
+            <ButtonBorder onClick={onMore}>More</ButtonBorder>
+          </Stack>
+        }
       >
         Unable to check for app updates
       </Alert>

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -54,6 +54,7 @@ export function WidgetView(props: {
   updateEvent: AppUpdateEvent;
   platform: Platform;
   clusterGetter: ClusterGetter;
+  mx?: string | number;
   onMore(): void;
   onDownload(): void;
   onInstall(): void;
@@ -62,17 +63,16 @@ export function WidgetView(props: {
   const { updateEvent } = props;
   const { autoUpdatesStatus } = updateEvent;
 
-  const issueRequiringAttention = findAutoUpdatesIssuesRequiringAttention(
-    autoUpdatesStatus,
-    getClusterName
-  );
+  const issueRequiringAttention =
+    autoUpdatesStatus &&
+    findAutoUpdatesIssuesRequiringAttention(autoUpdatesStatus, getClusterName);
 
   if (issueRequiringAttention) {
     return (
       <Alert
         kind="danger"
-        width="100%"
         mb={0}
+        mx={props.mx}
         details={issueRequiringAttention}
         secondaryAction={{
           content: 'Resolve',
@@ -89,8 +89,8 @@ export function WidgetView(props: {
     return (
       <Alert
         kind="danger"
-        width="100%"
         mb={0}
+        mx={props.mx}
         details={updateEvent.error.message}
         secondaryAction={{
           content: 'More',
@@ -134,6 +134,7 @@ export function WidgetView(props: {
       primaryButton={
         button ? { name: button.name, onClick: button.action } : undefined
       }
+      mx={props.mx}
     />
   );
 }
@@ -150,6 +151,7 @@ function AvailableUpdate(props: {
     name: string;
     onClick(): void;
   };
+  mx: string | number | undefined;
 }) {
   const hasUnreachableClusters = !!props.unreachableClusters.length;
   const isNonTeleportServer =
@@ -160,13 +162,14 @@ function AvailableUpdate(props: {
     <Stack
       justifyContent="space-between"
       gap={1}
-      width="100%"
       css={`
         border: 1px solid ${props => props.theme.colors.text.disabled};
         background: ${props => props.theme.colors.interactive.tonal.neutral[0]};
       `}
       borderRadius={3}
       px={3}
+      mx={props.mx}
+      width="100%"
       py="12px"
     >
       <Flex width="100%" alignItems="center" justifyContent="space-between">

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -168,7 +168,6 @@ function AvailableUpdate(props: {
       borderRadius={3}
       px={3}
       mx={props.mx}
-      width="100%"
       py="12px"
     >
       <Flex width="100%" alignItems="center" justifyContent="space-between">

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -20,10 +20,9 @@ import { ComponentType } from 'react';
 
 import { ButtonPrimary, ButtonSecondary, Flex, P3, Stack, Text } from 'design';
 import { Alert } from 'design/Alert';
-import { Info, Warning } from 'design/Icon';
+import { Info } from 'design/Icon';
 import { IconProps } from 'design/Icon/Icon';
 import { UnreachableCluster } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
-import { getErrorMessage } from 'shared/utils/error';
 
 import { Platform } from 'teleterm/mainProcess/types';
 import {
@@ -141,7 +140,7 @@ export function WidgetView(props: {
 
 function AvailableUpdate(props: {
   version: string;
-  description: string | { Icon: ComponentType<IconProps>; text: string };
+  description: string;
   unreachableClusters: UnreachableCluster[];
   downloadHost: string;
   platform: Platform;
@@ -186,14 +185,7 @@ function AvailableUpdate(props: {
           )}
           <Stack gap={0}>
             <Text bold>Teleport Connect {props.version}</Text>
-            {typeof props.description === 'object' ? (
-              <Flex gap={1}>
-                <props.description.Icon size="small" />
-                <P3>{props.description.text}</P3>
-              </Flex>
-            ) : (
-              <P3>{props.description}</P3>
-            )}
+            <P3>{props.description}</P3>
           </Stack>
         </Flex>
         <Flex gap={2}>
@@ -211,7 +203,7 @@ function AvailableUpdate(props: {
         <Stack ml={1}>
           {hasUnreachableClusters && (
             <IconAndText
-              Icon={Warning}
+              Icon={Info}
               text="Unable to retrieve accepted client versions from some clusters."
             />
           )}
@@ -251,7 +243,7 @@ function makeUpdaterContent({
   onDownload(): void;
   onInstall(): void;
 }): {
-  description: string | { Icon: ComponentType<IconProps>; text: string };
+  description: string;
   button?: {
     name: string;
     action(): void;
@@ -286,10 +278,7 @@ function makeUpdaterContent({
       };
     case 'error':
       return {
-        description: {
-          Icon: Warning,
-          text: getErrorMessage(updateEvent.error),
-        },
+        description: 'Update failed',
       };
   }
 }

--- a/web/packages/teleterm/src/ui/AppUpdater/common.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/common.ts
@@ -38,7 +38,9 @@ export function getDownloadHost(event: AppUpdateEvent): string {
     case 'update-available':
     case 'download-progress':
     case 'update-downloaded':
-      return new URL(event.update.files.at(0).url).host;
+    case 'error':
+      const url = event.update?.files?.at(0)?.url;
+      return url && new URL(url).host;
     default:
       return '';
   }

--- a/web/packages/teleterm/src/ui/AppUpdater/index.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/index.ts
@@ -19,3 +19,4 @@
 export * from './DetailsView';
 export * from './WidgetView';
 export * from './AppUpdaterContext';
+export { type ClusterGetter } from './common';

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -155,15 +155,19 @@ export const SsoError = (storyProps: StoryProps) => {
 };
 
 export const LocalWithPasswordless = (storyProps: StoryProps) => {
+  const props = makeProps(storyProps);
+  props.initAttempt.data.allowPasswordless = true;
+
   return (
     <TestContainer>
-      <ClusterLoginPresentation {...makeProps(storyProps)} />
+      <ClusterLoginPresentation {...props} />
     </TestContainer>
   );
 };
 
 export const LocalLoggedInUserWithPasswordless = (storyProps: StoryProps) => {
   const props = makeProps(storyProps);
+  props.initAttempt.data.allowPasswordless = true;
   props.loggedInUserName = 'llama';
 
   return (

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -32,6 +32,7 @@ const meta: Meta<StoryProps> = {
   argTypes: compatibilityArgType,
   args: {
     compatibility: 'compatible',
+    showUpdate: true,
   },
 };
 export default meta;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
@@ -22,6 +22,7 @@ import { render, screen } from 'design/utils/testing';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { AppUpdaterContextProvider } from 'teleterm/ui/AppUpdater';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 
@@ -41,12 +42,14 @@ it('keeps the focus on the password field on submission error', async () => {
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <ClusterLogin
-        clusterUri={cluster.uri}
-        onCancel={() => {}}
-        prefill={{ username: 'alice' }}
-        reason={undefined}
-      />
+      <AppUpdaterContextProvider>
+        <ClusterLogin
+          clusterUri={cluster.uri}
+          onCancel={() => {}}
+          prefill={{ username: 'alice' }}
+          reason={undefined}
+        />
+      </AppUpdaterContextProvider>
     </MockAppContextProvider>
   );
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.test.tsx
@@ -19,6 +19,7 @@
 import userEvent from '@testing-library/user-event';
 
 import { render, screen } from 'design/utils/testing';
+import { ClientVersionStatus } from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
@@ -61,4 +62,84 @@ it('keeps the focus on the password field on submission error', async () => {
 
   await screen.findByText('whoops something went wrong');
   expect(passwordField).toHaveFocus();
+});
+
+it('shows go to updates button in compatibility warning if there are clusters providing updates', async () => {
+  const clusterFoo = makeRootCluster({ uri: '/clusters/foo' });
+  const clusterBar = makeRootCluster({ uri: '/clusters/bar' });
+  const appContext = new MockAppContext();
+  appContext.addRootCluster(clusterFoo);
+  appContext.addRootCluster(clusterBar);
+
+  jest.spyOn(appContext.tshd, 'getAuthSettings').mockResolvedValue(
+    new MockedUnaryCall({
+      localAuthEnabled: true,
+      authProviders: [],
+      hasMessageOfTheDay: false,
+      authType: 'local',
+      allowPasswordless: false,
+      localConnectorName: '',
+      clientVersionStatus: ClientVersionStatus.TOO_NEW,
+      versions: {
+        minClient: '16.0.0-aa',
+        client: '17.0.0',
+        server: '17.0.0',
+      },
+    })
+  );
+
+  jest
+    .spyOn(appContext.mainProcessClient, 'subscribeToAppUpdateEvents')
+    .mockImplementation(callback => {
+      callback({
+        kind: 'update-not-available',
+        autoUpdatesStatus: {
+          enabled: true,
+          source: 'managing-cluster',
+          version: '19.0.0',
+          options: {
+            highestCompatibleVersion: '',
+            managingClusterUri: clusterBar.uri,
+            unreachableClusters: [],
+            clusters: [
+              {
+                clusterUri: clusterFoo.uri,
+                toolsAutoUpdate: true,
+                toolsVersion: '19.0.0',
+                minToolsVersion: '18.0.0-aa',
+                otherCompatibleClusters: [],
+              },
+              {
+                clusterUri: clusterBar.uri,
+                toolsAutoUpdate: true,
+                toolsVersion: '17.0.0',
+                minToolsVersion: '16.0.0-aa',
+                otherCompatibleClusters: [],
+              },
+            ],
+          },
+        },
+      });
+      return { cleanup: () => {} };
+    });
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <AppUpdaterContextProvider>
+        <ClusterLogin
+          clusterUri={clusterFoo.uri}
+          onCancel={() => {}}
+          prefill={{ username: 'alice' }}
+          reason={undefined}
+        />
+      </AppUpdaterContextProvider>
+    </MockAppContextProvider>
+  );
+
+  expect(
+    await screen.findByText('Detected potentially incompatible version')
+  ).toBeVisible();
+  expect(
+    await screen.findByRole('button', { name: 'Go to Auto Updates' })
+  ).toBeVisible();
 });

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -54,7 +54,18 @@ export function ClusterLogin(props: Props & { reason: ClusterConnectReason }) {
 export const ClusterLoginPresentation = (
   props: ClusterLoginPresentationProps
 ) => {
-  return <StepSlider flows={loginViews} currFlow="default" {...props} />;
+  return (
+    <StepSlider
+      flows={loginViews}
+      currFlow="default"
+      css={`
+        // Prevents displaying a scrollbar by the slider.
+        // Instead, the entire dialog should be scrollable.
+        flex-shrink: 0;
+      `}
+      {...props}
+    />
+  );
 };
 
 export type ClusterLoginPresentationProps = State & {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -54,13 +54,7 @@ export function ClusterLogin(props: Props & { reason: ClusterConnectReason }) {
 export const ClusterLoginPresentation = (
   props: ClusterLoginPresentationProps
 ) => {
-  return (
-    <StepSlider<typeof loginViews>
-      flows={loginViews}
-      currFlow="default"
-      {...props}
-    />
-  );
+  return <StepSlider flows={loginViews} currFlow="default" {...props} />;
 };
 
 export type ClusterLoginPresentationProps = State & {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -25,16 +25,20 @@ import {
   Flex,
   H2,
   Indicator,
+  StepSlider,
   Text,
 } from 'design';
 import * as Alerts from 'design/Alert';
 import { DialogContent, DialogHeader } from 'design/Dialog';
 import * as Icons from 'design/Icon';
+import { ArrowBack } from 'design/Icon';
+import type { StepComponentProps } from 'design/StepSlider';
 import { AuthSettings } from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
 import { PrimaryAuthType } from 'shared/services';
 
 import { publicAddrWithTargetPort } from 'teleterm/services/tshd/app';
 import { getTargetNameFromUri } from 'teleterm/services/tshd/gateway';
+import { DetailsView } from 'teleterm/ui/AppUpdater';
 import { ClusterConnectReason } from 'teleterm/ui/services/modals';
 
 import { outermostPadding } from '../spacing';
@@ -47,11 +51,23 @@ export function ClusterLogin(props: Props & { reason: ClusterConnectReason }) {
   return <ClusterLoginPresentation {...state} reason={reason} />;
 }
 
+export const ClusterLoginPresentation = (
+  props: ClusterLoginPresentationProps
+) => {
+  return (
+    <StepSlider<typeof loginViews>
+      flows={loginViews}
+      currFlow="default"
+      {...props}
+    />
+  );
+};
+
 export type ClusterLoginPresentationProps = State & {
   reason: ClusterConnectReason;
 };
 
-export function ClusterLoginPresentation({
+function ClusterLoginForm({
   title,
   initAttempt,
   init,
@@ -69,9 +85,18 @@ export function ClusterLoginPresentation({
   shouldSkipVersionCheck,
   disableVersionCheck,
   platform,
-}: ClusterLoginPresentationProps) {
+  next,
+  refCallback,
+  clusterGetter,
+  changeAppUpdatesManagingCluster,
+  appUpdateEvent,
+  cancelAppUpdateDownload,
+  quitAndInstallAppUpdate,
+  downloadAppUpdate,
+  checkForAppUpdates,
+}: ClusterLoginPresentationProps & StepComponentProps) {
   return (
-    <>
+    <Flex ref={refCallback} flexDirection="column">
       <DialogHeader px={outermostPadding}>
         <H2>
           Log in to <b>{title}</b>
@@ -125,12 +150,66 @@ export function ClusterLoginPresentation({
             shouldSkipVersionCheck={shouldSkipVersionCheck}
             disableVersionCheck={disableVersionCheck}
             platform={platform}
+            clusterGetter={clusterGetter}
+            checkForAppUpdates={checkForAppUpdates}
+            changeAppUpdatesManagingCluster={changeAppUpdatesManagingCluster}
+            appUpdateEvent={appUpdateEvent}
+            cancelAppUpdateDownload={cancelAppUpdateDownload}
+            downloadAppUpdate={downloadAppUpdate}
+            quitAndInstallAppUpdate={quitAndInstallAppUpdate}
+            switchToAppUpdateDetails={next}
           />
         )}
       </DialogContent>
-    </>
+    </Flex>
   );
 }
+
+const AppUpdateDetails = ({
+  refCallback,
+  platform,
+  downloadAppUpdate,
+  checkForAppUpdates,
+  cancelAppUpdateDownload,
+  quitAndInstallAppUpdate,
+  changeAppUpdatesManagingCluster,
+  appUpdateEvent,
+  clusterGetter,
+  onCloseDialog,
+  prev,
+}: ClusterLoginPresentationProps & StepComponentProps) => {
+  return (
+    <Flex ref={refCallback} flexDirection="column">
+      <DialogHeader px={outermostPadding}>
+        <Flex alignItems="center" gap={1}>
+          <ButtonIcon title="Go Back" onClick={prev}>
+            <ArrowBack />
+          </ButtonIcon>
+          <H2>App Updates</H2>
+        </Flex>
+        <ButtonIcon ml="auto" p={3} onClick={onCloseDialog} aria-label="Close">
+          <Icons.Cross size="medium" />
+        </ButtonIcon>
+      </DialogHeader>
+      <Flex px={4}>
+        <DetailsView
+          onInstall={() => quitAndInstallAppUpdate()}
+          platform={platform}
+          changeManagingCluster={clusterUri =>
+            changeAppUpdatesManagingCluster(clusterUri)
+          }
+          updateEvent={appUpdateEvent}
+          onDownload={() => downloadAppUpdate()}
+          onCancelDownload={() => cancelAppUpdateDownload()}
+          clusterGetter={clusterGetter}
+          onCheckForUpdates={() => checkForAppUpdates()}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
+const loginViews = { default: [ClusterLoginForm, AppUpdateDetails] };
 
 function getPrimaryAuthType(auth: AuthSettings): PrimaryAuthType {
   if (auth.localConnectorName === 'passwordless') {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/CompatibilityWarning.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/CompatibilityWarning.tsx
@@ -27,10 +27,12 @@ import {
 import { Platform } from 'teleterm/mainProcess/types';
 
 export function CompatibilityWarning(props: {
+  isAnyClusterProvidingUpdates: boolean;
   authSettings: AuthSettings;
   platform: Platform;
   shouldSkipVersionCheck: boolean;
   disableVersionCheck(): void;
+  onSwitchToAppUpdateDetails(): void;
   mx?: number;
 }) {
   if (props.shouldSkipVersionCheck) {
@@ -56,15 +58,22 @@ export function CompatibilityWarning(props: {
               fill="border"
               intent="neutral"
               inputAlignment
-              action={{
-                content: (
-                  <>
-                    Download in Browser
-                    <NewTab size="small" ml={1} />
-                  </>
-                ),
-                href: buildDownloadUrl(props.platform),
-              }}
+              action={
+                props.isAnyClusterProvidingUpdates
+                  ? {
+                      content: 'Go to Auto Updates',
+                      onClick: props.onSwitchToAppUpdateDetails,
+                    }
+                  : {
+                      content: (
+                        <>
+                          Download in Browser
+                          <NewTab size="small" ml={1} />
+                        </>
+                      ),
+                      href: buildDownloadUrl(props.platform),
+                    }
+              }
             />
             <ActionButton
               fill="minimal"

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -71,6 +71,11 @@ export default function LoginForm(props: Props) {
     shouldSkipVersionCheck: props.shouldSkipVersionCheck,
     disableVersionCheck: props.disableVersionCheck,
     platform: props.platform,
+    isAnyClusterProvidingUpdates:
+      props.appUpdateEvent.autoUpdatesStatus?.options.clusters.some(
+        c => c.toolsAutoUpdate
+      ),
+    onSwitchToAppUpdateDetails: props.switchToAppUpdateDetails,
   };
   const appUpdateWidgetViewProps = {
     updateEvent: props.appUpdateEvent,

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -27,7 +27,10 @@ import { Attempt } from 'shared/hooks/useAsync';
 import type { PrimaryAuthType } from 'shared/services';
 
 import { Platform } from 'teleterm/mainProcess/types';
+import { AppUpdateEvent } from 'teleterm/services/appUpdater';
+import { ClusterGetter, WidgetView } from 'teleterm/ui/AppUpdater';
 import * as types from 'teleterm/ui/services/clusters/types';
+import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { outermostPadding } from '../../spacing';
 import type { PasswordlessLoginState } from '../useClusterLogin';
@@ -69,6 +72,14 @@ export default function LoginForm(props: Props) {
     disableVersionCheck: props.disableVersionCheck,
     platform: props.platform,
   };
+  const appUpdateWidgetViewProps = {
+    updateEvent: props.appUpdateEvent,
+    onDownload: () => props.downloadAppUpdate(),
+    onInstall: () => props.quitAndInstallAppUpdate(),
+    platform: props.platform,
+    onMore: () => props.switchToAppUpdateDetails(),
+    clusterGetter: props.clusterGetter,
+  };
   const ssoEnabled = authProviders?.length > 0;
 
   // If local auth was not enabled, disregard any primary auth type config
@@ -82,6 +93,7 @@ export default function LoginForm(props: Props) {
           </Alerts.Danger>
         )}
         <CompatibilityWarning {...compatibilityWarningProps} />
+        <WidgetView {...appUpdateWidgetViewProps} />
         <FormSso {...props} />
       </FlexBordered>
     );
@@ -97,6 +109,7 @@ export default function LoginForm(props: Props) {
           Login has not been enabled
         </Alerts.Danger>
         <CompatibilityWarning {...compatibilityWarningProps} />
+        <WidgetView {...appUpdateWidgetViewProps} />
       </FlexBordered>
     );
   }
@@ -120,6 +133,7 @@ export default function LoginForm(props: Props) {
         mx={outermostPadding}
         {...compatibilityWarningProps}
       />
+      <WidgetView mx={outermostPadding} {...appUpdateWidgetViewProps} />
       <StepSlider<typeof loginViews>
         flows={loginViews}
         currFlow={'default'}
@@ -321,6 +335,14 @@ export type Props = {
   shouldSkipVersionCheck: boolean;
   disableVersionCheck(): void;
   platform: Platform;
+  switchToAppUpdateDetails(): void;
+  appUpdateEvent: AppUpdateEvent;
+  downloadAppUpdate(): Promise<void>;
+  cancelAppUpdateDownload(): Promise<void>;
+  checkForAppUpdates(): Promise<void>;
+  quitAndInstallAppUpdate(): void;
+  changeAppUpdatesManagingCluster(clusterUri: RootClusterUri): Promise<void>;
+  clusterGetter: ClusterGetter;
 };
 
 const OutermostPadding = styled(Box).attrs({ px: outermostPadding })``;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -35,6 +35,7 @@ export const TestContainer: FC<PropsWithChildren> = ({ children }) => (
 
 export interface StoryProps {
   compatibility: 'compatible' | 'client-too-old' | 'client-too-new';
+  showUpdate: boolean;
 }
 
 export const compatibilityArgType: ArgTypes<StoryProps> = {
@@ -42,6 +43,10 @@ export const compatibilityArgType: ArgTypes<StoryProps> = {
     control: { type: 'radio' },
     options: ['compatible', 'client-too-old', 'client-too-new'],
     description: 'Client compatibility',
+  },
+  showUpdate: {
+    type: 'boolean',
+    description: 'Show app update',
   },
 };
 
@@ -75,6 +80,27 @@ export function makeProps(
     shouldSkipVersionCheck: false,
     disableVersionCheck: () => {},
     platform: 'darwin',
+    changeAppUpdatesManagingCluster: async () => {},
+    checkForAppUpdates: async () => {},
+    downloadAppUpdate: async () => {},
+    clusterGetter: {
+      findCluster: () => undefined,
+    },
+    quitAndInstallAppUpdate: async () => {},
+    cancelAppUpdateDownload: async () => {},
+    appUpdateEvent: {
+      kind: 'update-not-available',
+      autoUpdatesStatus: {
+        enabled: false,
+        reason: 'no-cluster-with-auto-update',
+        options: {
+          unreachableClusters: [],
+          clusters: [],
+          highestCompatibleVersion: '',
+          managingClusterUri: '',
+        },
+      },
+    },
   };
 
   switch (storyProps.compatibility) {
@@ -97,6 +123,44 @@ export function makeProps(
         server: '17.0.0',
       };
     }
+  }
+
+  if (storyProps.showUpdate) {
+    props.appUpdateEvent = {
+      kind: 'update-available',
+      update: {
+        version: '19.0.0',
+        files: [
+          {
+            url: 'https://cdn.teleport.dev/connect-update',
+            sha512: '',
+          },
+        ],
+        path: '',
+        releaseDate: '',
+        sha512: '',
+      },
+      autoDownload: true,
+      autoUpdatesStatus: {
+        enabled: true,
+        source: 'highest-compatible',
+        version: '19.0.0',
+        options: {
+          unreachableClusters: [],
+          managingClusterUri: '',
+          clusters: [
+            {
+              clusterUri: '/clusters/foo',
+              toolsAutoUpdate: true,
+              minToolsVersion: '18.0.0',
+              toolsVersion: '19.0.0',
+              otherCompatibleClusters: [],
+            },
+          ],
+          highestCompatibleVersion: '19.0.0',
+        },
+      },
+    };
   }
 
   return props;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -44,7 +44,7 @@ export default function useClusterLogin(props: Props) {
     return Promise.all([
       tshd.getAuthSettings({ clusterUri }).then(({ response }) => response),
       mainProcessClient.checkForAppUpdates(),
-    ]).then(r => r[0]);
+    ]).then(([authSettings]) => authSettings);
   });
 
   const [loginAttempt, login, setAttempt] = useAsync(

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -43,6 +43,8 @@ export default function useClusterLogin(props: Props) {
   const [initAttempt, init] = useAsync(() => {
     return Promise.all([
       tshd.getAuthSettings({ clusterUri }).then(({ response }) => response),
+      // checkForAppUpdates doesn't return a rejected promise, errors are
+      // surfaced in app updates widget and details view.
       mainProcessClient.checkForAppUpdates(),
     ]).then(([authSettings]) => authSettings);
   });

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -26,6 +26,7 @@ import {
   makeRetryableError,
   makeRootCluster,
 } from 'teleterm/services/tshd/testHelpers';
+import { AppUpdaterContextProvider } from 'teleterm/ui/AppUpdater';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import ModalsHost from 'teleterm/ui/ModalsHost';
@@ -321,12 +322,14 @@ it('shows a login modal when a request to a cluster from the current workspace f
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <ConnectionsContextProvider>
-        <VnetContextProvider>
-          <SearchBarConnected />
-          <ModalsHost />
-        </VnetContextProvider>
-      </ConnectionsContextProvider>
+      <AppUpdaterContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <SearchBarConnected />
+            <ModalsHost />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
+      </AppUpdaterContextProvider>
     </MockAppContextProvider>
   );
 


### PR DESCRIPTION
Part 6 of https://github.com/gravitational/teleport/issues/50948. [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0144-client-tools-updates.md#teleport-connect-automatic-updates-added-on-2025-07-10-by-gzdunek).

Adds showing the update widget in the login dialog:
<img width="516" height="424" alt="image" src="https://github.com/user-attachments/assets/8bf52799-ebde-46bd-b488-9b2c0c944441" />