### PR TITLE
Add docs for Teleport Connect managed updates

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -219,6 +219,7 @@
     "SVIDs",
     "SailPoint",
     "Secretless",
+    "setx",
     "Shockbyte",
     "Silverfort's",
     "Slackbot",

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -98,11 +98,12 @@ to manage updates, you can manually choose the cluster in the
 Like the CLI tools, Teleport Connect respects the `TELEPORT_CDN_BASE_URL` and
 `TELEPORT_TOOLS_VERSION` environment variables.
 
-* `TELEPORT_CDN_BASE_URL` lets you use custom builds or mirror the CDN in a private
+`TELEPORT_CDN_BASE_URL` lets you use custom builds or mirror the CDN in a private
 network (for example `https://example.com`).
-* `TELEPORT_TOOLS_VERSION` controls client tool updates:
-* Set to `off` to completely disable managed updates.
-* Set to a specific version (e.g. `18.0.1`) to override the cluster-provided version
+
+`TELEPORT_TOOLS_VERSION` controls client tool updates:
+- Set to `off` to completely disable managed updates.
+- Set to a specific version (e.g. `18.0.1`) to override the cluster-provided version
 (for example, to work around a known issue).
 
 To use an environment variable with Teleport Connect, open your terminal and launch
@@ -114,25 +115,25 @@ For a permanent setup, follow the instructions below:
 <Tabs>
   <TabItem label="macOS">
     To set the variable for your current login session, open the Terminal and type:
-    ```console
-    launchctl set env TELEPORT_TOOLS_VERSION X.Y.Z
+    ```code
+    $ launchctl set env TELEPORT_TOOLS_VERSION X.Y.Z
     ```
     Then run Teleport Connect as usual. This setting persists until you log out.
   </TabItem>
   <TabItem label="Windows">
     To set the variable permanently for your user account, open the Command Prompt and type:
-    ```console
-    setx TELEPORT_TOOLS_VERSION X.Y.Z
+    ```code
+    $ setx TELEPORT_TOOLS_VERSION X.Y.Z
     ```
     Then run Teleport Connect as usual. To clear it, use:
-    ```console
-    setx TELEPORT_TOOLS_VERSION ""
+    ```code
+    $ setx TELEPORT_TOOLS_VERSION ""
     ```
   </TabItem>
   <TabItem label="Linux">
     To set the variable permanently for the app, prepend the environment variable to
     the `Exec=` line in  `usr/share/applications/teleport-connect.desktop` file:
-    ```console
+    ```text
     Exec=env TELEPORT_TOOLS_VERSION=X.Y.Z "/opt/Teleport Connect/teleport-connect" %U
     ```
   </TabItem>

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -20,7 +20,7 @@ version. Teleport Connect supports macOS, Linux, and Windows.
 <TabItem label="macOS">
 Double-click the downloaded `.dmg` file and drag the Teleport Connect icon to the Applications folder.
 
-To upgrade Teleport Connect to a newer version, drag the new version to the Applications folder.
+To manually upgrade Teleport Connect to a newer version, drag the new version to the Applications folder.
 </TabItem>
 <TabItem label="Linux">
 Download the DEB (Debian-based distros) or RPM (RHEL-based distros) package and install it using
@@ -57,6 +57,85 @@ When upgrading to 17.3.0+ from an older version, the installer will
 automatically handle the migration to a per-machine installation.
 
 </TabItem>
