### PR TITLE
Fix sftp readdir breaking on broken symlinks

### DIFF
--- a/lib/sshutils/sftp/local.go
+++ b/lib/sshutils/sftp/local.go
@@ -54,11 +54,11 @@ func (l localFS) ReadDir(path string) ([]os.FileInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		// if the file is a symlink, return the info of the linked file
-		if info.Mode().Type()&os.ModeSymlink != 0 {
-			info, err = os.Stat(filepath.Join(path, info.Name()))
-			if err != nil {
-				return nil, err
+		// If the file is a valid symlink, return the info of the linked file.
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolvedInfo, err := os.Stat(filepath.Join(path, info.Name()))
+			if err == nil {
+				info = resolvedInfo
 			}
 		}
 

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -46,11 +46,11 @@ func (r *RemoteFS) ReadDir(path string) ([]os.FileInfo, error) {
 		return nil, err
 	}
 	for i := range fileInfos {
-		// if the file is a symlink, return the info of the linked file
-		if fileInfos[i].Mode().Type()&os.ModeSymlink != 0 {
-			fileInfos[i], err = r.Stat(portablepath.Join(path, fileInfos[i].Name()))
-			if err != nil {
-				return nil, err
+		// If the file is a valid symlink, return the info of the linked file.
+		if fileInfos[i].Mode()&os.ModeSymlink != 0 {
+			resolvedInfo, err := r.Stat(portablepath.Join(path, fileInfos[i].Name()))
+			if err == nil {
+				fileInfos[i] = resolvedInfo
 			}
 		}
 	}


### PR DESCRIPTION
This change fixes a bug where an sftp readdir command would fail (and not return any entries) on a directory containing a broken symlink.

Fixes #55699.

Changelog: Fixed sftp readdir failing due to broken symlinks