### PR TITLE
Add e2e tests for client tools managed updates

### DIFF
--- a/integration/autoupdate/e2e/main.go
+++ b/integration/autoupdate/e2e/main.go
@@ -1,0 +1,234 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/gravitational/teleport/integration/helpers/archive"
+)
+
+// Source is used for defining Teleport source directory by local ID.
+type Source struct {
+	ID   int
+	Path string
+}
+
+// VersionInfo defines what version label must be used during compilation.
+type VersionInfo struct {
+	Version  string
+	SourceID int
+}
+
+var sources = []Source{
+	// Path to Teleport source code with previous v1 version of CTMU.
+	{ID: 1, Path: "../teleport-sync"},
+	// Path to Teleport source code with latest version of CTMU.
+	{ID: 2, Path: "./"},
+}
+
+var versions = []VersionInfo{
+	{"17.5.1", 1},
+	{"17.5.4", 1},
+	{"17.5.7", 1},
+	{"18.0.0", 2},
+	{"18.5.5", 2},
+	{"18.5.7", 2},
+}
+
+func main() {
+	ctx := context.Background()
+	outputDir := "./test-packages"
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		slog.ErrorContext(ctx, "Failed to create output directory: %v", err)
+		return
+	}
+
+	for _, v := range versions {
+		source := findSourceByID(v.SourceID)
+		if source == nil {
+			slog.ErrorContext(ctx, "No source with ID %d", v.SourceID)
+			return
+		}
+
+		fmt.Printf("Processing version %s from path %s\n", v.Version, source.Path)
+		if err := processVersion(v, *source, outputDir); err != nil {
+			slog.ErrorContext(ctx, "Error processing version %s: %v", v.Version, err)
+			return
+		}
+	}
+
+	fmt.Printf("\nServing %s on http://localhost:8080\n", outputDir)
+	http.Handle("/", http.FileServer(http.Dir(outputDir)))
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		slog.ErrorContext(ctx, "Failed to start server: %v", err)
+	}
+}
+
+func findSourceByID(id int) *Source {
+	for _, s := range sources {
+		if s.ID == id {
+			return &s
+		}
+	}
+	return nil
+}
+
+func processVersion(v VersionInfo, source Source, outputDir string) error {
+	ctx := context.Background()
+	versionDir := filepath.Join(outputDir, "v"+v.Version)
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		return fmt.Errorf("create version dir: %w", err)
+	}
+
+	versionFile := filepath.Join(source.Path, "api/version.go")
+	if err := updateVersionFile(versionFile, v.Version); err != nil {
+		return fmt.Errorf("update version file: %w", err)
+	}
+
+	if err := runMake(source.Path); err != nil {
+		return fmt.Errorf("make build: %w", err)
+	}
+
+	for _, bin := range []string{"tsh", "tctl"} {
+		src := filepath.Join(source.Path, "build", bin)
+		dst := filepath.Join(versionDir, bin)
+		if err := copyFile(src, dst); err != nil {
+			return fmt.Errorf("copy %s: %w", bin, err)
+		}
+	}
+
+	archivePath := filepath.Join(outputDir, fmt.Sprintf("teleport-%s.pkg", v.Version))
+	if err := archive.CompressDirToPkgFile(ctx, versionDir, archivePath, "com.example.pkgtest"); err != nil {
+		return fmt.Errorf("compress dir to pkgfile: %w", err)
+	}
+	if err := writeSHA256(archivePath); err != nil {
+		return fmt.Errorf("sha256sum: %w", err)
+	}
+
+	archivePath = filepath.Join(outputDir, fmt.Sprintf("teleport-v%s-windows-amd64-bin.zip", v.Version))
+	if err := archive.CompressDirToZipFile(ctx, versionDir, archivePath); err != nil {
+		return fmt.Errorf("compress dir to zipfile: %w", err)
+	}
+	if err := writeSHA256(archivePath); err != nil {
+		return fmt.Errorf("sha256sum: %w", err)
+	}
+
+	archivePath = filepath.Join(outputDir, fmt.Sprintf("teleport-v%s-linux-%s-bin.tar.gz", v.Version, runtime.GOARCH))
+	if err := archive.CompressDirToTarGzFile(ctx, versionDir, archivePath); err != nil {
+		return fmt.Errorf("compress dir to tarfile: %w", err)
+	}
+	if err := writeSHA256(archivePath); err != nil {
+		return fmt.Errorf("sha256sum: %w", err)
+	}
+
+	return nil
+}
+
+func updateVersionFile(path, version string) error {
+	tmpPath := path + ".tmp"
+	in, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "const Version = ") {
+			fmt.Fprintf(out, "const Version = \"%s\"\n", version)
+		} else {
+			fmt.Fprintln(out, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func runMake(dir string) error {
+	cmd := exec.Command("make", "build/tsh", "build/tctl")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GITHUB_REPOSITORY_OWNER=gravitational")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func copyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	srcInfo, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+
+	return out.Close()
+}
+
+func writeSHA256(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+
+	sum := hex.EncodeToString(hash.Sum(nil))
+	shaPath := path + ".sha256"
+
+	return os.WriteFile(shaPath, []byte(sum+"  "+filepath.Base(path)+"\n"), 0644)
+}

--- a/integration/autoupdate/e2e/main.go
+++ b/integration/autoupdate/e2e/main.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
  * Teleport
  * Copyright (C) 2025  Gravitational, Inc.

--- a/integration/autoupdate/e2e/updater_func_test.go
+++ b/integration/autoupdate/e2e/updater_func_test.go
@@ -1,0 +1,314 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main_test
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// configPath path of the configuration file used by `tctl`
+	// to configure client tools managed update configuration.
+	configPath = "/etc/teleport-local.yaml"
+	// proxy is the cluster address used in the e2e test.
+	proxy = "localhost:9443"
+
+	tshV1  = "./test-packages/v17.5.1/tsh"
+	tctlV1 = "./test-packages/v17.5.1/tctl"
+	tshV2  = "./test-packages/v18.0.0/tsh"
+	tctlV2 = "./test-packages/v18.0.0/tctl"
+)
+
+var (
+	// pattern is template for response on version command for client tools {tsh, tctl}.
+	pattern = regexp.MustCompile(`(?m)Teleport v(.*) git`)
+	// user is username registered in cluster for the tests.
+	user = os.Getenv("TELEPORT_TEST_USER")
+	// secret used for the `user` created in cluster to generate TOTP.
+	secret = os.Getenv("TELEPORT_TEST_SECRET")
+	// password is default password for `user`.
+	password = os.Getenv("TELEPORT_TEST_PASSWORD")
+)
+
+func TestMain(m *testing.M) {
+	// If test environment variables is not set, we have to skip tests.
+	if user == "" || secret == "" || password == "" {
+		return
+	}
+
+	enableMU(tctlV1)
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+// TestSameVersionCheck: v1 -> v2(env) -> v2(re-install) -> v2(login to same version).
+func TestSameVersionCheck(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TELEPORT_CDN_BASE_URL", "http://localhost:8080")
+	t.Setenv("TELEPORT_HOME", tempDir)
+	t.Setenv("TELEPORT_TOOLS_DIR", filepath.Join(tempDir, ".tsh", "bin"))
+
+	v := checkVersion(t, tshV1, []string{"TELEPORT_TOOLS_VERSION=18.5.5"})
+	assert.Equal(t, "18.5.5", v)
+
+	v = checkVersion(t, tshV1, []string{})
+	assert.Equal(t, "18.5.5", v)
+
+	// Trigger migration.
+	v = checkVersion(t, tshV2, []string{})
+	assert.Equal(t, "18.0.0", v)
+	printConfig(t, tempDir)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV2, "18.0.0")
+	time.Sleep(time.Second)
+	login(t, tshV2, proxy, []string{})
+	v = checkVersion(t, tshV2, []string{})
+	assert.Equal(t, "18.0.0", v)
+
+	// Show the configuration generated after test execution.
+	printConfig(t, tempDir)
+}
+
+// TestV1UpgradeDowngrade: v1 -> v2(env) -> v1(login) -> v1(login).
+func TestV1UpgradeDowngrade(t *testing.T) {
+	proxy := "localhost:9443"
+	tempDir := t.TempDir()
+	t.Setenv("TELEPORT_CDN_BASE_URL", "http://localhost:8080")
+	t.Setenv("TELEPORT_HOME", tempDir)
+	t.Setenv("TELEPORT_TOOLS_DIR", filepath.Join(tempDir, ".tsh", "bin"))
+
+	v := checkVersion(t, tshV1, []string{"TELEPORT_TOOLS_VERSION=18.0.0"})
+	require.Equal(t, "18.0.0", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV1, "17.5.4")
+	time.Sleep(time.Second)
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "17.5.4", v)
+
+	// Login to the cluster.
+	setClusterVersion(t, tctlV1, "17.5.7")
+
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "17.5.7", v)
+
+	// Show the configuration generated after test execution.
+	printConfig(t, tempDir)
+}
+
+// TestV1UpgradeToV2: v1 -> v1(env) -> v1(login) -> v2(login) -> v2(login).
+func TestV1UpgradeToV2(t *testing.T) {
+	proxy := "localhost:9443"
+	tempDir := t.TempDir()
+	t.Setenv("TELEPORT_CDN_BASE_URL", "http://localhost:8080")
+	t.Setenv("TELEPORT_HOME", tempDir)
+	t.Setenv("TELEPORT_TOOLS_DIR", filepath.Join(tempDir, ".tsh", "bin"))
+
+	v := checkVersion(t, tshV1, []string{"TELEPORT_TOOLS_VERSION=17.5.4"})
+	require.Equal(t, "17.5.4", v)
+
+	setClusterVersion(t, tctlV1, "17.5.7")
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "17.5.7", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV1, "18.0.0")
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "18.0.0", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV1, "18.5.5")
+
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "18.5.5", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV1, "18.5.7")
+
+	login(t, tshV1, proxy, []string{})
+	v = checkVersion(t, tshV1, []string{})
+	require.Equal(t, "18.5.7", v)
+
+	// Show the configuration generated after test execution.
+	printConfig(t, tempDir)
+}
+
+// TestV2DowngradeUpgrade: v2 -> v1(env) -> v2(login) -> v2(login).
+func TestV2DowngradeUpgrade(t *testing.T) {
+	proxy := "localhost:9443"
+	tempDir := t.TempDir()
+	t.Setenv("TELEPORT_CDN_BASE_URL", "http://localhost:8080")
+	t.Setenv("TELEPORT_HOME", tempDir)
+	t.Setenv("TELEPORT_TOOLS_DIR", filepath.Join(tempDir, ".tsh", "bin"))
+
+	v := checkVersion(t, tshV2, []string{"TELEPORT_TOOLS_VERSION=17.5.4"})
+	require.Equal(t, "17.5.4", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV2, "18.5.5")
+	login(t, tshV2, proxy, []string{})
+	v = checkVersion(t, tshV2, []string{})
+	require.Equal(t, "18.5.5", v)
+
+	setClusterVersion(t, tctlV2, "18.5.7")
+	//logout(t, tshV2, []string{})
+
+	// Login to the cluster
+	login(t, tshV2, proxy, []string{})
+	v = checkVersion(t, tshV2, []string{})
+	require.Equal(t, "18.5.7", v)
+
+	// Show the configuration generated after test execution.
+	printConfig(t, tempDir)
+}
+
+// TestV2RegularUpgrade: v2 -> v2(login) -> v2(login).
+func TestV2RegularUpgrade(t *testing.T) {
+	proxy := "localhost:9443"
+	tempDir := t.TempDir()
+	t.Setenv("TELEPORT_CDN_BASE_URL", "http://localhost:8080")
+	t.Setenv("TELEPORT_HOME", tempDir)
+	t.Setenv("TELEPORT_TOOLS_DIR", filepath.Join(tempDir, ".tsh", "bin"))
+
+	v := checkVersion(t, tshV2, []string{})
+	require.Equal(t, "18.0.0", v)
+
+	// Login to the cluster
+	setClusterVersion(t, tctlV2, "18.5.5")
+	login(t, tshV2, proxy, []string{})
+	v = checkVersion(t, tshV2, []string{})
+	require.Equal(t, "18.5.5", v)
+
+	setClusterVersion(t, tctlV2, "18.5.7")
+	login(t, tshV2, proxy, []string{})
+	v = checkVersion(t, tshV2, []string{})
+	require.Equal(t, "18.5.7", v)
+
+	// Show the configuration generated after test execution.
+	printConfig(t, tempDir)
+}
+
+func checkVersion(t *testing.T, tsh string, env []string) string {
+	t.Helper()
+	cmd := exec.Command(tsh, "version", "--insecure")
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	matches := pattern.FindStringSubmatch(string(out))
+	require.Len(t, matches, 2)
+	fmt.Println(string(out))
+
+	return matches[1]
+}
+
+func enableMU(tctl string) {
+	cmd := exec.Command(tctl, "-c", configPath, "--insecure", "autoupdate", "client-tools", "enable")
+	cmd.Env = os.Environ()
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Error enabling MU: %s\n", err)
+	}
+	fmt.Println(string(out))
+}
+
+func setClusterVersion(t *testing.T, tctl string, version string) {
+	t.Helper()
+	cmd := exec.Command(tctl, "-c", configPath, "--insecure", "autoupdate", "client-tools", "target", version)
+	cmd.Env = os.Environ()
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	fmt.Println(string(out))
+	time.Sleep(time.Second)
+}
+
+func logout(t *testing.T, tsh string, env []string) {
+	t.Helper()
+	cmd := exec.Command(tsh, "logout", "--insecure")
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	fmt.Println(string(out))
+}
+
+func login(t *testing.T, tsh, proxy string, env []string) {
+	t.Helper()
+
+	var cmdErr error
+	for range 3 {
+		cmd := exec.Command(tsh, "login", "--proxy", proxy, "--user", user, "--insecure", "--skip-version-check")
+		cmd.Env = append(os.Environ(), env...)
+
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err)
+		defer ptmx.Close()
+
+		scanner := bufio.NewScanner(ptmx)
+
+		go func() {
+			for scanner.Scan() {
+				line := scanner.Text()
+				fmt.Println(line)
+				switch {
+				case strings.Contains(line, fmt.Sprintf("Enter password for Teleport user %s:", user)):
+					_, _ = ptmx.Write([]byte(password + "\n"))
+				case strings.Contains(line, "Enter an OTP code from a device:"):
+					code, err := totp.GenerateCode(secret, time.Now())
+					require.NoError(t, err)
+					_, _ = ptmx.Write([]byte(code + "\n"))
+				}
+			}
+		}()
+
+		if cmdErr = cmd.Wait(); cmdErr == nil {
+			return
+		}
+	}
+	require.NoError(t, cmdErr)
+}
+
+func printConfig(t *testing.T, tempDir string) {
+	t.Helper()
+	f, err := os.ReadFile(filepath.Join(tempDir, ".tsh", "bin", ".config.json"))
+	if os.IsNotExist(err) {
+		fmt.Println("Config file not found.")
+		return
+	}
+	require.NoError(t, err)
+	fmt.Println(string(f))
+}

--- a/integration/autoupdate/e2e/updater_func_test.go
+++ b/integration/autoupdate/e2e/updater_func_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
  * Teleport
  * Copyright (C) 2025  Gravitational, Inc.


### PR DESCRIPTION
This PR adds end-to-end tests for client tools managed updates to verify various upgrade and downgrade scenarios between v1 and v2 versions. These tests are designed to validate the interaction between already released versions of tsh and tctl that have integrated managed updates. And should be used in next versions of CTMU (e.g. v3).

A separate build script targets two Teleport repositories with different versions of client tools managed updates, builds the tsh and tctl binaries, and then packages them in all supported archive formats - `.pkg` for macOS, `.zip` for Windows, and `.tar.gz` for Unix. The script then starts an HTTP server to host these packages.

The end-to-end tests use this local CDN to download the required versions for in-cluster testing. Before running the tests, the cluster must have a test user configured to simulate updates during login. These tests must be run manually and are not intended for CI execution due to the significant amount of time required to complete them.

Related: https://github.com/gravitational/teleport/pull/57785