### PR TITLE
Stub out teleport version in tests

### DIFF
--- a/lib/client/db/mysql/repl/commands.go
+++ b/lib/client/db/mysql/repl/commands.go
@@ -125,14 +125,14 @@ func newCommands() (*commandManager, error) {
 			name:        "teleport",
 			shortcut:    't',
 			description: "Show Teleport interactive shell information, such as execution limitations.",
-			execFunc: func(_ *REPL, _ string) (string, bool) {
+			execFunc: func(r *REPL, _ string) (string, bool) {
 				var sb strings.Builder
 				for _, l := range descriptiveLimitations {
 					sb.WriteString("- " + strings.ReplaceAll(l, "\n", "\n  ") + lineBreak)
 				}
 				return fmt.Sprintf(
 					"Teleport MySQL interactive shell (v%s)\n\nLimitations: \n%s",
-					teleport.Version,
+					cmp.Or(r.teleportVersion, teleport.Version),
 					sb.String(),
 				), false
 			},

--- a/lib/client/db/mysql/repl/commands_test.go
+++ b/lib/client/db/mysql/repl/commands_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport"
 	clientproto "github.com/gravitational/teleport/api/client/proto"
 )
 
@@ -72,6 +71,7 @@ func TestCommands(t *testing.T) {
 			Username:    "test-user",
 			Database:    "test-database",
 		},
+		teleportVersion: "19.0.0-dev",
 	}
 	tests := []struct {
 		desc               string
@@ -122,7 +122,7 @@ func TestCommands(t *testing.T) {
 			desc:    "teleport",
 			cmdName: "teleport",
 			assertCommandReply: func(t require.TestingT, val any, _ ...any) {
-				require.Contains(t, val, teleport.Version, "expected teleport command to include current Teleport version")
+				require.Contains(t, val, "v19.0.0-dev", "expected teleport command to include current Teleport version")
 			},
 		},
 		{

--- a/lib/client/db/mysql/repl/repl_test.go
+++ b/lib/client/db/mysql/repl/repl_test.go
@@ -108,6 +108,7 @@ func TestREPL(t *testing.T) {
 			require.NoError(t, err)
 			testREPL.(*REPL).testPassword = testSrv.password
 			testREPL.(*REPL).disableQueryTimings = true
+			testREPL.(*REPL).teleportVersion = "19.0.0-dev"
 			err = testREPL.Run(t.Context())
 			require.NoError(t, err)
 			goldenName := strings.ReplaceAll(test.name, " ", "-")


### PR DESCRIPTION
This only affects test code.

These tests broke when I tried to backport them because I had missed a few places where I should have overridden the `teleport.Version` in tests, so this PR prevents the tests from failing when we try to bump `teleport.Version` on the next major release.