### PR TITLE
Deflake Test_formatDatabaseRolesForDB

### DIFF
--- a/tool/tsh/common/db_print.go
+++ b/tool/tsh/common/db_print.go
@@ -155,6 +155,7 @@ func formatDatabaseRolesForDB(database types.Database, accessChecker services.Ac
 			)
 			return ""
 		}
+		slices.Sort(roles)
 		return fmt.Sprintf("%v", roles)
 	}
 	return ""


### PR DESCRIPTION
Sort the roles before formatting, which matches the original behavior prior to #57480.