### PR TITLE
[v16] Fix kube port-forward race with multiple ports

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1769,11 +1769,22 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 	}
 
 	auditSent := map[string]bool{} // Set of `addr`. Can be multiple ports on single call. Using bool to simplify the check.
+	var auditSentMu sync.Mutex
 	onPortForward := func(addr string, success bool) {
-		if !sess.isLocalKubernetesCluster || auditSent[addr] {
+		if !sess.isLocalKubernetesCluster {
 			return
 		}
-		auditSent[addr] = true
+
+		auditSentMu.Lock()
+		isAuditSent := auditSent[addr]
+		if !isAuditSent {
+			auditSent[addr] = true
+		}
+		auditSentMu.Unlock()
+		if isAuditSent {
+			return
+		}
+
 		portForward := &apievents.PortForward{
 			Metadata: apievents.Metadata{
 				Type: events.PortForwardEvent,

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -766,36 +766,118 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 		return nil, err
 	}
 	defer conn.Close()
-	var (
-		data      httpstream.Stream
-		errStream httpstream.Stream
-	)
+
+	// Create a context for managing goroutines.
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	// Wait for all active port forwards to complete before returning.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// Get pod name
+	podName := p.ByName("name")
+
+	type portStream struct {
+		data       httpstream.Stream
+		error      httpstream.Stream
+		processing bool // Prevent duplicate handlers
+	}
+
+	portStreams := make(map[string]*portStream)
+	var streamsMu sync.Mutex
 
 	for {
 		select {
+		case <-ctx.Done():
+			s.log.WithContext(ctx).Info(ctx, "Context canceled")
+			return nil, nil
 		case <-conn.CloseChan():
+			s.log.WithContext(ctx).Info(ctx, "Connection closed")
 			return nil, nil
 		case stream := <-streamChan:
+			port := stream.Headers().Get(portHeader)
+			if port == "" {
+				s.log.WithContext(ctx).Warn(ctx, "Skipping a stream without a port header")
+				continue
+			}
+
+			streamsMu.Lock()
+			if _, ok := portStreams[port]; !ok {
+				portStreams[port] = &portStream{}
+			}
+
+			ps := portStreams[port]
+
 			switch stream.Headers().Get(StreamType) {
 			case StreamTypeError:
-				errStream = stream
+				ps.error = stream
 			case StreamTypeData:
-				data = stream
+				ps.data = stream
+			default:
+				s.log.WithContext(ctx).Warn(ctx, "Unknown stream type", "type", stream.Headers().Get(StreamType))
+			}
+
+			// Check whether the port is ready to process.
+			if ps.data != nil && ps.error != nil && !ps.processing {
+				ps.processing = true
+
+				// Process each port.
+				// Use a separate goroutine with each port for concurrency testing.
+				wg.Add(1)
+				go s.handlePortForward(ctx, &wg, port, podName, ps.data, ps.error)
+			}
+
+			streamsMu.Unlock()
+		}
+	}
+}
+
+// handlePortForward reads and writes to a port-forward stream.
+func (s *KubeMockServer) handlePortForward(ctx context.Context, wg *sync.WaitGroup, port string, podName string, dataStream, errorStream httpstream.Stream) {
+	defer wg.Done()
+	defer errorStream.Close()
+
+	// Unblock stream read when the context cancels.
+	stop := context.AfterFunc(ctx, func() { dataStream.Close() })
+	defer func() {
+		// Ensure that dataStream closes only once.
+		// httpstream.Stream.Close is not idempotent.
+		// stop() is true when AfterFunc hasn't run.
+		if stop() {
+			dataStream.Close()
+		}
+	}()
+
+	// Read from source.
+	buf := make([]byte, 1024)
+	n, readErr := dataStream.Read(buf)
+
+	// Process any data received, regardless of error.
+	// Behavior is based on the io.Reader contract.
+	// Handles the case where Read returns data and io.EOF.
+	if n > 0 {
+		// Write to target.
+		_, writeErr := fmt.Fprint(dataStream, PortForwardPayload, podName, string(buf[:n]))
+		if writeErr != nil {
+			s.log.WithContext(ctx).Error("Unable to write response", "error", writeErr)
+			if _, errWriteErr := errorStream.Write([]byte(writeErr.Error())); errWriteErr != nil {
+				s.log.WithContext(ctx).Error("Unable to write error", "error", errWriteErr)
 			}
 		}
-		if errStream != nil && data != nil {
-			break
-		}
+		return
 	}
 
-	buf := make([]byte, 1024)
-	n, err := data.Read(buf)
-	if err != nil {
-		errStream.Write([]byte(err.Error()))
-		return nil, nil
+	// Check for read error.
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		s.log.WithContext(ctx).Error("Read error", "port", port, "error", readErr)
+		if _, writeErr := errorStream.Write([]byte(readErr.Error())); writeErr != nil {
+			s.log.WithContext(ctx).Error("Unable to write error", "error", writeErr)
+		}
+		return
 	}
-	fmt.Fprint(data, PortForwardPayload, p.ByName("name"), string(buf[:n]))
-	return nil, nil
+
+	s.log.WithContext(ctx).Info("Port forward completed", "port", port)
 }
 
 // httpStreamReceived is the httpstream.NewStreamHandler for port

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -389,7 +389,7 @@ func (c *TestContext) startKubeServices(t *testing.T) {
 	go func() {
 		err := c.KubeServer.Serve(c.kubeServerListener)
 		// ignore server closed error returned when .Close is called.
-		if errors.Is(err, http.ErrServerClosed) {
+		if errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
 			return
 		}
 		assert.NoError(t, err)
@@ -398,7 +398,7 @@ func (c *TestContext) startKubeServices(t *testing.T) {
 	go func() {
 		err := c.KubeProxy.Serve(c.kubeProxyListener)
 		// ignore server closed error returned when .Close is called.
-		if errors.Is(err, http.ErrServerClosed) {
+		if errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
 			return
 		}
 		assert.NoError(t, err)

--- a/lib/kube/proxy/websocket_client_testing.go
+++ b/lib/kube/proxy/websocket_client_testing.go
@@ -37,6 +37,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
 	clientremotecommand "k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport"
 
@@ -132,6 +133,15 @@ func newWebSocketClient(config *rest.Config, method string, u *url.URL, opts ...
 //	CLOSE
 func (e *wsStreamClient) StreamWithContext(_ context.Context, options clientremotecommand.StreamOptions) error {
 	return trace.Wrap(e.Stream(options))
+}
+
+func (e *wsStreamClient) GetPorts() ([]portforward.ForwardedPort, error) {
+	return []portforward.ForwardedPort{
+		{
+			Local:  uint16(e.listener.Addr().(*net.TCPAddr).Port),
+			Remote: 8080,
+		},
+	}, nil
 }
 
 // Stream copies the contents from stdin into the connection and respective stdout and stderr


### PR DESCRIPTION
Backport #57474 to branch/v16

changelog: Kubernetes Access: Fixed a bug when forwarding multiple ports to a single pod