### PR TITLE
fix: change log level from warning to error for Postgres client conne…

### DIFF
--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -198,7 +198,7 @@ func (s *ProxyServer) ServePostgres(listener net.Listener) error {
 			defer clientConn.Close()
 			err := s.PostgresProxy().HandleConnection(s.closeCtx, clientConn)
 			if err != nil && !utils.IsOKNetworkError(err) {
-				s.log.WarnContext(s.closeCtx, "Failed to handle Postgres client connection.", "error", err)
+				s.log.ErrorContext(s.closeCtx, "Failed to handle Postgres client connection.", "error", err)
 			}
 		}()
 	}


### PR DESCRIPTION
📎 Related Issue

Fixes: #41920 

✅ Changes

Standardized the log level for TLS verification failures across both Postgres and MySQL proxy handlers.

Now both will log at error level for consistency.