### PR TITLE
[loadtest] update teleport versions and minor clean up

### DIFF
--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -24,7 +24,7 @@ delete-gcp-cluster:
 destroy-deploy:
 	$(MAKE) -C control-plane destroy
 
-# deploys teleport auth and proxy
+# deploys teleport auth and proxy with assosciated pre-requisites (monitoring/storage/etc)
 .PHONY: deploy-control-plane
 deploy-control-plane:
 	$(MAKE) -C control-plane deploy

--- a/assets/loadtest/control-plane/Makefile
+++ b/assets/loadtest/control-plane/Makefile
@@ -4,7 +4,7 @@ deploy:
 	./init.sh
 	./apply.sh
 
-# initializes helm repos and install teleport
+# destroys resources that are not cleaned up by tearing down the k8s cluster.
 .PHONY: destroy
 destroy:
 	./clean-non-kube.sh

--- a/assets/loadtest/control-plane/monitoring/set-password.sh
+++ b/assets/loadtest/control-plane/monitoring/set-password.sh
@@ -11,4 +11,4 @@ if test -z "$GRAFANA_POD"; then
     exit 1
 fi
 
-kubectl exec --stdin --namespace="monitoring" --tty --container grafana $GRAFANA_POD -- grafana-cli admin reset-admin-password $GRAFANA_PASS
+kubectl exec --stdin --namespace="monitoring" --tty --container grafana $GRAFANA_POD -- grafana cli admin reset-admin-password $GRAFANA_PASS

--- a/assets/loadtest/control-plane/teleport/gen-dynamo-teleport.sh
+++ b/assets/loadtest/control-plane/teleport/gen-dynamo-teleport.sh
@@ -11,7 +11,6 @@ mkdir -p "$STATE_DIR"
 cat > "$values_yaml" <<EOF
 chartMode: aws
 clusterName: ${CLUSTER_NAME}.${ROUTE53_ZONE}      # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-teleportVersionOverride: ${TELEPORT_VERSION}
 proxyListenerMode: "multiplex"
 authentication:
   type: local

--- a/assets/loadtest/control-plane/teleport/gen-etcd-teleport.sh
+++ b/assets/loadtest/control-plane/teleport/gen-etcd-teleport.sh
@@ -11,7 +11,6 @@ mkdir -p "$STATE_DIR"
 cat > "$values_yaml" <<EOF
 chartMode: standalone
 clusterName: ${CLUSTER_NAME}.${ROUTE53_ZONE}      # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-teleportVersionOverride: ${TELEPORT_VERSION}
 
 extraArgs: ['--debug']
 image: "public.ecr.aws/gravitational-staging/teleport-distroless-debug"

--- a/assets/loadtest/control-plane/teleport/gen-firestore-teleport.sh
+++ b/assets/loadtest/control-plane/teleport/gen-firestore-teleport.sh
@@ -11,7 +11,6 @@ mkdir -p "$STATE_DIR"
 cat > "$values_yaml" <<EOF
 chartMode: gcp
 clusterName: ${CLUSTER_NAME}.${ROUTE53_ZONE}      # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-teleportVersionOverride: ${TELEPORT_VERSION}
 proxyListenerMode: "multiplex"
 authentication:
   type: local

--- a/assets/loadtest/control-plane/teleport/install-teleport.sh
+++ b/assets/loadtest/control-plane/teleport/install-teleport.sh
@@ -7,6 +7,7 @@ source vars.env
 values_yaml="$STATE_DIR/teleport-values.yaml"
 
 helm upgrade --install teleport teleport/teleport-cluster \
+  --version "$TELEPORT_VERSION" \
   --create-namespace \
   --namespace teleport \
   -f "$values_yaml"

--- a/assets/loadtest/helm/README.md
+++ b/assets/loadtest/helm/README.md
@@ -43,7 +43,7 @@ TOKEN=$(pwgen -n 30)
 Edit `values/teleport.yaml` (replace <your-name>), then install Teleport using the chart
 
 ```shell
-helm install teleport -n teleport --create-namespace <path/to/chart> --values values/teleport.yaml --set auth.teleportConfig.auth_service.tokens[0]="node:$TOKEN"
+helm install teleport -n teleport --version $TELEPORT_VERSION --create-namespace <path/to/chart> --values values/teleport.yaml --set auth.teleportConfig.auth_service.tokens[0]="node:$TOKEN"
 ```
 
 For v11 and below:

--- a/assets/loadtest/helm/node-agent/Chart.yaml
+++ b/assets/loadtest/helm/node-agent/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.1.0
 
-appVersion: "15.0.0"
+appVersion: "18.1.4"

--- a/assets/loadtest/helm/values/teleport.yaml
+++ b/assets/loadtest/helm/values/teleport.yaml
@@ -26,8 +26,6 @@ podMonitor:
   enabled: true
   interval: ""
 
-teleportVersionOverride: 15.0.0
-
 auth:
   teleportConfig:
     auth_service:


### PR DESCRIPTION
Corrects Makefile comments.
Replaces `grafana-cli` with `grafana cli` as the former is deprecated. 
Removes `teleportVersionOverride` helm value in favour of passing `helm --version` instead.