### PR TITLE
delete process.Config.HostUUID

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -555,7 +555,6 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			tconf.ReverseTunnels = []types.ReverseTunnel{rt}
 		}
 	}
-	tconf.HostUUID = i.Secrets.GetIdentity().ID.HostUUID
 	tconf.SSH.Addr.Addr = i.SSH
 	tconf.SSH.PublicAddrs = []utils.NetAddr{
 		{

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -763,7 +763,10 @@ func TestRootStaticHostUsers(t *testing.T) {
 	nodeCfg.SSH.Labels = map[string]string{
 		"foo": "bar",
 	}
-	_, err = instance.StartNode(nodeCfg)
+	nodeProcess, err := instance.StartNode(nodeCfg)
+	require.NoError(t, err)
+
+	nodeUUID, err := nodeProcess.WaitForHostID(t.Context())
 	require.NoError(t, err)
 
 	instance.WaitForNodeCount(context.Background(), helpers.Site, 2)
@@ -841,14 +844,14 @@ func TestRootStaticHostUsers(t *testing.T) {
 	t.Cleanup(func() { cleanupUsersAndGroups([]string{goodLogin, nonMatchingLogin, conflictingLogin}, groups) })
 
 	// Test that a node picks up new host users from the cache.
-	testStaticHostUsers(t, nodeCfg.HostUUID, goodLogin, goodLoginWithShell, nonMatchingLogin, conflictingLogin, groups)
+	testStaticHostUsers(t, nodeUUID, goodLogin, goodLoginWithShell, nonMatchingLogin, conflictingLogin, groups)
 	cleanupUsersAndGroups([]string{goodLogin, nonMatchingLogin, conflictingLogin}, groups)
 
 	require.NoError(t, instance.StopNodes())
 	_, err = instance.StartNode(nodeCfg)
 	require.NoError(t, err)
 	// Test that a new node picks up existing host users on startup.
-	testStaticHostUsers(t, nodeCfg.HostUUID, goodLogin, goodLoginWithShell, nonMatchingLogin, conflictingLogin, groups)
+	testStaticHostUsers(t, nodeUUID, goodLogin, goodLoginWithShell, nonMatchingLogin, conflictingLogin, groups)
 
 	// Check that a deleted resource doesn't affect the host user.
 	require.NoError(t, clt.DeleteStaticHostUser(context.Background(), goodLogin))
@@ -859,7 +862,7 @@ func TestRootStaticHostUsers(t *testing.T) {
 	require.Never(t, func() bool {
 		_, lookupErr = user.Lookup(goodLogin)
 		_, homeDirErr = os.Stat("/home/" + goodLogin)
-		_, sudoerErr = os.Stat(sudoersPath(goodLogin, nodeCfg.HostUUID))
+		_, sudoerErr = os.Stat(sudoersPath(goodLogin, nodeUUID))
 		return lookupErr != nil || homeDirErr != nil || sudoerErr != nil
 	}, 5*time.Second, time.Second,
 		"lookup err: %v\nhome dir err: %v\nsudoer err: %v\n",

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -625,7 +625,6 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 	p := &TeleportProcess{
 		Config: &servicecfg.Config{
 			Hostname:    "global-hostname",
-			HostUUID:    "global-uuid",
 			AdvertiseIP: "1.2.3.4",
 			Proxy: servicecfg.ProxyConfig{
 				PublicAddrs:         utils.MustParseAddrList("proxy-public-1", "proxy-public-2"),
@@ -769,7 +768,7 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.role.String(), func(t *testing.T) {
-			principals, dns, err := p.getAdditionalPrincipals(tt.role)
+			principals, dns, err := p.getAdditionalPrincipals(tt.role, "global-uuid")
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(principals, tt.wantPrincipals))
 			require.Empty(t, cmp.Diff(dns, tt.wantDNS, cmpopts.EquateEmpty()))

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -134,10 +134,6 @@ type Config struct {
 	// Keygen points to a key generator implementation
 	Keygen sshca.Authority
 
-	// HostUUID is a unique UUID of this host (it will be known via this UUID within
-	// a teleport cluster). It's automatically generated on 1st start
-	HostUUID string
-
 	// ReverseTunnels is a list of reverse tunnels to create on the
 	// first cluster start
 	ReverseTunnels []types.ReverseTunnel


### PR DESCRIPTION
In preparation for [RFD 27e](https://github.com/gravitational/teleport.e/pull/6963) where the host UUID will no longer be available until the node joins a cluster, this PR deletes `process.Config.HostUUID` and moves host UUID generation to `firstTimeConnect`. Future PRs will implement a new join service where the host UUID is assigned by the auth service.