### PR TITLE
Set MaxAge in web cookie if time until expiry is > 0

### DIFF
--- a/lib/web/session/cookie.go
+++ b/lib/web/session/cookie.go
@@ -70,10 +70,10 @@ func SetCookie(w http.ResponseWriter, user, sid string, expiry time.Time) error 
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	}
-	// if expiry is zero, we can skip MaxAge and treat as a session cookie.
+	// if expiry is zero or in the past, we can skip MaxAge and treat as a session cookie.
 	// Otherwise, set maxage
-	if !expiry.IsZero() {
-		c.MaxAge = int(time.Until(expiry).Seconds())
+	if maxAge := int(time.Until(expiry).Seconds()); maxAge > 0 {
+		c.MaxAge = maxAge
 	}
 	http.SetCookie(w, c)
 	return nil

--- a/lib/web/session/cookie_test.go
+++ b/lib/web/session/cookie_test.go
@@ -55,13 +55,13 @@ func TestCookies(t *testing.T) {
 			expectedCookie: "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; Max-Age=9; HttpOnly; Secure; SameSite=Lax",
 		},
 		{
-			name:           "expired cert",
+			name:           "expired cert (returns session cookie)",
 			expiry:         time.Now().Add(-10 * time.Second),
 			expectClear:    false,
-			expectedCookie: "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax",
+			expectedCookie: "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; HttpOnly; Secure; SameSite=Lax",
 		},
 		{
-			name:           "zero time",
+			name:           "zero time (returns session cookie)",
 			expiry:         time.Time{},
 			expectClear:    false,
 			expectedCookie: "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; HttpOnly; Secure; SameSite=Lax",


### PR DESCRIPTION
This updates the logic to only setting max-age if the provided expiry is in the future rather than any non-zero value. this fixes the failing tests in `e` due to a `time.Now()` being in the past (non-zero)