### PR TITLE
Update Helm chart guide reference link 

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -6,7 +6,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.28.0"
+      "version": "1.28.1"
     },
     "ansible": {
       "min_version": "2.9.6"

--- a/docs/config.json
+++ b/docs/config.json
@@ -6,7 +6,7 @@
       "nodeIP": "ip-172-31-35-170"
     },
     "access_graph": {
-      "version": "1.28.1"
+      "version": "1.28.0"
     },
     "ansible": {
       "min_version": "2.9.6"

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -7,7 +7,7 @@
     <h3>Add the repo</h3>
     <pre>helm repo add teleport https://charts.releases.teleport.dev</pre>
     <h3>Install a chart</h3>
-    <h4>See our <a href="https://goteleport.com/docs/kubernetes-access/helm/guides/">Helm chart guides</a> for HA setups in EKS or GKE.</h4>
+    <h4>See our <a href="https://goteleport.com/docs/reference/helm-reference/">Helm chart guides</a> for HA setups in EKS or GKE.</h4>
     <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-cluster">teleport-cluster:</a></b>
       # Install a single node Teleport cluster and provision a cert using ACME.
       # Set clusterName to a unique hostname, for example teleport.example.com


### PR DESCRIPTION
Changed the Helm chart guide URL in the example chart index.html to point to the reference documentation. 
