### PR TITLE
VNet UI: Fix placement of Resolve button, switch to filled buttons

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -109,7 +109,7 @@ export const DiagnosticsAlert = (props: {
         </Flex>
 
         <ActionButton
-          fill="minimal"
+          fill="filled"
           intent="neutral"
           inputAlignment
           action={{
@@ -142,7 +142,7 @@ export const DiagnosticsAlert = (props: {
       buttons={
         <>
           <ActionButton
-            fill="border"
+            fill="filled"
             intent="neutral"
             inputAlignment
             action={{

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -288,7 +288,7 @@ const VnetConnectionItemBase = forwardRef<
                 width={toggleVnetButtonWidth}
                 size="small"
                 intent="neutral"
-                fill="minimal"
+                fill="filled"
                 title=""
                 onClick={e => {
                   e.stopPropagation();
@@ -329,7 +329,7 @@ const VnetConnectionItemBase = forwardRef<
             (props.showExtraRightButtons ? (
               <Button
                 intent="neutral"
-                fill="minimal"
+                fill="filled"
                 key={toggleVnetButtonKey}
                 size="small"
                 width={toggleVnetButtonWidth}

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -214,7 +214,7 @@ const VnetStatus = () => {
       </Flex>
 
       <ActionButton
-        fill="minimal"
+        fill="filled"
         intent="neutral"
         inputAlignment
         action={{

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -207,23 +207,24 @@ const VnetStatus = () => {
   const serviceInfo = serviceInfoAttempt.data;
 
   const sshConfiguredIndicator = serviceInfo.sshConfigured ? null : (
-    <Flex>
-      <ConnectionStatusIndicator status={'warning'} inline mr={2} />
-      <Text>SSH clients are not configured to use VNet</Text>
-      <Box alignSelf={'center'}>
-        <ActionButton
-          fill="minimal"
-          intent="neutral"
-          inputAlignment
-          action={{
-            onClick: () =>
-              openSSHConfigurationModal({
-                vnetSSHConfigPath: serviceInfo.vnetSshConfigPath,
-              }),
-            content: 'Resolve',
-          }}
-        />
-      </Box>
+    <Flex justifyContent="space-between" alignItems="center">
+      <Flex>
+        <ConnectionStatusIndicator status={'warning'} inline mr={2} />
+        <Text>SSH clients are not configured to use VNet</Text>
+      </Flex>
+
+      <ActionButton
+        fill="minimal"
+        intent="neutral"
+        inputAlignment
+        action={{
+          onClick: () =>
+            openSSHConfigurationModal({
+              vnetSSHConfigPath: serviceInfo.vnetSshConfigPath,
+            }),
+          content: 'Resolve',
+        }}
+      />
     </Flex>
   );
 


### PR DESCRIPTION
While investigating a customer issue, I noticed that the "Resolve" button for the SSH config is position incorrectly on Windows. This is because there was no `justify-content: space-between` on the parent. The text was just wide enough on macOS so that the issue wasn't noticeable there, but you could see it on Windows.

This might be another argument in favor of using the same font on every OS. https://github.com/gravitational/teleport/issues/55592

I also changed the buttons in the VNet panel to filled buttons. With a minimal fill, the buttons had internal padding but no borders. With a fill in place, the bottom buttons align more nicely with the top "Stop VNet" button. It's still not ideal, but that requires a ton of more work, not only because of how padding works in this component but also because the "Stop VNet" button uses a custom width (and thus has a much smaller padding than regular buttons). I tried to fix this but I gave up after like 40 minutes after finding new corner cases.

<details>
<summary>Screenshots</summary>

## Windows

| Before | After |
| --- | --- |
| <img width="416" height="301" alt="windows-before-no-issues" src="https://github.com/user-attachments/assets/e2965f68-041e-4134-b5ca-1156b6e9e363" /> | <img width="416" height="301" alt="windows-after-no-issues" src="https://github.com/user-attachments/assets/eef51e98-ddf8-4731-8257-58ff1b355768" /> |
| <img width="416" height="301" alt="windows-before-issues-found" src="https://github.com/user-attachments/assets/4060d953-eb52-498f-91b2-de50b2a06adc" /> | <img width="416" height="301" alt="windows-after-issues-found" src="https://github.com/user-attachments/assets/b5ec03e9-64c0-4343-a7ab-b19fd3506cd6" /> |

## macOS

| Before | After |
| --- | --- |
| <img width="416" height="327" alt="macos-before-no-issues" src="https://github.com/user-attachments/assets/58771847-fa35-4fcf-bb3a-49d15acd7367" /> | <img width="416" height="327" alt="macos-after-no-issues" src="https://github.com/user-attachments/assets/63bce20e-b546-484c-9ff1-1f5d5df7aa91" /> |
| <img width="416" height="327" alt="macos-before-issues-found" src="https://github.com/user-attachments/assets/cdc7998e-0a9f-49f3-b150-9d6931e28a10" /> | <img width="416" height="327" alt="macos-after-issues-found" src="https://github.com/user-attachments/assets/c8a7c7f1-93c8-4cd5-9863-c692e8448f5e" /> |

</details>