### PR TITLE
Add session recording timeline to UI

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
@@ -1,5 +1,12 @@
 import { format } from 'date-fns';
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -8,15 +15,26 @@ import {
   ArrowLineLeft,
   ChevronLeft,
   DotsThreeMoreVertical,
+  Server,
   Terminal,
+  User,
 } from 'design/Icon';
-import { H3 } from 'design/Text';
+import Text, { H3 } from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip';
+import { useLocalStorage } from 'shared/hooks/useLocalStorage';
 
 import cfg from 'teleport/config';
 import { useSuspenseGetRecordingMetadata } from 'teleport/services/recordings/hooks';
+import { KeysEnum } from 'teleport/services/storageService';
 import { formatSessionRecordingDuration } from 'teleport/SessionRecordings/list/RecordingItem';
 import { RecordingPlayer } from 'teleport/SessionRecordings/view/RecordingPlayer';
+import type { PlayerHandle } from 'teleport/SessionRecordings/view/SshPlayer';
+import { KeyboardShortcuts } from 'teleport/SessionRecordings/view/Timeline/KeyboardShortcuts';
+
+import {
+  RecordingTimeline,
+  type RecordingTimelineHandle,
+} from './Timeline/RecordingTimeline';
 
 export type SummarySlot = (sessionId: string) => ReactNode;
 
@@ -26,15 +44,15 @@ interface RecordingWithMetadataProps {
   summarySlot?: SummarySlot;
 }
 
-const Grid = styled.div<{ sidebarVisible: boolean }>`
+const Grid = styled.div<{ sidebarHidden: boolean }>`
   display: grid;
   grid-template-areas: ${p =>
-    p.sidebarVisible
-      ? `'sidebar recording' 'timeline timeline'`
-      : `'recording recording' 'timeline timeline'`};
+    p.sidebarHidden
+      ? `'recording recording' 'timeline timeline'`
+      : `'sidebar recording' 'timeline timeline'`};
   grid-template-columns: 1fr 4fr;
   grid-template-rows: 1fr auto;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
@@ -55,15 +73,6 @@ const Player = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-`;
-
-const TerminalContainer = styled.div`
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
 `;
 
 const Sidebar = styled.div`
@@ -122,6 +131,21 @@ const ShowSidebarButton = styled(HideSidebarButton)`
   }
 `;
 
