### PR TITLE
[v17] Remove OmitCDP flag for db certs in PKINIT flow

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -212,7 +212,6 @@ func (d *DBCertGetter) GetCertificateBytes(ctx context.Context) (*WindowsCAAndKe
 		ClusterName:        clusterName.GetClusterName(),
 		AuthClient:         d.Auth,
 		ActiveDirectorySID: sid,
-		OmitCDP:            true,
 	}
 
 	certPEM, keyPEM, caCerts, err := windows.DatabaseCredentials(ctx, req)

--- a/lib/srv/db/common/kerberos/kinit/kinit_test.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit_test.go
@@ -244,7 +244,7 @@ func TestGetCertificate(t *testing.T) {
 	}
 
 	getter := &DBCertGetter{
-		Logger:   slog.New(log.DiscardHandler),
+		Logger:   slog.New(log.DiscardHandler{}),
 		Auth:     auth,
 		UserName: "alice",
 		ADConfig: types.AD{

--- a/lib/srv/db/common/kerberos/kinit/kinit_test.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils/log"
 )
 
 //go:embed testdata/kinit.cache
@@ -243,7 +244,7 @@ func TestGetCertificate(t *testing.T) {
 	}
 
 	getter := &DBCertGetter{
-		Logger:   slog.New(slog.DiscardHandler),
+		Logger:   slog.New(log.DiscardHandler),
 		Auth:     auth,
 		UserName: "alice",
 		ADConfig: types.AD{

--- a/lib/srv/db/common/kerberos/kinit/kinit_test.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit_test.go
@@ -22,12 +22,18 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 //go:embed testdata/kinit.cache
@@ -220,4 +226,38 @@ func TestKRBConfString(t *testing.T) {
 	require.ElementsMatch(t, []string{"host.example.com:88"}, conf.Realms[0].KDC)
 	require.Equal(t, "example.com", conf.LibDefaults.DefaultRealm)
 	require.False(t, conf.LibDefaults.RDNS)
+}
+
+func TestGetCertificate(t *testing.T) {
+	auth := &mockAuthClient{
+		generateDatabaseCert: func(ctx context.Context, request *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
+			require.NotEmpty(t, request.CRLDomain)
+
+			csr, err := tlsca.ParseCertificateRequestPEM(request.CSR)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			require.Equal(t, "CN=alice", csr.Subject.String())
+			return generateDatabaseCert(ctx, request)
+		},
+	}
+
+	getter := &DBCertGetter{
+		Logger:   slog.New(slog.DiscardHandler),
+		Auth:     auth,
+		UserName: "alice",
+		ADConfig: types.AD{
+			KeytabFile:             "",
+			Krb5File:               "",
+			Domain:                 "example.com",
+			SPN:                    "",
+			LDAPCert:               "",
+			KDCHostName:            "",
+			LDAPServiceAccountName: "administrator",
+			LDAPServiceAccountSID:  "S-1-5-21-2191801808-3167526388-2669316733-1104",
+		},
+	}
+
+	_, err := getter.GetCertificateBytes(context.Background())
+	require.NoError(t, err)
 }

--- a/lib/srv/db/common/kerberos/kinit/ldap_test.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap_test.go
@@ -78,15 +78,18 @@ func (m *mockAuthClient) GenerateDatabaseCert(ctx context.Context, request *prot
 }
 
 func (m *mockAuthClient) GenerateWindowsDesktopCert(ctx context.Context, request *proto.WindowsDesktopCertRequest) (*proto.WindowsDesktopCertResponse, error) {
-	return nil, trace.NotImplemented("GenerateWindowsDesktopCert")
+	return nil, trace.NotImplemented("GenerateWindowsDesktopCert not implemented")
 }
 
 func (m *mockAuthClient) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
-	return nil, trace.NotImplemented("GetCertAuthority")
+	return nil, trace.NotImplemented("GetCertAuthority not implemented")
 }
 
 func (m *mockAuthClient) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
-	return nil, trace.NotImplemented("GetClusterName")
+	return types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "test",
+		ClusterID:   "AAAA",
+	})
 }
 
 func TestTLSConfigForLDAP(t *testing.T) {
@@ -95,6 +98,8 @@ func TestTLSConfigForLDAP(t *testing.T) {
 	connector := newLDAPConnector(ldapConnectorConfig{
 		authClient: &mockAuthClient{
 			generateDatabaseCert: func(ctx context.Context, request *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
+				require.NotEmpty(t, request.CRLDomain)
+
 				csr, err := tlsca.ParseCertificateRequestPEM(request.CSR)
 				if err != nil {
 					return nil, trace.Wrap(err)


### PR DESCRIPTION
Manual backport of #57802 to branch/v17 due to significant merge conflicts.

changelog: Fix database PKINIT issues caused missing CDP information in the certificate
