### PR TITLE
fix PuTTY link in putty-winscp.mdx

### DIFF
--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -9,7 +9,7 @@ tags:
 ---
 
 This guide will show you how to use the Teleport client tool `tsh` to add saved sessions for use
-with [PuTTY](https://www.putty.org/), and then how to use PuTTY as a client to connect to SSH nodes.
+with [PuTTY](https://putty.software/), and then how to use PuTTY as a client to connect to SSH nodes.
 
 It will also show you how to optionally use these saved sessions with [WinSCP](https://winscp.net) to transfer
 files from SSH nodes using SFTP.


### PR DESCRIPTION
Closes #57966

The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803