### PR TITLE
docs: include mcp server name in tsh mcp config example

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/mcp-access/getting-started.mdx
@@ -115,7 +115,7 @@ teleport-mcp-demo A demo MCP server that shows current user and session informat
 To show configurations for your MCP client to connect:
 
 ```code
-$ tsh mcp config
+$ tsh mcp config teleport-mcp-demo
 Found MCP servers:
 teleport-mcp-demo
 

--- a/docs/pages/enroll-resources/mcp-access/stdio.mdx
+++ b/docs/pages/enroll-resources/mcp-access/stdio.mdx
@@ -147,7 +147,7 @@ everything everything MCP server stdio env=dev
 To show configurations for your MCP client to connect:
 
 ```code
-$ tsh mcp config
+$ tsh mcp config everything
 Found MCP servers:
 everything
 


### PR DESCRIPTION
Updated to match the output. With just `tsh mcp config` you get an error.