### PR TITLE
docs: Add AWS region names to Cloud architecture docs

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -51,24 +51,28 @@ The Teleport [Auth Service](authentication.mdx) is deployed in 2 AWS availabilit
 deployments are available as options for fault tolerance. AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime.
 Teleport Enterprise Cloud can run in one of the following AWS regions:
 
-- us-west-2 [US West (Oregon)]
-- us-east-1 [US East (N. Virginia)]
-- eu-central-1 [Europe (Frankfurt)]
-- ap-south-1 [Asia Pacific (Mumbai)]
-- ap-southeast-1 [Asia Pacific (Singapore)]
-- sa-east-1 [South America (São Paulo)]
-- ap-southeast-2 [Asia Pacific (Sydney)]
+|AWS Region Code|AWS Region Name|
+|---|---|
+|us-west-2|US West (Oregon)|
+|us-east-1|US East (N. Virginia)|
+|eu-central-1|Europe (Frankfurt)|
+|ap-south-1|Asia Pacific (Mumbai)|
+|ap-southeast-1|Asia Pacific (Singapore)|
+|sa-east-1|South America (São Paulo)|
+|ap-southeast-2|Asia Pacific (Sydney)|
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
 
-- us-west-2 [US West (Oregon)]
-- us-east-1 [US East (N. Virginia)]
-- eu-central-1 [Europe (Frankfurt)]
-- ap-south-1 [Asia Pacific (Mumbai)]
-- ap-southeast-1 [Asia Pacific (Singapore)]
-- sa-east-1 [South America (São Paulo)]
-- ap-southeast-2 [Asia Pacific (Sydney)]
+|AWS Region Code|AWS Region Name|
+|---|---|
+|us-west-2|US West (Oregon)|
+|us-east-1|US East (N. Virginia)|
+|eu-central-1|Europe (Frankfurt)|
+|ap-south-1|Asia Pacific (Mumbai)|
+|ap-southeast-1|Asia Pacific (Singapore)|
+|sa-east-1|South America (São Paulo)|
+|ap-southeast-2|Asia Pacific (Sydney)|
 
 <Admonition type="note">
   Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -51,24 +51,24 @@ The Teleport [Auth Service](authentication.mdx) is deployed in 2 AWS availabilit
 deployments are available as options for fault tolerance. AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime.
 Teleport Enterprise Cloud can run in one of the following AWS regions:
 
-- us-west-2
-- us-east-1
-- eu-central-1
-- ap-south-1
-- ap-southeast-1
-- sa-east-1
-- ap-southeast-2
+- us-west-2 [US West (Oregon)]
+- us-east-1 [US East (N. Virginia)]
+- eu-central-1 [Europe (Frankfurt)]
+- ap-south-1 [Asia Pacific (Mumbai)]
+- ap-southeast-1 [Asia Pacific (Singapore)]
+- sa-east-1 [South America (São Paulo)]
+- ap-southeast-2 [Asia Pacific (Sydney)]
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
 
-- us-west-2
-- us-east-1
-- eu-central-1
-- ap-south-1
-- ap-southeast-1
-- sa-east-1
-- ap-southeast-2
+- us-west-2 [US West (Oregon)]
+- us-east-1 [US East (N. Virginia)]
+- eu-central-1 [Europe (Frankfurt)]
+- ap-south-1 [Asia Pacific (Mumbai)]
+- ap-southeast-1 [Asia Pacific (Singapore)]
+- sa-east-1 [South America (São Paulo)]
+- ap-southeast-2 [Asia Pacific (Sydney)]
 
 <Admonition type="note">
   Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.


### PR DESCRIPTION
Makes it easier to identify the physical location in the world at a glance without needing to cross-reference against AWS docs.

Names sourced from https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html

