### PR TITLE
Simplify auto updates multi-cluster view

### DIFF
--- a/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
@@ -131,7 +131,7 @@ function ManagingClusterSelector({
         >
           <Stack gap={0}>
             <H3>Updates source</H3>
-            <P3>Multiple clusters can manage Teleport Connect version.</P3>
+            <P3>Choose which cluster to follow for updates.</P3>
           </Stack>
           <RadioGroup
             gap={2}
@@ -164,9 +164,9 @@ function makeOptions({
   onRetry(): void;
 }) {
   const highestCompatible = {
-    label: 'Use highest compatible version from your clusters',
+    label: 'Use the highest compatible version from your clusters',
     helperText: !highestCompatibleVersion ? (
-      <TextWithWarning text="No cluster provides version compatible with all other clusters." />
+      <TextWithWarning text="No cluster provides a version compatible with all other clusters." />
     ) : (
       `Teleport Connect ${highestCompatibleVersion} · Compatible with all clusters.`
     ),
@@ -186,7 +186,7 @@ function makeOptions({
 
       return {
         disabled,
-        label: `Use version from cluster ${getClusterName(c.clusterUri)}`,
+        label: getClusterName(c.clusterUri),
         helperText: [`Teleport Connect ${c.toolsVersion}`, compatibility]
           .filter(Boolean)
           .join(' · '),
@@ -199,7 +199,7 @@ function makeOptions({
     .map(c => {
       return {
         disabled,
-        label: `Use version from cluster ${getClusterName(c.clusterUri)}`,
+        label: getClusterName(c.clusterUri),
         helperText: (
           <>
             Teleport Connect {c.toolsVersion}
@@ -214,7 +214,7 @@ function makeOptions({
   const unreachableClusters = status.options.unreachableClusters.map(
     cluster => ({
       disabled,
-      label: `Use version from cluster ${getClusterName(cluster.clusterUri)}`,
+      label: getClusterName(cluster.clusterUri),
       helperText: (
         <UnreachableClusterHelper
           onRetry={onRetry}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
@@ -65,7 +65,7 @@ test('download button is available when autoDownload is false', async () => {
   ).toBeInTheDocument();
 });
 
-test('when there is no compatible client version, user needs to select cluster', async () => {
+test('when there are multiple clusters available, managing cluster can be selected', async () => {
   const changeManagingClusterSpy = jest.fn();
   render(
     <DetailsView
@@ -99,7 +99,7 @@ test('when there is no compatible client version, user needs to select cluster',
       clusterGetter={{
         findCluster: () => undefined,
       }}
-      platform={'darwin'}
+      platform="darwin"
       onCheckForUpdates={() => {}}
       onDownload={() => {}}
       onCancelDownload={() => {}}
@@ -112,30 +112,24 @@ test('when there is no compatible client version, user needs to select cluster',
       'Your clusters require incompatible client versions. To enable app updates, select which cluster should manage them.'
     )
   ).toBeInTheDocument();
-  expect(
-    await screen.findByText(
-      'Unable to retrieve accepted client versions from the cluster baz.'
-    )
-  ).toBeInTheDocument();
-  expect(
-    await screen.findByRole('checkbox', {
-      name: 'Use the highest compatible version from your clusters',
-    })
-  ).not.toBeChecked();
+
   const radioOptions = await screen.findAllByRole('radio');
-  expect(radioOptions).toHaveLength(3);
+  expect(radioOptions).toHaveLength(4);
 
   expect(radioOptions.at(0).closest('label')).toHaveTextContent(
     // The cluster name and the helper text are normally in separate lines.
-    'foo16.0.0 client, only compatible with this cluster.'
+    'Use highest compatible version from your clusters⚠︎︎ No cluster provides version compatible with all other clusters.'
   );
   expect(radioOptions.at(1).closest('label')).toHaveTextContent(
-    'bar18.0.0 client.⚠︎ Cannot provide updates, automatic client tools updates are disabled on this cluster.'
+    'Use version from cluster fooTeleport Connect 16.0.0'
   );
   expect(radioOptions.at(2).closest('label')).toHaveTextContent(
-    'baz⚠︎ Cannot provide updates, cluster is unreachable.NET_ERR'
+    'Use version from cluster barTeleport Connect 18.0.0⚠︎︎ Automatic client tools updates are disabled on this cluster.'
+  );
+  expect(radioOptions.at(3).closest('label')).toHaveTextContent(
+    'Use version from cluster baz⚠︎︎ Version unavailable · Cluster is unreachable.Show MoreRetry'
   );
 
-  await userEvent.click(radioOptions.at(0));
+  await userEvent.click(radioOptions.at(1));
   expect(changeManagingClusterSpy).toHaveBeenCalledWith('/clusters/foo');
 });

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
@@ -118,16 +118,16 @@ test('when there are multiple clusters available, managing cluster can be select
 
   expect(radioOptions.at(0).closest('label')).toHaveTextContent(
     // The cluster name and the helper text are normally in separate lines.
-    'Use highest compatible version from your clusters⚠︎︎ No cluster provides version compatible with all other clusters.'
+    'Use the highest compatible version from your clusters⚠︎︎ No cluster provides a version compatible with all other clusters.'
   );
   expect(radioOptions.at(1).closest('label')).toHaveTextContent(
-    'Use version from cluster fooTeleport Connect 16.0.0'
+    'fooTeleport Connect 16.0.0'
   );
   expect(radioOptions.at(2).closest('label')).toHaveTextContent(
-    'Use version from cluster barTeleport Connect 18.0.0⚠︎︎ Automatic client tools updates are disabled on this cluster.'
+    'barTeleport Connect 18.0.0⚠︎︎ Automatic client tools updates are disabled on this cluster.'
   );
   expect(radioOptions.at(3).closest('label')).toHaveTextContent(
-    'Use version from cluster baz⚠︎︎ Version unavailable · Cluster is unreachable.Show MoreRetry'
+    'baz⚠︎︎ Version unavailable · Cluster is unreachable.Show MoreRetry'
   );
 
   await userEvent.click(radioOptions.at(1));

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -168,12 +168,12 @@ function UpdaterState({
     case 'error':
       return (
         <Stack gap={3} width="100%">
-          <Alert width="100%" mb={0} details={event.error.message}>
-            An error occurred
-          </Alert>
           {event.update && (
             <AvailableUpdate update={event.update} platform={platform} />
           )}
+          <Alert mb={1} details={event.error.message}>
+            {event.update ? 'Update failed' : 'Unable to check for app updates'}
+          </Alert>
           <ButtonSecondary block onClick={onCheckForAppUpdates}>
             Try Again
           </ButtonSecondary>
@@ -219,6 +219,7 @@ function AvailableUpdate(props: { update: UpdateInfo; platform: Platform }) {
 
   return (
     <Stack>
+      <Text>A new version is available.</Text>
       <Flex gap={1} alignItems="center">
         {props.platform === 'darwin' ? (
           <img alt="App icon" height="50px" src={iconMac} />

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
@@ -58,7 +58,7 @@ export function AppUpdates(props: { hidden?: boolean; onClose(): void }) {
         width: '100%',
       })}
     >
-      <DialogHeader justifyContent="space-between" mb={4} alignItems="baseline">
+      <DialogHeader justifyContent="space-between" mb={3} alignItems="baseline">
         <H2>App Updates</H2>
         <ButtonIcon
           type="button"


### PR DESCRIPTION
The last part of https://github.com/gravitational/teleport/issues/50948. [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0144-client-tools-updates.md#teleport-connect-automatic-updates-added-on-2025-07-10-by-gzdunek).

After using the updater in the real app, I realized that it doesn't look great when there are multiple clusters. 
The management view occupies too much space and its options are not clear enough.

Summary of changes:
* All options are now radio options.
* Use highest compatible version option is no longer disabled if there's no compatible version. 
   * If you have clusters on incompatible versions, we show a warning that you have to choose one to continue receiving updates. But previously it was an irreversible decision, once you selected a cluster, you couldn't go back to the previous state. It was quite weird UX.
* Improved helper text under each option. 
   * For example, previously we used vague language like `19.0.0 client` instead of just `Teleport Connect 19.0.0`.
* The number of alerts has been minimized - we display errors and actions inline if there is a cluster list.

Updated view (I think it now looks closer to what you suggested during our call, Rafał :p)

<img width="498" height="533" alt="image" src="https://github.com/user-attachments/assets/db9c45ff-eab9-4a39-a0ae-3cc0b2a91ad7" />
