### PR TITLE
[v17] Web: fix AWS icon size in enroll integration page

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -67,12 +67,11 @@ export const NoCodeIntegrationDescription = () => (
  * IntegrationIcon wraps ResourceIcon with css required for integration
  * and plugin tiles.
  */
-export const IntegrationIcon = styled(ResourceIcon)<{ size?: number }>`
-  display: inline-block;
+export const IntegrationIcon = styled(ResourceIcon).withConfig({
+  shouldForwardProp: prop => prop !== 'size',
+})<{ size?: number }>`
+  margin: 0 auto;
   height: 100%;
-  ${({ size }) =>
-    size &&
-    `
-    max-height: ${size}px;
-  `}
+  min-width: 0;
+  ${({ size }) => `max-height: ${size || 80}px;`}
 `;


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/57910 to branch/v17

This is a manual backport as there was a merge conflict with css styles. This also sets a default of 80px, different from the original fix