### PR TITLE
Add source and owner columns to `tctl devices ls`

### DIFF
--- a/tool/tctl/common/devices_test.go
+++ b/tool/tctl/common/devices_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package common
 
 import (

--- a/tool/tctl/common/devices_test.go
+++ b/tool/tctl/common/devices_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+)
+
+func TestDeviceSourceToString(t *testing.T) {
+	tests := []struct {
+		name   string
+		source *devicepb.DeviceSource
+		want   string
+	}{
+		{
+			name:   "default name for origin",
+			source: &devicepb.DeviceSource{Origin: devicepb.DeviceOrigin_DEVICE_ORIGIN_INTUNE, Name: "intune"},
+			want:   "Intune",
+		},
+		{
+			name:   "custom name",
+			source: &devicepb.DeviceSource{Origin: devicepb.DeviceOrigin_DEVICE_ORIGIN_JAMF, Name: "cool jamf"},
+			want:   "cool jamf",
+		},
+		{
+			name:   "no source",
+			source: nil,
+			want:   "",
+		},
+		{
+			name:   "unsupported origin",
+			source: &devicepb.DeviceSource{Origin: 1337, Name: "even cooler jamf"},
+			// Show the name instead of something like "unknown" as name is required and likely more
+			// informative than displaying "unknown".
+			want: "even cooler jamf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, deviceSourceToString(tt.source))
+		})
+	}
+}


### PR DESCRIPTION
I added the source column in the Web UI in https://github.com/gravitational/teleport.e/pull/7082. I forgot that `tctl devices ls` should list it too.

I also added the owner column. The column order doesn't match the Web UI exactly, because the Web UI shows an icon next to the OS, so it's best if the OS is first.

```
$ ./build/tctl devices ls
Asset Tag                                  OS      Source Enroll Status Owner Device ID
------------------------------------------ ------- ------ ------------- ----- ------------------------------------
D13FA2ZLJ2P2                               macOS   Jamf   not enrolled        707debdc-e6dc-4d44-b9aa-d3610a5a76b4
CATESTDEVICE1                              macOS          not enrolled        8b04b9aa-97f9-4d9f-90ac-0338a6cd1c7b
DMY25J935S                                 macOS   Jamf   not enrolled        9f14e9e9-560f-4779-9034-2a912481d4f8
Parallels-1D2F1C1A121753126F4D12CCB548A5EC Windows Intune not enrolled        427e1d6a-cfbf-4826-b885-07e6560e76fb
W24PZN8M6N                                 macOS          enrolled      rav   12e53fbb-c3bc-440d-a9f3-f5b30243fdf8
```