### PR TITLE
[v18] Remove OmitCDP flag for db certs in PKINIT flow

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -178,7 +178,6 @@ func (d *dbCertGetter) getCertificate(ctx context.Context, username string) (*ge
 		TTL:                time.Minute * 10,
 		Domain:             d.domain,
 		ClusterName:        clusterName.GetClusterName(),
-		OmitCDP:            true,
 		Username:           username,
 		ActiveDirectorySID: sid,
 	}

--- a/lib/srv/db/common/kerberos/kinit/ldap_test.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap_test.go
@@ -90,6 +90,8 @@ func (m *mockAuthClient) GetClusterName(ctx context.Context) (types.ClusterName,
 func TestTLSConfigForLDAP(t *testing.T) {
 	auth := &mockAuthClient{
 		generateDatabaseCert: func(ctx context.Context, request *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
+			require.NotEmpty(t, request.CRLDomain)
+
 			csr, err := tlsca.ParseCertificateRequestPEM(request.CSR)
 			if err != nil {
 				return nil, trace.Wrap(err)


### PR DESCRIPTION
Backport #57802 to branch/v18

changelog: Fix database PKINIT issues caused missing CDP information in the certificate
