### PR TITLE
docs: include supported os for terraform provider

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
@@ -24,7 +24,8 @@ connect to Teleport as the temporary bot.
 ## Prerequisites
 
 - A running Teleport cluster, version 16.2 or higher
-- Local tsh/tctl clients with versions higher than 16.2
+- A macOS or Linux host where you use the Teleport terraform provider
+- Local tsh/tctl clients with versions higher than 16.2 on the host
 - Being locally logged in Teleport with a role that allows creating Bot and Token resources.
   You can use the default `editor` role for this.
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -16,7 +16,7 @@ For instructions on managing users and roles via Terraform, read
 the ["Managing users and roles with IaC" guide](../managing-resources/user-and-role.mdx).
 
 The provider must obtain an identity to connect to Teleport. The method to obtain it depends on where the Terraform code
-is executed. You must pick the correct guide for your setup:
+is executed. The Teleport Terraform provider is available for macOS and Linux machines. You must pick the correct guide for your setup:
 
 | Guide                                                                                                               | Use-case                                                                                                                                                                                                         | How it works                                                                                                                           |
 |---------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Have seen a recent case of Windows terraform being attempted. This adds in that macOS and Linux are the available types and part of local example pre-req.