### PR TITLE
[v18] don't fallback to loading user roles from backend on empty tls groups

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2920,7 +2920,7 @@ func (a *Server) AugmentWebSessionCertificates(ctx context.Context, opts *Augmen
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(*x509Identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(*x509Identity)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -4610,7 +4610,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req authclient.WebSession
 		return nil, trace.NotFound("web session has expired")
 	}
 
-	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3094,7 +3094,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 	// considering new or dropped access requests. This will include roles from
 	// currently assumed role access requests, and allowed resources from
 	// currently assumed resource access requests.
-	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(currentIdentity, a.authServer)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(currentIdentity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -2758,7 +2758,7 @@ func serverWithAllowRules(t *testing.T, srv *authtest.AuthServer, allowRules []t
 	_, err = srv.AuthServer.UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	localUser := authz.LocalUser{Username: username, Identity: tlsca.Identity{Username: username}}
+	localUser := authz.LocalUser{Username: username, Identity: tlsca.Identity{Username: username, Groups: []string{role.GetName()}}}
 	authContext, err := authz.ContextForLocalUser(ctx, localUser, srv.AuthServer.Services, srv.ClusterName, true /* disableDeviceAuthz */)
 	require.NoError(t, err)
 	authContext.AdminActionAuthState = authz.AdminActionAuthMFAVerified
@@ -3698,7 +3698,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
-	user, _, err := authtest.CreateUserAndRole(srv.AuthServer, "test-user", []string{}, nil)
+	user, role, err := authtest.CreateUserAndRole(srv.AuthServer, "test-user", []string{}, nil)
 	require.NoError(t, err)
 
 	targetCluster := "cluster"
@@ -3709,7 +3709,7 @@ func TestReplaceRemoteLocksRBAC(t *testing.T) {
 	}{
 		{
 			desc:     "users may not replace remote locks",
-			identity: authtest.TestUser(user.GetName()),
+			identity: authtest.TestUserWithRoles(user.GetName(), []string{role.GetName()}),
 			checkErr: trace.IsAccessDenied,
 		},
 		{
@@ -3939,7 +3939,7 @@ func TestKindClusterConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	getClusterConfigResources := func(ctx context.Context, user types.User) []error {
-		authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUser(user.GetName()).I))
+		authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUserWithRoles(user.GetName(), user.GetRoles()).I))
 		require.NoError(t, err, trace.DebugReport(err))
 		s := auth.NewServerWithRoles(
 			srv.AuthServer,
@@ -3953,7 +3953,9 @@ func TestKindClusterConfig(t *testing.T) {
 	}
 
 	t.Run("without KindClusterConfig privilege", func(t *testing.T) {
-		user, err := authtest.CreateUser(ctx, srv.AuthServer, "test-user")
+		role, err := types.NewRole("test-role", types.RoleSpecV6{})
+		require.NoError(t, err)
+		user, err := authtest.CreateUser(ctx, srv.AuthServer, "test-user", role)
 		require.NoError(t, err)
 		for _, err := range getClusterConfigResources(ctx, user) {
 			require.Error(t, err)
@@ -4865,7 +4867,7 @@ func TestListResources_KindUserGroup(t *testing.T) {
 	testUg2 := createUserGroup(t, srv.AuthServer, "a", map[string]string{"label": "value"})
 	testUg3 := createUserGroup(t, srv.AuthServer, "b", map[string]string{"label": "value"})
 
-	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUser(user.GetName()).I))
+	authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, authtest.TestUserWithRoles(user.GetName(), []string{role.GetName()}).I))
 	require.NoError(t, err)
 
 	s := auth.NewServerWithRoles(
@@ -8820,6 +8822,9 @@ func TestGenerateCertAuthorityCRL(t *testing.T) {
 	srv, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
+	_, err = authtest.CreateRole(ctx, srv.AuthServer.Services, "rolename", types.RoleSpecV6{})
+	require.NoError(t, err)
+
 	// Create a test user.
 	_, err = authtest.CreateUser(ctx, srv.AuthServer.Services, "username")
 	require.NoError(t, err)
@@ -8836,7 +8841,7 @@ func TestGenerateCertAuthorityCRL(t *testing.T) {
 		},
 		{
 			desc:      "User",
-			identity:  authtest.TestUser("username"),
+			identity:  authtest.TestUserWithRoles("username", []string{"rolename"}),
 			assertErr: require.NoError,
 		},
 		{

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -959,12 +959,22 @@ type TestIdentity struct {
 	Generation     uint64
 }
 
-// TestUser returns TestIdentity for local user
+// TestUser returns TestIdentity for local user. Note that this constructor only produces a
+// test identity suitable for use with the `NewClient` methods defined in this file, as those helpers
+// auto-populate roles.  Prefer using TestUserWithRoles for most usecases.
 func TestUser(username string) TestIdentity {
+	return TestUserWithRoles(username, nil)
+}
+
+// TestUserWithRoles returns a local user TestIdentity with the specified username and roles.
+func TestUserWithRoles(username string, roles []string) TestIdentity {
 	return TestIdentity{
 		I: authz.LocalUser{
 			Username: username,
-			Identity: tlsca.Identity{Username: username},
+			Identity: tlsca.Identity{
+				Username: username,
+				Groups:   roles,
+			},
 		},
 	}
 }
@@ -1155,6 +1165,15 @@ func (t *TLSServer) NewClientWithCert(clientCert tls.Certificate) (*authclient.C
 
 // NewClient returns new client to test server authenticated with identity
 func (t *TLSServer) NewClient(identity TestIdentity) (*authclient.Client, error) {
+	if localUser, ok := identity.I.(authz.LocalUser); ok && len(localUser.Identity.Groups) == 0 {
+		user, err := t.AuthServer.AuthServer.GetUser(context.TODO(), localUser.Username, false)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		localUser.Identity.Groups = user.GetRoles()
+		identity.I = localUser
+	}
 	tlsConfig, err := t.ClientTLSConfig(identity)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1340,7 +1340,7 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(u.Identity, accessPoint)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(u.Identity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -575,7 +575,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new bot user.
-	bot, err := types.NewUser("robot")
+	bot, _, err := authtest.CreateUserAndRole(client, "robot", []string{"robot-role"}, nil)
 	require.NoError(t, err)
 	botMetadata := bot.GetMetadata()
 	botMetadata.Labels = map[string]string{
@@ -583,7 +583,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 		types.BotGenerationLabel: "0",
 	}
 	bot.SetMetadata(botMetadata)
-	_, err = client.CreateUser(ctx, bot)
+	_, err = client.UpsertUser(ctx, bot)
 	require.NoError(t, err)
 
 	validTOTPCode := "valid"
@@ -645,6 +645,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
+					Groups:   localUser.GetRoles(),
 				},
 			},
 			wantAdminActionAuthorized: false,
@@ -654,6 +655,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:    localUser.GetName(),
+					Groups:      localUser.GetRoles(),
 					MFAVerified: "mfa-verified-test",
 				},
 			},
@@ -664,6 +666,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:         localUser.GetName(),
+					Groups:           localUser.GetRoles(),
 					PrivateKeyPolicy: keys.PrivateKeyPolicyHardwareKeyTouch,
 				},
 			},
@@ -675,6 +678,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: userWithHostName.GetName(),
 				Identity: tlsca.Identity{
 					Username: userWithHostName.GetName(),
+					Groups:   userWithHostName.GetRoles(),
 				},
 			},
 			wantAdminActionAuthorized: false,
@@ -684,6 +688,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
+					Groups:   localUser.GetRoles(),
 				},
 			},
 			withMFA:                   invalidMFA,
