### PR TITLE
Adding session recording encryption key rotation to `tctl`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -935,6 +935,12 @@ func (c *Client) RecordingMetadataServiceClient() recordingmetadatav1.RecordingM
 	return recordingmetadatav1.NewRecordingMetadataServiceClient(c.conn)
 }
 
+// RecordingEncryptionServiceClient returns an unadorned client for the session
+// recording encryption service.
+func (c *Client) RecordingEncryptionServiceClient() recordingencryptionv1pb.RecordingEncryptionServiceClient {
+	return recordingencryptionv1pb.NewRecordingEncryptionServiceClient(c.conn)
+}
+
 // GetVnetConfig returns the singleton VnetConfig resource.
 func (c *Client) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig, error) {
 	return c.VnetConfigServiceClient().GetVnetConfig(ctx, &vnet.GetVnetConfigRequest{})

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -551,7 +551,14 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	})
 
 	g.Go(func() error {
-		ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeSessionRecordingConfig")
+		ctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthPreference")
+		if err := initializeAuthPreference(ctx, asrv, cfg.AuthPreference); err != nil {
+			span.End()
+			return trace.Wrap(err)
+		}
+		span.End()
+
+		ctx, span = cfg.Tracer.Start(gctx, "auth/InitializeSessionRecordingConfig")
 		defer span.End()
 		return trace.Wrap(initializeSessionRecordingConfig(ctx, asrv, cfg.SessionRecordingConfig))
 	})
@@ -566,12 +573,6 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		ctx, span := cfg.Tracer.Start(gctx, "auth/InitializeVnetConfig")
 		defer span.End()
 		return trace.Wrap(initializeVnetConfig(ctx, asrv))
-	})
-
-	g.Go(func() error {
-		ctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthPreference")
-		defer span.End()
-		return trace.Wrap(initializeAuthPreference(ctx, asrv, cfg.AuthPreference))
 	})
 
 	g.Go(func() error {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -973,7 +973,7 @@ func applyAuthConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 				return trace.BadParameter("cannot set both proxy_checks_host_keys and session_recording_config at the same time, prefer session_recording_config.proxy_checks_host_keys")
 			}
 
-			src = *fc.Auth.SessionRecordingConfig
+			src = fc.Auth.SessionRecordingConfig.toSpec()
 		}
 
 		cfg.Auth.SessionRecordingConfig, err = types.NewSessionRecordingConfigFromConfigFile(src)

