### PR TITLE
Add MCP Server filter for WebUI

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -539,9 +539,19 @@ func MatchKinds(resource ResourceWithLabels, kinds []string) bool {
 	if len(kinds) == 0 {
 		return true
 	}
+
 	resourceKind := resource.GetKind()
 	switch resourceKind {
-	case KindApp, KindSAMLIdPServiceProvider, KindIdentityCenterAccount:
+	case KindApp:
+		if slices.Contains(kinds, resourceKind) {
+			return true
+		}
+
+		// MCP server resources are subkinds of app resources, but it is
+		// possible for certain APIs like ListUnifiedResources to use KindMCP as
+		// a kind filter.
+		return resource.GetSubKind() == SubKindMCP && slices.Contains(kinds, KindMCP)
+	case KindSAMLIdPServiceProvider, KindIdentityCenterAccount:
 		return slices.Contains(kinds, KindApp)
 	default:
 		return slices.Contains(kinds, resourceKind)

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -543,7 +543,7 @@ func MatchKinds(resource ResourceWithLabels, kinds []string) bool {
 	resourceKind := resource.GetKind()
 	switch resourceKind {
 	case KindApp:
-		if slices.Contains(kinds, resourceKind) {
+		if slices.Contains(kinds, KindApp) {
 			return true
 		}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1295,12 +1295,17 @@ var (
 		types.KindNode:                   {},
 		types.KindSAMLIdPServiceProvider: {},
 		types.KindWindowsDesktop:         {},
+		types.KindMCP:                    {},
 	}
 
 	defaultUnifiedResourceKinds = slices.Collect(maps.Keys(supportedUnifiedResourceKinds))
 )
 
 func (a *ServerWithRoles) checkKindAccess(kind string) error {
+	// MCP are apps internally atm.
+	if kind == types.KindMCP {
+		kind = types.KindApp
+	}
 	if _, ok := supportedUnifiedResourceKinds[kind]; !ok {
 		// Treat unknown kinds as an access denied error instead of a bad parameter
 		// to prevent rejecting the request if users have access to other kinds requested.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5943,6 +5943,9 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 		require.NoError(t, err)
 		_, err = srv.Auth().UpsertDatabaseServer(ctx, db)
 		require.NoError(t, err)
+
+		createTestAppServerV3(t, srv.Auth(), name, nil)
+		createTestMCPAppServer(t, srv.Auth(), "mcp-"+name, nil)
 	}
 
 	// create user and client
@@ -5975,6 +5978,21 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 		Limit: 5,
 	})
 	require.NoError(t, err, "sort field is not required")
+
+	t.Run("KindApp", func(t *testing.T) {
+		resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindApp},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 10) // 5 app + 5 mcp server
+	})
+	t.Run("KindMCP", func(t *testing.T) {
+		resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Kinds: []string{types.KindMCP},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 5)
+	})
 }
 
 func TestListUnifiedResources_WithPinnedResources(t *testing.T) {
@@ -10626,8 +10644,6 @@ func TestValidateOracleJoinToken(t *testing.T) {
 
 func createTestAppServerV3(t *testing.T, auth *auth.Server, name string, labels map[string]string) *types.AppServerV3 {
 	t.Helper()
-	ctx := t.Context()
-
 	app, err := types.NewAppV3(
 		types.Metadata{
 			Name:   name,
@@ -10638,10 +10654,15 @@ func createTestAppServerV3(t *testing.T, auth *auth.Server, name string, labels 
 		},
 	)
 	require.NoError(t, err)
+	return createTestAppServerFromApp(t, auth, app)
+}
+
+func createTestAppServerFromApp(t *testing.T, auth *auth.Server, app *types.AppV3) *types.AppServerV3 {
+	t.Helper()
 	appServer, err := types.NewAppServerV3(
 		types.Metadata{
-			Name:   name,
-			Labels: labels,
+			Name:   app.GetName(),
+			Labels: app.GetAllLabels(),
 		},
 		types.AppServerSpecV3{
 			HostID: "test-host-id",
@@ -10650,10 +10671,28 @@ func createTestAppServerV3(t *testing.T, auth *auth.Server, name string, labels 
 	)
 	require.NoError(t, err)
 
-	_, err = auth.UpsertApplicationServer(ctx, appServer)
+	_, err = auth.UpsertApplicationServer(t.Context(), appServer)
 	require.NoError(t, err, "upserting test Application Server")
 
 	return appServer
+}
+
+func createTestMCPAppServer(t *testing.T, auth *auth.Server, name string, labels map[string]string) *types.AppServerV3 {
+	t.Helper()
+	mcp, err := types.NewAppV3(
+		types.Metadata{
+			Name:   name,
+			Labels: labels,
+		},
+		types.AppSpecV3{
+			MCP: &types.MCP{
+				Command:       "test",
+				RunAsHostUser: "test",
+			},
+		},
+	)
+	require.NoError(t, err)
+	return createTestAppServerFromApp(t, auth, mcp)
 }
 
 func TestSAMLIdPRoleOptionCreateUpdateValidation(t *testing.T) {

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -659,6 +659,26 @@ func TestMatchResourceByFilters(t *testing.T) {
 				PredicateExpression: filterExpression,
 			},
 		},
+		{
+			name: "MCP server with mcp kind filter",
+			resource: func() types.ResourceWithLabels {
+				return newAppServerFromApp(t, newMCPServerApp(t, "foo"))
+			},
+			filters: MatchResourceFilter{
+				Kinds:               []string{types.KindMCP},
+				PredicateExpression: filterExpression,
+			},
+		},
+		{
+			name: "MCP server with app kind filter",
+			resource: func() types.ResourceWithLabels {
+				return newAppServerFromApp(t, newMCPServerApp(t, "foo"))
+			},
+			filters: MatchResourceFilter{
+				Kinds:               []string{types.KindApp},
+				PredicateExpression: filterExpression,
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -727,4 +747,24 @@ func TestResourceMatchersToTypes(t *testing.T) {
 			require.Equal(t, tt.out, ResourceMatchersToTypes(tt.in))
 		})
 	}
+}
+
+func newMCPServerApp(t *testing.T, name string) *types.AppV3 {
+	t.Helper()
+	app, err := types.NewAppV3(types.Metadata{
+		Name: name,
+	}, types.AppSpecV3{
+		MCP: &types.MCP{
+			Command:       "test",
+			RunAsHostUser: "test",
+		},
+	})
+	require.NoError(t, err)
+	return app
+}
+
+func newAppServerFromApp(t *testing.T, app *types.AppV3) types.AppServer {
+	appServer, err := types.NewAppServerV3FromApp(app, "_", "_")
+	require.NoError(t, err)
+	return appServer
 }

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -416,6 +416,10 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 			return ok
 		}
 
+		if _, ok := kinds[types.KindMCP]; ok && r.GetSubKind() == types.KindMCP {
+			return true
+		}
+
 		_, ok := kinds[types.KindIdentityCenterAccount]
 		return ok
 	case types.KindKubeServer:
@@ -446,8 +450,19 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 			return ok
 		}
 
-		_, ok := kinds[types.KindAppServer]
-		return ok
+		if _, ok := kinds[types.KindAppServer]; ok {
+			return ok
+		}
+
+		if _, ok := kinds[types.KindMCP]; ok {
+			type appGetter interface {
+				GetApp() types.Application
+			}
+			if appServer, ok := r.(appGetter); ok && appServer.GetApp().GetSubKind() == types.SubKindMCP {
+				return true
+			}
+		}
+		return false
 	default:
 		return false
 	}

--- a/lib/teleterm/services/unifiedresources/unifiedresources.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources.go
@@ -37,6 +37,7 @@ var supportedResourceKinds = []string{
 	types.KindApp,
 	types.KindSAMLIdPServiceProvider,
 	types.KindWindowsDesktop,
+	types.KindMCP,
 }
 
 func List(ctx context.Context, cluster *clusters.Cluster, client apiclient.ListUnifiedResourcesClient, req *proto.ListUnifiedResourcesRequest) (*ListResponse, error) {

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -33,20 +33,14 @@ import { ViewModeSwitch } from 'shared/components/Controls/ViewModeSwitch';
 import {
   IncludedResourceMode,
   ResourceHealthStatus,
-  SharedUnifiedResource,
   UnifiedResourcesQueryParams,
 } from './types';
-import { FilterKind, ResourceAvailabilityFilter } from './UnifiedResources';
-
-const kindToLabel: Record<SharedUnifiedResource['resource']['kind'], string> = {
-  app: 'Application',
-  db: 'Database',
-  windows_desktop: 'Desktop',
-  kube_cluster: 'Kubernetes',
-  node: 'Server',
-  user_group: 'User group',
-  git_server: 'Git Server',
-};
+import {
+  FilterKind,
+  getFilterKindName,
+  ResourceAvailabilityFilter,
+  ResourceFilterKind,
+} from './UnifiedResources';
 
 const sortFieldOptions = [
   { label: 'Name', value: 'name' },
@@ -148,13 +142,24 @@ export function FilterPanel({
           />
         </HoverTooltip>
         <MultiselectMenu
-          options={availableKinds.map(
-            ({ kind, disabled }: { kind: string; disabled: boolean }) => ({
-              value: kind,
-              label: kindToLabel[kind],
-              disabled: disabled,
-            })
-          )}
+          options={availableKinds
+            .slice()
+            .sort((a, b) =>
+              getFilterKindName(a.kind).localeCompare(getFilterKindName(b.kind))
+            )
+            .map(
+              ({
+                kind,
+                disabled,
+              }: {
+                kind: ResourceFilterKind;
+                disabled: boolean;
+              }) => ({
+                value: kind as string,
+                label: getFilterKindName(kind),
+                disabled: disabled,
+              })
+            )}
           selected={kinds || []}
           onChange={onKindsChanged}
           label="Types"

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -39,7 +39,6 @@ import {
   FilterKind,
   getFilterKindName,
   ResourceAvailabilityFilter,
-  ResourceFilterKind,
 } from './UnifiedResources';
 
 const sortFieldOptions = [
@@ -143,23 +142,14 @@ export function FilterPanel({
         </HoverTooltip>
         <MultiselectMenu
           options={availableKinds
-            .slice()
-            .sort((a, b) =>
+            .toSorted((a, b) =>
               getFilterKindName(a.kind).localeCompare(getFilterKindName(b.kind))
             )
-            .map(
-              ({
-                kind,
-                disabled,
-              }: {
-                kind: ResourceFilterKind;
-                disabled: boolean;
-              }) => ({
-                value: kind as string,
-                label: getFilterKindName(kind),
-                disabled: disabled,
-              })
-            )}
+            .map(({ kind, disabled }) => ({
+              value: kind as string,
+              label: getFilterKindName(kind),
+              disabled,
+            }))}
           selected={kinds || []}
           onChange={onKindsChanged}
           label="Types"

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -138,6 +138,10 @@ const story = ({
               kind: 'windows_desktop',
               disabled: false,
             },
+            {
+              kind: 'mcp',
+              disabled: false,
+            },
           ]}
           onShowStatusInfo={() => null}
           params={mergedParams}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -144,7 +144,7 @@ const filterKindNameMap: Record<ResourceFilterKind, string> = {
   app: 'Applications',
   db: 'Databases',
   windows_desktop: 'Desktops',
-  kube_cluster: 'Kubernetes',
+  kube_cluster: 'Kubernetes Clusters',
   node: 'SSH Resources',
   user_group: 'User Groups',
   git_server: 'Git Servers',

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -124,10 +124,39 @@ export type SelectedResource = {
   resource: SharedUnifiedResource['resource'];
 };
 
+/*
+ * ResourceFilterKind are resource kinds that can be used for filtering through
+ * ListUnifiedResources API.
+ *
+ * 'mcp' can be used to filter MCP servers by the backend, even though they are
+ * internally just app resources atm.
+ */
+export type ResourceFilterKind =
+  | SharedUnifiedResource['resource']['kind']
+  | 'mcp';
+
 export type FilterKind = {
-  kind: SharedUnifiedResource['resource']['kind'];
+  kind: ResourceFilterKind;
   disabled: boolean;
 };
+
+const filterKindNameMap: Record<ResourceFilterKind, string> = {
+  app: 'Applications',
+  db: 'Databases',
+  windows_desktop: 'Desktops',
+  kube_cluster: 'Kubernetes',
+  node: 'SSH Resources',
+  user_group: 'User Groups',
+  git_server: 'Git Servers',
+  mcp: 'MCP Servers',
+};
+
+/*
+ * getFilterKindName returns the human-readable name of the filter kind.
+ */
+export function getFilterKindName(kind: ResourceFilterKind): string {
+  return filterKindNameMap[kind] ?? kind;
+}
 
 export type ResourceAvailabilityFilter =
   | {

--- a/web/packages/teleport/src/Navigation/ResourcesSection.test.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getResourcesSection } from 'teleport/Navigation/ResourcesSection';
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+
+describe('getResourcesSection', () => {
+  test('titles for subsections by kind are sorted', () => {
+    const navSections = getResourcesSection({
+      clusterId: 'cluster',
+      preferences: makeDefaultUserPreferences(),
+      updatePreferences: async () => {},
+      searchParams: new URLSearchParams(),
+    });
+
+    const titles = navSections.subsections.map(s => s.title);
+
+    // First two sections are fixed.
+    const fixed = ['All Resources', 'Pinned Resources'];
+
+    // Kind filters that should be sorted alphabetically.
+    const kindFilters = [
+      'Applications',
+      'Databases',
+      'Desktops',
+      'Git Servers',
+      'Kubernetes Clusters',
+      'MCP Servers',
+      'SSH Resources',
+    ];
+
+    const expected = [
+      ...fixed,
+      ...kindFilters.toSorted((a, b) => a.localeCompare(b)),
+    ];
+
+    expect(titles).toEqual(expected);
+  });
+});

--- a/web/packages/teleport/src/Navigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.tsx
@@ -167,7 +167,7 @@ function getResourcesSubsections({
     pinnedOnly: false,
   });
 
-  const tops = [
+  return [
     {
       title: 'All Resources',
       icon: Icons.Server,
@@ -200,9 +200,6 @@ function getResourcesSubsections({
         currentKinds.length !== 1,
       onClick: () => setPinnedUserPreference(true),
     },
-  ];
-
-  const byKinds = [
     {
       title: getFilterKindName('app'),
       icon: Icons.Application,
@@ -280,8 +277,7 @@ function getResourcesSubsections({
       onClick: () => setPinnedUserPreference(false),
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
-  ].sort((a, b) => a.title.localeCompare(b.title));
-  return [...tops, ...byKinds];
+  ];
 }
 
 export function ResourcesSection({

--- a/web/packages/teleport/src/Navigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.tsx
@@ -23,11 +23,14 @@ import { Box, Flex, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { DefaultTab } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
 import { UserPreferences } from 'gen-proto-ts/teleport/userpreferences/v1/userpreferences_pb';
+import {
+  getFilterKindName,
+  ResourceFilterKind,
+} from 'shared/components/UnifiedResources';
 
 import { encodeUrlQueryParams } from 'teleport/components/hooks/useUrlFiltering';
 import { EncodeUrlQueryParamsProps } from 'teleport/components/hooks/useUrlFiltering/encodeUrlQueryParams';
 import cfg from 'teleport/config';
-import { ResourceIdKind } from 'teleport/services/agents';
 import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
@@ -68,7 +71,7 @@ type GetSubsectionProps = {
 
 function encodeUrlQueryParamsWithTypedKinds(
   params: Omit<EncodeUrlQueryParamsProps, 'kinds'> & {
-    kinds?: ResourceIdKind[];
+    kinds?: ResourceFilterKind[];
   }
 ) {
   return encodeUrlQueryParams(params);
@@ -114,7 +117,7 @@ function getResourcesSubsections({
     preferences?.unifiedResourcePreferences?.defaultTab === DefaultTab.PINNED;
 
   // isKindActive returns true if we are currently filtering for only the provided kind of resource.
-  const isKindActive = (kind: ResourceIdKind) => {
+  const isKindActive = (kind: ResourceFilterKind) => {
     // This subsection for this kind should only be marked active when it is the only kind being filtered for,
     // if there are multiple kinds then the "All Resources" button should be active.
     return currentKinds.length === 1 && currentKinds[0] === kind;
@@ -158,8 +161,13 @@ function getResourcesSubsections({
     kinds: ['git_server'],
     pinnedOnly: false,
   });
+  const mcpOnlyRoute = encodeUrlQueryParamsWithTypedKinds({
+    pathname: baseRoute,
+    kinds: ['mcp'],
+    pinnedOnly: false,
+  });
 
-  return [
+  const tops = [
     {
       title: 'All Resources',
       icon: Icons.Server,
@@ -192,8 +200,11 @@ function getResourcesSubsections({
         currentKinds.length !== 1,
       onClick: () => setPinnedUserPreference(true),
     },
+  ];
+
+  const byKinds = [
     {
-      title: 'Applications',
+      title: getFilterKindName('app'),
       icon: Icons.Application,
       route: applicationsOnlyRoute,
       searchableTags: ['resources', 'apps', 'applications'],
@@ -204,7 +215,7 @@ function getResourcesSubsections({
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
     {
-      title: 'Databases',
+      title: getFilterKindName('db'),
       icon: Icons.Database,
       route: databasesOnlyRoute,
       searchableTags: ['resources', 'dbs', 'databases'],
@@ -215,7 +226,7 @@ function getResourcesSubsections({
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
     {
-      title: 'Desktops',
+      title: getFilterKindName('windows_desktop'),
       icon: Icons.Desktop,
       route: desktopsOnlyRoute,
       searchableTags: ['resources', 'desktops', 'rdp', 'windows'],
@@ -226,7 +237,7 @@ function getResourcesSubsections({
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
     {
-      title: 'Git Servers',
+      title: getFilterKindName('git_server'),
       icon: Icons.GitHub,
       route: gitOnlyRoute,
       searchableTags: ['resources', 'git', 'github', 'git servers'],
@@ -237,7 +248,7 @@ function getResourcesSubsections({
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
     {
-      title: 'Kubernetes',
+      title: getFilterKindName('kube_cluster'),
       icon: Icons.Kubernetes,
       route: kubesOnlyRoute,
       searchableTags: ['resources', 'k8s', 'kubes', 'kubernetes'],
@@ -248,7 +259,18 @@ function getResourcesSubsections({
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
     {
-      title: 'SSH Resources',
+      title: getFilterKindName('mcp'),
+      icon: Icons.ModelContextProtocol,
+      route: mcpOnlyRoute,
+      searchableTags: ['resources', 'mcp', 'mcp servers'],
+      category: NavigationCategory.Resources,
+      exact: false,
+      customRouteMatchFn: () => isKindActive('mcp'),
+      onClick: () => setPinnedUserPreference(false),
+      subCategory: CustomNavigationSubcategory.FilteredViews,
+    },
+    {
+      title: getFilterKindName('node'),
       icon: Icons.Server,
       route: nodesOnlyRoute,
       searchableTags: ['resources', 'servers', 'nodes', 'ssh resources'],
@@ -258,7 +280,8 @@ function getResourcesSubsections({
       onClick: () => setPinnedUserPreference(false),
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },
-  ];
+  ].sort((a, b) => a.title.localeCompare(b.title));
+  return [...tops, ...byKinds];
 }
 
 export function ResourcesSection({

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -114,6 +114,10 @@ const getAvailableKindsWithAccess = (flags: FeatureFlags): FilterKind[] => {
       kind: 'git_server',
       disabled: !flags.gitServers,
     },
+    {
+      kind: 'mcp',
+      disabled: !flags.applications,
+    },
   ];
 };
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -494,6 +494,10 @@ const Resources = memo(
               kind: 'windows_desktop',
               disabled: false,
             },
+            {
+              kind: 'mcp',
+              disabled: false,
+            },
           ]}
           NoResources={
             <NoResources


### PR DESCRIPTION
changelog: added "MCP Servers" filter in resources view for Web UI and Teleport Connect

implements #57651 

changes:
- `ListUnifiedResources` api now supports `mcp` as a filter kind. The actual matching logic is handled by URC by checking if the resource is an app and has a subkind of `mcp`
- Added the 'MCP Servers' as kind filter in UI
- As discussed in slack, make the side panel and filter list consistent

WebUI Side panel:
<img width="352" height="533" alt="Screenshot 2025-08-20 at 1 47 30 PM" src="https://github.com/user-attachments/assets/b20c2bea-cbff-408f-bced-87fe616c2844" />

WebUI filter:
<img width="185" height="409" alt="Screenshot 2025-08-20 at 1 47 33 PM" src="https://github.com/user-attachments/assets/29b46624-fe04-4ee6-bc4d-336b98193ef9" />

Teleport Connect:
<img width="467" height="347" alt="Screenshot 2025-08-20 at 2 42 29 PM" src="https://github.com/user-attachments/assets/34a3f15b-8774-4698-8b51-c37fcba7720f" />
