### PR TITLE
[v16] Update Go to 1.24.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: '2'
 run:
-  go: '1.23'
+  go: '1.24'
   timeout: 15m
 linters:
   default: none

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -345,7 +345,7 @@ func (c *CircuitBreaker) beforeExecution() (uint64, error) {
 		c.cfg.OnExecute(false, StateTripped)
 
 		if c.cfg.TrippedErrorMessage != "" {
-			return generation, trace.ConnectionProblem(nil, c.cfg.TrippedErrorMessage)
+			return generation, trace.ConnectionProblem(nil, "%s", c.cfg.TrippedErrorMessage)
 		}
 
 		return generation, trace.Wrap(ErrStateTripped)

--- a/api/types/duration.go
+++ b/api/types/duration.go
@@ -59,7 +59,7 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 	}
 	out, err := parseDuration(stringVar)
 	if err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 	*d = out
 	return nil
@@ -83,7 +83,7 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	out, err := parseDuration(stringVar)
 	if err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 	*d = out
 	return nil
@@ -189,7 +189,7 @@ func parseDuration(s string) (Duration, error) {
 		return 0, nil
 	}
 	if s == "" {
-		return 0, trace.BadParameter("time: invalid duration " + orig)
+		return 0, trace.BadParameter("time: invalid duration %q", orig)
 	}
 	for s != "" {
 		var (
@@ -207,7 +207,7 @@ func parseDuration(s string) (Duration, error) {
 		pl := len(s)
 		v, s, err = leadingInt(s)
 		if err != nil {
-			return 0, trace.BadParameter("time: invalid duration " + orig)
+			return 0, trace.BadParameter("time: invalid duration %q", orig)
 		}
 		pre := pl != len(s) // whether we consumed anything before a period
 
@@ -221,7 +221,7 @@ func parseDuration(s string) (Duration, error) {
 		}
 		if !pre && !post {
 			// no digits (e.g. ".s" or "-.s")
-			return 0, trace.BadParameter("time: invalid duration " + orig)
+			return 0, trace.BadParameter("time: invalid duration %q", orig)
 		}
 
 		// Consume unit.
@@ -233,17 +233,17 @@ func parseDuration(s string) (Duration, error) {
 			}
 		}
 		if i == 0 {
-			return 0, trace.BadParameter("time: missing unit in duration " + orig)
+			return 0, trace.BadParameter("time: missing unit in duration %q", orig)
 		}
 		u := s[:i]
 		s = s[i:]
 		unit, ok := unitMap[u]
 		if !ok {
-			return 0, trace.BadParameter("time: unknown unit " + " in duration " + orig)
+			return 0, trace.BadParameter("time: unknown unit in duration %q", orig)
 		}
 		if v > (1<<63-1)/unit {
 			// overflow
-			return 0, trace.BadParameter("time: invalid duration " + orig)
+			return 0, trace.BadParameter("time: invalid duration %q", orig)
 		}
 		v *= unit
 		if f > 0 {
@@ -252,13 +252,13 @@ func parseDuration(s string) (Duration, error) {
 			v += int64(float64(f) * (float64(unit) / scale))
 			if v < 0 {
 				// overflow
-				return 0, trace.BadParameter("time: invalid duration " + orig)
+				return 0, trace.BadParameter("time: invalid duration %q", orig)
 			}
 		}
 		d += v
 		if d < 0 {
 			// overflow
-			return 0, trace.BadParameter("time: invalid duration " + orig)
+			return 0, trace.BadParameter("time: invalid duration %q", orig)
 		}
 	}
 

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -14,7 +14,6 @@ limitations under the License.
 package keys
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/gravitational/trace"
@@ -175,7 +174,7 @@ var privateKeyPolicyErrRegex = regexp.MustCompile(`private key policy not (met|s
 
 func NewPrivateKeyPolicyError(p PrivateKeyPolicy) error {
 	// TODO(Joerger): Replace with "private key policy not satisfied" in 16.0.0
-	return trace.BadParameter(fmt.Sprintf("private key policy not met: %s", p))
+	return trace.BadParameter("private key policy not met: %s", p)
 }
 
 // ParsePrivateKeyPolicyError checks if the given error is a private key policy

--- a/api/utils/retryutils/retry.go
+++ b/api/utils/retryutils/retry.go
@@ -195,7 +195,7 @@ func (r *Linear) For(ctx context.Context, retryFn func() error) error {
 		case <-r.After():
 			r.Inc()
 		case <-ctx.Done():
-			return trace.LimitExceeded(ctx.Err().Error())
+			return trace.LimitExceeded("%s", ctx.Err())
 		}
 	}
 }

--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -19,7 +19,6 @@ package sshutils
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -68,10 +67,11 @@ func ConnectProxyTransport(sconn ssh.Conn, req *DialReq, exclusive bool) (conn *
 		// passed to us via stderr.
 		errMessageBytes, _ := io.ReadAll(channel.Stderr())
 		errMessage := string(bytes.TrimSpace(errMessageBytes))
-		if len(errMessage) == 0 {
-			errMessage = fmt.Sprintf("failed connecting to %v [%v]", req.Address, req.ServerID)
+		if errMessage != "" {
+			return nil, false, trace.Errorf("%s", errMessage)
 		}
-		return nil, false, trace.Errorf(errMessage)
+
+		return nil, false, trace.Errorf("failed connecting to %v [%v]", req.Address, req.ServerID)
 	}
 
 	if exclusive {

--- a/api/utils/tlsutils/tlsutils.go
+++ b/api/utils/tlsutils/tlsutils.go
@@ -36,7 +36,7 @@ func ParseCertificatePEM(bytes []byte) (*x509.Certificate, error) {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	return cert, nil
 }

--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -106,5 +106,5 @@ func getLatest(ctx context.Context, versionSpec string, gh github.GitHub) (strin
 		}
 	}
 
-	return "", trace.NotFound("no releases matched " + versionSpec)
+	return "", trace.NotFound("no releases matched %q", versionSpec)
 }

--- a/build.assets/tooling/cmd/render-tests/main.go
+++ b/build.assets/tooling/cmd/render-tests/main.go
@@ -61,7 +61,7 @@ func readInput(input io.Reader, ch chan<- TestEvent, errCh chan<- error) {
 		for scanner.Scan() {
 			line := scanner.Text()
 			if line != "" {
-				err = trace.Errorf(line)
+				err = trace.Errorf("%s", line)
 				break
 			}
 		}

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.12
+go 1.24.6
 
 require (
 	buf.build/go/bufplugin v0.9.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.12
+GOLANG_VERSION ?= go1.24.6
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.12
+go 1.24.6
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/access/datadog/client.go
+++ b/integrations/access/datadog/client.go
@@ -131,14 +131,12 @@ func onAfterDatadogResponse(sink common.StatusSink) resty.ResponseMiddleware {
 		}
 
 		if resp.IsError() {
-			var details string
 			switch result := resp.Error().(type) {
 			case *ErrorResult:
-				details = fmt.Sprintf("http error code=%v, errors=[%v]", resp.StatusCode(), strings.Join(result.Errors, ", "))
+				return trace.Errorf("http error code=%v, errors=[%v]", resp.StatusCode(), strings.Join(result.Errors, ", "))
 			default:
-				details = fmt.Sprintf("unknown error result %#v", result)
+				return trace.Errorf("unknown error result %#v", result)
 			}
-			return trace.Errorf(details)
 		}
 		return nil
 	}

--- a/integrations/access/pagerduty/client.go
+++ b/integrations/access/pagerduty/client.go
@@ -125,23 +125,24 @@ func onAfterPagerDutyResponse(sink common.StatusSink) resty.ResponseMiddleware {
 			log.WithError(err).Errorf("Error while emitting PagerDuty plugin status: %v", err)
 		}
 
+		var errorFn = trace.Errorf
+		if status.GetCode() == types.PluginStatusCode_UNAUTHORIZED {
+			errorFn = func(msg string, args ...any) error {
+				return trace.AccessDenied(msg, args...)
+			}
+		}
+
 		if resp.IsError() {
-			var details string
 			switch result := resp.Error().(type) {
 			case *ErrorResult:
 				// Do we have a formatted PagerDuty API error response? We set
 				// an empty `ErrorResult` in the pre-request hook, and if the
 				// HTTP server returns an error, the `resty` middleware will
 				// attempt to unmarshal the error response into it.
-				details = fmt.Sprintf("http error code=%v, err_code=%v, message=%v, errors=[%v]", resp.StatusCode(), result.Code, result.Message, strings.Join(result.Errors, ", "))
+				return errorFn("http error code=%v, err_code=%v, message=%v, errors=[%v]", resp.StatusCode(), result.Code, result.Message, strings.Join(result.Errors, ", "))
 			default:
-				details = fmt.Sprintf("unknown error result %#v", result)
+				return errorFn("unknown error result %#v", result)
 			}
-
-			if status.GetCode() == types.PluginStatusCode_UNAUTHORIZED {
-				return trace.AccessDenied(details)
-			}
-			return trace.Errorf(details)
 		}
 		return nil
 	}

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.12
+go 1.24.6
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.12
+go 1.24.6
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3439,7 +3439,7 @@ func (a *Server) WithUserLock(ctx context.Context, username string, authenticate
 			log.Debugf("%v exceeds %v failed login attempts, locked until %v",
 				user.GetName(), defaults.MaxLoginAttempts, apiutils.HumanTimeFormat(status.LockExpires))
 
-			err := trace.AccessDenied(MaxFailedAttemptsErrMsg)
+			err := trace.AccessDenied("%s", MaxFailedAttemptsErrMsg)
 			return trace.WithField(err, ErrFieldKeyUserMaxedAttempts, true)
 		}
 	}
@@ -3483,7 +3483,7 @@ func (a *Server) WithUserLock(ctx context.Context, username string, authenticate
 		return trace.Wrap(fnErr)
 	}
 
-	retErr := trace.AccessDenied(MaxFailedAttemptsErrMsg)
+	retErr := trace.AccessDenied("%s", MaxFailedAttemptsErrMsg)
 	return trace.WithField(retErr, ErrFieldKeyUserMaxedAttempts, true)
 }
 
@@ -4880,12 +4880,12 @@ func (a *Server) ValidateToken(ctx context.Context, token string) (types.Provisi
 	tok, err := a.GetToken(ctx, token)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return nil, trace.AccessDenied(TokenExpiredOrNotFound)
+			return nil, trace.AccessDenied("%s", TokenExpiredOrNotFound)
 		}
 		return nil, trace.Wrap(err)
 	}
 	if !a.checkTokenTTL(tok) {
-		return nil, trace.AccessDenied(TokenExpiredOrNotFound)
+		return nil, trace.AccessDenied("%s", TokenExpiredOrNotFound)
 	}
 
 	return tok, nil
@@ -7108,7 +7108,7 @@ func (a *Server) verifyAccessRequestMonthlyLimit(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	if usage >= int(monthlyLimit) {
-		return trace.AccessDenied(limitReachedMessage)
+		return trace.AccessDenied("%s", limitReachedMessage)
 	}
 
 	return nil

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7914,22 +7914,22 @@ func checkOktaLockTarget(ctx context.Context, authzCtx *authz.Context, users ser
 	target := lock.Target()
 	switch {
 	case !target.Equals(types.LockTarget{User: target.User}):
-		return trace.BadParameter(errorMsg)
+		return trace.BadParameter("%s", errorMsg)
 
 	case target.User == "":
-		return trace.BadParameter(errorMsg)
+		return trace.BadParameter("%s", errorMsg)
 	}
 
 	targetUser, err := users.GetUser(ctx, target.User, false /* withSecrets */)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return trace.AccessDenied(errorMsg)
+			return trace.AccessDenied("%s", errorMsg)
 		}
 		return trace.Wrap(err)
 	}
 
 	if targetUser.Origin() != types.OriginOkta {
-		return trace.AccessDenied(errorMsg)
+		return trace.AccessDenied("%s", errorMsg)
 	}
 
 	return nil

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -970,7 +970,7 @@ func ValidateClientRedirect(clientRedirect string, ssoTestFlow bool, settings *t
 	}
 
 	if settings == nil {
-		return trace.AccessDenied(unknownRedirectHostnameErrMsg)
+		return trace.AccessDenied("%s", unknownRedirectHostnameErrMsg)
 	}
 
 	// allow HTTP or HTTPS redirects from IPs in specified CIDR ranges
@@ -1009,7 +1009,7 @@ func ValidateClientRedirect(clientRedirect string, ssoTestFlow bool, settings *t
 		}
 	}
 
-	return trace.AccessDenied(unknownRedirectHostnameErrMsg)
+	return trace.AccessDenied("%s", unknownRedirectHostnameErrMsg)
 }
 
 // populateGithubClaims builds a GithubClaims using queried

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -76,7 +76,7 @@ func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.Reg
 		if !hasLocalServiceRole {
 			msg := fmt.Sprintf("%q [%v] cannot requisition instance certs (token contains no local service roles)", req.NodeName, req.HostID)
 			log.Warn(msg)
-			return nil, trace.AccessDenied(msg)
+			return nil, trace.AccessDenied("%s", msg)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.Reg
 	if !provisionToken.GetRoles().Include(req.Role) && req.Role != types.RoleInstance {
 		msg := fmt.Sprintf("node %q [%v] can not join the cluster, the token does not allow %q role", req.NodeName, req.HostID, req.Role)
 		log.Warn(msg)
-		return nil, trace.BadParameter(msg)
+		return nil, trace.BadParameter("%s", msg)
 	}
 
 	return provisionToken, nil

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -601,7 +601,7 @@ func (a *Server) AuthenticateWebUser(ctx context.Context, req authclient.Authent
 	// to the local auth will be disabled by default.
 	if !authPref.GetAllowLocalAuth() && req.Session == nil {
 		a.emitNoLocalAuthEvent(username)
-		return nil, trace.AccessDenied(noLocalAuth)
+		return nil, trace.AccessDenied("%s", noLocalAuth)
 	}
 
 	if req.Session != nil {
@@ -659,7 +659,7 @@ func (a *Server) AuthenticateSSHUser(ctx context.Context, req authclient.Authent
 	// Disable all local auth requests, except headless requests.
 	if !authPref.GetAllowLocalAuth() && req.HeadlessAuthenticationID == "" {
 		a.emitNoLocalAuthEvent(username)
-		return nil, trace.AccessDenied(noLocalAuth)
+		return nil, trace.AccessDenied("%s", noLocalAuth)
 	}
 
 	clusterName, err := a.GetClusterName()
@@ -776,7 +776,7 @@ func getErrorByTraceField(err error) error {
 		log.WithError(err).Warn("Unexpected error type, wanted TraceError")
 		return trace.AccessDenied("an error has occurred")
 	case traceErr.GetFields()[ErrFieldKeyUserMaxedAttempts] != nil:
-		return trace.AccessDenied(MaxFailedAttemptsErrMsg)
+		return trace.AccessDenied("%s", MaxFailedAttemptsErrMsg)
 	}
 
 	return nil

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -189,13 +189,13 @@ func (a *Server) checkPasswordWOToken(ctx context.Context, user string, password
 
 	if err = bcrypt.CompareHashAndPassword(hash, password); err != nil {
 		log.Debugf("Password for %q does not match", user)
-		return trace.BadParameter(errMsg)
+		return trace.BadParameter("%s", errMsg)
 	}
 
 	// Careful! The bcrypt check above may succeed for an unknown user when the
 	// provided password is "barbaz", which is what fakePasswordHash hashes to.
 	if !userFound {
-		return trace.BadParameter(errMsg)
+		return trace.BadParameter("%s", errMsg)
 	}
 
 	// At this point, we know that the user provided a correct password, so we may
@@ -316,7 +316,7 @@ func (a *Server) changeUserAuthentication(ctx context.Context, req *proto.Change
 		return nil, trace.Wrap(err)
 	}
 	if !authPref.GetAllowLocalAuth() {
-		return nil, trace.AccessDenied(noLocalAuth)
+		return nil, trace.AccessDenied("%s", noLocalAuth)
 	}
 
 	reqPasswordless := len(req.GetNewPassword()) == 0 && authPref.GetAllowPasswordless()

--- a/lib/auth/storage/storage.go
+++ b/lib/auth/storage/storage.go
@@ -101,7 +101,7 @@ func (p *ProcessStorage) GetState(ctx context.Context, role types.SystemRole) (*
 	}
 	var res state.StateV2
 	if err := utils.FastUnmarshal(item.Value, &res); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	// an empty InitialLocalVersion is treated as an error by CheckAndSetDefaults, but if the field
@@ -169,7 +169,7 @@ func (p *ProcessStorage) ReadIdentity(name string, role types.SystemRole) (*stat
 	}
 	var res state.IdentityV2
 	if err := utils.FastUnmarshal(item.Value, &res); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := res.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -376,7 +376,7 @@ func (b *Backend) GetName() string {
 func (b *Backend) Create(ctx context.Context, item backend.Item) (*backend.Lease, error) {
 	rev, err := b.create(ctx, item, modeCreate)
 	if trace.IsCompareFailed(err) {
-		err = trace.AlreadyExists(err.Error())
+		err = trace.AlreadyExists("%s", err)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -400,7 +400,7 @@ func (b *Backend) Put(ctx context.Context, item backend.Item) (*backend.Lease, e
 func (b *Backend) Update(ctx context.Context, item backend.Item) (*backend.Lease, error) {
 	rev, err := b.create(ctx, item, modeUpdate)
 	if trace.IsCompareFailed(err) {
-		err = trace.NotFound(err.Error())
+		err = trace.NotFound("%s", err)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -592,7 +592,7 @@ func (b *Backend) CompareAndSwap(ctx context.Context, expected backend.Item, rep
 	if err != nil {
 		// in this case let's use more specific compare failed error
 		if trace.IsAlreadyExists(err) {
-			return nil, trace.CompareFailed(err.Error())
+			return nil, trace.CompareFailed("%s", err)
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -698,7 +698,7 @@ func (b *Backend) KeepAlive(ctx context.Context, lease backend.Lease, expires ti
 	_, err := b.svc.UpdateItemWithContext(ctx, input)
 	err = convertError(err)
 	if trace.IsCompareFailed(err) {
-		err = trace.NotFound(err.Error())
+		err = trace.NotFound("%s", err)
 	}
 	return err
 }
@@ -1062,17 +1062,17 @@ func convertError(err error) error {
 	}
 	switch aerr.Code() {
 	case dynamodb.ErrCodeConditionalCheckFailedException:
-		return trace.CompareFailed(aerr.Error())
+		return trace.CompareFailed("%s", aerr)
 	case dynamodb.ErrCodeProvisionedThroughputExceededException:
-		return trace.ConnectionProblem(aerr, aerr.Error())
+		return trace.ConnectionProblem(aerr, "%s", aerr)
 	case dynamodb.ErrCodeResourceNotFoundException, applicationautoscaling.ErrCodeObjectNotFoundException:
-		return trace.NotFound(aerr.Error())
+		return trace.NotFound("%s", aerr)
 	case dynamodb.ErrCodeItemCollectionSizeLimitExceededException:
-		return trace.BadParameter(aerr.Error())
+		return trace.BadParameter("%s", aerr)
 	case dynamodb.ErrCodeInternalServerError:
-		return trace.BadParameter(aerr.Error())
+		return trace.BadParameter("%s", aerr)
 	case dynamodbstreams.ErrCodeExpiredIteratorException, dynamodbstreams.ErrCodeLimitExceededException, dynamodbstreams.ErrCodeTrimmedDataAccessException:
-		return trace.ConnectionProblem(aerr, aerr.Error())
+		return trace.ConnectionProblem(aerr, "%s", aerr)
 	default:
 		return err
 	}

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -822,7 +822,7 @@ func (b *EtcdBackend) CompareAndSwap(ctx context.Context, expected backend.Item,
 	if err != nil {
 		err = convertErr(err)
 		if trace.IsNotFound(err) {
-			return nil, trace.CompareFailed(err.Error())
+			return nil, trace.CompareFailed("%s", err)
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -1068,14 +1068,14 @@ func convertErr(err error) error {
 	case errors.Is(err, context.DeadlineExceeded):
 		return trace.ConnectionProblem(err, "operation has timed out")
 	case errors.Is(err, rpctypes.ErrEmptyKey):
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	case errors.Is(err, rpctypes.ErrKeyNotFound):
-		return trace.NotFound(err.Error())
+		return trace.NotFound("%s", err)
 	}
 
 	ev, ok := status.FromError(err)
 	if !ok {
-		return trace.ConnectionProblem(err, err.Error())
+		return trace.ConnectionProblem(err, "%s", err)
 	}
 
 	switch ev.Code() {
@@ -1084,15 +1084,15 @@ func convertErr(err error) error {
 	case codes.DeadlineExceeded:
 		return trace.ConnectionProblem(err, "operation has timed out")
 	case codes.NotFound:
-		return trace.NotFound(err.Error())
+		return trace.NotFound("%s", err)
 	case codes.AlreadyExists:
-		return trace.AlreadyExists(err.Error())
+		return trace.AlreadyExists("%s", err)
 	case codes.FailedPrecondition:
-		return trace.CompareFailed(err.Error())
+		return trace.CompareFailed("%s", err)
 	case codes.ResourceExhausted:
-		return trace.LimitExceeded(err.Error())
+		return trace.LimitExceeded("%s", err)
 	default:
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 }
 

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -1075,7 +1075,7 @@ func (b *Backend) deleteDocuments(docs []*firestore.DocumentSnapshot) error {
 }
 
 // ConvertGRPCError converts gRPC errors
-func ConvertGRPCError(err error, args ...interface{}) error {
+func ConvertGRPCError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -1085,15 +1085,15 @@ func ConvertGRPCError(err error, args ...interface{}) error {
 	case codes.DeadlineExceeded:
 		return context.DeadlineExceeded
 	case codes.FailedPrecondition:
-		return trace.BadParameter(err.Error(), args...)
+		return trace.BadParameter("%s", err)
 	case codes.NotFound:
-		return trace.NotFound(err.Error(), args...)
+		return trace.NotFound("%s", err)
 	case codes.AlreadyExists:
-		return trace.AlreadyExists(err.Error(), args...)
+		return trace.AlreadyExists("%s", err)
 	case codes.OK:
 		return nil
 	default:
-		return trace.Wrap(err, args...)
+		return trace.Wrap(err)
 	}
 }
 

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -967,7 +967,7 @@ func (l *Backend) inTransaction(ctx context.Context, f func(tx *sql.Tx) error) (
 		}
 		if err != nil && !trace.IsNotFound(err) {
 			if isConstraintError(trace.Unwrap(err)) {
-				err = trace.AlreadyExists(err.Error())
+				err = trace.AlreadyExists("%s", err)
 			}
 			// transaction aborted by interrupt, no action needed
 			if isInterrupt(trace.Unwrap(err)) {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2458,7 +2458,7 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 			message := "Desktop sessions cannot be played with tsh play." +
 				" Export the recording to video with tsh recordings export" +
 				" or view the recording in your web browser."
-			return trace.BadParameter(message)
+			return trace.BadParameter("%s", message)
 		case *apievents.AppSessionStart, *apievents.AppSessionChunk:
 			return trace.BadParameter("Interactive session replay is not supported for app sessions." +
 				" To play app sessions, specify --format=json or --format=yaml.")
@@ -2478,9 +2478,8 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 			lastTime = evt.Time
 		case *apievents.DatabaseSessionStart:
 			if !slices.Contains(libplayer.SupportedDatabaseProtocols, evt.DatabaseProtocol) {
-				return trace.NotImplemented("Interactive database session replay is only supported for " +
-					strings.Join(libplayer.SupportedDatabaseProtocols, ",") + " databases." +
-					" To play other database sessions, specify --format=json or --format=yaml.")
+				return trace.NotImplemented("Interactive database session replay is only supported for %s databases."+
+					" To play other database sessions, specify --format=json or --format=yaml.", strings.Join(libplayer.SupportedDatabaseProtocols, ","))
 			}
 		default:
 			continue

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -349,7 +349,7 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 			//  An alternative we have here is querying the cluster to check if device
 			//  trust is required, a check similar to `IsMFARequired`.
 			log.Infof("Access denied to %v connecting to %v: %v", sshConfig.User, nodeName, err)
-			return nil, trace.AccessDenied(`access denied to %v connecting to %v`, sshConfig.User, nodeName)
+			return nil, trace.AccessDenied("access denied to %v connecting to %v", sshConfig.User, nodeName)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/kube/kube.go
+++ b/lib/client/kube/kube.go
@@ -56,7 +56,7 @@ func CheckIfCertsAreAllowedToAccessCluster(k *client.Key, rootCluster, teleportC
 	}
 	errMsg := "Your user's Teleport role does not allow Kubernetes access." +
 		" Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set."
-	return trace.AccessDenied(errMsg)
+	return trace.AccessDenied("%s", errMsg)
 }
 
 // checkIfCertHasKubeGroupsAndUsers checks if the certificate has Kubernetes groups or users

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -46,16 +46,16 @@ func ConvertRequestFailureError(err error) error {
 func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) error {
 	switch statusCode {
 	case http.StatusForbidden:
-		return trace.AccessDenied(requestErr.Error())
+		return trace.AccessDenied("%s", requestErr)
 	case http.StatusConflict:
-		return trace.AlreadyExists(requestErr.Error())
+		return trace.AlreadyExists("%s", requestErr)
 	case http.StatusNotFound:
-		return trace.NotFound(requestErr.Error())
+		return trace.NotFound("%s", requestErr)
 	case http.StatusBadRequest:
 		// Some services like memorydb, redshiftserverless may return 400 with
 		// "AccessDeniedException" instead of 403.
 		if strings.Contains(requestErr.Error(), redshiftserverless.ErrCodeAccessDeniedException) {
-			return trace.AccessDenied(requestErr.Error())
+			return trace.AccessDenied("%s", requestErr)
 		}
 	}
 
@@ -69,18 +69,18 @@ func ConvertIAMError(err error) error {
 	if errors.As(err, &awsErr) {
 		switch awsErr.Code() {
 		case iam.ErrCodeUnmodifiableEntityException:
-			return trace.AccessDenied(awsErr.Error())
+			return trace.AccessDenied("%s", awsErr)
 
 		case iam.ErrCodeNoSuchEntityException:
-			return trace.NotFound(awsErr.Error())
+			return trace.NotFound("%s", awsErr)
 
 		case iam.ErrCodeMalformedPolicyDocumentException,
 			iam.ErrCodeInvalidInputException,
 			iam.ErrCodeDeleteConflictException:
-			return trace.BadParameter(awsErr.Error())
+			return trace.BadParameter("%s", awsErr)
 
 		case iam.ErrCodeLimitExceededException:
-			return trace.LimitExceeded(awsErr.Error())
+			return trace.LimitExceeded("%s", awsErr)
 		}
 	}
 
@@ -96,17 +96,17 @@ func ConvertIAMv2Error(err error) error {
 
 	var entityExistsError *iamtypes.EntityAlreadyExistsException
 	if errors.As(err, &entityExistsError) {
-		return trace.AlreadyExists(*entityExistsError.Message)
+		return trace.AlreadyExists("%s", *entityExistsError.Message)
 	}
 
 	var entityNotFound *iamtypes.NoSuchEntityException
 	if errors.As(err, &entityNotFound) {
-		return trace.NotFound(*entityNotFound.Message)
+		return trace.NotFound("%s", *entityNotFound.Message)
 	}
 
 	var malformedPolicyDocument *iamtypes.MalformedPolicyDocumentException
 	if errors.As(err, &malformedPolicyDocument) {
-		return trace.BadParameter(*malformedPolicyDocument.Message)
+		return trace.BadParameter("%s", *malformedPolicyDocument.Message)
 	}
 
 	var re *awshttp.ResponseError

--- a/lib/cloud/azure/errors.go
+++ b/lib/cloud/azure/errors.go
@@ -41,14 +41,14 @@ func ConvertResponseError(err error) error {
 	case errors.As(err, &responseErr):
 		switch responseErr.StatusCode {
 		case http.StatusForbidden:
-			return trace.AccessDenied(responseErr.Error())
+			return trace.AccessDenied("%s", responseErr)
 		case http.StatusConflict:
-			return trace.AlreadyExists(responseErr.Error())
+			return trace.AlreadyExists("%s", responseErr)
 		case http.StatusNotFound:
-			return trace.NotFound(responseErr.Error())
+			return trace.NotFound("%s", responseErr)
 		}
 	case errors.As(err, &authenticationFailedErr):
-		return trace.AccessDenied(authenticationFailedErr.Error())
+		return trace.AccessDenied("%s", authenticationFailedErr)
 	}
 	return err // Return unmodified.
 }

--- a/lib/cloud/azure/redis_enterprise.go
+++ b/lib/cloud/azure/redis_enterprise.go
@@ -176,7 +176,7 @@ func (c *redisEnterpriseClient) listDatabasesByClusters(ctx context.Context, clu
 func (c *redisEnterpriseClient) listDatabasesByCluster(ctx context.Context, cluster *armredisenterprise.Cluster) ([]*RedisEnterpriseDatabase, error) {
 	resourceID, err := arm.ParseResourceID(StringVal(cluster.ID))
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	var databases []*RedisEnterpriseDatabase

--- a/lib/cloud/imds/aws/imds.go
+++ b/lib/cloud/imds/aws/imds.go
@@ -55,7 +55,7 @@ func convertLoadConfigError(configErr error) error {
 	var sharedConfigProfileNotExistError config.SharedConfigProfileNotExistError
 	switch {
 	case errors.As(configErr, &sharedConfigProfileNotExistError):
-		return trace.NotFound(configErr.Error())
+		return trace.NotFound("%s", configErr)
 	}
 
 	return configErr

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3935,7 +3935,7 @@ func TestApplyOktaConfig(t *testing.T) {
 				},
 			},
 			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, trace.BadParameter(`okta_service is enabled but no api_endpoint is specified`))
+				require.ErrorIs(t, err, trace.BadParameter("okta_service is enabled but no api_endpoint is specified"))
 			},
 		},
 		{
@@ -3961,7 +3961,7 @@ func TestApplyOktaConfig(t *testing.T) {
 				APIEndpoint: `http://`,
 			},
 			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, trace.BadParameter(`api_endpoint has no host`))
+				require.ErrorIs(t, err, trace.BadParameter("api_endpoint has no host"))
 			},
 		},
 		{
@@ -3974,7 +3974,7 @@ func TestApplyOktaConfig(t *testing.T) {
 				APIEndpoint: `//hostname`,
 			},
 			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, trace.BadParameter(`api_endpoint has no scheme`))
