### PR TITLE
Add optional CustomCompare to sortcache index

### DIFF
--- a/lib/utils/sortcache/sortcache.go
+++ b/lib/utils/sortcache/sortcache.go
@@ -19,6 +19,8 @@ package sortcache
 
 import (
 	"iter"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/google/btree"
@@ -313,4 +315,29 @@ func (c *SortCache[T, I]) Len() int {
 	c.rw.RLock()
 	defer c.rw.RUnlock()
 	return len(c.values)
+}
+
+// NumericPrefixCompare returns a comparison function that sorts keys by their numeric prefix.
+// Keys are expected to be in the format "number/suffix" where the numeric part is used for
+// sorting and the suffix is used as a secondary sort key for ties.
+// If parsing fails, falls back to lexicographic comparison.
+func NumericPrefixCompare(a, b string) bool {
+	partsA := strings.Split(a, "/")
+	partsB := strings.Split(b, "/")
+
+	if len(partsA) < 2 || len(partsB) < 2 {
+		return a < b
+	}
+
+	countA, errA := strconv.Atoi(partsA[0])
+	countB, errB := strconv.Atoi(partsB[0])
+
+	if errA != nil || errB != nil {
+		return a < b
+	}
+
+	if countA != countB {
+		return countA < countB
+	}
+	return a < b
 }

--- a/lib/utils/sortcache/sortcache_test.go
+++ b/lib/utils/sortcache/sortcache_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -455,26 +454,7 @@ func TestCustomCompare(t *testing.T) {
 			"count": func(r numericResource) string { return fmt.Sprintf("%d/%s", r.Count, r.ID) },
 		},
 		CustomCompareFns: map[string]func(a, b string) bool{
-			"count": func(a, b string) bool {
-				partsA := strings.Split(a, "/")
-				partsB := strings.Split(b, "/")
-
-				if len(partsA) < 2 || len(partsB) < 2 {
-					return a < b
-				}
-
-				countA, errA := strconv.Atoi(partsA[0])
-				countB, errB := strconv.Atoi(partsB[0])
-
-				if errA != nil || errB != nil {
-					return a < b
-				}
-
-				if countA != countB {
-					return countA < countB
-				}
-				return a < b
-			},
+			"count": NumericPrefixCompare,
 		},
 	})
 


### PR DESCRIPTION
We have a requirement that requires a resource to be sorted by some internal "count" of something (Access Lists sorted by member count, for example). Currently, our keys are strings and sorted lexicographically which causes two issues if we naively just sorted by the count as key.
1. the keys must be strings, which means we lose numeric sorting so we'd have some weird orders like [1 100 2 27 30]. 
2. items can have the same count, which would just override each other.

Rather than doing something like an extreme leftpad of zeros, this PR adds an optional `CustomCompareFns` map of indexName->func. When doing comparing, if a func exists for the index name, we use that func instead of the default. 

if i missed an even simpler approach, please let me know.

contributes to https://github.com/gravitational/teleport/issues/57985