### PR TITLE
Remove sydney region from list of available regions

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -59,7 +59,6 @@ Teleport Enterprise Cloud can run in one of the following AWS regions:
 |ap-south-1|Asia Pacific (Mumbai)|
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
-|ap-southeast-2|Asia Pacific (Sydney)|
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
@@ -72,11 +71,6 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 |ap-south-1|Asia Pacific (Mumbai)|
 |ap-southeast-1|Asia Pacific (Singapore)|
 |sa-east-1|South America (São Paulo)|
-|ap-southeast-2|Asia Pacific (Sydney)|
-
-<Admonition type="note">
-  Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.
-</Admonition>
 
 ## Releases
 


### PR DESCRIPTION
Sydney is not a region that is generally available to all customers. We have the ability to deploy proxies and auth for select customers when requested. We have other regions with a similar use case that are not listed here. 

We plan to discuss how to document these new use cases in the near future. This PR ensures we are not setting the wrong expectations today.
