### PR TITLE
[cache] unify generic resource test utility

### DIFF
--- a/lib/cache/access_monitoring_rule_test.go
+++ b/lib/cache/access_monitoring_rule_test.go
@@ -37,7 +37,7 @@ func TestAccessMonitoringRules(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*accessmonitoringrulesv1.AccessMonitoringRule]{
+	testResources153(t, p, testFuncs[*accessmonitoringrulesv1.AccessMonitoringRule]{
 		newResource: func(name string) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
 			return newAccessMonitoringRule(t), nil
 		},
@@ -50,7 +50,7 @@ func TestAccessMonitoringRules(t *testing.T) {
 			return results, err
 		},
 		cacheGet: p.cache.GetAccessMonitoringRule,
-		cacheList: func(ctx context.Context) ([]*accessmonitoringrulesv1.AccessMonitoringRule, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*accessmonitoringrulesv1.AccessMonitoringRule, error) {
 			results, _, err := p.cache.ListAccessMonitoringRules(ctx, 0, "")
 			return results, err
 		},
@@ -59,7 +59,7 @@ func TestAccessMonitoringRules(t *testing.T) {
 			return err
 		},
 		deleteAll: p.accessMonitoringRules.DeleteAllAccessMonitoringRules,
-	})
+	}, withSkipPaginationTest())
 }
 
 func TestListAccessMonitoringRulesWithFilter(t *testing.T) {

--- a/lib/cache/auto_update_test.go
+++ b/lib/cache/auto_update_test.go
@@ -33,7 +33,7 @@ func TestAutoUpdateConfig(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*autoupdatev1.AutoUpdateConfig]{
+	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateConfig]{
 		newResource: func(name string) (*autoupdatev1.AutoUpdateConfig, error) {
 			return newAutoUpdateConfig(t), nil
 		},
@@ -48,7 +48,7 @@ func TestAutoUpdateConfig(t *testing.T) {
 			}
 			return []*autoupdatev1.AutoUpdateConfig{item}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*autoupdatev1.AutoUpdateConfig, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*autoupdatev1.AutoUpdateConfig, error) {
 			item, err := p.cache.GetAutoUpdateConfig(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateConfig{}, nil
@@ -58,7 +58,7 @@ func TestAutoUpdateConfig(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateConfig(ctx))
 		},
-	})
+	}, withSkipPaginationTest())
 }
 
 // TestAutoUpdateVersion tests that CRUD operations on AutoUpdateVersion resource are
@@ -69,7 +69,7 @@ func TestAutoUpdateVersion(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*autoupdatev1.AutoUpdateVersion]{
+	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateVersion]{
 		newResource: func(name string) (*autoupdatev1.AutoUpdateVersion, error) {
 			return newAutoUpdateVersion(t), nil
 		},
@@ -84,7 +84,7 @@ func TestAutoUpdateVersion(t *testing.T) {
 			}
 			return []*autoupdatev1.AutoUpdateVersion{item}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*autoupdatev1.AutoUpdateVersion, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*autoupdatev1.AutoUpdateVersion, error) {
 			item, err := p.cache.GetAutoUpdateVersion(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateVersion{}, nil
@@ -94,7 +94,7 @@ func TestAutoUpdateVersion(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateVersion(ctx))
 		},
-	})
+	}, withSkipPaginationTest())
 }
 
 // TestAutoUpdateAgentRollout tests that CRUD operations on AutoUpdateAgentRollout resource are