+				require.ErrorIs(t, err, trace.BadParameter("api_endpoint has no scheme"))
 			},
 		},
 		{
@@ -3986,7 +3986,7 @@ func TestApplyOktaConfig(t *testing.T) {
 				APIEndpoint: "https://test-endpoint",
 			},
 			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, trace.BadParameter(`okta_service is enabled but no api_token_path is specified`))
+				require.ErrorIs(t, err, trace.BadParameter("okta_service is enabled but no api_token_path is specified"))
 			},
 		},
 		{
@@ -3999,7 +3999,7 @@ func TestApplyOktaConfig(t *testing.T) {
 				APITokenPath: "/non-existent/path",
 			},
 			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.ErrorIs(t, err, trace.BadParameter(`error trying to find file %s`, i...))
+				require.ErrorIs(t, err, trace.BadParameter("error trying to find file %s", i...))
 			},
 		},
 		{

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -691,12 +691,12 @@ func getRoleARNForAssumedRole(iamClient iamClient, identity awslib.Identity) (aw
 		RoleName: aws.String(identity.GetName()),
 	})
 	if err != nil || out == nil || out.Role == nil || out.Role.Arn == nil {
-		return nil, trace.BadParameter(failedToResolveAssumeRoleARN)
+		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN)
 	}
 
 	roleIdentity, err := awslib.IdentityFromArn(*out.Role.Arn)
 	if err != nil {
-		return nil, trace.BadParameter(failedToResolveAssumeRoleARN)
+		return nil, trace.BadParameter("%s", failedToResolveAssumeRoleARN)
 	}
 	return roleIdentity, nil
 }

