### PR TITLE
AWS IAM Roles Anywhere: fix stats endpoint

### DIFF
--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -537,11 +538,13 @@ func TestCollectIntegrationStats(t *testing.T) {
 		clt := &mockRelevantAWSRegionsClient{
 			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{},
 			databaseServices: &proto.ListResourcesResponse{},
-			databases:        make([]types.Database, 0),
+			databases: []types.Database{
+				&types.DatabaseV3{Spec: types.DatabaseSpecV3{AWS: types.AWS{Region: "us-west-1"}}},
+			},
 		}
 
 		deployedDatabaseServicesClient := &mockDeployedDatabaseServices{
-			listErr: trace.AccessDenied("AccessDenied to ECS:ListServices"),
+			listErr: errors.New("only aws oidc integrations can list deployed database services"),
 		}
 		req := collectIntegrationStatsRequest{
 			logger:                logger,


### PR DESCRIPTION
The integration/<name>/stats endpoint can be used for both AWS OIDC and AWS IAM Roles Anywhere integrations.

It is used by the UI to show the summary of the integration.

When used for the Roles Anywhere, it was also asking for the number of deployed database services.
This feature is not yet implemented in the Roles Anywhere integration, and so it's not possible to count the deployed services.

This PR changes the flow to only count the services if this is an AWS OIDC integration.