### PR TITLE
Add vt10x to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - dependency-name: github.com/microsoft/go-mssqldb
       - dependency-name: github.com/redis/go-redis/v9
       - dependency-name: github.com/vulcand/predicate
+      - dependency-name: github.com/hinshun/vt10x
     open-pull-requests-limit: 20
     groups:
       go:


### PR DESCRIPTION
As per the `go.mod` instructions for replaced modules, this adds `vt10x` to dependabot's ignore list