+const TimelineContainer = styled.div`
+  grid-area: timeline;
+`;
+
+const ItemSpan = styled.span`
+  background: ${p => p.theme.colors.spotBackground[0]};
+  line-height: 1;
+  padding: ${p => p.theme.space[1]}px ${p => p.theme.space[1]}px;
+  border-radius: ${p => p.theme.radii[3]}px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 13px;
+  gap: ${p => p.theme.space[1]}px;
+`;
+
 export function RecordingWithMetadata({
   clusterId,
   sessionId,
@@ -132,11 +156,27 @@ export function RecordingWithMetadata({
     sessionId,
   });
 
-  const [sidebarVisible, setSidebarVisible] = useState(true);
+  const playerRef = useRef<PlayerHandle>(null);
+  const timelineRef = useRef<RecordingTimelineHandle>(null);
+
+  const [timelineHidden, setTimelineHidden] = useLocalStorage(
+    KeysEnum.SESSION_RECORDING_TIMELINE_HIDDEN,
+    false
+  );
+  const [sidebarHidden, setSidebarHidden] = useLocalStorage(
+    KeysEnum.SESSION_RECORDING_SIDEBAR_HIDDEN,
+    false
+  );
+  const [showAbsoluteTime, setShowAbsoluteTime] = useLocalStorage(
+    KeysEnum.SESSION_RECORDING_TIMELINE_SHOW_ABSOLUTE_TIME,
+    false
+  );
+
+  const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
 
   const toggleSidebar = useCallback(() => {
-    setSidebarVisible(prev => !prev);
-  }, []);
+    setSidebarHidden(!sidebarHidden);
+  }, [setSidebarHidden, sidebarHidden]);
 
   const summary = useMemo(
     () => (summarySlot ? summarySlot(sessionId) : null),
@@ -146,77 +186,182 @@ export function RecordingWithMetadata({
   const startTime = new Date(data.metadata.startTime * 1000);
   const endTime = new Date(data.metadata.endTime * 1000);
 
+  const handleTimeChange = useCallback((time: number) => {
+    if (!timelineRef.current) {
+      return;
+    }
+
+    timelineRef.current.moveToTime(time);
+  }, []);
+
+  const handleTimelineTimeChange = useCallback((time: number) => {
+    if (!playerRef.current || !timelineRef.current) {
+      return;
+    }
+
+    playerRef.current.moveToTime(time);
+    timelineRef.current.moveToTime(time);
+  }, []);
+
+  const handleHideTimeline = useCallback(() => {
+    setTimelineHidden(true);
+  }, [setTimelineHidden]);
+
+  const showTimeline = useMemo(() => {
+    if (!timelineHidden) {
+      return;
+    }
+
+    return () => setTimelineHidden(false);
+  }, [timelineHidden, setTimelineHidden]);
+
+  const handleCloseKeyboardShortcuts = useCallback(() => {
+    setKeyboardShortcutsOpen(false);
+  }, []);
+
+  const handleOpenKeyboardShortcuts = useCallback(() => {
+    setKeyboardShortcutsOpen(true);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      switch (event.key) {
+        case 't':
+          setTimelineHidden(!timelineHidden);
+          break;
+        case 'a':
+          setShowAbsoluteTime(!showAbsoluteTime);
+          break;
+        case 's':
+          setSidebarHidden(!sidebarHidden);
+          break;
+        case '?':
+          setKeyboardShortcutsOpen(prev => !prev);
+          break;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    setShowAbsoluteTime,
+    setSidebarHidden,
+    setTimelineHidden,
+    showAbsoluteTime,
+    sidebarHidden,
+    timelineHidden,
+  ]);
+
   return (
-    <Grid sidebarVisible={sidebarVisible}>
-      <Player>
-        <RecordingPlayer
-          clusterId={clusterId}
-          sessionId={sessionId}
-          durationMs={data.metadata.duration}
-          recordingType="ssh"
-        />
-      </Player>
+    <>
+      <Grid sidebarHidden={sidebarHidden}>
+        <Player>
+          <RecordingPlayer
+            clusterId={clusterId}
+            sessionId={sessionId}
+            durationMs={data.metadata.duration}
+            onTimeChange={handleTimeChange}
+            recordingType="ssh"
+            ref={playerRef}
+            showTimeline={showTimeline}
+          />
+        </Player>
 
-      {sidebarVisible ? (
-        <Sidebar>
-          <Flex flexDirection="column" gap={4} pt={3}>
-            <Flex pl={3} pr={2} justifyContent="space-between">
-              <BackLink to={cfg.getRecordingsRoute(clusterId)}>
-                <ChevronLeft size="small" />
-                Back to Session Recordings
-              </BackLink>
+        {sidebarHidden ? (
+          <HoverTooltip tipContent="Show Sidebar" placement="right">
+            <ShowSidebarButton onClick={toggleSidebar}>
+              <DotsThreeMoreVertical size="large" />
+            </ShowSidebarButton>
+          </HoverTooltip>
+        ) : (
+          <Sidebar>
+            <Flex flexDirection="column" gap={4} pt={3}>
+              <Flex pl={3} pr={2} justifyContent="space-between">
+                <BackLink to={cfg.getRecordingsRoute(clusterId)}>
+                  <ChevronLeft size="small" />
+                  Back to Session Recordings
+                </BackLink>
 
-              <HoverTooltip tipContent="Hide Sidebar">
-                <HideSidebarButton onClick={toggleSidebar}>
-                  <ArrowLineLeft size="small" />
-                </HideSidebarButton>
-              </HoverTooltip>
+                <HoverTooltip tipContent="Hide Sidebar">
+                  <HideSidebarButton onClick={toggleSidebar}>
+                    <ArrowLineLeft size="small" />
+                  </HideSidebarButton>
+                </HoverTooltip>
+              </Flex>
+
+              <Flex alignItems="center" gap={3} px={3}>
+                <Terminal />
+
+                <H3>SSH Session</H3>
+              </Flex>
+
+              <InfoGrid>
+                <InfoGridLabel>User</InfoGridLabel>
+
+                <div>
+                  <ItemSpan>
+                    <User size="small" color="sessionRecording.user" />
+
+                    <Text>{data.metadata.user}</Text>
+                  </ItemSpan>
+                </div>
+
+                <InfoGridLabel>Resource</InfoGridLabel>
+
+                <div>
+                  <ItemSpan>
+                    <Server size="small" color="sessionRecording.resource" />
+
+                    <Text>{data.metadata.resourceName}</Text>
+                  </ItemSpan>
+                </div>
+
+                <InfoGridLabel>Duration</InfoGridLabel>
+
+                <div>
+                  {formatSessionRecordingDuration(data.metadata.duration)}
+                </div>
+
+                <InfoGridLabel>Cluster</InfoGridLabel>
+
+                <div>{data.metadata.clusterName}</div>
+
+                <InfoGridLabel>Start Time</InfoGridLabel>
+
+                <div>{format(startTime, 'MMM dd, yyyy HH:mm')}</div>
+
+                <InfoGridLabel>End Time</InfoGridLabel>
+
+                <div>{format(endTime, 'MMM dd, yyyy HH:mm')}</div>
+              </InfoGrid>
+
+              {summary && <Summary>{summary}</Summary>}
             </Flex>
+          </Sidebar>
+        )}
 
-            <Flex alignItems="center" gap={3} px={3}>
-              <Terminal />
+        {data.frames.length > 0 && !timelineHidden && (
+          <TimelineContainer>
+            <RecordingTimeline
+              frames={data.frames}
+              metadata={data.metadata}
+              onHide={handleHideTimeline}
+              onOpenKeyboardShortcuts={handleOpenKeyboardShortcuts}
+              onTimeChange={handleTimelineTimeChange}
+              ref={timelineRef}
+              showAbsoluteTime={showAbsoluteTime}
+            />
+          </TimelineContainer>
+        )}
+      </Grid>
 
-              <H3>SSH Session</H3>
-            </Flex>
-
-            <InfoGrid>
-              <InfoGridLabel>User</InfoGridLabel>
-
-              <div>{data.metadata.user}</div>
-
-              <InfoGridLabel>Resource</InfoGridLabel>
-
-              <div>{data.metadata.resourceName}</div>
-
-              <InfoGridLabel>Duration</InfoGridLabel>
-
-              <div>
-                {formatSessionRecordingDuration(data.metadata.duration)}
-              </div>
-
-              <InfoGridLabel>Cluster</InfoGridLabel>
-
-              <div>{data.metadata.clusterName}</div>
-
-              <InfoGridLabel>Start Time</InfoGridLabel>
-
-              <div>{format(startTime, 'MMM dd, yyyy HH:mm')}</div>
-
-              <InfoGridLabel>End Time</InfoGridLabel>
-
-              <div>{format(endTime, 'MMM dd, yyyy HH:mm')}</div>
-            </InfoGrid>
-
-            {summary && <Summary>{summary}</Summary>}
-          </Flex>
-        </Sidebar>
-      ) : (
-        <HoverTooltip tipContent="Show Sidebar" placement="right">
-          <ShowSidebarButton onClick={toggleSidebar}>
-            <DotsThreeMoreVertical size="large" />
-          </ShowSidebarButton>
-        </HoverTooltip>
-      )}
-    </Grid>
+      <KeyboardShortcuts
+        open={keyboardShortcutsOpen}
+        onClose={handleCloseKeyboardShortcuts}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/58313

This hooks up the recording timeline component to the UI, adding in keyboard shortcuts for hiding/showing the timeline/sidebar and some other ones

<img width="1781" height="1359" alt="image" src="https://github.com/user-attachments/assets/168d5bf7-4163-4ccf-8093-c60cc64c869d" />

changelog: New SSH session recordings now show an interactive timeline