### PR TITLE
Allow OIDC Connector to Omit 'max_age' Parameter From Auth Requests

### DIFF
--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -19,6 +19,7 @@ package types
 import (
 	"net/netip"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -575,8 +576,13 @@ func (o *OIDCConnectorV3) WithMFASettings() error {
 	o.Spec.ClientSecret = o.Spec.MFASettings.ClientSecret
 	o.Spec.ACR = o.Spec.MFASettings.AcrValues
 	o.Spec.Prompt = o.Spec.MFASettings.Prompt
-	o.Spec.MaxAge = &MaxAge{
-		Value: o.Spec.MFASettings.MaxAge,
+	// In rare cases, some providers will complain about the presence of the 'max_age'
+	// parameter in auth requests. Provide users with a workaround to omit it.
+	omitMaxAge := os.Getenv("TELEPORT_OIDC_OMIT_MFA_MAX_AGE") == "true"
+	if !omitMaxAge {
+		o.Spec.MaxAge = &MaxAge{
+			Value: o.Spec.MFASettings.MaxAge,
+		}
 	}
 	return nil
 }

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -579,12 +579,10 @@ func (o *OIDCConnectorV3) WithMFASettings() error {
 	o.Spec.Prompt = o.Spec.MFASettings.Prompt
 	// In rare cases, some providers will complain about the presence of the 'max_age'
 	// parameter in auth requests. Provide users with a workaround to omit it.
-	omitMaxAge, err := strconv.ParseBool(os.Getenv("TELEPORT_OIDC_OMIT_MFA_MAX_AGE"))
-	if err != nil {
-		return trace.Wrap(err, "Invalid value for 'TELEPORT_OIDC_OMIT_MFA_MAX_AGE'")
-	}
-
-	if !omitMaxAge {
+	omitMaxAge, _ := strconv.ParseBool(os.Getenv("TELEPORT_OIDC_OMIT_MFA_MAX_AGE"))
+	if omitMaxAge {
+		o.Spec.MaxAge = nil
+	} else {
 		o.Spec.MaxAge = &MaxAge{
 			Value: o.Spec.MFASettings.MaxAge,
 		}

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -578,7 +579,11 @@ func (o *OIDCConnectorV3) WithMFASettings() error {
 	o.Spec.Prompt = o.Spec.MFASettings.Prompt
 	// In rare cases, some providers will complain about the presence of the 'max_age'
 	// parameter in auth requests. Provide users with a workaround to omit it.
-	omitMaxAge := os.Getenv("TELEPORT_OIDC_OMIT_MFA_MAX_AGE") == "true"
+	omitMaxAge, err := strconv.ParseBool(os.Getenv("TELEPORT_OIDC_OMIT_MFA_MAX_AGE"))
+	if err != nil {
+		return trace.Wrap(err, "Invalid value for 'TELEPORT_OIDC_OMIT_MFA_MAX_AGE'")
+	}
+
 	if !omitMaxAge {
 		o.Spec.MaxAge = &MaxAge{
 			Value: o.Spec.MFASettings.MaxAge,


### PR DESCRIPTION
By default, `max_age` is set to `0` when a connector is configured for MFA. Some users have requested the ability to omit this parameter entirely as their IdP will reject the request when present. 