### PR TITLE
Allow `"*"` in `kubernetes_users`

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -319,15 +319,16 @@ determines this from the `kubernetes_users` and `kubernetes_groups` fields in a
 user's roles.
 
 If a user has exactly one value in `kubernetes_users`, the Teleport Kubernetes
-Service impersonates that user. If there are no values in `kubernetes_users`,
-the Kubernetes Service uses the user's Teleport username.
+Service impersonates that user. If there are no values or a wildcard (`*`) in
+`kubernetes_users`, the Kubernetes Service uses the user's Teleport username.
 
 The Kubernetes Service will deny a request if a user has multiple
 `kubernetes_users` and has not specified one when authenticating to a cluster
 (i.e., using the `--as` flag described in the previous section).
 
 If the user has not specified a Kubernetes group to impersonate, the Kubernetes
-Service uses all values within `kubernetes_groups`.
+Service uses all values within `kubernetes_groups`, unless there is a
+[wildcard](#specifying-a-wildcard-in-kubernetes_users) in `kubernetes_users`.
 
 With the `kube-access` role above, after you authenticate to Teleport, the
 Kubernetes Service uses impersonation headers to forward requests to the API
@@ -504,6 +505,23 @@ will be accessible to the user if the principals in the `kubernetes_users` and
 Requesting access to a Kubernetes Namespace allows you to access all resources
 in that namespace but you won't be able to access any other supported resources
 in the cluster.
+
+#### Specifying a wildcard in `kubernetes_users`
+
+You can specify a wildcard (`*`) in `kubernetes_users` to allow impersonation of
+any user. This is useful if you have a component such as the Argo CD control
+plane that needs a broad set standing privileges for cluster-level operations,
+but uses impersonation to scope privileges down when acting on their user's
+behalf.
+
+When a wildcard is present, if no user is manually being impersonated (e.g.
+by passing the `--as` flag to `tsh kube login`), the Kubernetes Service uses the
+user's Teleport username.
+
+While you can still manually impersonate groups using the `--as-groups` flag,
+the Kubernetes Service will not automatically impersonate `kubernetes_groups`
+when the wildcard is present, because this would make it ineffective to
+impersonate a low-privileged user.
 
 ### `kubernetes_resources`
 

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -327,8 +327,17 @@ The Kubernetes Service will deny a request if a user has multiple
 (i.e., using the `--as` flag described in the previous section).
 
 If the user has not specified a Kubernetes group to impersonate, the Kubernetes
-Service uses all values within `kubernetes_groups`, unless there is a
-[wildcard](#specifying-a-wildcard-in-kubernetes_users) in `kubernetes_users`.
+Service uses all values within `kubernetes_groups`.
+
+<Admonition type="warning">
+    When impersonating a less privileged user, remember that unless you're
+    also manually impersonating specific groups (e.g. using `--as-groups` flag),
+    the Kubernetes Service will automatically impersonate any groups within
+    `kubernetes_groups`.
+
+    This can be confusing because you will have the combined permissions of both
+    the user and any automatically-impersonated groups.
+</Admonition>
 
 With the `kube-access` role above, after you authenticate to Teleport, the
 Kubernetes Service uses impersonation headers to forward requests to the API
@@ -505,23 +514,6 @@ will be accessible to the user if the principals in the `kubernetes_users` and
 Requesting access to a Kubernetes Namespace allows you to access all resources
 in that namespace but you won't be able to access any other supported resources
 in the cluster.
-
-#### Specifying a wildcard in `kubernetes_users`
-
-You can specify a wildcard (`*`) in `kubernetes_users` to allow impersonation of
-any user. This is useful if you have a component such as the Argo CD control
-plane that needs a broad set standing privileges for cluster-level operations,
-but uses impersonation to scope privileges down when acting on their user's
-behalf.
-
-When a wildcard is present, if no user is manually being impersonated (e.g.
-by passing the `--as` flag to `tsh kube login`), the Kubernetes Service uses the
-user's Teleport username.
-
-While you can still manually impersonate groups using the `--as-groups` flag,
-the Kubernetes Service will not automatically impersonate `kubernetes_groups`
-when the wildcard is present, because this would make it ineffective to
-impersonate a low-privileged user.
 
 ### `kubernetes_resources`
 

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -248,7 +248,7 @@ func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.He
 		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
 	restConfig := details.getKubeRestConfig()
-	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, headers)
+	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -935,18 +935,19 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 		{
 			desc:       "kubernetes_users wildcard, no impersonation headers",
 			username:   "ted-lasso",
-			kubeUsers:  []string{"*"},
+			kubeUsers:  []string{types.Wildcard},
 			kubeGroups: []string{"kube-group-a"},
 			inHeaders:  http.Header{},
 			wantHeaders: http.Header{
-				ImpersonateUserHeader: []string{"ted-lasso"},
+				ImpersonateUserHeader:  []string{"ted-lasso"},
+				ImpersonateGroupHeader: []string{"kube-group-a"},
 			},
 			errAssertion: require.NoError,
 		},
 		{
 			desc:       "kubernetes_users wildcard, impersonation headers given",
 			username:   "ted-lasso",
-			kubeUsers:  []string{"*"},
+			kubeUsers:  []string{types.Wildcard},
 			kubeGroups: []string{"kube-group-a"},
 			inHeaders: http.Header{
 				ImpersonateUserHeader:  []string{"kube-user-a"},

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1552,6 +1552,11 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 	kubeClusterLabels := map[string]string{
 		"label": "value",
 	}
+	baseAuthCtx := authz.Context{
+		User: &types.UserV2{
+			Metadata: types.Metadata{Name: "ted-lasso"},
+		},
+	}
 	type args struct {
 		req *http.Request
 		ctx *authContext
@@ -1568,6 +1573,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					Header: http.Header{},
 				},
 				ctx: &authContext{
+					Context:           baseAuthCtx,
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}},
@@ -1591,6 +1597,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					},
 				},
 				ctx: &authContext{
+					Context:           baseAuthCtx,
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},
@@ -1611,6 +1618,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 					Header: http.Header{},
 				},
 				ctx: &authContext{
+					Context:           baseAuthCtx,
 					kubeClusterName:   "clusterName",
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -358,6 +358,7 @@ func deleteResources[T kubeObjectInterface](
 
 		impersonatedUsers, impersonatedGroups, err := computeImpersonatedPrincipals(
 			set.New(allowedKubeUsers...), set.New(allowedKubeGroups...),
+			params.authCtx.User.GetName(),
 			params.header,
 		)
 		if err != nil {


### PR DESCRIPTION
Fixes #58274.

changelog: Support setting `"*"` in role `kubernetes_users`
