### PR TITLE
Revert "chore: remove buf local plugin config"

### DIFF
--- a/buf-legacy.yaml
+++ b/buf-legacy.yaml
@@ -21,6 +21,7 @@ lint:
     # - COMMENT_MESSAGE
     - COMMENT_RPC
     - COMMENT_SERVICE
+    - PAGINATION_REQUIRED
   except:
     # MINIMAL
     - PACKAGE_DIRECTORY_MATCH
@@ -35,3 +36,12 @@ lint:
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_REQUEST_STANDARD_NAME
     - RPC_RESPONSE_STANDARD_NAME
+plugins:
+  - plugin:
+      - env
+      - GOWORK=off
+      - go
+      - -C
+      - ./build.assets/tooling
+      - run
+      - ./cmd/buf-plugin-linters

--- a/buf.yaml
+++ b/buf.yaml
@@ -17,6 +17,7 @@ lint:
     - COMMENT_RPC
     - COMMENT_SERVICE
     - PACKAGE_NO_IMPORT_CYCLE
+    - PAGINATION_REQUIRED
     - UNARY_RPC
   except:
     - FIELD_NOT_REQUIRED
@@ -83,3 +84,13 @@ breaking:
   ignore:
     # TODO(codingllama): Remove ignore once the PDP API is stable.
     - api/proto/teleport/decision/v1alpha1
+
+plugins:
+  - plugin:
+      - env
+      - GOWORK=off
+      - go
+      - -C
+      - ./build.assets/tooling
+      - run
+      - ./cmd/buf-plugin-linters


### PR DESCRIPTION
Reverts gravitational/teleport#57653

With #57692, #57693 and #57694 merged, this is now safe to re-enable on master
without breaking backport branch CI flows. 


Tested with:
```
# Verify revert:
make grpc
make protos/lint
make protos/breaking

# On branch/v{16,17,18}
buf breaking 'https://github.com/gravitational/teleport.git#branch=revert-57653-okraport/disable-local-buf-plugin' --against .
```