### PR TITLE
Add initial log message with version to tbot

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -21,7 +21,6 @@ package tbot
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"runtime"
 	"sync"
@@ -122,7 +121,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 	defer func() { apitracing.EndSpan(span, err) }()
 	b.log.InfoContext(
 		ctx, "Initializing tbot",
-		"version", versionString(),
+		"version", versionLogValue(),
 	)
 
 	if err := metrics.RegisterPrometheusCollectors(
@@ -371,11 +370,10 @@ func checkDestinations(ctx context.Context, cfg *config.BotConfig) error {
 	return nil
 }
 
-func versionString() string {
-	return fmt.Sprintf(
-		"v%s git:%s %s\n",
-		teleport.Version,
-		teleport.Gitref,
-		runtime.Version(),
+func versionLogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("teleport", teleport.Version),
+		slog.String("teleport_git", teleport.Gitref),
+		slog.String("go", runtime.Version()),
 	)
 }

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -21,7 +21,9 @@ package tbot
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -118,6 +120,10 @@ func (b *Bot) getClient() *apiclient.Client {
 func (b *Bot) Run(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Bot/Run")
 	defer func() { apitracing.EndSpan(span, err) }()
+	b.log.InfoContext(
+		ctx, "Initializing tbot",
+		"version", versionString(),
+	)
 
 	if err := metrics.RegisterPrometheusCollectors(
 		metrics.BuildCollector(),
@@ -363,4 +369,13 @@ func checkDestinations(ctx context.Context, cfg *config.BotConfig) error {
 	}
 
 	return nil
+}
+
+func versionString() string {
+	return fmt.Sprintf(
+		"v%s git:%s %s\n",
+		teleport.Version,
+		teleport.Gitref,
+		runtime.Version(),
+	)
 }


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/58009

Adds a log message that includes the current tbot version on start. Users tend to be fairly good at including logs in support tickets, but, often forget to state the current version or attribute older logs to the wrong version of tbot. This relatively minor change should reduce how often we have to go back to query the version with the customer and provide a source of truth for the version actually running when multiple versions of tbot are available in the environment.

changelog: TBot now emits a log message stating the current version on startup