### PR TITLE
Update discover finished view to accept custom messages

### DIFF
--- a/web/packages/teleport/src/Discover/Shared/Finished/Finished.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Finished/Finished.story.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cfg from 'teleport/config';
+
 import type { AgentStepProps } from '../../types';
 import { Finished as Component } from './Finished';
 
@@ -49,6 +51,15 @@ export const FinishedWithAutoEnroll = () => (
         requiredVpcsAndSubnets: undefined,
       },
     }}
+  />
+);
+
+export const FinishedWithMessageProps = () => (
+  <Component
+    {...props}
+    title="Resource Added Custom Message"
+    resourceText="Custom completion details"
+    redirect={cfg.routes.discover}
   />
 );
 

--- a/web/packages/teleport/src/Discover/Shared/Finished/Finished.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Finished/Finished.tsx
@@ -26,10 +26,18 @@ import history from 'teleport/services/history';
 import type { AgentStepProps } from '../../types';
 import celebratePamPng from './celebrate-pam.png';
 
-export function Finished(props: AgentStepProps) {
+//  Message fields will optionally override defaults and agent-based logic
+type Message = {
+  title?: string;
+  resourceText?: string;
+  redirect?: string;
+};
+
+export function Finished(props: AgentStepProps & Message) {
   let title = 'Resource Successfully Added';
   let resourceText =
     'You can start accessing this resource right away or add another resource.';
+  let redirect = cfg.routes.root;
 
   if (props.agentMeta) {
     if (props.agentMeta.autoDiscovery) {
@@ -39,6 +47,16 @@ export function Finished(props: AgentStepProps) {
       resourceText = `Resource [${props.agentMeta.resourceName}] has been successfully added to
       this Teleport Cluster. ${resourceText}`;
     }
+  }
+
+  if (props.title) {
+    title = props.title;
+  }
+  if (props.resourceText) {
+    resourceText = props.resourceText;
+  }
+  if (props.redirect) {
+    redirect = props.redirect;
   }
 
   return (
@@ -52,7 +70,7 @@ export function Finished(props: AgentStepProps) {
         <ButtonPrimary
           width="270px"
           size="large"
-          onClick={() => history.push(cfg.routes.root, true)}
+          onClick={() => history.push(redirect, true)}
           mr={3}
         >
           Browse Existing Resources


### PR DESCRIPTION
Updates the `Finished` component to accept an optional set of message props. When present, the prop will override any default or component agent based logic. 

This feels more scalable than another set of `if (props.agentMeta.X)` (lines 42-50) to support the messages needed for the aws roles anywhere success page.

<img width="1097" height="339" alt="Screenshot 2025-08-08 at 9 15 39 AM" src="https://github.com/user-attachments/assets/36d33eca-6326-4449-a120-c2c85afc6025" />

Supports https://github.com/issues/assigned?issue=gravitational%7Cteleport%7C53192