--- a/tool/tctl/common/recordings_encryption_command.go
+++ b/tool/tctl/common/recordings_encryption_command.go
@@ -1,0 +1,207 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+)
+
+type recordingsEncryptionCommand struct {
+	// cmd implements the "tctl recordings encryptino" parent command
+	cmd *kingpin.CmdClause
+
+	// rotateCmd implements the "tctl recordings encryption rotate" subcommand.
+	rotateCmd *kingpin.CmdClause
+
+	// statusCmd implements the "tctl recordings encryption status" subcommand.
+	statusCmd *kingpin.CmdClause
+
+	// completeCmd implements the "tctl recordings encryption complete" subcommand.
+	completeCmd *kingpin.CmdClause
+
+	// rollbackCmd implements the "tctl recordings encryption rollback" subcommand.
+	rollbackCmd *kingpin.CmdClause
+
+	// format is the output format of statusCmd (text, json, or yaml)
+	format string
+
+	// stdout allows for redirecting command output. Useful for tests.
+	stdout io.Writer
+}
+
+// Initialize allows recordingsEncryptionCommand to plug itself into the CLI parser.
+func (c *recordingsEncryptionCommand) Initialize(recordingsCmd *kingpin.CmdClause, stdout io.Writer) {
+	c.cmd = recordingsCmd.Command("encryption", "Manage encryption properties of session recordings.")
+
+	c.rotateCmd = c.cmd.Command("rotate", "Rotate encryption keys used for encrypting session recordings.")
+	c.statusCmd = c.cmd.Command("status", "Show current rotation status.")
+	c.statusCmd.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)+". Defaults to 'text'.").Default(teleport.Text).StringVar(&c.format)
+	c.completeCmd = c.cmd.Command("complete-rotation", "Completes an in-progress encryption key rotation.")
+	c.rollbackCmd = c.cmd.Command("rollback-rotation", "Rolls back an in-progress encryption key rotation.")
+	if stdout == nil {
+		c.stdout = os.Stdout
+	}
+}
+
+// TryRun attempts to run subcommands like "recordings encryption rotate".
+func (c *recordingsEncryptionCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	switch cmd {
+	case c.rotateCmd.FullCommand():
+		commandFunc = c.Rotate
+	case c.statusCmd.FullCommand():
+		commandFunc = c.Status
+	case c.completeCmd.FullCommand():
+		commandFunc = c.Complete
+	case c.rollbackCmd.FullCommand():
+		commandFunc = c.Rollback
+	default:
+		return false, nil
+	}
+	client, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	err = commandFunc(ctx, client)
+	closeFn(ctx)
+
+	return true, trace.Wrap(err)
+}
+
+// Rotate initiates a key rotation. It should fail if a key rotation is already
+// in progress.
+func (c *recordingsEncryptionCommand) Rotate(ctx context.Context, tc *authclient.Client) error {
+	client := tc.RecordingEncryptionServiceClient()
+	if _, err := client.RotateKey(ctx, &recordingencryptionv1.RotateKeyRequest{}); err != nil {
+		return trace.Errorf("rotating key encryption keys: %v", err)
+	}
+	fmt.Fprintln(c.stdout, "Rotation started")
+	return nil
+}
+
+// Complete an in progress key rotation. It should fail if any key is marked
+// 'inaccessible'.
+func (c *recordingsEncryptionCommand) Complete(ctx context.Context, tc *authclient.Client) error {
+	client := tc.RecordingEncryptionServiceClient()
+	if _, err := client.CompleteRotation(ctx, &recordingencryptionv1.CompleteRotationRequest{}); err != nil {
+		return trace.Errorf("completing encryption key rotation: %v", err)
+	}
+
+	fmt.Fprintln(c.stdout, "Rotation completed")
+	return nil
+}
+
+// Rollback an in progress key rotation.
+func (c *recordingsEncryptionCommand) Rollback(ctx context.Context, tc *authclient.Client) error {
+	client := tc.RecordingEncryptionServiceClient()
+	if _, err := client.RollbackRotation(ctx, &recordingencryptionv1.RollbackRotationRequest{}); err != nil {
+		return trace.Errorf("rolling back encryption key rotation: %v", err)
+	}
+
+	fmt.Fprintln(c.stdout, "Rotation rollback successful")
+	return nil
+}
+
+// Status displays the current rotation status of the active encryption keys.
+func (c *recordingsEncryptionCommand) Status(ctx context.Context, tc *authclient.Client) error {
+	client := tc.RecordingEncryptionServiceClient()
+	res, err := client.GetRotationState(ctx, &recordingencryptionv1.GetRotationStateRequest{})
+	if err != nil {
+		return trace.Errorf("fetching encryption key status: %v", err)
+	}
+
+	switch c.format {
+	case teleport.Text, "":
+		return trace.Wrap(c.writeStatusText(c.stdout, res.GetKeyPairStates()))
+	case teleport.YAML:
+		return trace.Wrap(c.writeStatusYAML(c.stdout, res.GetKeyPairStates()))
+	case teleport.JSON:
+		return trace.Wrap(c.writeStatusJSON(c.stdout, res.GetKeyPairStates()))
+	}
+
+	return trace.Wrap(err, "writing encryption key status")
+}
+
+func (c *recordingsEncryptionCommand) writeStatusJSON(w io.Writer, keyStates []*recordingencryptionv1.FingerprintWithState) error {
+	data, err := json.MarshalIndent(keyStates, "", "    ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+func (c *recordingsEncryptionCommand) writeStatusYAML(w io.Writer, keyStates []*recordingencryptionv1.FingerprintWithState) error {
+	return trace.Wrap(utils.WriteYAML(w, keyStates))
+}
+
+func (c *recordingsEncryptionCommand) writeStatusText(w io.Writer, keyStates []*recordingencryptionv1.FingerprintWithState) error {
+	rotationState := recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_UNSPECIFIED
+	t := asciitable.MakeTable([]string{"Key Pair Fingerprint", "State"})
+	for _, pair := range keyStates {
+		if pair.State == recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_INACCESSIBLE {
+			rotationState = pair.State
+		}
+
+		if pair.State == recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ROTATING {
+			if rotationState != recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_INACCESSIBLE {
+				rotationState = pair.State
+			}
+		}
+
+		t.AddRow([]string{pair.Fingerprint, c.getFriendlyStatusString(pair.State)})
+	}
+
+	switch rotationState {
+	case recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_INACCESSIBLE:
+		fmt.Fprintln(w, "Rotation failed due to inaccessible key")
+	case recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ROTATING:
+		fmt.Fprintln(w, "Rotation in progress")
+	}
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func (c *recordingsEncryptionCommand) getFriendlyStatusString(state recordingencryptionv1.KeyPairState) string {
+	switch state {
+	case recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ROTATING:
+		return "rotating"
+	case recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE:
+		return "active"
+	case recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_INACCESSIBLE:
+		return "inaccessible"
+	default:
+		return "unknown"
+	}
+}

--- a/tool/tctl/common/recordings_encryption_command_test.go
+++ b/tool/tctl/common/recordings_encryption_command_test.go
@@ -1,0 +1,139 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+func TestRecordingEncryptionKeyRotation(t *testing.T) {
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+			SessionRecordingConfig: &config.SessionRecordingConfig{
+				Mode: "node",
+				Encryption: &config.SessionRecordingEncryptionConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, clt.Close())
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	// get initial status to confirm one active key exists
+	keyStates := getEncryptionKeyStates(t, clt)
+	require.Len(t, keyStates, 1)
+	initialKeyState := keyStates[0]
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE, initialKeyState.State)
+
+	// start key rotation
+	_, err = runRecordingsCommand(t, clt, []string{"recordings", "encryption", "rotate"})
+	require.NoError(t, err)
+
+	// refetch status to confirm original key is now 'rotating' and new key is 'active'
+	keyStates = getEncryptionKeyStates(t, clt)
+	require.Len(t, keyStates, 2)
+	rotatedKeyState := keyStates[0]
+	newKeyState := keyStates[1]
+
+	require.Equal(t, initialKeyState.Fingerprint, rotatedKeyState.Fingerprint)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ROTATING, rotatedKeyState.State)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE, newKeyState.State)
+
+	// confirm a second rotation fails when one is already in progress
+	_, err = runRecordingsCommand(t, clt, []string{"recordings", "encryption", "rotate"})
+	require.Error(t, err)
+
+	// rollback rotation
+	_, err = runRecordingsCommand(t, clt, []string{"recordings", "encryption", "rollback-rotation"})
+	require.NoError(t, err)
+
+	// ensure initial key is the only active key remaining
+	keyStates = getEncryptionKeyStates(t, clt)
+	require.Len(t, keyStates, 1)
+	newKeyState = keyStates[0]
+	require.Equal(t, initialKeyState.Fingerprint, newKeyState.Fingerprint)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE, newKeyState.State)
+
+	// start a new rotation
+	_, err = runRecordingsCommand(t, clt, []string{"recordings", "encryption", "rotate"})
+	require.NoError(t, err)
+
+	// confirm in progress rotation state
+	keyStates = getEncryptionKeyStates(t, clt)
+	require.Len(t, keyStates, 2)
+	rotatedKeyState = keyStates[0]
+	newKeyState = keyStates[1]
+	require.Equal(t, initialKeyState.Fingerprint, rotatedKeyState.Fingerprint)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ROTATING, rotatedKeyState.State)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE, newKeyState.State)
+
+	// complete rotation
+	_, err = runRecordingsCommand(t, clt, []string{"recordings", "encryption", "complete-rotation"})
+	require.NoError(t, err)
+
+	// ensure remaining active key is new
+	keyStates = getEncryptionKeyStates(t, clt)
+	require.Len(t, keyStates, 1)
+	finalKeyState := keyStates[0]
+	require.Equal(t, newKeyState.Fingerprint, finalKeyState.Fingerprint)
+	require.Equal(t, recordingencryptionv1.KeyPairState_KEY_PAIR_STATE_ACTIVE, finalKeyState.State)
+}
+
+func getEncryptionKeyStates(t *testing.T, client *authclient.Client) []*recordingencryptionv1.FingerprintWithState {
+	var keyStates []*recordingencryptionv1.FingerprintWithState
+	out, err := runRecordingsCommand(t, client, []string{"recordings", "encryption", "status", "--format", "json"})
+	require.NoError(t, err)
+	err = json.Unmarshal(out.Bytes(), &keyStates)
+	require.NoError(t, err)
+
+	return keyStates
+}
+
+func runRecordingsCommand(t *testing.T, client *authclient.Client, args []string) (*bytes.Buffer, error) {
+	var stdoutBuf bytes.Buffer
+	command := &RecordingsCommand{
+		stdout: &stdoutBuf,
+	}
+
+	return &stdoutBuf, runCommand(t, client, command, args)
+}

