### PR TITLE
Recording metadata service proto definition changes

### DIFF
--- a/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata.pb.go
+++ b/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata.pb.go
@@ -25,6 +25,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -305,7 +306,13 @@ type SessionRecordingMetadata struct {
 	// StartCols is the number of columns in the terminal at the start of the session.
 	StartCols int32 `protobuf:"varint,3,opt,name=start_cols,json=startCols,proto3" json:"start_cols,omitempty"`
 	// StartRows is the number of rows in the terminal at the start of the session.
-	StartRows     int32 `protobuf:"varint,4,opt,name=start_rows,json=startRows,proto3" json:"start_rows,omitempty"`
+	StartRows int32 `protobuf:"varint,4,opt,name=start_rows,json=startRows,proto3" json:"start_rows,omitempty"`
+	// StartTime is the start time of the session recording.
+	StartTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	// EndTime is the end time of the session recording.
+	EndTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	// ClusterName is the name of the cluster where the session recording took place.
+	ClusterName   string `protobuf:"bytes,7,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -366,6 +373,27 @@ func (x *SessionRecordingMetadata) GetStartRows() int32 {
 		return x.StartRows
 	}
 	return 0
+}
+
+func (x *SessionRecordingMetadata) GetStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTime
+	}
+	return nil
+}
+
+func (x *SessionRecordingMetadata) GetEndTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EndTime
+	}
+	return nil
+}
+
+func (x *SessionRecordingMetadata) GetClusterName() string {
+	if x != nil {
+		return x.ClusterName
+	}
+	return ""
 }
 
 // SessionRecordingMetadataWithFrames contains metadata and frames for a session recording.
@@ -528,7 +556,7 @@ var File_teleport_recordingmetadata_v1_recordingmetadata_proto protoreflect.File
 
 const file_teleport_recordingmetadata_v1_recordingmetadata_proto_rawDesc = "" +
 	"\n" +
-	"5teleport/recordingmetadata/v1/recordingmetadata.proto\x12\x1dteleport.recordingmetadata.v1\x1a\x1egoogle/protobuf/duration.proto\"\xa0\x03\n" +
+	"5teleport/recordingmetadata/v1/recordingmetadata.proto\x12\x1dteleport.recordingmetadata.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa0\x03\n" +
 	"\x15SessionRecordingEvent\x12<\n" +
 	"\fstart_offset\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\vstartOffset\x128\n" +
 	"\n" +
@@ -544,14 +572,18 @@ const file_teleport_recordingmetadata_v1_recordingmetadata_proto_rawDesc = "" +
 	"\x04user\x18\x01 \x01(\tR\x04user\"E\n" +
 	"\x1bSessionRecordingResizeEvent\x12\x12\n" +
 	"\x04cols\x18\x01 \x01(\x05R\x04cols\x12\x12\n" +
-	"\x04rows\x18\x02 \x01(\x05R\x04rows\"\xdd\x01\n" +
+	"\x04rows\x18\x02 \x01(\x05R\x04rows\"\xf2\x02\n" +
 	"\x18SessionRecordingMetadata\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12L\n" +
 	"\x06events\x18\x02 \x03(\v24.teleport.recordingmetadata.v1.SessionRecordingEventR\x06events\x12\x1d\n" +
 	"\n" +
 	"start_cols\x18\x03 \x01(\x05R\tstartCols\x12\x1d\n" +
 	"\n" +
-	"start_rows\x18\x04 \x01(\x05R\tstartRows\"\xcb\x01\n" +
+	"start_rows\x18\x04 \x01(\x05R\tstartRows\x129\n" +
+	"\n" +
+	"start_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tstartTime\x125\n" +
+	"\bend_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\aendTime\x12!\n" +
+	"\fcluster_name\x18\a \x01(\tR\vclusterName\"\xcb\x01\n" +
 	"\"SessionRecordingMetadataWithFrames\x12S\n" +
 	"\bmetadata\x18\x01 \x01(\v27.teleport.recordingmetadata.v1.SessionRecordingMetadataR\bmetadata\x12P\n" +
 	"\x06frames\x18\x02 \x03(\v28.teleport.recordingmetadata.v1.SessionRecordingThumbnailR\x06frames\"\x83\x02\n" +
@@ -587,6 +619,7 @@ var file_teleport_recordingmetadata_v1_recordingmetadata_proto_goTypes = []any{
 	(*SessionRecordingMetadataWithFrames)(nil), // 5: teleport.recordingmetadata.v1.SessionRecordingMetadataWithFrames
 	(*SessionRecordingThumbnail)(nil),          // 6: teleport.recordingmetadata.v1.SessionRecordingThumbnail
 	(*durationpb.Duration)(nil),                // 7: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),              // 8: google.protobuf.Timestamp
 }
 var file_teleport_recordingmetadata_v1_recordingmetadata_proto_depIdxs = []int32{
 	7,  // 0: teleport.recordingmetadata.v1.SessionRecordingEvent.start_offset:type_name -> google.protobuf.Duration
@@ -596,15 +629,17 @@ var file_teleport_recordingmetadata_v1_recordingmetadata_proto_depIdxs = []int32
 	3,  // 4: teleport.recordingmetadata.v1.SessionRecordingEvent.resize:type_name -> teleport.recordingmetadata.v1.SessionRecordingResizeEvent
 	7,  // 5: teleport.recordingmetadata.v1.SessionRecordingMetadata.duration:type_name -> google.protobuf.Duration
 	0,  // 6: teleport.recordingmetadata.v1.SessionRecordingMetadata.events:type_name -> teleport.recordingmetadata.v1.SessionRecordingEvent
-	4,  // 7: teleport.recordingmetadata.v1.SessionRecordingMetadataWithFrames.metadata:type_name -> teleport.recordingmetadata.v1.SessionRecordingMetadata
-	6,  // 8: teleport.recordingmetadata.v1.SessionRecordingMetadataWithFrames.frames:type_name -> teleport.recordingmetadata.v1.SessionRecordingThumbnail
-	7,  // 9: teleport.recordingmetadata.v1.SessionRecordingThumbnail.start_offset:type_name -> google.protobuf.Duration
-	7,  // 10: teleport.recordingmetadata.v1.SessionRecordingThumbnail.end_offset:type_name -> google.protobuf.Duration
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	8,  // 7: teleport.recordingmetadata.v1.SessionRecordingMetadata.start_time:type_name -> google.protobuf.Timestamp
+	8,  // 8: teleport.recordingmetadata.v1.SessionRecordingMetadata.end_time:type_name -> google.protobuf.Timestamp
+	4,  // 9: teleport.recordingmetadata.v1.SessionRecordingMetadataWithFrames.metadata:type_name -> teleport.recordingmetadata.v1.SessionRecordingMetadata
+	6,  // 10: teleport.recordingmetadata.v1.SessionRecordingMetadataWithFrames.frames:type_name -> teleport.recordingmetadata.v1.SessionRecordingThumbnail
+	7,  // 11: teleport.recordingmetadata.v1.SessionRecordingThumbnail.start_offset:type_name -> google.protobuf.Duration
+	7,  // 12: teleport.recordingmetadata.v1.SessionRecordingThumbnail.end_offset:type_name -> google.protobuf.Duration
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_teleport_recordingmetadata_v1_recordingmetadata_proto_init() }

--- a/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata_service.pb.go
+++ b/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata_service.pb.go
@@ -121,29 +121,29 @@ func (*GetMetadataResponseChunk_Metadata) isGetMetadataResponseChunk_Chunk() {}
 
 func (*GetMetadataResponseChunk_Frame) isGetMetadataResponseChunk_Chunk() {}
 
-// GetThumbnailsRequest is a request for retrieving multiple session's thumbnails.
-type GetThumbnailsRequest struct {
+// GetThumbnailRequest is a request for a session's thumbnail.
+type GetThumbnailRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// SessionIds are the ID of the sessions whose thumbnails are being requested.
-	SessionIds    []string `protobuf:"bytes,1,rep,name=session_ids,json=sessionIds,proto3" json:"session_ids,omitempty"`
+	// SessionId is the ID of the session whose thumbnail is being requested.
+	SessionId     string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetThumbnailsRequest) Reset() {
-	*x = GetThumbnailsRequest{}
+func (x *GetThumbnailRequest) Reset() {
+	*x = GetThumbnailRequest{}
 	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetThumbnailsRequest) String() string {
+func (x *GetThumbnailRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetThumbnailsRequest) ProtoMessage() {}
+func (*GetThumbnailRequest) ProtoMessage() {}
 
-func (x *GetThumbnailsRequest) ProtoReflect() protoreflect.Message {
+func (x *GetThumbnailRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -155,67 +155,58 @@ func (x *GetThumbnailsRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetThumbnailsRequest.ProtoReflect.Descriptor instead.
-func (*GetThumbnailsRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetThumbnailRequest.ProtoReflect.Descriptor instead.
+func (*GetThumbnailRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *GetThumbnailsRequest) GetSessionIds() []string {
-	if x != nil {
-		return x.SessionIds
-	}
-	return nil
-}
-
-// GetThumbnailsResponse is a response for retrieving multiple session's thumbnails.
-type GetThumbnailsResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// SessionId is the ID of the session for which the thumbnail is being retrieved.
-	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	// Thumbnail is the thumbnail of the session.
-	Thumbnail     *SessionRecordingThumbnail `protobuf:"bytes,2,opt,name=thumbnail,proto3" json:"thumbnail,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *GetThumbnailsResponse) Reset() {
-	*x = GetThumbnailsResponse{}
-	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *GetThumbnailsResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetThumbnailsResponse) ProtoMessage() {}
-
-func (x *GetThumbnailsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetThumbnailsResponse.ProtoReflect.Descriptor instead.
-func (*GetThumbnailsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *GetThumbnailsResponse) GetSessionId() string {
+func (x *GetThumbnailRequest) GetSessionId() string {
 	if x != nil {
 		return x.SessionId
 	}
 	return ""
 }
 
-func (x *GetThumbnailsResponse) GetThumbnail() *SessionRecordingThumbnail {
+// GetThumbnailResponse is a response for retrieving a session's thumbnail.
+type GetThumbnailResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Thumbnail is the thumbnail for the session.
+	Thumbnail     *SessionRecordingThumbnail `protobuf:"bytes,1,opt,name=thumbnail,proto3" json:"thumbnail,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetThumbnailResponse) Reset() {
+	*x = GetThumbnailResponse{}
+	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetThumbnailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetThumbnailResponse) ProtoMessage() {}
+
+func (x *GetThumbnailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetThumbnailResponse.ProtoReflect.Descriptor instead.
+func (*GetThumbnailResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *GetThumbnailResponse) GetThumbnail() *SessionRecordingThumbnail {
 	if x != nil {
 		return x.Thumbnail
 	}
@@ -276,19 +267,17 @@ const file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_rawDesc
 	"\x18GetMetadataResponseChunk\x12U\n" +
 	"\bmetadata\x18\x01 \x01(\v27.teleport.recordingmetadata.v1.SessionRecordingMetadataH\x00R\bmetadata\x12P\n" +
 	"\x05frame\x18\x02 \x01(\v28.teleport.recordingmetadata.v1.SessionRecordingThumbnailH\x00R\x05frameB\a\n" +
-	"\x05chunk\"7\n" +
-	"\x14GetThumbnailsRequest\x12\x1f\n" +
-	"\vsession_ids\x18\x01 \x03(\tR\n" +
-	"sessionIds\"\x8e\x01\n" +
-	"\x15GetThumbnailsResponse\x12\x1d\n" +
+	"\x05chunk\"4\n" +
+	"\x13GetThumbnailRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12V\n" +
-	"\tthumbnail\x18\x02 \x01(\v28.teleport.recordingmetadata.v1.SessionRecordingThumbnailR\tthumbnail\"3\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"n\n" +
+	"\x14GetThumbnailResponse\x12V\n" +
+	"\tthumbnail\x18\x01 \x01(\v28.teleport.recordingmetadata.v1.SessionRecordingThumbnailR\tthumbnail\"3\n" +
 	"\x12GetMetadataRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId2\x95\x02\n" +
-	"\x18RecordingMetadataService\x12|\n" +
-	"\rGetThumbnails\x123.teleport.recordingmetadata.v1.GetThumbnailsRequest\x1a4.teleport.recordingmetadata.v1.GetThumbnailsResponse0\x01\x12{\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId2\x90\x02\n" +
+	"\x18RecordingMetadataService\x12w\n" +
+	"\fGetThumbnail\x122.teleport.recordingmetadata.v1.GetThumbnailRequest\x1a3.teleport.recordingmetadata.v1.GetThumbnailResponse\x12{\n" +
 	"\vGetMetadata\x121.teleport.recordingmetadata.v1.GetMetadataRequest\x1a7.teleport.recordingmetadata.v1.GetMetadataResponseChunk0\x01BfZdgithub.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1;recordingmetadatav1b\x06proto3"
 
 var (
@@ -306,8 +295,8 @@ func file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_rawDescG
 var file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_goTypes = []any{
 	(*GetMetadataResponseChunk)(nil),  // 0: teleport.recordingmetadata.v1.GetMetadataResponseChunk
-	(*GetThumbnailsRequest)(nil),      // 1: teleport.recordingmetadata.v1.GetThumbnailsRequest
-	(*GetThumbnailsResponse)(nil),     // 2: teleport.recordingmetadata.v1.GetThumbnailsResponse
+	(*GetThumbnailRequest)(nil),       // 1: teleport.recordingmetadata.v1.GetThumbnailRequest
+	(*GetThumbnailResponse)(nil),      // 2: teleport.recordingmetadata.v1.GetThumbnailResponse
 	(*GetMetadataRequest)(nil),        // 3: teleport.recordingmetadata.v1.GetMetadataRequest
 	(*SessionRecordingMetadata)(nil),  // 4: teleport.recordingmetadata.v1.SessionRecordingMetadata
 	(*SessionRecordingThumbnail)(nil), // 5: teleport.recordingmetadata.v1.SessionRecordingThumbnail
@@ -315,10 +304,10 @@ var file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_goTypes =
 var file_teleport_recordingmetadata_v1_recordingmetadata_service_proto_depIdxs = []int32{
 	4, // 0: teleport.recordingmetadata.v1.GetMetadataResponseChunk.metadata:type_name -> teleport.recordingmetadata.v1.SessionRecordingMetadata
 	5, // 1: teleport.recordingmetadata.v1.GetMetadataResponseChunk.frame:type_name -> teleport.recordingmetadata.v1.SessionRecordingThumbnail
-	5, // 2: teleport.recordingmetadata.v1.GetThumbnailsResponse.thumbnail:type_name -> teleport.recordingmetadata.v1.SessionRecordingThumbnail
-	1, // 3: teleport.recordingmetadata.v1.RecordingMetadataService.GetThumbnails:input_type -> teleport.recordingmetadata.v1.GetThumbnailsRequest
+	5, // 2: teleport.recordingmetadata.v1.GetThumbnailResponse.thumbnail:type_name -> teleport.recordingmetadata.v1.SessionRecordingThumbnail
+	1, // 3: teleport.recordingmetadata.v1.RecordingMetadataService.GetThumbnail:input_type -> teleport.recordingmetadata.v1.GetThumbnailRequest
 	3, // 4: teleport.recordingmetadata.v1.RecordingMetadataService.GetMetadata:input_type -> teleport.recordingmetadata.v1.GetMetadataRequest
-	2, // 5: teleport.recordingmetadata.v1.RecordingMetadataService.GetThumbnails:output_type -> teleport.recordingmetadata.v1.GetThumbnailsResponse
+	2, // 5: teleport.recordingmetadata.v1.RecordingMetadataService.GetThumbnail:output_type -> teleport.recordingmetadata.v1.GetThumbnailResponse
 	0, // 6: teleport.recordingmetadata.v1.RecordingMetadataService.GetMetadata:output_type -> teleport.recordingmetadata.v1.GetMetadataResponseChunk
 	5, // [5:7] is the sub-list for method output_type
 	3, // [3:5] is the sub-list for method input_type

--- a/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata_service_grpc.pb.go
@@ -33,8 +33,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	RecordingMetadataService_GetThumbnails_FullMethodName = "/teleport.recordingmetadata.v1.RecordingMetadataService/GetThumbnails"
-	RecordingMetadataService_GetMetadata_FullMethodName   = "/teleport.recordingmetadata.v1.RecordingMetadataService/GetMetadata"
+	RecordingMetadataService_GetThumbnail_FullMethodName = "/teleport.recordingmetadata.v1.RecordingMetadataService/GetThumbnail"
+	RecordingMetadataService_GetMetadata_FullMethodName  = "/teleport.recordingmetadata.v1.RecordingMetadataService/GetMetadata"
 )
 
 // RecordingMetadataServiceClient is the client API for RecordingMetadataService service.
@@ -43,8 +43,8 @@ const (
 //
 // RecordingMetadataService provides methods to retrieve metadata and thumbnails for a session recording.
 type RecordingMetadataServiceClient interface {
-	// GetThumbnails retrieves the thumbnails for many session recordings.
-	GetThumbnails(ctx context.Context, in *GetThumbnailsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetThumbnailsResponse], error)
+	// GetThumbnail retrieves the thumbnail for a session recording.
+	GetThumbnail(ctx context.Context, in *GetThumbnailRequest, opts ...grpc.CallOption) (*GetThumbnailResponse, error)
 	// GetMetadata retrieves the metadata for a session recording.
 	GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetMetadataResponseChunk], error)
 }
@@ -57,28 +57,19 @@ func NewRecordingMetadataServiceClient(cc grpc.ClientConnInterface) RecordingMet
 	return &recordingMetadataServiceClient{cc}
 }
 
-func (c *recordingMetadataServiceClient) GetThumbnails(ctx context.Context, in *GetThumbnailsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetThumbnailsResponse], error) {
+func (c *recordingMetadataServiceClient) GetThumbnail(ctx context.Context, in *GetThumbnailRequest, opts ...grpc.CallOption) (*GetThumbnailResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &RecordingMetadataService_ServiceDesc.Streams[0], RecordingMetadataService_GetThumbnails_FullMethodName, cOpts...)
+	out := new(GetThumbnailResponse)
+	err := c.cc.Invoke(ctx, RecordingMetadataService_GetThumbnail_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[GetThumbnailsRequest, GetThumbnailsResponse]{ClientStream: stream}
-	if err := x.ClientStream.SendMsg(in); err != nil {
-		return nil, err
-	}
-	if err := x.ClientStream.CloseSend(); err != nil {
-		return nil, err
-	}
-	return x, nil
+	return out, nil
 }
-
-// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type RecordingMetadataService_GetThumbnailsClient = grpc.ServerStreamingClient[GetThumbnailsResponse]
 
 func (c *recordingMetadataServiceClient) GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetMetadataResponseChunk], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &RecordingMetadataService_ServiceDesc.Streams[1], RecordingMetadataService_GetMetadata_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &RecordingMetadataService_ServiceDesc.Streams[0], RecordingMetadataService_GetMetadata_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +92,8 @@ type RecordingMetadataService_GetMetadataClient = grpc.ServerStreamingClient[Get
 //
 // RecordingMetadataService provides methods to retrieve metadata and thumbnails for a session recording.
 type RecordingMetadataServiceServer interface {
-	// GetThumbnails retrieves the thumbnails for many session recordings.
-	GetThumbnails(*GetThumbnailsRequest, grpc.ServerStreamingServer[GetThumbnailsResponse]) error
+	// GetThumbnail retrieves the thumbnail for a session recording.
+	GetThumbnail(context.Context, *GetThumbnailRequest) (*GetThumbnailResponse, error)
 	// GetMetadata retrieves the metadata for a session recording.
 	GetMetadata(*GetMetadataRequest, grpc.ServerStreamingServer[GetMetadataResponseChunk]) error
 	mustEmbedUnimplementedRecordingMetadataServiceServer()
@@ -115,8 +106,8 @@ type RecordingMetadataServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedRecordingMetadataServiceServer struct{}
 
-func (UnimplementedRecordingMetadataServiceServer) GetThumbnails(*GetThumbnailsRequest, grpc.ServerStreamingServer[GetThumbnailsResponse]) error {
-	return status.Errorf(codes.Unimplemented, "method GetThumbnails not implemented")
+func (UnimplementedRecordingMetadataServiceServer) GetThumbnail(context.Context, *GetThumbnailRequest) (*GetThumbnailResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetThumbnail not implemented")
 }
 func (UnimplementedRecordingMetadataServiceServer) GetMetadata(*GetMetadataRequest, grpc.ServerStreamingServer[GetMetadataResponseChunk]) error {
 	return status.Errorf(codes.Unimplemented, "method GetMetadata not implemented")
@@ -143,16 +134,23 @@ func RegisterRecordingMetadataServiceServer(s grpc.ServiceRegistrar, srv Recordi
 	s.RegisterService(&RecordingMetadataService_ServiceDesc, srv)
 }
 
-func _RecordingMetadataService_GetThumbnails_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(GetThumbnailsRequest)
-	if err := stream.RecvMsg(m); err != nil {
-		return err
+func _RecordingMetadataService_GetThumbnail_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetThumbnailRequest)
+	if err := dec(in); err != nil {
+		return nil, err
 	}
-	return srv.(RecordingMetadataServiceServer).GetThumbnails(m, &grpc.GenericServerStream[GetThumbnailsRequest, GetThumbnailsResponse]{ServerStream: stream})
+	if interceptor == nil {
+		return srv.(RecordingMetadataServiceServer).GetThumbnail(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RecordingMetadataService_GetThumbnail_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RecordingMetadataServiceServer).GetThumbnail(ctx, req.(*GetThumbnailRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
-
-// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type RecordingMetadataService_GetThumbnailsServer = grpc.ServerStreamingServer[GetThumbnailsResponse]
 
 func _RecordingMetadataService_GetMetadata_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(GetMetadataRequest)
@@ -171,13 +169,13 @@ type RecordingMetadataService_GetMetadataServer = grpc.ServerStreamingServer[Get
 var RecordingMetadataService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "teleport.recordingmetadata.v1.RecordingMetadataService",
 	HandlerType: (*RecordingMetadataServiceServer)(nil),
-	Methods:     []grpc.MethodDesc{},
-	Streams: []grpc.StreamDesc{
+	Methods: []grpc.MethodDesc{
 		{
-			StreamName:    "GetThumbnails",
-			Handler:       _RecordingMetadataService_GetThumbnails_Handler,
-			ServerStreams: true,
+			MethodName: "GetThumbnail",
+			Handler:    _RecordingMetadataService_GetThumbnail_Handler,
 		},
+	},
+	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "GetMetadata",
 			Handler:       _RecordingMetadataService_GetMetadata_Handler,

--- a/api/proto/teleport/recordingmetadata/v1/recordingmetadata.proto
+++ b/api/proto/teleport/recordingmetadata/v1/recordingmetadata.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 package teleport.recordingmetadata.v1;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1;recordingmetadatav1";
 
@@ -65,6 +66,12 @@ message SessionRecordingMetadata {
   int32 start_cols = 3;
   // StartRows is the number of rows in the terminal at the start of the session.
   int32 start_rows = 4;
+  // StartTime is the start time of the session recording.
+  google.protobuf.Timestamp start_time = 5;
+  // EndTime is the end time of the session recording.
+  google.protobuf.Timestamp end_time = 6;
+  // ClusterName is the name of the cluster where the session recording took place.
+  string cluster_name = 7;
 }
 
 // SessionRecordingMetadataWithFrames contains metadata and frames for a session recording.

--- a/api/proto/teleport/recordingmetadata/v1/recordingmetadata_service.proto
+++ b/api/proto/teleport/recordingmetadata/v1/recordingmetadata_service.proto
@@ -22,8 +22,8 @@ option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport
 
 // RecordingMetadataService provides methods to retrieve metadata and thumbnails for a session recording.
 service RecordingMetadataService {
-  // GetThumbnails retrieves the thumbnails for many session recordings.
-  rpc GetThumbnails(GetThumbnailsRequest) returns (stream GetThumbnailsResponse);
+  // GetThumbnail retrieves the thumbnail for a session recording.
+  rpc GetThumbnail(GetThumbnailRequest) returns (GetThumbnailResponse);
   // GetMetadata retrieves the metadata for a session recording.
   rpc GetMetadata(GetMetadataRequest) returns (stream GetMetadataResponseChunk);
 }
@@ -39,18 +39,16 @@ message GetMetadataResponseChunk {
   }
 }
 
-// GetThumbnailsRequest is a request for retrieving multiple session's thumbnails.
-message GetThumbnailsRequest {
-  // SessionIds are the ID of the sessions whose thumbnails are being requested.
-  repeated string session_ids = 1;
+// GetThumbnailRequest is a request for a session's thumbnail.
+message GetThumbnailRequest {
+  // SessionId is the ID of the session whose thumbnail is being requested.
+  string session_id = 1;
 }
 
-// GetThumbnailsResponse is a response for retrieving multiple session's thumbnails.
-message GetThumbnailsResponse {
-  // SessionId is the ID of the session for which the thumbnail is being retrieved.
-  string session_id = 1;
-  // Thumbnail is the thumbnail of the session.
-  teleport.recordingmetadata.v1.SessionRecordingThumbnail thumbnail = 2;
+// GetThumbnailResponse is a response for retrieving a session's thumbnail.
+message GetThumbnailResponse {
+  // Thumbnail is the thumbnail for the session.
+  teleport.recordingmetadata.v1.SessionRecordingThumbnail thumbnail = 1;
 }
 
 // GetMetadataRequest is a request for retrieving a session's metadata.


### PR DESCRIPTION
Now that we're not going to emit an audit event when a recording's thumbnail is accessed, this changes `GetThumbnails` to `GetThumbnail` so they can be requested individually

Adds the session start/end timestamps to the metadata proto message so we can implement #50890 and adds the cluster name so we can implement #9183

These protobufs aren't used anywhere currently so no risk of backwards compatibility issues