### PR TITLE
Add maxUnavailable option to podDisruptionBudget

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/pdb.yaml
+++ b/examples/chart/teleport-kube-agent/templates/pdb.yaml
@@ -14,7 +14,12 @@ metadata:
   {{- toYaml .Values.extraLabels.podDisruptionBudget | nindent 4 }}
 {{- end }}
 spec:
+{{- if .Values.highAvailability.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.highAvailability.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.highAvailability.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.highAvailability.podDisruptionBudget.maxUnavailable }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -403,8 +403,7 @@
                     "$id": "#/properties/highAvailability/properties/podDisruptionBudget",
                     "type": "object",
                     "required": [
-                        "enabled",
-                        "minAvailable"
+                        "enabled"
                     ],
                     "properties": {
                         "enabled": {
@@ -416,6 +415,11 @@
                             "$id": "#/properties/highAvailability/properties/podDisruptionBudget/properties/minAvailable",
                             "type": "integer",
                             "default": 1
+                        },
+                        "maxUnavailable": {
+                            "$id": "#/properties/highAvailability/properties/podDisruptionBudget/properties/maxUnavailable",
+                            "type": "integer",
+                            "default": null
                         }
                     }
                 },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -828,6 +828,10 @@ highAvailability:
     # available pod specified on the PodDisruptionBudget.
     minAvailable: 1
 
+    # highAvailability.podDisruptionBudget.maxUnavailable(int) -- is the maximum
+    # unavailable pod specified on the PodDisruptionBudget.
+    maxUnavailable: null
+
 # podMonitor -- controls the PodMonitor CR (from monitoring.coreos.com/v1)
 # This CRD is managed by the prometheus-operator and allows workload to
 # get monitored. To use this value, you need to run a `prometheus-operator`


### PR DESCRIPTION
This allows setting the maxUnavailable in podDisruptionBudget. Needed for K8s clusters where policies on setting PDBs are restricted and does not allow for mixAvailable