### PR TITLE
Supporting 4096-bit pre-generated RSA keys during testing

### DIFF
--- a/lib/auth/recordingencryption/manager_test.go
+++ b/lib/auth/recordingencryption/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -39,28 +40,18 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/cryptosuites/cryptosuitestest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-// It takes forever to generate RSA4096 keys so we generate and cache a few to be used by the fakeKeyStore
-// instead of actually generating a new key every time a test needs one. This cuts down flaky test execution
-// time to ~20-30s instead of timing out at >10m
-var cachedDecrypters = initDecrypters()
-
-func initDecrypters() []crypto.Decrypter {
-	var decrypters []crypto.Decrypter
-	for range 10 {
-		decrypter, err := cryptosuites.GenerateDecrypterWithAlgorithm(cryptosuites.RSA4096)
-		if err != nil {
-			panic("failed to generate RSA 4096 key")
-		}
-
-		decrypters = append(decrypters, decrypter)
-	}
-
-	return decrypters
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cryptosuitestest.PrecomputeRSAKeys(ctx)
+	exitCode := m.Run()
+	cancel()
+	os.Exit(exitCode)
 }
 
 type oaepDecrypter struct {
@@ -76,8 +67,6 @@ type fakeKeyStore struct {
 	keyType   types.PrivateKeyType // abusing this field as a way to simulate different auth servers
 	keys      map[string][]crypto.Decrypter
 	currLabel types.KeyLabel
-
-	cacheIdx int
 }
 
 func newFakeKeyStore(keyType types.PrivateKeyType) *fakeKeyStore {
@@ -88,18 +77,22 @@ func newFakeKeyStore(keyType types.PrivateKeyType) *fakeKeyStore {
 }
 
 func (f *fakeKeyStore) genKeys() (crypto.Decrypter, []byte, error) {
-	decrypter := cachedDecrypters[f.cacheIdx]
-	f.cacheIdx += 1
-	if f.cacheIdx >= len(cachedDecrypters) {
-		f.cacheIdx = 0
-	}
-
-	publicKey, err := x509.MarshalPKIXPublicKey(decrypter.Public())
+	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.RSA4096)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return decrypter, publicKey, nil
+	private, ok := signer.(*rsa.PrivateKey)
+	if !ok {
+		return nil, nil, trace.Errorf("expected RSA key")
+	}
+
+	publicKey, err := x509.MarshalPKIXPublicKey(&private.PublicKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return private, publicKey, nil
 }
 
 func (f *fakeKeyStore) createKey() (crypto.Decrypter, []byte, error) {

--- a/lib/cryptosuites/cryptosuitestest/precompute.go
+++ b/lib/cryptosuites/cryptosuitestest/precompute.go
@@ -30,17 +30,24 @@ import (
 // save on CPU usage.
 func PrecomputeRSAKeys(ctx context.Context) {
 	internalrsa.StartPrecomputeOnce.Do(func() {
-		go precomputeTestKeys(ctx)
+		go precomputeTestKeys(ctx, constants.RSAKeySize)
+		go precomputeTestKeys(ctx, 4096)
 	})
 }
 
-func precomputeTestKeys(ctx context.Context) {
-	generatedTestKeys := generateTestKeys(ctx)
-	keysToReuse := make([]*rsa.PrivateKey, 0, testKeysNumber)
-	for range testKeysNumber {
+func precomputeTestKeys(ctx context.Context, bitSize int) {
+	source := internalrsa.PrecomputedKeys
+	count := testKeysNumber
+	if bitSize == 4096 {
+		source = internalrsa.PrecomputedKeys4096
+		count = testKeysNumber4096
+	}
+	generatedTestKeys := generateTestKeys(ctx, bitSize)
+	keysToReuse := make([]*rsa.PrivateKey, 0, count)
+	for range count {
 		select {
 		case k := <-generatedTestKeys:
-			internalrsa.PrecomputedKeys <- k
+			source <- k
 			keysToReuse = append(keysToReuse, k)
 		case <-ctx.Done():
 			return
@@ -50,7 +57,7 @@ func precomputeTestKeys(ctx context.Context) {
 	for {
 		for _, k := range keysToReuse {
 			select {
-			case internalrsa.PrecomputedKeys <- k:
+			case source <- k:
 			case <-ctx.Done():
 				return
 			}
@@ -61,13 +68,20 @@ func precomputeTestKeys(ctx context.Context) {
 // testKeysNumber is the number of RSA keys generated in tests.
 const testKeysNumber = 25
 
-func generateTestKeys(ctx context.Context) <-chan *rsa.PrivateKey {
-	generatedTestKeys := make(chan *rsa.PrivateKey, testKeysNumber)
-	for range testKeysNumber {
+// testKeysNumber is the number of RSA 4096 keys generated in tests.
+const testKeysNumber4096 = 3
+
+func generateTestKeys(ctx context.Context, bitSize int) <-chan *rsa.PrivateKey {
+	count := testKeysNumber
+	if bitSize == 4096 {
+		count = testKeysNumber4096
+	}
+	generatedTestKeys := make(chan *rsa.PrivateKey, count)
+	for range count {
 		// Generate each key in a separate goroutine to take advantage of
 		// multiple cores if possible.
 		go func() {
-			private, err := generateRSAPrivateKey()
+			private, err := generateRSAPrivateKey(bitSize)
 			if err != nil {
 				// Use only in tests. Safe to panic.
 				panic(err)
@@ -84,7 +98,7 @@ func generateTestKeys(ctx context.Context) <-chan *rsa.PrivateKey {
 	return generatedTestKeys
 }
 
-func generateRSAPrivateKey() (*rsa.PrivateKey, error) {
+func generateRSAPrivateKey(bitSize int) (*rsa.PrivateKey, error) {
 	//nolint:forbidigo // This is the one function allowed to generate RSA keys.
-	return rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
+	return rsa.GenerateKey(rand.Reader, bitSize)
 }

--- a/lib/cryptosuites/internal/rsa/rsa.go
+++ b/lib/cryptosuites/internal/rsa/rsa.go
@@ -35,28 +35,35 @@ var (
 	// PrecomputedKeys is a queue of cached keys ready for usage.
 	PrecomputedKeys = make(chan *rsa.PrivateKey, 25)
 
+	// PrecomputedKeys4096 is a queue of cached 4096-bit keys ready for usage.
+	PrecomputedKeys4096 = make(chan *rsa.PrivateKey, 3)
+
 	// StartPrecomputeOnce is used to start the background task that precomputes key pairs.
 	StartPrecomputeOnce sync.Once
 )
 
 // GenerateKey returns a newly generated RSA private key.
 func GenerateKey() (*rsa.PrivateKey, error) {
-	return getOrGenerateRSAPrivateKey()
+	return getOrGenerateRSAPrivateKey(constants.RSAKeySize)
 }
 
 // GenerateKey4096 generates a 4096-bit RSA private key meant for use in asymmetric encryption use cases such as
-// encrypted session recordings. It is exposed as a separate function from [GenerateKey] so that the precomputed
-// keys optimization used for sign/verify use cases does not have to be extended to support mixed key sizes.
+// encrypted session recordings.
 func GenerateKey4096() (*rsa.PrivateKey, error) {
-	return generateRSAPrivateKey(4096)
+	return getOrGenerateRSAPrivateKey(4096)
 }
 
-func getOrGenerateRSAPrivateKey() (*rsa.PrivateKey, error) {
+func getOrGenerateRSAPrivateKey(bitSize int) (*rsa.PrivateKey, error) {
+	source := PrecomputedKeys
+	if bitSize == 4096 {
+		source = PrecomputedKeys4096
+	}
+
 	select {
-	case k := <-PrecomputedKeys:
+	case k := <-source:
 		return k, nil
 	default:
-		rsaKeyPair, err := generateRSAPrivateKey(constants.RSAKeySize)
+		rsaKeyPair, err := generateRSAPrivateKey(bitSize)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR extends the precomputed RSA key system to support 4096-bit keys in order to speed up tests that need to generate those keys

Blocks #57780 