### PR TITLE
docs: update cloud auth service desc

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -47,8 +47,10 @@ own AWS account where retention period can be managed independently.
 ## High Availability
 
 ### Auth Service
-The Teleport [Auth Service](authentication.mdx) is deployed in 2 AWS availability zones. Single or multi-region zone
-deployments are available as options for fault tolerance. AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime.
+The Teleport [Auth Service](authentication.mdx) is deployed to two AWS availability zones in a single region.
+AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime for single region deployments.
+Teleport also supports multi-region high availability mode, which implements regional failover by deploying
+the Auth Service to more than one region.
 Teleport Enterprise Cloud can run in one of the following AWS regions:
 
 - us-west-2

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -47,7 +47,7 @@ own AWS account where retention period can be managed independently.
 ## High Availability
 
 ### Auth Service
-The Teleport [Auth Service](authentication.mdx) is deployed to two AWS availability zones in a single region.
+The Teleport [Auth Service](architecture.mdx#teleport-auth-service) is deployed to two AWS availability zones in a single region.
 AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime for single region deployments.
 Teleport also supports multi-region high availability mode, which implements regional failover by deploying
 the Auth Service to more than one region.


### PR DESCRIPTION
Incorporates comments on the cloud auth service from #57732 that didn't make it in. Will backport #57732 after this goes in.