### PR TITLE
improve trusted cluster updates

### DIFF
--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -370,7 +370,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 			CAs:   []types.CertAuthority{leafClusterCA},
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "already registered")
+		require.Contains(t, err.Error(), "conflicts with an existing cluster or ca")
 	})
 
 	t.Run("Host User and Database CA are returned by default", func(t *testing.T) {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -477,18 +477,11 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *aut
 	// TODO(bernardjkim) consider using UpsertTrustedClusterV2 in VX.0.0
 	out, err := client.UpsertTrustedCluster(ctx, tc)
 	if err != nil {
-		// If force is used and UpsertTrustedCluster returns trace.AlreadyExists,
-		// this means the user tried to upsert a cluster whose exact match already
-		// exists in the backend, nothing needs to occur other than happy message
-		// that the trusted cluster has been created.
-		if rc.force && trace.IsAlreadyExists(err) {
-			out = tc
-		} else {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
 	}
+
 	if out.GetName() != tc.GetName() {
-		fmt.Printf("WARNING: trusted cluster %q resource has been renamed to match remote cluster name %q\n", name, out.GetName())
+		fmt.Printf("WARNING: trusted cluster resource %q has been renamed to match root cluster name %q. this will become an error in future teleport versions, please update your configuration to use the correct name.\n", name, out.GetName())
 	}
 	fmt.Printf("trusted cluster %q has been %v\n", out.GetName(), UpsertVerb(exists, rc.force))
 	return nil


### PR DESCRIPTION
Currently, a misnamed trusted cluster resource being used to perform an update appears to succeed when the update actually fails.  This confusing behavior results from a combination of a few issues.  First, we allow trusted cluster resources to be renamed inflight, which is just a bad idea.  Second, because the resource in this case is misnamed, the leaf auth server thinks it doesn't exist yet and re-attempts joining with the root, which looks to the root like an attempt to overwrite an existing trust relationship and is therefore rejected.  Finally, `tctl` suppresses `AlreadyExists` errors client-side for dubious reasons.  Combined, this result in a failure to update with no apparent problems client-side, and even when the user does discover the resulting error logs they are likely to be confused as to what is really going on.

This PR makes the root-side error a generic trace error and removes error suppression from tctl.  It also updates related error/log messages to indicate that future versions of teleport may do away with trusted cluster resource renaming (we already have an existing `UpsertTrustedClusterV2` method that does away with this behavior).

changelog: fixed an issue that would cause trusted cluster resource updates to fail silently.