### PR TITLE
[Web] Update help and support page and move security/business contact management

### DIFF
--- a/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
+++ b/web/packages/teleport/src/Clusters/ClusterList/ClusterList.tsx
@@ -24,7 +24,6 @@ import Table, { Cell } from 'design/DataTable';
 import { Primary, Secondary } from 'design/Label';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 
-import { DropdownDivider } from 'teleport/components/Dropdown';
 import cfg from 'teleport/config';
 import { Cluster } from 'teleport/services/clusters';
 
@@ -84,12 +83,6 @@ function renderActionCell({ clusterId }: Cluster, flags: MenuFlags) {
       renderMenuItem('Session Recordings', cfg.getRecordingsRoute(clusterId))
     );
   }
-
-  $items.push(<DropdownDivider key="divider" />);
-
-  $items.push(
-    renderMenuItem('Manage Cluster', cfg.getManageClusterRoute(clusterId))
-  );
 
   return (
     <Cell align="right">{$items && <MenuButton children={$items} />}</Cell>

--- a/web/packages/teleport/src/Clusters/Clusters.tsx
+++ b/web/packages/teleport/src/Clusters/Clusters.tsx
@@ -33,7 +33,6 @@ import { useFeatures } from 'teleport/FeaturesContext';
 import useTeleport from 'teleport/useTeleport';
 
 import ClusterList from './ClusterList';
-import { ManageCluster } from './ManageCluster';
 import { buildACL } from './utils';
 
 export function Clusters() {
@@ -44,11 +43,6 @@ export function Clusters() {
         exact
         path={cfg.routes.clusters}
         component={ClusterListPage}
-      />
-      <Route
-        key="cluster-management"
-        path={cfg.routes.manageCluster}
-        component={ManageCluster}
       />
     </Switch>
   );

--- a/web/packages/teleport/src/Support/Support.story.tsx
+++ b/web/packages/teleport/src/Support/Support.story.tsx
@@ -48,25 +48,7 @@ export const SupportOSS = () => (
 
 export const SupportOSSWithCTA = () => (
   <Provider>
-    <Support {...props} showPremiumSupportCTA={true} />
-  </Provider>
-);
-
-export const SupportCloud = () => (
-  <Provider>
-    <Support {...props} isCloud={true} />
-  </Provider>
-);
-
-export const SupportEnterprise = () => (
-  <Provider>
-    <Support {...props} isEnterprise={true} />
-  </Provider>
-);
-
-export const SupportEnterpriseWithCTA = () => (
-  <Provider>
-    <Support {...props} isEnterprise={true} showPremiumSupportCTA={true} />
+    <Support {...props} showPremiumSupportCta={true} />
   </Provider>
 );
 
@@ -85,6 +67,6 @@ const props: Props = {
   isEnterprise: false,
   isCloud: false,
   tunnelPublicAddress: null,
-  showPremiumSupportCTA: false,
+  showPremiumSupportCta: false,
   licenseExpiryDateText: '2027-05-09 06:52:58',
 };

--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -20,9 +20,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Box, Flex, H2, H3, Text } from 'design';
+import { Box, Card, Flex, H2, H3, Text } from 'design';
 import * as Icons from 'design/Icon';
-import { MultiRowBox, Row } from 'design/MultiRowBox';
+import { P } from 'design/Text/Text';
 
 import { ButtonLockedFeature } from 'teleport/components/ButtonLockedFeature';
 import {
@@ -39,8 +39,8 @@ export function SupportContainer({ children }: { children?: React.ReactNode }) {
   const ctx = useTeleport();
   const cluster = ctx.storeUser.state.cluster;
 
-  // showCTA returns the premium support value for enterprise customers and true for OSS users
-  const showCTA = cfg.isEnterprise ? !cfg.premiumSupport : true;
+  // showCta returns the premium support value for enterprise customers and true for OSS users
+  const showCta = cfg.edition === 'ent' ? !cfg.premiumSupport : true;
 
   return (
     <Support
@@ -48,9 +48,11 @@ export function SupportContainer({ children }: { children?: React.ReactNode }) {
       isEnterprise={cfg.isEnterprise}
       tunnelPublicAddress={cfg.tunnelPublicAddress}
       isCloud={cfg.isCloud}
-      showPremiumSupportCTA={showCTA}
-      children={children}
-    />
+      showPremiumSupportCta={showCta}
+      authVersion={cluster.authVersion}
+    >
+      {children}
+    </Support>
   );
 }
 
@@ -63,47 +65,32 @@ export const Support = ({
   tunnelPublicAddress,
   isCloud,
   children,
-  showPremiumSupportCTA,
+  showPremiumSupportCta,
 }: Props) => {
   useNoMinWidth();
   const docs = getDocUrls(authVersion, isEnterprise);
 
   return (
-    <FeatureBox maxWidth="2000px">
+    <FeatureBox maxWidth="2000px" p={{ _: 2, small: 6 }}>
       <FeatureHeader>
         <FeatureHeaderTitle>Help & Support</FeatureHeaderTitle>
       </FeatureHeader>
-      <StyledMultiRowBox mb={3}>
-        <StyledRow>
-          <Flex alignItems="center" justifyContent="start">
-            <IconBox>
-              <Icons.Cluster />
-            </IconBox>
-            <H2>Cluster Information</H2>
-          </Flex>
-        </StyledRow>
-        <StyledRow
+      <SupportSectionsWrapper isCloud={isCloud}>
+        <SupportSectionCard
           css={`
-            padding-left: ${props => props.theme.space[6]}px;
+            grid-column: auto;
+            @media screen and (min-width: ${props =>
+                props.theme.breakpoints.small}) {
+              grid-column: span 2;
+            }
           `}
         >
-          <DataItem title="Cluster Name" data={clusterId} />
-          <DataItem title="Teleport Version" data={authVersion} />
-          <DataItem title="Public Address" data={publicURL} />
-          {tunnelPublicAddress && (
-            <DataItem title="Public SSH Tunnel" data={tunnelPublicAddress} />
-          )}
-          {isEnterprise && !cfg.isCloud && licenseExpiryDateText && (
-            <DataItem title="License Expiry" data={licenseExpiryDateText} />
-          )}
-        </StyledRow>
-      </StyledMultiRowBox>
-      <MobileSeparator />
-      <StyledMultiRowBox mb={3}>
-        <StyledRow>
-          <SupportContentFlex
-            alignItems="center"
+          <Flex
+            alignItems={{ _: 'flex-start', small: 'center' }}
             justifyContent="space-between"
+            flexDirection={{ _: 'column', small: 'row' }}
+            mb={3}
+            gap={2}
           >
             <Flex alignItems="center">
               <IconBox>
@@ -112,25 +99,19 @@ export const Support = ({
               <H2>Support and Resource Pages</H2>
             </Flex>
             <SupportButtonBox>
-              {showPremiumSupportCTA && (
+              {showPremiumSupportCta && (
                 <ButtonLockedFeature event={CtaEvent.CTA_PREMIUM_SUPPORT}>
-                  Unlock Premium Support w/Enterprise
+                  Unlock Premium Support with&nbsp;Enterprise
                 </ButtonLockedFeature>
               )}
             </SupportButtonBox>
-          </SupportContentFlex>
-        </StyledRow>
-        <StyledRow
-          css={`
-            padding-left: ${props => props.theme.space[6]}px;
-          `}
-        >
+          </Flex>
           <SupportLinksFlex>
-            <Box>
+            <SupportLinkCategory>
               <H3 ml={2} mb={1}>
-                Support
+                Contact Support
               </H3>
-              {isEnterprise && !showPremiumSupportCTA && (
+              {isEnterprise && !showPremiumSupportCta && (
                 <ExternalSupportLink
                   title="Create a Support Ticket"
                   url="https://support.goteleport.com"
@@ -148,8 +129,8 @@ export const Support = ({
                 title="Send Product Feedback"
                 url="mailto:support@goteleport.com"
               />
-            </Box>
-            <Box>
+            </SupportLinkCategory>
+            <SupportLinkCategory>
               <H3 ml={2} mb={1}>
                 Resources
               </H3>
@@ -165,8 +146,8 @@ export const Support = ({
               />
               <DownloadLink isCloud={isCloud} isEnterprise={isEnterprise} />
               <ExternalSupportLink title="FAQ" url={docs.faq} />
-            </Box>
-            <Box>
+            </SupportLinkCategory>
+            <SupportLinkCategory>
               <H3 ml={2} mb={1}>
                 Updates
               </H3>
@@ -178,35 +159,64 @@ export const Support = ({
                 title="Teleport Blog"
                 url="https://goteleport.com/blog/"
               />
-            </Box>
+            </SupportLinkCategory>
           </SupportLinksFlex>
-        </StyledRow>
-      </StyledMultiRowBox>
-      {children}
+        </SupportSectionCard>
+        <SupportSectionCard
+          css={
+            !isCloud &&
+            `
+            grid-column: span 2;
+            @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
+              grid-column: auto;
+            }
+          `
+          }
+        >
+          <Flex alignItems="center" justifyContent="start" mb={3}>
+            <IconBox>
+              <Icons.Cluster />
+            </IconBox>
+            <H2>Cluster Information</H2>
+          </Flex>
+          <Flex flexDirection="column" justifyContent="center">
+            <P>Cluster Name: {clusterId}</P>
+            <P>Teleport Version: {authVersion}</P>
+            <P>Public Address: {publicURL}</P>
+            {tunnelPublicAddress && (
+              <P>Public SSH Tunnel: {tunnelPublicAddress}</P>
+            )}
+            {isEnterprise && !cfg.isCloud && !!licenseExpiryDateText && (
+              <P>License Expiry: {licenseExpiryDateText}</P>
+            )}
+          </Flex>
+        </SupportSectionCard>
+
+        {children}
+      </SupportSectionsWrapper>
     </FeatureBox>
   );
 };
 
-export const StyledMultiRowBox = styled(MultiRowBox)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    border: none;
+const SupportSectionsWrapper = styled(Box)<{ isCloud?: boolean }>`
+  display: grid;
+  gap: ${props => props.theme.space[3]}px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: auto;
+  width: 100%;
+
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
+    grid-template-columns: 1fr !important;
+    gap: ${props => props.theme.space[2]}px;
   }
 `;
 
-export const StyledRow = styled(Row)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    border: none !important;
-    padding-left: 0;
-    padding-bottom: 0;
-  }
-`;
+export const SupportSectionCard = styled(Card)`
+  padding: ${props => props.theme.space[4]}px;
+  box-shadow: ${props => props.theme.boxShadow[0]};
 
-export const MobileSeparator = styled.div`
-  width: 100vw;
-  margin-left: -${props => props.theme.space[6]}px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    border-bottom: ${props =>
-      `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2]}`};
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
+    padding: ${props => props.theme.space[3]}px;
   }
 `;
 
@@ -216,25 +226,28 @@ export const IconBox = styled(Box)`
   border-radius: ${props => props.theme.radii[3]}px;
   margin-right: ${props => props.theme.space[3]}px;
   background: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+  border: ${props => props.theme.borders[1]};
+  border-color: ${props => props.theme.colors.interactive.tonal.neutral[2]};
 
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
+  .icon {
+    height: 16px;
+    width: 16px;
+  }
+
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
     background: transparent;
     margin-right: ${props => props.theme.space[1]}px;
   }
 `;
 
-const SupportContentFlex = styled(Flex)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+const SupportLinkCategory = styled(Flex)`
+  flex-direction: column;
+  gap: ${props => props.theme.space[1]}px;
 `;
 
 const SupportButtonBox = styled(Box)`
-  width: 320px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    margin-left: ${props => props.theme.space[6]}px;
-    margin-top: ${props => props.theme.space[2]}px;
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
+    width: 100%;
   }
 `;
 
@@ -242,10 +255,10 @@ const SupportLinksFlex = styled(Flex)`
   justify-content: space-between;
   flex-wrap: wrap;
   max-width: 70%;
-  @media screen and (max-width: ${props => props.theme.breakpoints.tablet}) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.medium}) {
     max-width: 100%;
   }
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
     flex-direction: column;
     gap: ${props => props.theme.space[3]}px;
     margin-bottom: ${props => props.theme.space[3]}px;
@@ -254,7 +267,7 @@ const SupportLinksFlex = styled(Flex)`
 
 const DataItemFlex = styled(Flex)`
   margin-bottom: ${props => props.theme.space[3]}px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.small}) {
     flex-direction: column;
     padding-left: ${props => props.theme.space[2]}px;
   }
@@ -340,7 +353,6 @@ const StyledSupportLink = styled.a.attrs({
   color: ${props => props.theme.colors.text.main};
   border-radius: 4px;
   text-decoration: none;
-  margin-bottom: 8px;
   padding: 4px 8px;
   transition: all 0.3s;
 
@@ -368,5 +380,5 @@ export type Props = {
   isCloud: boolean;
   tunnelPublicAddress?: string;
   children?: React.ReactNode;
-  showPremiumSupportCTA: boolean;
+  showPremiumSupportCta: boolean;
 };

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
@@ -59,7 +59,15 @@ export const ExternalAuditStorageCta = () => {
   }
 
   return (
-    <CtaContainer mb={3}>
+    <CtaContainer
+      css={`
+        grid-column: span 2;
+        @media screen and (max-width: ${props =>
+            props.theme.breakpoints.mobile}) {
+          grid-column: auto;
+        }
+      `}
+    >
       <Flex
         justifyContent="space-between"
         css={`

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -174,7 +174,6 @@ const cfg = {
     sso: '/web/sso',
     cluster: '/web/cluster/:clusterId/',
     clusters: '/web/clusters',
-    manageCluster: '/web/clusters/:clusterId/manage',
 
     trustedClusters: '/web/trust',
     audit: '/web/cluster/:clusterId/audit',
@@ -729,10 +728,6 @@ const cfg = {
 
   getNodesRoute(clusterId: string) {
     return generatePath(cfg.routes.nodes, { clusterId });
-  },
-
-  getManageClusterRoute(clusterId: string) {
-    return generatePath(cfg.routes.manageCluster, { clusterId });
   },
 
   getUnifiedResourcesRoute(clusterId: string) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -645,7 +645,7 @@ export class FeatureClusters implements TeleportFeature {
   };
 
   hasAccess(flags: FeatureFlags) {
-    return cfg.isDashboard || flags.trustedClusters;
+    return flags.trustedClusters && !cfg.isCloud && !cfg.isDashboard;
   }
 
   showInDashboard = true;


### PR DESCRIPTION
## Purpose

`e` counterpart https://github.com/gravitational/teleport.e/pull/7113

This PR updates the help and support page styles to match latest designs and moves the security/business contact management to `help and support`. This PR also removes the `manage cluster` page and hides the `trusted clusters` page from cloud users.


## Demo

### OSS
<img width="1239" height="570" alt="image" src="https://github.com/user-attachments/assets/e8582f88-05e6-43f3-a766-6c1414d26d60" />


### Self-hosted enterprise
<img width="1239" height="570" alt="image" src="https://github.com/user-attachments/assets/86df9135-8e3f-4d51-badb-541a43eba955" />

### Self-hosted enterprise dashboard

<img width="1499" height="846" alt="image" src="https://github.com/user-attachments/assets/ef3363e2-af45-4afc-bd25-0601c0348ce8" />

### Cloud

<img width="1499" height="852" alt="image" src="https://github.com/user-attachments/assets/65545b83-55c9-4394-80f9-24882eabffe5" />



