### PR TITLE
docs: remove tctl mention only for macOS and Linux

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
@@ -30,7 +30,6 @@ connect to Teleport as the temporary bot.
 
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then
 verify that you can run `tctl` commands using your current credentials.
-`tctl` is supported on macOS and Linux machines.
 
 For example:
 


### PR DESCRIPTION
`tctl` is available on windows from v16 on.