--- a/lib/devicetrust/testenv/fake_device_service.go
+++ b/lib/devicetrust/testenv/fake_device_service.go
@@ -231,7 +231,7 @@ func (s *FakeDeviceService) CreateDeviceEnrollToken(ctx context.Context, req *de
 
 	// Auto-enrollment path.
 	if err := validateCollectedData(req.DeviceData); err != nil {
-		return nil, trace.AccessDenied(err.Error())
+		return nil, trace.AccessDenied("%s", err)
 	}
 
 	return &devicepb.DeviceEnrollToken{
@@ -625,11 +625,11 @@ func (s *FakeDeviceService) spendDeviceWebToken(webToken *devicepb.DeviceWebToke
 
 		switch {
 		case storedToken == "": // Invalid attempt state or token already spent.
-			return nil, trace.AccessDenied(invalidWebTokenMessage)
+			return nil, trace.AccessDenied("%s", invalidWebTokenMessage)
 		case storedToken != webToken.Token: // Bad token
-			return nil, trace.AccessDenied(invalidWebTokenMessage)
+			return nil, trace.AccessDenied("%s", invalidWebTokenMessage)
 		case attempt.expectedDeviceID != dev.pb.Id: // Failed expected device check.
-			return nil, trace.AccessDenied(invalidWebTokenMessage)
+			return nil, trace.AccessDenied("%s", invalidWebTokenMessage)
 		}
 
 		// Issue a new confirmation token.
@@ -642,7 +642,7 @@ func (s *FakeDeviceService) spendDeviceWebToken(webToken *devicepb.DeviceWebToke
 	}
 
 	// Token ID not found.
-	return nil, trace.AccessDenied(invalidWebTokenMessage)
+	return nil, trace.AccessDenied("%s", invalidWebTokenMessage)
 }
 
 func authenticateDeviceMacOS(dev *storedDevice, stream authenticateDeviceStream) error {

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -393,10 +393,10 @@ func (l *Log) handleAWSValidationError(ctx context.Context, err error, sessionID
 
 	se, ok := trimEventSize(in)
 	if !ok {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 	if err := l.putAuditEvent(context.WithValue(ctx, largeEventHandledContextKey, true), sessionID, se); err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 	fields := log.Fields{"event_id": in.GetID(), "event_type": in.GetType()}
 	l.WithFields(fields).Info("Uploaded trimmed event to DynamoDB backend.")
@@ -1106,20 +1106,20 @@ func convertError(err error) error {
 
 	switch aerr.Code() {
 	case dynamodb.ErrCodeConditionalCheckFailedException:
-		return trace.AlreadyExists(aerr.Error())
+		return trace.AlreadyExists("%s", aerr)
 	case dynamodb.ErrCodeProvisionedThroughputExceededException:
-		return trace.ConnectionProblem(aerr, aerr.Error())
+		return trace.ConnectionProblem(aerr, "%s", aerr)
 	case dynamodb.ErrCodeResourceNotFoundException:
-		return trace.NotFound(aerr.Error())
+		return trace.NotFound("%s", aerr)
 	case dynamodb.ErrCodeItemCollectionSizeLimitExceededException:
-		return trace.BadParameter(aerr.Error())
+		return trace.BadParameter("%s", aerr)
 	case dynamodb.ErrCodeInternalServerError:
-		return trace.BadParameter(aerr.Error())
+		return trace.BadParameter("%s", aerr)
 	case ErrValidationException:
 		// A ValidationException  type is missing from AWS SDK.
 		// Use errAWSValidation that for most cases will contain:
 		// "Item size has exceeded the maximum allowed size" AWS validation error.
-		return trace.Wrap(errAWSValidation, aerr.Error())
+		return trace.Wrap(errAWSValidation, "%s", aerr)
 	default:
 		return err
 	}

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -535,7 +535,7 @@ func (u *Uploader) upload(ctx context.Context, up *upload) error {
 	case <-stream.Done():
 		if errStream, ok := stream.(interface{ Error() error }); ok {
 			if err := errStream.Error(); err != nil {
-				return trace.ConnectionProblem(err, err.Error())
+				return trace.ConnectionProblem(err, "%s", err)
 			}
 		}
 

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -332,15 +332,15 @@ func (h *Handler) ensureBucket() error {
 	return nil
 }
 
-func convertGCSError(err error, args ...interface{}) error {
+func convertGCSError(err error) error {
 	if err == nil {
 		return nil
 	}
 
 	switch {
 	case errors.Is(err, storage.ErrBucketNotExist), errors.Is(err, storage.ErrObjectNotExist):
-		return trace.NotFound(err.Error(), args...)
+		return trace.NotFound("%s", err)
 	default:
-		return trace.Wrap(err, args...)
+		return trace.Wrap(err)
 	}
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -427,7 +427,7 @@ func (h *Handler) ensureBucket(ctx context.Context) error {
 		ACL:    aws.String("private"),
 	}
 	_, err = h.client.CreateBucketWithContext(ctx, input)
-	err = awsutils.ConvertS3Error(err, fmt.Sprintf("bucket %v already exists", aws.String(h.Bucket)))
+	err = awsutils.ConvertS3Error(err)
 	if err != nil {
 		if !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err)
@@ -444,9 +444,9 @@ func (h *Handler) ensureBucket(ctx context.Context) error {
 		},
 	}
 	_, err = h.client.PutBucketVersioningWithContext(ctx, ver)
-	err = awsutils.ConvertS3Error(err, fmt.Sprintf("failed to set versioning state for bucket %q", h.Bucket))
+	err = awsutils.ConvertS3Error(err)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "failed to set versioning state for bucket %q", h.Bucket)
 	}
 
 	// Turn on server-side encryption for the bucket.
@@ -461,9 +461,9 @@ func (h *Handler) ensureBucket(ctx context.Context) error {
 				}},
 			},
 		})
-		err = awsutils.ConvertS3Error(err, fmt.Sprintf("failed to set versioning state for bucket %q", h.Bucket))
+		err = awsutils.ConvertS3Error(err)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "failed to set encryption state for bucket %q", h.Bucket)
 		}
 	}
 	return nil

