### PR TITLE
Enable HTTP caching for Kubernetes OIDC joining

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	github.com/gravitational/roundtrip v1.0.2
 	github.com/gravitational/teleport/api v0.0.0
 	github.com/gravitational/trace v1.5.1
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/guptarohit/asciigraph v0.7.3
@@ -411,7 +412,6 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -758,7 +758,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		as.k8sJWKSValidator = kubetoken.ValidateTokenWithJWKS
 	}
 	if as.k8sOIDCValidator == nil {
-		as.k8sOIDCValidator = kubetoken.ValidateTokenWithOIDC
+		as.k8sOIDCValidator = kubetoken.NewKubernetesOIDCTokenValidator()
 	}
 
 	if as.gcpIDTokenValidator == nil {
@@ -1225,7 +1225,7 @@ type Server struct {
 	k8sJWKSValidator k8sJWKSValidator
 	// k8sOIDCValidator allows tokens from Kubernetes to be validated by the
 	// auth server using a known OIDC endpoint. It can be overridden in tests.
-	k8sOIDCValidator k8sOIDCValidator
+	k8sOIDCValidator *kubetoken.KubernetesOIDCTokenValidator
 
 	// gcpIDTokenValidator allows ID tokens from GCP to be validated by the auth
 	// server. It can be overridden for the purpose of tests.

--- a/lib/auth/join_kubernetes.go
+++ b/lib/auth/join_kubernetes.go
@@ -35,13 +35,6 @@ type k8sTokenReviewValidator interface {
 
 type k8sJWKSValidator func(now time.Time, jwksData []byte, clusterName string, token string) (*kubetoken.ValidationResult, error)
 
-type k8sOIDCValidator func(
-	ctx context.Context,
-	issuerURL string,
-	clusterName string,
-	token string,
-) (*kubetoken.ValidationResult, error)
-
 func (a *Server) checkKubernetesJoinRequest(
 	ctx context.Context,
 	req *types.RegisterUsingTokenRequest,

--- a/lib/auth/join_kubernetes.go
+++ b/lib/auth/join_kubernetes.go
@@ -77,7 +77,7 @@ func (a *Server) checkKubernetesJoinRequest(
 			return nil, trace.WrapWithMessage(err, "reviewing kubernetes token with static_jwks")
 		}
 	case types.KubernetesJoinTypeOIDC:
-		result, err = a.k8sOIDCValidator(
+		result, err = a.k8sOIDCValidator.ValidateTokenWithOIDC(
 			ctx,
 			token.Spec.Kubernetes.OIDC.Issuer,
 			clusterName,

--- a/lib/kube/token/validator.go
+++ b/lib/kube/token/validator.go
@@ -368,6 +368,8 @@ type KubernetesOIDCTokenValidator struct {
 	client *http.Client
 }
 
+// NewKubernetesOIDCTokenValidator returns a token validator populated with a
+// caching HTTP client.
 func NewKubernetesOIDCTokenValidator() *KubernetesOIDCTokenValidator {
 	return &KubernetesOIDCTokenValidator{
 		client: oidc.NewCachingHTTPClient(),

--- a/lib/kube/token/validator_test.go
+++ b/lib/kube/token/validator_test.go
@@ -956,7 +956,10 @@ func TestValidateTokenWithOIDC(t *testing.T) {
 
 			issuer := fmt.Sprintf("http://%s", idp.server.Listener.Addr().String())
 
-			result, err := ValidateTokenWithOIDC(ctx, issuer, tt.audience, tt.token)
+			v := KubernetesOIDCTokenValidator{
+				client: http.DefaultClient,
+			}
+			result, err := v.ValidateTokenWithOIDC(ctx, issuer, tt.audience, tt.token)
 			tt.assertError(t, err)
 
 			require.Empty(t, cmp.Diff(

--- a/lib/oidc/token_validator.go
+++ b/lib/oidc/token_validator.go
@@ -53,6 +53,10 @@ func ValidateToken[C oidc.Claims](
 	)
 }
 
+// ValidateTokenWithClient validates an OIDC token against a generic claim type,
+// but accepts a custom HTTP client. This custom client can be used in tandem
+// with the client returned by `NewCachingHTTPClient()` to cache OpenID and JWKS
+// responses.
 func ValidateTokenWithClient[C oidc.Claims](
 	ctx context.Context,
 	httpClient *http.Client,
@@ -76,7 +80,7 @@ func ValidateTokenWithClient[C oidc.Claims](
 
 	// TODO(noah): Ideally we'd cache the remote keyset across joins/join tokens
 	// based on the issuer.
-	ks := rp.NewRemoteKeySet(otelhttp.DefaultClient, dc.JwksURI)
+	ks := rp.NewRemoteKeySet(httpClient, dc.JwksURI)
 	verifier := rp.NewIDTokenVerifier(issuerURL, audience, ks, opts...)
 	// TODO(noah): It'd be ideal if we could extend the verifier to use an
 	// injected "now" time.


### PR DESCRIPTION
This enables HTTP caching for the Kubernetes OIDC join subtype.

This adds a new `ValidateTokenWithClient` helper that can be used to provide a custom client for anything currently using our shared OIDC validation helper. Clients just need to swap in a caching `*http.Client`; this PR only updates the Kubernetes OIDC join method for backporting purposes, but it should be straightforward to enable caching on other join methods in the future.

This relies on caching at the HTTP client layer as we otherwise don't have any ability to cache responses without significant tweaks to our OIDC library. This makes use of `gregjones/httpcache` which is already in our dependency tree; see [this thread](https://github.com/gravitational/teleport/pull/57789#discussion_r2268243665) for some additional library selection notes.

changelog: Cache OIDC responses for Kubernetes OIDC joining