### PR TITLE
Fix condition that guards conversion of gateway into kube gateway

### DIFF
--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -875,12 +875,12 @@ func (s *Service) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) er
 	defer s.gatewaysMu.RUnlock()
 	for _, gw := range s.gateways {
 		targetURI := gw.TargetURI()
-		if !targetURI.IsKube() && targetURI.GetRootClusterURI() != cluster.URI {
+		if !targetURI.IsKube() || targetURI.GetRootClusterURI() != cluster.URI {
 			continue
 		}
 		kubeGw, err := gateway.AsKube(gw)
 		if err != nil {
-			s.cfg.Logger.ErrorContext(ctx, "Could not clear certs for kube when assuming request", "error", err, "target_uri", targetURI)
+			return trace.Wrap(err)
 		}
 		kubeGw.ClearCerts()
 	}


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/54410 the condition 
```go
if !(targetURI.IsKube() && targetURI.GetRootClusterURI() == cluster.URI) {
```
has been changed to
```go
if !targetURI.IsKube() && targetURI.GetRootClusterURI() != cluster.URI {
```

It unfortunately has a different meaning - if the target is not a kube URI but still belongs to the current cluster, the new condition would not return early, whereas the original condition would.

changelog: Fixed a Teleport Connect crash that occurred when assuming an access request while an application or database connection was active