--- a/lib/integrations/awsoidc/eice_opentunnel.go
+++ b/lib/integrations/awsoidc/eice_opentunnel.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -366,12 +365,11 @@ func (i *eicedConn) handleIOError(err error) error {
 	var closeErr *websocket.CloseError
 	if errors.As(err, &closeErr) {
 		return trace.ConnectionProblem(err,
-			fmt.Sprintf("Could not connect to %s via EC2 Instance Connect Endpoint %s. "+
+			"Could not connect to %s via EC2 Instance Connect Endpoint %s. "+
 				"Please ensure the instance's SecurityGroups allow inbound TCP traffic on port 22 from %s",
-				i.ec2InstanceID,
-				i.eiceID,
-				i.subnetID,
-			),
+			i.ec2InstanceID,
+			i.eiceID,
+			i.subnetID,
 		)
 	}
 	return trace.Wrap(err)

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -336,7 +336,7 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 
 	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
 	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
-		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`, clusterName)
+		return "", trace.AccessDenied("can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.", clusterName)
 	}
 
 	// When clusters are using CONFIG_MAP, API is not acessible and thus Teleport can't install the Teleport's Helm chart.

--- a/lib/kube/kubeconfig/context_overwrite.go
+++ b/lib/kube/kubeconfig/context_overwrite.go
@@ -83,7 +83,7 @@ func parseContextOverrideError(err error) error {
 		"Please check the template syntax and try again.\n" +
 		supportedFunctionsMsg
 	if err == nil {
-		return trace.BadParameter(msg)
+		return trace.BadParameter("%s", msg)
 	}
 	return trace.BadParameter(
 		msg+

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -532,7 +532,7 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	userTypeI, err := authz.UserFromContext(ctx)
 	if err != nil {
 		f.log.WithError(err).Warn("error getting user from context")
-		return nil, trace.AccessDenied(accessDeniedMsg)
+		return nil, trace.AccessDenied("%s", accessDeniedMsg)
 	}
 	switch userTypeI.(type) {
 	case authz.LocalUser:
@@ -541,10 +541,10 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		isRemoteUser = true
 	case authz.BuiltinRole:
 		f.log.Warningf("Denying proxy access to unauthenticated user of type %T - this can sometimes be caused by inadvertently using an HTTP load balancer instead of a TCP load balancer on the Kubernetes port.", userTypeI)
-		return nil, trace.AccessDenied(accessDeniedMsg)
+		return nil, trace.AccessDenied("%s", accessDeniedMsg)
 	default:
 		f.log.Warningf("Denying proxy access to unsupported user type: %T.", userTypeI)
-		return nil, trace.AccessDenied(accessDeniedMsg)
+		return nil, trace.AccessDenied("%s", accessDeniedMsg)
 	}
 
 	userContext, err := f.cfg.Authz.Authorize(ctx)
@@ -556,7 +556,7 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	if err != nil {
 		f.log.WithError(err).Warn("Unable to setup context.")
 		if trace.IsAccessDenied(err) {
-			return nil, trace.AccessDenied(accessDeniedMsg)
+			return nil, trace.AccessDenied("%s", accessDeniedMsg)
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -1066,16 +1066,16 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		kubeAccessDetails, err := f.getKubeAccessDetails(actx.kubeServers, actx.Checker, actx.kubeClusterName, actx.sessionTTL, actx.kubeResource)
 		if err != nil && !trace.IsNotFound(err) {
 			if actx.kubeResource != nil {
-				return trace.AccessDenied(notFoundMessage)
+				return trace.AccessDenied("%s", notFoundMessage)
 			}
 			// TODO (tigrato): should return another message here.
-			return trace.AccessDenied(accessDeniedMsg)
+			return trace.AccessDenied("%s", accessDeniedMsg)
 			// roles.CheckKubeGroupsAndUsers returns trace.NotFound if the user does
 			// does not have at least one configured kubernetes_users or kubernetes_groups.
 		} else if trace.IsNotFound(err) {
 			const errMsg = "Your user's Teleport role does not allow Kubernetes access." +
 				" Please ask cluster administrator to ensure your role has appropriate kubernetes_groups and kubernetes_users set."
-			return trace.NotFound(errMsg)
+			return trace.NotFound("%s", errMsg)
 		}
 
 		kubeUsers = kubeAccessDetails.kubeUsers
@@ -1103,7 +1103,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		case errors.Is(err, services.ErrTrustedDeviceRequired):
 			return trace.Wrap(err)
 		case err != nil:
-			return trace.AccessDenied(notFoundMessage)
+			return trace.AccessDenied("%s", notFoundMessage)
 		}
 
 		// If the user has active Access requests we need to validate that they allow
@@ -1119,7 +1119,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			// list will be empty.
 			allowed, denied := actx.Checker.GetKubeResources(ks)
 			if result, err := matchKubernetesResource(*actx.kubeResource, allowed, denied); err != nil || !result {
-				return trace.AccessDenied(notFoundMessage)
+				return trace.AccessDenied("%s", notFoundMessage)
 			}
 		}
 		// store a copy of the Kubernetes Cluster.
@@ -1130,7 +1130,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		f.log.WithField("auth_context", actx.String()).Debug("Skipping authorization for proxy-based kubernetes cluster,")
 		return nil
 	}
-	return trace.AccessDenied(notFoundMessage)
+	return trace.AccessDenied("%s", notFoundMessage)
 }
 
 // matchKubernetesResource checks if the Kubernetes Resource does not match any

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -83,7 +83,7 @@ func (f *Forwarder) listResources(sess *clusterSession, w http.ResponseWriter, r
 				sess.requestVerb,
 				sess.apiResource,
 			)
-			return nil, trace.AccessDenied(notFoundMessage)
+			return nil, trace.AccessDenied("%s", notFoundMessage)
 		}
 		// isWatch identifies if the request is long-lived watch stream based on
 		// HTTP connection.

--- a/lib/kube/proxy/websocket_client_testing.go
+++ b/lib/kube/proxy/websocket_client_testing.go
@@ -473,7 +473,7 @@ func (e *wsStreamClient) handlePortForwardRequest(conn net.Conn, remoteConn *gwe
 						return
 					}
 				case portforwardErrChan:
-					err := trace.Errorf(string(buf[1:]))
+					err := trace.Errorf("%s", string(buf[1:]))
 					errChan <- trace.Wrap(err)
 					// Once we receive an error from streamErr, we must stop processing.
 					// The server also stops the execution and closes the connection.

--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -201,7 +201,7 @@ func (c *Client) request(ctx context.Context, method string, uri string, payload
 			lastErr = trace.Wrap(graphError)
 		} else {
 			// API did not return a valid error structure, best-effort reporting.
-			lastErr = trace.Errorf(resp.Status)
+			lastErr = trace.Errorf("%s", resp.Status)
 		}
 		if !isRetriable(resp.StatusCode) {
 			break

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -580,12 +580,12 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			}
 
 			if m.PROXYProtocolMode == PROXYProtocolOff {
-				return nil, trace.BadParameter(externalProxyProtocolDisabledError)
+				return nil, trace.BadParameter("%s", externalProxyProtocolDisabledError)
 			}
 
 			if unsignedPROXYLineReceived {
 				// We allow only one unsigned PROXY line
-				return nil, trace.BadParameter(duplicateUnsignedProxyLineError)
+				return nil, trace.BadParameter("%s", duplicateUnsignedProxyLineError)
 			}
 			unsignedPROXYLineReceived = true
 
@@ -601,7 +601,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 
 			if proxyLine != nil && proxyLine.IsVerified {
 				// Unsigned PROXY line after signed one should not happen
-				return nil, trace.BadParameter(unsignedPROXYLineAfterSignedError)
+				return nil, trace.BadParameter("%s", unsignedPROXYLineAfterSignedError)
 			}
 
 			proxyLine = newPROXYLine
@@ -615,7 +615,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			if newPROXYLine == nil {
 				if unsignedPROXYLineReceived {
 					// We allow only one unsigned PROXY line
-					return nil, trace.BadParameter(duplicateUnsignedProxyLineError)
+					return nil, trace.BadParameter("%s", duplicateUnsignedProxyLineError)
 				}
 				unsignedPROXYLineReceived = true
 				continue // Skipping LOCAL command of PROXY protocol
@@ -645,7 +645,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 			// we accept, otherwise reject
 			if newPROXYLine.IsVerified {
 				if proxyLine != nil && proxyLine.IsVerified {
-					return nil, trace.BadParameter(duplicateSignedProxyLineError)
+					return nil, trace.BadParameter("%s", duplicateSignedProxyLineError)
 				}
 
 				proxyLine = newPROXYLine
@@ -658,12 +658,12 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 
 			// This is unsigned proxy line, return error if external PROXY protocol is not enabled
 			if m.PROXYProtocolMode == PROXYProtocolOff {
-				return nil, trace.BadParameter(externalProxyProtocolDisabledError)
+				return nil, trace.BadParameter("%s", externalProxyProtocolDisabledError)
 			}
 
 			if unsignedPROXYLineReceived {
 				// We allow only one unsigned PROXY line
-				return nil, trace.BadParameter(duplicateUnsignedProxyLineError)
+				return nil, trace.BadParameter("%s", duplicateUnsignedProxyLineError)
 			}
 			unsignedPROXYLineReceived = true
 
@@ -679,7 +679,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 
 			// Unsigned PROXY line after signed should not happen
 			if proxyLine != nil && proxyLine.IsVerified {
-				return nil, trace.BadParameter(unsignedPROXYLineAfterSignedError)
+				return nil, trace.BadParameter("%s", unsignedPROXYLineAfterSignedError)
 			}
 
 			proxyLine = newPROXYLine
@@ -698,7 +698,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 		}
 	}
 	// if code ended here after three attempts, something is wrong
-	return nil, trace.BadParameter(unknownProtocolError)
+	return nil, trace.BadParameter("%s", unknownProtocolError)
 }
 
 // checkPROXYProtocolRequirement checks that if multiplexer is required to receive unsigned PROXY line

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -492,7 +492,7 @@ func (p *PAM) codeToError(returnValue C.int) error {
 	// released.
 	err := C._pam_strerror(pamHandle, p.pamh, returnValue)
 	if err != nil {
-		return trace.BadParameter(C.GoString(err))
+		return trace.BadParameter("%s", C.GoString(err))
 	}
 
 	return nil

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -642,14 +642,14 @@ func (s *localSite) getConn(params reversetunnelclient.DialParams) (conn net.Con
 	// Skip direct dial when the tunnel error is not a not found error. This
 	// means the agent is tunneling but the connection failed for some reason.
 	if !trace.IsNotFound(tunnelErr) {
-		return nil, false, trace.ConnectionProblem(tunnelErr, tunnelMsg)
+		return nil, false, trace.ConnectionProblem(tunnelErr, "%s", tunnelMsg)
 	}
 
 	skip, err := s.skipDirectDial(params)
 	if err != nil {
 		return nil, false, trace.Wrap(err)
 	} else if skip {
-		return nil, false, trace.ConnectionProblem(tunnelErr, tunnelMsg)
+		return nil, false, trace.ConnectionProblem(tunnelErr, "%s", tunnelMsg)
 	}
 
 	// If no tunnel connection was found, dial to the target host.
@@ -667,7 +667,7 @@ func (s *localSite) getConn(params reversetunnelclient.DialParams) (conn net.Con
 		directMsg := getTunnelErrorMessage(params, "direct dial", directErr)
 		s.log.WithField("address", params.To.String()).Debugf("All attempted dial methods failed. tunnel=%q, peer=%q, direct=%q", tunnelErr, peerErr, directErr)
 		aggregateErr := trace.NewAggregate(tunnelErr, peerErr, directErr)
-		return nil, false, trace.ConnectionProblem(aggregateErr, directMsg)
+		return nil, false, trace.ConnectionProblem(aggregateErr, "%s", directMsg)
 	}
 
 	// Return a direct dialed connection.

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -952,11 +952,10 @@ func (s *remoteSite) connThroughTunnel(req *sshutils.DialReq) (*sshutils.ChConn,
 	if err == nil {
 		// Return the appropriate message if the user is trying to connect to a
 		// cluster or a node.
-		message := fmt.Sprintf("cluster %v is offline", s.GetName())
 		if req.Address != constants.RemoteAuthServer {
-			message = fmt.Sprintf("node %v is offline", req.Address)
+			return nil, trace.ConnectionProblem(nil, "node %v is offline", req.Address)
 		}
-		err = trace.ConnectionProblem(nil, message)
+		return nil, trace.ConnectionProblem(nil, "cluster %v is offline", s.GetName())
 	}
 	return nil, err
 }

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -956,7 +956,7 @@ func (s *server) checkClientCert(logger *log.Entry, user string, clusterName str
 		FIPS: s.FIPS,
 	}
 	if err := checker.CheckCert(user, cert); err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 
 	return nil

--- a/lib/services/access.go
+++ b/lib/services/access.go
@@ -79,12 +79,12 @@ func CheckDynamicLabelsInDenyRules(r types.Role) error {
 		}
 		for label := range labelMatchers.Labels {
 			if strings.HasPrefix(label, types.TeleportDynamicLabelPrefix) {
-				return trace.BadParameter(dynamicLabelsErrorMessage)
+				return trace.BadParameter("%s", dynamicLabelsErrorMessage)
 			}
 		}
 		const expressionMatch = `"` + types.TeleportDynamicLabelPrefix
 		if strings.Contains(labelMatchers.Expression, expressionMatch) {
-			return trace.BadParameter(dynamicLabelsErrorMessage)
+			return trace.BadParameter("%s", dynamicLabelsErrorMessage)
 		}
 	}
 
