### PR TITLE
Web UI: Add DeviceSource to TrustedDevice type

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.test.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { DeviceOrigin, deviceSource, DeviceSource } from './types';
+
+describe('deviceSource', () => {
+  const tests: Array<{
+    name: string;
+    source: DeviceSource | undefined;
+    want: string;
+  }> = [
+    {
+      name: 'default name for origin',
+      source: { origin: DeviceOrigin.Intune, name: 'intune' },
+      want: 'Intune',
+    },
+    {
+      name: 'custom name',
+      source: { origin: DeviceOrigin.Jamf, name: 'cool jamf' },
+      want: 'cool jamf',
+    },
+    {
+      name: 'no source',
+      source: undefined,
+      want: '',
+    },
+    {
+      name: 'unsupported origin',
+      source: { origin: 1337 as DeviceOrigin, name: 'even cooler jamf' },
+      // Show the name instead of something like "unknown" as name is required and likely more
+      // informative than displaying "unknown".
+      want: 'even cooler jamf',
+    },
+  ];
+
+  test.each(tests)('$name', ({ source, want }) => {
+    expect(deviceSource(source)).toEqual(want);
+  });
+});

--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -25,6 +25,29 @@ export type TrustedDevice = {
   enrollStatus: 'enrolled' | 'not enrolled';
   owner: string;
   createTime?: Date;
+  /**
+   * source indicates how the device got into Teleport's inventory.
+   * Devices registered directly via Teleport through tctl have no assigned source.
+   */
+  source?: DeviceSource;
+};
+
+/**
+ * DeviceSource indicates how the device got into Teleport's inventory.
+ * Devices registered directly via Teleport through tctl have no assigned source.
+ */
+export type DeviceSource = {
+  /**
+   * name is an arbitrary name that can be set when using either the Jamf integration [1] or when
+   * registering devices through the Teleport API.
+   *
+   * When using the Jamf or Intune integrations with default settings, it's set to "jamf" and
+   * "intune" respectively.
+   *
+   * [1]: https://goteleport.com/docs/identity-governance/device-trust/jamf-integration/#optional-sync-multiple-sources
+   */
+  name: string;
+  origin: DeviceOrigin;
 };
 
 export type TrustedDeviceOSType = 'Windows' | 'Linux' | 'macOS';
@@ -40,4 +63,43 @@ export type DeviceListProps = {
   pagerPosition?: PagerPosition;
   fetchStatus?: 'loading' | 'disabled' | '';
   fetchData?: () => void;
+};
+
+export enum DeviceOrigin {
+  Unspecified = 0,
+  /**
+   * Api is only ever set if a customer wrote a 3rd-party solution for syncing devices and uses
+   * Teleport's API directly. The customer would be steered into using this origin, as setting the
+   * origin and the name is required by the API (see e/lib/devicetrust/storage.ValidateDeviceForCreate).
+   */
+  Api,
+  Jamf,
+  Intune,
+}
+
+export function deviceSource(source: DeviceSource | undefined): string {
+  if (!source) {
+    return '';
+  }
+
+  // Display the name only if it's not equal to the default name used by the given origin.
+  if (source.name == originToDefaultName[source.origin]) {
+    return originToPrettyName[source.origin];
+  }
+
+  return source.name;
+}
+
+/**
+ * originToDefaultName maps an origin to the default name each MDM integration uses as its source
+ * name.
+ */
+const originToDefaultName: Partial<Record<DeviceOrigin, string>> = {
+  [DeviceOrigin.Jamf]: 'jamf',
+  [DeviceOrigin.Intune]: 'intune',
+};
+
+const originToPrettyName: Partial<Record<DeviceOrigin, string>> = {
+  [DeviceOrigin.Jamf]: 'Jamf',
+  [DeviceOrigin.Intune]: 'Intune',
 };


### PR DESCRIPTION
* Part of https://github.com/gravitational/teleport.e/issues/6930

Changes in the PR are necessary to display the source column in the trusted devices table. Since we're now going to offer a second source for devices (Intune in addition to the existing Jamf integration), customers should be able to discern the source for devices if they use both integrations at the same time.