### PR TITLE
Fixing flaky keystore tests due to RSA 4096 keygen latency

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4015,7 +4015,7 @@ func TestCAGeneration(t *testing.T) {
 	keyStoreManager, err := keystore.NewManager(t.Context(), &servicecfg.KeystoreConfig{}, &keystore.Options{
 		ClusterName:          &types.ClusterNameV2{Metadata: types.Metadata{Name: clusterName}},
 		AuthPreferenceGetter: &fakeAuthPreferenceGetter{},
-		RSAKeyPairSource: func() (priv []byte, pub []byte, err error) {
+		RSAKeyPairSource: func(alg cryptosuites.Algorithm) (priv []byte, pub []byte, err error) {
 			return privKey, pubKey, nil
 		},
 	})

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -600,9 +600,21 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 		},
 		kmsClient:         testGCPKMSClient,
 		clockworkOverride: clock,
+		RSAKeyPairSource: func(alg cryptosuites.Algorithm) ([]byte, []byte, error) {
+			switch alg {
+			case cryptosuites.RSA2048:
+				return testRSA2048PrivateKeyPEM, nil, nil
+			case cryptosuites.RSA4096:
+				return testRSA4096PrivateKeyPEM, nil, nil
+			}
+
+			return nil, nil, trace.Errorf("unexpected algorithm: %v", alg)
+		},
 	}
 
-	softwareBackend := newSoftwareKeyStore(&softwareConfig{})
+	softwareBackend := newSoftwareKeyStore(&softwareConfig{
+		rsaKeyPairSource: baseOpts.RSAKeyPairSource,
+	})
 	backends = append(backends, &backendDesc{
 		name:                "software",
 		config:              servicecfg.KeystoreConfig{},


### PR DESCRIPTION
Because recording encryption generates RSA 4096 keypairs, the software keystore backend can be flaky due to the massive overhead driving up latency. This PR parses a pre-generated RSA 4096 keypair to improve test timings.
