### PR TITLE
[v18] AWS IAM Roles Anywhere: Test connection ignores the Profile sync

### DIFF
--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -321,7 +321,7 @@ func (s *AWSRolesAnywhereService) AWSRolesAnywherePing(ctx context.Context, req 
 		return nil, trace.Wrap(err)
 	}
 
-	pingResp, err := awsra.Ping(ctx, pingClient)
+	pingResp, err := awsra.Ping(ctx, pingClient, profileARN)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -74,10 +74,10 @@ func NewPingClient(ctx context.Context, req *AWSClientConfig) (PingClient, error
 // Ping calls the following AWS API:
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListProfiles.html
 // https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ListTagsForResource.html
-// It returns a list of Roles Anywhere Profiles that are enabled.\
+// It returns a list of Roles Anywhere Profiles that are enabled.
 //
-// If profileARN is provided, it will ignore that specific Profile when counting the list of profiles.
-func Ping(ctx context.Context, clt PingClient, profileARN string) (*PingResponse, error) {
+// It will ignore any profile matching ignoredProfileARN.
+func Ping(ctx context.Context, clt PingClient, ignoredProfileARN string) (*PingResponse, error) {
 	var errs []error
 
 	profileCounter := 0
@@ -92,10 +92,10 @@ func Ping(ctx context.Context, clt PingClient, profileARN string) (*PingResponse
 			break
 		}
 		for _, profile := range profiles {
-			// Ignore disabled profiles, profiles without assigned roles and
+			// Ignore disabled profiles, profiles without assigned roles and the ignoreProfileARN.
 			if profile.Enabled &&
 				len(profile.Roles) > 0 &&
-				profile.Arn != profileARN {
+				profile.Arn != ignoredProfileARN {
 
 				profileCounter++
 			}

--- a/lib/integrations/awsra/ping_test.go
+++ b/lib/integrations/awsra/ping_test.go
@@ -75,11 +75,11 @@ func TestPing(t *testing.T) {
 				disabledProfile,
 				profileWithoutRoles,
 			},
-		})
+		}, *syncProfile.ProfileArn)
 		require.NoError(t, err)
 
 		require.Equal(t, "123456789012", resp.AccountID)
-		require.Equal(t, 2, resp.EnabledProfileCounter)
+		require.Equal(t, 1, resp.EnabledProfileCounter)
 	})
 
 }


### PR DESCRIPTION
Backport #58256 to branch/v18