### PR TITLE
docs: update delete in TODO comment from v19 to v20

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -120,7 +120,7 @@ type MFAChallengeResponse struct {
 	WebauthnResponse *wantypes.CredentialAssertionResponse `json:"webauthn_response,omitempty"`
 	// SSOResponse is a response from an SSO MFA flow.
 	SSOResponse *SSOResponse `json:"sso_response"`
-	// TODO(Joerger): DELETE IN v19.0.0, WebauthnResponse used instead.
+	// TODO(Joerger): DELETE IN v20.0.0, WebauthnResponse used instead.
 	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse"`
 }
 


### PR DESCRIPTION
Follow up task from https://github.com/gravitational/teleport.e/pull/7100#discussion_r2298580574.

This change defers the TODO action so we preserve backwards compatibility in v19.