### PR TITLE
[v16] Use `_self` as target when opening Device Trust deep link to Connect

### DIFF
--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -59,7 +59,11 @@ export const PassthroughPage = () => {
   const downloadLinks = getConnectDownloadLinks(platform, cluster.proxyVersion);
 
   useEffect(() => {
-    window.open(deviceTrustAuthorize);
+    // Use _self as the target to avoid opening a new blank tab to launch the deep link.
+    // On Chrome the blank tab would disappear after approving a deep link launch, but in Firefox
+    // and Safari it'd stay open. With _self, even if the user cancels the launch there will be no
+    // tab to close.
+    window.open(deviceTrustAuthorize, '_self');
 
     // the deviceWebToken is only valid for 5 minutes, so we can forward
     // to the dashboard


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport.e/pull/7114

This is an unusual backport of ent PR to OSS. This is because certain files that previously were in the OSS repo were moved to teleport.e (https://github.com/gravitational/teleport.e/pull/6218), but that work was not backported to v16.