### PR TITLE
[draft] Fix connection fallback race in kube Forwarder

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -519,14 +519,14 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 // It is used to properly handle client disconnections.
 func (s *session) disconnectPartyOnErr(idString string, err error) {
 	if idString == sessionRecorderID {
-		s.log.ErrorContext(s.sess.connCtx, "Failed to write to session recorder, closing session")
+		s.log.ErrorContext(s.sess.sessionCtx, "Failed to write to session recorder, closing session")
 		s.Close()
 		return
 	}
 
 	id, uuidParseErr := uuid.Parse(idString)
 	if uuidParseErr != nil {
-		s.log.ErrorContext(s.sess.connCtx, "Unable to decode party id",
+		s.log.ErrorContext(s.sess.sessionCtx, "Unable to decode party id",
 			"party_id", idString,
 			"error", uuidParseErr,
 		)
@@ -535,14 +535,14 @@ func (s *session) disconnectPartyOnErr(idString string, err error) {
 
 	wasActive, leaveErr := s.leave(id)
 	if leaveErr != nil {
-		s.log.ErrorContext(s.sess.connCtx, "Failed to disconnect party from the session",
+		s.log.ErrorContext(s.sess.sessionCtx, "Failed to disconnect party from the session",
 			"party_id", idString,
 			"error", leaveErr,
 		)
 	}
 	if wasActive {
 		// log the error only if it was the reason for the user disconnection.
-		s.log.ErrorContext(s.sess.connCtx, "Encountered error with party, disconnecting them from the session",
+		s.log.ErrorContext(s.sess.sessionCtx, "Encountered error with party, disconnecting them from the session",
 			"error", err,
 			"party_id", idString,
 		)
@@ -561,11 +561,11 @@ func (s *session) checkPresence() error {
 		}
 
 		if participant.Mode == string(types.SessionModeratorMode) && time.Now().UTC().After(participant.LastActive.Add(PresenceMaxDifference)) {
-			s.log.DebugContext(s.sess.connCtx, "Participant is not active, kicking", "participant_id", participant.ID)
+			s.log.DebugContext(s.sess.sessionCtx, "Participant is not active, kicking", "participant_id", participant.ID)
 			id, _ := uuid.Parse(participant.ID)
 			_, err := s.unlockedLeave(id)
 			if err != nil {
-				s.log.WarnContext(s.sess.connCtx, "Failed to kick participant for inactivity",
+				s.log.WarnContext(s.sess.sessionCtx, "Failed to kick participant for inactivity",
 					"participant_id", participant.ID,
 					"error", err,
 				)


### PR DESCRIPTION
Fixes #56780

Fixes a race condition in kube `clusterSession` related to `connMonitorCancel`. `getExecutor()`'s `NewFallbackExecutor` wrote to `connMonitorCancel`, while `close()` read.