### PR TITLE
Remove deprecated testenv helpers 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -268,7 +268,6 @@ linters:
             - '!**/integrations/lib/testing/integration/authhelper.go'
             - '!**/integrations/lib/testing/integration/suite.go'
             - '!**/integrations/operator/controllers/resources/testlib/**'
-            - '!**/tool/teleport/testenv/**'
           deny:
             - pkg: github.com/stretchr/testify
               desc: testify should not be imported outside of test code
@@ -307,7 +306,6 @@ linters:
             - '!**/lib/utils/cli.go'
             - '!**/lib/utils/mcptest/**'
             - '!**/lib/utils/testutils/**'
-            - '!**/tool/teleport/testenv/**'
           deny:
             - pkg: testing
               desc: testing should not be imported outside of tests

--- a/integrations/terraform-mwi/provider/kubernetes_test.go
+++ b/integrations/terraform-mwi/provider/kubernetes_test.go
@@ -93,34 +93,36 @@ func setupKubernetesHarness(
 	kubeMock := startKubeAPIMock(t)
 	kubeConfigPath := mustCreateKubeConfigFile(t, k8ClientConfig(kubeMock.URL))
 
-	return testenv.MakeTestServer(
-		t,
-		func(o *testenv.TestServersOpts) error {
-			testenv.WithClusterName(teleClusterName)(o)
-			testenv.WithConfig(func(cfg *servicecfg.Config) {
-				cfg.Logger = log
-				cfg.Proxy.PublicAddrs = []utils.NetAddr{
-					{
-						AddrNetwork: "tcp",
-						Addr: net.JoinHostPort(
-							"localhost",
-							strconv.Itoa(cfg.Proxy.WebAddr.Port(0)),
-						),
-					},
-				}
-				cfg.Proxy.TunnelPublicAddrs = []utils.NetAddr{
-					cfg.Proxy.ReverseTunnelListenAddr,
-				}
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		testenv.WithClusterName(teleClusterName),
+		testenv.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Logger = log
+			cfg.Proxy.PublicAddrs = []utils.NetAddr{
+				{
+					AddrNetwork: "tcp",
+					Addr: net.JoinHostPort(
+						"localhost",
+						strconv.Itoa(cfg.Proxy.WebAddr.Port(0)),
+					),
+				},
+			}
+			cfg.Proxy.TunnelPublicAddrs = []utils.NetAddr{
+				cfg.Proxy.ReverseTunnelListenAddr,
+			}
 
-				cfg.Kube.Enabled = true
-				cfg.Kube.KubeconfigPath = kubeConfigPath
-				cfg.Kube.ListenAddr = utils.MustParseAddr(
-					helpers.NewListener(t, service.ListenerKube, &cfg.FileDescriptors))
-			})(o)
-			return nil
-		},
+			cfg.Kube.Enabled = true
+			cfg.Kube.KubeconfigPath = kubeConfigPath
+			cfg.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &cfg.FileDescriptors))
+		}),
 		testenv.WithProxyKube(),
-	), kubeMock
+	)
+	if err != nil {
+		t.Fatalf("failed to create Teleport process: %v", err)
+	}
+
+	return process, kubeMock
 }
 
 func setupKubernetesAccessBot(

--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -29,12 +29,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -78,21 +76,6 @@ func init() {
 	}
 
 	modules.SetModules(&cliModules{})
-}
-
-// MakeTestServer creates a Teleport Server for testing.
-// Deprecated: Use NewTestServer instead.
-// TODO(tross): Remove this after everything has migrated to NewTeleportProcess
-func MakeTestServer(t *testing.T, opts ...TestServerOptFunc) *service.TeleportProcess {
-	process, err := NewTeleportProcess(t.TempDir(), opts...)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		require.NoError(t, process.Close())
-		require.NoError(t, process.Wait())
-	})
-
-	return process
 }
 
 // NewTeleportProcess creates a Teleport Server for testing.
@@ -550,20 +533,6 @@ func (p *cliModules) EnableAccessGraph() {}
 func (p *cliModules) EnableAccessMonitoring() {}
 
 func (p *cliModules) SetFeatures(f modules.Features) {
-}
-
-// MakeDefaultAuthClient reimplements the bare minimum needed to create a
-// default root-level auth client for a Teleport server started by
-// MakeTestServer.
-// Deprecated: Prefer using NewDefaultAuthClient
-// TODO(tross): Remove once all callers are converted to NewDefaultAuthClient.
-func MakeDefaultAuthClient(t *testing.T, process *service.TeleportProcess) *authclient.Client {
-	t.Helper()
-
-	clt, err := NewDefaultAuthClient(process)
-	require.NoError(t, err)
-
-	return clt
 }
 
 // NewDefaultAuthClient reimplements the bare minimum needed to create a


### PR DESCRIPTION
Now that e has been updated to include https://github.com/gravitational/teleport.e/pull/7024 the deprecated helpers, and all testing dependencies can be removed from the tool/teleport/testenv package.