### PR TITLE
Fix nonenforcement in the Lint (Docs) style check

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: Check docs style
         working-directory: 'docs/content/current'
         run: |
-          echo "Running Vale style checks. For information about ignoring Vale rules, see: https://vale.sh/docs/formats/mdx#comments"
+          echo "Running Vale style checks. For information about ignoring Vale rules using comments, see: https://vale.sh/docs/formats/mdx#comments"
           "${GITHUB_WORKSPACE}/vale" --config docs/.vale.ini docs/pages
 
       - name: Test the docs build

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -56,15 +56,15 @@ workflow for using `tsh` to access an infrastructure resource.
 ### Log in to Teleport 
 
 Log in to your Teleport cluster, assigning <Var name="teleport.example.com" />
-to the domain name of the Teleport Proxy Service in your cluster and <Var
-name="myser" /> to your Teleport username:
+to the domain name of the Teleport Proxy Service in your cluster and 
+<Var name="myuser" /> to your Teleport username:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="myuser" />
 ```
 
-This command retrieves the user's certificates and saves them into `~/.tsh/<Var
-name="teleport.example.com" />`.
+This command retrieves the user's certificates and saves them into 
+`~/.tsh/<Var name="teleport.example.com" />`.
 
 ### List resources that you can access
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -26,7 +26,7 @@ This guide will explain how to:
 Teleport uses AWS IAM Roles Anywhere to issue temporary credentials for assuming target IAM roles.
 
 Access is managed through Teleport's RBAC policies, ensuring credentials are only generated for authorized users and roles.
-No additional service is required, as it runs in the control plane (Proxy and Auth Services).
+No additional service is required, as it runs in the control plane (Proxy Service and Auth Service).
 
 For web console access, you can navigate to the resources page in Teleport Web UI and click on the AWS Application which is named after the Roles Anywhere profile.
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -209,8 +209,10 @@ following IAM policy and attach it to the new role:
     ]
 }
 ```
-Edit the trust policy of the new role to allow the Discovery Service
-to assume it:
+
+Edit the trust policy of the new role to allow the Discovery Service to assume
+it, adding the <Var name="Discovery Service role's ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",
@@ -218,15 +220,17 @@ to assume it:
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "<Var name="discovery service role's ARN" />"
+                "AWS": "<Var name="Discovery Service role's ARN" />"
             },
             "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+
 Create the following policy in the Discovery Service's account and attach it
-to the Discovery Service's role:
+to the Discovery Service's role, adding the <Var name="new role ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -198,8 +198,10 @@ following IAM policy and attach it to the new role:
     ]
 }
 ```
+
 Edit the trust policy of the new role to allow the Discovery Service
-to assume it:
+to assume it, including the <Var name="Discovery Service role's ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",
@@ -207,15 +209,17 @@ to assume it:
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "<Var name="discovery service role's ARN" />"
+                "AWS": "<Var name="Discovery Service role's ARN" />"
             },
             "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+
 Create the following policy in the Discovery Service's account and attach it
-to the Discovery Service's role:
+to the Discovery Service's role, adding the <Var name="new role ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database Access with Amazon RDS Oracle with Kerberos Authentication
 sidebar_label: Amazon RDS Oracle
-description: How to configure Teleport Database Access with Amazon RDS Oracle with Kerberos authentication.
+description: How to enroll Amazon RDS Oracle in your Teleport cluster with Kerberos authentication.
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/alloydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/alloydb.mdx
@@ -27,7 +27,7 @@ labels:
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5: Configure GCP IAM 
-### IAM setup: roles for the database user and database service
+### IAM setup: roles for the database user and Teleport Database Service
 
 To grant Teleport access to your AlloyDB instances, you need to create two service accounts:
 - `teleport-db-service`: for the Teleport Database Service to access AlloyDB metadata.

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting Database Access
-description: Common issues and resolutions for Teleport's Database Access
+description: Common issues and resolutions for protecting databases with Teleport.
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/kubernetes-access/faq.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Access FAQ
-description: Frequently asked questions about Teleport Kubernetes Access
+description: Frequently asked questions about protecting Kubernetes clusters with Teleport.
 tags:
  - faq
  - zero-trust

--- a/docs/pages/identity-governance/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/entra-id/manual-installation.mdx
@@ -86,13 +86,14 @@ The following permissions need to be added to the application.
 
 ## Step 5/5. Install the Entra ID plugin
 
-Now run the `tctl plugins install entraid` command.
+Now run the `tctl plugins install entraid` command, including the name of the
+<Var name="Access List owner"/>:
 
 ```code
 $ tctl plugins install entraid \
     --name entra-id-default \
     --auth-connector-name entra-id \
