### PR TITLE
Block setting Expiry on AccessList ResourceHeader

### DIFF
--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -55,6 +55,9 @@ func TestAccessList(t *testing.T) {
 			_, err := p.accessLists.UpsertAccessList(ctx, item)
 			return trace.Wrap(err)
 		},
+		changeResource: func(item *accesslist.AccessList) {
+			item.SetOrigin("okta")
+		},
 		list: func(ctx context.Context) ([]*accesslist.AccessList, error) {
 			return stream.Collect(clientutils.Resources(ctx, p.accessLists.ListAccessLists))
 		},


### PR DESCRIPTION
We don't support Access Lists expiring; prevent setting `ResourceHeader.Metadata.Expires` field to non-zero value (currently possible via `tctl edit`).
