### PR TITLE
[v18] Helm: add kube joining support to teleport-kube-agent chart (#57603)

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -99,8 +99,8 @@ values, the implications of each join method, and guides to set up each method.
 Common join-methods for the `teleport-kube-agent` are:
 - `token`: the most basic one, with regular ephemeral secret tokens
 - `kubernetes`: either the `in-cluster` variant (if the agent runs in the
-  same Kubernetes cluster as the `teleport-cluster` chart) or the `JWKS`
-  variant (works in every Kubernetes cluster, regardless of the Teleport Auth
+  same Kubernetes cluster as the `teleport-cluster` chart) or the `JWKS/OIDC`
+  variants (work in every Kubernetes cluster, regardless of the Teleport Auth
   Service location).
 
 ### `joinParams.tokenName`
@@ -123,6 +123,21 @@ included in the agent's configuration.
 If method is `token`, `joinParams.tokenName` can be empty if the token
 is provided through an existing Kubernetes Secret, see
 [`joinTokenSecret`](#joinTokenSecret) for more details and instructions.
+
+If method is `kubernetes`, you must set [`teleportClusterName`](#teleportClusterName).
+
+## `teleportClusterName`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`teleportClusterName` is the name of the joined Teleport cluster.
+Setting this value is required when joining via the
+[Kubernetes JWKS or OIDC](../../reference/join-methods.mdx#kubernetes-jwks) join method.
+
+When this value is set, the chart mounts a kubernetes service account token
+via a projected volume and configures Teleport to use it for joining.
 
 ## `kubeClusterName`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/_helpers.tpl
@@ -66,7 +66,7 @@ teleport.dev/release: '{{ include "teleport-cluster.operator.namespacedRelease" 
 {{- if empty $clusterAddr -}}
     {{- required "The `teleportAddress` value is mandatory when deploying a standalone operator." .Values.teleportAddress -}}
     {{- if and (eq .Values.joinMethod "kubernetes") (empty .Values.teleportClusterName) (not (hasSuffix ":3025" .Values.teleportAddress)) -}}
-        {{- fail "When joining using the Kubernetes JWKS join method, you must set the value `teleportClusterName`" -}}
+        {{- fail "When joining using the Kubernetes JWKS or OIDC join method, you must set the value `teleportClusterName`" -}}
     {{- end -}}
 {{- else -}}
     {{- $clusterAddr | printf "%s:3025" -}}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -169,6 +169,10 @@ spec:
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 10 }}
           {{- end }}
+          {{- if .Values.teleportClusterName }}
+          - name: KUBERNETES_TOKEN_PATH
+            value: /var/run/secrets/tokens/join-sa-token
+          {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"
         {{- if .Values.insecureSkipProxyTLSVerify }}
@@ -211,6 +215,11 @@ spec:
         - mountPath: /etc/teleport-secrets
           name: "auth-token"
           readOnly: true
+{{- if .Values.teleportClusterName }}
+        - mountPath: /var/run/secrets/tokens
+          name: join-sa-token
+          readOnly: true
+{{- end }}
 {{- if .Values.storage.enabled }}
         - mountPath: /var/lib/teleport
           name: "{{ .Release.Name }}-teleport-data"
@@ -241,6 +250,19 @@ spec:
       - name: "auth-token"
         secret:
           secretName: {{ coalesce .Values.secretName .Values.joinTokenSecret.name }}
+      {{- if .Values.teleportClusterName }}
+      {{- /* This volume is used to obtain a service account token that can be used
+       to join the Teleport cluster using the kubernetes join method.
+       To ensure backward compatibility, we use .Values.teleportClusterName as a feature flag.
+       The token must have the cluster name as audience, and its TTL must not exceed 30 minutes. */}}
+      - name: join-sa-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: join-sa-token
+                expirationSeconds: 600
+                audience: {{ .Values.teleportClusterName }}
+      {{- end }}
 {{- if not .Values.storage.enabled }}
       - name: "data"
         emptyDir: {}

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -824,3 +824,61 @@ tests:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 3600
+
+  - it: should mount a projected SA token when teleportClusterName is set
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+    set:
+      teleportClusterName: teleport.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: join-sa-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    path: join-sa-token
+                    expirationSeconds: 600
+                    audience: teleport.example.com
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+              mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+              readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBERNETES_TOKEN_PATH
+            value: /var/run/secrets/tokens/join-sa-token
+
+  - it: should not mount a projected SA token when teleportClusterName is not set
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+    set:
+      teleportClusterName: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: join-sa-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    path: join-sa-token
+                    expirationSeconds: 600
+                    audience: ""
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /var/run/secrets/tokens
+            name: join-sa-token
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBERNETES_TOKEN_PATH
+            value: /var/run/secrets/tokens/join-sa-token

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -78,6 +78,11 @@
             "type": "string",
             "default": ""
         },
+        "teleportClusterName": {
+            "$id": "#/properties/teleportClusterName",
+            "type": "string",
+            "default": ""
+        },
         "apps": {
             "$id": "#/properties/apps",
             "type": "array",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -72,8 +72,8 @@ joinParams:
   # Common join-methods for the `teleport-kube-agent` are:
   # - `token`: the most basic one, with regular ephemeral secret tokens
   # - `kubernetes`: either the `in-cluster` variant (if the agent runs in the
-  #   same Kubernetes cluster as the `teleport-cluster` chart) or the `JWKS`
-  #   variant (works in every Kubernetes cluster, regardless of the Teleport Auth
+  #   same Kubernetes cluster as the `teleport-cluster` chart) or the `JWKS/OIDC`
+  #   variants (work in every Kubernetes cluster, regardless of the Teleport Auth
   #   Service location).
   method: "token"
 
@@ -91,7 +91,17 @@ joinParams:
   # If method is `token`, `joinParams.tokenName` can be empty if the token
   # is provided through an existing Kubernetes Secret, see
   # [`joinTokenSecret`](#joinTokenSecret) for more details and instructions.
+  #
+  # If method is `kubernetes`, you must set [`teleportClusterName`](#teleportClusterName).
   tokenName: ""
+
+# teleportClusterName(string) -- is the name of the joined Teleport cluster.
+# Setting this value is required when joining via the
+# [Kubernetes JWKS or OIDC](../../reference/join-methods.mdx#kubernetes-jwks) join method.
+#
+# When this value is set, the chart mounts a kubernetes service account token
+# via a projected volume and configures Teleport to use it for joining.
+teleportClusterName: ""
 
 ################################################################
 # Values that must be provided if Kubernetes access is enabled.


### PR DESCRIPTION
Manual backport of https://github.com/gravitational/teleport/pull/57603 to `branch/v18`.

Changelog: The teleport-kube-agent Helm chart now supports kubernetes joining. `teleportClusterName` must be set to enable the feature.