-    --default-owner=<Var name="Access List Owner"/> \
+    --default-owner=<Var name="Access List owner"/> \
     --no-access-graph \
     --manual-setup
 ```

--- a/docs/pages/identity-governance/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/entra-id/terraform.mdx
@@ -140,8 +140,13 @@ foreach ($appRole in $appRoles) {
 
 </details>
 
-Once you have the permission IDs and the principal ID of the managed identity ready,
-create `tfvars` with your inputs.
+Once you have the permission IDs and the principal ID of the managed identity
+ready, create `tfvars` with your inputs. Assign values to the variables below:
+
+- <Var name="Permission IDs"/> 
+- <Var name="Principal ID of the managed identity"/>
+
+Enter the following command to populate your `tfvars` file:
 
 ```bash
 cat > variables.auto.tfvars << EOF

--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -376,7 +376,7 @@ Here's what you need to do:
 
 1. Set up [LiteLLM Proxy Server (LLM
    Gateway)](https://docs.litellm.ai/docs/#litellm-proxy-server-llm-gateway) on a
-   host accessible from the Teleport Auth server.
+   host accessible from the Teleport Auth Service.
 2. Add a model of your choice to the LiteLLM configuration. In this example,
    let's call it `my-custom-model`.
 3. Configure a Teleport inference model. Use `spec.openai.base_url` property to

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -14,6 +14,9 @@ of `teleport.yaml` must include at least one entry:
 
 (!docs/pages/includes/discovery/discovery-group.mdx!)
 
+Assign <Var name="teleport.example.com:443" /> to the host and port of the
+Teleport Proxy Service in your cluster:
+
 ```yaml
 # teleport.yaml
 version: v3

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-token.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-token.mdx
@@ -1,5 +1,6 @@
 Add a new entry to `spec.allow` in `token.yaml` and set `aws_account` to the
-account number of the new account.
+account number of the new account, including the 
+<Var name="destination AWS account ID" />:
 
 ```diff
 # token.yaml

--- a/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
@@ -7,10 +7,10 @@ labels:
  - ai
 ---
 
-## Enforce access and privileges for agents
+Teleport enables you to enforce access and privileges for agents.
 
-Security must be enforced deterministically; AI agents cannot be trusted to follow high-level instructions like "don't delete production". 
-Teleport solves this by issuing each agent its own identity and requiring the agent's actions (for example, database queries) to flow through the Teleport proxy. 
+Security must be enforced deterministically. AI agents cannot be trusted to follow high-level instructions like "don't delete production". 
+Teleport solves this by issuing each agent its own identity and requiring the agent's actions (for example, database queries) to flow through the Teleport Proxy Service. 
 This allows Teleport to apply Role-Based Access Control (RBAC) at both the network and protocol level.
 
 Teleport can secure infrastructure components such as SSH servers, Kubernetes clusters, databases, or MCP servers, when accessed by agents. 

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -281,8 +281,8 @@ restrictive privileges than the Argo control plane has generally. This can be
 used to create a permission boundary where applications deployed to the same
 cluster, but in different projects, cannot read or modify each other's resources.
 
-In order to use Argo CD impersonation with Teleport Kubernetes Access, your bot
-must have a role where `kubernetes_users` contains a wildcard. For example:
+In order to use Argo CD impersonation with Teleport, your bot must have a role
+where `kubernetes_users` contains a wildcard. For example:
 
 ```yaml
 kind: role
@@ -307,8 +307,8 @@ operate on application-scoped resources. Because your role has permission to
 impersonate many users, it's ambiguous which one Teleport should use by default.
 
 When `kubernetes_users` contains a wildcard, and no specific user is being
-impersonated, Kubernetes Access will fall back to sending your bot's Teleport
-username by default. You should therefore create a RoleBinding or
+impersonated, the Teleport Kubernetes Service will fall back to sending your
+bot's Teleport username by default. You should therefore create a RoleBinding or
 ClusterRoleBinding, in the **target cluster**, granting your bot user the
 broader permissions needed by the Argo CD control plane.
 
@@ -320,8 +320,8 @@ $ kubectl create clusterrolebinding example-bot-edit \
 
 <Admonition type="warning">
 When using impersonation to create a permission boundary between Argo CD
-projects, remember that Kubernetes Access will automatically impersonate any
-groups listed in `kubernetes_groups` by default.
+projects, remember that the Teleport Kubernetes Service will automatically
+impersonate any groups listed in `kubernetes_groups` by default.
 
 You should ensure that your bot user does not have any roles which contain
 `kubernetes_groups`, otherwise the privilege isolation provided by impersonating

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/mcp.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/mcp.mdx
@@ -23,7 +23,7 @@ grant human users access to MCP servers, you should instead refer to the
 
 ## How it works
 
-The Teleport Application Access agent is deployed in front of the MCP server
+The Teleport Application Service agent is deployed in front of the MCP server
 that you wish to protect access to. This agent is responsible for enforcing
 access control based on roles configured in Teleport.
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -611,6 +611,8 @@ for Kubernetes sessions together with the user and session fields above.
 The following database session fields can be used in `where` expressions to filter access
 for database sessions together with the user and session fields above.
 
+{/* vale messaging.capitalization = NO */}
+
 | Database Session Field | Description | Type |
 |---|---|---|
 | `session.db_service` | The name of the database service where the session took place. | `string` |
@@ -620,6 +622,8 @@ for database sessions together with the user and session fields above.
 | `session.db_user` | The database user used during the session. | `string` |
 | `session.db_labels` | The labels assigned to the database where the session took place. | `dict<string, string>` |
 | `session.db_type` | The type of the database (e.g., "postgres", "mysql"). | `string` |
+
+{/* vale messaging.capitalization = YES */}
 
 </TabItem>
 <TabItem value="Windows Desktop Sessions" label="Windows Desktop Sessions">

--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -110,10 +110,11 @@ Any encryption keys are provisioned using the same key storage backend
 configured for CAs.
 
 <Admonition type="note">
-In distributed HA environments where there are multiple Teleport Auth Services,
-it is important that all services have access to the same key storage backend
-and keys. Otherwise availability of session replay may be degraded. This holds
-true even when using [Manual Encryption Key Management](#manual-encryption-key-management).
+In distributed HA environments where there are multiple Teleport Auth Service
+instances, it is important that all services have access to the same key storage
+backend and keys. Otherwise availability of session replay may be degraded. This
+holds true even when using [Manual Encryption Key
+Management](#manual-encryption-key-management).
 </Admonition>
 
 ### Record at the SSH node
@@ -315,9 +316,9 @@ configuration from a corresponding `inference_model` resource to generate
 session recording. The inference model specifies, among other options, which
 inference provider and provider-specific model is used to generate a summary.
 
-No more than 150 concurrent summary jobs will be executed per Auth Service. If
-more sessions arrive, the auth server will wait until the previous ones are
-summarized.
+No more than 150 concurrent summary jobs will be executed per Auth Service
+instance. If more sessions arrive, the Auth Service instance will wait until the
+previous ones are summarized.
 
 Session recording summaries are stored along with session recordings and can be
 viewed using the Teleport web app.

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -288,7 +288,7 @@ This join method is recommended for on-prem environments
 without a specialized [delegated join method](#delegated-join-methods).
 
 At this time, `bound_keypair` can only be used to join Machine and Workload ID
-bots, and cannot be used to join other Teleport agent types.
+bots, and cannot be used to join other Teleport Agent types.
 
 (!docs/pages/includes/provision-token/bound-keypair-spec.mdx!)
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportAccessList`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportAppV3`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportAutoupdateConfigV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportAutoupdateVersionV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportBotV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportDatabaseV3`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportGithubConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportLoginRule`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportOIDCConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportOktaImportRule`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportOpenSSHEICEServerV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportOpenSSHServerV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportProvisionToken`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportRole`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportRoleV6`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportRoleV7`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportRoleV8`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportSAMLConnector`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportTrustedClusterV2`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportUser`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide is a comprehensive reference to the fields in the `TeleportWorkloadIdentityV1`
 resource, which you can apply after installing the Teleport Kubernetes operator.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
 Follow [the database dynamic registration guide](../../../../enroll-resources/database-access/guides/dynamic-registration.mdx)
 to complete deploying a database_service and access the database resource

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
@@ -10,6 +10,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
 
 

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
@@ -23,7 +23,7 @@ Bound Keypair Joining is available in v18.1.0 and is intended to replace `token`
 joining as the default recommended join method in Teleport v19.0.0.
 
 At this time, Bound Keypair Joining can only be used to join Machine and
-Workload ID bots and cannot be used to join other Teleport agent types.
+Workload ID bots and cannot be used to join other Teleport Agent types.
 </Admonition>
 
 ## Use cases

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
@@ -307,7 +307,7 @@ the values we wrote previously.
 
 Finally deploy the Teleport Kubernetes Agent using the values we previously set in the provision token:
 - The namespace in which you will deploy the agent: <Var name="teleport"/>
-- The name of the Teleport agent release: <Var name="teleport-agent"/>
+- The name of the Teleport Agent release: <Var name="teleport-agent"/>
 
 ```code
 $ helm upgrade --install <Var name="teleport-agent"/> teleport/teleport-kube-agent \

--- a/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
@@ -8,10 +8,14 @@ labels:
  - azure
 ---
 
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide shows how to configure Microsoft Entra ID (formerly Azure AD) as an 
 OIDC identity provider for Teleport. With this configuration, users can access 
 Teleport by authenticating with Entra ID, and be granted with permissions to 
 access or manage resource in Teleport based on their group membership in Entra ID.
+
+{/* vale 3rd-party-products.former-names = YES */}
 
 A SAML-based Entra ID IdP configuration version is available in this [guide](entra-id.mdx).
 
@@ -159,10 +163,14 @@ Entra ID are preserved as user's traits in the user resource.
 
 ### (Optional) Groups overage claim
 
+{/* vale 3rd-party-products.former-names = NO */}
+
 If user's group membership exceeds the 200 group limit, Microsoft Entra ID issues a
 groups overage claim instead of the expected `groups` claim. The groups overage 
 claim contains an Azure AD Graph API link, which indicates that the user's group 
 membership is to be queried from the Microsoft Graph API. 
+
+{/* vale 3rd-party-products.former-names = YES */}
 
 If your user's group membership do not exceed the group limit, you can skip this
 step. Otherwise, you will need to grant Teleport with a Microsoft Graph API 
@@ -196,7 +204,23 @@ Microsoft Graph API.
 Before creating the Auth Connector resource, its useful to first generate the 
 configuration spec and test the configuration.
 
-The Auth Connector spec can be configured by using the `tctl sso configure` command. 
+The Auth Connector spec can be configured by using the `tctl sso configure`
+command. We will show you how to run the command with the following flags:
+
+- `--name`: Teleport resource name for the Microsoft Entra ID Auth Connector. 
+- `--display`: Display name for the Microsoft Entra ID Auth Connector
+- `--issuer-url`: Microsoft Entra ID OIDC issuer URL. You need your Microsoft Entra 
+  ID tenant ID to configure this URL. Assign it to <Var name="Entra ID tenant ID" />.
+- `--id`: The application (client) ID of the enterprise application you created in 
+  Step 2. This value can be copied from the "Overview" section of the enterprise 
+  application in the Azure Portal. Assign it to <Var name="Enterprise application client ID" />.
+- `--secret`: The client secret we created in Step 4.
+- `--claims-to-roles`: A mapping of OIDC claims/values to be associated with
+  Teleport roles. Note that the Entra ID `groups` claim includes group's object
+  ID. As such, you will need to map groups by using groups object ID. Assign
+  <Var name="Object ID of ad-app-admin group" /> to the object ID ot
+  `ad-app-admin` and <Var name="Object ID of ad-app-support group" /> to the
+  object ID of `ad-app-support`:
 
 ```code
 $ tctl sso configure oidc --name "entra-id" \
@@ -210,18 +234,6 @@ $ tctl sso configure oidc --name "entra-id" \
   --scope email \
   --scope profile > entraid-oidc-connector.yaml
 ```
-
-- `--name`: Teleport resource name for the Microsoft Entra ID Auth Connector. 
-- `--display`: Display name for the Microsoft Entra ID Auth Connector
-- `--issuer-url`: Microsoft Entra ID OIDC issuer URL. You need your Microsoft Entra 
-  ID tenant ID to configure this URL.
-- `--id`: The application (client) ID of the enterprise application you created in 
-  Step 2. This value can be copied from the "Overview" section of the enterprise 
-  application in the Azure Portal. 
-- `--secret`: The client secret we created in Step 4.
-- `--claims-to-roles`: A mapping of OIDC claims/values to be associated with
-  Teleport roles. Note that the Entra ID `groups` claim includes group's object ID.
-  As such, you will need to map groups by using groups object ID.
 
 <details>
 <summary>Example YAML Auth Connector resource file created by the `tctl sso configure` command</summary>
@@ -245,7 +257,7 @@ spec:
   client_secret: example-secret-value
   display: Entra ID
   issuer_url: https://login.microsoftonline.com/0297d2f3-62c3-4598-aaa1-2104929ba73c/v2.0
-  redirect_url: https://example.teleport.sh:443/v1/webapi/oidc/callback
+  redirect_url: https://<Var name="example.teleport.sh" />:443/v1/webapi/oidc/callback
   scope:
   - openid
   - email

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -8,10 +8,14 @@ tags:
  - azure
 ---
 
+{/* vale 3rd-party-products.former-names = NO */}
+
 This guide will cover how to configure Microsoft Entra ID (formerly Azure AD) as
 a SAML identity provider to issue credentials to specific groups of users with 
 a SAML Authentication Connector. When used in combination with role-based access 
 control (RBAC), it allows Teleport administrators to define policies like:
+
+{/* vale 3rd-party-products.former-names = YES */}
 
 - Only members of the "DBA" Microsoft Entra ID group can connect to PostgreSQL
   databases.

--- a/docs/vale-styles/3rd-party-products/aws-vs-amazon.yml
+++ b/docs/vale-styles/3rd-party-products/aws-vs-amazon.yml
@@ -15,7 +15,7 @@
 #   /^AWS /{ print gensub(/AWS (.*)/,"  \"Amazon \\1\"","1") ": " $0}'
 extends: substitution
 message: "Incorrect AWS product name. Use %s instead of %s."
-level: warning
+level: error
 ignorecase: true
 swap:
   "Amazon Account Management": AWS Account Management

--- a/docs/vale-styles/3rd-party-products/former-names.yml
+++ b/docs/vale-styles/3rd-party-products/former-names.yml
@@ -5,7 +5,7 @@ scope:
   - list
   - paragraph
 message: Use '%s' instead of '%s', which is an outdated product name.
-level: warning
+level: error
 swap:
   Azure AD: Microsoft Entra ID
   Azure Active Directory: Microsoft Entra ID

--- a/docs/vale-styles/examples/teleport-accounts.yml
+++ b/docs/vale-styles/examples/teleport-accounts.yml
@@ -1,7 +1,7 @@
 extends: substitution
 message: "Incorrect example of a Teleport account URL. Use %s instead of %s."
 scope: raw # So we can catch instances in code fences
-level: warning
+level: error
 scope:
 ignorecase: true
 swap:

--- a/docs/vale-styles/messaging/capitalization.yml
+++ b/docs/vale-styles/messaging/capitalization.yml
@@ -5,7 +5,7 @@ scope:
   - list
   - paragraph
 message: "Capitalize the names of Teleport services and features (%s is incorrect). See the Core Concepts page (https://goteleport.com/docs/core-concepts/) for a reference."
-level: warning
+level: error
 ignorecase: false
 tokens:
   # Allow for mentions of a local proxy service, but not "proxy service".
@@ -19,7 +19,7 @@ tokens:
   - db service
   - desktop service
   - discovery service
-  - kubernetes service
+  - 'kubernetes service (?!account)'
   - machine id
   - ssh service
   - Teleport agent

--- a/docs/vale-styles/messaging/consistent-terms.yml
+++ b/docs/vale-styles/messaging/consistent-terms.yml
@@ -7,7 +7,7 @@ scope:
   - list
   - paragraph
 message: For consistent product messaging in the docs, use '%s' instead of '%s'.
-level: warning
+level: error
 # Ignoring case because this rule is about word choice, rather than its
 # presentation/format.
 ignorecase: true

--- a/docs/vale-styles/messaging/protocol-products.yml
+++ b/docs/vale-styles/messaging/protocol-products.yml
@@ -1,7 +1,9 @@
 extends: existence
 message: Avoid the impression that Teleport consists of multiple products for secure access, e.g., "Database Access" or "Server Access". Instead, talk about enrolling resources in your Teleport cluster, protecting resources with Teleport, or the ability for Teleport to proxy various protocols.
-level: warning
+level: error
 ignorecase: false
+scope:
+  - '~text.frontmatter.title & ~text.frontmatter.sidebar_label'
 tokens:
   - 'Server Access'
   - 'Application Access'

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -56,6 +56,10 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/operator and run "make crd-docs".*/}
 
+{/* Disable the outdated name check since custom resource fields occasionally
+need to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 {{.Intro}}
 
 {{ range .Sections}}

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -10,6 +10,10 @@ tags:
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
+{/* Disable the outdated name check since data source fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -10,6 +10,10 @@ tags:
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
+{/* Disable the outdated name check since resource fields occasionally need
+to refer to these. */}
+{/* vale 3rd-party-products.former-names = NO */}
+
 This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
 {{ includefileifexists (printf "./examples/resources/%s/introduction.md" .Name)}}
 


### PR DESCRIPTION
The step of the Lint (Docs) GitHub Actions workflow that checks prose style using the Vale linter currently always passes because no Vale styles have the `error` level.

This change fixes the remaining Vale warnings and sets most Vale styles to the `error` level so the prose check makes a difference in CI. It Keeps the warning level for rules with the `raw` scope since they cannot be ignored with MDX comments. The plan is to move these to remark so authors can ignore them if necessary.

Edit the `capitalization` Vale rule to allow "kubernetes service account" (though it may be necessary to enforce "Kubernetes" capitalization at some point in a separate style rule).

Also clarify the message printed to the top of the style check output re: ignoring Vale rules using comments.