### PR TITLE
Add the canvas renderers for the session timeline

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/constants.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/constants.ts
@@ -1,0 +1,13 @@
+import { font } from 'design/theme/fonts';
+
+export const LEFT_PADDING = 24;
+export const EVENT_ROW_HEIGHT = 28;
+export const EVENT_SECTION_PADDING = 8;
+export const RULER_HEIGHT = 35;
+
+export const BASE_FRAME_WIDTH = 240;
+
+export const DEFAULT_FRAME_HEIGHT = 250;
+export const DEFAULT_MAX_FRAME_WIDTH = 250;
+
+export const CANVAS_FONT = font.slice(0, -1); // remove the semicolon at the end

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
@@ -1,0 +1,243 @@
+import type { DefaultTheme } from 'styled-components';
+
+import {
+  SessionRecordingEventType,
+  type SessionRecordingEvent,
+  type SessionRecordingMetadata,
+} from 'teleport/services/recordings';
+import { formatSessionRecordingDuration } from 'teleport/SessionRecordings/list/RecordingItem';
+
+import {
+  CANVAS_FONT,
+  EVENT_ROW_HEIGHT,
+  EVENT_SECTION_PADDING,
+  LEFT_PADDING,
+  RULER_HEIGHT,
+} from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+type EventRow = TimelineEventMeasured[];
+
+type EventRowWithPositions = TimelineEventPositioned[];
+
+type TimelineEventMeasured = SessionRecordingEvent & {
+  title: string;
+  textWidth: number;
+};
+
+type TimelineEventPositioned = TimelineEventMeasured & {
+  endPosition: number;
+  startPosition: number;
+  textMetrics: TextMetrics;
+};
+
+function getEventStyles(theme: DefaultTheme, type: SessionRecordingEventType) {
+  switch (type) {
+    case SessionRecordingEventType.Inactivity:
+      return theme.colors.sessionRecordingTimeline.events.inactivity;
+    case SessionRecordingEventType.Resize:
+      return theme.colors.sessionRecordingTimeline.events.resize;
+    case SessionRecordingEventType.Join:
+      return theme.colors.sessionRecordingTimeline.events.join;
+    default:
+      return theme.colors.sessionRecordingTimeline.events.default;
+  }
+}
+
+function getEventTitle(event: SessionRecordingEvent) {
+  switch (event.type) {
+    case SessionRecordingEventType.Inactivity:
+      return `Inactivity for ${formatSessionRecordingDuration(event.endTime - event.startTime)}`;
+    case SessionRecordingEventType.Join:
+      return `${event.user} joined`;
+    default:
+      return 'Event';
+  }
+}
+
+export class EventsRenderer extends TimelineCanvasRenderer {
+  private height = 0;
+  private rows: EventRow[] = [];
+  private rowsWithPositions: EventRowWithPositions[] = [];
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+
+    this.createEventRows(metadata.events);
+  }
+
+  _render({ containerWidth, offset }: TimelineRenderContext) {
+    const eventRows = this.getVisibleEvents(offset, containerWidth);
+
+    for (const [index, row] of eventRows.entries()) {
+      for (const event of row) {
+        const startX = event.startPosition;
+        const endX = event.endPosition;
+        this.ctx.save();
+
+        const x = startX;
+
+        const y =
+          EVENT_SECTION_PADDING + index * EVENT_ROW_HEIGHT + RULER_HEIGHT;
+        const width = endX - startX;
+        const height = 24;
+        const radius = 8;
+
+        const styles = getEventStyles(this.theme, event.type);
+
+        this.ctx.fillStyle = styles.background;
+
+        this.ctx.beginPath();
+        this.ctx.roundRect(x, y, width, height, radius);
+
+        this.ctx.fill();
+        this.ctx.fillStyle = styles.text;
+
+        this.ctx.font = `bold 12px ${CANVAS_FONT}`;
+
+        const textWidth = event.textMetrics.width;
+        const textHeight =
+          event.textMetrics.actualBoundingBoxAscent +
+          event.textMetrics.actualBoundingBoxDescent;
+
+        const textPadding = 8;
+        const visibleStart = Math.max(startX, -offset);
+        const defaultTextOffset = Math.max(
+          visibleStart - startX + textPadding,
+          textPadding
+        );
+
+        let textOffset = defaultTextOffset;
+
+        if (textWidth > 0) {
+          const maxTextOffset = Math.max(
+            textPadding,
+            width - textWidth - textPadding
+          );
+          textOffset = Math.min(defaultTextOffset, maxTextOffset);
+        }
+
+        const textY =
+          y +
+          (height - textHeight) / 2 +
+          event.textMetrics.actualBoundingBoxAscent;
+
+        this.ctx.fillText(event.title, x + textOffset, textY + 1);
+
+        this.ctx.restore();
+      }
+    }
+  }
+
+  calculate() {
+    const eventRowsWithPositions: EventRowWithPositions[] = [];
+
+    for (let i = 0; i < this.rows.length; i++) {
+      const row = this.rows[i];
+      const positionedRow: EventRowWithPositions = [];
+
+      for (const event of row) {
+        const startPosition =
+          LEFT_PADDING + (event.startTime / this.duration) * this.timelineWidth;
+        const endPosition =
+          LEFT_PADDING + (event.endTime / this.duration) * this.timelineWidth;
+
+        this.ctx.save();
+
+        this.ctx.font = `bold 12px ${CANVAS_FONT}`;
+
+        const textMetrics = this.ctx.measureText(event.title);
+
+        this.ctx.restore();
+
+        positionedRow.push({
+          ...event,
+          endPosition,
+          startPosition,
+          textMetrics,
+        });
+      }
+
+      eventRowsWithPositions.push(positionedRow);
+    }
+
+    this.rowsWithPositions = eventRowsWithPositions;
+  }
+
+  getHeight() {
+    return this.height;
+  }
+
+  private createEventRows(events: SessionRecordingEvent[]) {
+    const sortedEvents = [...events].sort((a, b) => a.startTime - b.startTime);
+    const rows: EventRow[] = [];
+
+    for (const event of sortedEvents) {
+      if (event.type === SessionRecordingEventType.Resize) {
+        continue;
+      }
+
+      let placed = false;
+
+      const title = getEventTitle(event);
+
+      for (const row of rows) {
+        const lastEventInRow = row[row.length - 1];
+
+        if (lastEventInRow.endTime <= event.startTime) {
+          const textWidth = this.ctx.measureText(title).width;
+
+          row.push({ ...event, textWidth, title });
+
+          placed = true;
+          break;
+        }
+      }
+
+      if (!placed) {
+        const textWidth = this.ctx.measureText(title).width;
+
+        rows.push([{ ...event, textWidth, title }]);
+      }
+    }
+
+    this.rows = rows;
+    this.height = this.rows.length * EVENT_ROW_HEIGHT + EVENT_SECTION_PADDING;
+  }
+
+  private getVisibleEvents(
+    offset: number,
+    containerWidth: number
+  ): EventRowWithPositions[] {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const visibleRows: EventRowWithPositions[] = [];
+
+    for (const row of this.rowsWithPositions) {
+      const visibleRow: EventRowWithPositions = [];
+
+      for (const event of row) {
+        if (
+          event.startPosition <= visibleEnd &&
+          event.endPosition >= visibleStart
+        ) {
+          visibleRow.push(event);
+        }
+      }
+
+      if (visibleRow.length > 0) {
+        visibleRows.push(visibleRow);
+      }
+    }
+
+    return visibleRows;
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
@@ -1,0 +1,376 @@
+import type { DefaultTheme } from 'styled-components';
+
+import type { SessionRecordingThumbnail } from 'teleport/services/recordings';
+import {
+  generateTerminalSVGStyleTag,
+  injectSVGStyles,
+  svgToDataURIBase64,
+} from 'teleport/SessionRecordings/svg';
+import { calculateThumbnailViewport } from 'teleport/SessionRecordings/view/Timeline/utils';
+
+import {
+  BASE_FRAME_WIDTH,
+  DEFAULT_FRAME_HEIGHT,
+  DEFAULT_MAX_FRAME_WIDTH,
+  EVENT_SECTION_PADDING,
+  LEFT_PADDING,
+  RULER_HEIGHT,
+} from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+const FRAME_RATIO = 138 / 240;
+
+interface ThumbnailWithId extends SessionRecordingThumbnail {
+  id: string;
+}
+
+interface ThumbnailWithPosition extends ThumbnailWithId {
+  index: number;
+  position: number;
+  width: number;
+  isEnd: boolean;
+}
+
+export class FramesRenderer extends TimelineCanvasRenderer {
+  private readonly frames: ThumbnailWithId[] = [];
+  private framesAtCurrentZoom: ThumbnailWithPosition[] = [];
+
+  private frameHeight = FRAME_RATIO * BASE_FRAME_WIDTH;
+  private maxFrameWidth = 0;
+
+  private loadedImageElements = new Map<string, HTMLImageElement>();
+  private loadedImages = new Map<string, OffscreenCanvas>();
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    duration: number,
+    frames: SessionRecordingThumbnail[],
+    initialHeight: number,
+    eventsHeight: number
+  ) {
+    super(ctx, theme, duration);
+
+    const svgTheme = generateTerminalSVGStyleTag(theme);
+
+    this.frameHeight =
+      initialHeight - eventsHeight - RULER_HEIGHT - EVENT_SECTION_PADDING * 2;
+
+    this.maxFrameWidth =
+      (DEFAULT_MAX_FRAME_WIDTH / DEFAULT_FRAME_HEIGHT) * initialHeight;
+
+    this.frames = frames.map((frame, index) => ({
+      ...frame,
+      id: `frame-${index}`,
+      svg: svgToDataURIBase64(injectSVGStyles(frame.svg, svgTheme)),
+    }));
+
+    this.setHeight(initialHeight, eventsHeight);
+  }
+
+  _render({ containerWidth, eventsHeight, offset }: TimelineRenderContext) {
+    const framesToRender = this.getVisibleFrames(offset, containerWidth);
+
+    for (let i = 0; i < framesToRender.length; i++) {
+      const frame = framesToRender[i];
+      const img = this.loadedImages.get(frame.id);
+
+      if (img) {
+        this.ctx.drawImage(
+          img,
+          frame.position,
+          eventsHeight + EVENT_SECTION_PADDING + RULER_HEIGHT,
+          frame.width,
+          this.frameHeight
+        );
+      }
+    }
+  }
+
+  calculate() {
+    const framesWithPositions: ThumbnailWithPosition[] = [];
+
+    for (let i = 0; i < this.frames.length; i++) {
+      const frame = this.frames[i];
+      const frameAspectRatio = frame.cols / frame.rows;
+
+      const calculatedWidth = Math.ceil(this.frameHeight * frameAspectRatio);
+      const frameWidth = Math.min(calculatedWidth, this.maxFrameWidth);
+
+      const position =
+        (frame.startOffset / this.duration) * this.timelineWidth + LEFT_PADDING;
+
+      framesWithPositions.push({
+        ...frame,
+        index: i,
+        isEnd: i === this.frames.length - 1,
+        position,
+        width: frameWidth,
+      });
+    }
+
+    const framesAtZoom: ThumbnailWithPosition[] = [];
+
+    for (const frame of framesWithPositions) {
+      if (framesAtZoom.length === 0) {
+        framesAtZoom.push(frame);
+
+        continue;
+      }
+
+      const lastFrame = framesAtZoom[framesAtZoom.length - 1];
+      const lastFrameEnd = lastFrame.position + lastFrame.width;
+
+      if (frame.isEnd || frame.position >= lastFrameEnd - 1) {
+        framesAtZoom.push(frame);
+      }
+    }
+
+    this.framesAtCurrentZoom = framesAtZoom;
+  }
+
+  destroy() {
+    this.framesAtCurrentZoom = [];
+    this.loadedImageElements.clear();
+  }
+
+  loadNonVisibleFrames(): Promise<OffscreenCanvas[]> {
+    const nonVisibleFrames = this.frames.filter(
+      frame => !this.loadedImages.has(frame.id)
+    );
+
+    return Promise.all(nonVisibleFrames.map(frame => this.loadImage(frame)));
+  }
+
+  loadVisibleFrames(
+    offset: number,
+    containerWidth: number
+  ): Promise<OffscreenCanvas[]> {
+    const visibleFrames = this.getVisibleFrames(offset, containerWidth);
+
+    return Promise.all(visibleFrames.map(frame => this.loadImage(frame)));
+  }
+
+  recreateImages(render: () => void) {
+    for (const frame of this.frames) {
+      const img = this.loadedImageElements.get(frame.id);
+      const existingCanvas = this.loadedImages.get(frame.id);
+
+      if (img && existingCanvas) {
+        const newCanvas = new OffscreenCanvas(img.width, img.height);
+
+        this.drawFrame(frame, newCanvas, img);
+
+        render();
+      }
+    }
+  }
+
+  recreateVisibleImages(
+    offset: number,
+    containerWidth: number,
+    render: () => void
+  ) {
+    const visibleFrames = this.getVisibleFrames(offset, containerWidth);
+
+    for (const frame of visibleFrames) {
+      const img = this.loadedImageElements.get(frame.id);
+      const canvas = this.loadedImages.get(frame.id);
+
+      if (img && canvas) {
+        this.drawFrame(frame, canvas, img);
+
+        render();
+      }
+    }
+  }
+
+  setHeight(height: number, eventsHeight: number) {
+    this.frameHeight =
+      height - eventsHeight - RULER_HEIGHT - EVENT_SECTION_PADDING * 2;
+
+    this.maxFrameWidth =
+      (DEFAULT_MAX_FRAME_WIDTH / DEFAULT_FRAME_HEIGHT) * height;
+  }
+
+  private binarySearchFrameIndex(position: number): number {
+    let left = 0;
+    let right = this.framesAtCurrentZoom.length - 1;
+    let result = 0;
+
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2);
+      const frame = this.framesAtCurrentZoom[mid];
+
+      if (frame.position <= position) {
+        result = mid;
+        left = mid + 1;
+      } else {
+        right = mid - 1;
+      }
+    }
+
+    return Math.max(0, result - 1);
+  }
+
+  private getVisibleFrames(
+    offset: number,
+    containerWidth: number
+  ): ThumbnailWithPosition[] {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const frames: ThumbnailWithPosition[] = [];
+    const startIndex = this.binarySearchFrameIndex(visibleStart);
+
+    for (let i = startIndex; i < this.framesAtCurrentZoom.length; i++) {
+      const frame = this.framesAtCurrentZoom[i];
+
+      if (frame.isEnd) {
+        if (frame.position < visibleEnd + frame.width) {
+          const frameBefore = frames.find(
+            f => f.position + f.width > visibleEnd - 100 - frame.width
+          );
+
+          if (!frameBefore) {
+            frames.push({
+              ...frame,
+              position: visibleEnd - 100 - frame.width,
+            });
+          }
+
+          continue;
+        }
+
+        continue;
+      }
+
+      if (frame.position > visibleEnd) {
+        break;
+      }
+
+      const frameEnd = frame.position + frame.width;
+
+      if (frameEnd >= visibleStart) {
+        frames.push(frame);
+      }
+    }
+
+    return frames;
+  }
+
+  private drawFrame(
+    frame: ThumbnailWithId,
+    canvas: OffscreenCanvas,
+    image: HTMLImageElement
+  ) {
+    const frameAspectRatio = frame.cols / frame.rows;
+    const calculatedWidth = Math.ceil(this.frameHeight * frameAspectRatio);
+    const width = Math.min(calculatedWidth, this.maxFrameWidth);
+    const height = this.frameHeight;
+
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      throw new Error('Failed to get offscreen canvas context');
+    }
+
+    ctx.scale(dpr, dpr);
+
+    ctx.save();
+
+    // Calculate viewport position
+    const viewport = calculateThumbnailViewport(
+      frame,
+      image.width,
+      image.height
+    );
+
+    // Calculate source dimensions maintaining aspect ratio
+    const imageAspect = image.width / image.height;
+    const canvasAspect = width / height;
+
+    let adjustedSourceWidth = viewport.sourceWidth;
+    let adjustedSourceHeight = viewport.sourceHeight;
+
+    // Adjust source dimensions to match canvas aspect ratio
+    if (imageAspect > canvasAspect) {
+      // Image is wider - adjust width
+      const adjustedFullWidth = image.height * canvasAspect;
+      adjustedSourceWidth = adjustedFullWidth / viewport.zoomLevel;
+    } else {
+      // Image is taller - adjust height
+      const adjustedFullHeight = image.width / canvasAspect;
+      adjustedSourceHeight = adjustedFullHeight / viewport.zoomLevel;
+    }
+
+    const borderRadius = 12;
+
+    // Create clipping path for rounded corners
+    ctx.beginPath();
+    ctx.roundRect(0, 0, width, height, borderRadius);
+    ctx.clip();
+
+    // Draw the image
+    ctx.drawImage(
+      image,
+      viewport.sourceX,
+      viewport.sourceY,
+      adjustedSourceWidth,
+      adjustedSourceHeight,
+      0,
+      0,
+      width,
+      height
+    );
+
+    ctx.restore();
+
+    // Draw border AFTER restore to avoid clipping
+    ctx.save();
+    ctx.strokeStyle = this.theme.colors.sessionRecordingTimeline.frameBorder;
+    ctx.lineWidth = 1;
+
+    ctx.beginPath();
+    // Adjust border position by 0.5px to ensure it's fully visible
+    ctx.roundRect(0.5, 0.5, width - 1, height - 1, borderRadius);
+    ctx.stroke();
+
+    ctx.restore();
+
+    this.loadedImages.set(frame.id, canvas);
+  }
+
+  private loadImage(frame: ThumbnailWithId): Promise<OffscreenCanvas> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+
+      img.onload = () => {
+        try {
+          const offscreen = new OffscreenCanvas(img.width, img.height);
+
+          this.drawFrame(frame, offscreen, img);
+          this.loadedImageElements.set(frame.id, img);
+
+          resolve(offscreen);
+        } catch {
+          reject(new Error(`Failed to process image for frame ${frame.id}`));
+        }
+      };
+
+      img.onerror = () => {
+        reject(new Error(`Failed to load image for frame ${frame.id}`));
+      };
+
+      img.src = frame.svg;
+    });
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ProgressLineRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ProgressLineRenderer.ts
@@ -1,0 +1,31 @@
+import { LEFT_PADDING } from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+export class ProgressLineRenderer extends TimelineCanvasRenderer {
+  private currentTime = 0;
+  private position = 0;
+
+  _render({ containerHeight }: TimelineRenderContext) {
+    this.ctx.strokeStyle =
+      this.theme.colors.sessionRecordingTimeline.progressLine;
+    this.ctx.lineWidth = 2;
+
+    this.ctx.beginPath();
+    this.ctx.moveTo(this.position, 0);
+    this.ctx.lineTo(this.position, containerHeight);
+    this.ctx.stroke();
+  }
+
+  calculate() {
+    this.position =
+      (this.currentTime / this.duration) * this.timelineWidth + LEFT_PADDING;
+  }
+
+  setCurrentTime(currentTime: number) {
+    this.currentTime = currentTime;
+    this.calculate();
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -1,0 +1,443 @@
+import type { DefaultTheme } from 'styled-components';
+
+import {
+  SessionRecordingEventType,
+  type SessionRecordingMetadata,
+  type SessionRecordingResizeEvent,
+} from 'teleport/services/recordings';
+
+import { LEFT_PADDING } from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+interface EventWithCalculatedPosition {
+  event: ResizeTimelineEventPositioned;
+  row: number;
+  y: number;
+}
+
+interface LineSegment {
+  end: number;
+  start: number;
+}
+
+interface ResizeTimelineEventPositioned extends SessionRecordingResizeEvent {
+  title: string;
+  endPosition: number;
+  originalRow: number;
+  startPosition: number;
+  textMetrics: TextMetrics;
+}
+
+function calculateEventEndTimes(
+  resizeEvents: SessionRecordingResizeEvent[],
+  duration: number
+) {
+  const events: SessionRecordingResizeEvent[] = [];
+
+  for (const event of resizeEvents) {
+    const lastResizeEvent = events.findLast(e => e.startTime < event.startTime);
+
+    if (lastResizeEvent) {
+      lastResizeEvent.endTime = event.startTime - 1;
+    }
+
+    events.push(event);
+  }
+
+  const lastResizeEvent = events.findLast(
+    e => e.type === SessionRecordingEventType.Resize
+  );
+
+  if (lastResizeEvent) {
+    lastResizeEvent.endTime = duration;
+  }
+
+  return events;
+}
+
+export class ResizeEventsRenderer extends TimelineCanvasRenderer {
+  private allEvents: ResizeTimelineEventPositioned[] = [];
+  private readonly resizeEvents: SessionRecordingResizeEvent[] = [];
+
+  private borderRadius = 6;
+  private rowHeight = 20;
+  private textPadding = 3.5;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+
+    this.resizeEvents = calculateEventEndTimes(
+      metadata.events.filter(
+        event => event.type === SessionRecordingEventType.Resize
+      ),
+      metadata.duration
+    );
+  }
+
+  _render(context: TimelineRenderContext) {
+    const eventsWithPositions = this.getEventPositions(
+      context.offset,
+      context.containerWidth,
+      context.containerHeight
+    );
+
+    for (const { event, row, y } of eventsWithPositions) {
+      this.renderEvent(context, event, row, y, eventsWithPositions);
+    }
+  }
+
+  calculate() {
+    this.allEvents = [];
+
+    for (let i = 0; i < this.resizeEvents.length; i++) {
+      const event = this.resizeEvents[i];
+
+      const startPosition =
+        (event.startTime / this.duration) * this.timelineWidth + LEFT_PADDING;
+      const endPosition =
+        (event.endTime / this.duration) * this.timelineWidth + LEFT_PADDING;
+
+      this.ctx.save();
+
+      this.ctx.font = `bold 10px ${this.theme.fonts.mono}`;
+
+      const title = `${event.cols}x${event.rows}`;
+
+      const textMetrics = this.ctx.measureText(title);
+
+      this.ctx.restore();
+
+      this.allEvents.push({
+        ...event,
+        title,
+        endPosition,
+        originalRow: 0,
+        startPosition,
+        textMetrics,
+      });
+    }
+
+    const rows: ResizeTimelineEventPositioned[][] = [];
+
+    for (let i = this.allEvents.length - 1; i >= 0; i--) {
+      const event = this.allEvents[i];
+      let placed = false;
+
+      for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+        const hasOverlap = rows[rowIndex].some(
+          existingEvent =>
+            existingEvent.startPosition <
+              event.startPosition + event.textMetrics.width &&
+            event.startPosition <
+              existingEvent.startPosition + existingEvent.textMetrics.width
+        );
+
+        if (!hasOverlap) {
+          event.originalRow = rowIndex;
+          rows[rowIndex].push(event);
+
+          placed = true;
+
+          break;
+        }
+      }
+
+      if (!placed) {
+        event.originalRow = rows.length;
+        rows.push([event]);
+      }
+    }
+  }
+
+  private calculateLineSegments(
+    lineX: number,
+    lineStartY: number,
+    lineEndY: number,
+    rowIndex: number,
+    currentEvent: ResizeTimelineEventPositioned,
+    offset: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): LineSegment[] {
+    let segments: LineSegment[] = [{ end: lineEndY, start: lineStartY }];
+
+    for (const eventPos of allEvents) {
+      const { event: otherEvent, row: otherRow, y: otherY } = eventPos;
+
+      if (otherEvent === currentEvent || otherRow >= rowIndex) continue;
+
+      const textPadding = 8;
+      const visibleStart = Math.max(otherEvent.startPosition, -offset);
+      const defaultTextOffset = Math.max(
+        visibleStart - otherEvent.startPosition + textPadding,
+        textPadding
+      );
+
+      const width = otherEvent.endPosition - otherEvent.startPosition;
+      let textOffset = defaultTextOffset;
+
+      if (otherEvent.textMetrics.width > 0) {
+        const maxTextOffset = Math.max(
+          textPadding,
+          width - otherEvent.textMetrics.width - textPadding
+        );
+        textOffset = Math.min(defaultTextOffset, maxTextOffset);
+      }
+
+      const otherX = otherEvent.startPosition + textOffset;
+      const otherTextWidth = otherEvent.textMetrics.width;
+
+      const otherRectX = otherX - this.textPadding;
+      const otherRectWidth = otherTextWidth + this.textPadding * 2;
+
+      const otherTextHeight =
+        otherEvent.textMetrics.actualBoundingBoxAscent +
+        otherEvent.textMetrics.actualBoundingBoxDescent;
+      const otherRectY =
+        otherY -
+        otherEvent.textMetrics.actualBoundingBoxAscent -
+        this.textPadding;
+      const otherRectHeight = otherTextHeight + this.textPadding * 2;
+
+      if (
+        lineX >= otherRectX &&
+        lineX <= otherRectX + otherRectWidth &&
+        lineStartY <= otherRectY + otherRectHeight &&
+        lineEndY >= otherRectY
+      ) {
+        const newSegments: LineSegment[] = [];
+
+        for (const segment of segments) {
+          if (segment.start < otherRectY && segment.end > otherRectY) {
+            newSegments.push({ end: otherRectY, start: segment.start });
+          }
+
+          if (
+            segment.start < otherRectY + otherRectHeight &&
+            segment.end > otherRectY + otherRectHeight
+          ) {
+            newSegments.push({
+              end: segment.end,
+              start: otherRectY + otherRectHeight,
+            });
+          }
+
+          if (
+            segment.start >= otherRectY + otherRectHeight ||
+            segment.end <= otherRectY
+          ) {
+            newSegments.push(segment);
+          }
+        }
+
+        segments = newSegments;
+      }
+    }
+
+    return segments;
+  }
+
+  private getEventPositions(
+    offset: number,
+    containerWidth: number,
+    containerHeight: number
+  ): EventWithCalculatedPosition[] {
+    const viewStart = -offset;
+    const viewEnd = -offset + containerWidth;
+    const buffer = containerWidth / 2;
+
+    const activeEvents = this.allEvents.filter(
+      event =>
+        event.endPosition > viewStart - buffer &&
+        event.startPosition < viewEnd + buffer
+    );
+
+    const sortedEvents = [...activeEvents].sort(
+      (a, b) => a.startPosition - b.startPosition
+    );
+
+    const eventsWithPositions: EventWithCalculatedPosition[] = [];
+    const rowEndPositions = new Map<number, number>();
+
+    for (const event of sortedEvents) {
+      const baseRow = event.originalRow;
+
+      let targetRow = baseRow;
+
+      const padding = 10;
+
+      for (let i = 0; i < baseRow; i++) {
+        const rowEnd = rowEndPositions.get(i) ?? -Infinity;
+
+        if (event.startPosition >= rowEnd + padding) {
+          targetRow = i;
+
+          break;
+        }
+      }
+
+      const y = this.getYForRow(targetRow, containerHeight);
+
+      eventsWithPositions.push({
+        event,
+        row: targetRow,
+        y,
+      });
+
+      rowEndPositions.set(targetRow, event.endPosition);
+    }
+
+    return eventsWithPositions;
+  }
+
+  private getYForRow(row: number, containerHeight: number): number {
+    const bottom = containerHeight - 10;
+
+    return bottom - row * this.rowHeight;
+  }
+
+  private renderEvent(
+    context: TimelineRenderContext,
+    event: ResizeTimelineEventPositioned,
+    row: number,
+    y: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): void {
+    const textPadding = 8;
+    const visibleStart = Math.max(event.startPosition, -context.offset);
+    const defaultTextOffset = Math.max(
+      visibleStart - event.startPosition + textPadding,
+      textPadding
+    );
+
+    const width = event.endPosition - event.startPosition;
+    let textOffset = defaultTextOffset;
+
+    if (event.textMetrics.width > 0) {
+      const maxTextOffset = Math.max(
+        textPadding,
+        width - event.textMetrics.width - textPadding
+      );
+      textOffset = Math.min(defaultTextOffset, maxTextOffset);
+    }
+
+    const x = event.startPosition + textOffset;
+
+    this.renderResizeEventBox(context, event, x, y);
+    this.renderResizeEventText(context, event, x, y);
+    this.renderResizeEventLine(context, event, x, y, row, allEvents);
+  }
+
+  private renderResizeEventBox(
+    context: TimelineRenderContext,
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number
+  ): void {
+    const textWidth = event.textMetrics.width;
+    const textHeight =
+      event.textMetrics.actualBoundingBoxAscent +
+      event.textMetrics.actualBoundingBoxDescent;
+
+    const rectX = x - this.textPadding;
+    const rectY =
+      y - event.textMetrics.actualBoundingBoxAscent - this.textPadding;
+    const rectWidth = textWidth + this.textPadding * 2;
+    const rectHeight = textHeight + this.textPadding * 2;
+
+    this.ctx.save();
+
+    this.ctx.fillStyle = 'rgba(0, 0, 0, 0.8)';
+    this.ctx.beginPath();
+    this.ctx.roundRect(rectX, rectY, rectWidth, rectHeight, this.borderRadius);
+    this.ctx.fill();
+
+    this.ctx.save();
+    this.ctx.shadowColor = 'rgba(0, 0, 0, .05)';
+    this.ctx.shadowBlur = 4;
+    this.ctx.shadowOffsetX = 0;
+    this.ctx.shadowOffsetY = 0;
+
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.background;
+    this.ctx.beginPath();
+    this.ctx.roundRect(rectX, rectY, rectWidth, rectHeight, this.borderRadius);
+    this.ctx.fill();
+    this.ctx.strokeStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.border;
+    this.ctx.lineWidth = 1.5;
+    this.ctx.stroke();
+
+    this.ctx.restore();
+    this.ctx.restore();
+  }
+
+  private renderResizeEventLine(
+    context: TimelineRenderContext,
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number,
+    rowIndex: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): void {
+    const textWidth = event.textMetrics.width;
+    const textHeight =
+      event.textMetrics.actualBoundingBoxAscent +
+      event.textMetrics.actualBoundingBoxDescent;
+
+    const rectY =
+      y - event.textMetrics.actualBoundingBoxAscent - this.textPadding;
+    const rectHeight = textHeight + this.textPadding * 2;
+
+    const lineX = x + textWidth / 2;
+    const lineStartY = rectY + rectHeight;
+    const lineEndY = context.containerHeight;
+
+    this.ctx.save();
+
+    this.ctx.strokeStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.border;
+    this.ctx.lineWidth = 1.5;
+
+    const segments = this.calculateLineSegments(
+      lineX,
+      lineStartY,
+      lineEndY,
+      rowIndex,
+      event,
+      context.offset,
+      allEvents
+    );
+
+    for (const segment of segments) {
+      this.ctx.beginPath();
+      this.ctx.moveTo(lineX, segment.start);
+      this.ctx.lineTo(lineX, segment.end);
+      this.ctx.stroke();
+    }
+
+    this.ctx.restore();
+  }
+
+  private renderResizeEventText(
+    options: TimelineRenderContext,
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number
+  ): void {
+    this.ctx.save();
+
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.text;
+    this.ctx.font = `bold 10px ${this.theme.fonts.mono}`;
+
+    this.ctx.fillText(event.title, x, y);
+    this.ctx.restore();
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarkersRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarkersRenderer.ts
@@ -1,0 +1,184 @@
+import type { DefaultTheme } from 'styled-components';
+
+import type { SessionRecordingMetadata } from 'teleport/services/recordings';
+
+import { CANVAS_FONT, LEFT_PADDING } from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+interface SubTick {
+  height: number;
+  position: number;
+}
+
+interface TimeMarker {
+  absolute: boolean;
+  label: string;
+  position: number;
+  time: number;
+}
+
+export class TimeMarkersRenderer extends TimelineCanvasRenderer {
+  private subTicks: SubTick[] = [];
+  private timeMarkers: TimeMarker[] = [];
+  private showAbsoluteTime = false;
+
+  private readonly startTime: number;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+    this.startTime = metadata.startTime;
+  }
+
+  _render({ containerWidth, offset }: TimelineRenderContext) {
+    const { markers, subTicks } = this.getVisibleTimeMarkers(
+      offset,
+      containerWidth
+    );
+
+    this.ctx.font = `10px ${CANVAS_FONT}`;
+
+    for (const marker of markers) {
+      const textWidth = this.ctx.measureText(marker.label).width;
+      const x = marker.position + LEFT_PADDING;
+
+      this.ctx.fillStyle =
+        this.theme.colors.sessionRecordingTimeline.timeMarks.primary;
+      this.ctx.fillRect(x, 0, 1, 10);
+
+      if (marker.absolute) {
+        this.ctx.font = `bold 10px ${CANVAS_FONT}`;
+      }
+
+      this.ctx.fillStyle = marker.absolute
+        ? this.theme.colors.sessionRecordingTimeline.timeMarks.absolute
+        : this.theme.colors.sessionRecordingTimeline.timeMarks.text;
+
+      this.ctx.fillText(marker.label, x - textWidth / 2, 24);
+
+      if (marker.absolute) {
+        this.ctx.font = `10px ${CANVAS_FONT}`;
+      }
+    }
+
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.timeMarks.secondary;
+
+    for (const tick of subTicks) {
+      this.ctx.fillRect(tick.position + LEFT_PADDING, 0, 1, tick.height);
+    }
+  }
+
+  calculate() {
+    const markers: TimeMarker[] = [];
+
+    let interval = 1000;
+    let pixelsPerSecond = (this.timelineWidth / this.duration) * 1000;
+
+    if (pixelsPerSecond < 10) interval = 10000;
+    else if (pixelsPerSecond < 50) interval = 5000;
+    else if (pixelsPerSecond > 200) interval = 1000;
+
+    for (let time = 0; time < this.duration + interval; time += interval) {
+      // if show absolute time is enabled, change the 0:00, 1:00, etc, labels to absolute time
+      const absolute = this.showAbsoluteTime && (time / 1000) % 60 === 0;
+      const label = absolute
+        ? formatAbsoluteTime(this.startTime + time)
+        : formatRelativeTime(time / 1000);
+
+      markers.push({
+        absolute,
+        label,
+        position: (time / this.duration) * this.timelineWidth,
+        time,
+      });
+    }
+
+    const subTicks: SubTick[] = [];
+
+    const markerSpacing = (interval / this.duration) * this.timelineWidth;
+
+    let numSubticks = 0;
+    if (markerSpacing > 300) numSubticks = 9;
+    else if (markerSpacing > 200) numSubticks = 7;
+    else if (markerSpacing > 150) numSubticks = 4;
+    else if (markerSpacing > 100) numSubticks = 3;
+    else if (markerSpacing > 50) numSubticks = 1;
+
+    for (let i = 0; i < markers.length - 1; i++) {
+      const currentMarker = markers[i];
+
+      for (let j = 1; j <= numSubticks; j++) {
+        const fraction = j / (numSubticks + 1);
+        const position = currentMarker.position + markerSpacing * fraction;
+
+        let height = 4;
+        if (numSubticks % 2 === 1) {
+          height = j === Math.ceil(numSubticks / 2) ? 6 : 4;
+        } else {
+          const mid1 = numSubticks / 2;
+          const mid2 = mid1 + 1;
+          height = j === mid1 || j === mid2 ? 6 : 4;
+        }
+
+        subTicks.push({ height, position });
+      }
+    }
+
+    this.timeMarkers = markers;
+    this.subTicks = subTicks;
+  }
+
+  setShowAbsoluteTime(show: boolean) {
+    this.showAbsoluteTime = show;
+
+    this.calculate();
+  }
+
+  private getVisibleTimeMarkers(offset: number, containerWidth: number) {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const visibleMarkers: TimeMarker[] = [];
+    const visibleSubTicks: SubTick[] = [];
+
+    for (const marker of this.timeMarkers) {
+      if (marker.position >= visibleStart && marker.position <= visibleEnd) {
+        visibleMarkers.push(marker);
+      }
+    }
+
+    for (const subTick of this.subTicks) {
+      if (subTick.position >= visibleStart && subTick.position <= visibleEnd) {
+        visibleSubTicks.push(subTick);
+      }
+    }
+
+    return { markers: visibleMarkers, subTicks: visibleSubTicks };
+  }
+}
+
+function formatRelativeTime(seconds: number) {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function formatAbsoluteTime(timestamp: number) {
+  const date = new Date(timestamp);
+
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  const period = hours >= 12 ? 'pm' : 'am';
+  const displayHours = hours % 12 || 12;
+
+  return `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer.ts
@@ -1,0 +1,36 @@
+import type { DefaultTheme } from 'styled-components';
+
+export interface TimelineRenderContext {
+  containerHeight: number;
+  containerWidth: number;
+  eventsHeight: number;
+  offset: number;
+}
+
+export abstract class TimelineCanvasRenderer {
+  protected timelineWidth = 0;
+
+  constructor(
+    protected ctx: CanvasRenderingContext2D,
+    protected theme: DefaultTheme,
+    protected duration: number
+  ) {}
+
+  abstract _render(context: TimelineRenderContext): void;
+
+  abstract calculate(): void;
+
+  render(context: TimelineRenderContext) {
+    this.ctx.save();
+
+    this._render(context);
+
+    this.ctx.restore();
+  }
+
+  setTimelineWidth(timelineWidth: number) {
+    this.timelineWidth = timelineWidth;
+
+    this.calculate();
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
@@ -1,0 +1,175 @@
+import type { SessionRecordingThumbnail } from 'teleport/services/recordings';
+import { LEFT_PADDING } from 'teleport/SessionRecordings/view/Timeline/constants';
+
+const zoomLevelWithCursor = 4; // Zoom in when cursor is visible
+const zoomLevelWithoutCursor = 1.5; // Less zoom when cursor is not visible
+
+// calculateThumbnailViewport calculates the portion of the thumbnail image to display
+// based on the cursor position and whether the cursor is visible.
+// It returns the source coordinates and dimensions to be used in drawing the image,
+// as well as the zoom level applied.
+export function calculateThumbnailViewport(
+  thumbnail: SessionRecordingThumbnail,
+  width: number,
+  height: number
+) {
+  // Use different zoom levels based on cursor visibility
+  const zoomLevel = thumbnail.cursorVisible
+    ? zoomLevelWithCursor
+    : zoomLevelWithoutCursor;
+
+  const visibleWidthPercent = 100 / zoomLevel;
+  const visibleHeightPercent = 100 / zoomLevel;
+
+  let bgPosX: number;
+  let bgPosY: number;
+
+  if (thumbnail.cursorVisible) {
+    // Calculate cursor position as percentage
+    const cursorPercentX = (thumbnail.cursorX / thumbnail.cols) * 100;
+    const cursorPercentY = (thumbnail.cursorY / thumbnail.rows) * 100;
+
+    // Calculate the top-left position percentage to center on cursor
+    bgPosX = Math.max(
+      0,
+      Math.min(
+        100 - visibleWidthPercent,
+        cursorPercentX - visibleWidthPercent / 2
+      )
+    );
+    bgPosY = Math.max(
+      0,
+      Math.min(
+        100 - visibleHeightPercent,
+        cursorPercentY - visibleHeightPercent / 2
+      )
+    );
+  } else {
+    // Center the viewport when cursor is not visible
+    bgPosX = (100 - visibleWidthPercent) / 2;
+    bgPosY = (100 - visibleHeightPercent) / 2;
+  }
+
+  // Calculate source dimensions
+  const sourceWidth = width / zoomLevel;
+  const sourceHeight = height / zoomLevel;
+
+  // Convert percentages to pixel coordinates on the source image
+  const maxSourceX = width - sourceWidth;
+  const maxSourceY = height - sourceHeight;
+
+  const sourceX = (bgPosX / (100 - visibleWidthPercent)) * maxSourceX || 0;
+  const sourceY = (bgPosY / (100 - visibleHeightPercent)) * maxSourceY || 0;
+
+  return {
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    zoomLevel,
+  };
+}
+
+const EDGE_THRESHOLD = 100;
+const VISIBILITY_BUFFER = 50;
+
+export function calculateNextUserControlled(
+  relativePosition: number,
+  containerWidth: number,
+  isInteracting: boolean,
+  currentUserControlled: boolean
+) {
+  if (isInteracting) {
+    return currentUserControlled;
+  }
+
+  const isIndicatorFullyVisible =
+    relativePosition >= VISIBILITY_BUFFER &&
+    relativePosition <= containerWidth - VISIBILITY_BUFFER;
+
+  const isIndicatorPartiallyVisible =
+    relativePosition >= -EDGE_THRESHOLD &&
+    relativePosition <= containerWidth + EDGE_THRESHOLD;
+
+  const isApproachingRightEdge =
+    relativePosition > containerWidth - EDGE_THRESHOLD &&
+    relativePosition <= containerWidth;
+
+  const isApproachingLeftEdge =
+    relativePosition < EDGE_THRESHOLD && relativePosition >= 0;
+
+  // User manually scrolled away from the progress line
+  if (!isIndicatorPartiallyVisible) {
+    return true;
+  }
+
+  // Progress line is fully visible, user control can be disabled
+  if (isIndicatorFullyVisible) {
+    return false;
+  }
+
+  // If user was controlling and line is approaching edge, give back control to auto-scroll
+  if (
+    currentUserControlled &&
+    (isApproachingRightEdge || isApproachingLeftEdge)
+  ) {
+    return false;
+  }
+
+  return currentUserControlled;
+}
+
+export function shouldAutoScroll(
+  relativePosition: number,
+  containerWidth: number,
+  isInteracting: boolean,
+  isUserControlled: boolean
+) {
+  if (isInteracting || isUserControlled) {
+    return false;
+  }
+
+  const shouldJumpForward = relativePosition > containerWidth - EDGE_THRESHOLD;
+  const shouldJumpBackward = relativePosition < 0;
+
+  return shouldJumpForward || shouldJumpBackward;
+}
+
+export function calculateAutoScrollOffset(
+  timePosition: number,
+  relativePosition: number,
+  containerWidth: number,
+  timelineWidth: number,
+  force?: boolean
+) {
+  const totalWidth = timelineWidth + LEFT_PADDING;
+  const maxOffset = 0;
+  const minOffset = Math.min(0, containerWidth - totalWidth);
+
+  if (force) {
+    const targetRelativePosition = LEFT_PADDING + VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  if (relativePosition > containerWidth - EDGE_THRESHOLD) {
+    const targetRelativePosition = LEFT_PADDING + VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    if (newOffset < minOffset) {
+      return minOffset;
+    }
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  if (relativePosition < 0) {
+    const targetRelativePosition = containerWidth - VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/58310

This adds the supporting canvas renderers (frames, events, resize events, time markers) that the timeline renderer will need. This is an incomplete solution to keep the size of the PRs down and will be hooked up in future PRs

<img width="1781" height="1359" alt="image" src="https://github.com/user-attachments/assets/c60f2ee0-91f8-421b-8fe1-987c2cd15e02" />
