### PR TITLE
AWS Roles Anywhere: profile sync summary web api

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -338,6 +338,26 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 	}
 	ret.Integration = uiIg
 
+	integrationStatus := req.integration.GetStatus()
+
+	switch req.integration.GetSubKind() {
+	case types.IntegrationSubKindAWSRolesAnywhere:
+		ret.RolesAnywhereProfileSync = &ui.RolesAnywhereProfileSync{}
+
+		awsRolesAnywhereSpec := req.integration.GetAWSRolesAnywhereIntegrationSpec()
+		if awsRolesAnywhereSpec != nil {
+			ret.RolesAnywhereProfileSync.Enabled = awsRolesAnywhereSpec.ProfileSyncConfig.Enabled
+		}
+
+		if integrationStatus.AWSRolesAnywhere != nil {
+			ret.RolesAnywhereProfileSync.Status = integrationStatus.AWSRolesAnywhere.LastProfileSync.Status
+			ret.RolesAnywhereProfileSync.ErrorMessage = integrationStatus.AWSRolesAnywhere.LastProfileSync.ErrorMessage
+			ret.RolesAnywhereProfileSync.SyncedProfiles = int(integrationStatus.AWSRolesAnywhere.LastProfileSync.SyncedProfiles)
+			ret.RolesAnywhereProfileSync.SyncStartTime = integrationStatus.AWSRolesAnywhere.LastProfileSync.StartTime
+			ret.RolesAnywhereProfileSync.SyncEndTime = integrationStatus.AWSRolesAnywhere.LastProfileSync.EndTime
+		}
+	}
+
 	var nextPage string
 	for {
 		filters := &usertasksv1.ListUserTasksFilters{

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -124,6 +124,9 @@ type IntegrationWithSummary struct {
 	AWSRDS ResourceTypeSummary `json:"awsrds"`
 	// AWSEKS contains the summary for the AWS EKS resources for this integration.
 	AWSEKS ResourceTypeSummary `json:"awseks"`
+
+	// RolesAnywhereProfileSync contains the summary for the AWS Roles Anywhere Profile Sync.
+	RolesAnywhereProfileSync *RolesAnywhereProfileSync `json:"rolesAnywhereProfileSync,omitempty"`
 }
 
 // ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.
@@ -148,6 +151,26 @@ type ResourceTypeSummary struct {
 	// ECSDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
 	// Only applicable for AWS RDS resource summary.
 	ECSDatabaseServiceCount int `json:"ecsDatabaseServiceCount,omitempty"`
+}
+
+// RolesAnywhereProfileSync contains the summary for the AWS Roles Anywhere Profile Sync.
+type RolesAnywhereProfileSync struct {
+	// Enabled indicates whether the profile sync is enabled.
+	Enabled bool `json:"enabled"`
+
+	// Status is the string representation of the profile sync status.
+	// Either ERROR or SUCCESS.
+	Status string `json:"status,omitempty"`
+	// ErrorMessage is the error message from the last sync when the Status is ERROR.
+	ErrorMessage string `json:"errorMessage,omitempty"`
+
+	// SyncedProfiles is the number of profiles that were imported into Teleport.
+	SyncedProfiles int `json:"syncedProfiles,omitempty"`
+
+	// SyncStartTime is the time when the profile sync started.
+	SyncStartTime time.Time `json:"syncStartTime,omitempty"`
+	// SyncEndTime is the time when the profile sync ended.
+	SyncEndTime time.Time `json:"syncEndTime,omitempty"`
 }
 
 // IntegrationDiscoveryRule describes a discovery rule associated with an integration.


### PR DESCRIPTION
This PR adds the AWS IAM Roles Anywhere Status fields to the already existing endpoint which returns the integration status.