### PR TITLE
Support azure joining with VMSS

### DIFF
--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -346,9 +346,9 @@ func claimsToIdentifiers(tokenClaims *accessTokenClaims) (subscriptionID, resour
 		return "", "", trace.Wrap(err, "failed to parse resource id from claims")
 	}
 
-	supportedResourceTypes := []string{azureVirtualMachine, azureVirtualMachineScaleSet}
 	for _, resourceType := range resourceID.ResourceType.Types {
-		if slices.Contains(supportedResourceTypes, resourceType) {
+		switch resourceType {
+		case azureVirtualMachine, azureVirtualMachineScaleSet:
 			return resourceID.SubscriptionID, resourceID.ResourceGroupName, nil
 		}
 	}

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -55,6 +55,8 @@ const (
 	azureUserAgent = "teleport"
 	// azureVirtualMachine specifies the Azure virtual machine resource type.
 	azureVirtualMachine = "virtualMachines"
+	// azureVirtualMachineScaleSet specifies the Azure virtual machine scale set resource type.
+	azureVirtualMachineScaleSet = "virtualMachineScaleSets"
 )
 
 // Structs for unmarshaling attested data. Schema can be found at
@@ -343,10 +345,14 @@ func claimsToIdentifiers(tokenClaims *accessTokenClaims) (subscriptionID, resour
 	if err != nil {
 		return "", "", trace.Wrap(err, "failed to parse resource id from claims")
 	}
-	if !slices.Contains(resourceID.ResourceType.Types, azureVirtualMachine) {
-		return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
+
+	supportedResourceTypes := []string{azureVirtualMachine, azureVirtualMachineScaleSet}
+	for _, resourceType := range resourceID.ResourceType.Types {
+		if slices.Contains(supportedResourceTypes, resourceType) {
+			return resourceID.SubscriptionID, resourceID.ResourceGroupName, nil
+		}
 	}
-	return resourceID.SubscriptionID, resourceID.ResourceGroupName, nil
+	return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
 }
 
 func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token *types.ProvisionTokenV2) error {


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/31758
Changelog: Enable Azure joining with VMSS

## Details
The Azure join method uses managed identity access tokens to authenticate a joining resource. Regular VM instances request access tokens that include claims with an Azure resource ID of type `virtualMachines`. VMSS instances request access tokens that include claims with an Azure resource ID of type `virtualMachineScaleSets`.