### PR TITLE
fix proxy recording permit handling

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -780,6 +780,7 @@ type proxyingPermit struct {
 	MaxConnections        int64
 	DisconnectExpiredCert time.Time
 	MappedRoles           []string
+	SessionRecordingMode  constants.SessionRecordingMode
 }
 
 func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAuthority, clusterName string) (*proxyingPermit, error) {
@@ -824,6 +825,7 @@ func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAu
 		MaxConnections:        accessChecker.MaxConnections(),
 		DisconnectExpiredCert: getDisconnectExpiredCertFromSSHIdentity(accessChecker, authPref, ident),
 		MappedRoles:           accessInfo.Roles,
+		SessionRecordingMode:  accessChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH),
 	}, nil
 }
 

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -271,7 +271,7 @@ func TestCreateOrJoinSession(t *testing.T) {
 	require.NoError(t, err)
 
 	runningSessionID := rsession.NewID()
-	sess, _, err := newSession(ctx, runningSessionID, registry, newTestServerContext(t, srv, nil, nil), newMockSSHChannel(), sessionTypeInteractive)
+	sess, _, err := newSession(ctx, runningSessionID, registry, newTestServerContext(t, srv, nil, &decisionpb.SSHAccessPermit{}), newMockSSHChannel(), sessionTypeInteractive)
 	require.NoError(t, err)
 
 	t.Cleanup(sess.Stop)

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -226,6 +226,9 @@ func TestSession_newRecorder(t *testing.T) {
 			sctx: &ServerContext{
 				SessionRecordingConfig: proxyRecording,
 				term:                   &terminal{},
+				Identity: IdentityContext{
+					AccessPermit: &decisionpb.SSHAccessPermit{},
+				},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -247,6 +250,9 @@ func TestSession_newRecorder(t *testing.T) {
 			sctx: &ServerContext{
 				SessionRecordingConfig: proxyRecordingSync,
 				term:                   &terminal{},
+				Identity: IdentityContext{
+					AccessPermit: &decisionpb.SSHAccessPermit{},
+				},
 			},
 			errAssertion: require.NoError,
 			recAssertion: isNotSessionWriter,
@@ -336,6 +342,9 @@ func TestSession_newRecorder(t *testing.T) {
 				srv: &mockServer{
 					MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
 					datadir:             t.TempDir(),
+				},
+				Identity: IdentityContext{
+					AccessPermit: &decisionpb.SSHAccessPermit{},
 				},
 				term: &terminal{},
 			},
@@ -1168,7 +1177,7 @@ func TestSessionRecordingMode(t *testing.T) {
 				},
 			}
 
-			gotMode := sess.sessionRecordingMode()
+			gotMode := sess.sessionRecordingLocation()
 			require.Equal(t, tt.expectedMode, gotMode)
 		})
 	}

--- a/lib/srv/termmanager.go
+++ b/lib/srv/termmanager.go
@@ -125,11 +125,13 @@ func (g *TermManager) writeToClients(p []byte) {
 		// writeToClients is called with the lock held, so we need to release it
 		// before calling OnWriteError to avoid a deadlock if OnWriteError
 		// calls DeleteWriter/DeleteReader.
-		g.mu.Unlock()
-		for _, deleteWriter := range toDelete {
-			g.OnWriteError(deleteWriter.key, deleteWriter.err)
-		}
-		g.mu.Lock()
+		func() {
+			g.mu.Unlock()
+			defer g.mu.Lock()
+			for _, deleteWriter := range toDelete {
+				g.OnWriteError(deleteWriter.key, deleteWriter.err)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
Fixes an issue that would cause some unhappy paths in `srv/sess.go` to panic when running in proxy recording mode.

The refactor in https://github.com/gravitational/teleport/pull/54081 switched `lib/srv` to pass around operation-specific "permits" instead of an access checker interface.  Components were intentionally only switched over to support the subset of permits that they were expected to be called with, but some session recording logic was erroneously set up to always expect to be called during an ssh access attempt, when it might actually be called either during ssh access or proxy recording mode.  This slipped past our test coverage because the locations where the logic depended on the permit were in unhappy paths that weren't well-exercised.  This PR reworks the relevant logic to support proxying or access permits, adds session recording mode to the proxying permit, and moves the extraction of the permit parameters into the happy path to ensure that they won't be missed in the future if additional operations start to use these codepaths.

Issue was discovered by @tigrato during investigation of some flaky test panics.