### PR TITLE
[PoC] Prototype for Kubernetes health checks

### DIFF
--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -58,6 +58,14 @@ type KubeServer interface {
 	SetCluster(KubeCluster) error
 	// ProxiedService provides common methods for a proxied service.
 	ProxiedService
+	// GetTargetHealth gets health details for a target Kubernetes cluster.
+	GetTargetHealth() TargetHealth
+	// SetTargetHealth sets health details for a target Kubernetes cluster.
+	SetTargetHealth(h TargetHealth)
+	// GetTargetHealthStatus gets the health status of a target Kubernetes cluster.
+	GetTargetHealthStatus() TargetHealthStatus
+	// SetTargetHealthStatus sets the health status of a target Kubernetes cluster.
+	SetTargetHealthStatus(status TargetHealthStatus)
 }
 
 // NewKubernetesServerV3 creates a new kube server instance.
@@ -299,6 +307,38 @@ func (s *KubernetesServerV3) CloneResource() ResourceWithLabels {
 // match against the list of search values.
 func (s *KubernetesServerV3) MatchSearch(values []string) bool {
 	return MatchSearch(nil, values, nil)
+}
+
+// GetTargetHealth gets health details for a target Kubernetes cluster.
+func (s *KubernetesServerV3) GetTargetHealth() TargetHealth {
+	if s.Status.TargetHealth == nil {
+		return TargetHealth{}
+	}
+	return *s.Status.TargetHealth
+}
+
+// SetTargetHealth sets health details for a target Kubernetes cluster.
+func (s *KubernetesServerV3) SetTargetHealth(h TargetHealth) {
+	if s.Status == nil {
+		s.Status = &KubernetesServerStatusV3{}
+	}
+	s.Status.TargetHealth = &h
+}
+
+// GetTargetHealthStatus gets the health status of a target Kubernetes cluster.
+func (s *KubernetesServerV3) GetTargetHealthStatus() TargetHealthStatus {
+	if s.Status.TargetHealth == nil {
+		return ""
+	}
+	return TargetHealthStatus(s.Status.TargetHealth.Status)
+}
+
+// SetTargetHealthStatus sets the health status of a target Kubernetes cluster.
+func (s *KubernetesServerV3) SetTargetHealthStatus(status TargetHealthStatus) {
+	if s.Status.TargetHealth == nil {
+		s.Status.TargetHealth = &TargetHealth{}
+	}
+	s.Status.TargetHealth.Status = string(status)
 }
 
 // IsEqual determines if two kube server resources are equivalent to one another.

--- a/api/types/target_health.go
+++ b/api/types/target_health.go
@@ -25,8 +25,10 @@ import (
 type TargetHealthProtocol string
 
 const (
-	// TargetHealthProtocolTCP is a target health check protocol.
-	TargetHealthProtocolTCP TargetHealthProtocol = "TCP"
+	// TargetHealthProtocolTCP is the TCP target health check protocol.
+	TargetHealthProtocolTCP TargetHealthProtocol = "tcp"
+	// TargetHealthProtocolHTTP is the HTTP target health check protocol.
+	TargetHealthProtocolHTTP TargetHealthProtocol = "http"
 )
 
 // TargetHealthStatus is a target resource's health status.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -170,6 +170,10 @@ type ReadProxyAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
 
+	// HealthCheckConfigReader defines methods for fetching health check config
+	// resources.
+	services.HealthCheckConfigReader
+
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
@@ -472,6 +476,10 @@ type RemoteProxyAccessPoint interface {
 type ReadKubernetesAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
+
+	// HealthCheckConfigReader defines methods for fetching health check config
+	// resources.
+	services.HealthCheckConfigReader
 
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
@@ -1317,7 +1325,7 @@ type Cache interface {
 	// GitServerGetter defines methods for fetching Git servers.
 	services.GitServerGetter
 
-	// HealthCheckConfigReader defines methods for fetching health checkc config
+	// HealthCheckConfigReader defines methods for fetching health check config
 	// resources.
 	services.HealthCheckConfigReader
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -926,6 +926,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindAccessGraphSettings, services.RO()),
 				types.NewRule(types.KindRelayServer, services.RO()),
 				types.NewRule(types.KindAccessList, services.RO()),
+				types.NewRule(types.KindHealthCheckConfig, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{
@@ -1204,6 +1205,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindLock, services.RO()),
 						types.NewRule(types.KindKubernetesCluster, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
+						types.NewRule(types.KindHealthCheckConfig, services.RO()),
 					},
 				},
 			})

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -271,6 +271,7 @@ func ForProxy(cfg Config) Config {
 		{Kind: types.KindUserTask},
 		{Kind: types.KindGitServer},
 		{Kind: types.KindRelayServer},
+		{Kind: types.KindHealthCheckConfig},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg
@@ -367,6 +368,7 @@ func ForKubernetes(cfg Config) Config {
 		{Kind: types.KindKubeServer},
 		{Kind: types.KindKubernetesCluster},
 		{Kind: types.KindKubeWaitingContainer},
+		{Kind: types.KindHealthCheckConfig},
 	}
 	cfg.QueueSize = defaults.KubernetesQueueSize
 	return cfg

--- a/lib/healthcheck/config.go
+++ b/lib/healthcheck/config.go
@@ -33,13 +33,13 @@ import (
 // healthCheckConfig is an internal health check config type converted from a
 // [*healthcheckconfigv1.HealthCheckConfig] with defaults set.
 type healthCheckConfig struct {
-	name                  string
-	protocol              types.TargetHealthProtocol
-	interval              time.Duration
-	timeout               time.Duration
-	healthyThreshold      uint32
-	unhealthyThreshold    uint32
-	databaseLabelMatchers types.LabelMatchers
+	name                    string
+	interval                time.Duration
+	timeout                 time.Duration
+	healthyThreshold        uint32
+	unhealthyThreshold      uint32
+	databaseLabelMatchers   types.LabelMatchers
+	kubernetesLabelMatchers types.LabelMatchers
 }
 
 // newHealthCheckConfig converts a health check config protobuf message into a
@@ -47,16 +47,15 @@ type healthCheckConfig struct {
 func newHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig) *healthCheckConfig {
 	spec := cfg.GetSpec()
 	match := spec.GetMatch()
+
 	return &healthCheckConfig{
-		name:               cfg.GetMetadata().GetName(),
-		timeout:            cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
-		interval:           cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
-		healthyThreshold:   cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
-		unhealthyThreshold: cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
-		// we only support plain TCP health checks currently, but eventually we
-		// may add support for other protocols such as TLS or HTTP
-		protocol:              types.TargetHealthProtocolTCP,
-		databaseLabelMatchers: newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
+		name:                    cfg.GetMetadata().GetName(),
+		timeout:                 cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
+		interval:                cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
+		healthyThreshold:        cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
+		unhealthyThreshold:      cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
+		databaseLabelMatchers:   newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
+		kubernetesLabelMatchers: newLabelMatchers(match.GetKubernetesLabelsExpression(), match.GetKubernetesLabels()),
 	}
 }
 
@@ -66,7 +65,6 @@ func (h *healthCheckConfig) equivalent(other *healthCheckConfig) bool {
 	return (h == nil && other == nil) ||
 		h != nil && other != nil &&
 			h.name == other.name &&
-			h.protocol == other.protocol &&
 			h.interval == other.interval &&
 			h.timeout == other.timeout &&
 			h.healthyThreshold == other.healthyThreshold &&
@@ -79,6 +77,8 @@ func (h *healthCheckConfig) getLabelMatchers(kind string) types.LabelMatchers {
 	switch kind {
 	case types.KindDatabase:
 		return h.databaseLabelMatchers
+	case types.KindKubernetesCluster:
+		return h.kubernetesLabelMatchers
 	}
 	// unreachable since we enforce a list of supported target resource kinds,
 	// but empty matchers do the right thing anyway: don't match anything.

--- a/lib/healthcheck/config_test.go
+++ b/lib/healthcheck/config_test.go
@@ -77,12 +77,16 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				interval:           time.Second * 43,
 				healthyThreshold:   7,
 				unhealthyThreshold: 8,
-				protocol:           types.TargetHealthProtocolTCP,
 				databaseLabelMatchers: types.LabelMatchers{
 					Labels: types.Labels{
 						"foo": utils.Strings{"bar", "baz"},
 					},
 					Expression: `labels["qux"] == "*"`,
+				},
+				kubernetesLabelMatchers: types.LabelMatchers{
+					Labels: types.Labels{},
+					// TODO(rana):
+					// Expression: `labels["qux"] == "*"`,
 				},
 			},
 		},
@@ -95,10 +99,14 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				interval:           defaults.HealthCheckInterval,
 				healthyThreshold:   defaults.HealthCheckHealthyThreshold,
 				unhealthyThreshold: defaults.HealthCheckUnhealthyThreshold,
-				protocol:           types.TargetHealthProtocolTCP,
 				databaseLabelMatchers: types.LabelMatchers{
 					Labels:     types.Labels{},
 					Expression: `labels["*"] == "*"`,
+				},
+				kubernetesLabelMatchers: types.LabelMatchers{
+					Labels: types.Labels{},
+					// TODO(rana):
+					// Expression: `labels["*"] == "*"`,
 				},
 			},
 		},
@@ -139,7 +147,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			desc: "all fields equal",
 			a: &healthCheckConfig{
 				name:               "test",
-				protocol:           "http",
 				interval:           time.Second,
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
@@ -147,7 +154,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name:               "test",
-				protocol:           "http",
 				interval:           time.Second,
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
@@ -159,7 +165,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			desc: "all fields equal ignoring labels",
 			a: &healthCheckConfig{
 				name:                  "test",
-				protocol:              "http",
 				interval:              time.Second,
 				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
@@ -168,7 +173,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name:                  "test",
-				protocol:              "http",
 				interval:              time.Second,
 				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
@@ -184,16 +188,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name: "test2",
-			},
-			want: false,
-		},
-		{
-			desc: "different protocol",
-			a: &healthCheckConfig{
-				protocol: "http",
-			},
-			b: &healthCheckConfig{
-				protocol: "tcp",
 			},
 			want: false,
 		},

--- a/lib/healthcheck/manager.go
+++ b/lib/healthcheck/manager.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
@@ -36,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/interval"
+	"github.com/gravitational/trace"
 )
 
 // Manager manages health checks for registered resource targets.