@@ -93,7 +93,7 @@ func CheckDynamicLabelsInDenyRules(r types.Role) error {
 		r.GetImpersonateConditions(types.Deny).Where,
 	} {
 		if strings.Contains(where, types.TeleportDynamicLabelPrefix) {
-			return trace.BadParameter(dynamicLabelsErrorMessage)
+			return trace.BadParameter("%s", dynamicLabelsErrorMessage)
 		}
 	}
 

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -109,7 +109,7 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*accesslist.Access
 	}
 	var accessList accesslist.AccessList
 	if err := utils.FastUnmarshal(data, &accessList); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := accessList.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -204,7 +204,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	}
 	var member accesslist.AccessListMember
 	if err := utils.FastUnmarshal(data, &member); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := member.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -399,7 +399,7 @@ func UnmarshalAccessListReview(data []byte, opts ...MarshalOption) (*accesslist.
 	}
 	var review accesslist.Review
 	if err := utils.FastUnmarshal(data, &review); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := review.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -94,7 +94,7 @@ func UnmarshalApp(data []byte, opts ...MarshalOption) (types.Application, error)
 	case types.V3:
 		var app types.AppV3
 		if err := utils.FastUnmarshal(data, &app); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := app.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
@@ -146,7 +146,7 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 	case types.V3:
 		var s types.AppServerV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/audit.go
