### PR TITLE
[v17] docs: bump access_graph version to v1.28.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -6,7 +6,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.28.0"
+      "version": "1.28.1"
     },
     "ansible": {
       "min_version": "2.9.6"


### PR DESCRIPTION
Backport #57983 to branch/v17