### PR TITLE
[web] Tweak design of RequestCheckout for long-term to match designs

### DIFF
--- a/web/packages/design/src/ButtonSelect/ButtonSelect.story.tsx
+++ b/web/packages/design/src/ButtonSelect/ButtonSelect.story.tsx
@@ -16,55 +16,135 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { useArgs } from 'storybook/preview-api';
 
 import Flex from 'design/Flex';
 import { H2 } from 'design/Text';
 
 import { ButtonSelect } from './ButtonSelect';
 
+const defaultArgs = {
+  fullWidth: false,
+  disabled: false,
+  onChange: action('onChange'),
+} as const;
+
+type StoryMeta = Meta<typeof ButtonSelect>;
+
+type Story = StoryObj<typeof ButtonSelect>;
+
 export default {
   title: 'Design/ButtonSelect',
+  component: ButtonSelect,
+  argTypes: {
+    options: {
+      control: false,
+      description: 'Array of options to display in the button select',
+      table: {
+        type: {
+          summary:
+            '{ value: (string | number | bigint), label: string, disabled?: boolean, tooltip?: string }[]',
+        },
+      },
+    },
+    activeValue: {
+      control: false,
+      description: 'The value of the currently active option',
+      table: { type: { summary: 'string | number | bigint' } },
+    },
+    onChange: {
+      control: false,
+      description: 'Callback function called when the active button changes',
+      table: {
+        type: { summary: '(selectedValue: string | number | bigint) => void' },
+      },
+    },
+    fullWidth: {
+      control: { type: 'boolean' },
+      description:
+        'If true, the button select will take the full width of its container',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'If true, all options will be disabled',
+      table: { defaultValue: { summary: 'false' } },
+    },
+  },
+  args: defaultArgs,
+  render: (args => {
+    const [{ activeValue }, updateArgs] =
+      useArgs<NonNullable<StoryMeta['args']>>();
+    const onChange = (value: typeof activeValue) => {
+      value ??= args.options[0]?.value;
+      updateArgs({ activeValue: value });
+      args.onChange?.(value);
+    };
+
+    return (
+      <Flex flexDirection="column" gap={3} maxWidth="600px">
+        <ButtonSelect
+          {...args}
+          activeValue={activeValue ?? args.options[0]?.value}
+          onChange={onChange}
+        />
+        <H2>{`Active Value: ${activeValue ?? args.options[0]?.value}`}</H2>
+      </Flex>
+    );
+  }) satisfies StoryFn<typeof ButtonSelect>,
+} satisfies StoryMeta;
+
+const WithTwoOptions: Story = {
+  args: {
+    options: [
+      { value: '1', label: 'Option 1' },
+      { value: '2', label: 'Option 2' },
+    ],
+  },
 };
 
