### PR TITLE
docs: Redesign MWI guides into goal-based, tiled pages for complete workflows

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on AWS
+title: tbot on AWS
 description: How to install and configure Machine ID on an AWS EC2 instance
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Azure DevOps
+title: tbot on Azure DevOps
 description: How to install and configure Machine ID on Azure DevOps.
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Azure
+title: tbot on Azure
 description: How to install and configure Machine ID on an Azure VM
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Bitbucket Pipelines
+title: tbot on Bitbucket Pipelines
 description: How to install and configure Machine ID on Bitbucket Pipelines
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on CircleCI
+title: tbot on CircleCI
 description: How to install and configure Machine ID on CircleCI
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on GCP
+title: tbot on GCP
 description: How to install and configure Machine ID on a GCP VM
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on GitHub Actions
+title: tbot on GitHub Actions
 description: How to install and configure Machine ID on GitHub Actions
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on GitLab CI
+title: tbot on GitLab CI
 description: How to install and configure Machine ID on GitLab CI
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Jenkins
+title: tbot on Jenkins
 description: How to install and configure Machine ID on Jenkins
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Kubernetes
+title: tbot on Kubernetes
 description: How to install and configure Machine ID on Kubernetes
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux-tpm.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux-tpm.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Linux (TPM)
+title: tbot on Linux (TPM)
 description: How to install and configure Machine ID on a Linux host and use a TPM 2.0 for authentication
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying tbot on Linux
+title: tbot on Linux
 description: How to install and configure Machine ID on a Linux host
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuring Workload Identity and AWS OIDC Federation
+title: AWS OIDC Federation
 description: Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuring Workload Identity and AWS Roles Anywhere
+title: AWS Roles Anywhere
 description: Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
 labels:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuring Workload Identity and Azure Federated Credentials
+title: Azure Federated Credentials
 description: Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
 labels:
  - how-to


### PR DESCRIPTION
To address one of Doc's quarterly goals, this PR addresses:

- Restructure MWI content into goal-oriented workflows, and trim redundant title verbs
- Present workflows using a tile-based approach at the entry point page.
- Consolidate relevant steps where possible (deployment, configuration, access, etc.) and reduce redundancy between existing MWI pages.
