### PR TITLE
AWS IAM Roles Anywhere: Test connection ignores the Profile sync

### DIFF
--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -321,7 +321,7 @@ func (s *AWSRolesAnywhereService) AWSRolesAnywherePing(ctx context.Context, req 
 		return nil, trace.Wrap(err)
 	}
 
-	pingResp, err := awsra.Ping(ctx, pingClient)
+	pingResp, err := awsra.Ping(ctx, pingClient, profileARN)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -74,10 +74,10 @@ func NewPingClient(ctx context.Context, req *AWSClientConfig) (PingClient, error
 // Ping calls the following AWS API:
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
-// It returns a list of Roles Anywhere Profiles that are enabled.\
+// It returns a list of Roles Anywhere Profiles that are enabled.
 //
-// If profileARN is provided, it will ignore that specific Profile when counting the list of profiles.
-func Ping(ctx context.Context, clt PingClient, profileARN string) (*PingResponse, error) {
+// It will ignore any profile matching ignoredProfileARN.
+func Ping(ctx context.Context, clt PingClient, ignoredProfileARN string) (*PingResponse, error) {
 	var errs []error
 
 	profileCounter := 0
@@ -92,10 +92,10 @@ func Ping(ctx context.Context, clt PingClient, profileARN string) (*PingResponse
 			break
 		}
 		for _, profile := range profiles {
-			// Ignore disabled profiles, profiles without assigned roles and
+			// Ignore disabled profiles, profiles without assigned roles and the ignoreProfileARN.
 			if profile.Enabled &&
 				len(profile.Roles) > 0 &&
-				profile.Arn != profileARN {
+				profile.Arn != ignoredProfileARN {
 
 				profileCounter++
 			}

--- a/lib/integrations/awsra/ping_test.go
+++ b/lib/integrations/awsra/ping_test.go
@@ -75,11 +75,11 @@ func TestPing(t *testing.T) {
 				disabledProfile,
 				profileWithoutRoles,
 			},
-		})
+		}, *syncProfile.ProfileArn)
 		require.NoError(t, err)
 
 		require.Equal(t, "123456789012", resp.AccountID)
-		require.Equal(t, 2, resp.EnabledProfileCounter)
+		require.Equal(t, 1, resp.EnabledProfileCounter)
 	})
 
 }


### PR DESCRIPTION
When the user is setting up the AWS IAM Roles Anywhere integration, they will test the connection.
This test connection (aka ping) will let the user know if the credentials are working and how many profiles they have that they can use.

Before this PR, we were also counting the Profile that is used to sync profiles.
Even though, this is a valid Profile, it will not be added as an AWS App, it is only used to sync profiles.

After this PR, we are no longer including it.
The UI, when there's no profiles, will also let the user know about this and ask them to create profiles.