### PR TITLE
[v18] Fix incorrect scp exit status for OpenSSH nodes

### DIFF
--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -237,6 +237,14 @@ func (r *remoteSFTPSubsystem) Wait() error {
 		err = trace.ConnectionProblem(nil, "context is closing")
 	}
 
+	var exitStatus int
+	if err != nil {
+		exitStatus = 1
+	}
+	r.subsystem.serverContext.SendExecResult(r.subsystem.ctx, srv.ExecResult{
+		Code: exitStatus,
+	})
+
 	// emit an event to the audit log with the result of execution
 	r.subsystem.emitAuditEvent(r.subsystem.ctx, err)
 	return trace.Wrap(err)


### PR DESCRIPTION
Backport #58288 to branch/v18

changelog: Fixed incorrect scp exit status between OpenSSH clients and servers
