### PR TITLE
Fix potential panic with `eiceSigner` in proxy recording mode.

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -371,6 +371,7 @@ func New(c ServerConfig) (*Server, error) {
 		targetAddr:      c.TargetAddr,
 		targetHostname:  c.TargetHostname,
 		targetServer:    c.TargetServer,
+		eiceSigner:      c.EICESigner,
 	}
 
 	// Set the ciphers, KEX, and MACs that the in-memory server will send to the


### PR DESCRIPTION
`eiceSigner` is never set and can result in a panic [here](https://github.com/gravitational/teleport/blob/93c911fec14cfb6d878d92f7c63bc9696adcb3d1/lib/srv/forward/sshserver.go#L659) when connecting to an agentless node in EICE mode when using proxy recording mode. This was introduced in https://github.com/gravitational/teleport/pull/55574, and given the combination of niche features, was unlikely to be reported. It also has not landed in a release.