### PR TITLE
[v17] Enable Managed Updates when adding new Kubernetes agents

### DIFF
--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -136,6 +136,7 @@ helm repo update
   --set roles="{{.set_roles}}" \
   --set proxyAddr={{.auth_server}} \
   --set authToken={{.token}} \
+  --set updater.enabled=true \
   --create-namespace \
   --namespace=teleport-agent \
   --version={{.version}}


### PR DESCRIPTION
Backport #57324 to branch/v17

changelog: enroll new Kubernetes agents in Managed Updates
