### PR TITLE
Hardcode the lowest supported Connect versions that support managed updates

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -26,7 +26,6 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 import { createConfigServiceClient } from '../services/config';
 import { openTabContextMenu } from './contextMenus/tabContextMenu';
 import { openTerminalContextMenu } from './contextMenus/terminalContextMenu';
-import { deserializeError } from './ipcSerializer';
 import {
   AgentProcessState,
   ChildProcessAddresses,

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -234,9 +234,6 @@ export default function createMainProcessClient(): MainProcessClient {
     },
     subscribeToAppUpdateEvents: listener => {
       const ipcListener = (_, updateEvent: AppUpdateEvent) => {
-        if (updateEvent.kind === 'error') {
-          updateEvent.error = deserializeError(updateEvent.error);
-        }
         listener(updateEvent);
       };
 

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
@@ -136,8 +136,8 @@ test('auto-downloads update when all clusters are reachable', async () => {
         {
           clusterUri: '/clusters/foo',
           toolsAutoUpdate: true,
-          toolsVersion: '18.0.0',
-          minToolsVersion: '17.0.0-aa',
+          toolsVersion: '19.0.0',
+          minToolsVersion: '18.0.0-aa',
         },
       ],
       unreachableClusters: [],
@@ -168,8 +168,8 @@ test('does not auto-download update when there are unreachable clusters', async 
         {
           clusterUri: '/clusters/foo',
           toolsAutoUpdate: true,
-          toolsVersion: '18.0.0',
-          minToolsVersion: '17.0.0-aa',
+          toolsVersion: '19.0.0',
+          minToolsVersion: '18.0.0-aa',
         },
       ],
       unreachableClusters: [
@@ -198,8 +198,8 @@ test('does not auto-download update when all clusters are reachable and noAutoDo
         {
           clusterUri: '/clusters/foo',
           toolsAutoUpdate: true,
-          toolsVersion: '18.0.0',
-          minToolsVersion: '17.0.0-aa',
+          toolsVersion: '19.0.0',
+          minToolsVersion: '18.0.0-aa',
         },
       ],
       unreachableClusters: [],
@@ -222,8 +222,8 @@ test('discards previous update if a new one is found that should not auto-downlo
       {
         clusterUri: '/clusters/foo',
         toolsAutoUpdate: true,
-        toolsVersion: '18.0.0',
-        minToolsVersion: '17.0.0-aa',
+        toolsVersion: '19.0.0',
+        minToolsVersion: '18.0.0-aa',
       },
     ],
     unreachableClusters: [],
@@ -240,7 +240,7 @@ test('discards previous update if a new one is found that should not auto-downlo
     expect.objectContaining({
       kind: 'update-downloaded',
       update: expect.objectContaining({
-        version: '18.0.0',
+        version: '19.0.0',
       }),
     })
   );
@@ -249,16 +249,16 @@ test('discards previous update if a new one is found that should not auto-downlo
     {
       clusterUri: '/clusters/foo',
       toolsAutoUpdate: true,
-      toolsVersion: '18.0.0',
-      minToolsVersion: '17.0.0-aa',
+      toolsVersion: '19.0.0',
+      minToolsVersion: '18.0.0-aa',
     },
 
     // This cluster is on newer version, so it will be providing updates.
     {
       clusterUri: '/clusters/bar',
       toolsAutoUpdate: true,
-      toolsVersion: '18.0.1',
-      minToolsVersion: '17.0.0-aa',
+      toolsVersion: '19.0.1',
+      minToolsVersion: '18.0.0-aa',
     },
   ];
   await setup.appUpdater.checkForUpdates({ noAutoDownload: true });
@@ -268,7 +268,7 @@ test('discards previous update if a new one is found that should not auto-downlo
       autoDownload: false,
       kind: 'update-available',
       update: expect.objectContaining({
-        version: '18.0.1',
+        version: '19.0.1',
       }),
     })
   );
@@ -283,8 +283,8 @@ test('discards previous update if the latest check returns no update', async () 
       {
         clusterUri: '/clusters/foo',
         toolsAutoUpdate: true,
-        toolsVersion: '18.0.0',
-        minToolsVersion: '17.0.0-aa',
+        toolsVersion: '19.0.0',
+        minToolsVersion: '18.0.0-aa',
       },
     ],
     unreachableClusters: [],
@@ -301,7 +301,7 @@ test('discards previous update if the latest check returns no update', async () 
     expect.objectContaining({
       kind: 'update-downloaded',
       update: expect.objectContaining({
-        version: '18.0.0',
+        version: '19.0.0',
       }),
     })
   );

--- a/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
+++ b/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
@@ -74,7 +74,7 @@ export class ClientToolsUpdateProvider extends Provider<UpdateInfo> {
     const { baseUrl, version } = clientTools;
     const updatesSupport = areManagedUpdatesSupportedInConnect(version);
     if (updatesSupport.supported === false) {
-      throw new UnsupportedVersionError(updatesSupport.minVersion);
+      throw new UnsupportedVersionError(version, updatesSupport.minVersion);
     }
 
     const fileUrl = `${baseUrl}/${makeDownloadFilename(this.nativeUpdater, version)}`;

--- a/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
+++ b/web/packages/teleterm/src/services/appUpdater/clientToolsUpdateProvider.ts
@@ -29,6 +29,10 @@ import {
 } from 'electron-updater';
 import { ProviderRuntimeOptions } from 'electron-updater/out/providers/Provider';
 
+import { compare, major } from 'shared/utils/semVer';
+
+import { UnsupportedVersionError } from './errors';
+
 const CHECKSUM_FETCH_TIMEOUT = 5_000;
 // Example: 99a2fe26681073de56de4229dd9cd6655fef22759579b7b9bc359e018ea1007099a2fe26681073de56de4229dd9cd6655fef22759579b7b9bc359e018ea10070  Teleport Connect-17.5.4-mac.zip
 const CHECKSUM_FORMAT = /^.+\s+.+$/;
@@ -68,6 +72,11 @@ export class ClientToolsUpdateProvider extends Provider<UpdateInfo> {
     }
 
     const { baseUrl, version } = clientTools;
+    const updatesSupport = areManagedUpdatesSupportedInConnect(version);
+    if (updatesSupport.supported === false) {
+      throw new UnsupportedVersionError(updatesSupport.minVersion);
+    }
+
     const fileUrl = `${baseUrl}/${makeDownloadFilename(this.nativeUpdater, version)}`;
     const sha512 = await fetchChecksum(fileUrl);
 
@@ -145,4 +154,29 @@ async function fetchChecksum(fileUrl: string): Promise<string> {
   }
 
   return checksumText.split(' ').at(0);
+}
+
+// TODO(gzdunek) DELETE IN v20.0.0
+function areManagedUpdatesSupportedInConnect(
+  version: string
+): { supported: true } | { supported: false; minVersion: string } {
+  const thresholds = {
+    18: '18.2.0',
+    17: '17.7.3',
+  };
+
+  const majorVersion = major(version);
+  if (majorVersion >= 19) {
+    return { supported: true };
+  }
+
+  const minVersion = thresholds[majorVersion];
+  if (!minVersion) {
+    // For any lower version show v17 as the min supported version.
+    return { supported: false, minVersion: thresholds['17'] };
+  }
+
+  return compare(version, minVersion) >= 0
+    ? { supported: true }
+    : { supported: false, minVersion };
 }

--- a/web/packages/teleterm/src/services/appUpdater/errors.ts
+++ b/web/packages/teleterm/src/services/appUpdater/errors.ts
@@ -22,9 +22,9 @@
  * Kept in a separate file to allow importing in the renderer process.
  */
 export class UnsupportedVersionError extends Error {
-  constructor(minVersion: string) {
+  constructor(wantedVersion: string, minVersion: string) {
     super(
-      `Teleport Connect cannot update to this version. Managed updates are supported in version ${minVersion} and later.`
+      `Teleport Connect cannot update to version ${wantedVersion}. Managed updates are supported in version ${minVersion} and later.`
     );
     this.name = 'UnsupportedVersionError';
   }

--- a/web/packages/teleterm/src/services/appUpdater/errors.ts
+++ b/web/packages/teleterm/src/services/appUpdater/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Thrown when the app cannot be updated to unsupported version.
+ *
+ * Kept in a separate file to allow importing in the renderer process.
+ */
+export class UnsupportedVersionError extends Error {
+  constructor(minVersion: string) {
+    super(
+      `Teleport Connect cannot update to this version. Managed updates are supported in version ${minVersion} and later.`
+    );
+    this.name = 'UnsupportedVersionError';
+  }
+}

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdaterContext.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdaterContext.tsx
@@ -26,6 +26,7 @@ import {
   useState,
 } from 'react';
 
+import { deserializeError } from 'teleterm/mainProcess/ipcSerializer';
 import { type AppUpdateEvent } from 'teleterm/services/appUpdater';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
@@ -48,7 +49,12 @@ export function AppUpdaterContextProvider(props: PropsWithChildren) {
 
   useEffect(() => {
     const { cleanup: cleanUpEvents } =
-      appContext.mainProcessClient.subscribeToAppUpdateEvents(setUpdateEvent);
+      appContext.mainProcessClient.subscribeToAppUpdateEvents(event => {
+        if (event.kind === 'error') {
+          event.error = deserializeError(event.error);
+        }
+        setUpdateEvent(event);
+      });
     const { cleanup: cleanUpDialog } =
       appContext.mainProcessClient.subscribeToOpenAppUpdateDialog(openDialog);
 

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -34,6 +34,7 @@ import { Checks, Info } from 'design/Icon';
 
 import { Platform } from 'teleterm/mainProcess/types';
 import { AppUpdateEvent, UpdateInfo } from 'teleterm/services/appUpdater';
+import { UnsupportedVersionError } from 'teleterm/services/appUpdater/errors';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { AutoUpdatesManagement } from './AutoUpdatesManagement';
@@ -172,7 +173,11 @@ function UpdaterState({
             <AvailableUpdate update={event.update} platform={platform} />
           )}
           <Alert mb={1} details={event.error.message}>
-            {event.update ? 'Update failed' : 'Unable to check for app updates'}
+            {event.update
+              ? 'Update failed'
+              : event.error.name === UnsupportedVersionError.name
+                ? 'Incompatible managed update version'
+                : 'Unable to check for app updates'}
           </Alert>
           <ButtonSecondary block onClick={onCheckForAppUpdates}>
             Try Again

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -172,7 +172,7 @@ function UpdaterState({
           {event.update && (
             <AvailableUpdate update={event.update} platform={platform} />
           )}
-          <Alert mb={1} details={event.error.message}>
+          <Alert mb={1} details={event.error.message} width="100%">
             {event.update
               ? 'Update failed'
               : event.error.name === UnsupportedVersionError.name

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -87,6 +87,7 @@ export function WidgetView({
       <Alert
         kind="danger"
         mb={0}
+        {...rest}
         details={
           <Stack gap={2}>
             {issueRequiringAttention}

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -100,13 +100,6 @@ export function WidgetView({
     );
   }
 
-  if (
-    updateEvent.kind === 'error' &&
-    updateEvent.error.name === UnsupportedVersionError.name
-  ) {
-    return;
-  }
-
   // If an error occurred when there was no update info, return early.
   if (updateEvent.kind === 'error' && !updateEvent.update) {
     return (
@@ -122,7 +115,9 @@ export function WidgetView({
           </Stack>
         }
       >
-        Unable to check for app updates
+        {updateEvent.error.name === UnsupportedVersionError.name
+          ? 'Incompatible managed update version'
+          : 'Unable to check for app updates'}
       </Alert>
     );
   }

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -38,6 +38,7 @@ import {
   AppUpdateEvent,
   AutoUpdatesStatus,
 } from 'teleterm/services/appUpdater';
+import { UnsupportedVersionError } from 'teleterm/services/appUpdater/errors';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import {
@@ -97,6 +98,13 @@ export function WidgetView({
         App updates are disabled
       </Alert>
     );
+  }
+
+  if (
+    updateEvent.kind === 'error' &&
+    updateEvent.error.name === UnsupportedVersionError.name
+  ) {
+    return;
   }
 
   // If an error occurred when there was no update info, return early.


### PR DESCRIPTION
This prevents Connect from attempting to update to a version that doesn't support managed updates. This could result in bad UX:
* The app wouldn't be able to update itself to the newer version.
* Older releases don't have SHA-512 checksums, so the update would fail anyway (showing an error during login).
