### PR TITLE
Recognize `e/lib/intune/testenv` as a testing package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,6 +191,7 @@ linters:
             - '!**/e/lib/aws/identitycenter/test/**'
             - '!**/e/lib/devicetrust/testenv/**'
             - '!**/e/lib/jamf/testenv/**'
+            - '!**/e/lib/intune/testenv/**'
             - '!**/e/lib/idp/saml/testenv/**'
             - '!**/e/lib/operatortest/**'
             - '!**/e/tests/**'
@@ -268,6 +269,7 @@ linters:
             - '!**/integrations/lib/testing/integration/authhelper.go'
             - '!**/integrations/lib/testing/integration/suite.go'
             - '!**/integrations/operator/controllers/resources/testlib/**'
+            - '!**/e/lib/intune/testenv/**'
           deny:
             - pkg: github.com/stretchr/testify
               desc: testify should not be imported outside of test code
@@ -281,6 +283,7 @@ linters:
             - '!**/e/lib/devicetrust/storage/storage.go'
             - '!**/e/lib/idp/saml/testenv/**'
             - '!**/e/lib/jamf/testenv/**'
+            - '!**/e/lib/intune/testenv/**'
             - '!**/e/lib/okta/api/oktaapitest/**'
             - '!**/e/lib/operatortest/**'
             - '!**/e/tests/**'


### PR DESCRIPTION
Doing so will let me remove [`nolint:depguard` from that package](https://github.com/gravitational/teleport.e/blob/1f4d73a1111ca5c626aad45b5319e2a5fd55d605/lib/intune/testenv/testenv.go#L12-L15).

Adding an exception for specific linter rules in the config of a linter is arguably more specific and safe than a blanket nolint on a whole linter.