+</Tabs>
+
+### Managed updates
+
+Teleport Connect supports [Teleport Client Tool Managed Updates](../upgrading/client-tools-managed-updates.mdx).
+When enabled in your cluster, the app checks for available updates at login,
+downloads them automatically, and prompts you to restart. On Windows and Linux,
+you may be asked to provide administrator credentials to complete the installation.
+
+You can also check for updates manually via "Check for Updates…" in the
+additional actions menu.
+
+<Admonition
+  type="warning"
+  title="Note"
+>
+  Managed updates are not supported for Linux `tar.gz` builds.
+</Admonition>
+
+#### Multiple clusters
+
+If you are connected to multiple clusters, Teleport Connect selects the highest client
+version that is compatible across all clusters according to [Teleport component compatibility rules](../upgrading/overview.mdx#component-compatibility).
+If clusters require incompatible versions, or if you want a different cluster
+to manage updates, you can manually choose the cluster in the
+"Check for Updates…" dialog, available in the additional actions menu.
+
+<Admonition
+  type="note"
+  title="Note"
+>
+  Multi-cluster support differs between Teleport Connect and the tsh/tctl CLI tools.
+  The CLI tools can switch versions on the fly to match the one required by each cluster.
+  Teleport Connect, as an installed desktop application, can only run a single version at a time.
+</Admonition>
+
+#### Managed updates configuration
+
+Like the CLI tools, Teleport Connect respects the `TELEPORT_CDN_BASE_URL` and
+`TELEPORT_TOOLS_VERSION` environment variables.
+
+* `TELEPORT_CDN_BASE_URL` lets you use custom builds or mirror the CDN in a private
+network (for example `https://example.com`).
+* `TELEPORT_TOOLS_VERSION` controls client tool updates:
+* Set to `off` to completely disable managed updates.
+* Set to a specific version (e.g. `18.0.1`) to override the cluster-provided version
+(for example, to work around a known issue).
+
+To use an environment variable with Teleport Connect, open your terminal and launch
+the app from there, providing the variable.
+It will apply only for that session, so you can test settings or override
+cluster-provided updates without affecting your system-wide configuration.
+For a permanent setup, follow the instructions below:
+
+<Tabs>
+  <TabItem label="macOS">
+    To set the variable for your current login session, open the Terminal and type:
+    ```console
+    launchctl set env TELEPORT_TOOLS_VERSION X.Y.Z
+    ```
+    Then run Teleport Connect as usual. This setting persists until you log out.
+  </TabItem>
+  <TabItem label="Windows">
+    To set the variable permanently for your user account, open the Command Prompt and type:
+    ```console
+    setx TELEPORT_TOOLS_VERSION X.Y.Z
+    ```
+    Then run Teleport Connect as usual. To clear it, use:
+    ```console
+    setx TELEPORT_TOOLS_VERSION ""
+    ```
+  </TabItem>
+  <TabItem label="Linux">
+    To set the variable permanently for the app, prepend the environment variable to
+    the `Exec=` line in  `usr/share/applications/teleport-connect.desktop` file:
+    ```console
+    Exec=env TELEPORT_TOOLS_VERSION=X.Y.Z "/opt/Teleport Connect/teleport-connect" %U
+    ```
+  </TabItem>
 </Tabs>
 
 ## User interface

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -73,7 +73,8 @@ additional actions menu.
   type="warning"
   title="Note"
 >
-  Managed updates are not supported for Linux `tar.gz` builds.
+  To use managed updates on Linux, make sure the app was installed with a package
+  manager. The `.tar.gz` distribution is not compatible with managed updates.
 </Admonition>
 
 #### Multiple clusters

--- a/docs/pages/upgrading/client-tools-managed-updates.mdx
+++ b/docs/pages/upgrading/client-tools-managed-updates.mdx
@@ -10,6 +10,8 @@ This documentation explains how to keep Teleport client tools like `tsh` and `tc
 Updates can be managed by cluster or self-managed, ensuring tools are secure, free from bugs,
 and compatible with your Teleport cluster.
 
+For detailed information on managed updates in Teleport Connect, see [Teleport Connect Managed updates](../connect-your-client/teleport-connect.mdx#managed-updates).
+
 Why keep client tools updated?
 
 - **Security**: Updates deliver patches for known vulnerabilities.


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/50948. 
[RFD](https://github.com/gravitational/teleport/blob/master/rfd/0144-client-tools-updates.md#teleport-connect-automatic-updates-added-on-2025-07-10-by-gzdunek)

Extends Teleport Connect docs with the managed updates section.