### PR TITLE
[v16] Import the host description when discovering desktops

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -44,6 +44,10 @@ const (
 	// attrName is the name of an LDAP object.
 	attrName = "name"
 
+	// description is a description of an LDAP object.
+	attrDescription          = "description"
+	attrDescriptionMaxLength = 1024 // https://learn.microsoft.com/en-us/windows/win32/adschema/a-description
+
 	// attrCommonName is the common name of an LDAP object, or "CN".
 	attrCommonName = "cn"
 
@@ -366,5 +370,9 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 	// purge them if they stop being detected, and discovery of large Windows fleets can
 	// take a long time.
 	desktop.SetExpiry(s.cfg.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL * 3))
+
+	description := entry.GetAttributeValue(attrDescription)
+	desktop.Metadata.Description = description[:min(len(description), attrDescriptionMaxLength)]
+
 	return desktop, nil
 }

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -104,6 +104,7 @@ const (
 // see: https://docs.microsoft.com/en-us/windows/win32/adschema/c-computer#windows-server-2012-attributes
 var computerAttributes = []string{
 	attrName,
+	attrDescription,
 	attrCommonName,
 	attrDistinguishedName,
 	attrDNSHostName,


### PR DESCRIPTION
Backport #57962 to branch/v16

changelog: Windows desktop LDAP discovery now auto-populates the resource's description field.
