### PR TITLE
[v18] Fix Teleport Connect connecting to WDS v17 and earlier

### DIFF
--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -187,7 +187,12 @@ export class TdpClient extends EventEmitter<EventMap> {
       this.sendClientScreenSpec(options.screenSpec);
     }
 
-    if (options.keyboardLayout !== undefined) {
+    // 0 represents the default keyboard layout from the point of view of the
+    // remote desktop, so there is no need to send this message. Additionally,
+    // for clients (Connect) that don't support specifying a keyboard layout
+    // and WDS versions that don't support this feature (v17 and earlier), this
+    // avoids the connection crashing.
+    if (options.keyboardLayout !== undefined && options.keyboardLayout !== 0) {
       this.sendClientKeyboardLayout(options.keyboardLayout);
     }
 


### PR DESCRIPTION
Backport #57743 to branch/v18

changelog: Fixed connection issues to Windows Desktop Services (v17 or earlier) in Teleport Connect.
