### PR TITLE
Dynamo-Athena migration - handle empty checkpoint file gracefully

### DIFF
--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -773,6 +773,9 @@ func (t *task) loadEmitterCheckpoint(ctx context.Context, exportARN string) (*ch
 			return nil, nil
 		}
 		return nil, trace.Wrap(err)
+	} else if len(bb) == 0 {
+		// If the file is empty, ignore it. This may occur due to OOM errors.
+		return nil, nil
 	}
 	var out checkpointData
 	if err := json.Unmarshal(bb, &out); err != nil {

--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -205,6 +205,7 @@ func MigrateWithAWS(ctx context.Context, cfg Config, awsCfg aws.Config) error {
 		return trace.Wrap(err)
 	}
 
+	// TODO(Joerger): Take the exportARN from the checkpoint file rather than starting a new export.
 	exportInfo, err := t.GetOrStartExportAndWaitForResults(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -365,7 +365,8 @@ func (t *task) getEventsFromDataFiles(ctx context.Context, exportInfo *exportInf
 	// this should be done at the beginning of program execution.
 	checkpoint, err := t.loadEmitterCheckpoint(ctx, exportInfo.ExportARN)
 	if err != nil {
-		_, err := prompt.Confirmation(ctx, os.Stdout, prompt.Stdin(), fmt.Sprintf("It seems that a previous migration %s stopped with error and there was an issue resuming it: %v. Would you like to start a new migration?", exportInfo.ExportARN, err))
+		t.Logger.InfoContext(ctx, "Failed to load checkpoint file from previous migration attempt", "file", t.CheckpointPath, "error", err)
+		_, err := prompt.Confirmation(ctx, os.Stdout, prompt.Stdin(), fmt.Sprintf("It seems that a previous migration %s stopped with error and there was an issue resuming it. Would you like to start a new migration?", exportInfo.ExportARN))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -782,7 +783,7 @@ func (t *task) loadEmitterCheckpoint(ctx context.Context, exportARN string) (*ch
 
 	var out checkpointData
 	if err := json.Unmarshal(bb, &out); err != nil {
-		return nil, trace.Wrap(err, "failed to load checkpoint file %q from previous migration attempt", t.CheckpointPath)
+		return nil, trace.Wrap(err)
 	}
 
 	// There are checkpoints for different export, assume there is no checkpoint saved.


### PR DESCRIPTION
The error reported below was caused by an empty checkpoint file getting read and failing to unmarshal. This empty checkpoint file seems to have been generated after a run that failed with an OOM error.

This PR updates the tool to prompt for restart with it fails to load a checkpoint file, rather than erroring out with a non descriptive error.

Further improvements can be made to handle checkpoint issues and prompts at the start of the tool, but this tool is rarely used and does not warrant further optimizations and UX improvements.

Closes https://github.com/gravitational/teleport/issues/57670