### PR TITLE
[v18] docs: Add AWS region names to Cloud architecture docs

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -50,24 +50,24 @@ own AWS account where retention period can be managed independently.
 The Teleport [Auth Service](authentication.mdx) is deployed in 2 AWS availability zones, and can tolerate a single zone failure. AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime.
 Teleport Enterprise Cloud can run in one of the following AWS regions:
 
-- us-west-2
-- us-east-1
-- eu-central-1
-- ap-south-1
-- ap-southeast-1
-- sa-east-1
-- ap-southeast-2
+- us-west-2 [US West (Oregon)]
+- us-east-1 [US East (N. Virginia)]
+- eu-central-1 [Europe (Frankfurt)]
+- ap-south-1 [Asia Pacific (Mumbai)]
+- ap-southeast-1 [Asia Pacific (Singapore)]
+- sa-east-1 [South America (São Paulo)]
+- ap-southeast-2 [Asia Pacific (Sydney)]
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
 
-- us-west-2
-- us-east-1
-- eu-central-1
-- ap-south-1
-- ap-southeast-1
-- sa-east-1
-- ap-southeast-2
+- us-west-2 [US West (Oregon)]
+- us-east-1 [US East (N. Virginia)]
+- eu-central-1 [Europe (Frankfurt)]
+- ap-south-1 [Asia Pacific (Mumbai)]
+- ap-southeast-1 [Asia Pacific (Singapore)]
+- sa-east-1 [South America (São Paulo)]
+- ap-southeast-2 [Asia Pacific (Sydney)]
 
 <Admonition type="note">
   Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -58,7 +58,6 @@ Teleport Enterprise Cloud can run in one of the following AWS regions:
 |ap-south-1|Asia Pacific (Mumbai)|
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
-|ap-southeast-2|Asia Pacific (Sydney)|
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
@@ -71,10 +70,7 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 |ap-south-1|Asia Pacific (Mumbai)|
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
-|ap-southeast-2|Asia Pacific (Sydney)|
 
-<Admonition type="note">
-  Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.
 </Admonition>
 
 ## Releases

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -50,24 +50,28 @@ own AWS account where retention period can be managed independently.
 The Teleport [Auth Service](authentication.mdx) is deployed in 2 AWS availability zones, and can tolerate a single zone failure. AWS guarantees [99.99%](https://aws.amazon.com/compute/sla/) of monthly uptime.
 Teleport Enterprise Cloud can run in one of the following AWS regions:
 
-- us-west-2 [US West (Oregon)]
-- us-east-1 [US East (N. Virginia)]
-- eu-central-1 [Europe (Frankfurt)]
-- ap-south-1 [Asia Pacific (Mumbai)]
-- ap-southeast-1 [Asia Pacific (Singapore)]
-- sa-east-1 [South America (São Paulo)]
-- ap-southeast-2 [Asia Pacific (Sydney)]
+|AWS Region Code|AWS Region Name|
+|---|---|
+|us-west-2|US West (Oregon)|
+|us-east-1|US East (N. Virginia)|
+|eu-central-1|Europe (Frankfurt)|
+|ap-south-1|Asia Pacific (Mumbai)|
+|ap-southeast-1|Asia Pacific (Singapore)|
+|sa-east-1|South America (São Paulo)|
+|ap-southeast-2|Asia Pacific (Sydney)|
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
 
-- us-west-2 [US West (Oregon)]
-- us-east-1 [US East (N. Virginia)]
-- eu-central-1 [Europe (Frankfurt)]
-- ap-south-1 [Asia Pacific (Mumbai)]
-- ap-southeast-1 [Asia Pacific (Singapore)]
-- sa-east-1 [South America (São Paulo)]
-- ap-southeast-2 [Asia Pacific (Sydney)]
+|AWS Region Code|AWS Region Name|
+|---|---|
+|us-west-2|US West (Oregon)|
+|us-east-1|US East (N. Virginia)|
+|eu-central-1|Europe (Frankfurt)|
+|ap-south-1|Asia Pacific (Mumbai)|
+|ap-southeast-1|Asia Pacific (Singapore)|
+|sa-east-1|South America (São Paulo)|
+|ap-southeast-2|Asia Pacific (Sydney)|
 
 <Admonition type="note">
   Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -71,7 +71,6 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
 
-
 ## Releases
 
 Teleport Enterprise Cloud only serves the latest stable release of the Teleport software

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -71,7 +71,6 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
 
-</Admonition>
 
 ## Releases
 


### PR DESCRIPTION
Backport #58205 to branch/v18