@@ -695,6 +700,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
+					Groups:   localUser.GetRoles(),
 				},
 			},
 			withMFA:                   validMFAWithReuse,
@@ -705,6 +711,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
+					Groups:   localUser.GetRoles(),
 				},
 			},
 			withMFA:                   validMFA,
@@ -715,6 +722,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username: localUser.GetName(),
+					Groups:   localUser.GetRoles(),
 				},
 			},
 			withMFA:                   validMFAWithReuse,
@@ -733,6 +741,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: bot.GetName(),
 				Identity: tlsca.Identity{
 					Username: bot.GetName(),
+					Groups:   bot.GetRoles(),
 				},
 			},
 			wantAdminActionAuthorized: true,
@@ -742,6 +751,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:     localUser.GetName(),
+					Groups:       localUser.GetRoles(),
 					Impersonator: hostFQDN(uuid.NewString(), clusterName),
 				},
 			},
@@ -752,6 +762,7 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 				Username: localUser.GetName(),
 				Identity: tlsca.Identity{
 					Username:     localUser.GetName(),
+					Groups:       localUser.GetRoles(),
 					Impersonator: bot.GetName(),
 				},
 			},

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1360,35 +1360,15 @@ func AccessInfoFromRemoteSSHIdentity(unmappedIdentity *sshca.Identity, roleMap t
 // AccessInfoFromLocalTLSIdentity returns a new AccessInfo populated from the given
 // tlsca.Identity. Should only be used for cluster local users as roles will not
 // be mapped.
-func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity, access UserGetter) (*AccessInfo, error) {
-	roles := identity.Groups
-	traits := identity.Traits
-
-	// Legacy certs are not encoded with roles or traits,
-	// so we fallback to the traits and roles in the backend.
-	// empty traits are a valid use case in standard certs,
-	// so we only check for whether roles are empty.
+func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity) (*AccessInfo, error) {
 	if len(identity.Groups) == 0 {
-		if access == nil {
-			return nil, trace.BadParameter("UserGetter not provided")
-		}
-		u, err := access.GetUser(context.TODO(), identity.Username, false)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		const msg = "Failed to find roles in x509 identity. Fetching " +
-			"from backend. If the identity provider allows username changes, this can " +
-			"potentially allow an attacker to change the role of the existing user."
-		slog.WarnContext(context.Background(), msg, "username", identity.Username)
-		roles = u.GetRoles()
-		traits = u.GetTraits()
+		return nil, trace.BadParameter("tls identity %q does not encode any roles, this may indicate a malformed certificate or one that was issued by an incompatible teleport version", identity.Username)
 	}
 
 	return &AccessInfo{
 		Username:           identity.Username,
-		Roles:              roles,
-		Traits:             traits,
+		Roles:              identity.Groups,
+		Traits:             identity.Traits,
 		AllowedResourceIDs: identity.AllowedResourceIDs,
 	}, nil
 }

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -198,7 +198,7 @@ func makeTestAuthContext(t *testing.T, roleSet services.RoleSet) *authz.Context 
 			Principals: user.GetLogins(),
 		},
 	}
-	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity.Identity, nil)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity.Identity)
 	require.NoError(t, err)
 	checker := services.NewAccessCheckerWithRoleSet(accessInfo, "my-cluster", roleSet)
 	return &authz.Context{


### PR DESCRIPTION
Backport #57575 to branch/v18