@@ -105,7 +105,7 @@ func TestAutoUpdateAgentRollout(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*autoupdatev1.AutoUpdateAgentRollout]{
+	testResources153(t, p, testFuncs[*autoupdatev1.AutoUpdateAgentRollout]{
 		newResource: func(name string) (*autoupdatev1.AutoUpdateAgentRollout, error) {
 			return newAutoUpdateAgentRollout(t), nil
 		},
@@ -120,7 +120,7 @@ func TestAutoUpdateAgentRollout(t *testing.T) {
 			}
 			return []*autoupdatev1.AutoUpdateAgentRollout{item}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
 			item, err := p.cache.GetAutoUpdateAgentRollout(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateAgentRollout{}, nil
@@ -130,5 +130,5 @@ func TestAutoUpdateAgentRollout(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateAgentRollout(ctx))
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -39,7 +39,7 @@ func TestBotInstanceCache(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*machineidv1.BotInstance]{
+	testResources153(t, p, testFuncs[*machineidv1.BotInstance]{
 		newResource: func(key string) (*machineidv1.BotInstance, error) {
 			return &machineidv1.BotInstance{
 				Kind:     types.KindBotInstance,
@@ -55,7 +55,7 @@ func TestBotInstanceCache(t *testing.T) {
 		cacheGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
 			return p.cache.GetBotInstance(ctx, "bot-1", key)
 		},
-		cacheList: func(ctx context.Context) ([]*machineidv1.BotInstance, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*machineidv1.BotInstance, error) {
 			results, _, err := p.cache.ListBotInstances(ctx, "", 0, "", "", nil)
 			return results, err
 		},
@@ -79,7 +79,7 @@ func TestBotInstanceCache(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return p.botInstanceService.DeleteAllBotInstances(ctx)
 		},
-	})
+	}, withSkipPaginationTest())
 }
 
 // TestBotInstanceCachePaging tests that items from the cache are paginated.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -175,28 +175,83 @@ type testPack struct {
 	plugin                  *local.PluginsService
 }
 
-// testFuncs are functions to support testing an object in a cache.
-type testFuncs[T types.Resource] struct {
-	newResource    func(string) (T, error)
-	create         func(context.Context, T) error
-	list           func(context.Context) ([]T, error)
-	cacheGet       func(context.Context, string) (T, error)
-	cacheList      func(context.Context, int) ([]T, error)
-	update         func(context.Context, T) error
-	deleteAll      func(context.Context) error
-	changeResource func(T)
+// resourceOps contains helpers to modify the state of either types.Resource or types.Resource153  which
+// have a slightly different interface.
+type resourceOps[T any] struct {
+	Name    func(T) string
+	Setup   func(T)
+	Modify  func(T)
+	cmpOpts []cmp.Option
 }
 
-// testFuncs153 are functions to support testing an RFD153-style resource in a cache.
-type testFuncs153[T types.Resource153] struct {
+func defaultResourceOps[T types.Resource]() *resourceOps[T] {
+	return &resourceOps[T]{
+		Modify: func(t T) {
+			// types.Resource metadata is immutable, modify expiry only.
+			if t.Expiry().IsZero() {
+				t.SetExpiry(time.Now().Add(30 * time.Minute))
+			} else {
+				t.SetExpiry(t.Expiry().Add(30 * time.Minute))
+			}
+		},
+		Name: func(t T) string { return t.GetName() },
+		Setup: func(t T) {
+			// types.Resource metadata is immutable, modify expiry only.
+			if t.Expiry().IsZero() {
+				t.SetExpiry(time.Now().Add(30 * time.Minute))
+			} else {
+				t.SetExpiry(t.Expiry().Add(30 * time.Minute))
+			}
+		},
+		cmpOpts: []cmp.Option{
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+			cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		},
+	}
+}
+
+func defaultResource153Ops[T types.Resource153]() *resourceOps[T] {
+	return &resourceOps[T]{
+		Setup: func(t T) {
+			metadata := t.GetMetadata()
+			if metadata.Expires == nil {
+				metadata.Expires = timestamppb.New(time.Now().Add(30 * time.Minute))
+			} else {
+				expiry := metadata.Expires.AsTime()
+				metadata.Expires = timestamppb.New(expiry.Add(30 * time.Minute))
+			}
+			metadata.Labels = map[string]string{"label": "value1"}
+		},
+		Modify: func(t T) {
+			metadata := t.GetMetadata()
+			if metadata.Expires == nil {
+				metadata.Expires = timestamppb.New(time.Now().Add(30 * time.Minute))
+			} else {
+				expiry := metadata.Expires.AsTime()
+				metadata.Expires = timestamppb.New(expiry.Add(30 * time.Minute))
+			}
+			metadata.Labels["label"] = "value2"
+		},
+		Name: func(t T) string { return t.GetMetadata().GetName() },
+		cmpOpts: []cmp.Option{
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+			protocmp.Transform(),
+			cmpopts.EquateEmpty(),
+		},
+	}
+}
+
+// testFuncs are functions to support testing an object in a cache.
+type testFuncs[T any] struct {
 	newResource func(string) (T, error)
 	create      func(context.Context, T) error
 	list        func(context.Context) ([]T, error)
 	cacheGet    func(context.Context, string) (T, error)
-	cacheList   func(context.Context) ([]T, error)
+	cacheList   func(context.Context, int) ([]T, error)
 	update      func(context.Context, T) error
 	delete      func(context.Context, string) error
 	deleteAll   func(context.Context) error
+	resource    *resourceOps[T]
 }
 
 func (t *testPack) Close() {
@@ -1276,6 +1331,7 @@ type testOptions struct {
 
 type optionsFunc func(*testOptions)
 
+// TODO(okraport): remove this when all getters support pagination.
 func withSkipPaginationTest() optionsFunc {
 	return func(opts *testOptions) {
 		opts.skipPaginationTest = true
@@ -1290,135 +1346,54 @@ func withSkipPaginationTest() optionsFunc {
 // resource list request/call.
 const defaultTestPageSize = 2
 
-// testResources is a generic tester for resources.
+// testResources is a wrapper for testing resources conforming to types.Resource
 func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[T], opts ...optionsFunc) {
+	funcs.resource = defaultResourceOps[T]()
+	testResourcesInternal(t, p, funcs, opts...)
+}
+
+// testResources153 is a wrapper for testing resources conforming to types.Resource153
+func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs testFuncs[T], opts ...optionsFunc) {
+	funcs.resource = defaultResource153Ops[T]()
+	testResourcesInternal(t, p, funcs, opts...)
+}
+
+// testResourcesInternal is a generic tester for resources.
+func testResourcesInternal[T any](t *testing.T, p *testPack, funcs testFuncs[T], opts ...optionsFunc) {
 	t.Helper()
+	require.NotNil(t, funcs.resource)
+	require.NotNil(t, funcs.resource.Name)
+	if funcs.update != nil {
+		require.NotNil(t, funcs.resource.Modify)
+		require.NotNil(t, funcs.resource.Setup)
+	}
+
 	var options testOptions
 	for _, opt := range opts {
 		opt(&options)
 	}
 	ctx := t.Context()
 
-	if funcs.changeResource == nil {
-		funcs.changeResource = func(t T) {
-			if t.Expiry().IsZero() {
-				t.SetExpiry(time.Now().Add(30 * time.Minute))
-			} else {
-				t.SetExpiry(t.Expiry().Add(30 * time.Minute))
-			}
-		}
-	}
 	if !options.skipPaginationTest {
 		testResourcePagination(t, p, funcs)
 	}
 
 	// Create a resource.
-	r, err := funcs.newResource("test-sp")
-	require.NoError(t, err)
-	funcs.changeResource(r)
-
-	err = funcs.create(ctx, r)
-	require.NoError(t, err)
-
-	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
-		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
-	}
-
-	// Check that the resource is now in the backend.
-	out, err := funcs.list(ctx)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]T{r}, out, cmpOpts...))
-
-	// Wait until the information has been replicated to the cache.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		// Make sure the cache has a single resource in it.
-		out, err = funcs.cacheList(ctx, defaultTestPageSize)
-		assert.NoError(t, err)
-		assert.Empty(t, cmp.Diff([]T{r}, out, cmpOpts...))
-	}, time.Second*2, time.Millisecond*250)
-
-	// cacheGet is optional as not every resource implements it
-	if funcs.cacheGet != nil {
-		// Make sure a single cache get works.
-		getR, err := funcs.cacheGet(ctx, r.GetName())
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(r, getR, cmpOpts...))
-
-		// Make sure we get a NotFoundError (and not a panic) when the resource
-		// is not found.
-		_, err = funcs.cacheGet(ctx, "no-such-resource")
-		require.ErrorAs(t, err, new(*trace.NotFoundError))
-	}
-
-	// update is optional as not every resource implements it
-	if funcs.update != nil {
-		// Not all create functions will result in resource being updated
-		// with the latest revision. To avoid any conditional update
-		// failures caused by mismatched revisions, an updated
-		// copy of the resource is loaded prior to updating.
-		if funcs.cacheGet != nil {
-			var err error
-			r, err = funcs.cacheGet(ctx, r.GetName())
-			require.NoError(t, err)
-		}
-		// Update the resource and upsert it into the backend again.
-		funcs.changeResource(r)
-		err = funcs.update(ctx, r)
-		require.NoError(t, err)
-	}
-
-	// Check that the resource is in the backend and only one exists (so an
-	// update occurred).
-	out, err = funcs.list(ctx)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]T{r}, out, cmpOpts...))
-
-	// Check that information has been replicated to the cache.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		// Make sure the cache has a single resource in it.
-		out, err = funcs.cacheList(ctx, defaultTestPageSize)
-		assert.NoError(t, err)
-		assert.Empty(t, cmp.Diff([]T{r}, out, cmpOpts...))
-	}, time.Second*2, time.Millisecond*250)
-
-	// Remove all service providers from the backend.
-	err = funcs.deleteAll(ctx)
-	require.NoError(t, err)
-	// Check that information has been replicated to the cache.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		// Check that the cache is now empty.
-		out, err = funcs.cacheList(ctx, defaultTestPageSize)
-		assert.NoError(t, err)
-		assert.Empty(t, out)
-	}, time.Second*2, time.Millisecond*250)
-
-}
-
-// testResources153 is a generic tester for RFD153-style resources.
-func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs testFuncs153[T]) {
-	ctx := context.Background()
-
-	// Create a resource.
-	r, err := funcs.newResource("test-resource")
+	r, err := funcs.newResource("test-resource-1")
 	require.NoError(t, err)
 	// update is optional as not every resource implements it
 	if funcs.update != nil {
-		r.GetMetadata().Labels = map[string]string{"label": "value1"}
+		funcs.resource.Setup(r)
 	}
 
 	err = funcs.create(ctx, r)
 	require.NoError(t, err)
 
-	cmpOpts := []cmp.Option{
-		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
-		protocmp.Transform(),
-		cmpopts.EquateEmpty(),
-	}
+	cmpOpts := funcs.resource.cmpOpts
 
 	assertCacheContents := func(expected []T) {
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			out, err := funcs.cacheList(ctx)
+			out, err := funcs.cacheList(ctx, 0)
 			assert.NoError(t, err)
 
 			// If the cache is expected to be empty, then test explicitly for
@@ -1437,6 +1412,7 @@ func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs test
 	// Check that the resource is now in the backend.
 	out, err := funcs.list(ctx)
 	require.NoError(t, err)
+	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff([]T{r}, out, cmpOpts...))
 
 	// Wait until the information has been replicated to the cache.
@@ -1445,15 +1421,29 @@ func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs test
 	// cacheGet is optional as not every resource implements it
 	if funcs.cacheGet != nil {
 		// Make sure a single cache get works.
-		getR, err := funcs.cacheGet(ctx, r.GetMetadata().GetName())
+		getR, err := funcs.cacheGet(ctx, funcs.resource.Name(r))
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(r, getR, cmpOpts...))
+
+		// Make sure we get a NotFoundError (and not a panic) when the resource
+		// is not found.
+		_, err = funcs.cacheGet(ctx, "no-such-resource")
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	}
 
 	// update is optional as not every resource implements it
 	if funcs.update != nil {
+		// Not all create functions will result in resource being updated
+		// with the latest revision. To avoid any conditional update
+		// failures caused by mismatched revisions, an updated
+		// copy of the resource is loaded prior to updating.
+		if funcs.cacheGet != nil {
+			var err error
+			r, err = funcs.cacheGet(ctx, funcs.resource.Name(r))
+			require.NoError(t, err)
+		}
 		// Update the resource and upsert it into the backend again.
-		r.GetMetadata().Labels["label"] = "value2"
+		funcs.resource.Modify(r)
 		err = funcs.update(ctx, r)
 		require.NoError(t, err)
 	}
