### PR TITLE
Change the new session recording endpoints

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1176,8 +1176,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerGet))
 	h.DELETE("/webapi/sites/:site/gitservers/:name", h.WithClusterAuth(h.gitServerDelete))
 
-	h.GET("/webapi/sites/:site/session-recording/:session_id/thumbnail", h.WithClusterAuth(h.getSessionRecordingThumbnail))
-	h.GET("/webapi/sites/:site/session-recording/:session_id/metadata/ws", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
+	h.GET("/webapi/sites/:site/sessionthumbnail/:session_id", h.WithClusterAuth(h.getSessionRecordingThumbnail))
+	h.GET("/webapi/sites/:site/sessionrecording/:session_id/metadata/ws", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
 }
 
 // GetProxyClient returns authenticated auth server client


### PR DESCRIPTION
For some reason, `/webapi/sites/cluster/sessionrecording/:session_id/thumbnail` gives a 500 error (haven't had time to debug why), but `/webapi/sites/cluster/sessionthumbnail/:session_id` doesn't, so this updates that URL so it works

Changing the metadata endpoint from `session-recording` to `sessionrecording` to match other routes. Keeping this in that format as the new playback endpoint in https://github.com/gravitational/teleport/pull/58116 also follows the same pattern (doesn't seem to 500 for websocket endpoints)