### PR TITLE
Fix Teleport Connect connecting to WDS v17 and earlier

### DIFF
--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -187,7 +187,12 @@ export class TdpClient extends EventEmitter<EventMap> {
       this.sendClientScreenSpec(options.screenSpec);
     }
 
-    if (options.keyboardLayout !== undefined) {
+    // 0 represents the default keyboard layout from the point of view of the
+    // remote desktop, so there is no need to send this message. Additionally,
+    // for clients (Connect) that don't support specifying a keyboard layout
+    // and WDS versions that don't support this feature (v17 and earlier), this
+    // avoids the connection crashing.
+    if (options.keyboardLayout !== undefined && options.keyboardLayout !== 0) {
       this.sendClientKeyboardLayout(options.keyboardLayout);
     }
 


### PR DESCRIPTION
In version 18 of Teleport, I added a `KeyboardLayout` message to Desktop Access that allows a user to specify their keyboard layout to be sent to remote Windows Desktops. This was not backported to older versions, so a version check was added to the proxy to make sure this message wasn't sent to an old Windows Desktop Service and cause a panic.

Teleport Connect connects to WDS using a different method to the web version which bypasses the existing version check. This PR adds a check to see if the keyboard layout is set, if it isn't, don't send the message.

Changelog: Fixed connection issues to Windows Desktop Services (v17 or earlier) in Teleport Connect.