### PR TITLE
Add ListAccessListsV2 to support sorting and searching

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
@@ -231,6 +231,207 @@ func (x *ListAccessListsResponse) GetNextToken() string {
 	return ""
 }
 
+// ListAccessListsV2Request is the request for getting filtered and sorted paginated access lists.
+type ListAccessListsV2Request struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// page_size is the size of the page to request.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// page_token is the token to begin the next page with.
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	// sort_by specifies the sort order for the results.
+	SortBy *types.SortBy `protobuf:"bytes,3,opt,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
+	// filter is a collection of fields to filter access lists.
+	Filter        *AccessListsFilter `protobuf:"bytes,4,opt,name=filter,proto3" json:"filter,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAccessListsV2Request) Reset() {
+	*x = ListAccessListsV2Request{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAccessListsV2Request) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAccessListsV2Request) ProtoMessage() {}
+
+func (x *ListAccessListsV2Request) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAccessListsV2Request.ProtoReflect.Descriptor instead.
+func (*ListAccessListsV2Request) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ListAccessListsV2Request) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListAccessListsV2Request) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+func (x *ListAccessListsV2Request) GetSortBy() *types.SortBy {
+	if x != nil {
+		return x.SortBy
+	}
+	return nil
+}
+
+func (x *ListAccessListsV2Request) GetFilter() *AccessListsFilter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
+}
+
+// AccessListsFilter is used to collect filter options for listing access lists.
+type AccessListsFilter struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// search is a search term to filter access lists by name.
+	Search string `protobuf:"bytes,1,opt,name=search,proto3" json:"search,omitempty"`
+	// owners indicates returned access lists should be owned by one of the provider owners
+	Owners []string `protobuf:"bytes,2,rep,name=owners,proto3" json:"owners,omitempty"`
+	// roles indicates returned access lists should great one of the provider roles
+	Roles []string `protobuf:"bytes,3,rep,name=roles,proto3" json:"roles,omitempty"`
+	// origin is origin of the resource
+	Origin        string `protobuf:"bytes,4,opt,name=origin,proto3" json:"origin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AccessListsFilter) Reset() {
+	*x = AccessListsFilter{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AccessListsFilter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AccessListsFilter) ProtoMessage() {}
+
+func (x *AccessListsFilter) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AccessListsFilter.ProtoReflect.Descriptor instead.
+func (*AccessListsFilter) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *AccessListsFilter) GetSearch() string {
+	if x != nil {
+		return x.Search
+	}
+	return ""
+}
+
+func (x *AccessListsFilter) GetOwners() []string {
+	if x != nil {
+		return x.Owners
+	}
+	return nil
+}
+
+func (x *AccessListsFilter) GetRoles() []string {
+	if x != nil {
+		return x.Roles
+	}
+	return nil
+}
+
+func (x *AccessListsFilter) GetOrigin() string {
+	if x != nil {
+		return x.Origin
+	}
+	return ""
+}
+
+// ListAccessListsV2Response is the response for getting paginated access lists.
+type ListAccessListsV2Response struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// access_lists is the list of access lists.
+	AccessLists []*AccessList `protobuf:"bytes,1,rep,name=access_lists,json=accessLists,proto3" json:"access_lists,omitempty"`
+	// next_page_token is the next page token.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAccessListsV2Response) Reset() {
+	*x = ListAccessListsV2Response{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAccessListsV2Response) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAccessListsV2Response) ProtoMessage() {}
+
+func (x *ListAccessListsV2Response) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAccessListsV2Response.ProtoReflect.Descriptor instead.
+func (*ListAccessListsV2Response) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListAccessListsV2Response) GetAccessLists() []*AccessList {
+	if x != nil {
+		return x.AccessLists
+	}
+	return nil
+}
+
+func (x *ListAccessListsV2Response) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 // GetInheritedGrantsRequest is the request for getting inherited grants.
 type GetInheritedGrantsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -242,7 +443,7 @@ type GetInheritedGrantsRequest struct {
 
 func (x *GetInheritedGrantsRequest) Reset() {
 	*x = GetInheritedGrantsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[4]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -254,7 +455,7 @@ func (x *GetInheritedGrantsRequest) String() string {
 func (*GetInheritedGrantsRequest) ProtoMessage() {}
 
 func (x *GetInheritedGrantsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[4]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -267,7 +468,7 @@ func (x *GetInheritedGrantsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInheritedGrantsRequest.ProtoReflect.Descriptor instead.
 func (*GetInheritedGrantsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{4}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetInheritedGrantsRequest) GetAccessListId() string {
@@ -288,7 +489,7 @@ type GetInheritedGrantsResponse struct {
 
 func (x *GetInheritedGrantsResponse) Reset() {
 	*x = GetInheritedGrantsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[5]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -300,7 +501,7 @@ func (x *GetInheritedGrantsResponse) String() string {
 func (*GetInheritedGrantsResponse) ProtoMessage() {}
 
 func (x *GetInheritedGrantsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[5]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -313,7 +514,7 @@ func (x *GetInheritedGrantsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInheritedGrantsResponse.ProtoReflect.Descriptor instead.
 func (*GetInheritedGrantsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{5}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetInheritedGrantsResponse) GetGrants() *AccessListGrants {
@@ -334,7 +535,7 @@ type GetAccessListRequest struct {
 
 func (x *GetAccessListRequest) Reset() {
 	*x = GetAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[6]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -346,7 +547,7 @@ func (x *GetAccessListRequest) String() string {
 func (*GetAccessListRequest) ProtoMessage() {}
 
 func (x *GetAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[6]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -359,7 +560,7 @@ func (x *GetAccessListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{6}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetAccessListRequest) GetName() string {
@@ -380,7 +581,7 @@ type UpsertAccessListRequest struct {
 
 func (x *UpsertAccessListRequest) Reset() {
 	*x = UpsertAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[7]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -392,7 +593,7 @@ func (x *UpsertAccessListRequest) String() string {
 func (*UpsertAccessListRequest) ProtoMessage() {}
 
 func (x *UpsertAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[7]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -405,7 +606,7 @@ func (x *UpsertAccessListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertAccessListRequest.ProtoReflect.Descriptor instead.
 func (*UpsertAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{7}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *UpsertAccessListRequest) GetAccessList() *AccessList {
@@ -426,7 +627,7 @@ type UpdateAccessListRequest struct {
 
 func (x *UpdateAccessListRequest) Reset() {
 	*x = UpdateAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[8]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -438,7 +639,7 @@ func (x *UpdateAccessListRequest) String() string {
 func (*UpdateAccessListRequest) ProtoMessage() {}
 
 func (x *UpdateAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[8]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -451,7 +652,7 @@ func (x *UpdateAccessListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAccessListRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{8}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *UpdateAccessListRequest) GetAccessList() *AccessList {
@@ -472,7 +673,7 @@ type DeleteAccessListRequest struct {
 
 func (x *DeleteAccessListRequest) Reset() {
 	*x = DeleteAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[9]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -484,7 +685,7 @@ func (x *DeleteAccessListRequest) String() string {
 func (*DeleteAccessListRequest) ProtoMessage() {}
 
 func (x *DeleteAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[9]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -497,7 +698,7 @@ func (x *DeleteAccessListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessListRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{9}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeleteAccessListRequest) GetName() string {
@@ -516,7 +717,7 @@ type DeleteAllAccessListsRequest struct {
 
 func (x *DeleteAllAccessListsRequest) Reset() {
 	*x = DeleteAllAccessListsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[10]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -528,7 +729,7 @@ func (x *DeleteAllAccessListsRequest) String() string {
 func (*DeleteAllAccessListsRequest) ProtoMessage() {}
 
 func (x *DeleteAllAccessListsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[10]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -541,7 +742,7 @@ func (x *DeleteAllAccessListsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAllAccessListsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllAccessListsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{10}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{13}
 }
 
 // GetAccessListsToReviewRequest is the request for getting access lists that
@@ -554,7 +755,7 @@ type GetAccessListsToReviewRequest struct {
 
 func (x *GetAccessListsToReviewRequest) Reset() {
 	*x = GetAccessListsToReviewRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -566,7 +767,7 @@ func (x *GetAccessListsToReviewRequest) String() string {
 func (*GetAccessListsToReviewRequest) ProtoMessage() {}
 
 func (x *GetAccessListsToReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[11]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -579,7 +780,7 @@ func (x *GetAccessListsToReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListsToReviewRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessListsToReviewRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{11}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{14}
 }
 
 // GetAccessListsToReviewResponse is the response for getting access lists that
@@ -593,7 +794,7 @@ type GetAccessListsToReviewResponse struct {
 
 func (x *GetAccessListsToReviewResponse) Reset() {
 	*x = GetAccessListsToReviewResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -605,7 +806,7 @@ func (x *GetAccessListsToReviewResponse) String() string {
 func (*GetAccessListsToReviewResponse) ProtoMessage() {}
 
 func (x *GetAccessListsToReviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[12]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -618,7 +819,7 @@ func (x *GetAccessListsToReviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListsToReviewResponse.ProtoReflect.Descriptor instead.
 func (*GetAccessListsToReviewResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{12}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetAccessListsToReviewResponse) GetAccessLists() []*AccessList {
@@ -640,7 +841,7 @@ type CountAccessListMembersRequest struct {
 
 func (x *CountAccessListMembersRequest) Reset() {
 	*x = CountAccessListMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -652,7 +853,7 @@ func (x *CountAccessListMembersRequest) String() string {
 func (*CountAccessListMembersRequest) ProtoMessage() {}
 
 func (x *CountAccessListMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -665,7 +866,7 @@ func (x *CountAccessListMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountAccessListMembersRequest.ProtoReflect.Descriptor instead.
 func (*CountAccessListMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{13}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CountAccessListMembersRequest) GetAccessListName() string {
@@ -689,7 +890,7 @@ type CountAccessListMembersResponse struct {
 
 func (x *CountAccessListMembersResponse) Reset() {
 	*x = CountAccessListMembersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -701,7 +902,7 @@ func (x *CountAccessListMembersResponse) String() string {
 func (*CountAccessListMembersResponse) ProtoMessage() {}
 
 func (x *CountAccessListMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -714,7 +915,7 @@ func (x *CountAccessListMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountAccessListMembersResponse.ProtoReflect.Descriptor instead.
 func (*CountAccessListMembersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{14}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CountAccessListMembersResponse) GetCount() uint32 {
@@ -747,7 +948,7 @@ type ListAccessListMembersRequest struct {
 
 func (x *ListAccessListMembersRequest) Reset() {
 	*x = ListAccessListMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -759,7 +960,7 @@ func (x *ListAccessListMembersRequest) String() string {
 func (*ListAccessListMembersRequest) ProtoMessage() {}
 
 func (x *ListAccessListMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[15]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -772,7 +973,7 @@ func (x *ListAccessListMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListMembersRequest.ProtoReflect.Descriptor instead.
 func (*ListAccessListMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{15}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListAccessListMembersRequest) GetPageSize() int32 {
@@ -810,7 +1011,7 @@ type ListAccessListMembersResponse struct {
 
 func (x *ListAccessListMembersResponse) Reset() {
 	*x = ListAccessListMembersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +1023,7 @@ func (x *ListAccessListMembersResponse) String() string {
 func (*ListAccessListMembersResponse) ProtoMessage() {}
 
 func (x *ListAccessListMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[16]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +1036,7 @@ func (x *ListAccessListMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListMembersResponse.ProtoReflect.Descriptor instead.
 func (*ListAccessListMembersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{16}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListAccessListMembersResponse) GetMembers() []*Member {
@@ -866,7 +1067,7 @@ type ListAllAccessListMembersRequest struct {
 
 func (x *ListAllAccessListMembersRequest) Reset() {
 	*x = ListAllAccessListMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[17]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -878,7 +1079,7 @@ func (x *ListAllAccessListMembersRequest) String() string {
 func (*ListAllAccessListMembersRequest) ProtoMessage() {}
 
 func (x *ListAllAccessListMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[17]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -891,7 +1092,7 @@ func (x *ListAllAccessListMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListMembersRequest.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{17}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListAllAccessListMembersRequest) GetPageSize() int32 {
@@ -922,7 +1123,7 @@ type ListAllAccessListMembersResponse struct {
 
 func (x *ListAllAccessListMembersResponse) Reset() {
 	*x = ListAllAccessListMembersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[18]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -934,7 +1135,7 @@ func (x *ListAllAccessListMembersResponse) String() string {
 func (*ListAllAccessListMembersResponse) ProtoMessage() {}
 
 func (x *ListAllAccessListMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[18]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -947,7 +1148,7 @@ func (x *ListAllAccessListMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListMembersResponse.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListMembersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{18}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListAllAccessListMembersResponse) GetMembers() []*Member {
@@ -978,7 +1179,7 @@ type UpsertAccessListWithMembersRequest struct {
 
 func (x *UpsertAccessListWithMembersRequest) Reset() {
 	*x = UpsertAccessListWithMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[19]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1191,7 @@ func (x *UpsertAccessListWithMembersRequest) String() string {
 func (*UpsertAccessListWithMembersRequest) ProtoMessage() {}
 
 func (x *UpsertAccessListWithMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[19]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1204,7 @@ func (x *UpsertAccessListWithMembersRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use UpsertAccessListWithMembersRequest.ProtoReflect.Descriptor instead.
 func (*UpsertAccessListWithMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{19}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UpsertAccessListWithMembersRequest) GetAccessList() *AccessList {
@@ -1034,7 +1235,7 @@ type UpsertAccessListWithMembersResponse struct {
 
 func (x *UpsertAccessListWithMembersResponse) Reset() {
 	*x = UpsertAccessListWithMembersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[20]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1046,7 +1247,7 @@ func (x *UpsertAccessListWithMembersResponse) String() string {
 func (*UpsertAccessListWithMembersResponse) ProtoMessage() {}
 
 func (x *UpsertAccessListWithMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[20]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1059,7 +1260,7 @@ func (x *UpsertAccessListWithMembersResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpsertAccessListWithMembersResponse.ProtoReflect.Descriptor instead.
 func (*UpsertAccessListWithMembersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{20}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *UpsertAccessListWithMembersResponse) GetAccessList() *AccessList {
@@ -1089,7 +1290,7 @@ type GetAccessListMemberRequest struct {
 
 func (x *GetAccessListMemberRequest) Reset() {
 	*x = GetAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[21]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1101,7 +1302,7 @@ func (x *GetAccessListMemberRequest) String() string {
 func (*GetAccessListMemberRequest) ProtoMessage() {}
 
 func (x *GetAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[21]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1114,7 +1315,7 @@ func (x *GetAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{21}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetAccessListMemberRequest) GetAccessList() string {
@@ -1145,7 +1346,7 @@ type GetStaticAccessListMemberRequest struct {
 
 func (x *GetStaticAccessListMemberRequest) Reset() {
 	*x = GetStaticAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1157,7 +1358,7 @@ func (x *GetStaticAccessListMemberRequest) String() string {
 func (*GetStaticAccessListMemberRequest) ProtoMessage() {}
 
 func (x *GetStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[22]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1170,7 +1371,7 @@ func (x *GetStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*GetStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{22}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetStaticAccessListMemberRequest) GetAccessList() string {
@@ -1199,7 +1400,7 @@ type GetStaticAccessListMemberResponse struct {
 
 func (x *GetStaticAccessListMemberResponse) Reset() {
 	*x = GetStaticAccessListMemberResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1211,7 +1412,7 @@ func (x *GetStaticAccessListMemberResponse) String() string {
 func (*GetStaticAccessListMemberResponse) ProtoMessage() {}
 
 func (x *GetStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[23]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1224,7 +1425,7 @@ func (x *GetStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
 func (*GetStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{23}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetStaticAccessListMemberResponse) GetMember() *Member {
@@ -1246,7 +1447,7 @@ type GetAccessListOwnersRequest struct {
 
 func (x *GetAccessListOwnersRequest) Reset() {
 	*x = GetAccessListOwnersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1258,7 +1459,7 @@ func (x *GetAccessListOwnersRequest) String() string {
 func (*GetAccessListOwnersRequest) ProtoMessage() {}
 
 func (x *GetAccessListOwnersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[24]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1271,7 +1472,7 @@ func (x *GetAccessListOwnersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListOwnersRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessListOwnersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{24}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetAccessListOwnersRequest) GetAccessList() string {
@@ -1294,7 +1495,7 @@ type GetAccessListOwnersResponse struct {
 
 func (x *GetAccessListOwnersResponse) Reset() {
 	*x = GetAccessListOwnersResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1306,7 +1507,7 @@ func (x *GetAccessListOwnersResponse) String() string {
 func (*GetAccessListOwnersResponse) ProtoMessage() {}
 
 func (x *GetAccessListOwnersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[25]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1319,7 +1520,7 @@ func (x *GetAccessListOwnersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessListOwnersResponse.ProtoReflect.Descriptor instead.
 func (*GetAccessListOwnersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{25}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetAccessListOwnersResponse) GetOwners() []*AccessListOwner {
@@ -1341,7 +1542,7 @@ type UpsertAccessListMemberRequest struct {
 
 func (x *UpsertAccessListMemberRequest) Reset() {
 	*x = UpsertAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1353,7 +1554,7 @@ func (x *UpsertAccessListMemberRequest) String() string {
 func (*UpsertAccessListMemberRequest) ProtoMessage() {}
 
 func (x *UpsertAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[26]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1366,7 +1567,7 @@ func (x *UpsertAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*UpsertAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{26}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *UpsertAccessListMemberRequest) GetMember() *Member {
@@ -1388,7 +1589,7 @@ type UpsertStaticAccessListMemberRequest struct {
 
 func (x *UpsertStaticAccessListMemberRequest) Reset() {
 	*x = UpsertStaticAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1400,7 +1601,7 @@ func (x *UpsertStaticAccessListMemberRequest) String() string {
 func (*UpsertStaticAccessListMemberRequest) ProtoMessage() {}
 
 func (x *UpsertStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[27]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1413,7 +1614,7 @@ func (x *UpsertStaticAccessListMemberRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpsertStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*UpsertStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{27}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UpsertStaticAccessListMemberRequest) GetMember() *Member {
@@ -1435,7 +1636,7 @@ type UpsertStaticAccessListMemberResponse struct {
 
 func (x *UpsertStaticAccessListMemberResponse) Reset() {
 	*x = UpsertStaticAccessListMemberResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1447,7 +1648,7 @@ func (x *UpsertStaticAccessListMemberResponse) String() string {
 func (*UpsertStaticAccessListMemberResponse) ProtoMessage() {}
 
 func (x *UpsertStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[28]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1460,7 +1661,7 @@ func (x *UpsertStaticAccessListMemberResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpsertStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
 func (*UpsertStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{28}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UpsertStaticAccessListMemberResponse) GetMember() *Member {
@@ -1482,7 +1683,7 @@ type UpdateAccessListMemberRequest struct {
 
 func (x *UpdateAccessListMemberRequest) Reset() {
 	*x = UpdateAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1494,7 +1695,7 @@ func (x *UpdateAccessListMemberRequest) String() string {
 func (*UpdateAccessListMemberRequest) ProtoMessage() {}
 
 func (x *UpdateAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[29]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1507,7 +1708,7 @@ func (x *UpdateAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{29}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *UpdateAccessListMemberRequest) GetMember() *Member {
@@ -1531,7 +1732,7 @@ type DeleteAccessListMemberRequest struct {
 
 func (x *DeleteAccessListMemberRequest) Reset() {
 	*x = DeleteAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1543,7 +1744,7 @@ func (x *DeleteAccessListMemberRequest) String() string {
 func (*DeleteAccessListMemberRequest) ProtoMessage() {}
 
 func (x *DeleteAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[30]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1556,7 +1757,7 @@ func (x *DeleteAccessListMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{30}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DeleteAccessListMemberRequest) GetAccessList() string {
@@ -1587,7 +1788,7 @@ type DeleteStaticAccessListMemberRequest struct {
 
 func (x *DeleteStaticAccessListMemberRequest) Reset() {
 	*x = DeleteStaticAccessListMemberRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1599,7 +1800,7 @@ func (x *DeleteStaticAccessListMemberRequest) String() string {
 func (*DeleteStaticAccessListMemberRequest) ProtoMessage() {}
 
 func (x *DeleteStaticAccessListMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[31]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1612,7 +1813,7 @@ func (x *DeleteStaticAccessListMemberRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use DeleteStaticAccessListMemberRequest.ProtoReflect.Descriptor instead.
 func (*DeleteStaticAccessListMemberRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{31}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DeleteStaticAccessListMemberRequest) GetAccessList() string {
@@ -1639,7 +1840,7 @@ type DeleteStaticAccessListMemberResponse struct {
 
 func (x *DeleteStaticAccessListMemberResponse) Reset() {
 	*x = DeleteStaticAccessListMemberResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1651,7 +1852,7 @@ func (x *DeleteStaticAccessListMemberResponse) String() string {
 func (*DeleteStaticAccessListMemberResponse) ProtoMessage() {}
 
 func (x *DeleteStaticAccessListMemberResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[32]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1664,7 +1865,7 @@ func (x *DeleteStaticAccessListMemberResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use DeleteStaticAccessListMemberResponse.ProtoReflect.Descriptor instead.
 func (*DeleteStaticAccessListMemberResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{32}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{35}
 }
 
 // DeleteAllAccessListMembersForAccessListRequest is the request for deleting
@@ -1679,7 +1880,7 @@ type DeleteAllAccessListMembersForAccessListRequest struct {
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) Reset() {
 	*x = DeleteAllAccessListMembersForAccessListRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1691,7 +1892,7 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) String() string {
 func (*DeleteAllAccessListMembersForAccessListRequest) ProtoMessage() {}
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[33]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1704,7 +1905,7 @@ func (x *DeleteAllAccessListMembersForAccessListRequest) ProtoReflect() protoref
 
 // Deprecated: Use DeleteAllAccessListMembersForAccessListRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllAccessListMembersForAccessListRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{33}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *DeleteAllAccessListMembersForAccessListRequest) GetAccessList() string {
@@ -1724,7 +1925,7 @@ type DeleteAllAccessListMembersRequest struct {
 
 func (x *DeleteAllAccessListMembersRequest) Reset() {
 	*x = DeleteAllAccessListMembersRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1736,7 +1937,7 @@ func (x *DeleteAllAccessListMembersRequest) String() string {
 func (*DeleteAllAccessListMembersRequest) ProtoMessage() {}
 
 func (x *DeleteAllAccessListMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[34]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1749,7 +1950,7 @@ func (x *DeleteAllAccessListMembersRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use DeleteAllAccessListMembersRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAllAccessListMembersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{34}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{37}
 }
 
 // ListAccessListReviewsRequest is the request for getting paginated access list
@@ -1768,7 +1969,7 @@ type ListAccessListReviewsRequest struct {
 
 func (x *ListAccessListReviewsRequest) Reset() {
 	*x = ListAccessListReviewsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1780,7 +1981,7 @@ func (x *ListAccessListReviewsRequest) String() string {
 func (*ListAccessListReviewsRequest) ProtoMessage() {}
 
 func (x *ListAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[35]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1793,7 +1994,7 @@ func (x *ListAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListReviewsRequest.ProtoReflect.Descriptor instead.
 func (*ListAccessListReviewsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{35}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListAccessListReviewsRequest) GetAccessList() string {
@@ -1831,7 +2032,7 @@ type ListAccessListReviewsResponse struct {
 
 func (x *ListAccessListReviewsResponse) Reset() {
 	*x = ListAccessListReviewsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1843,7 +2044,7 @@ func (x *ListAccessListReviewsResponse) String() string {
 func (*ListAccessListReviewsResponse) ProtoMessage() {}
 
 func (x *ListAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[36]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1856,7 +2057,7 @@ func (x *ListAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAccessListReviewsResponse.ProtoReflect.Descriptor instead.
 func (*ListAccessListReviewsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{36}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListAccessListReviewsResponse) GetReviews() []*Review {
@@ -1887,7 +2088,7 @@ type ListAllAccessListReviewsRequest struct {
 
 func (x *ListAllAccessListReviewsRequest) Reset() {
 	*x = ListAllAccessListReviewsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1899,7 +2100,7 @@ func (x *ListAllAccessListReviewsRequest) String() string {
 func (*ListAllAccessListReviewsRequest) ProtoMessage() {}
 
 func (x *ListAllAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[37]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1912,7 +2113,7 @@ func (x *ListAllAccessListReviewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListReviewsRequest.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListReviewsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{37}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ListAllAccessListReviewsRequest) GetPageSize() int32 {
@@ -1943,7 +2144,7 @@ type ListAllAccessListReviewsResponse struct {
 
 func (x *ListAllAccessListReviewsResponse) Reset() {
 	*x = ListAllAccessListReviewsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1955,7 +2156,7 @@ func (x *ListAllAccessListReviewsResponse) String() string {
 func (*ListAllAccessListReviewsResponse) ProtoMessage() {}
 
 func (x *ListAllAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[38]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1968,7 +2169,7 @@ func (x *ListAllAccessListReviewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllAccessListReviewsResponse.ProtoReflect.Descriptor instead.
 func (*ListAllAccessListReviewsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{38}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListAllAccessListReviewsResponse) GetReviews() []*Review {
@@ -1997,7 +2198,7 @@ type CreateAccessListReviewRequest struct {
 
 func (x *CreateAccessListReviewRequest) Reset() {
 	*x = CreateAccessListReviewRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2009,7 +2210,7 @@ func (x *CreateAccessListReviewRequest) String() string {
 func (*CreateAccessListReviewRequest) ProtoMessage() {}
 
 func (x *CreateAccessListReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[39]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2022,7 +2223,7 @@ func (x *CreateAccessListReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessListReviewRequest.ProtoReflect.Descriptor instead.
 func (*CreateAccessListReviewRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{39}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CreateAccessListReviewRequest) GetReview() *Review {
@@ -2046,7 +2247,7 @@ type CreateAccessListReviewResponse struct {
 
 func (x *CreateAccessListReviewResponse) Reset() {
 	*x = CreateAccessListReviewResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2058,7 +2259,7 @@ func (x *CreateAccessListReviewResponse) String() string {
 func (*CreateAccessListReviewResponse) ProtoMessage() {}
 
 func (x *CreateAccessListReviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[40]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2071,7 +2272,7 @@ func (x *CreateAccessListReviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessListReviewResponse.ProtoReflect.Descriptor instead.
 func (*CreateAccessListReviewResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{40}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CreateAccessListReviewResponse) GetReviewName() string {
@@ -2102,7 +2303,7 @@ type DeleteAccessListReviewRequest struct {
 
 func (x *DeleteAccessListReviewRequest) Reset() {
 	*x = DeleteAccessListReviewRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2114,7 +2315,7 @@ func (x *DeleteAccessListReviewRequest) String() string {
 func (*DeleteAccessListReviewRequest) ProtoMessage() {}
 
 func (x *DeleteAccessListReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[41]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2328,7 @@ func (x *DeleteAccessListReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessListReviewRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessListReviewRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{41}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *DeleteAccessListReviewRequest) GetReviewName() string {
@@ -2160,7 +2361,7 @@ type AccessRequestPromoteRequest struct {
 
 func (x *AccessRequestPromoteRequest) Reset() {
 	*x = AccessRequestPromoteRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2172,7 +2373,7 @@ func (x *AccessRequestPromoteRequest) String() string {
 func (*AccessRequestPromoteRequest) ProtoMessage() {}
 
 func (x *AccessRequestPromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[42]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2185,7 +2386,7 @@ func (x *AccessRequestPromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestPromoteRequest.ProtoReflect.Descriptor instead.
 func (*AccessRequestPromoteRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{42}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AccessRequestPromoteRequest) GetRequestId() string {
@@ -2221,7 +2422,7 @@ type AccessRequestPromoteResponse struct {
 
 func (x *AccessRequestPromoteResponse) Reset() {
 	*x = AccessRequestPromoteResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2233,7 +2434,7 @@ func (x *AccessRequestPromoteResponse) String() string {
 func (*AccessRequestPromoteResponse) ProtoMessage() {}
 
 func (x *AccessRequestPromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[43]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2246,7 +2447,7 @@ func (x *AccessRequestPromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessRequestPromoteResponse.ProtoReflect.Descriptor instead.
 func (*AccessRequestPromoteResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{43}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *AccessRequestPromoteResponse) GetAccessRequest() *types.AccessRequestV3 {
@@ -2268,7 +2469,7 @@ type GetSuggestedAccessListsRequest struct {
 
 func (x *GetSuggestedAccessListsRequest) Reset() {
 	*x = GetSuggestedAccessListsRequest{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2280,7 +2481,7 @@ func (x *GetSuggestedAccessListsRequest) String() string {
 func (*GetSuggestedAccessListsRequest) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[44]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2293,7 +2494,7 @@ func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsRequest.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{44}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetSuggestedAccessListsRequest) GetAccessRequestId() string {
@@ -2315,7 +2516,7 @@ type GetSuggestedAccessListsResponse struct {
 
 func (x *GetSuggestedAccessListsResponse) Reset() {
 	*x = GetSuggestedAccessListsResponse{}
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2327,7 +2528,7 @@ func (x *GetSuggestedAccessListsResponse) String() string {
 func (*GetSuggestedAccessListsResponse) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[45]
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2340,7 +2541,7 @@ func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsResponse.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{45}
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetSuggestedAccessListsResponse) GetAccessLists() []*AccessList {
@@ -2365,7 +2566,21 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x17ListAccessListsResponse\x12E\n" +
 	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12\x1d\n" +
 	"\n" +
-	"next_token\x18\x02 \x01(\tR\tnextToken\"A\n" +
+	"next_token\x18\x02 \x01(\tR\tnextToken\"\xc1\x01\n" +
+	"\x18ListAccessListsV2Request\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12&\n" +
+	"\asort_by\x18\x03 \x01(\v2\r.types.SortByR\x06sortBy\x12A\n" +
+	"\x06filter\x18\x04 \x01(\v2).teleport.accesslist.v1.AccessListsFilterR\x06filter\"q\n" +
+	"\x11AccessListsFilter\x12\x16\n" +
+	"\x06search\x18\x01 \x01(\tR\x06search\x12\x16\n" +
+	"\x06owners\x18\x02 \x03(\tR\x06owners\x12\x14\n" +
+	"\x05roles\x18\x03 \x03(\tR\x05roles\x12\x16\n" +
+	"\x06origin\x18\x04 \x01(\tR\x06origin\"\x8a\x01\n" +
+	"\x19ListAccessListsV2Response\x12E\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"A\n" +
 	"\x19GetInheritedGrantsRequest\x12$\n" +
 	"\x0eaccess_list_id\x18\x01 \x01(\tR\faccessListId\"^\n" +
 	"\x1aGetInheritedGrantsResponse\x12@\n" +
@@ -2492,10 +2707,11 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1eGetSuggestedAccessListsRequest\x12*\n" +
 	"\x11access_request_id\x18\x01 \x01(\tR\x0faccessRequestId\"h\n" +
 	"\x1fGetSuggestedAccessListsResponse\x12E\n" +
-	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists2\xc9\x1c\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists2\xc8\x1d\n" +
 	"\x11AccessListService\x12o\n" +
-	"\x0eGetAccessLists\x12-.teleport.accesslist.v1.GetAccessListsRequest\x1a..teleport.accesslist.v1.GetAccessListsResponse\x12r\n" +
-	"\x0fListAccessLists\x12..teleport.accesslist.v1.ListAccessListsRequest\x1a/.teleport.accesslist.v1.ListAccessListsResponse\x12a\n" +
+	"\x0eGetAccessLists\x12-.teleport.accesslist.v1.GetAccessListsRequest\x1a..teleport.accesslist.v1.GetAccessListsResponse\x12w\n" +
+	"\x0fListAccessLists\x12..teleport.accesslist.v1.ListAccessListsRequest\x1a/.teleport.accesslist.v1.ListAccessListsResponse\"\x03\x88\x02\x01\x12x\n" +
+	"\x11ListAccessListsV2\x120.teleport.accesslist.v1.ListAccessListsV2Request\x1a1.teleport.accesslist.v1.ListAccessListsV2Response\x12a\n" +
 	"\rGetAccessList\x12,.teleport.accesslist.v1.GetAccessListRequest\x1a\".teleport.accesslist.v1.AccessList\x12g\n" +
 	"\x10UpsertAccessList\x12/.teleport.accesslist.v1.UpsertAccessListRequest\x1a\".teleport.accesslist.v1.AccessList\x12g\n" +
 	"\x10UpdateAccessList\x12/.teleport.accesslist.v1.UpdateAccessListRequest\x1a\".teleport.accesslist.v1.AccessList\x12[\n" +
@@ -2536,151 +2752,160 @@ func file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP() []byte {
 	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescData
 }
 
-var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
+var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*GetAccessListsRequest)(nil),                          // 0: teleport.accesslist.v1.GetAccessListsRequest
 	(*GetAccessListsResponse)(nil),                         // 1: teleport.accesslist.v1.GetAccessListsResponse
 	(*ListAccessListsRequest)(nil),                         // 2: teleport.accesslist.v1.ListAccessListsRequest
 	(*ListAccessListsResponse)(nil),                        // 3: teleport.accesslist.v1.ListAccessListsResponse
-	(*GetInheritedGrantsRequest)(nil),                      // 4: teleport.accesslist.v1.GetInheritedGrantsRequest
-	(*GetInheritedGrantsResponse)(nil),                     // 5: teleport.accesslist.v1.GetInheritedGrantsResponse
-	(*GetAccessListRequest)(nil),                           // 6: teleport.accesslist.v1.GetAccessListRequest
-	(*UpsertAccessListRequest)(nil),                        // 7: teleport.accesslist.v1.UpsertAccessListRequest
-	(*UpdateAccessListRequest)(nil),                        // 8: teleport.accesslist.v1.UpdateAccessListRequest
-	(*DeleteAccessListRequest)(nil),                        // 9: teleport.accesslist.v1.DeleteAccessListRequest
-	(*DeleteAllAccessListsRequest)(nil),                    // 10: teleport.accesslist.v1.DeleteAllAccessListsRequest
-	(*GetAccessListsToReviewRequest)(nil),                  // 11: teleport.accesslist.v1.GetAccessListsToReviewRequest
-	(*GetAccessListsToReviewResponse)(nil),                 // 12: teleport.accesslist.v1.GetAccessListsToReviewResponse
-	(*CountAccessListMembersRequest)(nil),                  // 13: teleport.accesslist.v1.CountAccessListMembersRequest
-	(*CountAccessListMembersResponse)(nil),                 // 14: teleport.accesslist.v1.CountAccessListMembersResponse
-	(*ListAccessListMembersRequest)(nil),                   // 15: teleport.accesslist.v1.ListAccessListMembersRequest
-	(*ListAccessListMembersResponse)(nil),                  // 16: teleport.accesslist.v1.ListAccessListMembersResponse
-	(*ListAllAccessListMembersRequest)(nil),                // 17: teleport.accesslist.v1.ListAllAccessListMembersRequest
-	(*ListAllAccessListMembersResponse)(nil),               // 18: teleport.accesslist.v1.ListAllAccessListMembersResponse
-	(*UpsertAccessListWithMembersRequest)(nil),             // 19: teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	(*UpsertAccessListWithMembersResponse)(nil),            // 20: teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	(*GetAccessListMemberRequest)(nil),                     // 21: teleport.accesslist.v1.GetAccessListMemberRequest
-	(*GetStaticAccessListMemberRequest)(nil),               // 22: teleport.accesslist.v1.GetStaticAccessListMemberRequest
-	(*GetStaticAccessListMemberResponse)(nil),              // 23: teleport.accesslist.v1.GetStaticAccessListMemberResponse
-	(*GetAccessListOwnersRequest)(nil),                     // 24: teleport.accesslist.v1.GetAccessListOwnersRequest
-	(*GetAccessListOwnersResponse)(nil),                    // 25: teleport.accesslist.v1.GetAccessListOwnersResponse
-	(*UpsertAccessListMemberRequest)(nil),                  // 26: teleport.accesslist.v1.UpsertAccessListMemberRequest
-	(*UpsertStaticAccessListMemberRequest)(nil),            // 27: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
-	(*UpsertStaticAccessListMemberResponse)(nil),           // 28: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
-	(*UpdateAccessListMemberRequest)(nil),                  // 29: teleport.accesslist.v1.UpdateAccessListMemberRequest
-	(*DeleteAccessListMemberRequest)(nil),                  // 30: teleport.accesslist.v1.DeleteAccessListMemberRequest
-	(*DeleteStaticAccessListMemberRequest)(nil),            // 31: teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
-	(*DeleteStaticAccessListMemberResponse)(nil),           // 32: teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
-	(*DeleteAllAccessListMembersForAccessListRequest)(nil), // 33: teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	(*DeleteAllAccessListMembersRequest)(nil),              // 34: teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	(*ListAccessListReviewsRequest)(nil),                   // 35: teleport.accesslist.v1.ListAccessListReviewsRequest
-	(*ListAccessListReviewsResponse)(nil),                  // 36: teleport.accesslist.v1.ListAccessListReviewsResponse
-	(*ListAllAccessListReviewsRequest)(nil),                // 37: teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	(*ListAllAccessListReviewsResponse)(nil),               // 38: teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	(*CreateAccessListReviewRequest)(nil),                  // 39: teleport.accesslist.v1.CreateAccessListReviewRequest
-	(*CreateAccessListReviewResponse)(nil),                 // 40: teleport.accesslist.v1.CreateAccessListReviewResponse
-	(*DeleteAccessListReviewRequest)(nil),                  // 41: teleport.accesslist.v1.DeleteAccessListReviewRequest
-	(*AccessRequestPromoteRequest)(nil),                    // 42: teleport.accesslist.v1.AccessRequestPromoteRequest
-	(*AccessRequestPromoteResponse)(nil),                   // 43: teleport.accesslist.v1.AccessRequestPromoteResponse
-	(*GetSuggestedAccessListsRequest)(nil),                 // 44: teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	(*GetSuggestedAccessListsResponse)(nil),                // 45: teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	(*AccessList)(nil),                                     // 46: teleport.accesslist.v1.AccessList
-	(*AccessListGrants)(nil),                               // 47: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                                         // 48: teleport.accesslist.v1.Member
-	(*AccessListOwner)(nil),                                // 49: teleport.accesslist.v1.AccessListOwner
-	(*Review)(nil),                                         // 50: teleport.accesslist.v1.Review
-	(*timestamppb.Timestamp)(nil),                          // 51: google.protobuf.Timestamp
-	(*types.AccessRequestV3)(nil),                          // 52: types.AccessRequestV3
-	(*emptypb.Empty)(nil),                                  // 53: google.protobuf.Empty
+	(*ListAccessListsV2Request)(nil),                       // 4: teleport.accesslist.v1.ListAccessListsV2Request
+	(*AccessListsFilter)(nil),                              // 5: teleport.accesslist.v1.AccessListsFilter
+	(*ListAccessListsV2Response)(nil),                      // 6: teleport.accesslist.v1.ListAccessListsV2Response
+	(*GetInheritedGrantsRequest)(nil),                      // 7: teleport.accesslist.v1.GetInheritedGrantsRequest
+	(*GetInheritedGrantsResponse)(nil),                     // 8: teleport.accesslist.v1.GetInheritedGrantsResponse
+	(*GetAccessListRequest)(nil),                           // 9: teleport.accesslist.v1.GetAccessListRequest
+	(*UpsertAccessListRequest)(nil),                        // 10: teleport.accesslist.v1.UpsertAccessListRequest
+	(*UpdateAccessListRequest)(nil),                        // 11: teleport.accesslist.v1.UpdateAccessListRequest
+	(*DeleteAccessListRequest)(nil),                        // 12: teleport.accesslist.v1.DeleteAccessListRequest
+	(*DeleteAllAccessListsRequest)(nil),                    // 13: teleport.accesslist.v1.DeleteAllAccessListsRequest
+	(*GetAccessListsToReviewRequest)(nil),                  // 14: teleport.accesslist.v1.GetAccessListsToReviewRequest
+	(*GetAccessListsToReviewResponse)(nil),                 // 15: teleport.accesslist.v1.GetAccessListsToReviewResponse
+	(*CountAccessListMembersRequest)(nil),                  // 16: teleport.accesslist.v1.CountAccessListMembersRequest
+	(*CountAccessListMembersResponse)(nil),                 // 17: teleport.accesslist.v1.CountAccessListMembersResponse
+	(*ListAccessListMembersRequest)(nil),                   // 18: teleport.accesslist.v1.ListAccessListMembersRequest
+	(*ListAccessListMembersResponse)(nil),                  // 19: teleport.accesslist.v1.ListAccessListMembersResponse
+	(*ListAllAccessListMembersRequest)(nil),                // 20: teleport.accesslist.v1.ListAllAccessListMembersRequest
+	(*ListAllAccessListMembersResponse)(nil),               // 21: teleport.accesslist.v1.ListAllAccessListMembersResponse
+	(*UpsertAccessListWithMembersRequest)(nil),             // 22: teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	(*UpsertAccessListWithMembersResponse)(nil),            // 23: teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	(*GetAccessListMemberRequest)(nil),                     // 24: teleport.accesslist.v1.GetAccessListMemberRequest
+	(*GetStaticAccessListMemberRequest)(nil),               // 25: teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	(*GetStaticAccessListMemberResponse)(nil),              // 26: teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	(*GetAccessListOwnersRequest)(nil),                     // 27: teleport.accesslist.v1.GetAccessListOwnersRequest
+	(*GetAccessListOwnersResponse)(nil),                    // 28: teleport.accesslist.v1.GetAccessListOwnersResponse
+	(*UpsertAccessListMemberRequest)(nil),                  // 29: teleport.accesslist.v1.UpsertAccessListMemberRequest
+	(*UpsertStaticAccessListMemberRequest)(nil),            // 30: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	(*UpsertStaticAccessListMemberResponse)(nil),           // 31: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	(*UpdateAccessListMemberRequest)(nil),                  // 32: teleport.accesslist.v1.UpdateAccessListMemberRequest
+	(*DeleteAccessListMemberRequest)(nil),                  // 33: teleport.accesslist.v1.DeleteAccessListMemberRequest
+	(*DeleteStaticAccessListMemberRequest)(nil),            // 34: teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	(*DeleteStaticAccessListMemberResponse)(nil),           // 35: teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	(*DeleteAllAccessListMembersForAccessListRequest)(nil), // 36: teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	(*DeleteAllAccessListMembersRequest)(nil),              // 37: teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	(*ListAccessListReviewsRequest)(nil),                   // 38: teleport.accesslist.v1.ListAccessListReviewsRequest
+	(*ListAccessListReviewsResponse)(nil),                  // 39: teleport.accesslist.v1.ListAccessListReviewsResponse
+	(*ListAllAccessListReviewsRequest)(nil),                // 40: teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	(*ListAllAccessListReviewsResponse)(nil),               // 41: teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	(*CreateAccessListReviewRequest)(nil),                  // 42: teleport.accesslist.v1.CreateAccessListReviewRequest
+	(*CreateAccessListReviewResponse)(nil),                 // 43: teleport.accesslist.v1.CreateAccessListReviewResponse
+	(*DeleteAccessListReviewRequest)(nil),                  // 44: teleport.accesslist.v1.DeleteAccessListReviewRequest
+	(*AccessRequestPromoteRequest)(nil),                    // 45: teleport.accesslist.v1.AccessRequestPromoteRequest
+	(*AccessRequestPromoteResponse)(nil),                   // 46: teleport.accesslist.v1.AccessRequestPromoteResponse
+	(*GetSuggestedAccessListsRequest)(nil),                 // 47: teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	(*GetSuggestedAccessListsResponse)(nil),                // 48: teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	(*AccessList)(nil),                                     // 49: teleport.accesslist.v1.AccessList
+	(*types.SortBy)(nil),                                   // 50: types.SortBy
+	(*AccessListGrants)(nil),                               // 51: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                                         // 52: teleport.accesslist.v1.Member
+	(*AccessListOwner)(nil),                                // 53: teleport.accesslist.v1.AccessListOwner
+	(*Review)(nil),                                         // 54: teleport.accesslist.v1.Review
+	(*timestamppb.Timestamp)(nil),                          // 55: google.protobuf.Timestamp
+	(*types.AccessRequestV3)(nil),                          // 56: types.AccessRequestV3
+	(*emptypb.Empty)(nil),                                  // 57: google.protobuf.Empty
 }
 var file_teleport_accesslist_v1_accesslist_service_proto_depIdxs = []int32{
-	46, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	46, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	47, // 2: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	46, // 3: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	46, // 4: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	46, // 5: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	48, // 6: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	48, // 7: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	46, // 8: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	48, // 9: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
-	46, // 10: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	48, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	48, // 12: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	49, // 13: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	48, // 14: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	48, // 15: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	48, // 16: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	48, // 17: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	50, // 18: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	50, // 19: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	50, // 20: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
-	51, // 21: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
-	52, // 22: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
-	46, // 23: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	0,  // 24: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
-	2,  // 25: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
-	6,  // 26: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
-	7,  // 27: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
-	8,  // 28: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
-	9,  // 29: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
-	10, // 30: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
-	11, // 31: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
-	13, // 32: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
-	15, // 33: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
-	17, // 34: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
-	21, // 35: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
-	22, // 36: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
-	24, // 37: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
-	26, // 38: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
-	27, // 39: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
-	29, // 40: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
-	30, // 41: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
-	31, // 42: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
-	33, // 43: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	34, // 44: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	19, // 45: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	35, // 46: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
-	37, // 47: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	39, // 48: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
-	41, // 49: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
-	42, // 50: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
-	44, // 51: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	4,  // 52: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
-	1,  // 53: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
-	3,  // 54: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
-	46, // 55: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
-	46, // 56: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
-	46, // 57: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
-	53, // 58: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
-	53, // 59: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
-	12, // 60: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
-	14, // 61: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
-	16, // 62: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
-	18, // 63: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
-	48, // 64: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
-	23, // 65: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
-	25, // 66: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
-	48, // 67: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
-	28, // 68: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
-	48, // 69: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
-	53, // 70: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
-	32, // 71: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
-	53, // 72: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
-	53, // 73: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
-	20, // 74: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	36, // 75: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
-	38, // 76: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	40, // 77: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
-	53, // 78: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
-	43, // 79: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
-	45, // 80: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	5,  // 81: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
-	53, // [53:82] is the sub-list for method output_type
-	24, // [24:53] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	49, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	49, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	50, // 2: teleport.accesslist.v1.ListAccessListsV2Request.sort_by:type_name -> types.SortBy
+	5,  // 3: teleport.accesslist.v1.ListAccessListsV2Request.filter:type_name -> teleport.accesslist.v1.AccessListsFilter
+	49, // 4: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	51, // 5: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	49, // 6: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	49, // 7: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	49, // 8: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	52, // 9: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	52, // 10: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	49, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	52, // 12: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
+	49, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	52, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	52, // 15: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	53, // 16: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	52, // 17: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	52, // 18: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	52, // 19: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	52, // 20: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	54, // 21: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	54, // 22: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	54, // 23: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
+	55, // 24: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
+	56, // 25: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
+	49, // 26: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	0,  // 27: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
+	2,  // 28: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
+	4,  // 29: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
+	9,  // 30: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
+	10, // 31: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
+	11, // 32: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
+	12, // 33: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
+	13, // 34: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
+	14, // 35: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
+	16, // 36: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
+	18, // 37: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
+	20, // 38: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
+	24, // 39: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
+	25, // 40: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	27, // 41: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
+	29, // 42: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
+	30, // 43: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	32, // 44: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
+	33, // 45: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
+	34, // 46: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	36, // 47: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	37, // 48: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	22, // 49: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	38, // 50: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
+	40, // 51: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	42, // 52: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
+	44, // 53: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
+	45, // 54: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
+	47, // 55: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	7,  // 56: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
+	1,  // 57: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
+	3,  // 58: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
+	6,  // 59: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
+	49, // 60: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
+	49, // 61: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
+	49, // 62: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
+	57, // 63: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
+	57, // 64: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
+	15, // 65: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
+	17, // 66: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
+	19, // 67: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
+	21, // 68: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
+	52, // 69: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
+	26, // 70: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	28, // 71: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
+	52, // 72: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
+	31, // 73: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	52, // 74: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
+	57, // 75: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
+	35, // 76: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	57, // 77: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
+	57, // 78: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
+	23, // 79: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	39, // 80: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
+	41, // 81: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	43, // 82: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
+	57, // 83: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
+	46, // 84: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
+	48, // 85: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	8,  // 86: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
+	57, // [57:87] is the sub-list for method output_type
+	27, // [27:57] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_service_proto_init() }
@@ -2695,7 +2920,7 @@ func file_teleport_accesslist_v1_accesslist_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   46,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
@@ -36,6 +36,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	AccessListService_GetAccessLists_FullMethodName                          = "/teleport.accesslist.v1.AccessListService/GetAccessLists"
 	AccessListService_ListAccessLists_FullMethodName                         = "/teleport.accesslist.v1.AccessListService/ListAccessLists"
+	AccessListService_ListAccessListsV2_FullMethodName                       = "/teleport.accesslist.v1.AccessListService/ListAccessListsV2"
 	AccessListService_GetAccessList_FullMethodName                           = "/teleport.accesslist.v1.AccessListService/GetAccessList"
 	AccessListService_UpsertAccessList_FullMethodName                        = "/teleport.accesslist.v1.AccessListService/UpsertAccessList"
 	AccessListService_UpdateAccessList_FullMethodName                        = "/teleport.accesslist.v1.AccessListService/UpdateAccessList"
@@ -73,8 +74,12 @@ const (
 type AccessListServiceClient interface {
 	// GetAccessLists returns a list of all access lists.
 	GetAccessLists(ctx context.Context, in *GetAccessListsRequest, opts ...grpc.CallOption) (*GetAccessListsResponse, error)
+	// Deprecated: Do not use.
 	// ListAccessLists returns a paginated list of all access lists.
+	// Deprecated: Use ListAccessListsV2 instead.
 	ListAccessLists(ctx context.Context, in *ListAccessListsRequest, opts ...grpc.CallOption) (*ListAccessListsResponse, error)
+	// ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+	ListAccessListsV2(ctx context.Context, in *ListAccessListsV2Request, opts ...grpc.CallOption) (*ListAccessListsV2Response, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(ctx context.Context, in *GetAccessListRequest, opts ...grpc.CallOption) (*AccessList, error)
 	// UpsertAccessList creates or updates an access list resource.
@@ -167,10 +172,21 @@ func (c *accessListServiceClient) GetAccessLists(ctx context.Context, in *GetAcc
 	return out, nil
 }
 
+// Deprecated: Do not use.
 func (c *accessListServiceClient) ListAccessLists(ctx context.Context, in *ListAccessListsRequest, opts ...grpc.CallOption) (*ListAccessListsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListAccessListsResponse)
 	err := c.cc.Invoke(ctx, AccessListService_ListAccessLists_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *accessListServiceClient) ListAccessListsV2(ctx context.Context, in *ListAccessListsV2Request, opts ...grpc.CallOption) (*ListAccessListsV2Response, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListAccessListsV2Response)
+	err := c.cc.Invoke(ctx, AccessListService_ListAccessListsV2_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -455,8 +471,12 @@ func (c *accessListServiceClient) GetInheritedGrants(ctx context.Context, in *Ge
 type AccessListServiceServer interface {
 	// GetAccessLists returns a list of all access lists.
 	GetAccessLists(context.Context, *GetAccessListsRequest) (*GetAccessListsResponse, error)
+	// Deprecated: Do not use.
 	// ListAccessLists returns a paginated list of all access lists.
+	// Deprecated: Use ListAccessListsV2 instead.
 	ListAccessLists(context.Context, *ListAccessListsRequest) (*ListAccessListsResponse, error)
+	// ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+	ListAccessListsV2(context.Context, *ListAccessListsV2Request) (*ListAccessListsV2Response, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, *GetAccessListRequest) (*AccessList, error)
 	// UpsertAccessList creates or updates an access list resource.
@@ -544,6 +564,9 @@ func (UnimplementedAccessListServiceServer) GetAccessLists(context.Context, *Get
 }
 func (UnimplementedAccessListServiceServer) ListAccessLists(context.Context, *ListAccessListsRequest) (*ListAccessListsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListAccessLists not implemented")
+}
+func (UnimplementedAccessListServiceServer) ListAccessListsV2(context.Context, *ListAccessListsV2Request) (*ListAccessListsV2Response, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListAccessListsV2 not implemented")
 }
 func (UnimplementedAccessListServiceServer) GetAccessList(context.Context, *GetAccessListRequest) (*AccessList, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAccessList not implemented")
@@ -679,6 +702,24 @@ func _AccessListService_ListAccessLists_Handler(srv interface{}, ctx context.Con
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AccessListServiceServer).ListAccessLists(ctx, req.(*ListAccessListsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AccessListService_ListAccessListsV2_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAccessListsV2Request)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessListServiceServer).ListAccessListsV2(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccessListService_ListAccessListsV2_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessListServiceServer).ListAccessListsV2(ctx, req.(*ListAccessListsV2Request))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1183,6 +1224,10 @@ var AccessListService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListAccessLists",
 			Handler:    _AccessListService_ListAccessLists_Handler,
+		},
+		{
+			MethodName: "ListAccessListsV2",
+			Handler:    _AccessListService_ListAccessListsV2_Handler,
 		},
 		{
 			MethodName: "GetAccessList",

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -28,7 +28,12 @@ service AccessListService {
   // GetAccessLists returns a list of all access lists.
   rpc GetAccessLists(GetAccessListsRequest) returns (GetAccessListsResponse);
   // ListAccessLists returns a paginated list of all access lists.
-  rpc ListAccessLists(ListAccessListsRequest) returns (ListAccessListsResponse);
+  // Deprecated: Use ListAccessListsV2 instead.
+  rpc ListAccessLists(ListAccessListsRequest) returns (ListAccessListsResponse) {
+    option deprecated = true;
+  }
+  // ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+  rpc ListAccessListsV2(ListAccessListsV2Request) returns (ListAccessListsV2Response);
   // GetAccessList returns the specified access list resource.
   rpc GetAccessList(GetAccessListRequest) returns (AccessList);
   // UpsertAccessList creates or updates an access list resource.
@@ -122,7 +127,6 @@ message GetAccessListsResponse {
 message ListAccessListsRequest {
   // page_size is the size of the page to request.
   int32 page_size = 1;
-
   // next_token is the page token.
   string next_token = 2;
 }
@@ -133,6 +137,38 @@ message ListAccessListsResponse {
   repeated AccessList access_lists = 1;
   // next_token is the next page token.
   string next_token = 2;
+}
+
+// ListAccessListsV2Request is the request for getting filtered and sorted paginated access lists.
+message ListAccessListsV2Request {
+  // page_size is the size of the page to request.
+  int32 page_size = 1;
+  // page_token is the token to begin the next page with.
+  string page_token = 2;
+  // sort_by specifies the sort order for the results.
+  types.SortBy sort_by = 3;
+  // filter is a collection of fields to filter access lists.
+  AccessListsFilter filter = 4;
+}
+
+// AccessListsFilter is used to collect filter options for listing access lists.
+message AccessListsFilter {
+  // search is a search term to filter access lists by name.
+  string search = 1;
+  // owners indicates returned access lists should be owned by one of the provider owners
+  repeated string owners = 2;
+  // roles indicates returned access lists should great one of the provider roles
+  repeated string roles = 3;
+  // origin is origin of the resource
+  string origin = 4;
+}
+
+// ListAccessListsV2Response is the response for getting paginated access lists.
+message ListAccessListsV2Response {
+  // access_lists is the list of access lists.
+  repeated AccessList access_lists = 1;
+  // next_page_token is the next page token.
+  string next_page_token = 2;
 }
 
 // GetInheritedGrantsRequest is the request for getting inherited grants.

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.client.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.client.ts
@@ -66,6 +66,8 @@ import type { UpdateAccessListRequest } from "./accesslist_service_pb";
 import type { UpsertAccessListRequest } from "./accesslist_service_pb";
 import type { AccessList } from "./accesslist_pb";
 import type { GetAccessListRequest } from "./accesslist_service_pb";
+import type { ListAccessListsV2Response } from "./accesslist_service_pb";
+import type { ListAccessListsV2Request } from "./accesslist_service_pb";
 import type { ListAccessListsResponse } from "./accesslist_service_pb";
 import type { ListAccessListsRequest } from "./accesslist_service_pb";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
@@ -87,10 +89,18 @@ export interface IAccessListServiceClient {
     getAccessLists(input: GetAccessListsRequest, options?: RpcOptions): UnaryCall<GetAccessListsRequest, GetAccessListsResponse>;
     /**
      * ListAccessLists returns a paginated list of all access lists.
+     * Deprecated: Use ListAccessListsV2 instead.
      *
+     * @deprecated
      * @generated from protobuf rpc: ListAccessLists(teleport.accesslist.v1.ListAccessListsRequest) returns (teleport.accesslist.v1.ListAccessListsResponse);
      */
     listAccessLists(input: ListAccessListsRequest, options?: RpcOptions): UnaryCall<ListAccessListsRequest, ListAccessListsResponse>;
+    /**
+     * ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+     *
+     * @generated from protobuf rpc: ListAccessListsV2(teleport.accesslist.v1.ListAccessListsV2Request) returns (teleport.accesslist.v1.ListAccessListsV2Response);
+     */
+    listAccessListsV2(input: ListAccessListsV2Request, options?: RpcOptions): UnaryCall<ListAccessListsV2Request, ListAccessListsV2Response>;
     /**
      * GetAccessList returns the specified access list resource.
      *
@@ -294,7 +304,9 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
     }
     /**
      * ListAccessLists returns a paginated list of all access lists.
+     * Deprecated: Use ListAccessListsV2 instead.
      *
+     * @deprecated
      * @generated from protobuf rpc: ListAccessLists(teleport.accesslist.v1.ListAccessListsRequest) returns (teleport.accesslist.v1.ListAccessListsResponse);
      */
     listAccessLists(input: ListAccessListsRequest, options?: RpcOptions): UnaryCall<ListAccessListsRequest, ListAccessListsResponse> {
@@ -302,12 +314,21 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
         return stackIntercept<ListAccessListsRequest, ListAccessListsResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+     *
+     * @generated from protobuf rpc: ListAccessListsV2(teleport.accesslist.v1.ListAccessListsV2Request) returns (teleport.accesslist.v1.ListAccessListsV2Response);
+     */
+    listAccessListsV2(input: ListAccessListsV2Request, options?: RpcOptions): UnaryCall<ListAccessListsV2Request, ListAccessListsV2Response> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ListAccessListsV2Request, ListAccessListsV2Response>("unary", this._transport, method, opt, input);
+    }
+    /**
      * GetAccessList returns the specified access list resource.
      *
      * @generated from protobuf rpc: GetAccessList(teleport.accesslist.v1.GetAccessListRequest) returns (teleport.accesslist.v1.AccessList);
      */
     getAccessList(input: GetAccessListRequest, options?: RpcOptions): UnaryCall<GetAccessListRequest, AccessList> {
-        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        const method = this.methods[3], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAccessListRequest, AccessList>("unary", this._transport, method, opt, input);
     }
     /**
@@ -316,7 +337,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertAccessList(teleport.accesslist.v1.UpsertAccessListRequest) returns (teleport.accesslist.v1.AccessList);
      */
     upsertAccessList(input: UpsertAccessListRequest, options?: RpcOptions): UnaryCall<UpsertAccessListRequest, AccessList> {
-        const method = this.methods[3], opt = this._transport.mergeOptions(options);
+        const method = this.methods[4], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertAccessListRequest, AccessList>("unary", this._transport, method, opt, input);
     }
     /**
@@ -325,7 +346,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpdateAccessList(teleport.accesslist.v1.UpdateAccessListRequest) returns (teleport.accesslist.v1.AccessList);
      */
     updateAccessList(input: UpdateAccessListRequest, options?: RpcOptions): UnaryCall<UpdateAccessListRequest, AccessList> {
-        const method = this.methods[4], opt = this._transport.mergeOptions(options);
+        const method = this.methods[5], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateAccessListRequest, AccessList>("unary", this._transport, method, opt, input);
     }
     /**
@@ -334,7 +355,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAccessList(teleport.accesslist.v1.DeleteAccessListRequest) returns (google.protobuf.Empty);
      */
     deleteAccessList(input: DeleteAccessListRequest, options?: RpcOptions): UnaryCall<DeleteAccessListRequest, Empty> {
-        const method = this.methods[5], opt = this._transport.mergeOptions(options);
+        const method = this.methods[6], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAccessListRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -343,7 +364,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAllAccessLists(teleport.accesslist.v1.DeleteAllAccessListsRequest) returns (google.protobuf.Empty);
      */
     deleteAllAccessLists(input: DeleteAllAccessListsRequest, options?: RpcOptions): UnaryCall<DeleteAllAccessListsRequest, Empty> {
-        const method = this.methods[6], opt = this._transport.mergeOptions(options);
+        const method = this.methods[7], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAllAccessListsRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -353,7 +374,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetAccessListsToReview(teleport.accesslist.v1.GetAccessListsToReviewRequest) returns (teleport.accesslist.v1.GetAccessListsToReviewResponse);
      */
     getAccessListsToReview(input: GetAccessListsToReviewRequest, options?: RpcOptions): UnaryCall<GetAccessListsToReviewRequest, GetAccessListsToReviewResponse> {
-        const method = this.methods[7], opt = this._transport.mergeOptions(options);
+        const method = this.methods[8], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAccessListsToReviewRequest, GetAccessListsToReviewResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -363,7 +384,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: CountAccessListMembers(teleport.accesslist.v1.CountAccessListMembersRequest) returns (teleport.accesslist.v1.CountAccessListMembersResponse);
      */
     countAccessListMembers(input: CountAccessListMembersRequest, options?: RpcOptions): UnaryCall<CountAccessListMembersRequest, CountAccessListMembersResponse> {
-        const method = this.methods[8], opt = this._transport.mergeOptions(options);
+        const method = this.methods[9], opt = this._transport.mergeOptions(options);
         return stackIntercept<CountAccessListMembersRequest, CountAccessListMembersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -372,7 +393,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAccessListMembers(teleport.accesslist.v1.ListAccessListMembersRequest) returns (teleport.accesslist.v1.ListAccessListMembersResponse);
      */
     listAccessListMembers(input: ListAccessListMembersRequest, options?: RpcOptions): UnaryCall<ListAccessListMembersRequest, ListAccessListMembersResponse> {
-        const method = this.methods[9], opt = this._transport.mergeOptions(options);
+        const method = this.methods[10], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAccessListMembersRequest, ListAccessListMembersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -382,7 +403,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAllAccessListMembers(teleport.accesslist.v1.ListAllAccessListMembersRequest) returns (teleport.accesslist.v1.ListAllAccessListMembersResponse);
      */
     listAllAccessListMembers(input: ListAllAccessListMembersRequest, options?: RpcOptions): UnaryCall<ListAllAccessListMembersRequest, ListAllAccessListMembersResponse> {
-        const method = this.methods[10], opt = this._transport.mergeOptions(options);
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAllAccessListMembersRequest, ListAllAccessListMembersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -391,7 +412,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetAccessListMember(teleport.accesslist.v1.GetAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
      */
     getAccessListMember(input: GetAccessListMemberRequest, options?: RpcOptions): UnaryCall<GetAccessListMemberRequest, Member> {
-        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
     }
     /**
@@ -402,7 +423,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetStaticAccessListMember(teleport.accesslist.v1.GetStaticAccessListMemberRequest) returns (teleport.accesslist.v1.GetStaticAccessListMemberResponse);
      */
     getStaticAccessListMember(input: GetStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetStaticAccessListMemberRequest, GetStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -412,7 +433,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetAccessListOwners(teleport.accesslist.v1.GetAccessListOwnersRequest) returns (teleport.accesslist.v1.GetAccessListOwnersResponse);
      */
     getAccessListOwners(input: GetAccessListOwnersRequest, options?: RpcOptions): UnaryCall<GetAccessListOwnersRequest, GetAccessListOwnersResponse> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAccessListOwnersRequest, GetAccessListOwnersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -421,7 +442,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertAccessListMember(teleport.accesslist.v1.UpsertAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
      */
     upsertAccessListMember(input: UpsertAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertAccessListMemberRequest, Member> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
     }
     /**
@@ -432,7 +453,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertStaticAccessListMember(teleport.accesslist.v1.UpsertStaticAccessListMemberRequest) returns (teleport.accesslist.v1.UpsertStaticAccessListMemberResponse);
      */
     upsertStaticAccessListMember(input: UpsertStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertStaticAccessListMemberRequest, UpsertStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -441,7 +462,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpdateAccessListMember(teleport.accesslist.v1.UpdateAccessListMemberRequest) returns (teleport.accesslist.v1.Member);
      */
     updateAccessListMember(input: UpdateAccessListMemberRequest, options?: RpcOptions): UnaryCall<UpdateAccessListMemberRequest, Member> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateAccessListMemberRequest, Member>("unary", this._transport, method, opt, input);
     }
     /**
@@ -451,7 +472,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAccessListMember(teleport.accesslist.v1.DeleteAccessListMemberRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListMember(input: DeleteAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteAccessListMemberRequest, Empty> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAccessListMemberRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -462,7 +483,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteStaticAccessListMember(teleport.accesslist.v1.DeleteStaticAccessListMemberRequest) returns (teleport.accesslist.v1.DeleteStaticAccessListMemberResponse);
      */
     deleteStaticAccessListMember(input: DeleteStaticAccessListMemberRequest, options?: RpcOptions): UnaryCall<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteStaticAccessListMemberRequest, DeleteStaticAccessListMemberResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -472,7 +493,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAllAccessListMembersForAccessList(teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest) returns (google.protobuf.Empty);
      */
     deleteAllAccessListMembersForAccessList(input: DeleteAllAccessListMembersForAccessListRequest, options?: RpcOptions): UnaryCall<DeleteAllAccessListMembersForAccessListRequest, Empty> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAllAccessListMembersForAccessListRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -482,7 +503,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAllAccessListMembers(teleport.accesslist.v1.DeleteAllAccessListMembersRequest) returns (google.protobuf.Empty);
      */
     deleteAllAccessListMembers(input: DeleteAllAccessListMembersRequest, options?: RpcOptions): UnaryCall<DeleteAllAccessListMembersRequest, Empty> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAllAccessListMembersRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -491,7 +512,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: UpsertAccessListWithMembers(teleport.accesslist.v1.UpsertAccessListWithMembersRequest) returns (teleport.accesslist.v1.UpsertAccessListWithMembersResponse);
      */
     upsertAccessListWithMembers(input: UpsertAccessListWithMembersRequest, options?: RpcOptions): UnaryCall<UpsertAccessListWithMembersRequest, UpsertAccessListWithMembersResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpsertAccessListWithMembersRequest, UpsertAccessListWithMembersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -501,7 +522,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAccessListReviews(teleport.accesslist.v1.ListAccessListReviewsRequest) returns (teleport.accesslist.v1.ListAccessListReviewsResponse);
      */
     listAccessListReviews(input: ListAccessListReviewsRequest, options?: RpcOptions): UnaryCall<ListAccessListReviewsRequest, ListAccessListReviewsResponse> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAccessListReviewsRequest, ListAccessListReviewsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -511,7 +532,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: ListAllAccessListReviews(teleport.accesslist.v1.ListAllAccessListReviewsRequest) returns (teleport.accesslist.v1.ListAllAccessListReviewsResponse);
      */
     listAllAccessListReviews(input: ListAllAccessListReviewsRequest, options?: RpcOptions): UnaryCall<ListAllAccessListReviewsRequest, ListAllAccessListReviewsResponse> {
-        const method = this.methods[23], opt = this._transport.mergeOptions(options);
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListAllAccessListReviewsRequest, ListAllAccessListReviewsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -522,7 +543,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: CreateAccessListReview(teleport.accesslist.v1.CreateAccessListReviewRequest) returns (teleport.accesslist.v1.CreateAccessListReviewResponse);
      */
     createAccessListReview(input: CreateAccessListReviewRequest, options?: RpcOptions): UnaryCall<CreateAccessListReviewRequest, CreateAccessListReviewResponse> {
-        const method = this.methods[24], opt = this._transport.mergeOptions(options);
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
         return stackIntercept<CreateAccessListReviewRequest, CreateAccessListReviewResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -531,7 +552,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: DeleteAccessListReview(teleport.accesslist.v1.DeleteAccessListReviewRequest) returns (google.protobuf.Empty);
      */
     deleteAccessListReview(input: DeleteAccessListReviewRequest, options?: RpcOptions): UnaryCall<DeleteAccessListReviewRequest, Empty> {
-        const method = this.methods[25], opt = this._transport.mergeOptions(options);
+        const method = this.methods[26], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteAccessListReviewRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
@@ -540,7 +561,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: AccessRequestPromote(teleport.accesslist.v1.AccessRequestPromoteRequest) returns (teleport.accesslist.v1.AccessRequestPromoteResponse);
      */
     accessRequestPromote(input: AccessRequestPromoteRequest, options?: RpcOptions): UnaryCall<AccessRequestPromoteRequest, AccessRequestPromoteResponse> {
-        const method = this.methods[26], opt = this._transport.mergeOptions(options);
+        const method = this.methods[27], opt = this._transport.mergeOptions(options);
         return stackIntercept<AccessRequestPromoteRequest, AccessRequestPromoteResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -550,7 +571,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetSuggestedAccessLists(teleport.accesslist.v1.GetSuggestedAccessListsRequest) returns (teleport.accesslist.v1.GetSuggestedAccessListsResponse);
      */
     getSuggestedAccessLists(input: GetSuggestedAccessListsRequest, options?: RpcOptions): UnaryCall<GetSuggestedAccessListsRequest, GetSuggestedAccessListsResponse> {
-        const method = this.methods[27], opt = this._transport.mergeOptions(options);
+        const method = this.methods[28], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetSuggestedAccessListsRequest, GetSuggestedAccessListsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -559,7 +580,7 @@ export class AccessListServiceClient implements IAccessListServiceClient, Servic
      * @generated from protobuf rpc: GetInheritedGrants(teleport.accesslist.v1.GetInheritedGrantsRequest) returns (teleport.accesslist.v1.GetInheritedGrantsResponse);
      */
     getInheritedGrants(input: GetInheritedGrantsRequest, options?: RpcOptions): UnaryCall<GetInheritedGrantsRequest, GetInheritedGrantsResponse> {
-        const method = this.methods[28], opt = this._transport.mergeOptions(options);
+        const method = this.methods[29], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetInheritedGrantsRequest, GetInheritedGrantsResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.grpc-server.ts
@@ -63,6 +63,8 @@ import { UpdateAccessListRequest } from "./accesslist_service_pb";
 import { UpsertAccessListRequest } from "./accesslist_service_pb";
 import { AccessList } from "./accesslist_pb";
 import { GetAccessListRequest } from "./accesslist_service_pb";
+import { ListAccessListsV2Response } from "./accesslist_service_pb";
+import { ListAccessListsV2Request } from "./accesslist_service_pb";
 import { ListAccessListsResponse } from "./accesslist_service_pb";
 import { ListAccessListsRequest } from "./accesslist_service_pb";
 import { GetAccessListsResponse } from "./accesslist_service_pb";
@@ -82,10 +84,18 @@ export interface IAccessListService extends grpc.UntypedServiceImplementation {
     getAccessLists: grpc.handleUnaryCall<GetAccessListsRequest, GetAccessListsResponse>;
     /**
      * ListAccessLists returns a paginated list of all access lists.
+     * Deprecated: Use ListAccessListsV2 instead.
      *
+     * @deprecated
      * @generated from protobuf rpc: ListAccessLists(teleport.accesslist.v1.ListAccessListsRequest) returns (teleport.accesslist.v1.ListAccessListsResponse);
      */
     listAccessLists: grpc.handleUnaryCall<ListAccessListsRequest, ListAccessListsResponse>;
+    /**
+     * ListAccessListsV2 returns a paginated, filtered, and sorted list of all access lists.
+     *
+     * @generated from protobuf rpc: ListAccessListsV2(teleport.accesslist.v1.ListAccessListsV2Request) returns (teleport.accesslist.v1.ListAccessListsV2Response);
+     */
+    listAccessListsV2: grpc.handleUnaryCall<ListAccessListsV2Request, ListAccessListsV2Response>;
     /**
      * GetAccessList returns the specified access list resource.
      *
@@ -298,6 +308,16 @@ export const accessListServiceDefinition: grpc.ServiceDefinition<IAccessListServ
         requestDeserialize: bytes => ListAccessListsRequest.fromBinary(bytes),
         responseSerialize: value => Buffer.from(ListAccessListsResponse.toBinary(value)),
         requestSerialize: value => Buffer.from(ListAccessListsRequest.toBinary(value))
+    },
+    listAccessListsV2: {
+        path: "/teleport.accesslist.v1.AccessListService/ListAccessListsV2",
+        originalName: "ListAccessListsV2",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => ListAccessListsV2Response.fromBinary(bytes),
+        requestDeserialize: bytes => ListAccessListsV2Request.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(ListAccessListsV2Response.toBinary(value)),
+        requestSerialize: value => Buffer.from(ListAccessListsV2Request.toBinary(value))
     },
     getAccessList: {
         path: "/teleport.accesslist.v1.AccessListService/GetAccessList",

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_service_pb.ts
@@ -35,6 +35,7 @@ import { Review } from "./accesslist_pb";
 import { AccessListOwner } from "./accesslist_pb";
 import { Member } from "./accesslist_pb";
 import { AccessListGrants } from "./accesslist_pb";
+import { SortBy } from "../../legacy/types/types_pb";
 import { AccessList } from "./accesslist_pb";
 /**
  * GetAccessListsRequest is the request for getting all access lists.
@@ -93,6 +94,87 @@ export interface ListAccessListsResponse {
      * @generated from protobuf field: string next_token = 2;
      */
     nextToken: string;
+}
+/**
+ * ListAccessListsV2Request is the request for getting filtered and sorted paginated access lists.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.ListAccessListsV2Request
+ */
+export interface ListAccessListsV2Request {
+    /**
+     * page_size is the size of the page to request.
+     *
+     * @generated from protobuf field: int32 page_size = 1;
+     */
+    pageSize: number;
+    /**
+     * page_token is the token to begin the next page with.
+     *
+     * @generated from protobuf field: string page_token = 2;
+     */
+    pageToken: string;
+    /**
+     * sort_by specifies the sort order for the results.
+     *
+     * @generated from protobuf field: types.SortBy sort_by = 3;
+     */
+    sortBy?: SortBy;
+    /**
+     * filter is a collection of fields to filter access lists.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.AccessListsFilter filter = 4;
+     */
+    filter?: AccessListsFilter;
+}
+/**
+ * AccessListsFilter is used to collect filter options for listing access lists.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.AccessListsFilter
+ */
+export interface AccessListsFilter {
+    /**
+     * search is a search term to filter access lists by name.
+     *
+     * @generated from protobuf field: string search = 1;
+     */
+    search: string;
+    /**
+     * owners indicates returned access lists should be owned by one of the provider owners
+     *
+     * @generated from protobuf field: repeated string owners = 2;
+     */
+    owners: string[];
+    /**
+     * roles indicates returned access lists should great one of the provider roles
+     *
+     * @generated from protobuf field: repeated string roles = 3;
+     */
+    roles: string[];
+    /**
+     * origin is origin of the resource
+     *
+     * @generated from protobuf field: string origin = 4;
+     */
+    origin: string;
+}
+/**
+ * ListAccessListsV2Response is the response for getting paginated access lists.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.ListAccessListsV2Response
+ */
+export interface ListAccessListsV2Response {
+    /**
+     * access_lists is the list of access lists.
+     *
+     * @generated from protobuf field: repeated teleport.accesslist.v1.AccessList access_lists = 1;
+     */
+    accessLists: AccessList[];
+    /**
+     * next_page_token is the next page token.
+     *
+     * @generated from protobuf field: string next_page_token = 2;
+     */
+    nextPageToken: string;
 }
 /**
  * GetInheritedGrantsRequest is the request for getting inherited grants.
@@ -957,6 +1039,201 @@ class ListAccessListsResponse$Type extends MessageType<ListAccessListsResponse> 
  * @generated MessageType for protobuf message teleport.accesslist.v1.ListAccessListsResponse
  */
 export const ListAccessListsResponse = new ListAccessListsResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ListAccessListsV2Request$Type extends MessageType<ListAccessListsV2Request> {
+    constructor() {
+        super("teleport.accesslist.v1.ListAccessListsV2Request", [
+            { no: 1, name: "page_size", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "page_token", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "sort_by", kind: "message", T: () => SortBy },
+            { no: 4, name: "filter", kind: "message", T: () => AccessListsFilter }
+        ]);
+    }
+    create(value?: PartialMessage<ListAccessListsV2Request>): ListAccessListsV2Request {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.pageSize = 0;
+        message.pageToken = "";
+        if (value !== undefined)
+            reflectionMergePartial<ListAccessListsV2Request>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListAccessListsV2Request): ListAccessListsV2Request {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* int32 page_size */ 1:
+                    message.pageSize = reader.int32();
+                    break;
+                case /* string page_token */ 2:
+                    message.pageToken = reader.string();
+                    break;
+                case /* types.SortBy sort_by */ 3:
+                    message.sortBy = SortBy.internalBinaryRead(reader, reader.uint32(), options, message.sortBy);
+                    break;
+                case /* teleport.accesslist.v1.AccessListsFilter filter */ 4:
+                    message.filter = AccessListsFilter.internalBinaryRead(reader, reader.uint32(), options, message.filter);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ListAccessListsV2Request, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* int32 page_size = 1; */
+        if (message.pageSize !== 0)
+            writer.tag(1, WireType.Varint).int32(message.pageSize);
+        /* string page_token = 2; */
+        if (message.pageToken !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.pageToken);
+        /* types.SortBy sort_by = 3; */
+        if (message.sortBy)
+            SortBy.internalBinaryWrite(message.sortBy, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.accesslist.v1.AccessListsFilter filter = 4; */
+        if (message.filter)
+            AccessListsFilter.internalBinaryWrite(message.filter, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.ListAccessListsV2Request
+ */
+export const ListAccessListsV2Request = new ListAccessListsV2Request$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AccessListsFilter$Type extends MessageType<AccessListsFilter> {
+    constructor() {
+        super("teleport.accesslist.v1.AccessListsFilter", [
+            { no: 1, name: "search", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "owners", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "roles", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "origin", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<AccessListsFilter>): AccessListsFilter {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.search = "";
+        message.owners = [];
+        message.roles = [];
+        message.origin = "";
+        if (value !== undefined)
+            reflectionMergePartial<AccessListsFilter>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AccessListsFilter): AccessListsFilter {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string search */ 1:
+                    message.search = reader.string();
+                    break;
+                case /* repeated string owners */ 2:
+                    message.owners.push(reader.string());
+                    break;
+                case /* repeated string roles */ 3:
+                    message.roles.push(reader.string());
+                    break;
+                case /* string origin */ 4:
+                    message.origin = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AccessListsFilter, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string search = 1; */
+        if (message.search !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.search);
+        /* repeated string owners = 2; */
+        for (let i = 0; i < message.owners.length; i++)
+            writer.tag(2, WireType.LengthDelimited).string(message.owners[i]);
+        /* repeated string roles = 3; */
+        for (let i = 0; i < message.roles.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.roles[i]);
+        /* string origin = 4; */
+        if (message.origin !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.origin);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.AccessListsFilter
+ */
+export const AccessListsFilter = new AccessListsFilter$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ListAccessListsV2Response$Type extends MessageType<ListAccessListsV2Response> {
+    constructor() {
+        super("teleport.accesslist.v1.ListAccessListsV2Response", [
+            { no: 1, name: "access_lists", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => AccessList },
+            { no: 2, name: "next_page_token", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ListAccessListsV2Response>): ListAccessListsV2Response {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.accessLists = [];
+        message.nextPageToken = "";
+        if (value !== undefined)
+            reflectionMergePartial<ListAccessListsV2Response>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListAccessListsV2Response): ListAccessListsV2Response {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated teleport.accesslist.v1.AccessList access_lists */ 1:
+                    message.accessLists.push(AccessList.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* string next_page_token */ 2:
+                    message.nextPageToken = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ListAccessListsV2Response, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated teleport.accesslist.v1.AccessList access_lists = 1; */
+        for (let i = 0; i < message.accessLists.length; i++)
+            AccessList.internalBinaryWrite(message.accessLists[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* string next_page_token = 2; */
+        if (message.nextPageToken !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.nextPageToken);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.ListAccessListsV2Response
+ */
+export const ListAccessListsV2Response = new ListAccessListsV2Response$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class GetInheritedGrantsRequest$Type extends MessageType<GetInheritedGrantsRequest> {
     constructor() {
@@ -3004,6 +3281,7 @@ export const GetSuggestedAccessListsResponse = new GetSuggestedAccessListsRespon
 export const AccessListService = new ServiceType("teleport.accesslist.v1.AccessListService", [
     { name: "GetAccessLists", options: {}, I: GetAccessListsRequest, O: GetAccessListsResponse },
     { name: "ListAccessLists", options: {}, I: ListAccessListsRequest, O: ListAccessListsResponse },
+    { name: "ListAccessListsV2", options: {}, I: ListAccessListsV2Request, O: ListAccessListsV2Response },
     { name: "GetAccessList", options: {}, I: GetAccessListRequest, O: AccessList },
     { name: "UpsertAccessList", options: {}, I: UpsertAccessListRequest, O: AccessList },
     { name: "UpdateAccessList", options: {}, I: UpdateAccessListRequest, O: AccessList },

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/gitserver"
 	"github.com/gravitational/teleport/api/client/proto"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	accessmonitoringrules "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
@@ -1216,6 +1217,8 @@ type Cache interface {
 	GetAccessLists(context.Context) ([]*accesslist.AccessList, error)
 	// ListAccessLists returns a paginated list of access lists.
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
+	// ListAccessListsV2 returns a paginated list of access lists.
+	ListAccessListsV2(context.Context, *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
 

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -19,10 +19,12 @@ package cache
 import (
 	"cmp"
 	"context"
+	"time"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
@@ -34,7 +36,24 @@ import (
 
 type accessListIndex string
 
-const accessListNameIndex accessListIndex = "name"
+const (
+	accessListNameIndex          accessListIndex = "name"
+	accessListAuditNextDateIndex accessListIndex = "auditNextDate"
+)
+
+func accessListNameIndexFn(al *accesslist.AccessList) string {
+	return al.GetMetadata().Name
+}
+
+func accessListAuditNextDateIndexFn(al *accesslist.AccessList) string {
+	if al.Spec.Audit.NextAuditDate.IsZero() {
+		// last lexical char make sure that if ACL don't have aduit date it will be at the end.
+		// Otherwise we will compare against `0001-01-01 00:00:00` which is the first element
+		// but means that the access list is not eligible for review.
+		return "z/" + al.GetName()
+	}
+	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + al.GetName()
+}
 
 func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.AccessList, accessListIndex], error) {
 	if upstream == nil {
@@ -46,9 +65,10 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 			types.KindAccessList,
 			(*accesslist.AccessList).Clone,
 			map[accessListIndex]func(*accesslist.AccessList) string{
-				accessListNameIndex: func(al *accesslist.AccessList) string {
-					return al.GetMetadata().Name
-				},
+				// sorted by name
+				accessListNameIndex: accessListNameIndexFn,
+				// sorted by upcoming audit date. lists with no audit dates sorted to the back
+				accessListAuditNextDateIndex: accessListAuditNextDateIndexFn,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
 			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAccessLists))
@@ -90,6 +110,50 @@ func (c *Cache) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, e
 		out = append(out, n.Clone())
 	}
 	return out, nil
+}
+
+// ListAccessListsV2 returns a filtered and sorted paginated list of access lists.
+func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListsV2")
+	defer span.End()
+
+	index := accessListNameIndex
+	keyFn := accessListNameIndexFn
+
+	var isDesc bool
+	sortBy := req.GetSortBy()
+	if sortBy != nil {
+		isDesc = req.GetSortBy().IsDesc
+
+		switch sortBy.Field {
+		case "name", "":
+			index = accessListNameIndex
+			keyFn = accessListNameIndexFn
+		case "auditNextDate":
+			index = accessListAuditNextDateIndex
+			keyFn = accessListAuditNextDateIndexFn
+		default:
+			return nil, "", trace.BadParameter("unsupported sort %q but expected name or auditNextDate", sortBy.Field)
+		}
+	}
+	lister := genericLister[*accesslist.AccessList, accessListIndex]{
+		cache:           c,
+		collection:      c.collections.accessLists,
+		isDesc:          isDesc,
+		index:           index,
+		defaultPageSize: 100,
+		upstreamList: func(ctx context.Context, limit int, start string) ([]*accesslist.AccessList, string, error) {
+			return c.Config.AccessLists.ListAccessListsV2(ctx, req)
+		},
+		filter: func(al *accesslist.AccessList) bool {
+			return services.MatchAccessList(al, req.GetFilter())
+		},
+		nextToken: func(al *accesslist.AccessList) string {
+			return keyFn(al)
+		},
+	}
+	out, next, err := lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+	return out, next, trace.Wrap(err)
 }
 
 // ListAccessLists returns a paginated list of access lists.

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -272,6 +274,109 @@ func TestAccessListReviews(t *testing.T) {
 		assert.Len(t, out, 10)
 	}, 15*time.Second, 100*time.Millisecond)
 
+}
+
+func TestListAccessListsV2(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	names := []string{"apple-list", "banana-access", "cherry-management", "apple-admin", "zebra-test"}
+
+	for i, name := range names {
+		al := newAccessList(t, name, clock)
+		auditDate := clock.Now().Add(time.Duration(i) * (time.Hour) * 24)
+		// add arbitrary date so we can make sure its not just sorted by name
+		if name == "banana-access" {
+			auditDate = clock.Now().Add(100 * (time.Hour) * 24)
+		}
+		al.Spec.Audit.NextAuditDate = auditDate
+
+		_, err := p.accessLists.UpsertAccessList(ctx, al)
+		require.NoError(t, err)
+	}
+
+	testCases := []struct {
+		name            string
+		search          string
+		sortBy          *types.SortBy
+		expectedNames   []string
+		pageSize        int
+		expectedNextKey string
+		startKey        string
+	}{
+		{
+			name:          "no filter - all lists",
+			expectedNames: []string{"apple-admin", "apple-list", "banana-access", "cherry-management", "zebra-test"},
+		},
+		{
+			name:          "sort by name reverse",
+			sortBy:        &types.SortBy{Field: "name", IsDesc: true},
+			expectedNames: []string{"zebra-test", "cherry-management", "banana-access", "apple-list", "apple-admin"},
+		},
+		{
+			name:          "sort by audit date",
+			sortBy:        &types.SortBy{Field: "auditNextDate", IsDesc: false},
+			expectedNames: []string{"apple-list", "cherry-management", "apple-admin", "zebra-test", "banana-access"},
+		},
+		{
+			name:          "sort by audit date reverse",
+			sortBy:        &types.SortBy{Field: "auditNextDate", IsDesc: true},
+			expectedNames: []string{"banana-access", "zebra-test", "apple-admin", "cherry-management", "apple-list"},
+		},
+		{
+			name:            "paginated results",
+			expectedNames:   []string{"apple-admin", "apple-list"},
+			pageSize:        2,
+			expectedNextKey: "banana-access",
+		},
+		{
+			name:            "paginated results reverse",
+			expectedNames:   []string{"zebra-test", "cherry-management", "banana-access"},
+			sortBy:          &types.SortBy{Field: "name", IsDesc: true},
+			pageSize:        3,
+			expectedNextKey: "apple-list",
+		},
+		{
+			name:          "with search",
+			search:        "apple",
+			expectedNames: []string{"apple-admin", "apple-list"},
+		},
+		{
+			name:          "with startKey",
+			startKey:      "banana-access",
+			expectedNames: []string{"banana-access", "cherry-management", "zebra-test"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				results, nextToken, err := p.cache.ListAccessListsV2(ctx, &accesslistv1.ListAccessListsV2Request{
+					PageSize:  int32(tc.pageSize),
+					PageToken: tc.startKey,
+					Filter: &accesslistv1.AccessListsFilter{
+						Search: tc.search,
+					},
+					SortBy: tc.sortBy,
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedNextKey, nextToken)
+
+				assert.Len(t, results, len(tc.expectedNames))
+				actualNames := make([]string, len(results))
+				for i, al := range results {
+					actualNames[i] = al.GetName()
+				}
+
+				assert.Equal(t, tc.expectedNames, actualNames)
+			}, 5*time.Second, 100*time.Millisecond)
+		})
+	}
 }
 
 func TestCountAccessListMembersScoping(t *testing.T) {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -87,6 +87,7 @@ type accessListAndMembersGetter struct {
 func (s *accessListAndMembersGetter) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
 	return s.memberService.WithPrefix(accessListName).ListResources(ctx, pageSize, pageToken)
 }
+
 func (s *accessListAndMembersGetter) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
 	return s.service.GetResource(ctx, name)
 }
@@ -169,6 +170,24 @@ func (a *AccessListService) GetInheritedGrants(ctx context.Context, accessListID
 // ListAccessLists returns a paginated list of access lists.
 func (a *AccessListService) ListAccessLists(ctx context.Context, pageSize int, nextToken string) ([]*accesslist.AccessList, string, error) {
 	return a.service.ListResources(ctx, pageSize, nextToken)
+}
+
+// ListAccessListsV2 returns a filtered and sorted paginated list of access lists.
+func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAccessListsV2Request) ([]*accesslist.AccessList, string, error) {
+	// Currently, the backend only sorts on lexicographical keys and not
+	// based on fields within a resource
+	if req.SortBy != nil && (req.GetSortBy().Field != "name" || req.GetSortBy().IsDesc != false) {
+		return nil, "", trace.BadParameter("unsupported sort, only name:asc is supported, but got %q (desc = %t)", req.GetSortBy().Field, req.GetSortBy().IsDesc)
+	}
+
+	if req.GetFilter().Search == "" && len(req.GetFilter().Owners) == 0 && len(req.GetFilter().Roles) == 0 {
+		r, nextToken, err := a.service.ListResources(ctx, int(req.GetPageSize()), req.GetPageToken())
+		return r, nextToken, trace.Wrap(err)
+	}
+
+	return a.service.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {
+		return services.MatchAccessList(item, req.GetFilter())
+	})
 }
 
 // GetAccessList returns the specified access list resource.


### PR DESCRIPTION
This PR adds a new API to access lists service/cache that will allow us to sort by name and auditNextDate as well as filter by a search term. This will support the upcoming changes to the frontend to use pagination in the AccessListManagement pages

`e`: https://github.com/gravitational/teleport.e/pull/7121

part of https://github.com/gravitational/teleport/issues/57985