@@ -1474,7 +1464,7 @@ func testResources153[T types.Resource153](t *testing.T, p *testPack, funcs test
 		require.NoError(t, funcs.create(ctx, r2))
 		assertCacheContents([]T{r, r2})
 		// Check that only one resource is deleted.
-		require.NoError(t, funcs.delete(ctx, r2.GetMetadata().Name))
+		require.NoError(t, funcs.delete(ctx, funcs.resource.Name(r2)))
 		assertCacheContents([]T{r})
 	}
 
@@ -2623,7 +2613,7 @@ func fetchEvent(t *testing.T, w types.Watcher, timeout time.Duration) types.Even
 	return ev
 }
 
-func testResourcePagination[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[T]) {
+func testResourcePagination[T any](t *testing.T, p *testPack, funcs testFuncs[T]) {
 	t.Helper()
 	totalItems := defaultTestPageSize + 1
 
@@ -2665,7 +2655,7 @@ func testResourcePagination[T types.Resource](t *testing.T, p *testPack, funcs t
 
 	seen := make(map[string]bool, totalItems)
 	for _, item := range out {
-		name := item.GetName()
+		name := funcs.resource.Name(item)
 		if seen[name] {
 			t.Fatalf("duplicate resource returned in pagination: %q", name)
 		}

--- a/lib/cache/cluster_config_test.go
+++ b/lib/cache/cluster_config_test.go
@@ -180,7 +180,7 @@ func TestAccessGraphSettings(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*clusterconfigv1.AccessGraphSettings]{
+	testResources153(t, p, testFuncs[*clusterconfigv1.AccessGraphSettings]{
 		newResource: func(name string) (*clusterconfigv1.AccessGraphSettings, error) {
 			return newAccessGraphSettings(t), nil
 		},
@@ -195,7 +195,7 @@ func TestAccessGraphSettings(t *testing.T) {
 			}
 			return []*clusterconfigv1.AccessGraphSettings{item}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*clusterconfigv1.AccessGraphSettings, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*clusterconfigv1.AccessGraphSettings, error) {
 			item, err := p.cache.GetAccessGraphSettings(ctx)
 			if trace.IsNotFound(err) {
 				return []*clusterconfigv1.AccessGraphSettings{}, nil
@@ -205,5 +205,5 @@ func TestAccessGraphSettings(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.clusterConfigS.DeleteAccessGraphSettings(ctx))
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/crown_jewel_test.go
+++ b/lib/cache/crown_jewel_test.go
@@ -33,7 +33,7 @@ func TestCrownJewel(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*crownjewelv1.CrownJewel]{
+	testResources153(t, p, testFuncs[*crownjewelv1.CrownJewel]{
 		newResource: func(name string) (*crownjewelv1.CrownJewel, error) {
 			return newCrownJewel(t, name), nil
 		},
@@ -45,10 +45,10 @@ func TestCrownJewel(t *testing.T) {
 			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*crownjewelv1.CrownJewel, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*crownjewelv1.CrownJewel, error) {
 			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		deleteAll: p.crownJewels.DeleteAllCrownJewels,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -274,7 +274,7 @@ func TestDatabaseObjects(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*dbobjectv1.DatabaseObject]{
+	testResources153(t, p, testFuncs[*dbobjectv1.DatabaseObject]{
 		newResource: func(name string) (*dbobjectv1.DatabaseObject, error) {
 			return newDatabaseObject(t, name), nil
 		},
@@ -286,7 +286,7 @@ func TestDatabaseObjects(t *testing.T) {
 			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*dbobjectv1.DatabaseObject, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*dbobjectv1.DatabaseObject, error) {
 			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
@@ -316,5 +316,5 @@ func TestDatabaseObjects(t *testing.T) {
 			}
 			return nil
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/health_check_config_test.go
+++ b/lib/cache/health_check_config_test.go
@@ -49,7 +49,7 @@ func TestHealthCheckConfig(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*healthcheckconfigv1.HealthCheckConfig]{
+	testResources153(t, p, testFuncs[*healthcheckconfigv1.HealthCheckConfig]{
 		newResource: func(name string) (*healthcheckconfigv1.HealthCheckConfig, error) {
 			return newHealthCheckConfig(t, name), nil
 		},
@@ -66,10 +66,10 @@ func TestHealthCheckConfig(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.healthCheckConfig.DeleteAllHealthCheckConfigs,
-		cacheList: func(ctx context.Context) ([]*healthcheckconfigv1.HealthCheckConfig, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*healthcheckconfigv1.HealthCheckConfig, error) {
 			items, _, err := p.cache.ListHealthCheckConfigs(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		cacheGet: p.cache.GetHealthCheckConfig,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/identitycenter_test.go
+++ b/lib/cache/identitycenter_test.go
@@ -53,7 +53,7 @@ func TestIdentityCenterAccount(t *testing.T) {
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[*identitycenterv1.Account]{
+	testResources153(t, fixturePack, testFuncs[*identitycenterv1.Account]{
 		newResource: func(s string) (*identitycenterv1.Account, error) {
 			return newIdentityCenterAccount(s), nil
 		},
@@ -75,14 +75,14 @@ func TestIdentityCenterAccount(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllIdentityCenterAccounts(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]*identitycenterv1.Account, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*identitycenterv1.Account, error) {
 			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListIdentityCenterAccounts2))
 		},
 		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.Account, error) {
 			r, err := fixturePack.cache.GetIdentityCenterAccount(ctx, id)
 			return r, trace.Wrap(err)
 		},
-	})
+	}, withSkipPaginationTest())
 }
 
 func newIdentityCenterPrincipalAssignment(id string) *identitycenterv1.PrincipalAssignment {
@@ -110,7 +110,7 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[*identitycenterv1.PrincipalAssignment]{
+	testResources153(t, fixturePack, testFuncs[*identitycenterv1.PrincipalAssignment]{
 		newResource: func(s string) (*identitycenterv1.PrincipalAssignment, error) {
 			return newIdentityCenterPrincipalAssignment(s), nil
 		},
@@ -131,14 +131,14 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllPrincipalAssignments(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]*identitycenterv1.PrincipalAssignment, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*identitycenterv1.PrincipalAssignment, error) {
 			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListPrincipalAssignments2))
 		},
 		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.PrincipalAssignment, error) {
 			r, err := fixturePack.cache.GetPrincipalAssignment(ctx, services.PrincipalAssignmentID(id))
 			return r, trace.Wrap(err)
 		},
-	})
+	}, withSkipPaginationTest())
 }
 
 func newIdentityCenterAccountAssignment(id string) *identitycenterv1.AccountAssignment {
@@ -165,7 +165,7 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[*identitycenterv1.AccountAssignment]{
+	testResources153(t, fixturePack, testFuncs[*identitycenterv1.AccountAssignment]{
 		newResource: func(s string) (*identitycenterv1.AccountAssignment, error) {
 			return newIdentityCenterAccountAssignment(s), nil
 		},
@@ -186,12 +186,12 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllAccountAssignments(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]*identitycenterv1.AccountAssignment, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*identitycenterv1.AccountAssignment, error) {
 			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListIdentityCenterAccountAssignments))
 		},
 		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.AccountAssignment, error) {
 			r, err := fixturePack.cache.GetAccountAssignment(ctx, services.IdentityCenterAccountAssignmentID(id))
 			return r.AccountAssignment, trace.Wrap(err)
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/notification_test.go
+++ b/lib/cache/notification_test.go
@@ -33,7 +33,7 @@ func TestUserNotifications(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*notificationsv1.Notification]{
+	testResources153(t, p, testFuncs[*notificationsv1.Notification]{
 		newResource: func(name string) (*notificationsv1.Notification, error) {
 			return newUserNotification(t, name), nil
 		},
@@ -45,12 +45,12 @@ func TestUserNotifications(t *testing.T) {
 			items, _, err := p.notifications.ListUserNotifications(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*notificationsv1.Notification, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*notificationsv1.Notification, error) {
 			items, _, err := p.cache.ListUserNotifications(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		deleteAll: p.notifications.DeleteAllUserNotifications,
-	})
+	}, withSkipPaginationTest())
 }
 
 // TestGlobalNotifications tests that CRUD operations on global notification resources are
@@ -61,7 +61,7 @@ func TestGlobalNotifications(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*notificationsv1.GlobalNotification]{
+	testResources153(t, p, testFuncs[*notificationsv1.GlobalNotification]{
 		newResource: func(name string) (*notificationsv1.GlobalNotification, error) {
 			return newGlobalNotification(t, name), nil
 		},
@@ -73,10 +73,10 @@ func TestGlobalNotifications(t *testing.T) {
 			items, _, err := p.notifications.ListGlobalNotifications(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*notificationsv1.GlobalNotification, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*notificationsv1.GlobalNotification, error) {
 			items, _, err := p.cache.ListGlobalNotifications(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		deleteAll: p.notifications.DeleteAllGlobalNotifications,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/plugin_static_credentials_test.go
+++ b/lib/cache/plugin_static_credentials_test.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -101,13 +100,6 @@ func TestPluginStaticCredentials(t *testing.T) {
 					return out, nil
 				},
 				cacheGet: cacheGet.fn,
-				changeResource: func(cred types.PluginStaticCredentials) {
-					// types.PluginStaticCredentials does not support Expires. Let's
-					// use labels.
-					labels := cred.GetStaticLabels()
-					labels["now"] = time.Now().String()
-					cred.SetStaticLabels(labels)
-				},
 			})
 		})
 	}

--- a/lib/cache/provisioning_test.go
+++ b/lib/cache/provisioning_test.go
@@ -58,7 +58,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 	fixturePack := newTestPack(t, ForAuth)
 	t.Cleanup(fixturePack.Close)
 
-	testResources153(t, fixturePack, testFuncs153[*provisioningv1.PrincipalState]{
+	testResources153(t, fixturePack, testFuncs[*provisioningv1.PrincipalState]{
 		newResource: func(s string) (*provisioningv1.PrincipalState, error) {
 			return newProvisioningPrincipalState(s), nil
 		},
@@ -80,7 +80,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteAllProvisioningStates(ctx))
 		},
-		cacheList: func(ctx context.Context) ([]*provisioningv1.PrincipalState, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*provisioningv1.PrincipalState, error) {
 			return stream.Collect(clientutils.Resources(ctx, fixturePack.cache.ListProvisioningStatesForAllDownstreams2))
 		},
 		cacheGet: func(ctx context.Context, id string) (*provisioningv1.PrincipalState, error) {
@@ -88,5 +88,5 @@ func TestProvisioningPrincipalState(t *testing.T) {
 				ctx, testDownstreamID, services.ProvisioningStateID(id))
 			return r, trace.Wrap(err)
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/recording_encryption_test.go
+++ b/lib/cache/recording_encryption_test.go
@@ -48,7 +48,7 @@ func TestRecordingEncryption(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*recordingencryptionv1.RecordingEncryption]{
+	testResources153(t, p, testFuncs[*recordingencryptionv1.RecordingEncryption]{
 		newResource: func(name string) (*recordingencryptionv1.RecordingEncryption, error) {
 			return newRecordingEncryption(), nil
 		},
@@ -67,7 +67,7 @@ func TestRecordingEncryption(t *testing.T) {
 			}
 			return []*recordingencryptionv1.RecordingEncryption{item}, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*recordingencryptionv1.RecordingEncryption, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*recordingencryptionv1.RecordingEncryption, error) {
 			item, err := p.cache.GetRecordingEncryption(ctx)
 			if trace.IsNotFound(err) {
 				return []*recordingencryptionv1.RecordingEncryption{}, nil
@@ -77,5 +77,5 @@ func TestRecordingEncryption(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.recordingEncryption.DeleteRecordingEncryption(ctx))
 		},
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/spiffe_federation_test.go
+++ b/lib/cache/spiffe_federation_test.go
@@ -50,7 +50,7 @@ func TestSPIFFEFederations(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*machineidv1.SPIFFEFederation]{
+	testResources153(t, p, testFuncs[*machineidv1.SPIFFEFederation]{
 		newResource: func(s string) (*machineidv1.SPIFFEFederation, error) {
 			return newSPIFFEFederation(s), nil
 		},
@@ -67,10 +67,10 @@ func TestSPIFFEFederations(t *testing.T) {
 			return p.spiffeFederations.DeleteAllSPIFFEFederations(ctx)
 		},
 
-		cacheList: func(ctx context.Context) ([]*machineidv1.SPIFFEFederation, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*machineidv1.SPIFFEFederation, error) {
 			items, _, err := p.cache.ListSPIFFEFederations(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		cacheGet: p.cache.GetSPIFFEFederation,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/static_host_user_test.go
+++ b/lib/cache/static_host_user_test.go
@@ -33,7 +33,7 @@ func TestStaticHostUsers(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*userprovisioningv2.StaticHostUser]{
+	testResources153(t, p, testFuncs[*userprovisioningv2.StaticHostUser]{
 		newResource: func(name string) (*userprovisioningv2.StaticHostUser, error) {
 			return newStaticHostUser(t, name), nil
 		},
@@ -45,11 +45,11 @@ func TestStaticHostUsers(t *testing.T) {
 			items, _, err := p.staticHostUsers.ListStaticHostUsers(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*userprovisioningv2.StaticHostUser, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*userprovisioningv2.StaticHostUser, error) {
 			items, _, err := p.cache.ListStaticHostUsers(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		cacheGet:  p.cache.GetStaticHostUser,
 		deleteAll: p.staticHostUsers.DeleteAllStaticHostUsers,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/user_task_test.go
+++ b/lib/cache/user_task_test.go
@@ -33,7 +33,7 @@ func TestUserTasks(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*usertasksv1.UserTask]{
+	testResources153(t, p, testFuncs[*usertasksv1.UserTask]{
 		newResource: func(name string) (*usertasksv1.UserTask, error) {
 			return newUserTasks(t), nil
 		},
@@ -45,10 +45,10 @@ func TestUserTasks(t *testing.T) {
 			items, _, err := p.userTasks.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
 			return items, trace.Wrap(err)
 		},
-		cacheList: func(ctx context.Context) ([]*usertasksv1.UserTask, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*usertasksv1.UserTask, error) {
 			items, _, err := p.cache.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
 			return items, trace.Wrap(err)
 		},
 		deleteAll: p.userTasks.DeleteAllUserTasks,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/workload_identity_test.go
+++ b/lib/cache/workload_identity_test.go
@@ -48,7 +48,7 @@ func TestWorkloadIdentity(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*workloadidentityv1pb.WorkloadIdentity]{
+	testResources153(t, p, testFuncs[*workloadidentityv1pb.WorkloadIdentity]{
 		newResource: func(s string) (*workloadidentityv1pb.WorkloadIdentity, error) {
 			return newWorkloadIdentity(s), nil
 		},
@@ -65,10 +65,10 @@ func TestWorkloadIdentity(t *testing.T) {
 			return p.workloadIdentity.DeleteAllWorkloadIdentities(ctx)
 		},
 
-		cacheList: func(ctx context.Context) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
+		cacheList: func(ctx context.Context, _ int) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
 			items, _, err := p.cache.ListWorkloadIdentities(ctx, 0, "")
 			return items, trace.Wrap(err)
 		},
 		cacheGet: p.cache.GetWorkloadIdentity,
-	})
+	}, withSkipPaginationTest())
 }


### PR DESCRIPTION
This commit removes `testResources153` and instead makes the resource handling within `testFuncs` more generic.

This ensures the test logic is consistent across both resource types.