### PR TITLE
Add database type elasticache-serverless

### DIFF
--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -247,6 +247,53 @@ func TestDatabaseElastiCacheEndpoint(t *testing.T) {
 	})
 }
 
+func TestDatabaseElastiCacheServerlessEndpoint(t *testing.T) {
+	t.Run("valid URI", func(t *testing.T) {
+		database, err := NewDatabaseV3(Metadata{
+			Name: "example",
+		}, DatabaseSpecV3{
+			Protocol: "redis",
+			URI:      "example-abc123.serverless.cac1.cache.amazonaws.com:6379",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, AWS{
+			Region: "ca-central-1",
+			ElastiCacheServerless: ElastiCacheServerless{
+				CacheName: "example",
+			},
+		}, database.GetAWS())
+		require.True(t, database.IsElastiCacheServerless())
+		require.True(t, database.IsAWSHosted())
+		require.True(t, database.IsCloudHosted())
+	})
+
+	t.Run("invalid URI", func(t *testing.T) {
+		database, err := NewDatabaseV3(Metadata{
+			Name: "example",
+		}, DatabaseSpecV3{
+			Protocol: "redis",
+			URI:      "some.serverless.cache.amazonaws.com:6379",
+			AWS: AWS{
+				Region: "us-east-5",
+				ElastiCacheServerless: ElastiCacheServerless{
+					CacheName: "example",
+				},
+			},
+		})
+
+		// A warning is logged, no error is returned, and AWS metadata is not
+		// updated.
+		require.NoError(t, err)
+		require.Equal(t, AWS{
+			Region: "us-east-5",
+			ElastiCacheServerless: ElastiCacheServerless{
+				CacheName: "example",
+			},
+		}, database.GetAWS())
+	})
+}
+
 func TestDatabaseMemoryDBEndpoint(t *testing.T) {
 	t.Run("valid URI", func(t *testing.T) {
 		database, err := NewDatabaseV3(Metadata{

--- a/api/utils/aws/endpoint_test.go
+++ b/api/utils/aws/endpoint_test.go
@@ -322,6 +322,73 @@ func TestParseElastiCacheEndpoint(t *testing.T) {
 	}
 }
 
+func TestParseElastiCacheServerlessEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputURI    string
+		expectInfo  *RedisEndpointInfo
+		expectError bool
+	}{
+		{
+			name:     "normal endpoint",
+			inputURI: "example-asdf123.serverless.cac1.cache.amazonaws.com:6379",
+			expectInfo: &RedisEndpointInfo{
+				ID:                       "example",
+				Region:                   "ca-central-1",
+				TransitEncryptionEnabled: true,
+				EndpointType:             ElastiCacheConfigurationEndpoint,
+			},
+		},
+		{
+			name:     "CN endpoint",
+			inputURI: "example-asdf123.serverless.cnn1.cache.amazonaws.com.cn:6379",
+			expectInfo: &RedisEndpointInfo{
+				ID:                       "example",
+				Region:                   "cn-north-1",
+				TransitEncryptionEnabled: true,
+				EndpointType:             ElastiCacheConfigurationEndpoint,
+			},
+		},
+		{
+			name:     "endpoint with schema and parameters",
+			inputURI: "redis://example-asdf123.serverless.cac1.cache.amazonaws.com:6379?a=b&c=d",
+			expectInfo: &RedisEndpointInfo{
+				ID:                       "example",
+				Region:                   "ca-central-1",
+				TransitEncryptionEnabled: true,
+				EndpointType:             ElastiCacheConfigurationEndpoint,
+			},
+		},
+		{
+			name:        "invalid suffix",
+			inputURI:    "example.serverless.cac1.cache.amazonaws.io:6379",
+			expectError: true,
+		},
+		{
+			name:        "invalid url",
+			inputURI:    "://example.serverless.cac1.cache.amazonaws.com:6379",
+			expectError: true,
+		},
+		{
+			name:        "invalid format",
+			inputURI:    "example.serverless.cache.amazonaws.com:6379",
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualInfo, err := ParseElastiCacheServerlessEndpoint(test.inputURI)
+			if test.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectInfo, actualInfo)
+			}
+		})
+	}
+}
+
 func TestParseMemoryDBEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/api/utils/aws/fuzz_test.go
+++ b/api/utils/aws/fuzz_test.go
@@ -91,6 +91,24 @@ func FuzzParseElastiCacheEndpoint(f *testing.F) {
 	})
 }
 
+func FuzzParseElastiCacheServerlessEndpoint(f *testing.F) {
+	f.Add("")
+	f.Add(":123")
+	f.Add("foo:123")
+	f.Add("cache.b.c.usnw1.amazonaws.com")
+	f.Add("a.b.c.d.amazonaws.com:6379")
+	f.Add("a.serverless.c.cac1.cache.amazonaws.com:6379")
+	f.Add("example-cache-abc123.serverless.cac1.cache.amazonaws.com:6379")
+	f.Add("redis://example-cache-abc123.serverless.cac1.cache.amazonaws.com:6379")
+	f.Add("://://example-cache-abc123.serverless.cac1.cache.amazonaws.com:6379")
+
+	f.Fuzz(func(t *testing.T, endpoint string) {
+		require.NotPanics(t, func() {
+			_, _ = ParseElastiCacheServerlessEndpoint(endpoint)
+		})
+	})
+}
+
 func FuzzParseDynamoDBEndpoint(f *testing.F) {
 	f.Add("")
 	f.Add(":123")

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -147,6 +147,9 @@ build_teleport_api_fuzzers() {
     FuzzParseElastiCacheEndpoint fuzz_parse_elasti_cache_endpoint
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/api/utils/aws \
+    FuzzParseElastiCacheServerlessEndpoint fuzz_parse_elasti_cache_serverless_endpoint
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/api/utils/aws \
     FuzzParseDynamoDBEndpoint fuzz_parse_dynamodb_endpoint
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/api/utils/azure \


### PR DESCRIPTION
Part of
- https://github.com/gravitational/teleport/issues/40225

Stacked on another PR:
- https://github.com/gravitational/teleport/pull/58014

This PR adds endpoint parsing and database spec validation for ElastiCache Serverless.