--- a/tool/tctl/common/tctl_test.go
+++ b/tool/tctl/common/tctl_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/cryptosuites/cryptosuitestest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -48,7 +49,11 @@ func TestMain(m *testing.M) {
 	}
 
 	modules.SetInsecureTestMode(true)
-	os.Exit(m.Run())
+	ctx, cancel := context.WithCancel(context.Background())
+	cryptosuitestest.PrecomputeRSAKeys(ctx)
+	exitCode := m.Run()
+	cancel()
+	os.Exit(exitCode)
 }
 
 func BenchmarkInit(b *testing.B) {


### PR DESCRIPTION
This PR adds subcommands for rotating session recording encryption keys under `tctl recordings encryption`. They are `rotate`, `status`, `complete-rotation`, and `rollback-rotation`.
- `rotate` will start a rotation by provisioning a new key and adding it to the active set of encryption keys.
- `status` will print the state of each key along with its fingerprint.
- 'complete-rotation' will move the rotated key of an in-progress rotation into a `RotatedKeys` resource which makes it usable for replays
- 'rollback-rotation' will remove the new key in an in-progress rotation and reinstate the original key. Running `rotate` and `rollback` should ultimately result in no changes being applied.

There's also a fix for using `manual_key_management` from the fileconfig included.

```
$ tctl recordings encryption --help
usage: tctl recordings encryption <command> [<args> ...]

Manage encryption properties of session recordings.

Flags:
  -d, --[no-]debug     Enable verbose logging to stderr
  -c, --config         Path to a configuration file [/etc/teleport.yaml] for an Auth Service instance. Can also be set via
                       the TELEPORT_CONFIG_FILE environment variable. Ignored if the auth_service is disabled.
      --auth-server    Attempts to connect to specific auth/proxy address(es) instead of local auth [127.0.0.1:3025]
  -i, --identity       Path to an identity file. Must be provided to make remote connections to auth. An identity file can be
                       exported with 'tctl auth sign'
      --[no-]insecure  When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data
                       you send can be intercepted or modified by an attacker.

Commands:
  recordings encryption rotate            Rotate encryption keys used for encrypting session recordings.
  recordings encryption status            Show current rotation status
  recordings encryption complete-rotation Completes an in-progress encryption key rotation.
  recordings encryption rollback-rotation Rolls back an in-progress encryption key rotation.
```