### PR TITLE
winpki: prevent CRL common names from overflowing

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -296,19 +296,34 @@ func crlContainerDN(domain string, caType types.CertAuthType) string {
 	return fmt.Sprintf("CN=%s,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,%s", crlKeyName(caType), DomainDN(domain))
 }
 
-// CRLDN computes the distinguished name for a Teleport issuer in Windows environments.
-func CRLDN(issuerID string, activeDirectoryDomain string, caType types.CertAuthType) string {
-	return "CN=" + issuerID + "," + crlContainerDN(activeDirectoryDomain, caType)
+// CRNCN computes the common name for a Teleport CRL in Windows environments.
+// The issuer SKID is optional, but should generally be set for compatibility
+// with clusters having more than one issuer (like those using HSMs).
+func CRLCN(issuerCN string, issuerSKID []byte) string {
+	name := issuerCN
+	if len(issuerSKID) > 0 {
+		id := base32.HexEncoding.EncodeToString(issuerSKID)
+		name = id + "_" + name
+	}
+	// The limit on the CN attribute should be 64 characters, but in practice
+	// we observe that certutil.exe truncates the CN as soon as it exceeds 51 characters.
+	return name[:min(len(name), 51)]
+}
+
+// CRLDN computes the distinguished name for a Teleport CRL in Windows environments.
+// The issuer SKID is optional, but should generally be set for compatibility
+// with clusters having more than one issuer (like those using HSMs).
+func CRLDN(issuerCN string, issuerSKID []byte, activeDirectoryDomain string, caType types.CertAuthType) string {
+	return "CN=" + CRLCN(issuerCN, issuerSKID) + "," + crlContainerDN(activeDirectoryDomain, caType)
 }
 
 // CRLDistributionPoint computes the CRL distribution point for certs issued.
 func CRLDistributionPoint(activeDirectoryDomain string, caType types.CertAuthType, issuer *tlsca.CertAuthority, includeSKID bool) string {
-	name := issuer.Cert.Subject.CommonName
+	var issuerSKID []byte
 	if includeSKID {
-		id := base32.HexEncoding.EncodeToString(issuer.Cert.SubjectKeyId)
-		name = id + "_" + name
+		issuerSKID = issuer.Cert.SubjectKeyId
 	}
-	crlDN := CRLDN(name, activeDirectoryDomain, caType)
+	crlDN := CRLDN(issuer.Cert.Subject.CommonName, issuerSKID, activeDirectoryDomain, caType)
 	return fmt.Sprintf("ldap:///%s?certificateRevocationList?base?objectClass=cRLDistributionPoint", crlDN)
 }
 

--- a/lib/winpki/windows_test.go
+++ b/lib/winpki/windows_test.go
@@ -37,6 +37,7 @@ func TestCRLDN(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		clusterName string
+		issuerSKID  []byte
 		crlDN       string
 		caType      types.CertAuthType
 	}{
@@ -62,9 +63,23 @@ func TestCRLDN(t *testing.T) {
 			caType:      types.UserCA,
 			crlDN:       "CN=cluster.goteleport.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
+		{
+			name:        "user CA with SKID",
+			clusterName: "example.com",
+			caType:      types.UserCA,
+			issuerSKID:  []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f, 0xa1, 0xba},
+			crlDN:       "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPV8DQ_example.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+		},
+		{
+			name:        "long CN truncated",
+			clusterName: "reallylongclustername.goteleport.com",
+			caType:      types.UserCA,
+			issuerSKID:  []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f, 0xa1, 0xba},
+			crlDN:       "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPV8DQ_reallylongclustern,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.crlDN, CRLDN(test.clusterName, "test.goteleport.com", test.caType))
+			require.Equal(t, test.crlDN, CRLDN(test.clusterName, test.issuerSKID, "test.goteleport.com", test.caType))
 		})
 	}
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -21,7 +21,6 @@ package common
 import (
 	"context"
 	"crypto/x509"
-	"encoding/base32"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -560,7 +559,7 @@ func (a *AuthCommand) GenerateCRLForCA(ctx context.Context, clusterAPI authComma
 			return trace.Wrap(err)
 		}
 
-		cn := base32.HexEncoding.EncodeToString(cert.SubjectKeyId) + "_" + cert.Subject.CommonName
+		cn := winpki.CRLCN(cert.Subject.CommonName, cert.SubjectKeyId)
 		filename := fmt.Sprintf("%s-%v-%v.crl", a.output, certType, cn)
 		if err := os.WriteFile(filename, out.crl, os.FileMode(0644)); err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
The addition of the issuer SKID to the CN for our CRLS  has caused long clusters to exceed the limit of how long a CN can be.

For database access, we rely on the user to run certutil commands to publish the CRL. While we expect the limit to be 64 characters, we observe that certutil starts truncating the CN as soon as it exceeds 51 characters (which causes it to get imported in a different location from what the certificate references).

Note: no changelog because this will land in the same release as #57822 and one changelog entry is enough to cover both fixes.