### PR TITLE
docs: fix table in backup restore

### DIFF
--- a/docs/pages/zero-trust-access/management/operations/backup-restore.mdx
+++ b/docs/pages/zero-trust-access/management/operations/backup-restore.mdx
@@ -71,8 +71,7 @@ full explanation in [Storage Backends](../../../reference/backends.mdx#etcd).)
 | - | - |
 | Local Filesystem | Back up the data directory (`/var/lib/teleport/` by default) |
 | S3 | [Amazon S3 documentation](https://docs.aws.amazon.com/aws-backup/latest/devguide/s3-backups.html) |
-| GCS | GCS has [built-in
-redundancy](https://cloud.google.com/storage/docs/availability-durability), but you may also use [cross-bucket replication](https://cloud.google.com/storage/docs/using-cross-bucket-replication) |
+| GCS | GCS has [built-in redundancy](https://cloud.google.com/storage/docs/availability-durability), but you may also use [cross-bucket replication](https://cloud.google.com/storage/docs/using-cross-bucket-replication) |
 | Azure Blob Storage | [Azure Blob backup documentation](https://learn.microsoft.com/en-us/azure/backup/blob-backup-overview)|
 
 ## Versioning dynamic resources with infrastructure as code


### PR DESCRIPTION
A cell got garbled with a extra line space.