### PR TITLE
Add local disable mode for CTMU configuration

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -269,6 +269,40 @@ func TestUpdateForOSSBuild(t *testing.T) {
 	matchVersion(t, string(out), testVersions[1])
 }
 
+// TestUpdateDisabledInConfiguration verifies that managed updates can be locally disabled,
+// regardless of the version advertised by the cluster.
+func TestUpdateDisabledInConfiguration(t *testing.T) {
+	testToolsDir := t.TempDir()
+	t.Setenv(types.HomeEnvVar, testToolsDir)
+	ctx := context.Background()
+
+	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
+	updater := tools.NewUpdater(
+		testToolsDir,
+		testVersions[0],
+		tools.WithBaseURL(baseURL),
+	)
+	err := updater.Update(ctx, testVersions[0])
+	require.NoError(t, err)
+
+	tshPath, err := updater.ToolPath("tsh", testVersions[0])
+	require.NoError(t, err)
+
+	// Set local mode to disabled state.
+	cmd := exec.CommandContext(ctx, tshPath, "update", "--mode", "disabled")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	// Verify that the installed version is not equal to requested one in disabled mode.
+	t.Setenv("TELEPORT_TOOLS_VERSION", testVersions[1])
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	matchVersion(t, string(out), testVersions[0])
+}
+
 func matchVersion(t *testing.T, output string, version string) {
 	t.Helper()
 	matches := pattern.FindStringSubmatch(output)

--- a/lib/autoupdate/tools/config.go
+++ b/lib/autoupdate/tools/config.go
@@ -62,6 +62,8 @@ type ClientToolsConfig struct {
 	// MaxTools defines the maximum number of tools allowed in the tools directory.
 	// Any tools exceeding this limit will be removed during the next installation.
 	MaxTools int `json:"max_tools"`
+	// Disabled disables managed updates for all clusters.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // AddTool adds a tool to the collection in the configuration, always placing it at the top.
@@ -136,6 +138,19 @@ func (c *Tool) PackageNames() []string {
 		}
 	}
 	return packageNames
+}
+
+// UpdateLocalMode stores the local disable mode for all clusters in the configuration.
+// It overrides the version advertised by the cluster configuration for client tools managed updates.
+func UpdateLocalMode(toolsDir string, disabled bool) error {
+	err := updateToolsConfig(toolsDir, func(ctc *ClientToolsConfig) error {
+		ctc.Disabled = disabled
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // getToolsConfig reads the configuration file for client tools managed updates,

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -195,7 +195,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	// is required if the user passed in the TELEPORT_TOOLS_VERSION
 	// explicitly.
 	err := updater.Update(ctxUpdate, toolsVersion)
-	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrNoBaseURL) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrNoBaseURL) && !errors.Is(err, ErrUpdateDisabled) {
 		slog.ErrorContext(ctx, "Failed to update tools version", "error", err, "version", toolsVersion)
 		// Continue executing the current version of the client tools (tsh, tctl)
 		// to avoid potential issues with update process (timeout, missing version).

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -73,6 +73,10 @@ const (
 var (
 	// pattern is template for response on version command for client tools {tsh, tctl}.
 	pattern = regexp.MustCompile(`(?m)Teleport v(.*) git`)
+	// ErrUpdateDisabled is error for local disabling managed updates.
+	ErrUpdateDisabled = errors.New("client tools managed updates are manually disabled locally, " +
+		"the required cluster version differs from the installed version and may not work correctly, " +
+		"run `tsh update --mode=enable` to re-enable managed updates")
 )
 
 // UpdateResponse contains information about after update process.
@@ -217,6 +221,12 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 	switch requestedVersion {
 	// The user has turned off any form of automatic updates.
 	case teleportToolsVersionEnvDisabled:
+		if err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+			ctc.SetConfig(proxyHost, u.localVersion, true)
+			return nil
+		}); err != nil {
+			return nil, trace.Wrap(err)
+		}
 		return &UpdateResponse{Version: "", ReExec: false}, nil
 	// Requested version already the same as client version.
 	case u.localVersion:
@@ -286,6 +296,9 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 // existing one and cleanups the previous downloads with defined updater directory suffix.
 func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
 	err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+		if ctc.Disabled {
+			return ErrUpdateDisabled
+		}
 		// ignoreTools is the list of tools installed and tracked by the config.
 		// They should be preserved during cleanup. If we have more than [defaultSizeStoredVersion]
 		// versions, the updater will forget about the least used version.


### PR DESCRIPTION
This PR introduces the ability to disable client tools managed updates from the client side, even if the cluster advertises a version.

Previously, the same behavior could only be achieved by setting `TELEPORT_TOOLS_VERSION=off` during `tsh login`, or by adding that setting to a shell profile. These changes extend the UX and simplify configuration.

When `tsh update --mode=disabled` is executed, a record is stored in the local configuration file. This suppresses update functionality and continuously shows a warning to the user.

This option is primarily useful for development workflows - for example, when developers need to disable updates during local testing changes of `tsh` or `tctl` to prevent a locally built binary from being re-executed by the released version after login to a cluster.

Related thread: https://gravitational.slack.com/archives/C0DF0TPMY/p1755215838037339
changelog: Add support for locally disabling managed updates for client tools (tsh, tctl) in configuration