### PR TITLE
Add CI check for `pnpm process-icons`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -310,3 +310,7 @@ jobs:
 
       - name: Lint licenses
         run: make lint-license
+
+      - name: Check icons
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: git config --global --add safe.directory $(realpath .) && make icons-up-to-date

--- a/Makefile
+++ b/Makefile
@@ -1637,6 +1637,15 @@ terraform-resources-up-to-date: must-start-clean/host
 		exit 1; \
 	fi
 
+# icons-up-to-date checks if icons were pre-processed before being added to the repo.
+.PHONY: icons-up-to-date
+icons-up-to-date: must-start-clean/host
+	pnpm process-icons
+	@if ! git diff --quiet; then \
+		./build.assets/please-run.sh "icons (see web/packages/design/src/Icon/README.md)" "pnpm process-icons"; \
+		exit 1; \
+	fi
+
 # go-generate will execute `go generate` and generate go code.
 .PHONY: go-generate
 go-generate:


### PR DESCRIPTION
The script was originally added in https://github.com/gravitational/teleport/pull/56031. Since then, it already happened a couple of times that we've forgot to run this command. This results in dirty files being left in the repo after running `pnpm process-icons`.

Forgetting to run it is annoying because then the onus is on the person pushing the updated version to see if the icon renders properly. This CI check enforces that icons are processed before being merged to the repo.

We use a tool called svgo for processing icons. It's possible that if svgo introduces some breaking change in its output, then backports with icons will need to re-run `pnpm process-icons` between release branches. But in that case, we can always just backport the update of svgo itself.