### PR TITLE
Fix incorrect scp exit status for OpenSSH nodes

### DIFF
--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -237,6 +237,14 @@ func (r *remoteSFTPSubsystem) Wait() error {
 		err = trace.ConnectionProblem(nil, "context is closing")
 	}
 
+	var exitStatus int
+	if err != nil {
+		exitStatus = 1
+	}
+	r.subsystem.serverContext.SendExecResult(r.subsystem.ctx, srv.ExecResult{
+		Code: exitStatus,
+	})
+
 	// emit an event to the audit log with the result of execution
 	r.subsystem.emitAuditEvent(r.subsystem.ctx, err)
 	return trace.Wrap(err)


### PR DESCRIPTION
This change fixes a bug where an scp with both OpenSSH client and server would have an exit status of 1, regardless of whether or not the transfer succeeded.

Fixes #20863.

Changelog: Fixed incorrect scp exit status between OpenSSH clients and servers