### PR TITLE
winpki: don't encode null groups in the certificate

### DIFF
--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1139,7 +1139,10 @@ func (a *accessChecker) DesktopGroups(s types.WindowsDesktop) ([]string, error) 
 		}
 	}
 
-	return groups.Elements(), nil
+	// These groups get encoded into a certificate that's parsed by
+	// Rust code on Windows. That code expects an empty JSON array,
+	// not a null value.
+	return groups.ElementsNotNil(), nil
 }
 
 func convertHostUserMode(mode types.CreateHostUserMode) decisionpb.HostUserMode {


### PR DESCRIPTION
Prefer an empty JSON array instead of null, since some versions of the deserializer on the Windows (Rust) side aren't tolerant of null values.