### PR TITLE
AWS IAM Roles Anywhere: ignore empty Trust Anchor on update

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -211,7 +211,11 @@ func (h *Handler) integrationsUpdate(w http.ResponseWriter, r *http.Request, p h
 		}
 
 		spec := integration.GetAWSRolesAnywhereIntegrationSpec()
-		spec.TrustAnchorARN = req.AWSRA.TrustAnchorARN
+
+		if req.AWSRA.TrustAnchorARN != "" {
+			spec.TrustAnchorARN = req.AWSRA.TrustAnchorARN
+		}
+
 		spec.ProfileSyncConfig = &types.AWSRolesAnywhereProfileSyncConfig{
 			Enabled:            req.AWSRA.ProfileSyncConfig.Enabled,
 			ProfileARN:         req.AWSRA.ProfileSyncConfig.ProfileARN,

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -163,11 +163,27 @@ func TestIntegrationsCRUDRolesAnywhere(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, createData, resp)
 
-	// Update integration
-	updatedTrustAnchor := "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-123456789012"
+	// Update integration without TrustAnchorARN
 	syncProfileARN := "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-123456789012"
 	syncRoleARN := "arn:aws:iam::123456789012:role/testrole"
 	updateIntegration := ui.UpdateIntegrationRequest{
+		AWSRA: &ui.IntegrationAWSRASpec{
+			ProfileSyncConfig: ui.AWSRAProfileSync{
+				Enabled:            false,
+				ProfileARN:         syncProfileARN,
+				RoleARN:            syncRoleARN,
+				ProfileNameFilters: []string{},
+			},
+		},
+	}
+	updateEndpoint := authPack.clt.Endpoint("webapi", "sites", wPack.server.ClusterName(), "integrations", integrationName)
+	updateResp, err := authPack.clt.PutJSON(ctx, updateEndpoint, updateIntegration)
+	require.NoError(t, err)
+	require.Equal(t, 200, updateResp.Code())
+
+	// Update integration
+	updatedTrustAnchor := "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-123456789012"
+	updateIntegration = ui.UpdateIntegrationRequest{
 		AWSRA: &ui.IntegrationAWSRASpec{
 			TrustAnchorARN: updatedTrustAnchor,
 			ProfileSyncConfig: ui.AWSRAProfileSync{
@@ -178,8 +194,8 @@ func TestIntegrationsCRUDRolesAnywhere(t *testing.T) {
 			},
 		},
 	}
-	updateEndpoint := authPack.clt.Endpoint("webapi", "sites", wPack.server.ClusterName(), "integrations", integrationName)
-	updateResp, err := authPack.clt.PutJSON(ctx, updateEndpoint, updateIntegration)
+	updateEndpoint = authPack.clt.Endpoint("webapi", "sites", wPack.server.ClusterName(), "integrations", integrationName)
+	updateResp, err = authPack.clt.PutJSON(ctx, updateEndpoint, updateIntegration)
 	require.NoError(t, err)
 	require.Equal(t, 200, updateResp.Code())
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -85,15 +85,6 @@ type AWSRAProfileSync struct {
 	ProfileNameFilters []string `json:"filters"`
 }
 
-// CheckAndSetDefaults for the aws oidc integration spec.
-func (r *IntegrationAWSRASpec) CheckAndSetDefaults() error {
-	if r.TrustAnchorARN == "" {
-		return trace.BadParameter("missing awsra.trustAnchorArn field")
-	}
-
-	return nil
-}
-
 // IntegrationGitHub contains the specific fields for the `github` subkind integration.
 type IntegrationGitHub struct {
 	Organization string `json:"organization"`
@@ -305,11 +296,6 @@ type UpdateIntegrationRequest struct {
 func (r *UpdateIntegrationRequest) CheckAndSetDefaults() error {
 	if r.AWSOIDC != nil {
 		if err := r.AWSOIDC.CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	if r.AWSRA != nil {
-		if err := r.AWSRA.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 	}


### PR DESCRIPTION
When updating the integration (e.g., when changing the profile filters), we were expecting to receive the Trust Anchor ARN, in order to perform a full upgrade on the resource.

However, this is not desirable in the UI.
Given that, the endpoint will now only update the profile sync fields.