@@ -328,6 +328,10 @@ func (m *manager) updateWorkersLocked(ctx context.Context) {
 // getConfigLocked gets a matching config for the the given resource or returns
 // nil if no config matches.
 func (m *manager) getConfigLocked(ctx context.Context, r types.ResourceWithLabels) *healthCheckConfig {
+	if m.configs == nil {
+		m.logger.WarnContext(ctx, "Health check config unavailable")
+		return nil
+	}
 	for _, cfg := range m.configs {
 		matched, _, err := services.CheckLabelsMatch(
 			types.Allow,

--- a/lib/healthcheck/net.go
+++ b/lib/healthcheck/net.go
@@ -1,0 +1,96 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package healthcheck
+
+import (
+	"context"
+	"net"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+)
+
+// EndpointsResolverFunc is callback func that returns endpoints for a target.
+type EndpointsResolverFunc func(ctx context.Context) ([]string, error)
+
+// dialFunc dials an address on the given network.
+type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// TargetDialer is a health check target which uses a net.Dialer.
+type TargetDialer struct {
+	// Resolver resolves the target endpoint(s).
+	Resolver EndpointsResolverFunc
+	// dial is used to dial network connections.
+	dial dialFunc
+}
+
+// NewTargetDialer returns a new TargetDialer ready for use.
+func NewTargetDialer(resolver EndpointsResolverFunc) *TargetDialer {
+	return &TargetDialer{
+		Resolver: resolver,
+		dial:     defaultDialer().DialContext,
+	}
+}
+
+// GetProtocol returns the network protocol used for checking health.
+func (t *TargetDialer) GetProtocol() types.TargetHealthProtocol {
+	return types.TargetHealthProtocolTCP
+}
+
+// CheckHealth checks the health of the target resource.
+func (t *TargetDialer) CheckHealth(ctx context.Context) ([]string, error) {
+	return t.dialEndpoints(ctx)
+}
+
+func (t *TargetDialer) dialEndpoints(ctx context.Context) ([]string, error) {
+	endpoints, err := t.Resolver(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to resolve target endpoints")
+	}
+	switch len(endpoints) {
+	case 0:
+		return nil, trace.NotFound("resolved zero target endpoints")
+	case 1:
+		return endpoints, t.dialEndpoint(ctx, endpoints[0])
+	default:
+		group, ctx := errgroup.WithContext(ctx)
+		group.SetLimit(10)
+		for _, ep := range endpoints {
+			group.Go(func() error {
+				return trace.Wrap(t.dialEndpoint(ctx, ep))
+			})
+		}
+		return endpoints, group.Wait()
+	}
+}
+
+func (t *TargetDialer) dialEndpoint(ctx context.Context, endpoint string) error {
+	conn, err := t.dial(ctx, "tcp", endpoint)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// an error while closing the connection could indicate an RST packet from
+	// the endpoint - that's a health check failure.
+	return trace.Wrap(conn.Close())
+}
+
+func defaultDialer() *net.Dialer {
+	return &net.Dialer{}
+}

--- a/lib/healthcheck/net_test.go
+++ b/lib/healthcheck/net_test.go
@@ -1,0 +1,118 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package healthcheck
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetDialer_dialEndpoints(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const healthyAddr = "healthy.com:123"
+	const unhealthyAddr = "unhealthy.com:123"
+	tests := []struct {
+		desc            string
+		resolver        EndpointsResolverFunc
+		wantErrContains string
+	}{
+		{
+			desc: "resolver error",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return nil, trace.Errorf("resolver error")
+			},
+			wantErrContains: "resolver error",
+		},
+		{
+			desc: "resolved zero addrs",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return nil, nil
+			},
+			wantErrContains: "resolved zero target endpoints",
+		},
+		{
+			desc: "resolved one healthy addr",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return []string{healthyAddr}, nil
+			},
+		},
+		{
+			desc: "resolved one unhealthy addr",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return []string{unhealthyAddr}, nil
+			},
+			wantErrContains: "unhealthy addr",
+		},
+		{
+			desc: "resolved multiple healthy addrs",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return []string{healthyAddr, healthyAddr, healthyAddr}, nil
+			},
+		},
+		{
+			desc: "resolved a mix of healthy and unhealthy addrs",
+			resolver: func(ctx context.Context) ([]string, error) {
+				return []string{healthyAddr, unhealthyAddr, healthyAddr}, nil
+			},
+			wantErrContains: "unhealthy addr",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			d := &TargetDialer{
+				Resolver: test.resolver,
+				dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					if addr == healthyAddr {
+						return fakeConn{}, nil
+					}
+					return nil, trace.Errorf("unhealthy addr")
+				},
+			}
+			_, err := d.dialEndpoints(ctx)
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+type fakeConn struct {
+	net.Conn
+}
+
+func (fakeConn) Close() error { return nil }
+
+type fakeResource struct {
+	kind string
+	types.ResourceWithLabels
+}
+
+func (r *fakeResource) GetKind() string {
+	return r.kind
+}

--- a/lib/healthcheck/target.go
+++ b/lib/healthcheck/target.go
@@ -20,30 +20,28 @@ package healthcheck
 
 import (
 	"context"
-	"net"
-
-	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 )
 
-// EndpointsResolverFunc is callback func that returns endpoints for a target.
-type EndpointsResolverFunc func(ctx context.Context) ([]string, error)
-
-// OnHealthChangeFunc is a func called on each health change.
-type OnHealthChangeFunc func(oldHealth, newHealth types.TargetHealth)
+// HealthChecker is a resource which provides health checks.
+type HealthChecker interface {
+	// CheckHealth checks the health of a target resource.
+	CheckHealth(ctx context.Context) ([]string, error)
+	// GetProtocol returns the network protocol used for checking health.
+	GetProtocol() types.TargetHealthProtocol
+}
 
 // Target is a health check target.
 type Target struct {
+	// HealthChecker checks the resource's health.
+	HealthChecker
 	// GetResource gets a copy of the target resource with updated labels.
 	GetResource func() types.ResourceWithLabels
-	// ResolverFn resolves the target endpoint(s).
-	ResolverFn EndpointsResolverFunc
 
 	// -- test fields below --
 
-	// dialFn used to mock dialing in tests
-	dialFn dialFunc
 	// onHealthCheck is called after each health check.
 	onHealthCheck func(lastResultErr error)
 	// onConfigUpdate is called after each config update.
@@ -56,15 +54,32 @@ func (t *Target) checkAndSetDefaults() error {
 	if t.GetResource == nil {
 		return trace.BadParameter("missing target resource getter")
 	}
-	if t.ResolverFn == nil {
-		return trace.BadParameter("missing target endpoint resolver")
-	}
-	if t.dialFn == nil {
-		t.dialFn = defaultDialer().DialContext
+	if t.HealthChecker == nil {
+		return trace.BadParameter("missing health checker")
 	}
 	return nil
 }
 
-func defaultDialer() *net.Dialer {
-	return &net.Dialer{}
-}
+// TODO(rana): REMOVE
+// Target is a resource which provides health checks.
+// type TargetPrevious interface {
+// 	// GetResource gets the target resource.
+// 	GetResource() types.ResourceWithLabels
+// 	// GetAddress gets the address of the target resource.
+// 	GetAddress() string
+// 	// GetProtocol gets the network communication protocol for the target resource.
+// 	GetProtocol() types.TargetHealthProtocol
+// 	// CheckAndSetDefaults checks and sets defaults settings for the target resource.
+// 	CheckAndSetDefaults() error
+// 	// CheckHealth checks the health of the target resource.
+// 	CheckHealth(ctx context.Context) error
+
+// 	// -- test methods below --
+
+// 	// OnHealthCheck is called after each health check.
+// 	OnHealthCheck(lastResultErr error)
+// 	// OnConfigUpdate is called after each config update.
+// 	OnConfigUpdate()
+// 	// OnClose is called after the target's worker closes.
+// 	OnClose()
+// }

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -30,7 +29,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -160,9 +158,6 @@ type worker struct {
 	metricType string
 }
 
-// dialFunc dials an address on the given network.
-type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
-
 // GetTargetHealth returns the worker's target health.
 func (w *worker) GetTargetHealth() *types.TargetHealth {
 	w.mu.RLock()
@@ -225,10 +220,6 @@ func (w *worker) run() {
 		case newCfg := <-w.healthCheckConfigUpdateCh:
 			w.updateHealthCheckConfig(w.closeContext, newCfg)
 		case <-w.closeContext.Done():
-			w.mu.RLock()
-			targetHealthStatus := w.targetHealth.Status
-			w.mu.RUnlock()
-			w.decrementPreviousMetric(targetHealthStatus)
 			return
 		}
 	}
@@ -238,7 +229,6 @@ func (w *worker) run() {
 func (w *worker) startHealthCheckInterval(ctx context.Context) {
 	w.log.InfoContext(ctx, "Health checker started",
 		"health_check_config", w.healthCheckCfg.name,
-		"protocol", w.healthCheckCfg.protocol,
 		"interval", log.StringerAttr(w.healthCheckCfg.interval),
 		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
@@ -276,25 +266,31 @@ func (w *worker) nextHealthCheck() <-chan time.Time {
 // updates the worker's health check result history, and possibly updates the
 // target health.
 func (w *worker) checkHealth(ctx context.Context) {
-	initializing := w.lastResultCount == 0
-	dialErr := w.dialEndpoints(ctx)
+	ctx, cancel := context.WithTimeout(ctx, w.healthCheckCfg.timeout)
+	defer cancel()
+
+	// check target health
+	var curErr error
+	w.lastResolvedEndpoints, curErr = w.target.CheckHealth(ctx)
+
 	if ctx.Err() == context.Canceled {
 		return
 	}
-	if (dialErr == nil) == (w.lastResultErr == nil) {
+	initializing := w.lastResultCount == 0
+	if (curErr == nil) == (w.lastResultErr == nil) {
 		w.lastResultCount++
 	} else {
 		// the passing/failing result streak has ended, so reset the count
 		w.lastResultCount = 1
 	}
-	w.lastResultErr = dialErr
+	w.lastResultErr = curErr
 
 	if w.lastResultErr != nil {
 		w.log.DebugContext(ctx, "Failed health check",
 			"error", w.lastResultErr,
 		)
 	}
-	// update target health when we exactly reach the threshold or initialize
+	// update target health when we initialize or exactly reach the threshold
 	if initializing || w.getThreshold(w.healthCheckCfg) == w.lastResultCount {
 		w.setThresholdReached(ctx)
 	}
@@ -322,7 +318,6 @@ func (w *worker) updateHealthCheckConfig(ctx context.Context, newCfg *healthChec
 	}
 	w.log.DebugContext(ctx, "Updated health check config",
 		"health_check_config", w.healthCheckCfg.name,
-		"protocol", w.healthCheckCfg.protocol,
 		"interval", log.StringerAttr(w.healthCheckCfg.interval),
 		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
@@ -345,41 +340,6 @@ func (w *worker) updateHealthCheckConfig(ctx context.Context, newCfg *healthChec
 	if newThreshold < oldThreshold && w.lastResultCount >= newThreshold {
 		w.setThresholdReached(ctx)
 	}
-}
-
-func (w *worker) dialEndpoints(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, w.healthCheckCfg.timeout)
-	defer cancel()
-	endpoints, err := w.target.ResolverFn(ctx)
-	if err != nil {
-		return trace.Wrap(err, "failed to resolve target endpoints")
-	}
-	w.lastResolvedEndpoints = endpoints
-	switch len(endpoints) {
-	case 0:
-		return trace.NotFound("resolved zero target endpoints")
-	case 1:
-		return w.dialEndpoint(ctx, endpoints[0])
-	default:
-		group, ctx := errgroup.WithContext(ctx)
-		group.SetLimit(10)
-		for _, ep := range endpoints {
-			group.Go(func() error {
-				return trace.Wrap(w.dialEndpoint(ctx, ep))
-			})
-		}
-		return group.Wait()
-	}
-}
-
-func (w *worker) dialEndpoint(ctx context.Context, endpoint string) error {
-	conn, err := w.target.dialFn(ctx, "tcp", endpoint)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// an error while closing the connection could indicate an RST packet from
-	// the endpoint - that's a health check failure.
-	return trace.Wrap(conn.Close())
 }
 
 // getThreshold returns the appropriate threshold to compare against the last
@@ -466,6 +426,7 @@ func (w *worker) setTargetHealthStatus(ctx context.Context, newStatus types.Targ
 	now := w.clock.Now()
 	w.targetHealth = types.TargetHealth{
 		Address:             strings.Join(w.lastResolvedEndpoints, ","),
+		Protocol:            string(w.target.GetProtocol()),
 		Status:              string(newStatus),
 		TransitionTimestamp: &now,
 		TransitionReason:    string(reason),
@@ -473,9 +434,6 @@ func (w *worker) setTargetHealthStatus(ctx context.Context, newStatus types.Targ
 	}
 	if w.lastResultErr != nil {
 		w.targetHealth.TransitionError = w.lastResultErr.Error()
-	}
-	if w.healthCheckCfg != nil {
-		w.targetHealth.Protocol = string(w.healthCheckCfg.protocol)
 	}
 }
 

--- a/lib/healthcheck/worker_experimental_test.go
+++ b/lib/healthcheck/worker_experimental_test.go
@@ -72,15 +72,17 @@ func TestGetTargetHealth(t *testing.T) {
 				worker, err := newWorker(t.Context(), workerConfig{
 					HealthCheckCfg: test.healthCheckConfig,
 					Target: Target{
+						HealthChecker: &TargetDialer{
+							Resolver: func(ctx context.Context) ([]string, error) {
+								return []string{"localhost:1234"}, nil
+							},
+							dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+								time.Sleep(5*time.Second - time.Nanosecond)
+								synctest.Wait()
+								return fakeConn{}, test.dialErr
+							},
+						},
 						GetResource: func() types.ResourceWithLabels { return nil },
-						ResolverFn: func(ctx context.Context) ([]string, error) {
-							return []string{"localhost:1234"}, nil
-						},
-						dialFn: func(ctx context.Context, network, addr string) (net.Conn, error) {
-							time.Sleep(5*time.Second - time.Nanosecond)
-							synctest.Wait()
-							return fakeConn{}, test.dialErr
-						},
 					},
 				})
 				assert.NoError(t, err)

--- a/lib/healthcheck/worker_test.go
+++ b/lib/healthcheck/worker_test.go
@@ -20,14 +20,12 @@ package healthcheck
 
 import (
 	"context"
-	"log/slog"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -37,7 +35,8 @@ import (
 func Test_newUnstartedWorker(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	listener, err := net.Listen("tcp", "localhost:0")
+	protocol := string(types.TargetHealthProtocolTCP)
+	listener, err := net.Listen(protocol, "localhost:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
@@ -63,15 +62,15 @@ func Test_newUnstartedWorker(t *testing.T) {
 			cfg: workerConfig{
 				HealthCheckCfg: nil,
 				Target: Target{
+					HealthChecker: NewTargetDialer(
+						func(ctx context.Context) ([]string, error) { return nil, nil },
+					),
 					GetResource: func() types.ResourceWithLabels { return db },
-					ResolverFn: func(ctx context.Context) ([]string, error) {
-						return []string{db.GetURI()}, nil
-					},
 				},
 			},
 			wantHealth: types.TargetHealth{
 				Address:          "",
-				Protocol:         "",
+				Protocol:         protocol,
 				Status:           string(types.TargetHealthStatusUnknown),
 				TransitionReason: string(types.TargetHealthTransitionReasonDisabled),
 				Message:          "No health check config matches this resource",
@@ -87,16 +86,16 @@ func Test_newUnstartedWorker(t *testing.T) {
 					unhealthyThreshold: 10,
 				},
 				Target: Target{
+					HealthChecker: NewTargetDialer(
+						func(ctx context.Context) ([]string, error) { return nil, nil },
+					),
 					GetResource: func() types.ResourceWithLabels { return db },
-					ResolverFn: func(ctx context.Context) ([]string, error) {
-						return []string{db.GetURI()}, nil
-					},
 				},
 				getTargetHealthTimeout: time.Millisecond,
 			},
 			wantHealth: types.TargetHealth{
 				Address:          "",
-				Protocol:         "",
+				Protocol:         protocol,
 				Status:           string(types.TargetHealthStatusUnknown),
 				TransitionReason: string(types.TargetHealthTransitionReasonInit),
 				Message:          "Health checker initialized",
@@ -112,9 +111,9 @@ func Test_newUnstartedWorker(t *testing.T) {
 					unhealthyThreshold: 10,
 				},
 				Target: Target{
-					ResolverFn: func(ctx context.Context) ([]string, error) {
-						return []string{db.GetURI()}, nil
-					},
+					HealthChecker: NewTargetDialer(
+						func(ctx context.Context) ([]string, error) { return nil, nil },
+					),
 				},
 			},
 			wantErr: "missing target resource getter",
@@ -135,87 +134,3 @@ func Test_newUnstartedWorker(t *testing.T) {
 		})
 	}
 }
-
-func Test_dialEndpoints(t *testing.T) {
-	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	const healthyAddr = "healthy.com:123"
-	const unhealthyAddr = "unhealthy.com:123"
-	tests := []struct {
-		desc            string
-		resolverFn      EndpointsResolverFunc
-		wantErrContains string
-	}{
-		{
-			desc: "resolver error",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return nil, trace.Errorf("resolver error")
-			},
-			wantErrContains: "resolver error",
-		},
-		{
-			desc: "resolved zero addrs",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return nil, nil
-			},
-			wantErrContains: "resolved zero target endpoints",
-		},
-		{
-			desc: "resolved one healthy addr",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return []string{healthyAddr}, nil
-			},
-		},
-		{
-			desc: "resolved one unhealthy addr",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return []string{unhealthyAddr}, nil
-			},
-			wantErrContains: "unhealthy addr",
-		},
-		{
-			desc: "resolved multiple healthy addrs",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return []string{healthyAddr, healthyAddr, healthyAddr}, nil
-			},
-		},
-		{
-			desc: "resolved a mix of healthy and unhealthy addrs",
-			resolverFn: func(ctx context.Context) ([]string, error) {
-				return []string{healthyAddr, unhealthyAddr, healthyAddr}, nil
-			},
-			wantErrContains: "unhealthy addr",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			w := &worker{
-				healthCheckCfg: &healthCheckConfig{},
-				log:            slog.Default(),
-				target: Target{
-					ResolverFn: test.resolverFn,
-					dialFn: func(ctx context.Context, network, addr string) (net.Conn, error) {
-						if addr == healthyAddr {
-							return fakeConn{}, nil
-						}
-						return nil, trace.Errorf("unhealthy addr")
-					},
-				},
-			}
-			err := w.dialEndpoints(ctx)
-			if test.wantErrContains != "" {
-				require.ErrorContains(t, err, test.wantErrContains)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
-}
-
-type fakeConn struct {
-	net.Conn
-}
-
-func (fakeConn) Close() error { return nil }

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,6 +34,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//
@@ -164,6 +165,12 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 
 func extractKubeCreds(ctx context.Context, component string, cluster string, clientCfg *rest.Config, log *slog.Logger, checkPermissions servicecfg.ImpersonationPermissionsChecker) (*staticKubeCreds, error) {
 	log = log.With("cluster", cluster)
+
+	// TODO(rana): REMOVE IF NOT NEEDED
+	// Increase rate limit to support health checks.
+	// clientCfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+	// clientCfg.QPS = 50
+	// clientCfg.Burst = 5 //100
 
 	log.DebugContext(ctx, "Checking Kubernetes impersonation permissions")
 	client, err := kubernetes.NewForConfig(clientCfg)

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/labels"
@@ -52,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+	"github.com/gravitational/teleport/lib/utils/log"
 )
 
 // TLSServerConfig is a configuration for TLS server
@@ -109,6 +111,8 @@ type TLSServerConfig struct {
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 	// InventoryHandle is used to send kube server heartbeats via the inventory control stream.
 	InventoryHandle inventory.DownstreamHandle
+	// HealthCheckManager manages health checks for Kubernetes clusters.
+	HealthCheckManager healthcheck.Manager
 }
 
 type awsClientsGetter struct{}
@@ -142,6 +146,9 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	}
 	if c.ConnectedProxyGetter == nil {
 		return trace.BadParameter("missing parameter ConnectedProxyGetter")
+	}
+	if c.HealthCheckManager == nil {
+		return trace.BadParameter("missing parameter HealthCheckManager")
 	}
 
 	if err := c.validateLabelKeys(); err != nil {
@@ -350,6 +357,11 @@ func (t *TLSServer) Serve(listener net.Listener, options ...ServeOption) error {
 		return trace.Wrap(err)
 	}
 
+	// Start the health check manager to monitor kube cluster health.
+	if err := t.HealthCheckManager.Start(t.closeContext); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// startStaticClusterHeartbeats starts the heartbeat process for static clusters.
 	// static clusters can be specified via kubeconfig or clusterName for Teleport agent
 	// running in Kubernetes.
@@ -412,6 +424,15 @@ func (t *TLSServer) close(ctx context.Context) error {
 	var errs []error
 	for _, kubeCluster := range t.fwd.kubeClusters() {
 		errs = append(errs, t.unregisterKubeCluster(ctx, kubeCluster.GetName()))
+
+		// Stop the kube health checker.
+		if err := t.stopHealthCheck(kubeCluster); err != nil {
+			t.log.WarnContext(ctx, "Failed to stop thekube health checker",
+				"kube_cluster", log.StringerAttr(kubeCluster),
+				"error", err,
+			)
+			errs = append(errs, err)
+		}
 	}
 	errs = append(errs, t.fwd.Close(), t.Server.Close())
 
@@ -490,7 +511,59 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 		return nil, trace.Wrap(err)
 	}
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
+
+	// Get the kube cluster health and send it to the auth server.
+	srv.SetTargetHealth(t.getTargetHealth(t.closeContext, cluster))
+
 	return srv, nil
+}
+
+// startHealthCheck starts checking the health of a Kubernetes cluster.
+func (t *TLSServer) startHealthCheck(cluster types.KubeCluster) error {
+	kubeDetails, err := t.fwd.findKubeDetailsByClusterName(cluster.GetName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = t.HealthCheckManager.AddTarget(healthcheck.Target{
+		HealthChecker: kubeDetails,
+		GetResource:   func() types.ResourceWithLabels { return cluster },
+	})
+	return trace.Wrap(err)
+}
+
+// stopHealthCheck stops checking the health of a Kubernetes cluster.
+func (t *TLSServer) stopHealthCheck(cluster types.KubeCluster) error {
+	err := t.HealthCheckManager.RemoveTarget(cluster)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// getTargetHealth returns the health of a Kubernetes cluster.
+func (t *TLSServer) getTargetHealth(ctx context.Context, cluster types.KubeCluster) types.TargetHealth {
+	health, err := t.HealthCheckManager.GetTargetHealth(cluster)
+	if err == nil {
+		return *health
+	}
+	if trace.IsNotFound(err) {
+		return types.TargetHealth{
+			Status:           string(types.TargetHealthStatusUnknown),
+			TransitionReason: string(types.TargetHealthTransitionReasonDisabled),
+			Message:          "The target health checker was not found",
+		}
+	}
+
+	t.log.WarnContext(ctx, "Failed to get kube cluster health",
+		"kube_cluster", log.StringerAttr(cluster),
+		"error", err,
+	)
+	return types.TargetHealth{
+		Status:           string(types.TargetHealthStatusUnknown),
+		TransitionReason: string(types.TargetHealthTransitionReasonInternalError),
+		TransitionError:  err.Error(),
+		Message:          "The kube service failed to get the kube cluster health status (this is a bug)",
+	}
 }
 
 // getKubeClusterWithServiceLabels finds the kube cluster by name, strips the credentials,
@@ -559,9 +632,12 @@ func (t *TLSServer) startStaticClustersHeartbeat() error {
 	// proxy_service will pretend to also be kube_server.
 	if t.KubeServiceType == KubeService ||
 		t.KubeServiceType == LegacyProxyService {
-		t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats")
-		for _, cluster := range t.fwd.kubeClusters() {
-			if err := t.startHeartbeat(cluster.GetName()); err != nil {
+		t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats and health checks")
+		for _, kc := range t.fwd.kubeClusters() {
+			if err := t.startHealthCheck(kc); err != nil {
+				return trace.Wrap(err)
+			}
+			if err := t.startHeartbeat(kc.GetName()); err != nil {
 				return trace.Wrap(err)
 			}
 		}

--- a/lib/services/health_check_config.go
+++ b/lib/services/health_check_config.go
@@ -71,8 +71,6 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 		return trace.BadParameter("spec is missing")
 	case s.Spec.Match == nil:
 		return trace.BadParameter("spec.match is missing")
-	case len(s.Spec.Match.DbLabels) == 0 && len(s.Spec.Match.DbLabelsExpression) == 0:
-		return trace.BadParameter("at least one of spec.match.db_labels or spec.match.db_labels_expression must be set")
 	}
 
 	for _, label := range s.Spec.Match.DbLabels {
@@ -83,6 +81,17 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 	if expr := s.Spec.Match.DbLabelsExpression; len(expr) > 0 {
 		if _, err := parseLabelExpression(expr); err != nil {
 			return trace.BadParameter("invalid spec.db_labels_expression: %v", err)
+		}
+	}
+
+	for _, label := range s.Spec.Match.KubernetesLabels {
+		if err := validateLabel(label); err != nil {
+			return trace.BadParameter("invalid spec.kubernetes_labels: %v", err)
+		}
+	}
+	if expr := s.Spec.Match.KubernetesLabelsExpression; len(expr) > 0 {
+		if _, err := parseLabelExpression(expr); err != nil {
+			return trace.BadParameter("invalid spec.kubernetes_labels_expression: %v", err)
 		}
 	}
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -874,6 +874,11 @@ func NewPresetHealthCheckConfig() *healthcheckconfigv1.HealthCheckConfig {
 					Name:   types.Wildcard,
 					Values: []string{types.Wildcard},
 				}},
+				// match all kubernetes clusters
+				KubernetesLabels: []*labelv1.Label{{
+					Name:   types.Wildcard,
+					Values: []string{types.Wildcard},
+				}},
 			},
 		},
 	}

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -1481,12 +1481,12 @@ func (s *Server) startHealthCheck(ctx context.Context, db types.Database) error 
 		return trace.Wrap(err)
 	}
 	err = s.cfg.healthCheckManager.AddTarget(healthcheck.Target{
+		HealthChecker: healthcheck.NewTargetDialer(resolver),
 		GetResource: func() types.ResourceWithLabels {
 			s.mu.RLock()
 			defer s.mu.RUnlock()
 			return s.copyDatabaseWithUpdatedLabelsLocked(db)
 		},
-		ResolverFn: resolver,
 	})
 	return trace.Wrap(err)
 }

--- a/lib/teleterm/apiserver/handler/handler_kubes.go
+++ b/lib/teleterm/apiserver/handler/handler_kubes.go
@@ -67,6 +67,11 @@ func newAPIKube(kube clusters.Kube) *api.Kube {
 		Name:   kube.KubernetesCluster.GetName(),
 		Uri:    kube.URI.String(),
 		Labels: apiLabels,
+		TargetHealth: &api.TargetHealth{
+			Status:  kube.TargetHealth.Status,
+			Error:   kube.TargetHealth.TransitionError,
+			Message: kube.TargetHealth.Message,
+		},
 	}
 }
 

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -41,6 +41,9 @@ type Kube struct {
 	URI uri.ResourceURI
 
 	KubernetesCluster types.KubeCluster
+
+	// TargetHealth describes the health status of the kube cluster.
+	TargetHealth types.TargetHealth
 }
 
 // reissueKubeCert issue new certificates for kube cluster and saves them to disk.

--- a/lib/teleterm/services/unifiedresources/unifiedresources.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources.go
@@ -125,6 +125,7 @@ func List(ctx context.Context, cluster *clusters.Cluster, client apiclient.ListU
 				Kube: &clusters.Kube{
 					URI:               cluster.URI.AppendKube(kubeCluster.GetName()),
 					KubernetesCluster: kubeCluster,
+					TargetHealth:      r.GetTargetHealth(),
 				},
 				RequiresRequest: requiresRequest,
 			})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3413,6 +3413,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 			unifiedResources = append(unifiedResources, kube)
 		case types.KubeServer:
 			kube := ui.MakeKubeCluster(r.GetCluster(), accessChecker, enriched.RequiresRequest)
+			kube.TargetHealth = r.GetTargetHealth()
 			unifiedResources = append(unifiedResources, kube)
 		default:
 			return nil, trace.Errorf("UI Resource has unknown type: %T", enriched)

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -127,6 +127,16 @@ type KubeCluster struct {
 	KubeGroups []string `json:"kubernetes_groups"`
 	// RequireRequest indicates if a returned resource is only accessible after an access request
 	RequiresRequest bool `json:"requiresRequest,omitempty"`
+	// TODO(rana): UPDATE COMMENTS FOR KUBE
+	// TargetHealth describes the health status of network connectivity
+	// reported from an agent (db_service) that is proxying this database.
+	//
+	// This field will be empty if the database was not extracted from
+	// a db_server resource. The following endpoints will set this field
+	// since these endpoints query for db_server under the hood and then
+	// extract db from it:
+	// - webapi/sites/:site/resources (unified resources)
+	TargetHealth types.TargetHealth `json:"targetHealth,omitzero"`
 }
 
 // MakeKubeCluster creates a kube cluster object for the web ui

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -172,7 +172,7 @@ export function FilterPanel({
           onChange={onHealthStatusChange}
           label="Health Status"
           tooltip={
-            'Health status filter is only available for database resources. Support for more resource types will be added in the future.'
+            'Health status filter is only available for database and Kubernetes resources. Support for more resource types will be added in the future.'
           }
           disabled={!isResourceStatusFilterSupported}
           buffered

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -170,6 +170,15 @@ export function StatusInfoHeader({
         </Box>
       </Flex>
     );
+  } else if (resource.kind === 'kube_cluster') {
+    return (
+      <Flex gap={3}>
+        <ResourceIcon name={'kube'} width="45px" height="45px" />
+        <Box>
+          <H2>{resource.name}</H2>
+        </Box>
+      </Flex>
+    );
   }
 }
 
@@ -183,6 +192,13 @@ function ConnectionHeader({
       <Flex gap={2} my={3}>
         <WarningIcon size={16} />
         <H3>DB Connection Issue</H3>
+      </Flex>
+    );
+  } else if (resource.kind === 'kube_cluster') {
+    return (
+      <Flex gap={2} my={3}>
+        <WarningIcon size={16} />
+        <H3>Kubernetes Cluster Issue</H3>
       </Flex>
     );
   }
@@ -246,8 +262,11 @@ function unknownStatus(numServers: number) {
 }
 
 function getTroubleShootingLink(resource: UnifiedResourceDefinition) {
-  if (resource.kind == 'db') {
-    return 'https://goteleport.com/docs/enroll-resources/database-access/troubleshooting';
+  switch (resource.kind) {
+    case 'db':
+      return 'https://goteleport.com/docs/enroll-resources/database-access/troubleshooting';
+    case 'kube_cluster':
+      return 'https://goteleport.com/docs/enroll-resources/kubernetes-access/troubleshooting';
   }
 }
 
@@ -255,6 +274,8 @@ function getAffectedResourceKind(resource: UnifiedResourceDefinition) {
   switch (resource.kind) {
     case 'db':
       return 'database services';
+    case 'kube_cluster':
+      return 'kubernetes clusters';
   }
 }
 
@@ -332,7 +353,7 @@ export function openStatusInfoPanel({
   guide: JSX.Element;
   isEnterprise?: boolean;
 }) {
-  if (resource.kind === 'db') {
+  if (resource.kind === 'db' || resource.kind === 'kube_cluster') {
     setInfoGuideConfig({
       guide,
       id: getResourceId(resource),

--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -108,6 +108,7 @@ export function makeUnifiedResourceViewItemKube(
       resourceType: 'Kubernetes',
     },
     requiresRequest: resource.requiresRequest,
+    status: resource.targetHealth?.status,
   };
 }
 

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -102,6 +102,7 @@ export interface UnifiedResourceKube {
   name: string;
   labels: ResourceLabel[];
   requiresRequest?: boolean;
+  targetHealth?: ResourceTargetHealth;
 }
 
 export type UnifiedResourceDesktop = {

--- a/web/packages/teleport/src/services/kube/makeKube.ts
+++ b/web/packages/teleport/src/services/kube/makeKube.ts
@@ -19,7 +19,7 @@
 import { Kube, KubeResource } from './types';
 
 export function makeKube(json): Kube {
-  const { name, requiresRequest } = json;
+  const { name, requiresRequest, targetHealth } = json;
   const labels = json.labels || [];
 
   return {
@@ -29,6 +29,11 @@ export function makeKube(json): Kube {
     users: json.kubernetes_users || [],
     groups: json.kubernetes_groups || [],
     requiresRequest,
+    targetHealth: targetHealth && {
+      status: targetHealth.status,
+      error: targetHealth.transition_error,
+      message: targetHealth.message,
+    },
   };
 }
 

--- a/web/packages/teleport/src/services/kube/types.ts
+++ b/web/packages/teleport/src/services/kube/types.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ResourceTargetHealth } from 'shared/components/UnifiedResources';
 import { ResourceLabel } from 'teleport/services/agents';
 
 export interface Kube {
@@ -25,6 +26,18 @@ export interface Kube {
   users?: string[];
   groups?: string[];
   requiresRequest?: boolean;
+  /**
+   * TODO(rana): REVISE COMMENTS
+   * targetHealth describes the health status of a Kubernetes cluster
+   * reported from an agent (db_service) that is proxying this database.
+   *
+   * This field will be empty if the database was not extracted from
+   * a db_server resource. The following endpoints will set this field
+   * since these endpoints query for db_server under the hood and then
+   * extract db from it:
+   * - webapi/sites/:site/resources (unified resources)
+   */
+  targetHealth?: ResourceTargetHealth;
 }
 
 /**

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -570,6 +570,11 @@ const mapToSharedResource = (
           labels: kube.labels,
           name: kube.name,
           requiresRequest: resource.requiresRequest,
+          targetHealth: kube.targetHealth && {
+            status: kube.targetHealth.status as ResourceHealthStatus,
+            error: kube.targetHealth.error,
+            message: kube.targetHealth.message,
+          },
         },
         ui: {
           ActionButton: <ConnectKubeActionButton kube={kube} />,


### PR DESCRIPTION
A proof-of-concept showing Kubernetes health check functionality.

Highlights:
- Uses TLS for health checking kube cluster
- Uses existing `healthcheck` package
- Uses similar patterns as DB health checks
- WebUI displays health status
  
Snapshot of UI showing Kubernetes health check message.
<img width="2168" height="878" alt="image" src="https://github.com/user-attachments/assets/b2274eae-a247-41b2-8a57-2785a607795c" />

 
Build and run to view health checks in the logs.
```zsh
make build/teleport
teleport start
```

The last log line is most interesting:
`Address:"[::]:3027" Protocol:"TCP" Status:"healthy" TransitionTimestamp:<seconds:1755475701 nanos:813754000 > TransitionReason:"threshold_reached" Message:"1 health check passed"`

```log
2025-08-17T17:08:21.805-07:00 DEBU [KUBERNETE] Starting watch. resource_kinds:health_check_config services/watcher.go:248
2025-08-17T17:08:21.805-07:00 DEBU [KUBERNETE] Started health check config resource watcher healthcheck/manager.go:245
2025-08-17T17:08:21.809-07:00 DEBU [KUBERNETE] Have all necessary Kubernetes impersonation permissions pid:42121.1 cluster:colima proxy/auth.go:181
2025-08-17T17:08:21.810-07:00 DEBU [KUBERNETE] Initialized Kubernetes credentials pid:42121.1 cluster:colima proxy/auth.go:206
2025-08-17T17:08:21.813-07:00 INFO [KUBERNETE] Starting Kube service. pid:42121.1 listen_address:[::]:3027 service/kubernetes.go:258
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Started health check config resource watcher healthcheck/manager.go:245
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Starting watch. resource_kinds:health_check_config services/watcher.go:248
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] List of known resources updated resources:[default] services/watcher.go:857
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Starting kubernetes_service heartbeats pid:42121.1 proxy/server.go:683
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] kube health check: startHealthCheck pid:42121.1 colima:[::]:3027 proxy/server.go:539
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Target health status is unknown target_name:colima target_kind:kube_cluster target_origin: reason:initialized message:Health checker initialized healthcheck/worker.go:461
2025-08-17T17:08:21.813-07:00 INFO [KUBERNETE] Health checker started target_name:colima target_kind:kube_cluster target_origin: health_check_config:default protocol:TCP interval:30s timeout:5s healthy_threshold:2 unhealthy_threshold:1 healthcheck/worker.go:208
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Not initializing Kube Cluster resource watcher pid:42121.1 proxy/watcher.go:40
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] Not initializing Kube Cluster resource watcher pid:42121.1 proxy/watcher.go:94
2025-08-17T17:08:21.813-07:00 INFO [KUBERNETE] Target became healthy target_name:colima target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:451
2025-08-17T17:08:21.813-07:00 DEBU [KUBERNETE] kube health check: getTargetHealth pid:42121.1 !BADKEY:Protocol:"TCP" Status:"unknown" TransitionTimestamp:<seconds:1755475701 nanos:813450000 > TransitionReason:"initialized" Message:"Health checker initialized"  proxy/server.go:584
2025-08-17T17:08:26.584-07:00 DEBU [KUBERNETE] kube health check: getTargetHealth pid:42121.1 !BADKEY:Address:"[::]:3027" Protocol:"TCP" Status:"healthy" TransitionTimestamp:<seconds:1755475701 nanos:813754000 > TransitionReason:"threshold_reached" Message:"1 health check passed"  proxy/server.go:584
```