### PR TITLE
Retry failed direct LDAP connections

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -392,8 +392,10 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 		)
 
 		if err != nil {
-			// If the connection fails, try the next server
-			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
+			if c.LocateServer.Enabled {
+				// If the connection fails and we're using LocateServer, log that a server failed.
+				c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
+			}
 			continue
 		}
 


### PR DESCRIPTION
With recent changes to Windows Desktop Service, an LDAP connection is no longer created and stored for a long time. New connections are created when they are needed. Apart of this change meant that the Windows Service would panic if it can't make its initial connection to an LDAP server.

We want to keep this behaviour if `LocateServer` is enabled, but not if `Addr` is being used.

This change allows `WindowsService` to be created in a degraded state and retries the LDAP connection until it is successful. This doesn't stop the `startDesktopDiscovery` function from running, but that goroutine fails gracefully until a successful connection is made.

From a user perspective they won't see any desktops appear in the UI and will see warning messages in the logs.