### PR TITLE
Fix uncaught exception caused by `tsh daemon stop` when `TELEPORT_TOOLS_VERSION` is set

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -814,7 +814,7 @@ export default class MainProcess {
       logger.error('daemon stop process failed to start', error);
     });
     daemonStop.stderr.setEncoding('utf-8');
-    daemonStop.stderr.on('data', logger.error);
+    daemonStop.stderr.on('data', data => logger.error(data));
   }
 
   private logProcessExitAndError(

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -808,6 +808,10 @@ export default class MainProcess {
       {
         windowsHide: true,
         timeout: 2_000,
+        env: {
+          ...process.env,
+          [TSH_AUTOUPDATE_ENV_VAR]: TSH_AUTOUPDATE_OFF,
+        },
       }
     );
     daemonStop.on('error', error => {


### PR DESCRIPTION
When closing Connect on Windows, I saw the following message:
<img width="561" height="270" alt="image" src="https://github.com/user-attachments/assets/51b82b74-c520-43b0-81b9-2d2b2c4601ec" />
This happened because a class method was passed without binding, causing `this` to be lost.
(Before https://github.com/gravitational/teleport/pull/56683 this could only log an error, but now it shows this alert.)

After I fixed that, I saw this in logs:
`
[20-08-25 16:08:33] [Daemon stop] error: 2025/08/20 16:08:33 ERROR Failed to update tools version error="archive file is not found: 404" version=19.0.0-dev.gzdunek.13
`
Turns out that we forgot to disable tsh autoupdates for `tsh daemon stop`. I had `TELEPORT_TOOLS_VERSION` set globally and it was read by tsh.

changelog: Fixed an uncaught exception in Teleport Connect on Windows when closing the app while the `TELEPORT_TOOLS_VERSION` environment variable is set