### PR TITLE
fix(web): Join tokens "access denied" with MFA

### DIFF
--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -120,13 +120,11 @@ class JoinTokenService {
 
   async editJoinToken(
     req: CreateJoinTokenRequest,
-    mfaResponse: MfaChallengeResponse,
-    abortSignal?: AbortSignal
+    mfaResponse: MfaChallengeResponse
   ) {
     const json = await api.put(
       cfg.getJoinTokenUrl({ action: 'update' }),
       req,
-      abortSignal,
       mfaResponse
     );
     return makeJoinToken(json);


### PR DESCRIPTION
## Summary

Patched an issue viewing join tokens in the web app with MFA enabled. It may have been introduced by #57718 as multiple calls are now being done internally. An "access denied" message is displayed after completing the MFA challenge.

<img width="1198" height="894" alt="Screenshot 2025-08-13 at 12 32 10" src="https://github.com/user-attachments/assets/f71e29e3-3f12-4e40-9126-b6d1d96aea80" />

## Changes
- Retrieve a reusable MFA challenge response and supply it when making the call for tokens