+++ b/lib/services/audit.go
@@ -52,7 +52,7 @@ func UnmarshalClusterAuditConfig(bytes []byte, opts ...MarshalOption) (types.Clu
 	}
 
 	if err := utils.FastUnmarshal(bytes, &auditConfig); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := auditConfig.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -109,7 +109,7 @@ func UnmarshalAuthPreference(bytes []byte, opts ...MarshalOption) (types.AuthPre
 	}
 
 	if err := utils.FastUnmarshal(bytes, &authPreference); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := authPreference.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -335,7 +335,7 @@ func UnmarshalCertAuthority(bytes []byte, opts ...MarshalOption) (types.CertAuth
 	case types.V2:
 		var ca types.CertAuthorityV2
 		if err := utils.FastUnmarshal(bytes, &ca); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 
 		if err := ValidateCertAuthority(&ca); err != nil {

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -49,7 +49,7 @@ func UnmarshalClusterName(bytes []byte, opts ...MarshalOption) (types.ClusterNam
 	}
 
 	if err := utils.FastUnmarshal(bytes, &clusterName); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	err = clusterName.CheckAndSetDefaults()

--- a/lib/services/connection_diagnostic.go
+++ b/lib/services/connection_diagnostic.go
@@ -89,7 +89,7 @@ func UnmarshalConnectionDiagnostic(data []byte, opts ...MarshalOption) (types.Co
 	case types.V1:
 		var s types.ConnectionDiagnosticV1
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 
 		if err := s.CheckAndSetDefaults(); err != nil {

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -100,7 +100,7 @@ func UnmarshalDatabase(data []byte, opts ...MarshalOption) (types.Database, erro
 	case types.V3:
 		var database types.DatabaseV3
 		if err := utils.FastUnmarshal(data, &database); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := database.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/databaseserver.go
+++ b/lib/services/databaseserver.go
@@ -61,7 +61,7 @@ func UnmarshalDatabaseServer(data []byte, opts ...MarshalOption) (types.Database
 	case types.V3:
 		var s types.DatabaseServerV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/databaseservice.go
+++ b/lib/services/databaseservice.go
@@ -75,7 +75,7 @@ func UnmarshalDatabaseService(data []byte, opts ...MarshalOption) (types.Databas
 	case types.V1:
 		var s types.DatabaseServiceV1
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/desktop.go
+++ b/lib/services/desktop.go
@@ -80,7 +80,7 @@ func UnmarshalWindowsDesktop(data []byte, opts ...MarshalOption) (types.WindowsD
 	case types.V3:
 		var s types.WindowsDesktopV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
@@ -132,7 +132,7 @@ func UnmarshalWindowsDesktopService(data []byte, opts ...MarshalOption) (types.W
 	case types.V3:
 		var s types.WindowsDesktopServiceV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/discoveryconfig.go
+++ b/lib/services/discoveryconfig.go
@@ -91,7 +91,7 @@ func UnmarshalDiscoveryConfig(data []byte, opts ...MarshalOption) (*discoverycon
 	}
 	var discoveryConfig *discoveryconfig.DiscoveryConfig
 	if err := utils.FastUnmarshal(data, &discoveryConfig); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := discoveryConfig.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/externalauditstorage.go
+++ b/lib/services/externalauditstorage.go
@@ -36,7 +36,7 @@ func UnmarshalExternalAuditStorage(data []byte, opts ...MarshalOption) (*externa
 	}
 	var out *externalauditstorage.ExternalAuditStorage
 	if err := utils.FastUnmarshal(data, &out); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/installer.go
+++ b/lib/services/installer.go
@@ -39,7 +39,7 @@ func UnmarshalInstaller(data []byte, opts ...MarshalOption) (types.Installer, er
 	}
 
 	if err := utils.FastUnmarshal(data, &installer); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := installer.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -91,7 +91,7 @@ func UnmarshalKubeServer(data []byte, opts ...MarshalOption) (types.KubeServer, 
 	case types.V3:
 		var s types.KubernetesServerV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
@@ -147,7 +147,7 @@ func UnmarshalKubeCluster(data []byte, opts ...MarshalOption) (types.KubeCluster
 	case types.V3:
 		var s types.KubernetesClusterV3
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/license.go
+++ b/lib/services/license.go
@@ -35,7 +35,7 @@ func UnmarshalLicense(bytes []byte) (types.License, error) {
 	var license types.LicenseV3
 	err := utils.FastUnmarshal(bytes, &license)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	if license.Version != types.V3 {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -690,5 +690,5 @@ func (a *AccessListService) VerifyAccessListCreateLimit(ctx context.Context, tar
 	}
 
 	const limitReachedMessage = "cluster has reached its limit for creating access lists, please contact the cluster administrator"
-	return trace.AccessDenied(limitReachedMessage)
+	return trace.AccessDenied("%s", limitReachedMessage)
 }

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -109,7 +109,7 @@ func unmarshalResource(data []byte, opts ...services.MarshalOption) (*testResour
 
 	var r testResource
 	if err := utils.FastUnmarshal(data, &r); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := r.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -70,7 +70,7 @@ func unmarshalResource153(data []byte, opts ...services.MarshalOption) (*testRes
 
 	var r testResource153
 	if err := utils.FastUnmarshal(data, &r); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	if r.Metadata == nil {

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -123,7 +123,7 @@ func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context
 			errMsg := fmt.Errorf("failed to configure entity descriptor with the given entity_id %q and acs_url %q: %w",
 				sp.GetEntityID(), sp.GetACSURL(), err)
 			s.log.Errorf(errMsg.Error())
-			return trace.BadParameter(errMsg.Error())
+			return trace.BadParameter("%s", errMsg)
 		}
 	}
 

--- a/lib/services/lock.go
+++ b/lib/services/lock.go
@@ -36,7 +36,7 @@ func LockInForceAccessDenied(lock types.Lock) error {
 	if len(msg) > 0 {
 		s += ": " + msg
 	}
-	err := trace.AccessDenied(s)
+	err := trace.AccessDenied("%s", s)
 	return trace.WithField(err, "lock-in-force", lock)
 }
 
@@ -85,7 +85,7 @@ func UnmarshalLock(bytes []byte, opts ...MarshalOption) (types.Lock, error) {
 
 	var lock types.LockV2
 	if err := utils.FastUnmarshal(bytes, &lock); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := lock.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/namespace.go
+++ b/lib/services/namespace.go
@@ -53,7 +53,7 @@ func UnmarshalNamespace(data []byte, opts ...MarshalOption) (*types.Namespace, e
 	// the namespace is always created by teleport now
 	var namespace types.Namespace
 	if err := utils.FastUnmarshal(data, &namespace); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	if err := namespace.CheckAndSetDefaults(); err != nil {

--- a/lib/services/networking.go
+++ b/lib/services/networking.go
@@ -39,7 +39,7 @@ func UnmarshalClusterNetworkingConfig(bytes []byte, opts ...MarshalOption) (type
 	}
 
 	if err := utils.FastUnmarshal(bytes, &netConfig); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	err = netConfig.CheckAndSetDefaults()

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -89,7 +89,7 @@ func UnmarshalOIDCConnector(bytes []byte, opts ...MarshalOption) (types.OIDCConn
 	case types.V2, types.V3:
 		var c types.OIDCConnectorV3
 		if err := utils.FastUnmarshal(bytes, &c); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := c.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -116,7 +116,7 @@ func UnmarshalOktaImportRule(data []byte, opts ...MarshalOption) (types.OktaImpo
 	case types.V1:
 		var i types.OktaImportRuleV1
 		if err := utils.FastUnmarshal(data, &i); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := i.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
@@ -168,7 +168,7 @@ func UnmarshalOktaAssignment(data []byte, opts ...MarshalOption) (types.OktaAssi
 	case types.V1:
 		var a types.OktaAssignmentV1
 		if err := utils.FastUnmarshal(data, &a); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := a.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/plugin_static_credentials.go
+++ b/lib/services/plugin_static_credentials.go
@@ -78,14 +78,14 @@ func UnmarshalPluginStaticCredentials(data []byte, opts ...MarshalOption) (types
 	// every field but one is unknown to [types.MessageWithHeader] so this
 	// unmarshal must discard unknown fields
 	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(data, protoadapt.MessageV2Of(&h)); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	switch h.ResourceHeader.Version {
 	case types.V1:
 		var pluginStaticCredentials types.PluginStaticCredentialsV1
 		if err := (protojson.UnmarshalOptions{DiscardUnknown: !cfg.DisallowUnknown}).Unmarshal(data, protoadapt.MessageV2Of(&pluginStaticCredentials)); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := pluginStaticCredentials.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/plugins.go
+++ b/lib/services/plugins.go
@@ -84,7 +84,7 @@ func UnmarshalPlugin(data []byte, opts ...MarshalOption) (types.Plugin, error) {
 		var plugin types.PluginV1
 		m := jsonpb.Unmarshaler{AllowUnknownFields: true}
 		if err := m.Unmarshal(bytes.NewReader(data), &plugin); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := plugin.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -92,7 +92,7 @@ func UnmarshalProvisionToken(data []byte, opts ...MarshalOption) (types.Provisio
 	case types.V2:
 		var p types.ProvisionTokenV2
 		if err := utils.FastUnmarshal(data, &p); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := p.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/restrictions.go
+++ b/lib/services/restrictions.go
@@ -61,7 +61,7 @@ func UnmarshalNetworkRestrictions(bytes []byte, opts ...MarshalOption) (types.Ne
 	case types.V4:
 		var nr types.NetworkRestrictionsV4
 		if err := utils.FastUnmarshal(bytes, &nr); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := ValidateNetworkRestrictions(&nr); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -3342,7 +3342,7 @@ func UnmarshalRoleV6(bytes []byte, opts ...MarshalOption) (*types.RoleV6, error)
 
 	var role types.RoleV6
 	if err := utils.FastUnmarshal(bytes, &role); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if role.Version != version {
 		return nil, trace.BadParameter("inconsistent version in role data, got %q and %q", role.Version, version)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -319,7 +319,7 @@ func UnmarshalSAMLConnectorWithValidationOptions(bytes []byte, validationOpts []
 	case types.V2:
 		var c types.SAMLConnectorV2
 		if err := utils.FastUnmarshal(bytes, &c); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 
 		if err := ValidateSAMLConnector(&c, nil, validationOpts...); err != nil {

--- a/lib/services/saml_idp_service_provider.go
+++ b/lib/services/saml_idp_service_provider.go
@@ -90,7 +90,7 @@ func UnmarshalSAMLIdPServiceProvider(data []byte, opts ...MarshalOption) (types.
 	case types.V1:
 		var s types.SAMLIdPServiceProviderV1
 		if err := utils.FastUnmarshal(data, &s); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := s.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/secreports.go
+++ b/lib/services/secreports.go
@@ -121,7 +121,7 @@ func UnmarshalAuditQuery(data []byte, opts ...MarshalOption) (*secreports.AuditQ
 	}
 	var out *secreports.AuditQuery
 	if err := utils.FastUnmarshal(data, &out); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -161,7 +161,7 @@ func UnmarshalSecurityReport(data []byte, opts ...MarshalOption) (*secreports.Re
 	}
 	var out *secreports.Report
 	if err := utils.FastUnmarshal(data, &out); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -199,7 +199,7 @@ func UnmarshalSecurityReportState(data []byte, opts ...MarshalOption) (*secrepor
 	}
 	var out *secreports.ReportState
 	if err := utils.FastUnmarshal(data, &out); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -237,7 +237,7 @@ func UnmarshalSecurityCostLimiter(data []byte, opts ...MarshalOption) (*secrepor
 	}
 	var out *secreports.CostLimiter
 	if err := utils.FastUnmarshal(data, &out); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -338,7 +338,7 @@ func UnmarshalSemaphore(bytes []byte, opts ...MarshalOption) (types.Semaphore, e
 	}
 
 	if err := utils.FastUnmarshal(bytes, &semaphore); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	err = semaphore.CheckAndSetDefaults()

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -362,7 +362,7 @@ func UnmarshalServer(bytes []byte, kind string, opts ...MarshalOption) (types.Se
 
 	var s types.ServerV2
 	if err := utils.FastUnmarshal(bytes, &s); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	s.Kind = kind
 	if err := s.CheckAndSetDefaults(); err != nil {

--- a/lib/services/server_info.go
+++ b/lib/services/server_info.go
@@ -39,7 +39,7 @@ func UnmarshalServerInfo(bytes []byte, opts ...MarshalOption) (types.ServerInfo,
 
 	var si types.ServerInfoV1
 	if err := utils.FastUnmarshal(bytes, &si); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := si.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/sessionrecording.go
+++ b/lib/services/sessionrecording.go
@@ -48,7 +48,7 @@ func UnmarshalSessionRecordingConfig(bytes []byte, opts ...MarshalOption) (types
 		return nil, trace.Wrap(err)
 	}
 	if err := utils.FastUnmarshal(bytes, &recConfig); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	err = recConfig.CheckAndSetDefaults()

--- a/lib/services/sessiontracker.go
+++ b/lib/services/sessiontracker.go
@@ -61,7 +61,7 @@ func UnmarshalSessionTracker(bytes []byte) (types.SessionTracker, error) {
 
 	var session types.SessionTrackerV1
 	if err := utils.FastUnmarshal(bytes, &session); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	if err := session.CheckAndSetDefaults(); err != nil {

--- a/lib/services/statictokens.go
+++ b/lib/services/statictokens.go
@@ -39,7 +39,7 @@ func UnmarshalStaticTokens(bytes []byte, opts ...MarshalOption) (types.StaticTok
 	}
 
 	if err := utils.FastUnmarshal(bytes, &staticTokens); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := staticTokens.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -158,7 +158,7 @@ func UnmarshalTrustedCluster(bytes []byte, opts ...MarshalOption) (types.Trusted
 	}
 
 	if err := utils.FastUnmarshal(bytes, &trustedCluster); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	// DELETE IN(7.0)
 	// temporarily allow to read trusted cluster with no role map

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -60,7 +60,7 @@ func UnmarshalReverseTunnel(bytes []byte, opts ...MarshalOption) (types.ReverseT
 	case types.V2:
 		var r types.ReverseTunnelV2
 		if err := utils.FastUnmarshal(bytes, &r); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := ValidateReverseTunnel(&r); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -75,7 +75,7 @@ func UnmarshalTunnelConnection(data []byte, opts ...MarshalOption) (types.Tunnel
 		var r types.TunnelConnectionV2
 
 		if err := utils.FastUnmarshal(data, &r); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 
 		if err := r.CheckAndSetDefaults(); err != nil {

--- a/lib/services/ui_config.go
+++ b/lib/services/ui_config.go
@@ -38,7 +38,7 @@ func UnmarshalUIConfig(data []byte, opts ...MarshalOption) (types.UIConfig, erro
 
 	var uiconfig types.UIConfigV1
 	if err := utils.FastUnmarshal(data, &uiconfig); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := uiconfig.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -100,7 +100,7 @@ func UnmarshalUser(bytes []byte, opts ...MarshalOption) (*types.UserV2, error) {
 	case types.V2:
 		var u types.UserV2
 		if err := utils.FastUnmarshal(bytes, &u); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 
 		if err := ValidateUser(&u); err != nil {

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -79,7 +79,7 @@ func UnmarshalUserLoginState(data []byte, opts ...MarshalOption) (*userloginstat
 	}
 	uls := &userloginstate.UserLoginState{}
 	if err := utils.FastUnmarshal(data, &uls); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := uls.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/usergroup.go
+++ b/lib/services/usergroup.go
@@ -79,7 +79,7 @@ func UnmarshalUserGroup(data []byte, opts ...MarshalOption) (types.UserGroup, er
 	case types.V1:
 		var g types.UserGroupV1
 		if err := utils.FastUnmarshal(data, &g); err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		if err := g.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/usertoken.go
+++ b/lib/services/usertoken.go
@@ -33,7 +33,7 @@ func UnmarshalUserToken(bytes []byte, opts ...MarshalOption) (types.UserToken, e
 
 	var token types.UserTokenV3
 	if err := utils.FastUnmarshal(bytes, &token); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := token.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/usertokensecrets.go
+++ b/lib/services/usertokensecrets.go
@@ -33,7 +33,7 @@ func UnmarshalUserTokenSecrets(bytes []byte, opts ...MarshalOption) (types.UserT
 
 	var secrets types.UserTokenSecretsV3
 	if err := utils.FastUnmarshal(bytes, &secrets); err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	if err := secrets.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -180,7 +180,7 @@ func (s *handler) formatForwardResponseError(rw http.ResponseWriter, r *http.Req
 func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.SessionContext) (*http.Request, error) {
 	forwardedHost, err := utils.GetSingleHeader(r.Header, "X-Forwarded-Host")
 	if err != nil {
-		return nil, trace.AccessDenied(err.Error())
+		return nil, trace.AccessDenied("%s", err)
 	} else if !azure.IsAzureEndpoint(forwardedHost) {
 		return nil, trace.AccessDenied("%q is not an Azure endpoint", forwardedHost)
 	}

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -205,7 +205,7 @@ func (s *handler) formatForwardResponseError(rw http.ResponseWriter, r *http.Req
 func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.SessionContext) (*http.Request, error) {
 	forwardedHost, err := utils.GetSingleHeader(r.Header, "X-Forwarded-Host")
 	if err != nil {
-		return nil, trace.AccessDenied(err.Error())
+		return nil, trace.AccessDenied("%s", err)
 	} else if !gcp.IsGCPEndpoint(forwardedHost) {
 		return nil, trace.AccessDenied("%q is not a GCP endpoint", forwardedHost)
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -258,7 +258,7 @@ func (h *AuthHandlers) CheckPortForward(addr string, ctx *ServerContext) error {
 
 		h.log.Warnf("Port forwarding request denied: %v.", systemErrorMessage)
 
-		return trace.AccessDenied(userErrorMessage)
+		return trace.AccessDenied("%s", userErrorMessage)
 	}
 
 	return nil

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -44,7 +44,7 @@ func TestDecodeChildError(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, DecodeChildError(&buf))
 
-	targetErr := trace.NotFound(user.UnknownUserError("test").Error())
+	targetErr := trace.NotFound("%s", user.UnknownUserError("test"))
 
 	writeChildError(&buf, targetErr)
 

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -139,7 +139,7 @@ func secretKeyFromAWSARN(inputARN string) (string, error) {
 	// elasticache/<region>/<account-id>/user/<user-id>
 	parsed, err := arn.Parse(inputARN)
 	if err != nil {
-		return "", trace.BadParameter(err.Error())
+		return "", trace.BadParameter("%s", err)
 	}
 	return secrets.Key(
 		parsed.Service,

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -86,9 +86,9 @@ func ConvertError(err error) error {
 func convertGCPError(err *googleapi.Error) error {
 	switch err.Code {
 	case http.StatusForbidden:
-		return trace.AccessDenied(err.Error())
+		return trace.AccessDenied("%s", err)
 	case http.StatusConflict:
-		return trace.CompareFailed(err.Error())
+		return trace.CompareFailed("%s", err)
 	}
 	return err // Return unmodified.
 }
@@ -97,7 +97,7 @@ func convertGCPError(err *googleapi.Error) error {
 func convertPostgresError(err *pgconn.PgError) error {
 	switch err.Code {
 	case pgerrcode.InvalidAuthorizationSpecification, pgerrcode.InvalidPassword:
-		return trace.AccessDenied(err.Error())
+		return trace.AccessDenied("%s", err)
 	}
 	return err // Return unmodified.
 }
@@ -106,7 +106,7 @@ func convertPostgresError(err *pgconn.PgError) error {
 func convertMySQLError(err *mysql.MyError) error {
 	switch err.Code {
 	case mysql.ER_ACCESS_DENIED_ERROR, mysql.ER_DBACCESS_DENIED_ERROR:
-		return trace.AccessDenied(fmtEscape(err))
+		return trace.AccessDenied("%s", fmtEscape(err))
 	}
 	return err // Return unmodified.
 }

--- a/lib/srv/db/mysql/protocol/version.go
+++ b/lib/srv/db/mysql/protocol/version.go
@@ -96,7 +96,7 @@ func readHandshakeError(connBuf io.Reader) (string, error) {
 	if !ok {
 		return "", trace.BadParameter("expected MySQL error package, got %T", handshakePacket)
 	}
-	return "", trace.ConnectionProblem(errors.New("failed to fetch MySQL version"), errPackage.Error())
+	return "", trace.ConnectionProblem(errors.New("failed to fetch MySQL version"), "%s", errPackage.Error())
 }
 
 // connReader is a net.Conn wrapper with additional Peek() method.

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -480,7 +480,7 @@ func (e *Engine) processServerResponse(cmd *redis.Cmd, err error, sessionCtx *co
 
 	switch {
 	case e.isIAMAuthError(err):
-		return common.ConvertConnectError(trace.AccessDenied(err.Error()), sessionCtx), nil
+		return common.ConvertConnectError(trace.AccessDenied("%s", err), sessionCtx), nil
 	case isRedisError(err):
 		// Redis errors should be returned to the client.
 		return err, nil

--- a/lib/srv/db/secrets/aws_secrets_manager.go
+++ b/lib/srv/db/secrets/aws_secrets_manager.go
@@ -313,9 +313,9 @@ func convertSecretsManagerError(err error) error {
 	// Match by exception code as many errors are sharing the same status code.
 	switch awsError.Code() {
 	case secretsmanager.ErrCodeResourceExistsException:
-		return trace.AlreadyExists(awsError.Error())
+		return trace.AlreadyExists("%s", awsError)
 	case secretsmanager.ErrCodeResourceNotFoundException:
-		return trace.NotFound(awsError.Error())
+		return trace.NotFound("%s", awsError)
 	}
 
 	// Match by status code.

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -448,7 +448,7 @@ func (w *Monitor) disconnectClient(reason string) {
 	w.Entry.Debugf("Disconnecting client: %v", reason)
 
 	if connWithCauseCloser, ok := w.Conn.(withCauseCloser); ok {
-		if err := connWithCauseCloser.CloseWithCause(trace.AccessDenied(reason)); err != nil {
+		if err := connWithCauseCloser.CloseWithCause(trace.AccessDenied("%s", reason)); err != nil {
 			w.Entry.WithError(err).Error("Failed to close connection.")
 		}
 	} else {

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -751,7 +751,7 @@ func runForward(handler forwardHandler) (errw io.Writer, code int, err error) {
 	}
 
 	if _, err := user.Lookup(c.Login); err != nil {
-		return errorWriter, teleport.RemoteCommandFailure, trace.NotFound(err.Error())
+		return errorWriter, teleport.RemoteCommandFailure, trace.NotFound("%s", err)
 	}
 
 	// build forwarder from first extra file that was passed to command

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -80,7 +80,7 @@ func parseProxySubsysRequest(request string) (proxySubsysRequest, error) {
 	const prefix = "proxy:"
 	// get rid of 'proxy:' prefix:
 	if strings.Index(request, prefix) != 0 {
-		return proxySubsysRequest{}, trace.BadParameter(paramMessage)
+		return proxySubsysRequest{}, trace.BadParameter("%s", paramMessage)
 	}
 	requestBody := strings.TrimPrefix(request, prefix)
 	namespace := apidefaults.Namespace
@@ -89,17 +89,17 @@ func parseProxySubsysRequest(request string) (proxySubsysRequest, error) {
 	var err error
 	switch {
 	case len(parts) == 0: // "proxy:"
-		return proxySubsysRequest{}, trace.BadParameter(paramMessage)
+		return proxySubsysRequest{}, trace.BadParameter("%s", paramMessage)
 	case len(parts) == 1: // "proxy:host:22"
 		targetHost, targetPort, err = utils.SplitHostPort(parts[0])
 		if err != nil {
-			return proxySubsysRequest{}, trace.BadParameter(paramMessage)
+			return proxySubsysRequest{}, trace.BadParameter("%s", paramMessage)
 		}
 	case len(parts) == 2: // "proxy:@clustername" or "proxy:host:22@clustername"
 		if parts[0] != "" {
 			targetHost, targetPort, err = utils.SplitHostPort(parts[0])
 			if err != nil {
-				return proxySubsysRequest{}, trace.BadParameter(paramMessage)
+				return proxySubsysRequest{}, trace.BadParameter("%s", paramMessage)
 			}
 		}
 		clusterName = parts[1]
@@ -111,7 +111,7 @@ func parseProxySubsysRequest(request string) (proxySubsysRequest, error) {
 		namespace = parts[1]
 		targetHost, targetPort, err = utils.SplitHostPort(parts[0])
 		if err != nil {
-			return proxySubsysRequest{}, trace.BadParameter(paramMessage)
+			return proxySubsysRequest{}, trace.BadParameter("%s", paramMessage)
 		}
 	}
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1664,7 +1664,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 
 	dialFunc, err := s.getDirectTCPIPForwardDialer(scx)
 	if err != nil {
-		if errors.Is(err, trace.NotFound(user.UnknownUserError(scx.Identity.Login).Error())) || errors.Is(err, trace.BadParameter("unknown user")) {
+		if errors.Is(err, trace.NotFound("%s", user.UnknownUserError(scx.Identity.Login))) || errors.Is(err, trace.BadParameter("unknown user")) {
 			// user does not exist for the provided login. Terminate the connection.
 			s.Logger.Warnf("Forwarding data via direct-tcpip channel failed. Terminating connection because user %q does not exist", scx.Identity.Login)
 			if err := ccx.ServerConn.Close(); err != nil {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -1643,12 +1643,12 @@ func (f *fakeHostUsersBackend) UpsertUser(name string, hostRoleInfo services.Hos
 
 func (f *fakeHostUsersBackend) UserExists(name string) error {
 	if f.users == nil {
-		return trace.NotFound(name)
+		return trace.NotFound("%s", name)
 	}
 
 	_, exists := f.users[name]
 	if !exists {
-		return trace.NotFound(name)
+		return trace.NotFound("%s", name)
 	}
 
 	return nil

--- a/lib/srv/statichostusers.go
+++ b/lib/srv/statichostusers.go
@@ -245,7 +245,7 @@ func (s *StaticHostUserHandler) handleNewHostUser(ctx context.Context, hostUser 
 				slog.Group("first_match", "labels", createUser.NodeLabels, "expression", createUser.NodeLabelsExpression),
 				slog.Group("second_match", "labels", matcher.NodeLabels, "expression", matcher.NodeLabelsExpression),
 			)
-			return trace.BadParameter(msg)
+			return trace.BadParameter("%s", msg)
 		}
 		createUser = matcher
 	}

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -109,7 +109,7 @@ type fakeDialer struct {
 func (f fakeDialer) DialSite(ctx context.Context, clusterName string, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
 	conn, ok := f.siteConns[clusterName]
 	if !ok {
-		return nil, trace.NotFound(clusterName)
+		return nil, trace.NotFound("%s", clusterName)
 	}
 
 	return conn, nil
@@ -119,7 +119,7 @@ func (f fakeDialer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr n
 	key := fmt.Sprintf("%s.%s.%s", host, port, cluster)
 	conn, ok := f.hostConns[key]
 	if !ok {
-		return nil, trace.NotFound(key)
+		return nil, trace.NotFound("%s", key)
 	}
 
 	return conn, nil

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -477,7 +477,7 @@ func chooseOneResource[T types.ResourceWithLabels](resources []T, name, resDesc 
 	default:
 		var out T
 		errMsg := formatAmbiguousMessage(name, resDesc, matches)
-		return out, trace.BadParameter(errMsg)
+		return out, trace.BadParameter("%s", errMsg)
 	}
 }
 

--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -135,7 +135,7 @@ func ParseCertificateRequestPEM(bytes []byte) (*x509.CertificateRequest, error) 
 	}
 	csr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	return csr, nil
 }
@@ -167,7 +167,7 @@ func ParseCertificatePEM(bytes []byte) (*x509.Certificate, error) {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 	return cert, nil
 }
@@ -187,7 +187,7 @@ func ParseCertificatePEMs(bytes []byte) ([]*x509.Certificate, error) {
 	for _, block := range blocks {
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return nil, trace.BadParameter(err.Error())
+			return nil, trace.BadParameter("%s", err)
 		}
 		certs = append(certs, cert)
 	}

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -162,7 +162,7 @@ func IsSignedByAWSSigV4(r *http.Request) bool {
 func VerifyAWSSignature(req *http.Request, credentials *credentials.Credentials) error {
 	sigV4, err := ParseSigV4(req.Header.Get("Authorization"))
 	if err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 
 	// Verifies the request is signed by the expected access key ID.
@@ -201,7 +201,7 @@ func VerifyAWSSignature(req *http.Request, credentials *credentials.Credentials)
 	// originated from AWS CLI and reuse it as a timestamp during request signing call.
 	t, err := time.Parse(AmzDateTimeFormat, reqCopy.Header.Get(AmzDateHeader))
 	if err != nil {
-		return trace.BadParameter(err.Error())
+		return trace.BadParameter("%s", err)
 	}
 
 	signer := NewSigner(credentials, sigV4.Service)

--- a/lib/utils/aws/s3.go
+++ b/lib/utils/aws/s3.go
@@ -35,7 +35,7 @@ import (
 
 // ConvertS3Error wraps S3 error and returns trace equivalent
 // It works on both sdk v1 and v2.
-func ConvertS3Error(err error, args ...interface{}) error {
+func ConvertS3Error(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -43,45 +43,45 @@ func ConvertS3Error(err error, args ...interface{}) error {
 	// SDK v1 errors:
 	var rerr awserr.RequestFailure
 	if errors.As(err, &rerr) && rerr.StatusCode() == http.StatusForbidden {
-		return trace.AccessDenied(rerr.Message())
+		return trace.AccessDenied("%s", rerr.Message())
 	}
 
 	var aerr awserr.Error
 	if errors.As(err, &aerr) {
 		switch aerr.Code() {
 		case s3.ErrCodeNoSuchKey, s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchUpload, "NotFound":
-			return trace.NotFound(aerr.Error(), args...)
+			return trace.NotFound("%s", aerr)
 		case s3.ErrCodeBucketAlreadyExists, s3.ErrCodeBucketAlreadyOwnedByYou:
-			return trace.AlreadyExists(aerr.Error(), args...)
+			return trace.AlreadyExists("%s", aerr)
 		default:
-			return trace.BadParameter(aerr.Error(), args...)
+			return trace.BadParameter("%s", aerr)
 		}
 	}
 
 	// SDK v2 errors:
 	var noSuchKey *s3types.NoSuchKey
 	if errors.As(err, &noSuchKey) {
-		return trace.NotFound(noSuchKey.Error(), args...)
+		return trace.NotFound("%s", noSuchKey)
 	}
 	var noSuchBucket *s3types.NoSuchBucket
 	if errors.As(err, &noSuchBucket) {
-		return trace.NotFound(noSuchBucket.Error(), args...)
+		return trace.NotFound("%s", noSuchBucket)
 	}
 	var noSuchUpload *s3types.NoSuchUpload
 	if errors.As(err, &noSuchUpload) {
-		return trace.NotFound(noSuchUpload.Error(), args...)
+		return trace.NotFound("%s", noSuchUpload)
 	}
 	var bucketAlreadyExists *s3types.BucketAlreadyExists
 	if errors.As(err, &bucketAlreadyExists) {
-		return trace.AlreadyExists(bucketAlreadyExists.Error(), args...)
+		return trace.AlreadyExists("%s", bucketAlreadyExists)
 	}
 	var bucketAlreadyOwned *s3types.BucketAlreadyOwnedByYou
 	if errors.As(err, &bucketAlreadyOwned) {
-		return trace.AlreadyExists(bucketAlreadyOwned.Error(), args...)
+		return trace.AlreadyExists("%s", bucketAlreadyOwned)
 	}
 	var notFound *s3types.NotFound
 	if errors.As(err, &notFound) {
-		return trace.NotFound(notFound.Error(), args...)
+		return trace.NotFound("%s", notFound)
 	}
 
 	return err

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -65,7 +65,7 @@ func GroupAdd(groupname string, gid string) (exitCode int, err error) {
 		if strings.Contains(string(output), "not a valid group name") {
 			errMsg = "invalid group name"
 		}
-		return code, trace.BadParameter(errMsg)
+		return code, trace.BadParameter("%s", errMsg)
 	default:
 		return code, trace.Wrap(err)
 	}

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -88,7 +88,7 @@ func replaceRegexCached(expression string, config RegexpConfig) (*regexp.Regexp,
 	}
 	expr, err := regexp.Compile(expression)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	regexpCache.Add(key, expr)
@@ -399,7 +399,7 @@ func mustCache[K comparable, V any](size int) *lru.Cache[K, V] {
 func MatchString(input, expression string) (bool, error) {
 	expr, err := compileRegexCached(expression)
 	if err != nil {
-		return false, trace.BadParameter(err.Error())
+		return false, trace.BadParameter("%s", err)
 	}
 
 	// Since the expression is always surrounded by ^ and $ this is an exact
@@ -420,7 +420,7 @@ func CompileExpression(expression string) (*regexp.Regexp, error) {
 
 	expr, err := regexp.Compile(expression)
 	if err != nil {
-		return nil, trace.BadParameter(err.Error())
+		return nil, trace.BadParameter("%s", err)
 	}
 
 	return expr, nil

--- a/lib/utils/spki.go
+++ b/lib/utils/spki.go
@@ -58,7 +58,7 @@ outer:
 				continue outer
 			}
 		}
-		return trace.BadParameter(errorMessage)
+		return trace.BadParameter("%s", errorMessage)
 	}
 
 	return nil

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2034,18 +2034,18 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
 		logger.WithError(err).Error("Error reading json.")
-		return nil, trace.AccessDenied(SSOLoginFailureMessage)
+		return nil, trace.AccessDenied("%s", SSOLoginFailureMessage)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		logger.WithError(err).Error("Missing request parameters.")
-		return nil, trace.AccessDenied(SSOLoginFailureMessage)
+		return nil, trace.AccessDenied("%s", SSOLoginFailureMessage)
 	}
 
 	remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		logger.WithError(err).Error("Failed to parse request remote address.")
-		return nil, trace.AccessDenied(SSOLoginFailureMessage)
+		return nil, trace.AccessDenied("%s", SSOLoginFailureMessage)
 	}
 
 	response, err := h.cfg.ProxyClient.CreateGithubAuthRequest(r.Context(), types.GithubAuthRequest{
@@ -2062,9 +2062,9 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 	if err != nil {
 		logger.WithError(err).Error("Failed to create GitHub auth request.")
 		if strings.Contains(err.Error(), auth.InvalidClientRedirectErrorMessage) {
-			return nil, trace.AccessDenied(SSOLoginFailureInvalidRedirect)
+			return nil, trace.AccessDenied("%s", SSOLoginFailureInvalidRedirect)
 		}
-		return nil, trace.AccessDenied(SSOLoginFailureMessage)
+		return nil, trace.AccessDenied("%s", SSOLoginFailureMessage)
 	}
 
 	return &client.SSOLoginConsoleResponse{
@@ -4883,7 +4883,7 @@ func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
 	// MaxRateError doesn't play well with errors.Is, hence the type assertion.
 	var maxRateError *ratelimit.MaxRateError
 	if errors.As(err, &maxRateError) {
-		return trace.LimitExceeded(err.Error())
+		return trace.LimitExceeded("%s", err)
 	}
 	return trace.Wrap(err)
 }
@@ -4892,7 +4892,7 @@ func (h *Handler) validateCookie(w http.ResponseWriter, r *http.Request) (*Sessi
 	const missingCookieMsg = "missing session cookie"
 	cookie, err := r.Cookie(websession.CookieName)
 	if err != nil || (cookie != nil && cookie.Value == "") {
-		return nil, trace.AccessDenied(missingCookieMsg)
+		return nil, trace.AccessDenied("%s", missingCookieMsg)
 	}
 	decodedCookie, err := websession.DecodeCookie(cookie.Value)
 	if err != nil {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -10055,7 +10055,7 @@ func (pc *proxyClientMock) GetToken(_ context.Context, token string) (types.Prov
 		return tok, nil
 	}
 
-	return nil, trace.NotFound(token)
+	return nil, trace.NotFound("%s", token)
 }
 
 func (pc *proxyClientMock) DeleteToken(_ context.Context, token string) error {
@@ -10064,7 +10064,7 @@ func (pc *proxyClientMock) DeleteToken(_ context.Context, token string) error {
 		delete(pc.tokens, token)
 		return nil
 	}
-	return trace.NotFound(token)
+	return trace.NotFound("%s", token)
 }
 
 func Test_consumeTokenForAPICall(t *testing.T) {

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -898,7 +898,7 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, 
 
 		if errors.Is(err, teleport.ErrNodeIsAmbiguous) {
 			const message = "error: ambiguous host could match multiple nodes\n\nHint: try addressing the node by unique id (ex: user@node-id)\n"
-			return nil, trace.NotFound(message)
+			return nil, trace.NotFound("%s", message)
 		}
 
 		return nil, trace.Wrap(err)

--- a/tool/tctl/common/plugin/okta.go
+++ b/tool/tctl/common/plugin/okta.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -154,12 +153,9 @@ func (s *oktaArgs) validateAndCheckDefaults(ctx context.Context, args *installPl
 		}
 	}
 	if s.scimToken != "" && s.appID == "" && s.userSync {
-		msg := []string{
-			"SCIM support requires App ID, which was not supplied and couldn't be deduced from the SAML connector",
-			"Specify the App ID explicitly with --app-id",
-			"SCIM support requires app-id to be set",
-		}
-		return trace.BadParameter(strings.Join(msg, "\n"))
+		return trace.BadParameter("SCIM support requires App ID, which was not supplied and couldn't be deduced from the SAML connector\n" +
+			"Specify the App ID explicitly with --app-id\n" +
+			"SCIM support requires app-id to be set\n")
 	}
 	return nil
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -497,7 +497,7 @@ func (rc *ResourceCommand) createRole(ctx context.Context, client *authclient.Cl
 	}
 	err = services.CheckDynamicLabelsInDenyRules(role)
 	if trace.IsBadParameter(err) {
-		return trace.BadParameter(dynamicLabelWarningMessage(role))
+		return trace.BadParameter("%s", dynamicLabelWarningMessage(role))
 	} else if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2017,7 +2017,7 @@ func resetAuthPreference(ctx context.Context, client *authclient.Client) error {
 
 	managedByStaticConfig := storedAuthPref.Origin() == types.OriginConfigFile
 	if managedByStaticConfig {
-		return trace.BadParameter(managedByStaticDeleteMsg)
+		return trace.BadParameter("%s", managedByStaticDeleteMsg)
 	}
 
 	return trace.Wrap(client.ResetAuthPreference(ctx))
@@ -2031,7 +2031,7 @@ func resetClusterNetworkingConfig(ctx context.Context, client *authclient.Client
 
 	managedByStaticConfig := storedNetConfig.Origin() == types.OriginConfigFile
 	if managedByStaticConfig {
-		return trace.BadParameter(managedByStaticDeleteMsg)
+		return trace.BadParameter("%s", managedByStaticDeleteMsg)
 	}
 
 	return trace.Wrap(client.ResetClusterNetworkingConfig(ctx))
@@ -2045,7 +2045,7 @@ func resetSessionRecordingConfig(ctx context.Context, client *authclient.Client)
 
 	managedByStaticConfig := storedRecConfig.Origin() == types.OriginConfigFile
 	if managedByStaticConfig {
-		return trace.BadParameter(managedByStaticDeleteMsg)
+		return trace.BadParameter("%s", managedByStaticDeleteMsg)
 	}
 
 	return trace.Wrap(client.ResetSessionRecordingConfig(ctx))
@@ -3483,7 +3483,7 @@ func getOneResourceNameToDelete[T types.ResourceWithLabels](rs []T, ref services
 			names = append(names, r.GetName())
 		}
 		msg := formatAmbiguousDeleteMessage(ref, resDesc, names)
-		return "", trace.BadParameter(msg)
+		return "", trace.BadParameter("%s", msg)
 	}
 }
 

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -452,11 +452,11 @@ func onDatabaseEnv(cf *CLIConf) error {
 	}
 
 	if !dbprofile.IsSupported(*database) {
-		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, *database))
+		return trace.BadParameter("%s", formatDbCmdUnsupportedDBProtocol(cf, *database))
 	}
 	requires := getDBLocalProxyRequirement(tc, *database)
 	if requires.localProxy {
-		return trace.BadParameter(formatDbCmdUnsupported(cf, *database, requires.localProxyReasons...))
+		return trace.BadParameter("%s", formatDbCmdUnsupported(cf, *database, requires.localProxyReasons...))
 	}
 
 	env, err := dbprofile.Env(tc, *database)
@@ -519,7 +519,7 @@ func onDatabaseConfig(cf *CLIConf) error {
 	// does NOT work (e.g. when ALPN local proxy is required).
 	if requires.localProxy {
 		msg := formatDbCmdUnsupported(cf, *database, requires.localProxyReasons...)
-		return trace.BadParameter(msg)
+		return trace.BadParameter("%s", msg)
 	}
 
 	host, port := tc.DatabaseProxyHostPort(*database)
@@ -749,7 +749,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 
 	switch dbInfo.Protocol {
 	case defaults.ProtocolDynamoDB, defaults.ProtocolClickHouseHTTP:
-		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, dbInfo.RouteToDatabase))
+		return trace.BadParameter("%s", formatDbCmdUnsupportedDBProtocol(cf, dbInfo.RouteToDatabase))
 	}
 
 	requires := getDBConnectLocalProxyRequirement(cf.Context, tc, dbInfo.RouteToDatabase, cf.LocalProxyTunnel)
@@ -1072,7 +1072,7 @@ func chooseOneDatabase(cf *CLIConf, databases types.Databases) (types.Database, 
 			formatDatabaseListCommand(cf.SiteName))
 	}
 	errMsg := formatAmbiguousDB(cf, selectors, databases)
-	return nil, trace.BadParameter(errMsg)
+	return nil, trace.BadParameter("%s", errMsg)
 }
 
 // findDatabasesByDiscoveredName returns all databases that have a discovered
@@ -1252,7 +1252,7 @@ func getDefaultDBUser(db types.Database, checker services.AccessChecker) (string
 			errMsg += fmt.Sprintf(" except %v", denied)
 		}
 	}
-	return "", trace.BadParameter(errMsg)
+	return "", trace.BadParameter("%s", errMsg)
 }
 
 // isDatabaseUserRequired returns whether the --db-user flag is required for
@@ -1301,7 +1301,7 @@ func getDefaultDBName(db types.Database, checker services.AccessChecker) (string
 			errMsg += fmt.Sprintf(" except %v", denied)
 		}
 	}
-	return "", trace.BadParameter(errMsg)
+	return "", trace.BadParameter("%s", errMsg)
 }
 
 func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route tlsca.RouteToDatabase, profile *client.ProfileStatus, requires *dbLocalProxyRequirement) (bool, error) {
@@ -1438,7 +1438,7 @@ func pickActiveDatabase(cf *CLIConf, tc *client.TeleportClient, activeRoutes []t
 	selectors := newDatabaseResourceSelectors(cf)
 	if routes := filterRoutesByPrefix(activeRoutes, selectors.name); len(routes) == 0 {
 		// no match is possible.
-		return nil, trace.NotFound(formatDBNotLoggedIn(cf.SiteName, selectors))
+		return nil, trace.NotFound("%s", formatDBNotLoggedIn(cf.SiteName, selectors))
 	}
 
 	db, err := getDatabaseByNameOrDiscoveredName(cf, tc, activeRoutes)
@@ -1448,7 +1448,7 @@ func pickActiveDatabase(cf *CLIConf, tc *client.TeleportClient, activeRoutes []t
 	if route, ok := findActiveDatabase(db.GetName(), activeRoutes); ok {
 		return &route, nil
 	}
-	return nil, trace.NotFound(formatDBNotLoggedIn(cf.SiteName, selectors))
+	return nil, trace.NotFound("%s", formatDBNotLoggedIn(cf.SiteName, selectors))
 }
 
 // maybePickActiveDatabase tries to pick a database automatically when selectors
@@ -1462,12 +1462,12 @@ func maybePickActiveDatabase(cf *CLIConf, activeRoutes []tlsca.RouteToDatabase) 
 		if selectors.name == "" {
 			switch len(activeRoutes) {
 			case 0:
-				return nil, trace.NotFound(formatDBNotLoggedIn(cf.SiteName, selectors))
+				return nil, trace.NotFound("%s", formatDBNotLoggedIn(cf.SiteName, selectors))
 			case 1:
 				log.Debugf("Auto-selecting the only active database %q", activeRoutes[0].ServiceName)
 				return &activeRoutes[0], nil
 			default:
-				return nil, trace.BadParameter(formatChooseActiveDB(activeRoutes))
+				return nil, trace.BadParameter("%s", formatChooseActiveDB(activeRoutes))
 			}
 		}
 		if route, ok := findActiveDatabase(selectors.name, activeRoutes); ok {

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1278,7 +1278,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 			if trace.IsNotFound(err) {
 				// rewrap not found errors as access denied, so we can retry
 				// fetching clusters with an access request.
-				return trace.AccessDenied(err.Error())
+				return trace.AccessDenied("%s", err)
 			}
 			return trace.Wrap(err)
 		}
@@ -1356,10 +1356,10 @@ func checkClusterSelection(cf *CLIConf, clusters types.KubeClusters, name string
 		query:  cf.PredicateExpression,
 	}
 	if len(clusters) == 0 {
-		return trace.NotFound(formatKubeNotFound(cf.SiteName, selectors))
+		return trace.NotFound("%s", formatKubeNotFound(cf.SiteName, selectors))
 	}
 	errMsg := formatAmbiguousKubeCluster(cf, selectors, clusters)
-	return trace.BadParameter(errMsg)
+	return trace.BadParameter("%s", errMsg)
 }
 
 func (c *kubeLoginCommand) getSelectors() resourceSelectors {

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -246,13 +246,13 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 	// In headless mode it's assumed user works on a remote machine where they don't have
 	// tsh credentials and can't login into Teleport Kubernetes clusters.
 	if cf.Headless {
-		return nil, nil, trace.BadParameter(errorMsg)
+		return nil, nil, trace.BadParameter("%s", errorMsg)
 	}
 
 	// Use logged-in clusters.
 	clusters := kubeconfig.LocalProxyClustersFromDefaultConfig(defaultConfig, tc.KubeClusterAddr())
 	if len(clusters) == 0 {
-		return nil, nil, trace.BadParameter(errorMsg)
+		return nil, nil, trace.BadParameter("%s", errorMsg)
 	}
 
 	c.printPrepare(cf, "Preparing the following Teleport Kubernetes clusters from the default kubeconfig:", clusters)

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -161,7 +161,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 		// Some scenarios require a local proxy tunnel, e.g.:
 		// - Snowflake, DynamoDB protocol
 		// - Hardware-backed private key policy
-		return trace.BadParameter(formatDbCmdUnsupported(cf, dbInfo.RouteToDatabase, requires.tunnelReasons...))
+		return trace.BadParameter("%s", formatDbCmdUnsupported(cf, dbInfo.RouteToDatabase, requires.tunnelReasons...))
 	}
 	if err := maybeDatabaseLogin(cf, tc, profile, dbInfo, requires); err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2174,7 +2174,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 			if capabilities.RequestPrompt != "" {
 				msg = msg + ", prompt=" + capabilities.RequestPrompt
 			}
-			err := trace.BadParameter(msg)
+			err := trace.BadParameter("%s", msg)
 			logoutErr := tc.Logout()
 			return trace.NewAggregate(err, logoutErr)
 		}
@@ -2761,8 +2761,7 @@ func executeAccessRequest(cf *CLIConf, tc *client.TeleportClient) error {
 			return trace.Wrap(err)
 		}); err != nil {
 			if strings.Contains(err.Error(), services.InvalidKubernetesKindAccessRequest) {
-				friendlyMsg := fmt.Sprintf("%s\nTry searching for specific kinds with:\n> tsh request search --kube-cluster=KUBE_CLUSTER_NAME --kind=KIND", err.Error())
-				return trace.BadParameter(friendlyMsg)
+				return trace.BadParameter("%s\nTry searching for specific kinds with:\n> tsh request search --kube-cluster=KUBE_CLUSTER_NAME --kind=KIND", err.Error())
 			}
 			return trace.Wrap(err)
 		}
@@ -5305,9 +5304,9 @@ func onRequestResolution(cf *CLIConf, tc *client.TeleportClient, req types.Acces
 			msg = fmt.Sprintf("%s, reason=%q", msg, reason)
 		}
 		if req.GetState().IsDenied() {
-			return trace.AccessDenied(msg)
+			return trace.AccessDenied("%s", msg)
 		}
-		return trace.Errorf(msg)
+		return trace.Errorf("%s", msg)
 	}
 
 	msg := "\nApproval received, getting updated certificates...\n\n"

--- a/webassets_noembed.go
+++ b/webassets_noembed.go
@@ -30,5 +30,5 @@ const webAssetsMissingError = "the teleport binary was built without web assets,
 
 // NewWebAssetsFilesystem is a no-op in this build mode.
 func NewWebAssetsFilesystem() (http.FileSystem, error) { //nolint:staticcheck // suppress 'never returns nil' as this is value is platform dependent
-	return nil, trace.NotFound(webAssetsMissingError)
+	return nil, trace.NotFound("%s", webAssetsMissingError)
 }


### PR DESCRIPTION
Now that Go 1.25 has been released, Go 1.23.12 is EOL, and as such has been replaced with the latest Go 1.24 release.


This also includes a backport of https://github.com/gravitational/teleport/pull/51812 and updates e to include https://github.com/gravitational/teleport.e/pull/7053 so that the linter passes in both repositories.

Changelog: Updated Go to 1.24.6.