### PR TITLE
[v16] Fix condition that guards conversion of gateway into kube gateway

### DIFF
--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -798,12 +798,12 @@ func (s *Service) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) er
 	defer s.gatewaysMu.RUnlock()
 	for _, gw := range s.gateways {
 		targetURI := gw.TargetURI()
-		if !targetURI.IsKube() && targetURI.GetRootClusterURI() != cluster.URI {
+		if !targetURI.IsKube() || targetURI.GetRootClusterURI() != cluster.URI {
 			continue
 		}
 		kubeGw, err := gateway.AsKube(gw)
 		if err != nil {
-			s.cfg.Log.Error("Could not clear certs for kube when assuming request", "error", err, "target_uri", targetURI)
+			return trace.Wrap(err)
 		}
 		kubeGw.ClearCerts()
 	}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/58032 to branch/v17

changelog: Fixed a Teleport Connect crash that occurred when assuming an access request while an application or database connection was active