### PR TITLE
bug(Integrations): fix icon size

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
@@ -72,7 +72,7 @@ export function IntegrationTileWithSpec({
         data-testid="tile-external-audit-storage"
       >
         <Flex flexBasis={100}>
-          <IntegrationIcon name={spec.icon} size={80} />
+          <IntegrationIcon name={spec.icon} />
         </Flex>
         <Flex>
           <Text>{spec.name}</Text>
@@ -152,7 +152,7 @@ export function GenericIntegrationTile({
       data-testid={`tile-${kind}`}
     >
       <Flex flexBasis={100}>
-        <IntegrationIcon name={icon} size={80} />
+        <IntegrationIcon name={icon} />
       </Flex>
       <Flex>
         <Text>{name}</Text>

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
@@ -72,7 +72,7 @@ export function IntegrationTileWithSpec({
         data-testid="tile-external-audit-storage"
       >
         <Flex flexBasis={100}>
-          <IntegrationIcon name={spec.icon} />
+          <IntegrationIcon name={spec.icon} size={80} />
         </Flex>
         <Flex>
           <Text>{spec.name}</Text>
@@ -152,7 +152,7 @@ export function GenericIntegrationTile({
       data-testid={`tile-${kind}`}
     >
       <Flex flexBasis={100}>
-        <IntegrationIcon name={icon} />
+        <IntegrationIcon name={icon} size={80} />
       </Flex>
       <Flex>
         <Text>{name}</Text>

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -72,10 +72,10 @@ export const NoCodeIntegrationDescription = () => (
  * and plugin tiles.
  */
 export const IntegrationIcon = styled(ResourceIcon).withConfig({
-  shouldForwardProp: (prop) => prop !== 'size',
+  shouldForwardProp: prop => prop !== 'size',
 })<{ size?: number }>`
   margin: 0 auto;
-  min-width: 0;
   height: 100%;
+  min-width: 0;
   ${({ size }) => size && `max-width: ${size}px;`}
 `;

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -71,10 +71,9 @@ export const NoCodeIntegrationDescription = () => (
  * IntegrationIcon wraps ResourceIcon with css required for integration
  * and plugin tiles.
  */
-export const IntegrationIcon = styled(ResourceIcon)<{ size?: number }>`
-  display: inline-block;
+export const IntegrationIcon = styled(ResourceIcon)`
   margin: 0 auto;
   height: 100%;
   min-width: 0;
-  ${({ size }) => size && `max-width: ${size}px;`}
+  max-width: 80px;
 `;

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -71,9 +71,11 @@ export const NoCodeIntegrationDescription = () => (
  * IntegrationIcon wraps ResourceIcon with css required for integration
  * and plugin tiles.
  */
-export const IntegrationIcon = styled(ResourceIcon)`
+export const IntegrationIcon = styled(ResourceIcon).withConfig({
+  shouldForwardProp: (prop) => prop !== 'size',
+})<{ size?: number }>`
   margin: 0 auto;
-  height: 100%;
   min-width: 0;
-  max-width: 80px;
+  height: 100%;
+  ${({ size }) => size && `max-width: ${size}px;`}
 `;


### PR DESCRIPTION
### Problem
Icons on the integration page were appearing teeny tiny for some tiles. Possibly a regression from https://github.com/gravitational/teleport/pull/57563 which added a `size` prop to the `ResourceIcon` component. 

### Fix

Updated the icon css to match other tiles ([Bots](https://github.com/gravitational/teleport/commit/dd212c8c8cc51e2334984436e512c4bd1198dd8d#diff-f7610d59a44e59fd47a08584425514667a13a4df39746c4018046902151dd107R52-R57))

**before**
<img  height="400" alt="tiny" src="https://github.com/user-attachments/assets/b05b70b8-6321-436e-a012-69e8a76b7939" />
**after**
<img  height="400" alt="regular" src="https://github.com/user-attachments/assets/7d7ac9a2-5e1a-4bbe-9d33-3ef7ec1d7709" />
