### PR TITLE
Add a "What's new" section to the homepage

### DIFF
--- a/docs/pages/includes/homepage/version-highlights.mdx
+++ b/docs/pages/includes/homepage/version-highlights.mdx
@@ -1,0 +1,19 @@
+import VersionHighlights from "@site/src/components/Pages/Homepage/VersionHighlights";
+
+<VersionHighlights
+  title="What's new in version 18"
+  highlights={[
+    {
+      title: "MCP server access",
+      description: "Teleport now provides the ability to connect to stdio-based MCP servers with connection proxying and audit logging support.",
+      tag: "Zero Trust Access",
+      href: "./connect-your-client/model-context-protocol/mcp-access/",
+    },
+    {
+      title: "MCP for database access",
+      description: "Teleport now allows MCP clients such as Claude Desktop to execute queries in Teleport-protected databases.",
+      tag: "Zero Trust Access",
+      href: "./connect-your-client/model-context-protocol/database-access/",
+    },
+  ]}
+/>

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -50,6 +50,8 @@ Started](./get-started.mdx) guide to enroll your first resource with Teleport.
 
 (!docs/pages/includes/homepage/products.mdx!)
 
+(!docs/pages/includes/homepage/version-highlights.mdx!)
+
 <Resources
   resources={[
     {


### PR DESCRIPTION
We addes support for a "What's new" component in
gravitational/docs-website#295. This change adds the component to the docs home page, populating it with content related to two MCP features introduced in v18.