-export const TwoOptions = () => {
-  const options = [
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-  ];
-
-  const [activeValue, setActiveValue] = useState('1');
-
-  return (
-    <Flex flexDirection="column" gap={3}>
-      <ButtonSelect
-        options={options}
-        activeValue={activeValue}
-        onChange={setActiveValue}
-      />
-      <H2>{`Active Value: ${activeValue}`}</H2>
-    </Flex>
-  );
+const WithFourOptions: Story = {
+  args: {
+    options: [
+      { value: '1', label: 'Option 1' },
+      { value: '2', label: 'Option 2' },
+      { value: '3', label: 'Option 3' },
+      { value: '4', label: 'Option 4' },
+    ],
+  },
 };
 
-export const FourOptions = () => {
-  const options = [
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
-    { value: '4', label: 'Option 4' },
-  ];
+const WithDisabledOption: Story = {
+  args: {
+    options: [
+      { value: '1', label: 'Option 1' },
+      { value: '2', label: 'Option 2' },
+      {
+        value: '3',
+        label: 'Option 3',
+        disabled: true,
+        tooltip: 'Option 3 is disabled',
+      },
+      { value: '4', label: 'Option 4' },
+    ],
+  },
+};
 
-  const [activeValue, setActiveValue] = useState('1');
+const WithNonStringValues: Story = {
+  args: {
+    options: [
+      { value: 1, label: 'Option 1' },
+      { value: 2, label: 'Option 2' },
+      { value: 3, label: 'Option 3' },
+    ],
+  },
+};
 
-  return (
-    <Flex flexDirection="column" gap={3}>
-      <ButtonSelect
-        options={options}
-        activeValue={activeValue}
-        onChange={setActiveValue}
-      />
-      <H2>{`Active Value: ${activeValue}`}</H2>
-    </Flex>
-  );
+export {
+  WithTwoOptions,
+  WithFourOptions,
+  WithDisabledOption,
+  WithNonStringValues,
 };

--- a/web/packages/design/src/ButtonSelect/ButtonSelect.tsx
+++ b/web/packages/design/src/ButtonSelect/ButtonSelect.tsx
@@ -18,9 +18,26 @@
 
 import styled from 'styled-components';
 
-import Flex from 'design/Flex';
+import { Button } from 'design/Button';
+import Flex, { FlexProps } from 'design/Flex';
+import { HoverTooltip } from 'design/Tooltip';
 
-import { Button } from '../Button/Button';
+type OptionValue = string | number | bigint;
+
+type Option<T> = {
+  value: T;
+  label: string;
+  disabled?: boolean;
+  tooltip?: string;
+};
+
+type ButtonSelectProps<T extends readonly Option<OptionValue>[]> = {
+  options: T;
+  activeValue: T[number]['value'];
+  onChange: (selectedValue: T[number]['value']) => void;
+  fullWidth?: boolean;
+  disabled?: boolean;
+};
 
 /**
  * ButtonSelect is a segmented button that allows users to select one of the provided options.
@@ -45,48 +62,52 @@ import { Button } from '../Button/Button';
  *   />
  * );
  */
-export const ButtonSelect = ({
+export const ButtonSelect = <T extends readonly Option<OptionValue>[]>({
   options,
   activeValue,
   onChange,
-}: {
-  options: { value: string; label: string }[];
-  activeValue: string;
-  onChange: (selectedvalue: string) => void;
-}) => {
-  const updateValue = (newValue: string) => {
+  disabled = false,
+  fullWidth = false,
+}: ButtonSelectProps<T> & FlexProps) => {
+  const updateValue = (newValue: T[number]['value']) => {
     if (activeValue !== newValue) {
       onChange(newValue);
     }
   };
 
   return (
-    <Wrapper>
+    <Wrapper $fullWidth={fullWidth}>
       {options.map(option => {
         const isActive = activeValue === option.value;
         return (
-          <ButtonSelectButton
-            key={option.value}
-            aria-label={option.label}
-            aria-checked={isActive}
-            onClick={() => updateValue(option.value)}
-            intent={isActive ? 'primary' : 'neutral'}
-          >
-            {option.label}
-          </ButtonSelectButton>
+          <HoverTooltip tipContent={option.tooltip} key={option.label}>
+            <ButtonSelectButton
+              aria-label={option.label}
+              aria-checked={isActive}
+              onClick={() =>
+                !(option.disabled || disabled) && updateValue(option.value)
+              }
+              intent={isActive ? 'primary' : 'neutral'}
+              disabled={option.disabled || disabled}
+            >
+              {option.label}
+            </ButtonSelectButton>
+          </HoverTooltip>
         );
       })}
     </Wrapper>
   );
 };
 
-const Wrapper = styled(Flex)`
+const Wrapper = styled(Flex)<{ $fullWidth?: boolean }>`
+  ${({ $fullWidth }) => !$fullWidth && 'width: min-content;'}
   & > * {
     min-width: fit-content;
   }
 `;
 
 const ButtonSelectButton = styled(Button)`
+  flex: 1 1 0;
   border-radius: 0px;
 
   &:focus-visible {

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/LongTerm.tsx
@@ -51,11 +51,11 @@ export const LongTermGroupingErrors = <
         kind="danger"
         details={
           grouping.validationMessage ||
-          'No resources are available for long-term access'
+          'No resources are available for permanent access'
         }
         wrapContents
       >
-        Long-term access unavailable
+        Permanent access unavailable
       </Alert>
     );
   }
@@ -94,7 +94,7 @@ const LongTermUnavailableError = <T extends PendingListItem = PendingListItem>({
   }
 
   const plural = uncoveredResources.length > 1;
-  const message = `${joinResourceNames(uncoveredResources)} ${plural ? 'are' : 'is'} not available for long-term access. Remove ${plural ? 'them' : 'it'} or switch to a short-term request.`;
+  const message = `${joinResourceNames(uncoveredResources)} ${plural ? 'are' : 'is'} not available for permanent access. Remove ${plural ? 'them' : 'it'} or switch to a temporary request.`;
 
   return (
     <Alert
@@ -113,7 +113,7 @@ const LongTermUnavailableError = <T extends PendingListItem = PendingListItem>({
       details={message}
       wrapContents
     >
-      Long-term access is not available for{' '}
+      Permanent access is not available for{' '}
       {plural ? 'some selected resources' : 'a selected resource'}
     </Alert>
   );
@@ -137,7 +137,7 @@ const GroupingResourcesError = <T extends PendingListItem = PendingListItem>({
   }
 
   const plural = incompatibleResources.length > 1;
-  const message = `Remove ${joinResourceNames(incompatibleResources)} and request ${plural ? 'them' : 'it'} separately, or switch to a short-term request.`;
+  const message = `Remove ${joinResourceNames(incompatibleResources)} and request ${plural ? 'them' : 'it'} separately, or switch to a temporary request.`;
 
   return (
     <Alert
@@ -156,7 +156,7 @@ const GroupingResourcesError = <T extends PendingListItem = PendingListItem>({
       details={message}
       wrapContents
     >
-      {plural ? 'Resources' : 'Resource'} cannot be grouped for long-term access
+      {plural ? 'Resources' : 'Resource'} cannot be grouped for permanent access
     </Alert>
   );
 };

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -34,6 +34,7 @@ import {
   ButtonIcon,
   ButtonPrimary,
   ButtonSecondary,
+  ButtonSelect,
   Link as ExternalLink,
   Flex,
   H2,
@@ -43,7 +44,6 @@ import {
   P3,
   Subtitle2,
   Text,
-  Toggle,
 } from 'design';
 import { Danger } from 'design/Alert';
 import Table, { Cell } from 'design/DataTable';
@@ -265,14 +265,14 @@ export function RequestCheckout<T extends PendingListItem>({
     if (!isResourceRequest) {
       return [
         true,
-        'Long-term access is only supported for resource-based requests.',
+        'Permanent access is only supported for resource-based requests.',
       ];
     }
     // If canProceed is false on initial dryRun, show validation msg and disable until req is re-run.
     if (dryRunResponse?.longTermResourceGrouping?.canProceed === false) {
       return [
         true,
-        'Long-term access is unavailable. ' +
+        'Permanent access is unavailable. ' +
           dryRunResponse.longTermResourceGrouping.validationMessage || '',
       ];
     }
@@ -552,29 +552,27 @@ export function RequestCheckout<T extends PendingListItem>({
                     <>
                       <Flex flexDirection="column" gap={2} mt={4}>
                         <Text bold>Request Type</Text>
-                        <HoverTooltip
-                          tipContent={longTermDisabledReason}
-                          placement="left"
-                        >
-                          <Toggle
-                            isToggled={isLongTerm}
-                            onToggle={() =>
-                              setRequestKind(
-                                isLongTerm
-                                  ? RequestKind.ShortTerm
-                                  : RequestKind.LongTerm
-                              )
-                            }
-                            disabled={longTermDisabled}
-                          >
-                            <Flex flexDirection="column" ml={3}>
-                              <Text>Long-Term Access</Text>
-                              <Text color="text.slightlyMuted" fontSize={1}>
-                                Granted via an Access List
-                              </Text>
-                            </Flex>
-                          </Toggle>
-                        </HoverTooltip>
+                        <ButtonSelect
+                          options={[
+                            {
+                              value: RequestKind.ShortTerm,
+                              label: 'Temporary',
+                            },
+                            {
+                              value: RequestKind.LongTerm,
+                              label: 'Permanent',
+                              disabled: longTermDisabled,
+                              tooltip: longTermDisabledReason,
+                            },
+                          ]}
+                          activeValue={
+                            isLongTerm
+                              ? RequestKind.LongTerm
+                              : RequestKind.ShortTerm
+                          }
+                          onChange={setRequestKind}
+                          fullWidth
+                        />
                       </Flex>
                       <Divider />
                     </>

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -236,7 +236,7 @@ export function RequestView({
                             whiteSpace: 'nowrap',
                           }}
                         >
-                          is requesting long-term access to resources:
+                          is requesting permanent access to resources:
                         </Text>
                         <ResourcesRequested resources={request.resources} />
                       </>
@@ -440,7 +440,7 @@ export function Timestamp({
           )
         ) : (
           <span>
-            {verb} this request to long-term access with access list{' '}
+            {verb} this request to permanent access with access list{' '}
             <b>{promotedAccessListTitle}</b> {createdDuration}
           </span>
         )}


### PR DESCRIPTION
## Context
Follow-up to https://github.com/gravitational/teleport/pull/54980.

- Align RequestCheckout with the latest designs
- Change wording from 'long/short-term' to 'permanent/temporary'
- Fixup props of `ButtonSelect` to accept non-string vals, and accept a `disabled` prop

## Screenshots
<img width="595" height="1033" alt="image" src="https://github.com/user-attachments/assets/ebb05610-d968-431f-8957-b902cb05cd1d" />
<img width="549" height="1032" alt="image" src="https://github.com/user-attachments/assets/be075d44-80e0-4823-b0b8-c3fdec5518bd" />
