### PR TITLE
Manual AMI updates for 18.1.5

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -2,7 +2,7 @@
 # This must be a _released_ version of Teleport, i.e. one which has binaries
 # available for download on https://goteleport.com/download
 # Unreleased versions will fail to build.
-TELEPORT_VERSION ?= 18.1.4
+TELEPORT_VERSION ?= 18.1.5
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/examples/aws/terraform/AMIS.md
+++ b/examples/aws/terraform/AMIS.md
@@ -6,116 +6,116 @@ This list is updated when new AMI versions are released.
 ### OSS
 
 ```
-# ap-northeast-1 v18.1.4 arm64 OSS: ami-00f58c26e3553e6c5
-# ap-northeast-1 v18.1.4 x86_64 OSS: ami-04a33984128357275
-# ap-northeast-2 v18.1.4 arm64 OSS: ami-0b02728382947af38
-# ap-northeast-2 v18.1.4 x86_64 OSS: ami-02b2f40d51637bf3b
-# ap-northeast-3 v18.1.4 arm64 OSS: ami-0f2a12e726fd0e376
-# ap-northeast-3 v18.1.4 x86_64 OSS: ami-073414dce838143b8
-# ap-south-1 v18.1.4 arm64 OSS: ami-093b8bf061877a8ef
-# ap-south-1 v18.1.4 x86_64 OSS: ami-00dba1712726cce67
-# ap-southeast-1 v18.1.4 arm64 OSS: ami-0bb05316ea507cc84
-# ap-southeast-1 v18.1.4 x86_64 OSS: ami-01e898932fb3a49b5
-# ap-southeast-2 v18.1.4 arm64 OSS: ami-0d3da18ecb44fa7e0
-# ap-southeast-2 v18.1.4 x86_64 OSS: ami-07f75dd2bf39b5982
-# ca-central-1 v18.1.4 arm64 OSS: ami-00320a861a1dc230c
-# ca-central-1 v18.1.4 x86_64 OSS: ami-0613d2c750b926849
-# eu-central-1 v18.1.4 arm64 OSS: ami-0dfc19c0571831074
-# eu-central-1 v18.1.4 x86_64 OSS: ami-070d18995aec999b7
-# eu-north-1 v18.1.4 arm64 OSS: ami-0f340c15480edc2c7
-# eu-north-1 v18.1.4 x86_64 OSS: ami-0a87af54b2a874163
-# eu-west-1 v18.1.4 arm64 OSS: ami-06e08f034b7734b51
-# eu-west-1 v18.1.4 x86_64 OSS: ami-04d0fbbfc37375c20
-# eu-west-2 v18.1.4 arm64 OSS: ami-0cecd64c3b6d29250
-# eu-west-2 v18.1.4 x86_64 OSS: ami-024b4d7cbe5b092b4
-# eu-west-3 v18.1.4 arm64 OSS: ami-0e60c9b55e4050d4f
-# eu-west-3 v18.1.4 x86_64 OSS: ami-0763e9f8f2705bec4
-# sa-east-1 v18.1.4 arm64 OSS: ami-0980b63af72d1333f
-# sa-east-1 v18.1.4 x86_64 OSS: ami-08564f3d70c4f7c7b
-# us-east-1 v18.1.4 arm64 OSS: ami-0bb8afb24cba3b18a
-# us-east-1 v18.1.4 x86_64 OSS: ami-0ec0db60e48e505cb
-# us-east-2 v18.1.4 arm64 OSS: ami-00efbbb8bebf22bd0
-# us-east-2 v18.1.4 x86_64 OSS: ami-0e5b9830453c06df6
-# us-west-1 v18.1.4 arm64 OSS: ami-05216d713e78fcfa8
-# us-west-1 v18.1.4 x86_64 OSS: ami-0349b6ddf28d50775
-# us-west-2 v18.1.4 arm64 OSS: ami-0dfcab5c69695acdc
-# us-west-2 v18.1.4 x86_64 OSS: ami-02ddc4450d27390b6
+# ap-northeast-1 v18.1.5 arm64 OSS: ami-0a71ca1e96a9d4e48
+# ap-northeast-1 v18.1.5 x86_64 OSS: ami-06feaa862cd66c693
+# ap-northeast-2 v18.1.5 arm64 OSS: ami-0258b25694c7aca59
+# ap-northeast-2 v18.1.5 x86_64 OSS: ami-09cebbdfa43ba87d2
+# ap-northeast-3 v18.1.5 arm64 OSS: ami-04b58cca68b378d9a
+# ap-northeast-3 v18.1.5 x86_64 OSS: ami-0bcb4dd33b9e4088e
+# ap-south-1 v18.1.5 arm64 OSS: ami-0ec6807196932cdba
+# ap-south-1 v18.1.5 x86_64 OSS: ami-0a03bb2dbb7a0789c
+# ap-southeast-1 v18.1.5 arm64 OSS: ami-006feea54d686e869
+# ap-southeast-1 v18.1.5 x86_64 OSS: ami-05cbb6e886c6347ea
+# ap-southeast-2 v18.1.5 arm64 OSS: ami-0dcef260e1ae82072
+# ap-southeast-2 v18.1.5 x86_64 OSS: ami-03b112172dcfa8e2e
+# ca-central-1 v18.1.5 arm64 OSS: ami-07f5a6fd892a4fc09
+# ca-central-1 v18.1.5 x86_64 OSS: ami-0a7b622aea3bf9381
+# eu-central-1 v18.1.5 arm64 OSS: ami-065b50e26286306c4
+# eu-central-1 v18.1.5 x86_64 OSS: ami-0b9263a153635b85f
+# eu-north-1 v18.1.5 arm64 OSS: ami-09b83ed7389f37a7d
+# eu-north-1 v18.1.5 x86_64 OSS: ami-076ecc917746577a3
+# eu-west-1 v18.1.5 arm64 OSS: ami-0902f8ff928875ae0
+# eu-west-1 v18.1.5 x86_64 OSS: ami-074ee886fe9db18ca
+# eu-west-2 v18.1.5 arm64 OSS: ami-01a735c2f4711bd9e
+# eu-west-2 v18.1.5 x86_64 OSS: ami-01eaec7ccfa6267f4
+# eu-west-3 v18.1.5 arm64 OSS: ami-098eaedf521d6a3a6
+# eu-west-3 v18.1.5 x86_64 OSS: ami-0ab82d71ae02bc8cf
+# sa-east-1 v18.1.5 arm64 OSS: ami-0e29127a081788557
+# sa-east-1 v18.1.5 x86_64 OSS: ami-0998516c742397173
+# us-east-1 v18.1.5 arm64 OSS: ami-064b6d2b85d37990d
+# us-east-1 v18.1.5 x86_64 OSS: ami-067a40320aa5e34fe
+# us-east-2 v18.1.5 arm64 OSS: ami-0cbaf62367f9285f7
+# us-east-2 v18.1.5 x86_64 OSS: ami-01a752cdde99b603a
+# us-west-1 v18.1.5 arm64 OSS: ami-0cf53cb8f171bfc32
+# us-west-1 v18.1.5 x86_64 OSS: ami-0a9cd936eaab86d4f
+# us-west-2 v18.1.5 arm64 OSS: ami-00f812ebaa6e5e29d
+# us-west-2 v18.1.5 x86_64 OSS: ami-0640708a0b94cdd2e
 ```
 
 ### Enterprise
 
 ```
-# ap-northeast-1 v18.1.4 arm64 Enterprise: ami-053aaa21ed6be61f5
-# ap-northeast-1 v18.1.4 x86_64 Enterprise: ami-0749287ed436b90b3
-# ap-northeast-2 v18.1.4 arm64 Enterprise: ami-00d3b5fc2372c231c
-# ap-northeast-2 v18.1.4 x86_64 Enterprise: ami-0a091802b84a0fe95
-# ap-northeast-3 v18.1.4 arm64 Enterprise: ami-0044a017f6628b914
-# ap-northeast-3 v18.1.4 x86_64 Enterprise: ami-04ff44b85c7555007
-# ap-south-1 v18.1.4 arm64 Enterprise: ami-04f816df15105b22d
-# ap-south-1 v18.1.4 x86_64 Enterprise: ami-00a9a4c427c2751c9
-# ap-southeast-1 v18.1.4 arm64 Enterprise: ami-0b01542887ed62ba0
-# ap-southeast-1 v18.1.4 x86_64 Enterprise: ami-0a0ea7ab9c5c4e653
-# ap-southeast-2 v18.1.4 arm64 Enterprise: ami-0e65d53ed5ab14656
-# ap-southeast-2 v18.1.4 x86_64 Enterprise: ami-0be9d4200b39d2699
-# ca-central-1 v18.1.4 arm64 Enterprise: ami-0345c18c1362fbeb7
-# ca-central-1 v18.1.4 x86_64 Enterprise: ami-0bb4dd24911840870
-# eu-central-1 v18.1.4 arm64 Enterprise: ami-0b3a2b0eeeb3d9dd0
-# eu-central-1 v18.1.4 x86_64 Enterprise: ami-00450f9cadb2ce5bd
-# eu-north-1 v18.1.4 arm64 Enterprise: ami-0c1c9506712311bf8
-# eu-north-1 v18.1.4 x86_64 Enterprise: ami-074a0f0c47519e153
-# eu-west-1 v18.1.4 arm64 Enterprise: ami-02dd6efb0f154cc0b
-# eu-west-1 v18.1.4 x86_64 Enterprise: ami-0701e956205696e3f
-# eu-west-2 v18.1.4 arm64 Enterprise: ami-0eccef3eb29733b16
-# eu-west-2 v18.1.4 x86_64 Enterprise: ami-0f70c032012971935
-# eu-west-3 v18.1.4 arm64 Enterprise: ami-01e0461628de4bbbe
-# eu-west-3 v18.1.4 x86_64 Enterprise: ami-0b0c5bebc44fe5eb0
-# sa-east-1 v18.1.4 arm64 Enterprise: ami-02df19d5d5ca62962
-# sa-east-1 v18.1.4 x86_64 Enterprise: ami-0d348274a7ba36ce6
-# us-east-1 v18.1.4 arm64 Enterprise: ami-0264e4994f34d4bc8
-# us-east-1 v18.1.4 x86_64 Enterprise: ami-0ae8a6e715bd8e27d
-# us-east-2 v18.1.4 arm64 Enterprise: ami-0a6bbf1a0c7669892
-# us-east-2 v18.1.4 x86_64 Enterprise: ami-0a11c9969c90f1fb4
-# us-west-1 v18.1.4 arm64 Enterprise: ami-0f3c2e610571bffdc
-# us-west-1 v18.1.4 x86_64 Enterprise: ami-0737d11444da908be
-# us-west-2 v18.1.4 arm64 Enterprise: ami-0156da5300fa44c50
-# us-west-2 v18.1.4 x86_64 Enterprise: ami-0dcfbe8175ef5f315
+# ap-northeast-1 v18.1.5 arm64 Enterprise: ami-01f6b43b77c867e7e
+# ap-northeast-1 v18.1.5 x86_64 Enterprise: ami-08e6c4721f1a6ccff
+# ap-northeast-2 v18.1.5 arm64 Enterprise: ami-0641b87a57c520578
+# ap-northeast-2 v18.1.5 x86_64 Enterprise: ami-069a3cb5d43c2f6ff
+# ap-northeast-3 v18.1.5 arm64 Enterprise: ami-029671b0b283b146f
+# ap-northeast-3 v18.1.5 x86_64 Enterprise: ami-05eea636a2dde3778
+# ap-south-1 v18.1.5 arm64 Enterprise: ami-0f3f51b121c99d726
+# ap-south-1 v18.1.5 x86_64 Enterprise: ami-071e073d8795a57f2
+# ap-southeast-1 v18.1.5 arm64 Enterprise: ami-041d07bdb0fb5de9f
+# ap-southeast-1 v18.1.5 x86_64 Enterprise: ami-0af2db03ece382cef
+# ap-southeast-2 v18.1.5 arm64 Enterprise: ami-0e824718f9e4b86e5
+# ap-southeast-2 v18.1.5 x86_64 Enterprise: ami-0392a910588a00bf4
+# ca-central-1 v18.1.5 arm64 Enterprise: ami-0acf3ba2ebc2211f3
+# ca-central-1 v18.1.5 x86_64 Enterprise: ami-0b071b8ad7e6455f9
+# eu-central-1 v18.1.5 arm64 Enterprise: ami-055ef2bb12a87f7b0
+# eu-central-1 v18.1.5 x86_64 Enterprise: ami-071248d5a749eb5be
+# eu-north-1 v18.1.5 arm64 Enterprise: ami-0433a46c949f4b5f8
+# eu-north-1 v18.1.5 x86_64 Enterprise: ami-06d1c618ec89ae360
+# eu-west-1 v18.1.5 arm64 Enterprise: ami-020382c0a8f2d3f51
+# eu-west-1 v18.1.5 x86_64 Enterprise: ami-0c70917656b6110f4
+# eu-west-2 v18.1.5 arm64 Enterprise: ami-01a0ddfd01c577fe8
+# eu-west-2 v18.1.5 x86_64 Enterprise: ami-088de4791d93a12ef
+# eu-west-3 v18.1.5 arm64 Enterprise: ami-093852c2196e15e4b
+# eu-west-3 v18.1.5 x86_64 Enterprise: ami-0b24613308449af3d
+# sa-east-1 v18.1.5 arm64 Enterprise: ami-008bdb367474bc42f
+# sa-east-1 v18.1.5 x86_64 Enterprise: ami-0e2dbf3558ae7d949
+# us-east-1 v18.1.5 arm64 Enterprise: ami-0e7769841bd9997d8
+# us-east-1 v18.1.5 x86_64 Enterprise: ami-06824ed57f9da8dc7
+# us-east-2 v18.1.5 arm64 Enterprise: ami-086d0067e1d3953af
+# us-east-2 v18.1.5 x86_64 Enterprise: ami-07c4e74d14126dd91
+# us-west-1 v18.1.5 arm64 Enterprise: ami-0fec8fc9fb327a60d
+# us-west-1 v18.1.5 x86_64 Enterprise: ami-0b71afae6f42afb30
+# us-west-2 v18.1.5 arm64 Enterprise: ami-083d4c8854cb0b7ad
+# us-west-2 v18.1.5 x86_64 Enterprise: ami-032f20e48baa91850
 ```
 
 ### Enterprise FIPS
 
 ```
-# ap-northeast-1 v18.1.4 arm64 Enterprise FIPS: ami-0044552861a87fc37
-# ap-northeast-1 v18.1.4 x86_64 Enterprise FIPS: ami-0174efee9ccb4cf2d
-# ap-northeast-2 v18.1.4 arm64 Enterprise FIPS: ami-020ef9e7514452514
-# ap-northeast-2 v18.1.4 x86_64 Enterprise FIPS: ami-0dae6a925591b96d9
-# ap-northeast-3 v18.1.4 arm64 Enterprise FIPS: ami-05b6aec7b501045ad
-# ap-northeast-3 v18.1.4 x86_64 Enterprise FIPS: ami-0238519d5969e30d8
-# ap-south-1 v18.1.4 arm64 Enterprise FIPS: ami-074f3cf6136684570
-# ap-south-1 v18.1.4 x86_64 Enterprise FIPS: ami-03e7f9e9b7740b09f
-# ap-southeast-1 v18.1.4 arm64 Enterprise FIPS: ami-0d8842386285169ae
-# ap-southeast-1 v18.1.4 x86_64 Enterprise FIPS: ami-0f06c7771dbb2492d
-# ap-southeast-2 v18.1.4 arm64 Enterprise FIPS: ami-0c1eccd3dc9c216c3
-# ap-southeast-2 v18.1.4 x86_64 Enterprise FIPS: ami-063d708339f62a232
-# ca-central-1 v18.1.4 arm64 Enterprise FIPS: ami-003456c021d4ffce9
-# ca-central-1 v18.1.4 x86_64 Enterprise FIPS: ami-01274e0cbbcc636e8
-# eu-central-1 v18.1.4 arm64 Enterprise FIPS: ami-005811041afd976cf
-# eu-central-1 v18.1.4 x86_64 Enterprise FIPS: ami-06b2750c921510020
-# eu-north-1 v18.1.4 arm64 Enterprise FIPS: ami-0d3093fb89745a77e
-# eu-north-1 v18.1.4 x86_64 Enterprise FIPS: ami-058211b3fcb5e6109
-# eu-west-1 v18.1.4 arm64 Enterprise FIPS: ami-0da30a1f82ef7b58e
-# eu-west-1 v18.1.4 x86_64 Enterprise FIPS: ami-03e9c8573478d4e56
-# eu-west-2 v18.1.4 arm64 Enterprise FIPS: ami-0ac78117b664f0047
-# eu-west-2 v18.1.4 x86_64 Enterprise FIPS: ami-0ba59104bca0413ae
-# eu-west-3 v18.1.4 arm64 Enterprise FIPS: ami-0377d69b88cdb7823
-# eu-west-3 v18.1.4 x86_64 Enterprise FIPS: ami-0b1e59a182b5534e0
-# sa-east-1 v18.1.4 arm64 Enterprise FIPS: ami-00fba519ce4a03455
-# sa-east-1 v18.1.4 x86_64 Enterprise FIPS: ami-0396ff67899c08ec0
-# us-east-1 v18.1.4 arm64 Enterprise FIPS: ami-0c9555fca4078aae4
-# us-east-1 v18.1.4 x86_64 Enterprise FIPS: ami-05de5f8be92dbdd47
-# us-east-2 v18.1.4 arm64 Enterprise FIPS: ami-057b63db2de33705d
-# us-east-2 v18.1.4 x86_64 Enterprise FIPS: ami-02b3bcb3631425278
-# us-west-1 v18.1.4 arm64 Enterprise FIPS: ami-08fa433db85b91924
-# us-west-1 v18.1.4 x86_64 Enterprise FIPS: ami-0e06d8a1c99eab0de
-# us-west-2 v18.1.4 arm64 Enterprise FIPS: ami-03997ebe01b10bf70
-# us-west-2 v18.1.4 x86_64 Enterprise FIPS: ami-05484fe752353e674
+# ap-northeast-1 v18.1.5 arm64 Enterprise FIPS: ami-05766148d1b256766
+# ap-northeast-1 v18.1.5 x86_64 Enterprise FIPS: ami-034f67b9b7fe648bc
+# ap-northeast-2 v18.1.5 arm64 Enterprise FIPS: ami-0b010940858af6e90
+# ap-northeast-2 v18.1.5 x86_64 Enterprise FIPS: ami-06e8f70bb65fc7bd3
+# ap-northeast-3 v18.1.5 arm64 Enterprise FIPS: ami-05f08d2e617fd5af3
+# ap-northeast-3 v18.1.5 x86_64 Enterprise FIPS: ami-0dab4bf7dab4177b6
+# ap-south-1 v18.1.5 arm64 Enterprise FIPS: ami-0509a6b80a759665f
+# ap-south-1 v18.1.5 x86_64 Enterprise FIPS: ami-0f4f9496d733a2f11
+# ap-southeast-1 v18.1.5 arm64 Enterprise FIPS: ami-026847d5b28a71369
+# ap-southeast-1 v18.1.5 x86_64 Enterprise FIPS: ami-0e407a15e07d395fe
+# ap-southeast-2 v18.1.5 arm64 Enterprise FIPS: ami-043eb71454715559d
+# ap-southeast-2 v18.1.5 x86_64 Enterprise FIPS: ami-02ac524a28be5214c
+# ca-central-1 v18.1.5 arm64 Enterprise FIPS: ami-0dec2c33eaadc4430
+# ca-central-1 v18.1.5 x86_64 Enterprise FIPS: ami-03b86cf7689d3cdea
+# eu-central-1 v18.1.5 arm64 Enterprise FIPS: ami-0ab9a806dfc94387e
+# eu-central-1 v18.1.5 x86_64 Enterprise FIPS: ami-028181235461c32b1
+# eu-north-1 v18.1.5 arm64 Enterprise FIPS: ami-03ce05163a6736722
+# eu-north-1 v18.1.5 x86_64 Enterprise FIPS: ami-0d4c7fc4c112ac1e2
+# eu-west-1 v18.1.5 arm64 Enterprise FIPS: ami-0bd32f5bef97acc15
+# eu-west-1 v18.1.5 x86_64 Enterprise FIPS: ami-0c2fb194aab68104c
+# eu-west-2 v18.1.5 arm64 Enterprise FIPS: ami-0da99b08853db794c
+# eu-west-2 v18.1.5 x86_64 Enterprise FIPS: ami-0e75221c3f5e0dcff
+# eu-west-3 v18.1.5 arm64 Enterprise FIPS: ami-03297044e7723cfd9
+# eu-west-3 v18.1.5 x86_64 Enterprise FIPS: ami-0a7417a4785c2f90a
+# sa-east-1 v18.1.5 arm64 Enterprise FIPS: ami-06f906a291035726d
+# sa-east-1 v18.1.5 x86_64 Enterprise FIPS: ami-012551019788c28c2
+# us-east-1 v18.1.5 arm64 Enterprise FIPS: ami-009b7783da14a8bde
+# us-east-1 v18.1.5 x86_64 Enterprise FIPS: ami-0b0844540ed6b6319
+# us-east-2 v18.1.5 arm64 Enterprise FIPS: ami-00e151e9a429878b3
+# us-east-2 v18.1.5 x86_64 Enterprise FIPS: ami-031f2d00d76ccd7ca
+# us-west-1 v18.1.5 arm64 Enterprise FIPS: ami-0738ba3acb60fb8cb
+# us-west-1 v18.1.5 x86_64 Enterprise FIPS: ami-031fe9234cf50e381
+# us-west-2 v18.1.5 arm64 Enterprise FIPS: ami-069313d929f73f13f
+# us-west-2 v18.1.5 x86_64 Enterprise FIPS: ami-0e34796dd645c729a
 ```

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -46,7 +46,7 @@ export TF_VAR_cluster_name="teleport.example.com"
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-export TF_VAR_ami_name="teleport-ent-18.1.4-arm64"
+export TF_VAR_ami_name="teleport-ent-18.1.5-arm64"
 
 # Instance types used for authentication server auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -98,7 +98,7 @@ TF_VAR_license_path ?= "/path/to/license"
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-TF_VAR_ami_name ?= "teleport-ent-18.1.4-arm64"
+TF_VAR_ami_name ?= "teleport-ent-18.1.5-arm64"
 
 # Route 53 hosted zone to use, must be a root zone registered in AWS, e.g. example.com
 TF_VAR_route53_zone ?= "example.com"


### PR DESCRIPTION
Forgot to set the latest flag when creating the 18.1.5 release so this didn't run automatically. Updated the AMI's manually using the script.