### PR TITLE
Web: fix access request checkout layout

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -321,7 +321,6 @@ export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
             sidePanelOpened: infoGuideSidePanelOpened,
             panelWidth: infoGuideConfig?.viewHasOwnSidePanel ? 0 : panelWidth,
           })}
-          position: relative;
         `}
       >
         {children}


### PR DESCRIPTION
CSS regression introduced by https://github.com/gravitational/teleport/pull/56832 where i added a `position: relative` in the Main layout where it caused the access request checkout to be wonky. more details [here](https://gravitational.slack.com/archives/C02DQ1C2BMW/p1754945928767239)

Not sure why I put that there (i think it was left over I forgot to remove), it doesn't affect the toast notifications (re-tested)

changelog: Fixed the web UI's access request submission panel getting stuck when scrolling down the page