### PR TITLE
feat(resource-locks): Dialog improvements and multiple locks handling

### DIFF
--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -468,6 +468,9 @@ const StyledButton = styled.button.withConfig({
 export const ButtonPrimary = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="filled" intent="primary" {...props} />;
+export const ButtonPrimaryBorder = <E extends React.ElementType = 'button'>(
+  props: ButtonProps<E>
+) => <Button fill="border" intent="primary" {...props} />;
 export const ButtonSecondary = <E extends React.ElementType = 'button'>(
   props: ButtonProps<E>
 ) => <Button fill="filled" intent="neutral" {...props} />;

--- a/web/packages/design/src/Button/buttons.story.tsx
+++ b/web/packages/design/src/Button/buttons.story.tsx
@@ -26,6 +26,7 @@ import {
   ButtonBorder,
   ButtonFill,
   ButtonPrimary,
+  ButtonPrimaryBorder,
   ButtonProps,
   ButtonSecondary,
   ButtonText,
@@ -87,6 +88,7 @@ export const Buttons = () => {
       </Table>{' '}
       <Flex gap={3}>
         <ButtonPrimary>Primary</ButtonPrimary>
+        <ButtonPrimaryBorder>Primary (border)</ButtonPrimaryBorder>
         <ButtonSecondary>Secondary</ButtonSecondary>
         <ButtonBorder>Border</ButtonBorder>
         <ButtonWarning>Warning</ButtonWarning>

--- a/web/packages/design/src/Button/index.ts
+++ b/web/packages/design/src/Button/index.ts
@@ -19,6 +19,7 @@
 export {
   Button,
   ButtonPrimary,
+  ButtonPrimaryBorder,
   ButtonWarning,
   ButtonSecondary,
   ButtonBorder,

--- a/web/packages/teleport/src/lib/locks/ResourceLockAndUnlock.story.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockAndUnlock.story.tsx
@@ -70,6 +70,48 @@ export const LockingDialogs: Story = {
   },
 };
 
+export const UnlockNotSupported: Story = {
+  args: {
+    targetKind: 'user',
+    targetName: 'example-user',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        listV2LocksSuccess({
+          locks: [
+            {
+              name: '785d167d-cb2b-4de4-8268-efb6d8932dde',
+              message: 'Locking bots until security alert is resolved.',
+              expires: '2023-01-01T00:00:00Z',
+              createdAt: '2023-01-01T00:00:00Z',
+              targets: {
+                user: 'example-user',
+              },
+            },
+            {
+              name: '0ef9909f-4980-40f7-bc85-ad9ef72bc059',
+              expires: '2023-01-01T00:00:00Z',
+              targets: {
+                user: 'example-user',
+              },
+            },
+            {
+              name: '0e07e3f6-55bc-421d-ab24-1b521a0b6452',
+              message:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+              createdAt: '2023-01-01T00:00:00Z',
+              targets: {
+                user: 'example-user',
+              },
+            },
+          ],
+        }),
+      ],
+    },
+  },
+};
+
 type Props = {
   targetKind: LockResourceKind;
   targetName: string;

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
@@ -31,7 +31,6 @@ import {
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
-import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
 import {
   createLockSuccess,
   listV2LocksSuccess,

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
@@ -16,15 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { UserEvent } from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
 import {
-  fireEvent,
   Providers,
   render,
   screen,
   testQueryClient,
+  userEvent,
   waitFor,
 } from 'design/utils/testing';
 
@@ -59,15 +60,7 @@ describe('ResourceLockDialog', () => {
 
     const onCancel = jest.fn();
 
-    render(
-      <ResourceLockDialog
-        targetKind="user"
-        targetName="test-user"
-        onCancel={onCancel}
-        onComplete={jest.fn()}
-      />,
-      { wrapper: makeWrapper() }
-    );
+    const { user } = renderComponent({ onCancel });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
@@ -75,7 +68,7 @@ describe('ResourceLockDialog', () => {
 
     expect(screen.getByText('Lock test-user?')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
@@ -84,25 +77,17 @@ describe('ResourceLockDialog', () => {
 
     const onComplete = jest.fn();
 
-    render(
-      <ResourceLockDialog
-        targetKind="user"
-        targetName="test-user"
-        onCancel={jest.fn()}
-        onComplete={onComplete}
-      />,
-      { wrapper: makeWrapper() }
-    );
+    const { user } = renderComponent({ onComplete });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
     });
 
-    inputMessage('This is a test message');
-    inputTtl('24h');
+    await inputMessage(user, 'This is a test message');
+    await inputTtl(user, '24h');
 
     withLockSuccess();
-    fireEvent.click(screen.getByRole('button', { name: 'Create Lock' }));
+    await user.click(screen.getByRole('button', { name: 'Create Lock' }));
 
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
@@ -127,21 +112,30 @@ describe('ResourceLockDialog', () => {
   });
 });
 
-function makeWrapper(params?: { customAcl?: ReturnType<typeof makeAcl> }) {
-  const {
-    customAcl = makeAcl({
-      lock: {
-        ...defaultAccess,
-        list: true,
-        remove: true,
-        create: true,
-        edit: true,
-      },
-    }),
-  } = params ?? {};
-  const ctx = createTeleportContext({
-    customAcl,
-  });
+function renderComponent(
+  params?: Pick<
+    Partial<ComponentPropsWithoutRef<typeof ResourceLockDialog>>,
+    'onCancel' | 'onComplete'
+  >
+) {
+  const { onCancel = jest.fn(), onComplete = jest.fn() } = params ?? {};
+  const user = userEvent.setup();
+  return {
+    ...render(
+      <ResourceLockDialog
+        targetKind="user"
+        targetName="test-user"
+        onCancel={onCancel}
+        onComplete={onComplete}
+      />,
+      { wrapper: makeWrapper() }
+    ),
+    user,
+  };
+}
+
+function makeWrapper() {
+  const ctx = createTeleportContext();
   return (props: PropsWithChildren) => (
     <Providers>
       <TeleportProviderBasic teleportCtx={ctx}>
@@ -151,14 +145,14 @@ function makeWrapper(params?: { customAcl?: ReturnType<typeof makeAcl> }) {
   );
 }
 
-async function inputMessage(value: string) {
+async function inputMessage(user: UserEvent, value: string) {
   const input = screen.getByLabelText('Reason');
-  fireEvent.change(input, { target: { value } });
+  await user.type(input, value);
 }
 
-async function inputTtl(value: string) {
+async function inputTtl(user: UserEvent, value: string) {
   const input = screen.getByLabelText('Expiry');
-  fireEvent.change(input, { target: { value } });
+  await user.type(input, value);
 }
 
 function withListLocksSuccess(

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.tsx
@@ -110,7 +110,7 @@ export function ResourceLockDialog(props: {
               }
             }}
           >
-            <DialogContent>
+            <DialogContent maxWidth="650px">
               <Text mb={3}>
                 Locking a resource will terminate all of its connections and
                 reject any new API requests.
@@ -125,6 +125,7 @@ export function ResourceLockDialog(props: {
               <FieldInput
                 label="Expiry"
                 value={ttl}
+                readonly={isLoading || lockPending}
                 onChange={e => setTtl(e.target.value)}
                 helperText={
                   'A duration string such as 12h, 2h 45m, 43200s. Valid time units are h, m and s.'

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.tsx
@@ -29,6 +29,7 @@ import Dialog, {
 import Flex from 'design/Flex/Flex';
 import Text from 'design/Text/Text';
 import FieldInput from 'shared/components/FieldInput/FieldInput';
+import { FieldTextArea } from 'shared/components/FieldTextArea/FieldTextArea';
 import { Validation } from 'shared/components/Validation/Validation';
 
 import { LockResourceKind } from 'teleport/LocksV2/NewLock/common';
@@ -114,7 +115,7 @@ export function ResourceLockDialog(props: {
                 Locking a resource will terminate all of its connections and
                 reject any new API requests.
               </Text>
-              <FieldInput
+              <FieldTextArea
                 label="Reason"
                 placeholder="Going down for maintenance"
                 value={message}

--- a/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.tsx
@@ -16,16 +16,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import format from 'date-fns/format';
+import parseISO from 'date-fns/parseISO';
+import { Link, useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
 import { Alert } from 'design/Alert/Alert';
-import { ButtonSecondary, ButtonWarning } from 'design/Button/Button';
+import {
+  ButtonPrimaryBorder,
+  ButtonSecondary,
+  ButtonWarning,
+} from 'design/Button/Button';
 import Dialog, {
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from 'design/DialogConfirmation';
-import Flex from 'design/Flex/Flex';
+import Flex from 'design/Flex';
+import Text from 'design/Text';
 
+import cfg from 'teleport/config';
 import { LockResourceKind } from 'teleport/LocksV2/NewLock/common';
 
 import { useResourceLock } from './useResourceLock';
@@ -68,7 +79,9 @@ export function ResourceUnlockDialog(props: {
 }) {
   const { targetKind, targetName, onCancel, onComplete } = props;
 
-  const { isLoading, canUnlock, unlock, unlockPending, unlockError } =
+  const history = useHistory();
+
+  const { isLoading, locks, canUnlock, unlock, unlockPending, unlockError } =
     useResourceLock({
       targetKind,
       targetName,
@@ -84,16 +97,56 @@ export function ResourceUnlockDialog(props: {
     onComplete();
   };
 
+  const multipleLocksExist = locks && locks.length > 1;
+
   return (
     <Dialog onClose={onCancel} open={true}>
       <DialogHeader>
         <DialogTitle>Unlock {targetName}?</DialogTitle>
       </DialogHeader>
-      <DialogContent>
-        <div>
-          This will remove the restrictions placed on <code>{targetName}</code>{' '}
-          and resume its activity.
-        </div>
+      <DialogContent maxWidth="650px">
+        {multipleLocksExist ? (
+          <div>
+            Multiple locks exist on <strong>{targetName}</strong> and they can
+            only be removed from the{' '}
+            <Link to={cfg.getLocksRoute()}>Session &amp; Identity Locks</Link>{' '}
+            page.
+          </div>
+        ) : (
+          <div>
+            This will remove the restrictions placed on{' '}
+            <code>{targetName}</code> and resume its activity.
+          </div>
+        )}
+
+        {locks ? (
+          <>
+            <LocksTitle>Lock details:</LocksTitle>
+
+            <LocksContainer>
+              {locks.map(lock => (
+                <LockItem key={lock.name}>
+                  <Text>
+                    <strong>Reason</strong>: {lock.message || 'none'}
+                  </Text>
+                  <Text>
+                    <strong>Locked on</strong>:{' '}
+                    {lock.createdAt
+                      ? format(parseISO(lock.createdAt), 'PP, p z')
+                      : 'unknown'}
+                  </Text>
+                  <Text>
+                    <strong>Expires</strong>:{' '}
+                    {lock.expires
+                      ? format(parseISO(lock.expires), 'PP, p z')
+                      : 'never'}
+                  </Text>
+                </LockItem>
+              ))}
+            </LocksContainer>
+          </>
+        ) : undefined}
+
         {unlockError ? (
           <Alert kind="danger" details={unlockError.message} mt={3} mb={0}>
             Failed to unlock <code>{targetName}</code>
@@ -102,12 +155,20 @@ export function ResourceUnlockDialog(props: {
       </DialogContent>
       <DialogFooter>
         <Flex gap={3}>
-          <ButtonWarning
-            onClick={handleUnlock}
-            disabled={isLoading || !canUnlock || unlockPending}
-          >
-            Remove Lock
-          </ButtonWarning>
+          {multipleLocksExist ? (
+            <ButtonPrimaryBorder
+              onClick={() => history.push(cfg.getLocksRoute())}
+            >
+              Go to Session and Identity Locks
+            </ButtonPrimaryBorder>
+          ) : (
+            <ButtonWarning
+              onClick={handleUnlock}
+              disabled={isLoading || !canUnlock || unlockPending}
+            >
+              Remove Lock
+            </ButtonWarning>
+          )}
           <ButtonSecondary
             disabled={isLoading || unlockPending}
             onClick={onCancel}
@@ -119,3 +180,27 @@ export function ResourceUnlockDialog(props: {
     </Dialog>
   );
 }
+
+const LocksTitle = styled(Text)`
+  font-weight: bold;
+  padding: ${({ theme }) => theme.space[3]}px 0;
+`;
+
+const LocksContainer = styled(Flex)`
+  flex-direction: column;
+  gap: ${props => props.theme.space[3]}px;
+`;
+
+const LockItem = styled(Flex)`
+  flex-direction: column;
+  gap: ${props => props.theme.space[2]}px;
+  padding: ${({ theme }) => theme.space[2]}px;
+  background-color: ${({ theme }) => theme.colors.interactive.tonal.neutral[0]};
+  border-left: 4px solid
+    ${({ theme }) => theme.colors.interactive.tonal.neutral[2]};
+  color: ${({ theme }) => theme.colors.text.slightlyMuted};
+
+  & strong {
+    font-weight: bold;
+  }
+`;

--- a/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.tsx
@@ -18,7 +18,8 @@
 
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
-import { Link, useHistory } from 'react-router-dom';
+import { MouseEventHandler } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Alert } from 'design/Alert/Alert';
@@ -76,10 +77,18 @@ export function ResourceUnlockDialog(props: {
    * Called when the user completes the unlock operation.
    */
   onComplete: () => void;
+  /**
+   * For testing only: called when the user wants to go to locks.
+   */
+  onGoToLocksForTesting?: MouseEventHandler<HTMLAnchorElement>;
 }) {
-  const { targetKind, targetName, onCancel, onComplete } = props;
-
-  const history = useHistory();
+  const {
+    targetKind,
+    targetName,
+    onCancel,
+    onComplete,
+    onGoToLocksForTesting,
+  } = props;
 
   const { isLoading, locks, canUnlock, unlock, unlockPending, unlockError } =
     useResourceLock({
@@ -109,7 +118,9 @@ export function ResourceUnlockDialog(props: {
           <div>
             Multiple locks exist on <strong>{targetName}</strong> and they can
             only be removed from the{' '}
-            <Link to={cfg.getLocksRoute()}>Session &amp; Identity Locks</Link>{' '}
+            <Link to={cfg.getLocksRoute()} onClick={onGoToLocksForTesting}>
+              Session and Identity Locks
+            </Link>{' '}
             page.
           </div>
         ) : (
@@ -157,7 +168,9 @@ export function ResourceUnlockDialog(props: {
         <Flex gap={3}>
           {multipleLocksExist ? (
             <ButtonPrimaryBorder
-              onClick={() => history.push(cfg.getLocksRoute())}
+              as="a"
+              href={cfg.getLocksRoute()}
+              onClick={onGoToLocksForTesting}
             >
               Go to Session and Identity Locks
             </ButtonPrimaryBorder>

--- a/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
+++ b/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
@@ -143,6 +143,44 @@ describe('useResourceLock', () => {
     expect(result.current.error).toBeNull();
     expect(result.current.locks).toHaveLength(2);
     expect(result.current.isLocked).toBe(true);
+    expect(result.current.canUnlock).toBe(true);
+  });
+
+  it('handles lock with other targets', async () => {
+    withListLocksSuccess({
+      locks: [
+        {
+          name: '76bc5cc7-b9bf-4a03-935f-8018c0a2bc05',
+          message: 'This is a test message',
+          expires: '2023-12-31T23:59:59Z',
+          targets: {
+            user: 'test-user',
+            role: 'test-role', // This target means the lock cannot be removed.
+          },
+          createdAt: '2023-01-01T00:00:00Z',
+          createdBy: 'admin',
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useResourceLock({
+          targetKind: 'user',
+          targetName: 'test-user',
+        }),
+      {
+        wrapper: makeWrapper(),
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.locks).toHaveLength(1);
+    expect(result.current.isLocked).toBe(true);
     expect(result.current.canUnlock).toBe(false);
   });
 

--- a/web/packages/teleport/src/lib/locks/useResourceLock.ts
+++ b/web/packages/teleport/src/lib/locks/useResourceLock.ts
@@ -91,11 +91,12 @@ export function useResourceLock(opts: {
     },
   });
 
-  // The lock (singular) can be removed if it targets only the given resource,
-  // otherwise it may affect other resources
+  // The lock/s can be removed if they all target the given resource, other
+  // locks may affect other resources
   const canUnlock =
     hasRemovePermission &&
-    data?.length === 1 &&
+    data &&
+    data.length > 0 &&
     data.reduce(
       (acc, lock) =>
         acc &&
@@ -128,6 +129,7 @@ export function useResourceLock(opts: {
     locks: isSuccess ? data : null,
     error,
     canUnlock,
+    /** Removes the lock. If there are multiple locks, only the first one is removed */
     unlock,
     unlockPending,
     unlockError,


### PR DESCRIPTION
## Summary
This change is the result of a design review. It refines the Resource Lock dialogs and improves how multiple locks are handled. Users are able to see lock details before unlocking and they're directed to the Session and Identity Locks section when multiple locks exist.

## Changes
- Use TextArea for lock reason field
- Replace `fireEvent` with `userEvent` in dialog tests
- Add a new button variant (`ButtonPrimaryBorder`) - used on the unlock dialog when there are multiple locks
- Add lock details to unlock dialog
- Handle multiple locks - these cant be removed, so users are redirected to the relevant page to manage the locks

## Reviewer notes
These changes can be seen most easily through Storybook (https://localhost:9002/?path=/story/teleport-lib-locks--locking-dialogs). Otherwise, to see it live, the lock dialogs are integrated with the bot details pages and they can be tested there.

## Demo
_Lock dialog with text area_
<img width="822" height="812" alt="Screenshot 2025-08-22 at 14 44 40" src="https://github.com/user-attachments/assets/553cfd79-ae41-46c8-a3d2-89eff9f2345b" />

_Unlock dialog with lock details_
<img width="822" height="812" alt="Screenshot 2025-08-22 at 14 46 18" src="https://github.com/user-attachments/assets/363a1ee1-821a-4e3e-94e2-fab39cf960bd" />

_Unlock dialog with details of multiple locks and navigation to Locks section_
<img width="822" height="812" alt="Screenshot 2025-08-22 at 14 44 21" src="https://github.com/user-attachments/assets/3dd09625-c421-46be-8964-4070bbf358ba" />
