### PR TITLE
Enable AWS Roles Anywhere Profile Sync

### DIFF
--- a/lib/integrations/awsra/profile_syncer.go
+++ b/lib/integrations/awsra/profile_syncer.go
@@ -42,8 +42,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// AWSRolesAnywherProfileSyncerParams contains the parameters for the AWS Roles Anywhere Profile Syncer.
-type AWSRolesAnywherProfileSyncerParams struct {
+// AWSRolesAnywhereProfileSyncerParams contains the parameters for the AWS Roles Anywhere Profile Syncer.
+type AWSRolesAnywhereProfileSyncerParams struct {
 	// Clock is used to calculate the expiration time of the AppServers.
 	Clock clockwork.Clock
 
@@ -108,7 +108,7 @@ type RolesAnywhereClient interface {
 	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
 }
 
-func (p *AWSRolesAnywherProfileSyncerParams) checkAndSetDefaults() error {
+func (p *AWSRolesAnywhereProfileSyncerParams) checkAndSetDefaults() error {
 	if p.KeyStoreManager == nil {
 		return trace.BadParameter("key store manager is required")
 	}
@@ -152,7 +152,7 @@ type AppServerUpserter interface {
 	UpsertApplicationServer(ctx context.Context, server types.AppServer) (*types.KeepAlive, error)
 }
 
-// RunAWSRolesAnywherProfileSyncer starts the AWS Roles Anywhere Profile Syncer.
+// RunAWSRolesAnywhereProfileSyncer starts the AWS Roles Anywhere Profile Syncer.
 // It will iterate over all AWS IAM Roles Anywhere integrations, and for each one:
 // 1. Check if the Profile Sync is enabled.
 // 2. Generate AWS credentials using the integration.
@@ -160,7 +160,7 @@ type AppServerUpserter interface {
 // 4. For each profile, check if it is enabled and has associated roles.
 // 5. Create an AppServer for each profile, using the profile name as the AppServer name.
 // AppServer name can be overridden by the `TeleportApplicationName` tag on the Profile.
-func RunAWSRolesAnywherProfileSyncer(ctx context.Context, params AWSRolesAnywherProfileSyncerParams) error {
+func RunAWSRolesAnywhereProfileSyncer(ctx context.Context, params AWSRolesAnywhereProfileSyncerParams) error {
 	if err := params.checkAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -179,7 +179,7 @@ func RunAWSRolesAnywherProfileSyncer(ctx context.Context, params AWSRolesAnywher
 	}
 }
 
-func runProfileSyncerIteration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams) error {
+func runProfileSyncerIteration(ctx context.Context, params AWSRolesAnywhereProfileSyncerParams) error {
 	integrations, err := integrationsWithProfileSyncEnabled(ctx, params.Cache)
 	if err != nil {
 		return trace.Wrap(err)
@@ -303,7 +303,7 @@ func integrationsWithProfileSyncEnabled(ctx context.Context, cache SyncerCache) 
 	return integrations, nil
 }
 
-func buildAWSRolesAnywhereClientForIntegration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams, integration types.Integration) (RolesAnywhereClient, error) {
+func buildAWSRolesAnywhereClientForIntegration(ctx context.Context, params AWSRolesAnywhereProfileSyncerParams, integration types.Integration) (RolesAnywhereClient, error) {
 	trustAnchorARN := integration.GetAWSRolesAnywhereIntegrationSpec().TrustAnchorARN
 	profileSyncProfileARN := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.ProfileARN
 	profileSyncRoleARN := integration.GetAWSRolesAnywhereIntegrationSpec().ProfileSyncConfig.RoleARN
@@ -371,7 +371,7 @@ type syncSummary struct {
 	profileErrors []error
 }
 
-func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywherProfileSyncerParams, integration types.Integration, proxyPublicAddr string) *syncSummary {
+func syncProfileForIntegration(ctx context.Context, params AWSRolesAnywhereProfileSyncerParams, integration types.Integration, proxyPublicAddr string) *syncSummary {
 	logger := params.Logger.With("integration", integration.GetName())
 
 	ret := &syncSummary{
@@ -439,7 +439,7 @@ var (
 )
 
 type processProfileRequest struct {
-	Params          AWSRolesAnywherProfileSyncerParams
+	Params          AWSRolesAnywhereProfileSyncerParams
 	Profile         *integrationv1.RolesAnywhereProfile
 	RAClient        RolesAnywhereClient
 	Integration     types.Integration
@@ -469,7 +469,7 @@ func processProfile(ctx context.Context, req processProfileRequest) error {
 	return nil
 }
 
-func convertProfile(params AWSRolesAnywherProfileSyncerParams, profile *integrationv1.RolesAnywhereProfile, integrationName string, proxyPublicAddr string) (types.AppServer, error) {
+func convertProfile(params AWSRolesAnywhereProfileSyncerParams, profile *integrationv1.RolesAnywhereProfile, integrationName string, proxyPublicAddr string) (types.AppServer, error) {
 	parsedProfileARN, err := arn.Parse(profile.Arn)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2766,7 +2766,7 @@ func (process *TeleportProcess) initAuthService() error {
 			return nil
 		}
 
-		params := awsra.AWSRolesAnywherProfileSyncerParams{
+		params := awsra.AWSRolesAnywhereProfileSyncerParams{
 			Clock:             process.Clock,
 			Logger:            logger,
 			KeyStoreManager:   authServer.GetKeyStore(),
@@ -2781,14 +2781,14 @@ func (process *TeleportProcess) initAuthService() error {
 			LockConfiguration: backend.LockConfiguration{
 				Backend:            process.backend,
 				LockNameComponents: []string{awsRolesAnywhereProfileSyncProcessName},
-				TTL:                1 * time.Minute,
+				TTL:                time.Minute,
 				RetryInterval:      syncInterval,
 			},
 			RefreshLockInterval: 20 * time.Second,
 		}
 
 		runFunction := func(ctx context.Context) error {
-			return trace.Wrap(awsra.RunAWSRolesAnywherProfileSyncer(ctx, params))
+			return trace.Wrap(awsra.RunAWSRolesAnywhereProfileSyncer(ctx, params))
 		}
 
 		waitWithJitter := retryutils.SeventhJitter(time.Second * 10)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -133,6 +133,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/s3sessions"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
+	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/joinserver"
@@ -2752,6 +2753,59 @@ func (process *TeleportProcess) initAuthService() error {
 
 	process.RegisterFunc("auth.recording_encryption_resolver", func() error {
 		return trace.Wrap(recordingEncryptionManager.Watch(process.GracefulExitContext(), authServer.Services))
+	})
+
+	awsRolesAnywhereProfileSyncProcessName := "aws-roles-anywhere.profile-sync"
+	process.RegisterFunc("auth."+awsRolesAnywhereProfileSyncProcessName+".service", func() error {
+		ctx := process.GracefulExitContext()
+		logger := process.logger.With("process", awsRolesAnywhereProfileSyncProcessName)
+
+		if _, err := process.WaitForEvent(ctx, TeleportReadyEvent); err != nil {
+			logger.DebugContext(ctx, "process exiting: failed to start AWS Roles Anywhere profile sync service")
+			return nil
+		}
+
+		params := awsra.AWSRolesAnywherProfileSyncerParams{
+			Clock:             process.Clock,
+			Logger:            logger,
+			KeyStoreManager:   authServer.GetKeyStore(),
+			Cache:             authServer.Cache,
+			StatusReporter:    authServer.Services,
+			AppServerUpserter: authServer.Services,
+			HostUUID:          process.Config.HostUUID,
+		}
+
+		runWhileLockedConfig := backend.RunWhileLockedConfig{
+			LockConfiguration: backend.LockConfiguration{
+				Backend:            process.backend,
+				LockNameComponents: []string{awsRolesAnywhereProfileSyncProcessName},
+				TTL:                1 * time.Minute,
+			},
+			RefreshLockInterval: 20 * time.Second,
+		}
+
+		runFunction := func(ctx context.Context) error {
+			return trace.Wrap(awsra.RunAWSRolesAnywherProfileSyncer(ctx, params))
+		}
+
+		waitWithJitter := retryutils.SeventhJitter(time.Second * 10)
+		for {
+			err := backend.RunWhileLocked(ctx, runWhileLockedConfig, runFunction)
+			if err != nil && ctx.Err() == nil {
+				logger.ErrorContext(
+					ctx,
+					"AWS Roles Anywhere profile syncer encountered a fatal error, it will restart after backoff",
+					"error", err,
+					"restart_after", waitWithJitter,
+				)
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(waitWithJitter):
+			}
+		}
 	})
 
 	// execute this when process is asked to exit:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2758,6 +2758,7 @@ func (process *TeleportProcess) initAuthService() error {
 	awsRolesAnywhereProfileSyncProcessName := "aws-roles-anywhere.profile-sync"
 	process.RegisterFunc("auth."+awsRolesAnywhereProfileSyncProcessName+".service", func() error {
 		ctx := process.GracefulExitContext()
+		syncInterval := 5 * time.Minute
 		logger := process.logger.With("process", awsRolesAnywhereProfileSyncProcessName)
 
 		if _, err := process.WaitForEvent(ctx, TeleportReadyEvent); err != nil {
@@ -2773,6 +2774,7 @@ func (process *TeleportProcess) initAuthService() error {
 			StatusReporter:    authServer.Services,
 			AppServerUpserter: authServer.Services,
 			HostUUID:          process.Config.HostUUID,
+			SyncPollInterval:  syncInterval,
 		}
 
 		runWhileLockedConfig := backend.RunWhileLockedConfig{
@@ -2780,6 +2782,7 @@ func (process *TeleportProcess) initAuthService() error {
 				Backend:            process.backend,
 				LockNameComponents: []string{awsRolesAnywhereProfileSyncProcessName},
 				TTL:                1 * time.Minute,
+				RetryInterval:      syncInterval,
 			},
 			RefreshLockInterval: 20 * time.Second,
 		}


### PR DESCRIPTION
This PR fixes the previous version of the sync service, which was disabled in https://github.com/gravitational/teleport/pull/57610

The previous version was too greedy on trying to ensure the process was always running.
Non-lock holders (aka the auth service which was not syncing the profiles), would retry to acquire the lock every 250ms which caused a hot-loop in writes to the backend.
This was especially painful for the DynamoDB backend:

<img width="1605" height="121" alt="image" src="https://github.com/user-attachments/assets/18457272-f9f8-464e-ad22-6f5f6d7ed584" />


This PR adds an explicit RetryInterval of 5 minutes, which greatly reduces the number of writes per second.
In case of failure, the Roles Anywhere Profile Syncer will be stopped, at most, for 10 minutes.


This was deployed to a Cloud tenant, and no error was reported.