### PR TITLE
Add GetHierarchyForUser

### DIFF
--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -123,3 +123,8 @@ func (a *AccessListMember) Clone() *AccessListMember {
 	utils.StrictObjectToStruct(a, &copy)
 	return copy
 }
+
+// IsExpired checks if the access list member is expired based on the current time.
+func (a *AccessListMember) IsExpired(t time.Time) bool {
+	return !a.Spec.Expires.IsZero() && !t.Before(a.Spec.Expires)
+}

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -46,6 +46,7 @@ const (
 type AccessListAndMembersGetter interface {
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
 }
 
 // GetMembersFor returns a flattened list of Members for an Access List, including inherited Members.
@@ -440,54 +441,230 @@ func UserMeetsRequirements(identity types.User, requires accesslist.Requires) bo
 	return true
 }
 
+type ancestorOptions struct {
+	validateUserRequirement bool
+	clock                   clockwork.Clock
+	user                    types.User
+}
+
+func (o *ancestorOptions) validate() error {
+	if o.validateUserRequirement {
+		if o.user == nil {
+			return trace.BadParameter("user is required when validateUserRequirement is true")
+		}
+		if o.clock == nil {
+			o.clock = clockwork.NewRealClock()
+		}
+	}
+	return nil
+}
+
+// ancestorOption is a functional option for configuring the behavior of GetAncestorsFor.
+type ancestorOption func(*ancestorOptions)
+
+func withUserRequirementsCheck(user types.User, clock clockwork.Clock) ancestorOption {
+	return func(opts *ancestorOptions) {
+		opts.validateUserRequirement = true
+		opts.user = user
+		opts.clock = clock
+	}
+}
+
+// HierarchyConfig holds dependencies for building access list hierarchies.
+type HierarchyConfig struct {
+	// AccessListService is used to fetch Access Lists and their members.
+	AccessListsService AccessListAndMembersGetter
+	// Getter is used to fetch Access Lists and their members.
+	Clock clockwork.Clock
+}
+
+// CheckAndSetDefaults validates the config and sets default values.
+func (c *HierarchyConfig) CheckAndSetDefaults() error {
+	if c.AccessListsService == nil {
+		return trace.BadParameter("AccessListsService is required")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// Hierarchy provides methods to compute access list hierarchies.
+type Hierarchy struct {
+	HierarchyConfig
+}
+
+// NewHierarchy constructs a HierarchyService with the given config.
+func NewHierarchy(cfg HierarchyConfig) (*Hierarchy, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Hierarchy{
+		HierarchyConfig: cfg,
+	}, nil
+}
+
+// GetHierarchyForUser builds the hierarchy of Access Lists for a given user,
+// starting from the provided list and traversing upward through its ancestors
+// using MemberOf/OwnerOf relationships. The returned hierarchy includes the
+// starting list (if the user meets the requirements) and may include ancestor
+// lists where the user satisfies membership or ownership requirements.
+// If the user fails to meet the requirements at any point, that branch is excluded.
+func (s *Hierarchy) GetHierarchyForUser(ctx context.Context, accessList *accesslist.AccessList, user types.User) (memberHierarchy, ownerHierarchy []*accesslist.AccessList, err error) {
+	if s.validDirectOwner(user, accessList) {
+		// User Is direct owner and meet the ownership requirements
+		// Include access list from the owner hierarchy
+		// and check if there is more ownership via nested ownership
+		// or via chained membership -> ownership relationships
+		// e.g. A has nested ownership B, B has nested membership C, C has direct members like alice
+		ownerHierarchy = append(ownerHierarchy, accessList)
+	}
+	ok, err := s.validMembership(ctx, accessList, user)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	if !ok {
+		// User is not a valid member of the starting access list
+		// return current owner hierarchy (not empty if user has a direct ownership)
+		// and empty member hierarchy
+		return memberHierarchy, ownerHierarchy, nil
+	}
+	// User is a valid member of the starting access list
+	// Include access list in the member hierarchy
+	memberHierarchy = append(memberHierarchy, accessList)
+
+	// Fetch ancestors via MemberOf edges while checking user requirements
+	ancestors, err := getAncestors(ctx, accessList, RelationshipKindMember, s.AccessListsService, withUserRequirementsCheck(user, s.Clock))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	owners, err := s.expandOwnerOf(ctx, ancestors, user)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return append(memberHierarchy, ancestors...), append(ownerHierarchy, owners...), nil
+}
+
+func (s *Hierarchy) validMembership(ctx context.Context, list *accesslist.AccessList, user types.User) (bool, error) {
+	m, err := s.AccessListsService.GetAccessListMember(ctx, list.GetName(), user.GetName())
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+	if m.IsExpired(s.Clock.Now()) || !UserMeetsRequirements(user, list.GetMembershipRequires()) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// Expand ancestors via OwnerOf edges while checking user requirements
+func (s *Hierarchy) expandOwnerOf(ctx context.Context, ancestors []*accesslist.AccessList, user types.User) ([]*accesslist.AccessList, error) {
+	var out []*accesslist.AccessList
+	for _, v := range ancestors {
+		for _, name := range v.Status.OwnerOf {
+			lst, err := s.AccessListsService.GetAccessList(ctx, name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if UserMeetsRequirements(user, lst.GetOwnershipRequires()) {
+				out = append(out, lst)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *Hierarchy) validDirectOwner(user types.User, acl *accesslist.AccessList) bool {
+	if !UserMeetsRequirements(user, acl.GetOwnershipRequires()) {
+		return false
+	}
+	for _, v := range acl.Spec.Owners {
+		if v.Name == user.GetName() {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAncestorsFor calculates and returns the set of Ancestor ACLs depending on
 // the supplied relationship criteria. Order of the ancestor list is undefined.
 func GetAncestorsFor(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter) ([]*accesslist.AccessList, error) {
+	return getAncestors(ctx, accessList, kind, g)
+}
+
+func getAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, opts ...ancestorOption) ([]*accesslist.AccessList, trace.Error) {
 	ancestorsMap := make(map[string]*accesslist.AccessList)
-	if err := collectAncestors(ctx, accessList, kind, g, make(map[string]struct{}), ancestorsMap); err != nil {
+	if err := collectAncestors(ctx, accessList, kind, g, make(map[string]struct{}), ancestorsMap, opts...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	ancestors := slices.Collect(maps.Values(ancestorsMap))
 	return ancestors, nil
 }
 
-func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, visited map[string]struct{}, ancestors map[string]*accesslist.AccessList) error {
+func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter, visited map[string]struct{}, ancestors map[string]*accesslist.AccessList, opts ...ancestorOption) error {
+	options := &ancestorOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	if err := options.validate(); err != nil {
+		return trace.Wrap(err)
+	}
 	if _, ok := visited[accessList.GetName()]; ok {
 		return nil
 	}
 	visited[accessList.GetName()] = struct{}{}
 
-	switch kind {
-	case RelationshipKindOwner:
+	isDirectMembershipExpired := func(acl, member string) (bool, error) {
+		if !options.validateUserRequirement {
+			return false, nil
+		}
+		m, err := g.GetAccessListMember(ctx, acl, member)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		return m.IsExpired(options.clock.Now()), nil
+	}
+
+	userMeetsRequirements := func(r accesslist.Requires) bool {
+		if options.user == nil {
+			return true
+		}
+		return UserMeetsRequirements(options.user, r)
+	}
+
+	if kind == RelationshipKindOwner {
 		// Add parents where this list is an owner to ancestors
 		for _, ownerParent := range accessList.Status.OwnerOf {
 			ownerParentAcl, err := g.GetAccessList(ctx, ownerParent)
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			if !userMeetsRequirements(ownerParentAcl.Spec.OwnershipRequires) {
+				continue
+			}
 			ancestors[ownerParent] = ownerParentAcl
 		}
-		// Recursively traverse parents where this list is a member
-		for _, memberParent := range accessList.Status.MemberOf {
-			memberParentAcl, err := g.GetAccessList(ctx, memberParent)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			if err := collectAncestors(ctx, memberParentAcl, kind, g, visited, ancestors); err != nil {
-				return trace.Wrap(err)
-			}
+	}
+	for _, memberParent := range accessList.Status.MemberOf {
+		memberParentAcl, err := g.GetAccessList(ctx, memberParent)
+		if err != nil {
+			return trace.Wrap(err)
 		}
-	default:
-		// Only collect parents where this list is a member
-		for _, memberParent := range accessList.Status.MemberOf {
-			memberParentAcl, err := g.GetAccessList(ctx, memberParent)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		expired, err := isDirectMembershipExpired(memberParent, accessList.GetName())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if expired || !userMeetsRequirements(memberParentAcl.Spec.MembershipRequires) {
+			continue
+		}
+
+		if kind == RelationshipKindMember {
 			ancestors[memberParent] = memberParentAcl
-			if err := collectAncestors(ctx, memberParentAcl, kind, g, visited, ancestors); err != nil {
-				return trace.Wrap(err)
-			}
+		}
+		if err := collectAncestors(ctx, memberParentAcl, kind, g, visited, ancestors, opts...); err != nil {
+			return trace.Wrap(err)
 		}
 	}
 

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -40,6 +40,19 @@ type mockAccessListAndMembersGetter struct {
 	members     map[string][]*accesslist.AccessListMember
 }
 
+func (m *mockAccessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
+	member, exists := m.members[accessListName]
+	if !exists {
+		return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+	}
+	for _, m := range member {
+		if m.GetName() == memberName {
+			return m, nil
+		}
+	}
+	return nil, trace.NotFound("access list %v member %v not found", accessListName, memberName)
+}
+
 func (m *mockAccessListAndMembersGetter) GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
 	accessList, exists := m.accessLists[accessListName]
 	if !exists {

--- a/lib/accesslists/hierarchy_user_test.go
+++ b/lib/accesslists/hierarchy_user_test.go
@@ -1,0 +1,521 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package accesslists_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/entitlements"
+	"github.com/gravitational/teleport/lib/accesslists"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestGetHierarchyForUser(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.AccessLists: {Enabled: true},
+			},
+		},
+	})
+	clock := clockwork.NewFakeClock()
+
+	tests := []struct {
+		name   string
+		start  string
+		state  state
+		traits trait.Traits
+		user   types.User
+		kind   accesslists.RelationshipKind
+		want   []string
+	}{
+		{
+			name: "access list hierarchy for user",
+			state: state{
+				mustMakeAccessList("root"):   {mustCreateMember("level1", withACLMemKind())},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  []string{"root", "level1", "level2"},
+		},
+		{
+			name: "member/expired direct user membership => empty",
+			state: state{
+				mustMakeAccessList("root"):   {mustCreateMember("level1", withACLMemKind())},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice", withExpiration(clock.Now().Add(-time.Hour)))},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  nil,
+		},
+		{
+			name: "member/stops at expired parent edge",
+			state: state{
+				mustMakeAccessList("root"):   {mustCreateMember("level1", withACLMemKind(), withExpiration(clock.Now().Add(-time.Hour)))},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  []string{"level1", "level2"},
+		},
+		{
+			name: "owner/includes start when user is direct owner (and member)",
+			state: state{
+				mustMakeAccessList("start", withOwners("alice")): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "start",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"start"},
+		},
+		{
+			name: "owner/expired direct user membership stops traversal but keeps start if direct owner",
+			state: state{
+				mustMakeAccessList("start", withOwners("alice")): {mustCreateMember("alice", withExpiration(clock.Now().Add(-time.Hour)))},
+			},
+			user:  makeUser("alice"),
+			start: "start",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"start"},
+		},
+		{
+			name: "member/no direct user membership => empty",
+			state: state{
+				mustMakeAccessList("root"):   {mustCreateMember("level1", withACLMemKind())},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("bob")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  nil,
+		},
+		{
+			name: "member/parent filtered by membership requirements",
+			state: state{
+				mustMakeAccessList("root"): {mustCreateMember("level1", withACLMemKind())},
+				mustMakeAccessList("level1", withMemberTraitReq("need")): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  []string{"level2"},
+		},
+		{
+			name: "owner/owner target filtered by ownership requirements",
+			state: state{
+				mustMakeAccessList("root", withOwners("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  nil,
+		},
+		{
+			name: "owner/user is indirect owner of two root access list where meets only one ownership requirement",
+			state: state{
+				mustMakeAccessList("side", withOwnerList("level1")): {},
+				mustMakeAccessList("root", withOwners("level1"), withOwnerTraitReq("need")): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"side"},
+		},
+		{
+			name: "owner/user is indirect owner of two root access list and don't meet ownership requirements for both",
+			state: state{
+				mustMakeAccessList("side", withOwnerList("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("root", withOwners("level1"), withOwnerTraitReq("need")): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{},
+		},
+		{
+			name: "owner/user is indirect owner of two root access list and meet ownership requirements for both",
+			state: state{
+				mustMakeAccessList("side", withOwnerList("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("root", withOwnerList("level1"), withOwnerTraitReq("need")): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice", mkTrait("need")),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"root", "side"},
+		},
+		{
+			name: "owner/owner target filtered by ownership requirements",
+			state: state{
+				mustMakeAccessList("root", withOwners("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  nil,
+		},
+		{
+			name: "owner/collect owner targets from ancestors' OwnerOf",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1")): {},
+				mustMakeAccessList("level1"):                        {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"):                        {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"root"},
+		},
+		{
+			name: "owner/not a direct owner and no owner targets => empty",
+			state: state{
+				mustMakeAccessList("lonely"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "lonely",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  nil,
+		},
+		{
+			name: "member/multiple parents included",
+			state: state{
+				mustMakeAccessList("rootA"):  {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("rootB"):  {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  []string{"rootA", "rootB", "level2"},
+		},
+		{
+			name: "member/parent included when membership requirements are met",
+			state: state{
+				mustMakeAccessList("root"): {mustCreateMember("level1", withACLMemKind())},
+				mustMakeAccessList("level1", withMemberTraitReq("ok")): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice", mkTrait("ok")),
+			start: "level2",
+			kind:  accesslists.RelationshipKindMember,
+			want:  []string{"root", "level1", "level2"},
+		},
+		{
+			name: "owner/owner target included when ownership requirements are met",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("level1"): {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice", mkTrait("need")),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"root"},
+		},
+		{
+			name: "owner/multiple owner targets discovered via ancestors",
+			state: state{
+				mustMakeAccessList("rootA", withOwnerList("level1")): {},
+				mustMakeAccessList("rootB", withOwnerList("level1")): {},
+				mustMakeAccessList("level1"):                         {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"):                         {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"rootA", "rootB"},
+		},
+		{
+			name: "member/start filtered out when start has unmet membership requirements",
+			state: state{
+				mustMakeAccessList("start", withMemberTraitReq("must")): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "start",
+			kind:  accesslists.RelationshipKindMember,
+			want:  nil,
+		},
+		{
+			name: "owner/start NOT included when ownership requirements are NOT met",
+			state: state{
+				mustMakeAccessList("start", withOwners("alice"), withOwnerTraitReq("need")): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "start",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  nil,
+		},
+		{
+			name: "owner/start included when user is among multiple direct owners",
+			state: state{
+				mustMakeAccessList("start", withOwners("bob", "alice")): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "start",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"start"},
+		},
+		{
+			name: "owner/direct and indirect owner => include both",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1")): {},
+				mustMakeAccessList("level1"): {
+					mustCreateMember("level2", withACLMemKind()),
+				},
+				mustMakeAccessList("level2", withOwners("alice")): {
+					mustCreateMember("alice"),
+				},
+			},
+			user:  makeUser("alice"),
+			start: "level2",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"level2", "root"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			bk, err := memory.New(memory.Config{
+				Context: ctx,
+				Clock:   clock,
+			})
+			require.NoError(t, err)
+			svc, err := local.NewAccessListService(bk, clock)
+			require.NoError(t, err)
+
+			require.NoError(t, upsertState(svc, tt.state))
+
+			acl, err := svc.GetAccessList(ctx, tt.start)
+			require.NoError(t, err)
+
+			h, err := accesslists.NewHierarchy(accesslists.HierarchyConfig{
+				AccessListsService: svc,
+				Clock:              clock,
+			})
+			require.NoError(t, err)
+
+			memberOf, ownerOf, err := h.GetHierarchyForUser(t.Context(), acl, tt.user)
+			require.NoError(t, err)
+
+			accessList := memberOf
+			if tt.kind == accesslists.RelationshipKindOwner {
+				accessList = ownerOf
+			}
+
+			got := make([]string, 0, len(accessList))
+			for _, a := range accessList {
+				got = append(got, a.GetName())
+			}
+			require.ElementsMatch(t, got, tt.want)
+		})
+	}
+}
+
+func withOwnerTraitReq(name string) option {
+	return func(opts *options) {
+		opts.ownershipRequire = accesslist.Requires{
+			Traits: mkTrait(name),
+		}
+	}
+}
+
+func withMemberTraitReq(name string) option {
+	return func(opts *options) {
+		opts.membershipRequire = accesslist.Requires{
+			Traits: mkTrait(name),
+		}
+	}
+}
+
+func mkTrait(name string) trait.Traits {
+	return trait.Traits{name: nil}
+}
+
+type state map[*accesslist.AccessList][]*accesslist.AccessListMember
+
+func upsertState(svc *local.AccessListService, state state) error {
+	ctx := context.Background()
+	for acl := range state {
+		for _, owner := range acl.GetOwners() {
+			if owner.MembershipKind == accesslist.MembershipKindList {
+				// Create placeholder access list for owner lists.
+				// to prevent backend check for the nested access list.
+				_, err := svc.UpsertAccessList(ctx, mustMakeAccessList(owner.Name))
+				if err != nil {
+					return trace.Wrap(err)
+				}
+			}
+		}
+		if _, err := svc.UpsertAccessList(ctx, acl); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	for acl, members := range state {
+		for _, member := range members {
+			member.Spec.AccessList = acl.GetName()
+			if _, err := svc.UpsertAccessListMember(ctx, member); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+	return nil
+}
+func makeUser(name string, traits ...trait.Traits) types.User {
+	user, err := types.NewUser(name)
+	if err != nil {
+		panic(err)
+	}
+	for _, t := range traits {
+		user.SetTraits(t)
+	}
+	return user
+}
+
+func withOwners(owners ...string) option {
+	return func(opts *options) {
+		for _, owner := range owners {
+			opts.owners = append(opts.owners, accesslist.Owner{Name: owner})
+		}
+	}
+}
+
+func withOwnerList(owners ...string) option {
+	return func(opts *options) {
+		for _, owner := range owners {
+			opts.owners = append(opts.owners, accesslist.Owner{Name: owner, MembershipKind: accesslist.MembershipKindList})
+		}
+	}
+}
+
+func mustMakeAccessList(name string, opts ...option) *accesslist.AccessList {
+	cfg := options{
+		owners: []accesslist.Owner{{Name: "system"}},
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	acl, err := accesslist.NewAccessList(header.Metadata{
+		Name: name,
+	}, accesslist.Spec{
+		Title:              name,
+		Owners:             cfg.owners,
+		Audit:              accesslist.Audit{NextAuditDate: time.Now()},
+		MembershipRequires: cfg.membershipRequire,
+		OwnershipRequires:  cfg.ownershipRequire,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return acl
+}
+
+type options struct {
+	kind              string
+	Expiration        time.Time
+	membershipRequire accesslist.Requires
+	ownershipRequire  accesslist.Requires
+	owners            []accesslist.Owner
+}
+
+type option func(*options)
+
+func withKind(kind string) option {
+	return func(opts *options) {
+		opts.kind = kind
+	}
+}
+
+func withACLMemKind() option {
+	return withKind(accesslist.MembershipKindList)
+}
+
+func withExpiration(expiration time.Time) option {
+	return func(opts *options) {
+		opts.Expiration = expiration
+	}
+}
+
+func mustCreateMember(memberName string, opts ...option) *accesslist.AccessListMember {
+	var cfg options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	clock := clockwork.NewRealClock()
+	member, err := accesslist.NewAccessListMember(
+		header.Metadata{
+			Name: memberName,
+		},
+		accesslist.AccessListMemberSpec{
+			AccessList:     "random", // will be updated during insert
+			Name:           memberName,
+			Joined:         clock.Now(),
+			AddedBy:        "added by",
+			Expires:        cfg.Expiration,
+			MembershipKind: cfg.kind,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return member
+}

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -91,6 +91,12 @@ func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name str
 	return s.service.GetResource(ctx, name)
 }
 
+// GetAccessListMember returns the specified access list member resource.
+// If a user is not directly a member of the access list the NotFound error is returned.
+func (s *accessListAndMembersGetter) GetAccessListMember(ctx context.Context, accessListName, memberName string) (*accesslist.AccessListMember, error) {
+	return s.memberService.WithPrefix(accessListName).GetResource(ctx, memberName)
+}
+
 // compile-time assertion that the AccessListService implements the AccessLists
 // interface
 var _ services.AccessLists = (*AccessListService)(nil)


### PR DESCRIPTION
### What


Add a function that builds and returns the full Access List hierarchy by traversing upward from a starting list.
During traversal, the function checks user membership and ownership requirements as well as membership expiration.
If a user fails to meet the requirements or the membership is expired, the affected branch is excluded from the hierarchy.
This ensures the resulting hierarchy only contains valid Access Lists where the user still qualifies, either as a member or as an owner membership types.

Parent PR: https://github.com/gravitational/teleport/pull/58026

TODO: 
- [ ] After merge do refactor mentioned in https://github.com/gravitational/teleport/pull/58237/files#r2294386085
- [ ] Add deep check if follow up pr
- [ ] Make UserMeetsRequirementsZeroAllocs