### PR TITLE
Implement endpoints + fetchers for fetching session recording metadata/thumbnails

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1177,7 +1177,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerDelete))
 
 	h.GET("/webapi/sites/:site/session-recording/:session_id/thumbnail", h.WithClusterAuth(h.getSessionRecordingThumbnail))
-	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata", h.WithClusterAuth(h.getSessionRecordingMetadata))
+	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1177,7 +1177,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerDelete))
 
 	h.GET("/webapi/sites/:site/session-recording/:session_id/thumbnail", h.WithClusterAuth(h.getSessionRecordingThumbnail))
-	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
+	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata/ws", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1175,6 +1175,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.PUT("/webapi/sites/:site/gitservers", h.WithClusterAuth(h.gitServerCreateOrUpsert))
 	h.GET("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerGet))
 	h.DELETE("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerDelete))
+
+	h.GET("/webapi/sites/:site/session-recording/:session_id/thumbnail", h.WithClusterAuth(h.getSessionRecordingThumbnail))
+	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata", h.WithClusterAuth(h.getSessionRecordingMetadata))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -1,0 +1,286 @@
+/**
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	recordingmetadatav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+)
+
+type sessionRecordingMessageType string
+
+const (
+	recordingThumbnailMessageType sessionRecordingMessageType = "thumbnail"
+	recordingMetadataMessageType  sessionRecordingMessageType = "metadata"
+	recordingErrorMessageType     sessionRecordingMessageType = "error"
+)
+
+type sessionRecordingErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// sessionRecordingMessageWrapper is a wrapper for session recording messages sent over WebSocket.
+// This makes it easier to have strongly typed messages on the frontend, switching on the `Type` field.
+type sessionRecordingMessageWrapper struct {
+	Type sessionRecordingMessageType `json:"type"`
+	Data interface{}                 `json:"data"`
+}
+
+// getSessionRecordingMetadata handles the WebSocket connection to stream session recording metadata and thumbnails.
+// The metadata is loaded over a websocket connection to avoid gRPC message size limits.
+// It sends metadata and thumbnails as JSON messages to the client.
+func (h *Handler) getSessionRecordingMetadata(
+	w http.ResponseWriter,
+	r *http.Request,
+	p httprouter.Params,
+	sctx *SessionContext,
+	site reversetunnelclient.RemoteSite,
+) (interface{}, error) {
+	sessionID := p.ByName("session_id")
+	if sessionID == "" {
+		return nil, trace.BadParameter("missing session ID in request URL")
+	}
+
+	h.logger.DebugContext(r.Context(), "upgrading to websocket")
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		h.logger.WarnContext(r.Context(), "failed upgrade", "error", err)
+		return nil, nil
+	}
+	defer ws.Close()
+
+	ctx := r.Context()
+	clt, err := sctx.GetUserClient(ctx, site)
+	if err != nil {
+		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+			Error: err.Error(),
+		})
+		return nil, nil
+	}
+
+	stream, err := clt.RecordingMetadataServiceClient().GetMetadata(ctx, &recordingmetadatav1.GetMetadataRequest{
+		SessionId: sessionID,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	metadata, err := stream.Recv()
+	if err != nil {
+		h.logger.ErrorContext(ctx, "failed to receive metadata", "session_id", sessionID, "error", err)
+		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+			Error: err.Error(),
+		})
+		return nil, nil
+	}
+
+	if metadata.GetMetadata() == nil {
+		h.logger.ErrorContext(ctx, "received nil metadata in stream", "session_id", sessionID)
+		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+			Error: trace.BadParameter("received nil metadata").Error(),
+		})
+		return nil, nil
+	}
+
+	if err := sendMessage(ws, recordingMetadataMessageType, encodeSessionRecordingMetadata(metadata.GetMetadata())); err != nil {
+		h.logger.ErrorContext(ctx, "failed to send metadata", "session_id", sessionID, "error", err)
+		return nil, nil
+	}
+
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			h.logger.ErrorContext(ctx, "failed to receive chunk", "session_id", sessionID, "error", err)
+			sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+				Error: err.Error(),
+			})
+			return nil, nil
+		}
+
+		if chunk.GetFrame() == nil {
+			h.logger.ErrorContext(ctx, "received nil frame in metadata stream")
+			sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+				Error: trace.BadParameter("received nil frame").Error(),
+			})
+			return nil, nil
+		}
+
+		if err := sendMessage(ws, recordingThumbnailMessageType, encodeSessionRecordingThumbnail(chunk.GetFrame())); err != nil {
+			h.logger.ErrorContext(ctx, "failed to send thumbnail", "session_id", sessionID, "error", err)
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func sendMessage(ws *websocket.Conn, msgType sessionRecordingMessageType, data interface{}) error {
+	return ws.WriteJSON(sessionRecordingMessageWrapper{
+		Type: msgType,
+		Data: data,
+	})
+}
+
+func (h *Handler) getSessionRecordingThumbnail(
+	w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite,
+) (any, error) {
+	sessionId := p.ByName("session_id")
+	if sessionId == "" {
+		return nil, trace.BadParameter("session_id is required")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	response, err := clt.RecordingMetadataServiceClient().GetThumbnail(r.Context(), &recordingmetadatav1.GetThumbnailRequest{
+		SessionId: sessionId,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if response.Thumbnail == nil {
+		return nil, trace.NotFound("thumbnail not found for session %q", sessionId)
+	}
+
+	return encodeSessionRecordingThumbnail(response.Thumbnail), nil
+}
+
+type baseEvent struct {
+	StartOffset int64  `json:"startTime"`
+	EndOffset   int64  `json:"endTime"`
+	Type        string `json:"type"`
+}
+
+type resizeEvent struct {
+	baseEvent
+	Cols int32 `json:"cols"`
+	Rows int32 `json:"rows"`
+}
+
+type joinEvent struct {
+	baseEvent
+	User string `json:"user"`
+}
+
+type inactivityEvent struct {
+	baseEvent
+}
+
+type sessionRecordingMetadata struct {
+	Duration    int64         `json:"duration"`
+	Events      []interface{} `json:"events"`
+	StartCols   int32         `json:"startCols"`
+	StartRows   int32         `json:"startRows"`
+	StartTime   int64         `json:"startTime"`
+	EndTime     int64         `json:"endTime"`
+	ClusterName string        `json:"clusterName"`
+}
+
+// encodeSessionRecordingMetadata converts the session recording metadata to a format more suitable for the frontend
+// to use.
+func encodeSessionRecordingMetadata(metadata *recordingmetadatav1.SessionRecordingMetadata) sessionRecordingMetadata {
+	result := sessionRecordingMetadata{
+		Duration:    convertDurationToMs(metadata.Duration),
+		StartCols:   metadata.StartCols,
+		StartRows:   metadata.StartRows,
+		Events:      make([]interface{}, 0, len(metadata.Events)),
+		StartTime:   metadata.StartTime.AsTime().Unix(),
+		EndTime:     metadata.EndTime.AsTime().Unix(),
+		ClusterName: metadata.ClusterName,
+	}
+
+	for _, event := range metadata.Events {
+		base := baseEvent{
+			StartOffset: convertDurationToMs(event.StartOffset),
+			EndOffset:   convertDurationToMs(event.EndOffset),
+		}
+
+		switch e := event.Event.(type) {
+		case *recordingmetadatav1.SessionRecordingEvent_Inactivity:
+			base.Type = "inactivity"
+			result.Events = append(result.Events, inactivityEvent{baseEvent: base})
+		case *recordingmetadatav1.SessionRecordingEvent_Join:
+			base.Type = "join"
+			result.Events = append(result.Events, joinEvent{
+				baseEvent: base,
+				User:      e.Join.User,
+			})
+		case *recordingmetadatav1.SessionRecordingEvent_Resize:
+			base.Type = "resize"
+			result.Events = append(result.Events, resizeEvent{
+				baseEvent: base,
+				Cols:      e.Resize.Cols,
+				Rows:      e.Resize.Rows,
+			})
+		}
+	}
+
+	return result
+}
+
+type sessionRecordingThumbnailResponse struct {
+	Svg           string `json:"svg"`
+	Cols          int32  `json:"cols"`
+	Rows          int32  `json:"rows"`
+	CursorX       int32  `json:"cursorX"`
+	CursorY       int32  `json:"cursorY"`
+	StartOffsetMs int64  `json:"startOffsetMs"`
+	EndOffsetMs   int64  `json:"endOffsetMs"`
+}
+
+// encodeSessionRecordingThumbnail converts the session recording thumbnail to a format more suitable for the frontend.
+func encodeSessionRecordingThumbnail(thumbnail *recordingmetadatav1.SessionRecordingThumbnail) sessionRecordingThumbnailResponse {
+	return sessionRecordingThumbnailResponse{
+		Svg:           string(thumbnail.Svg),
+		Cols:          thumbnail.Cols,
+		Rows:          thumbnail.Rows,
+		CursorX:       thumbnail.CursorX,
+		CursorY:       thumbnail.CursorY,
+		StartOffsetMs: convertDurationToMs(thumbnail.StartOffset),
+		EndOffsetMs:   convertDurationToMs(thumbnail.EndOffset),
+	}
+}
+
+func convertDurationToMs(d *durationpb.Duration) int64 {
+	if d == nil {
+		return 0
+	}
+	return d.Seconds*1000 + int64(d.Nanos/1000000)
+}

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -94,6 +94,9 @@ func (h *Handler) getSessionRecordingMetadata(
 		SessionId: sessionID,
 	})
 	if err != nil {
+		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
+			Error: err.Error(),
+		})
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -48,7 +48,7 @@ type sessionRecordingErrorResponse struct {
 // This makes it easier to have strongly typed messages on the frontend, switching on the `Type` field.
 type sessionRecordingMessageWrapper struct {
 	Type sessionRecordingMessageType `json:"type"`
-	Data interface{}                 `json:"data"`
+	Data any                         `json:"data"`
 }
 
 // getSessionRecordingMetadata handles the WebSocket connection to stream session recording metadata and thumbnails.
@@ -67,8 +67,6 @@ func (h *Handler) getSessionRecordingMetadata(
 		return nil, trace.BadParameter("missing session ID in request URL")
 	}
 
-	defer ws.Close()
-
 	ctx := r.Context()
 	clt, err := sctx.GetUserClient(ctx, cluster)
 	if err != nil {
@@ -85,7 +83,7 @@ func (h *Handler) getSessionRecordingMetadata(
 		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
 			Error: err.Error(),
 		})
-		return nil, trace.Wrap(err)
+		return nil, nil
 	}
 
 	metadata, err := stream.Recv()

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -90,7 +90,9 @@ func (h *Handler) getSessionRecordingMetadata(
 
 	metadata, err := stream.Recv()
 	if err != nil {
-		h.logger.ErrorContext(ctx, "failed to receive metadata", "session_id", sessionID, "error", err)
+		if !trace.IsNotFound(err) {
+			h.logger.ErrorContext(ctx, "failed to receive metadata", "session_id", sessionID, "error", err)
+		}
 		sendMessage(ws, recordingErrorMessageType, sessionRecordingErrorResponse{
 			Error: err.Error(),
 		})

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -1,5 +1,6 @@
-/**
- * Copyright (C) 2025 Gravitational, Inc.
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -141,12 +141,13 @@ export function createViteConfig(
           ws: true,
         },
         // /webapi/sites/:site/desktopplayback/:sid
-        '^\\/v[0-9]+\\/webapi\\/sites\\/(.*?)\\/desktopplayback\\/(.*?)': {
-          target: `wss://${target}`,
-          changeOrigin: false,
-          secure: false,
-          ws: true,
-        },
+        '^\\/v[0-9]+\\/webapi\\/sites\\/(.*?)\\/desktopplayback|session-recording\\/(.*?)':
+          {
+            target: `wss://${target}`,
+            changeOrigin: true,
+            secure: false,
+            ws: true,
+          },
         '^\\/v[0-9]+\\/webapi\\/assistant\\/(.*?)': {
           target: `https://${target}`,
           changeOrigin: false,

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -141,7 +141,7 @@ export function createViteConfig(
           ws: true,
         },
         // /webapi/sites/:site/desktopplayback/:sid
-        '^\\/v[0-9]+\\/webapi\\/sites\\/(.*?)\\/desktopplayback|session-recording\\/(.*?)':
+        '^(\\/v[0-9]+\\/webapi\\/sites\\/(.*?)\\/(desktopplayback|session-recording)\\/(.*?))(\\/ws)?':
           {
             target: `wss://${target}`,
             changeOrigin: true,

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -522,7 +522,7 @@ const cfg = {
 
     sessionRecording: {
       metadata:
-        '/v1/webapi/sites/:clusterId/session-recording/:sessionId/metadata',
+        '/v1/webapi/sites/:clusterId/session-recording/:sessionId/metadata/ws',
       thumbnail:
         '/v1/webapi/sites/:clusterId/session-recording/:sessionId/thumbnail',
     },

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -519,6 +519,13 @@ const cfg = {
       parse: '/v1/webapi/yaml/parse/:kind',
       stringify: '/v1/webapi/yaml/stringify/:kind',
     },
+
+    sessionRecording: {
+      metadata:
+        '/v1/webapi/sites/:clusterId/session-recording/:sessionId/metadata',
+      thumbnail:
+        '/v1/webapi/sites/:clusterId/session-recording/:sessionId/thumbnail',
+    },
   },
 
   playable_db_protocols: [],
@@ -892,6 +899,20 @@ const cfg = {
     }
 
     return route;
+  },
+
+  getSessionRecordingMetadataUrl(clusterId: string, sessionId: string) {
+    return generatePath(cfg.api.sessionRecording.metadata, {
+      clusterId,
+      sessionId,
+    });
+  },
+
+  getSessionRecordingThumbnailUrl(clusterId: string, sessionId: string) {
+    return generatePath(cfg.api.sessionRecording.thumbnail, {
+      clusterId,
+      sessionId,
+    });
   },
 
   getConnectionDiagnosticUrl() {

--- a/web/packages/teleport/src/services/recordings/hooks.ts
+++ b/web/packages/teleport/src/services/recordings/hooks.ts
@@ -1,0 +1,27 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createQueryHook } from 'teleport/services/queryHelpers';
+
+import { fetchSessionRecordingMetadata } from './metadata';
+
+export const { useSuspenseQuery: useSuspenseGetRecordingMetadata } =
+  createQueryHook(['recording', 'metadata'], fetchSessionRecordingMetadata);
+
+export const { useSuspenseQuery: useSuspenseGetRecordingThumbnail } =
+  createQueryHook(['recording', 'thumbnail'], fetchSessionRecordingMetadata);

--- a/web/packages/teleport/src/services/recordings/metadata.ts
+++ b/web/packages/teleport/src/services/recordings/metadata.ts
@@ -1,0 +1,116 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cfg from 'teleport/config';
+import { getAccessToken } from 'teleport/services/api';
+
+import {
+  SessionRecordingMessageType,
+  type SessionRecordingMessage,
+  type SessionRecordingMetadata,
+  type SessionRecordingThumbnail,
+} from './types';
+
+export interface SessionRecordingMetadataWithFrames {
+  metadata: SessionRecordingMetadata;
+  frames: SessionRecordingThumbnail[];
+}
+
+interface FetchSessionRecordingMetadataVariables {
+  clusterId: string;
+  sessionId: string;
+}
+
+// fetchSessionRecordingMetadata fetches metadata and thumbnails for a session recording
+// using a WebSocket connection, to avoid gRPC maximum message size limits.
+// It returns a promise that resolves with the metadata and an array of thumbnails.
+export function fetchSessionRecordingMetadata(
+  { clusterId, sessionId }: FetchSessionRecordingMetadataVariables,
+  signal?: AbortSignal
+) {
+  return new Promise<SessionRecordingMetadataWithFrames>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const url = cfg.getSessionRecordingMetadataUrl(clusterId, sessionId);
+
+    const params = new URLSearchParams();
+
+    params.set('access_token', getAccessToken());
+
+    const ws = new WebSocket(`${url}?${params.toString()}`);
+
+    let metadata: SessionRecordingMetadata | null = null;
+
+    const frames: SessionRecordingThumbnail[] = [];
+
+    function handleAbort() {
+      ws.close();
+      reject(new DOMException('Aborted', 'AbortError'));
+    }
+
+    signal?.addEventListener('abort', handleAbort);
+
+    ws.onmessage = event => {
+      const decoded = JSON.parse(event.data) as SessionRecordingMessage;
+
+      switch (decoded.type) {
+        case SessionRecordingMessageType.Thumbnail:
+          frames.push(decoded.data);
+
+          break;
+
+        case SessionRecordingMessageType.Metadata:
+          metadata = decoded.data;
+
+          break;
+
+        case SessionRecordingMessageType.Error:
+          signal?.removeEventListener('abort', handleAbort);
+          reject(new Error(decoded.data.message));
+
+          return;
+      }
+    };
+
+    ws.onerror = () => {
+      signal?.removeEventListener('abort', handleAbort);
+      reject(new Error('WebSocket connection failed'));
+    };
+
+    ws.onclose = () => {
+      signal?.removeEventListener('abort', handleAbort);
+
+      if (signal?.aborted) {
+        return;
+      }
+
+      if (!metadata) {
+        reject(new Error('No metadata received'));
+        return;
+      }
+
+      resolve({
+        metadata,
+        frames,
+      });
+    };
+  });
+}

--- a/web/packages/teleport/src/services/recordings/metadata.ts
+++ b/web/packages/teleport/src/services/recordings/metadata.ts
@@ -25,6 +25,7 @@ import {
   type SessionRecordingMetadata,
   type SessionRecordingThumbnail,
 } from './types';
+import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 
 export interface SessionRecordingMetadataWithFrames {
   metadata: SessionRecordingMetadata;
@@ -49,13 +50,7 @@ export function fetchSessionRecordingMetadata(
       return;
     }
 
-    const url = cfg.getSessionRecordingMetadataUrl(clusterId, sessionId);
-
-    const params = new URLSearchParams();
-
-    params.set('access_token', getAccessToken());
-
-    const ws = new WebSocket(`${url}?${params.toString()}`);
+    const ws = new AuthenticatedWebSocket(cfg.getSessionRecordingMetadataUrl(clusterId, sessionId));
 
     let metadata: SessionRecordingMetadata | null = null;
 

--- a/web/packages/teleport/src/services/recordings/metadata.ts
+++ b/web/packages/teleport/src/services/recordings/metadata.ts
@@ -17,7 +17,6 @@
  */
 
 import cfg from 'teleport/config';
-import { getAccessToken } from 'teleport/services/api';
 
 import {
   SessionRecordingMessageType,

--- a/web/packages/teleport/src/services/recordings/metadata.ts
+++ b/web/packages/teleport/src/services/recordings/metadata.ts
@@ -17,6 +17,7 @@
  */
 
 import cfg from 'teleport/config';
+import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 
 import {
   SessionRecordingMessageType,
@@ -24,7 +25,6 @@ import {
   type SessionRecordingMetadata,
   type SessionRecordingThumbnail,
 } from './types';
-import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 
 export interface SessionRecordingMetadataWithFrames {
   metadata: SessionRecordingMetadata;
@@ -49,7 +49,9 @@ export function fetchSessionRecordingMetadata(
       return;
     }
 
-    const ws = new AuthenticatedWebSocket(cfg.getSessionRecordingMetadataUrl(clusterId, sessionId));
+    const ws = new AuthenticatedWebSocket(
+      cfg.getSessionRecordingMetadataUrl(clusterId, sessionId)
+    );
 
     let metadata: SessionRecordingMetadata | null = null;
 

--- a/web/packages/teleport/src/services/recordings/recordings.ts
+++ b/web/packages/teleport/src/services/recordings/recordings.ts
@@ -20,7 +20,11 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
 import { makeRecording } from './makeRecording';
-import { RecordingsQuery, RecordingsResponse } from './types';
+import type {
+  RecordingsQuery,
+  RecordingsResponse,
+  SessionRecordingThumbnail,
+} from './types';
 
 export default class RecordingsService {
   maxFetchLimit = 5000;
@@ -52,4 +56,23 @@ export default class RecordingsService {
   ): Promise<{ durationMs: number; recordingType: string }> {
     return api.get(cfg.getSessionDurationUrl(clusterId, sessionId));
   }
+}
+
+interface FetchRecordingThumbnailVariables {
+  clusterId: string;
+  sessionId: string;
+}
+
+export async function fetchRecordingThumbnail(
+  { clusterId, sessionId }: FetchRecordingThumbnailVariables,
+  signal?: AbortSignal
+): Promise<SessionRecordingThumbnail> {
+  const url = cfg.getSessionRecordingThumbnailUrl(clusterId, sessionId);
+  const response = await api.get(url, signal);
+
+  if (!response) {
+    throw new Error('Failed to fetch recording thumbnail');
+  }
+
+  return response as SessionRecordingThumbnail;
 }

--- a/web/packages/teleport/src/services/recordings/types.ts
+++ b/web/packages/teleport/src/services/recordings/types.ts
@@ -41,3 +41,75 @@ export type Recording = {
   recordingType: RecordingType;
   playable: boolean;
 };
+
+export enum SessionRecordingMessageType {
+  Thumbnail = 'thumbnail',
+  Metadata = 'metadata',
+  Error = 'error',
+}
+
+export enum SessionRecordingEventType {
+  Inactivity = 'inactivity',
+  Join = 'join',
+  Resize = 'resize',
+}
+
+export interface SessionRecordingThumbnail {
+  svg: string;
+  cols: number;
+  rows: number;
+  cursorX: number;
+  cursorY: number;
+  startOffsetMs: number;
+  endOffsetMs: number;
+}
+
+export interface SessionRecordingMetadata {
+  durationMs: number;
+  events: SessionRecordingEvent[];
+  startCols: number;
+  startRows: number;
+  startTimeMs: number;
+  endTimeMs: number;
+  clusterName: string;
+}
+
+export interface SessionRecordingError {
+  message: string;
+}
+
+// This is a wrapper type to match the structure of messages sent over the WebSocket.
+type WrappedMessage<TType extends SessionRecordingMessageType, TData> = {
+  type: TType;
+  data: TData;
+}
+
+export type SessionRecordingMessage =
+  | WrappedMessage<SessionRecordingMessageType.Thumbnail, SessionRecordingThumbnail>
+  | WrappedMessage<SessionRecordingMessageType.Metadata, SessionRecordingMetadata>
+  | WrappedMessage<SessionRecordingMessageType.Error, SessionRecordingError>;
+
+interface BaseSessionRecordingEvent {
+  startOffsetMs: number;
+  endOffsetMs: number;
+}
+
+interface SessionRecordingInactivityEvent extends BaseSessionRecordingEvent {
+  type: SessionRecordingEventType.Inactivity;
+}
+
+interface SessionRecordingJoinEvent extends BaseSessionRecordingEvent {
+  type: SessionRecordingEventType.Join;
+  user: string;
+}
+
+interface SessionRecordingResizeEvent extends BaseSessionRecordingEvent {
+  type: SessionRecordingEventType.Resize;
+  cols: number;
+  rows: number;
+}
+
+type SessionRecordingEvent =
+  | SessionRecordingJoinEvent
+  | SessionRecordingResizeEvent
+  | SessionRecordingInactivityEvent;

--- a/web/packages/teleport/src/services/recordings/types.ts
+++ b/web/packages/teleport/src/services/recordings/types.ts
@@ -82,11 +82,17 @@ export interface SessionRecordingError {
 type WrappedMessage<TType extends SessionRecordingMessageType, TData> = {
   type: TType;
   data: TData;
-}
+};
 
 export type SessionRecordingMessage =
-  | WrappedMessage<SessionRecordingMessageType.Thumbnail, SessionRecordingThumbnail>
-  | WrappedMessage<SessionRecordingMessageType.Metadata, SessionRecordingMetadata>
+  | WrappedMessage<
+      SessionRecordingMessageType.Thumbnail,
+      SessionRecordingThumbnail
+    >
+  | WrappedMessage<
+      SessionRecordingMessageType.Metadata,
+      SessionRecordingMetadata
+    >
   | WrappedMessage<SessionRecordingMessageType.Error, SessionRecordingError>;
 
 interface BaseSessionRecordingEvent {


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/58031

This adds the endpoints to grab a session's metadata or thumbnail. The metadata endpoint is streamed over a websocket to avoid any potential gRPC message limits (and to avoid having to fetch multiple pages of frames and open the metadata file multiple times)