### PR TITLE
Wait for initial health check to get target health

### DIFF
--- a/lib/healthcheck/manager.go
+++ b/lib/healthcheck/manager.go
@@ -156,9 +156,9 @@ func (m *manager) AddTarget(target Target) error {
 		return trace.BadParameter("health check target resource kind %q is not supported", resource.GetKind())
 	}
 
+	key := newResourceKey(resource)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	key := newResourceKey(resource)
 	if _, ok := m.workers[key]; ok {
 		return trace.AlreadyExists("target health checker %q already exists", key)
 	}
@@ -202,9 +202,9 @@ func (m *manager) RemoveTarget(r types.ResourceWithLabels) error {
 // GetTargetHealth returns the health of a given resource.
 func (m *manager) GetTargetHealth(r types.ResourceWithLabels) (*types.TargetHealth, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	key := newResourceKey(r)
 	worker, ok := m.workers[key]
+	m.mu.RUnlock()
 	if !ok {
 		return nil, trace.NotFound("health checker %q not found", key)
 	}

--- a/lib/healthcheck/worker_experimental_test.go
+++ b/lib/healthcheck/worker_experimental_test.go
@@ -1,0 +1,98 @@
+//go:build go1.24 && enablesynctest
+
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package healthcheck
+
+import (
+	"context"
+	"net"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestGetTargetHealth(t *testing.T) {
+	t.Parallel()
+	enabledHCC := healthCheckConfig{
+		interval:           time.Minute,
+		timeout:            time.Minute,
+		healthyThreshold:   10,
+		unhealthyThreshold: 10,
+	}
+	tests := []struct {
+		desc              string
+		healthCheckConfig *healthCheckConfig
+		dialErr           error
+		wantStatus        types.TargetHealthStatus
+		wantReason        types.TargetHealthTransitionReason
+	}{
+		{
+			desc:              "healthy",
+			healthCheckConfig: &enabledHCC,
+			wantStatus:        "healthy",
+			wantReason:        types.TargetHealthTransitionReasonThreshold,
+		},
+		{
+			desc:       "disabled",
+			wantStatus: "unknown",
+			wantReason: types.TargetHealthTransitionReasonDisabled,
+		},
+		{
+			desc:              "unhealthy",
+			healthCheckConfig: &enabledHCC,
+			dialErr:           trace.Errorf("error dialing"),
+			wantStatus:        "unhealthy",
+			wantReason:        types.TargetHealthTransitionReasonThreshold,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			synctest.Run(func() {
+				defer cancel()
+				worker, err := newWorker(ctx, workerConfig{
+					HealthCheckCfg: test.healthCheckConfig,
+					Target: Target{
+						GetResource: func() types.ResourceWithLabels { return nil },
+						ResolverFn: func(ctx context.Context) ([]string, error) {
+							return []string{"localhost:1234"}, nil
+						},
+						dialFn: func(ctx context.Context, network, addr string) (net.Conn, error) {
+							time.Sleep(5*time.Second - time.Nanosecond)
+							synctest.Wait()
+							return fakeConn{}, test.dialErr
+						},
+					},
+				})
+				assert.NoError(t, err)
+				defer worker.Close()
+				health := worker.GetTargetHealth()
+				assert.Equal(t, test.wantStatus, types.TargetHealthStatus(health.Status))
+				assert.Equal(t, test.wantReason, types.TargetHealthTransitionReason(health.TransitionReason))
+			})
+		})
+	}
+}

--- a/lib/healthcheck/worker_test.go
+++ b/lib/healthcheck/worker_test.go
@@ -92,6 +92,7 @@ func Test_newUnstartedWorker(t *testing.T) {
 						return []string{db.GetURI()}, nil
 					},
 				},
+				getTargetHealthTimeout: time.Millisecond,
 			},
 			wantHealth: types.TargetHealth{
 				Address:          "",


### PR DESCRIPTION
This changes the health check system to delay reporting a target's health status until its initial health check has been performed. A delay allows the initial resource heartbeat to report a known healthy or unhealthy status instead of an unknown status due to initialization.