### PR TITLE
core scope pinning logic

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -44,11 +44,12 @@ import (
 )
 
 type APIConfig struct {
-	PluginRegistry plugin.Registry
-	AuthServer     *Server
-	AuditLog       events.AuditLogSessionStreamer
-	Authorizer     authz.Authorizer
-	Emitter        apievents.Emitter
+	PluginRegistry   plugin.Registry
+	AuthServer       *Server
+	AuditLog         events.AuditLogSessionStreamer
+	Authorizer       authz.Authorizer
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Emitter          apievents.Emitter
 	// KeepAlivePeriod defines period between keep alives
 	KeepAlivePeriod time.Duration
 	// KeepAliveCount specifies amount of missed keep alives

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -71,6 +71,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
@@ -123,6 +124,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/release"
 	"github.com/gravitational/teleport/lib/resourceusage"
+	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccesscache "github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -648,7 +650,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Services:                  services,
 		Cache:                     services,
 		scopedAccessBackend:       cfg.ScopedAccess,
-		scopedAccessCache:         scopedAccessCache,
+		ScopedAccessCache:         scopedAccessCache,
 		keyStore:                  cfg.KeyStore,
 		traceClient:               cfg.TraceClient,
 		fips:                      cfg.FIPS,
@@ -1120,9 +1122,9 @@ type Server struct {
 	// method on Services instead.
 	authclient.Cache
 
-	// scopedAccessCache is a specialized cache that provides read methods for select
+	// ScopedAccessCache is a specialized cache that provides read methods for select
 	// scoped access control resources.
-	scopedAccessCache *scopedaccesscache.Cache
+	ScopedAccessCache *scopedaccesscache.Cache
 
 	// scopedAccessBackend is the backend service for scoped access control resources.
 	scopedAccessBackend services.ScopedAccess
@@ -1334,6 +1336,18 @@ func (a *Server) SetLicense(license *liblicense.License) {
 // SetReleaseService sets the release service
 func (a *Server) SetReleaseService(svc release.Client) {
 	a.releaseService = svc
+}
+
+// ScopedAccess returns an implementation of services.ScopedAccess with all read methods routed
+// to the scoped access cache.
+func (a *Server) ScopedAccess() services.ScopedAccess {
+	return struct {
+		services.ScopedAccessReader
+		services.ScopedAccessWriter
+	}{
+		ScopedAccessReader: a.ScopedAccessCache,
+		ScopedAccessWriter: a.scopedAccessBackend,
+	}
 }
 
 // SetUpgradeWindowStartHourGetter sets the getter used to sync the ClusterMaintenanceConfig resource
@@ -2175,8 +2189,8 @@ func (a *Server) Close() error {
 		}
 	}
 
-	if a.scopedAccessCache != nil {
-		if err := a.scopedAccessCache.Close(); err != nil {
+	if a.ScopedAccessCache != nil {
+		if err := a.ScopedAccessCache.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -2422,8 +2436,12 @@ type certRequest struct {
 	// impersonator is a user who generates the certificate,
 	// is set when different from the user in the certificate
 	impersonator string
-	// checker is used to perform RBAC checks.
-	checker services.AccessChecker
+
+	// checker is an access checker that may either be scoped or unscoped. used to generate various
+	// certificate parameters, some of which differ depending on whether the cert being generated
+	// is scoped or not.
+	checker *services.SplitAccessChecker
+
 	// ttl is Duration of the certificate
 	ttl time.Duration
 	// compatibility is compatibility mode
@@ -2637,7 +2655,7 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 		user:            req.User,
 		sshPublicKey:    req.PublicKey,
 		compatibility:   constants.CertificateFormatStandard,
-		checker:         checker,
+		checker:         services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to OpenSSH certs.
 		ttl:             sessionTTL,
 		traits:          req.User.GetTraits(),
 		routeToCluster:  req.Cluster,
@@ -2705,7 +2723,7 @@ func (a *Server) GenerateUserTestCertsWithContext(ctx context.Context, req Gener
 		sshPublicKey:                     req.SSHPubKey,
 		tlsPublicKey:                     req.TLSPubKey,
 		routeToCluster:                   req.RouteToCluster,
-		checker:                          checker,
+		checker:                          services.NewUnscopedSplitAccessChecker(checker),
 		traits:                           userState.GetTraits(),
 		loginIP:                          req.PinnedIP,
 		pinIP:                            req.PinnedIP != "",
@@ -2792,7 +2810,7 @@ func (a *Server) GenerateUserAppTestCert(req AppTestCertRequest) ([]byte, error)
 	certs, err := a.generateUserCert(ctx, certRequest{
 		user:         userState,
 		tlsPublicKey: req.PublicKey,
-		checker:      checker,
+		checker:      services.NewUnscopedSplitAccessChecker(checker),
 		ttl:          req.TTL,
 		// Set the login to be a random string. Application certificates are never
 		// used to log into servers but SSH certificate generation code requires a
@@ -2856,7 +2874,7 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 		tlsPublicKey: req.PublicKey,
 		loginIP:      req.PinnedIP,
 		pinIP:        req.PinnedIP != "",
-		checker:      checker,
+		checker:      services.NewUnscopedSplitAccessChecker(checker),
 		ttl:          time.Hour,
 		traits: map[string][]string{
 			constants.TraitLogins: {req.Username},
@@ -3190,7 +3208,7 @@ func (a *Server) augmentUserCertificates(
 		return nil, trace.Wrap(err)
 	}
 	if err := a.verifyLocksForUserCerts(verifyLocksForUserCertsReq{
-		checker:              opts.checker,
+		checker:              services.NewUnscopedSplitAccessChecker(opts.checker), // TODO(fspmarshall/scopes): add scoping support to AugmentUserCertificates.
 		defaultMode:          readOnlyAuthPref.GetLockingMode(),
 		username:             x509Identity.Username,
 		mfaVerified:          x509Identity.MFAVerified,
@@ -3320,8 +3338,17 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		return nil, trace.Wrap(err)
 	}
 
-	if len(req.checker.GetAllowedResourceIDs()) > 0 && modules.GetModules().BuildType() != modules.BuildEnterprise {
-		return nil, fmt.Errorf("resource access requests: %w", ErrRequiresEnterprise)
+	if _, ok := req.checker.Scoped(); ok {
+		// require that the scope feature is enabled for scoped certificate creation
+		if err := scopes.AssertFeatureEnabled(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	if unscopedChecker, ok := req.checker.Unscoped(); ok {
+		if len(unscopedChecker.GetAllowedResourceIDs()) > 0 && modules.GetModules().BuildType() != modules.BuildEnterprise {
+			return nil, trace.Errorf("resource access requests: %w", ErrRequiresEnterprise)
+		}
 	}
 
 	// Reject the cert request if there is a matching lock in force.
@@ -3348,8 +3375,21 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if certificateFormat == teleport.CertificateFormatUnspecified {
-		certificateFormat = req.checker.CertificateFormat()
+
+	// scoped identities must use the standard certificate format, unscoped identities may have their
+	// certificate format customized by request parameters and/or role settings.
+	if unscopedChecker, ok := req.checker.Unscoped(); ok {
+		if certificateFormat == teleport.CertificateFormatUnspecified {
+			certificateFormat = unscopedChecker.CertificateFormat()
+		}
+	} else {
+		switch certificateFormat {
+		case constants.CertificateFormatStandard:
+		case teleport.CertificateFormatUnspecified:
+			certificateFormat = constants.CertificateFormatStandard
+		default:
+			return nil, trace.BadParameter("certificate format %q is not supported for scoped access", certificateFormat)
+		}
 	}
 
 	var sessionTTL time.Duration
@@ -3367,7 +3407,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		// Take whatever was passed in. Pass in 0 to CheckLoginDuration so all
 		// logins are returned for the role set.
 		sessionTTL = req.ttl
-		allowedLogins, err = req.checker.CheckLoginDuration(0)
+		allowedLogins, err = req.checker.Common().CheckLoginDuration(0)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3375,11 +3415,11 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		// Adjust session TTL to the smaller of two values: the session TTL requested
 		// in tsh (possibly using default_session_ttl) or the session TTL for the
 		// role.
-		sessionTTL = req.checker.AdjustSessionTTL(req.ttl)
+		sessionTTL = req.checker.Common().AdjustSessionTTL(req.ttl)
 		// Return a list of logins that meet the session TTL limit. This means if
 		// the requested session TTL is larger than the max session TTL for a login,
 		// that login will not be included in the list of allowed logins.
-		allowedLogins, err = req.checker.CheckLoginDuration(sessionTTL)
+		allowedLogins, err = req.checker.Common().CheckLoginDuration(sessionTTL)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3387,7 +3427,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	notAfter := a.clock.Now().UTC().Add(sessionTTL)
 
 	attestedKeyPolicy := keys.PrivateKeyPolicyNone
-	requiredKeyPolicy, err := req.checker.PrivateKeyPolicy(readOnlyAuthPref.GetPrivateKeyPolicy())
+	requiredKeyPolicy, err := req.checker.Common().PrivateKeyPolicy(readOnlyAuthPref.GetPrivateKeyPolicy())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3409,7 +3449,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 				sessionTTL:           sessionTTL,
 				readOnlyAuthPref:     readOnlyAuthPref,
 				userName:             req.user.GetName(),
-				userTraits:           req.checker.Traits(),
+				userTraits:           req.checker.Common().Traits(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err, "attesting SSH key")
@@ -3427,7 +3467,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 				sessionTTL:           sessionTTL,
 				readOnlyAuthPref:     readOnlyAuthPref,
 				userName:             req.user.GetName(),
-				userTraits:           req.checker.Traits(),
+				userTraits:           req.checker.Common().Traits(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err, "attesting TLS key")
@@ -3448,12 +3488,17 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		req.routeToCluster = clusterName
 	}
 	if req.routeToCluster != clusterName {
+		unscopedChecker, ok := req.checker.Unscoped()
+		if !ok {
+			return nil, trace.BadParameter("cannot generate certs for remote cluster %q, remote cluster access is only supported for unscoped certs", req.routeToCluster)
+		}
+
 		// Authorize access to a remote cluster.
 		rc, err := a.GetRemoteCluster(ctx, req.routeToCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if err := req.checker.CheckAccessToRemoteCluster(rc); err != nil {
+		if err := unscopedChecker.CheckAccessToRemoteCluster(rc); err != nil {
 			if trace.IsAccessDenied(err) {
 				return nil, trace.NotFound("remote cluster %q not found", req.routeToCluster)
 			}
@@ -3466,7 +3511,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	allowedLogins = append(allowedLogins, teleport.SSHSessionJoinPrincipal)
 
 	pinnedIP := ""
-	if caType == types.UserCA && (req.checker.PinSourceIP() || req.pinIP) {
+	if caType == types.UserCA && (req.checker.Common().PinSourceIP() || req.pinIP) {
 		if req.loginIP == "" {
 			return nil, trace.BadParameter("IP pinning is enabled for user %q but there is no client IP information", req.user.GetName())
 		}
@@ -3489,11 +3534,33 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		githubUsername = githubIdentities[0].Username
 	}
 
+	// collect fields which are mutually exclusive to scoped or unscoped certs
+	var (
+		scopePin           *scopesv1.Pin
+		roleNames          []string
+		allowedResourceIDs []types.ResourceID
+	)
+
+	if scopedChecker, ok := req.checker.Scoped(); ok {
+		scopePin = scopedChecker.ScopePin()
+	}
+
+	if unscopedChecker, ok := req.checker.Unscoped(); ok {
+		roleNames = unscopedChecker.RoleNames()
+		allowedResourceIDs = unscopedChecker.GetAllowedResourceIDs()
+	}
+
 	var signedSSHCert []byte
 	if req.sshPublicKey != nil {
 		sshSigner, err := a.keyStore.GetSSHSigner(ctx, ca)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+
+		// certificate extensions are only supported for unscoped ssh certs
+		var certificateExtensions []*types.CertExtension
+		if unscopedChecker, ok := req.checker.Unscoped(); ok {
+			certificateExtensions = unscopedChecker.CertificateExtensions()
 		}
 
 		params := sshca.UserCertificateRequest{
@@ -3505,10 +3572,11 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 				Username:                req.user.GetName(),
 				Impersonator:            req.impersonator,
 				Principals:              allowedLogins,
-				Roles:                   req.checker.RoleNames(),
-				PermitPortForwarding:    req.checker.CanPortForward(),
-				PermitAgentForwarding:   req.checker.CanForwardAgents(),
-				PermitX11Forwarding:     req.checker.PermitX11Forwarding(),
+				ScopePin:                scopePin,
+				Roles:                   roleNames,
+				PermitPortForwarding:    req.checker.Common().CanPortForward(),
+				PermitAgentForwarding:   req.checker.Common().CanForwardAgents(),
+				PermitX11Forwarding:     req.checker.Common().PermitX11Forwarding(),
 				RouteToCluster:          req.routeToCluster,
 				Traits:                  req.traits,
 				ActiveRequests:          req.activeRequests,
@@ -3522,8 +3590,8 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 				BotName:                 req.botName,
 				BotInstanceID:           req.botInstanceID,
 				JoinToken:               req.joinToken,
-				CertificateExtensions:   req.checker.CertificateExtensions(),
-				AllowedResourceIDs:      req.checker.GetAllowedResourceIDs(),
+				CertificateExtensions:   certificateExtensions,
+				AllowedResourceIDs:      allowedResourceIDs,
 				ConnectionDiagnosticID:  req.connectionDiagnosticID,
 				PrivateKeyPolicy:        attestedKeyPolicy,
 				DeviceID:                req.deviceExtensions.DeviceID,
@@ -3539,12 +3607,6 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		}
 	}
 
-	kubeGroups, kubeUsers, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
-	// NotFound errors are acceptable - this user may have no k8s access
-	// granted and that shouldn't prevent us from issuing a TLS cert.
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
 	// Ensure that the Kubernetes cluster name specified in the request exists
 	// when the certificate is intended for a local Kubernetes cluster.
 	// If the certificate is targeting a trusted Teleport cluster, it is the
@@ -3566,28 +3628,46 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		}
 	}
 
-	// See which database names and users this user is allowed to use.
-	dbNames, dbUsers, err := req.checker.CheckDatabaseNamesAndUsers(sessionTTL, req.overrideRoleTTL)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
+	var (
+		kubeGroups, kubeUsers []string
+		dbNames, dbUsers      []string
+		roleARNs              []string
+		azureIdentities       []string
+		gcpAccounts           []string
+	)
 
-	// See which AWS role ARNs this user is allowed to assume.
-	roleARNs, err := req.checker.CheckAWSRoleARNs(sessionTTL, req.overrideRoleTTL)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
+	// only unscoped identities currently support kube groups/users.
+	if unscopedChecker, ok := req.checker.Unscoped(); ok {
+		kubeGroups, kubeUsers, err = unscopedChecker.CheckKubeGroupsAndUsers(sessionTTL, req.overrideRoleTTL)
+		// NotFound errors are acceptable - this user may have no k8s access
+		// granted and that shouldn't prevent us from issuing a TLS cert.
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 
-	// See which Azure identities this user is allowed to assume.
-	azureIdentities, err := req.checker.CheckAzureIdentities(sessionTTL, req.overrideRoleTTL)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
+		// See which database names and users this user is allowed to use.
+		dbNames, dbUsers, err = unscopedChecker.CheckDatabaseNamesAndUsers(sessionTTL, req.overrideRoleTTL)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 
-	// Enumerate allowed GCP service accounts.
-	gcpAccounts, err := req.checker.CheckGCPServiceAccounts(sessionTTL, req.overrideRoleTTL)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
+		// See which AWS role ARNs this user is allowed to assume.
+		roleARNs, err = unscopedChecker.CheckAWSRoleARNs(sessionTTL, req.overrideRoleTTL)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+
+		// See which Azure identities this user is allowed to assume.
+		azureIdentities, err = unscopedChecker.CheckAzureIdentities(sessionTTL, req.overrideRoleTTL)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+
+		// Enumerate allowed GCP service accounts.
+		gcpAccounts, err = unscopedChecker.CheckGCPServiceAccounts(sessionTTL, req.overrideRoleTTL)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Generate AWS client side credentials if the user is trying to access an AWS App with an AWS Roles Anywhere Integration.
@@ -3601,7 +3681,8 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	identity := tlsca.Identity{
 		Username:          req.user.GetName(),
 		Impersonator:      req.impersonator,
-		Groups:            req.checker.RoleNames(),
+		ScopePin:          scopePin,
+		Groups:            roleNames,
 		Principals:        allowedLogins,
 		Usage:             req.usage,
 		RouteToCluster:    req.routeToCluster,
@@ -3646,7 +3727,7 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 		BotName:                 req.botName,
 		BotInstanceID:           req.botInstanceID,
 		JoinToken:               req.joinToken,
-		AllowedResourceIDs:      req.checker.GetAllowedResourceIDs(),
+		AllowedResourceIDs:      allowedResourceIDs,
 		PrivateKeyPolicy:        attestedKeyPolicy,
 		ConnectionDiagnosticID:  req.connectionDiagnosticID,
 		DeviceExtensions: tlsca.DeviceExtensions{
@@ -3797,8 +3878,8 @@ func (a *Server) attestHardwareKey(ctx context.Context, params *attestHardwareKe
 }
 
 type verifyLocksForUserCertsReq struct {
-	checker services.AccessChecker
-
+	// checker is a split access checker which may be scoped or unscoped.
+	checker *services.SplitAccessChecker
 	// defaultMode is the default locking mode, as recorded in the cluster
 	// Auth Preferences.
 	defaultMode constants.LockingMode
@@ -3823,17 +3904,22 @@ type verifyLocksForUserCertsReq struct {
 // verifyLocksForUserCerts verifies if any locks are in place before issuing new
 // user certificates.
 func (a *Server) verifyLocksForUserCerts(req verifyLocksForUserCertsReq) error {
-	checker := req.checker
-	lockingMode := checker.LockingMode(req.defaultMode)
+	lockingMode := req.checker.Common().LockingMode(req.defaultMode)
 
 	lockTargets := []types.LockTarget{
 		{User: req.username},
 		{MFADevice: req.mfaVerified},
 		{Device: req.deviceID},
 	}
-	lockTargets = append(lockTargets,
-		services.RolesToLockTargets(checker.RoleNames())...,
-	)
+
+	if unscopedChecker, ok := req.checker.Unscoped(); ok {
+		lockTargets = append(lockTargets,
+			services.RolesToLockTargets(unscopedChecker.RoleNames())...,
+		)
+	}
+
+	// TODO(fspmarshall/scopes): implement scoped role locking.
+
 	lockTargets = append(lockTargets,
 		services.AccessRequestsToLockTargets(req.activeAccessRequests)...,
 	)

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -25,16 +25,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -45,7 +51,10 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestServer_CreateAuthenticateChallenge_authPreference(t *testing.T) {
@@ -920,6 +929,166 @@ func TestServer_AuthenticateUser_passwordOnly(t *testing.T) {
 		_, err := s.AuthenticateWebUser(ctx, req)
 		return err
 	}))
+}
+
+// TestBasicSSHScopedLogin verifies the basic expected behavior of a scoped login attempt using password-only
+// auth and a rudimentary set of scoped roles.
+func TestBasicSSHScopedLogin(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx := context.Background()
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+
+	adminClient, err := testServer.NewClient(authtest.TestBuiltin(types.RoleAdmin))
+	require.NoError(t, err)
+
+	username := "alice"
+	password := uuid.NewString()
+
+	_, _, err = authtest.CreateUserAndRole(authServer, username, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, authServer.UpsertPassword(username, []byte(password)))
+
+	req := authclient.AuthenticateUserRequest{
+		Username: username,
+		Scope:    "/aa/bb",
+		Pass: &authclient.PassCreds{
+			Password: []byte(password),
+		},
+		SSHPublicKey: []byte(sshPubKey),
+		TLSPublicKey: []byte(tlsPubKey),
+	}
+
+	// user is not assigned any scoped roles applicable to /aa/bb, so login attempt should fail
+	_, err = authServer.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
+		AuthenticateUserRequest: req,
+	})
+	require.Error(t, err)
+
+	// set up some scoped roles
+	scopedRoles := []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "role-a",
+			},
+			Scope: "/aa",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/aa"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "role-b",
+			},
+			Scope: "/aa/bb",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/aa/bb"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "role-c",
+			},
+			Scope: "/aa/bb/cc",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/aa/bb/cc"},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "role-x",
+			},
+			Scope: "/xx",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/xx"},
+			},
+			Version: types.V1,
+		},
+	}
+
+	// Create the roles.
+	for _, role := range scopedRoles {
+		_, err := adminClient.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+	}
+
+	for _, role := range scopedRoles {
+		_, err = adminClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: &scopedaccessv1.ScopedRoleAssignment{
+				Kind: scopedaccess.KindScopedRoleAssignment,
+				Metadata: &headerv1.Metadata{
+					Name: uuid.NewString(),
+				},
+				Scope: role.GetScope(),
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+					User: "alice",
+					Assignments: []*scopedaccessv1.Assignment{
+						{
+							Role:  role.GetMetadata().GetName(),
+							Scope: role.GetScope(),
+						},
+					},
+				},
+				Version: types.V1,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	// the same authentication request should now succeed
+	authrsp, err := authServer.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
+		AuthenticateUserRequest: req,
+	})
+	require.NoError(t, err)
+
+	// verify that the expected scope pin is applied to ssh and tls certificates
+	expectedPin := &scopesv1.Pin{
+		Scope: "/aa/bb",
+		Assignments: map[string]*scopesv1.PinnedAssignments{
+			"/aa": {
+				Roles: []string{"role-a"},
+			},
+			"/aa/bb": {
+				Roles: []string{"role-b"},
+			},
+			"/aa/bb/cc": {
+				Roles: []string{"role-c"},
+			},
+		},
+	}
+
+	// parse and examine the ssh cert
+	sshCert, err := sshutils.ParseCertificate(authrsp.Cert)
+	require.NoError(t, err)
+
+	sshIdent, err := sshca.DecodeIdentity(sshCert)
+	require.NoError(t, err)
+
+	require.NotNil(t, sshIdent.ScopePin)
+	require.Empty(t, cmp.Diff(expectedPin, sshIdent.ScopePin, protocmp.Transform()))
+	require.Empty(t, sshIdent.Roles)
+
+	// parse and examine the tls cert
+	tlsCert, err := tlsca.ParseCertificatePEM(authrsp.TLSCert)
+	require.NoError(t, err)
+
+	tlsIdent, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+	require.NoError(t, err)
+
+	require.NotNil(t, tlsIdent.ScopePin)
+	require.Empty(t, cmp.Diff(expectedPin, tlsIdent.ScopePin, protocmp.Transform()))
+	require.Empty(t, tlsIdent.Groups)
 }
 
 func TestServer_AuthenticateUser_passwordOnly_failure(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3606,7 +3606,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		awsRoleARN:                       req.RouteToApp.AWSRoleARN,
 		azureIdentity:                    req.RouteToApp.AzureIdentity,
 		gcpServiceAccount:                req.RouteToApp.GCPServiceAccount,
-		checker:                          checker,
+		checker:                          services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to generateUserCerts.
 		// Copy IP from current identity to the generated certificate, if present,
 		// to avoid generateUserCerts() being used to drop IP pinning in the new certificates.
 		loginIP:                a.context.Identity.GetIdentity().LoginIP,

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1368,6 +1368,11 @@ type AuthenticateUserRequest struct {
 	// Username is a username
 	Username string `json:"username"`
 
+	// Scope, if non-empty, makes the authentication scoped. Scoping does not change core authentication
+	// behavior, but results in a more limited (scoped) set of credentials being issued upon successful
+	// authentication and some differences in locking behavior.
+	Scope string `json:"scope,omitempty"`
+
 	// SSHPublicKey is a public key in ssh authorized_keys format.
 	SSHPublicKey []byte `json:"ssh_public_key,omitempty"`
 	// TLSPublicKey is a public key in PEM-encoded PKCS#1 or PKIX format.

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -599,7 +599,7 @@ func (a *Server) generateInitialBotCerts(
 		ttl:            expires.Sub(a.GetClock().Now()),
 		sshPublicKey:   sshPubKey,
 		tlsPublicKey:   tlsPubKey,
-		checker:        checker,
+		checker:        services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to generateInitialBotCerts (likely not necessary until bot scoping work begins).
 		traits:         accessInfo.Traits,
 		renewable:      renewable,
 		includeHostCA:  true,

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -259,7 +259,7 @@ func (a *Server) SetCreateBoundKeypairValidator(validator CreateBoundKeypairVali
 	}
 }
 
-func (a *Server) AuthenticateUserLogin(ctx context.Context, req authclient.AuthenticateUserRequest) (services.UserState, services.AccessChecker, error) {
+func (a *Server) AuthenticateUserLogin(ctx context.Context, req authclient.AuthenticateUserRequest) (services.UserState, *services.SplitAccessChecker, error) {
 	return a.authenticateUserLogin(ctx, req)
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5692,7 +5692,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 
 	scopedAccessControl, err := scopedaccess.New(scopedaccess.Config{
 		Authorizer: cfg.Authorizer,
-		Reader:     cfg.AuthServer.scopedAccessCache,
+		Reader:     cfg.AuthServer.ScopedAccessCache,
 		Writer:     cfg.AuthServer.scopedAccessBackend,
 		Logger:     logger,
 	})
@@ -5750,10 +5750,11 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	dynamicwindowsv1pb.RegisterDynamicWindowsServiceServer(server, dynamicWindows)
 
 	trust, err := trustv1.NewService(&trustv1.ServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Cache:      cfg.AuthServer.Cache,
-		Backend:    cfg.AuthServer.Services,
-		AuthServer: cfg.AuthServer,
+		Authorizer:       cfg.Authorizer,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Cache:            cfg.AuthServer.Cache,
+		Backend:          cfg.AuthServer.Services,
+		AuthServer:       cfg.AuthServer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -289,7 +289,7 @@ func (a *Server) newWebSession(
 		ttl:            sessionTTL,
 		sshPublicKey:   sshAuthorizedKey,
 		tlsPublicKey:   tlsPublicKeyPEM,
-		checker:        checker,
+		checker:        services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to newWebSession.
 		traits:         req.Traits,
 		activeRequests: req.AccessRequests,
 	}
@@ -562,7 +562,7 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		user:           user,
 		loginIP:        req.LoginIP,
 		tlsPublicKey:   tlsPublicKey,
-		checker:        checker,
+		checker:        services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to newAppSession.
 		ttl:            req.SessionTTL,
 		traits:         req.Traits,
 		activeRequests: req.AccessRequests,
@@ -752,7 +752,7 @@ func (a *Server) CreateSessionCerts(ctx context.Context, req *SessionCertsReques
 		sshPublicKeyAttestationStatement: req.SSHAttestationStatement,
 		tlsPublicKeyAttestationStatement: req.TLSAttestationStatement,
 		compatibility:                    req.Compatibility,
-		checker:                          checker,
+		checker:                          services.NewUnscopedSplitAccessChecker(checker), // TODO(fspmarshall/scopes): add scoping support to CreateSessionCerts.
 		traits:                           req.UserState.GetTraits(),
 		routeToCluster:                   req.RouteToCluster,
 		kubernetesCluster:                req.KubernetesCluster,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -79,6 +79,7 @@ type AuthorizerOpts struct {
 	ClusterName         string
 	AccessPoint         AuthorizerAccessPoint
 	ReadOnlyAccessPoint ReadOnlyAuthorizerAccessPoint
+	ScopedRoleReader    services.ScopedRoleReader
 	MFAAuthenticator    MFAAuthenticator
 	LockWatcher         *services.LockWatcher
 	Logger              *slog.Logger
@@ -96,6 +97,10 @@ type AuthorizerOpts struct {
 
 // NewAuthorizer returns new authorizer using backends
 func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
+	return newAuthorizer(opts)
+}
+
+func newAuthorizer(opts AuthorizerOpts) (*authorizer, error) {
 	if opts.ClusterName == "" {
 		return nil, trace.BadParameter("missing parameter clusterName")
 	}
@@ -126,6 +131,7 @@ func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
 		clusterName:             opts.ClusterName,
 		accessPoint:             opts.AccessPoint,
 		readOnlyAccessPoint:     opts.ReadOnlyAccessPoint,
+		scopedRoleReader:        opts.ScopedRoleReader,
 		mfaAuthenticator:        opts.MFAAuthenticator,
 		lockWatcher:             opts.LockWatcher,
 		logger:                  logger,
@@ -217,6 +223,7 @@ type authorizer struct {
 	clusterName         string
 	accessPoint         AuthorizerAccessPoint
 	readOnlyAccessPoint ReadOnlyAuthorizerAccessPoint
+	scopedRoleReader    services.ScopedRoleReader
 	mfaAuthenticator    MFAAuthenticator
 	lockWatcher         *services.LockWatcher
 	logger              *slog.Logger
@@ -396,6 +403,12 @@ func (c *Context) GetDisconnectCertExpiry(authPref readonly.AuthPreference) time
 	return identity.Expires
 }
 
+// ErrScopedIdentity is returned by Authorize when it receives a scoped identity. Methods that implement
+// scoping support may check for this error and fallback to scoped authorization as appropriate.
+var ErrScopedIdentity = &trace.AccessDeniedError{
+	Message: "scoped certificates not supported",
+}
+
 // Authorize authorizes user based on identity supplied via context
 func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error) {
 	defer func() {
@@ -411,6 +424,11 @@ func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	if user, ok := userI.(LocalUser); ok && user.Identity.ScopePin != nil {
+		return nil, ErrScopedIdentity
+	}
+
 	authContext, err := a.fromUser(ctx, userI)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -607,6 +625,8 @@ func (a *authorizer) convertAuthorizerError(err error) error {
 		return trace.Wrap(err, "access denied")
 	case errors.Is(err, ErrIPPinningMissing) || errors.Is(err, ErrIPPinningMismatch) || errors.Is(err, ErrIPPinningNotAllowed):
 		a.logger.WarnContext(context.Background(), "ip pinning requirements not satisfied", "error", err)
+		return trace.Wrap(err)
+	case errors.Is(err, ErrScopedIdentity):
 		return trace.Wrap(err)
 	case trace.IsAccessDenied(err):
 		a.logger.WarnContext(context.Background(), "access denied", "error", err)

--- a/lib/authz/scoped.go
+++ b/lib/authz/scoped.go
@@ -1,0 +1,118 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package authz
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// ScopedAuthorizer provides an equivalent to the Authorizer.Authorize method intended for use
+// with scoped identities.
+type ScopedAuthorizer interface {
+
+	// AuthorizeScoped authorizes a scoped identity. Note that this a prototype implementation and
+	// does not have feature parity with standard Authorize. Scopes are a work in progress feature.
+	AuthorizeScoped(ctx context.Context) (*ScopedContext, error)
+}
+
+// NewScopedAuthorizer returns a new scoped authorizer
+func NewScopedAuthorizer(opts AuthorizerOpts) (ScopedAuthorizer, error) {
+	// TODO(fspmarshall/scopes): either fully bifurcate the authorizer and scoped authorizer, or
+	// refactor s.t. they share a common builder and implementation.
+	if opts.ScopedRoleReader == nil {
+		return nil, trace.BadParameter("scoped role reader is required to create a scoped authorizer")
+	}
+
+	return newAuthorizer(opts)
+}
+
+// AuthorizeScoped authorizes a scoped identity. This function should generally only be called by methods that
+// implement scoping support, and only if [ErrScopedIdentity] is returned by [Authorize].
+// XXX: this is a protoype implementation and does not have feature parity with standard Authorize. Scopes are
+// a work in progress feature. This method does not function without the unstable scope flag being set, and must
+// remain behind the feature flag until core functionality is finalized.
+func (a *authorizer) AuthorizeScoped(ctx context.Context) (scopedCtx *ScopedContext, err error) {
+	defer func() {
+		if err != nil {
+			err = a.convertAuthorizerError(err)
+		}
+	}()
+
+	if !scopes.FeatureEnabled() {
+		return nil, trace.AccessDenied("cannot authorize scoped operation, scoping is not enabled for this cluster")
+	}
+
+	if ctx == nil {
+		return nil, trace.AccessDenied("missing authentication context")
+	}
+
+	userI, err := UserFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user, ok := userI.(LocalUser)
+	if !ok {
+		return nil, trace.AccessDenied("scoped authorization is only supported for local users, got %T", userI)
+	}
+
+	if user.Identity.ScopePin == nil {
+		return nil, trace.AccessDenied("scoped authorization is not supported for unscoped identities")
+	}
+
+	if a.scopedRoleReader == nil {
+		return nil, trace.AccessDenied("authorizer not configured for scoped authorization")
+	}
+
+	scopedCtx, err = scopedContextForLocalUser(ctx, user, a.scopedRoleReader, a.clusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(fspmarshall/scopes): include controls like locks/device enforcement here or (better), refactor to
+	// have enforcement use a common implementation across scoped/unscoped authorize variants.
+
+	return scopedCtx, nil
+}
+
+func scopedContextForLocalUser(ctx context.Context, user LocalUser, reader services.ScopedRoleReader, clusterName string) (*ScopedContext, error) {
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(user.Identity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	checkerContext, err := services.NewScopedAccessCheckerContext(ctx, accessInfo, clusterName, reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ScopedContext{
+		CheckerContext: checkerContext,
+	}, nil
+}
+
+// ScopedContext is a scope-enabled authorization context.
+type ScopedContext struct {
+	CheckerContext *services.ScopedAccessCheckerContext
+}

--- a/lib/backend/dynamo/atomicwrite.go
+++ b/lib/backend/dynamo/atomicwrite.go
@@ -170,7 +170,7 @@ TxnLoop:
 		if i != 0 {
 			if retry == nil {
 				// ideally we want one of the concurrently canceled transactions to retry immediately, with the rest holding back. since we
-				// can't control wether that happens, the next best thing is to configure our backoff to use exponential scaling + full jitter,
+				// can't control whether that happens, the next best thing is to configure our backoff to use exponential scaling + full jitter,
 				// which strikes a nice balance between retrying quickly when under low contention, and rapidly spreading out retries when under
 				// high contention.
 				retry, err = retryutils.NewRetryV2(retryutils.RetryV2Config{

--- a/lib/backend/test/atomicwrite_shim.go
+++ b/lib/backend/test/atomicwrite_shim.go
@@ -139,7 +139,7 @@ func (a AtomicWriteShim) CompareAndSwap(ctx context.Context, expected backend.It
 		if err != nil {
 			if errors.Is(err, backend.ErrConditionFailed) {
 				// concurrent modification does not guarantee that the value was changed (may have been a redundant
-				// update or a keepalive), so we need to retry in order to determine wether or not the cas should
+				// update or a keepalive), so we need to retry in order to determine whether or not the cas should
 				// succeed.
 				continue
 			}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -195,6 +195,10 @@ type Config struct {
 	// (for example, using command-line flags).
 	ExplicitUsername bool
 
+	// Scope is the target scope, used during authentication/login to request certificates
+	// that are limited (pinned) to a given target scope.
+	Scope string
+
 	// Remote host to connect
 	Host string
 
@@ -4027,6 +4031,20 @@ func (tc *TeleportClient) SSHLogin(ctx context.Context, sshLoginFunc SSHLoginFun
 	// be persisted in the profile
 	tc.ProfileDefaultRelayAddr = response.ClientOptions.DefaultRelayAddr
 
+	tlsCert, err := tlsca.ParseCertificatePEM(response.TLSCert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ident, err := tlsca.FromSubject(tlsCert.Subject, time.Time{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if ident.ScopePin != nil {
+		log.DebugContext(ctx, "got scoped certificate identity", "scope", ident.ScopePin.Scope, "assignments", ident.ScopePin.Assignments)
+	}
+
 	return keyRing, nil
 }
 
@@ -4150,6 +4168,7 @@ func (tc *TeleportClient) NewSSHLogin(keyRing *KeyRing) (SSHLogin, error) {
 		TTL:                     tc.KeyTTL,
 		Insecure:                tc.InsecureSkipVerify,
 		Pool:                    loopbackPool(tc.WebProxyAddr),
+		Scope:                   tc.Scope,
 		Compatibility:           tc.CertificateFormat,
 		RouteToCluster:          tc.SiteName,
 		KubernetesCluster:       tc.KubernetesCluster,

--- a/lib/inventory/inventory.go
+++ b/lib/inventory/inventory.go
@@ -524,7 +524,7 @@ type UpstreamHandle interface {
 // when using this struct to inject control log entries, said entries won't be included until the next
 // normal instance heartbeat (though this may be triggered early via UpstreamHandle.HeartbeatInstance()).
 // The primary intended usage pattern is for periodic operations to append entries to the QualifiedPendingControlLog,
-// and then observe wether or not said entries end up being included on subsequent iterations. This
+// and then observe whether or not said entries end up being included on subsequent iterations. This
 // patterns lets us achieve a kind of lazy "locking", whereby complex coordination can occur without
 // large spikes in backend load. See the QualifiedPendingControlLog field for an example of this pattern.
 type instanceStateTracker struct {

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -96,6 +96,24 @@ func TestValidateSegment(t *testing.T) {
 			strongOk: false,
 			weakOk:   false,
 		},
+		{
+			name:     "leading uppercase segment",
+			segment:  "Aa",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "middle uppsercase segment",
+			segment:  "aAa",
+			strongOk: false,
+			weakOk:   true,
+		},
+		{
+			name:     "trailing uppercase segment",
+			segment:  "aA",
+			strongOk: false,
+			weakOk:   true,
+		},
 	}
 
 	for _, tt := range tts {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2523,10 +2523,12 @@ func (process *TeleportProcess) initAuthService() error {
 	// second, create the API Server: it's actually a collection of API servers,
 	// each serving requests for a "role" which is assigned to every connected
 	// client based on their certificate (user, server, admin, etc)
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+
+	authorizerOpts := authz.AuthorizerOpts{
 		ClusterName:         clusterName,
 		AccessPoint:         authServer,
 		ReadOnlyAccessPoint: authServer,
+		ScopedRoleReader:    authServer.ScopedAccessCache,
 		MFAAuthenticator:    authServer,
 		LockWatcher:         lockWatcher,
 		Logger:              process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentAuth, process.id)),
@@ -2537,10 +2539,17 @@ func (process *TeleportProcess) initAuthService() error {
 			DisableGlobalMode: true,
 			DisableRoleMode:   true,
 		},
-	})
+	}
+
+	authorizer, err := authz.NewAuthorizer(authorizerOpts)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	scopedAuthorizer, err := authz.NewScopedAuthorizer(authorizerOpts)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	var accessGraphCAData []byte
 	if cfg.AccessGraph.Enabled && cfg.AccessGraph.CA != "" {
 		accessGraphCAData, err = os.ReadFile(cfg.AccessGraph.CA)
@@ -2549,12 +2558,13 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 	}
 	apiConf := &auth.APIConfig{
-		AuthServer:     authServer,
-		Authorizer:     authorizer,
-		AuditLog:       process.auditLog,
-		PluginRegistry: process.PluginRegistry,
-		Emitter:        authServer,
-		MetadataGetter: uploadHandler,
+		AuthServer:       authServer,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: scopedAuthorizer,
+		AuditLog:         process.auditLog,
+		PluginRegistry:   process.PluginRegistry,
+		Emitter:          authServer,
+		MetadataGetter:   uploadHandler,
 		AccessGraph: auth.AccessGraphConfig{
 			Enabled:  cfg.AccessGraph.Enabled,
 			Address:  cfg.AccessGraph.Addr,

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -303,6 +304,9 @@ type AccessChecker interface {
 // host SSH certificate, TLS certificate, or user information stored in the
 // backend.
 type AccessInfo struct {
+	// ScopePin is an optional pin that ties an identity to a specific scope and set of scoped roles. When
+	// set, the Roles field must not be set.
+	ScopePin *scopesv1.Pin
 	// Roles is the list of cluster local roles for the identity.
 	Roles []string
 	// Traits is the set of traits for the identity.
@@ -339,15 +343,15 @@ type accessChecker struct {
 //   - `access RoleGetter` should be a RoleGetter which will be used to fetch the
 //     full RoleSet
 func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
+	if info.ScopePin != nil {
+		return nil, trace.BadParameter("cannot create unscoped AccessChecker based on scoped identity")
+	}
 	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &accessChecker{
-		info:         info,
-		localCluster: localCluster,
-		RoleSet:      roleSet,
-	}, nil
+
+	return newAccessChecker(info, localCluster, roleSet), nil
 }
 
 // NewAccessCheckerForUserSession is an alternative to NewAccessChecker that includes a UserSessionRoleNotFoundErrorMsg if
@@ -374,6 +378,10 @@ func NewAccessCheckerForUserSession(info *AccessInfo, localCluster string, acces
 // NewAccessCheckerWithRoleSet is similar to NewAccessChecker, but accepts the
 // full RoleSet rather than a RoleGetter.
 func NewAccessCheckerWithRoleSet(info *AccessInfo, localCluster string, roleSet RoleSet) AccessChecker {
+	return newAccessChecker(info, localCluster, roleSet)
+}
+
+func newAccessChecker(info *AccessInfo, localCluster string, roleSet RoleSet) *accessChecker {
 	return &accessChecker{
 		info:         info,
 		localCluster: localCluster,
@@ -395,6 +403,10 @@ type CurrentUserRoleGetter interface {
 // user's access to resources that may be located in remote/leaf Teleport
 // clusters.
 func NewAccessCheckerForRemoteCluster(ctx context.Context, localAccessInfo *AccessInfo, clusterName string, access CurrentUserRoleGetter) (AccessChecker, error) {
+	if localAccessInfo.ScopePin != nil {
+		return nil, trace.BadParameter("cannot create unscoped remote cluster AccessChecker based on scoped identity")
+	}
+
 	// Fetch the remote cluster's view of the current user's roles.
 	remoteRoles, err := access.GetCurrentUserRoles(ctx)
 	if err != nil {
@@ -1340,6 +1352,7 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 func AccessInfoFromLocalSSHIdentity(ident *sshca.Identity) *AccessInfo {
 	return &AccessInfo{
 		Username:           ident.Username,
+		ScopePin:           ident.ScopePin,
 		Roles:              ident.Roles,
 		Traits:             ident.Traits,
 		AllowedResourceIDs: ident.AllowedResourceIDs,
@@ -1350,6 +1363,10 @@ func AccessInfoFromLocalSSHIdentity(ident *sshca.Identity) *AccessInfo {
 // given remote cluster user's ssh identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
 func AccessInfoFromRemoteSSHIdentity(unmappedIdentity *sshca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+	if unmappedIdentity.ScopePin != nil {
+		return nil, trace.BadParameter("scope pinning is not supported for remote SSH identities")
+	}
+
 	// make a shallow copy of traits to avoid modifying the original
 	// (don't use maps.Clone, as we want to ensure the result is an empty, but not nil, map)
 	traits := make(map[string][]string, len(unmappedIdentity.Traits)+1)
@@ -1387,12 +1404,13 @@ func AccessInfoFromRemoteSSHIdentity(unmappedIdentity *sshca.Identity, roleMap t
 // tlsca.Identity. Should only be used for cluster local users as roles will not
 // be mapped.
 func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity) (*AccessInfo, error) {
-	if len(identity.Groups) == 0 {
-		return nil, trace.BadParameter("tls identity %q does not encode any roles, this may indicate a malformed certificate or one that was issued by an incompatible teleport version", identity.Username)
+	if len(identity.Groups) == 0 && identity.ScopePin == nil {
+		return nil, trace.BadParameter("tls identity %q has no roles or scope pin, this may indicate a malformed certificate or one that was issued by an incompatible teleport version", identity.Username)
 	}
 
 	return &AccessInfo{
 		Username:           identity.Username,
+		ScopePin:           identity.ScopePin,
 		Roles:              identity.Groups,
 		Traits:             identity.Traits,
 		AllowedResourceIDs: identity.AllowedResourceIDs,
@@ -1403,6 +1421,10 @@ func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity) (*AccessInfo, error
 // given remote cluster user's tlsca.Identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
 func AccessInfoFromRemoteTLSIdentity(identity tlsca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+	if identity.ScopePin != nil {
+		return nil, trace.BadParameter("scope pinning is not supported for remote TLS identities")
+	}
+
 	// Set internal traits for the remote user. This allows Teleport to work by
 	// passing exact logins, Kubernetes users/groups, database users/names, and
 	// AWS Role ARNs to the remote cluster.
@@ -1483,11 +1505,21 @@ type UserState interface {
 // user does not have any active access requests (initial web login, initial
 // tbot certs, tests).
 func AccessInfoFromUserState(user UserState) *AccessInfo {
-	roles := user.GetRoles()
-	traits := user.GetTraits()
+	return accessInfoFromUserState(user, user.GetRoles(), nil)
+}
+
+// ScopePinnedAccessInfoFromUserState returns a new AccessInfo populated from the
+// traits held by the user and the provided scope pin. Population/verification of the
+// scope pin must be performed prior to calling this function.
+func ScopePinnedAccessInfoFromUserState(user UserState, pin *scopesv1.Pin) *AccessInfo {
+	return accessInfoFromUserState(user, nil, pin)
+}
+
+func accessInfoFromUserState(user UserState, roles []string, pin *scopesv1.Pin) *AccessInfo {
 	return &AccessInfo{
 		Username: user.GetName(),
 		Roles:    roles,
-		Traits:   traits,
+		ScopePin: pin,
+		Traits:   user.GetTraits(),
 	}
 }

--- a/lib/services/readonly/cache.go
+++ b/lib/services/readonly/cache.go
@@ -53,7 +53,7 @@ type CacheConfig struct {
 	// Disabled is a flag that can be used to disable ttl-caching. Useful in tests that
 	// don't play nicely with stale data.
 	Disabled bool
-	// ReloadOnErr controls wether or not the underlying ttl cache will hold onto error
+	// ReloadOnErr controls whether or not the underlying ttl cache will hold onto error
 	// entries for the full TTL, or reload error entries immediately. As a general rule,
 	// this value aught to be true on auth servers and false on agents, though in practice
 	// the difference is small unless an unusually long TTL is used.

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -1,0 +1,403 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
+	"github.com/gravitational/teleport/lib/utils/once"
+)
+
+// ScopedAccessCheckerContext is the top-level scoped access checker state. It builds and caches scoped access
+// checkers "at" specific scopes, based on a user's identity.
+type ScopedAccessCheckerContext struct {
+	builder scopedAccessCheckerBuilder
+	// cachedCheckerForScope wraps builder.newCheckerAtScope with a [once.KeyedValue] to retain previously built
+	// checkers. this retention behavior is intended to support APIs that require multiple separate scoped
+	// access checks to be performed for separate resources within the same request.
+	cachedCheckerForScope func(ctx context.Context, scope string) (*ScopedAccessChecker, error)
+}
+
+// NewScopedAccessCheckerContext builds a scoped access checker context for a given identity. The context is
+// used to build scoped access checkers at various scopes, and to evaluate access to resources within those
+// scopes. Note that the supplied context.Context is captured and used to propagate cancellation during loading
+// of scoped roles. Cancellation of the context while access checks are still in progress may result in
+// spurious access denied errors.
+func NewScopedAccessCheckerContext(ctx context.Context, info *AccessInfo, localCluster string, reader ScopedRoleReader) (*ScopedAccessCheckerContext, error) {
+	builder := scopedAccessCheckerBuilder{
+		info:         info,
+		localCluster: localCluster,
+		reader:       reader,
+	}
+
+	if err := builder.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cachedCheckerForScope, _ := once.KeyedValue(builder.newCheckerAtScope)
+
+	return &ScopedAccessCheckerContext{
+		builder:               builder,
+		cachedCheckerForScope: cachedCheckerForScope,
+	}, nil
+}
+
+// CheckersForResourceScope returns a stream of scoped access checkers, descending from root to the specified resource
+// scope. This is the mechanism that *must* be used for getting checkers when checking access to a resource. This
+// method both evaluates immediate compliance of the resource scope with the scope pin, and yields correctly ordered
+// checkers for resource access evaluation. Subsequent decision parameterization must be performed with the checker that
+// yielded the initial allow decision.
+func (c *ScopedAccessCheckerContext) CheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*ScopedAccessChecker] {
+	return c.checkersForResourceScope(ctx, scope, true /* enforce pin */)
+}
+
+// RiskyUnpinnedCheckersForResourceScope returns a stream of scoped access checkers, descending from root to the specified
+// resource scope, but does not enforce the pinning scope. This is a risky operation that should only be used for certain APIs
+// that make an exception to pinning exclusion rules (e.g. allowing read operations to succeed for resources in a parent to the
+// pinned scope).
+func (c *ScopedAccessCheckerContext) RiskyUnpinnedCheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*ScopedAccessChecker] {
+	// this method is a risky variant of CheckersForResourceScope that does not enforce the pinning scope, and should only be used
+	// in contexts where the caller is certain that the resource scope is compatible with the pinning scope.
+	return c.checkersForResourceScope(ctx, scope, false /* enforce pin */)
+}
+
+func (c *ScopedAccessCheckerContext) checkersForResourceScope(ctx context.Context, scope string, enforcePin bool) stream.Stream[*ScopedAccessChecker] {
+	return func(yield func(*ScopedAccessChecker, error) bool) {
+		// deny immediately if the resource scope is not subject to the pinned scope. note that this denial isn't just an
+		// optimization, we have to perform this check separately from whatever access checks are performed by particular
+		// checkers. This is vital as the pin scope itself may deny access to a resource that would be permitted by any
+		// particular checker. For example, if a user has a scoped role assigned at /foo which grants access to all ssh
+		// nodes, but they are pinned to scope /foo/bar, the checker at /foo needs to permit access to all nodes subject to
+		// /foo, but the pin only permits access to resources subject to /foo/bar, even if the final allow decision is
+		// determined by a checker at /foo.
+		if enforcePin && !pinning.PinAppliesToResourceScope(c.builder.info.ScopePin, scope) {
+			yield(nil, trace.AccessDenied("scope pin %q does not apply to resource scope %q", c.builder.info.ScopePin.GetScope(), scope))
+			return
+		}
+
+		for checkerScope := range scopes.DescendingScopes(scope) {
+			checker, err := c.cachedCheckerForScope(ctx, checkerScope)
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			if !yield(checker, nil) {
+				return
+			}
+		}
+	}
+}
+
+// DoScopedDecision is a helper function that takes care of boilerplate for simple scoped decisions.  It calls the provided
+// decision function until one of three conditions is met:
+//
+// 1. Decision function executes without error (allow)
+// 2. Decision function returns an AccessExplicitlyDenied error (explicit deny)
+// 3. Checker stream is exhausted (implicit deny)
+//
+// The generic parameter may be used to propagate additional information/parameterization of the decision. For basic checks,
+// conventionally set D to struct{} to indicate that the presence/absence of the error alone is the entire decision state.
+// For logging/debuggin purposes, returning checker.Scope() as the decision value may be convenient.
+func DoScopedDecision[D any](checkers stream.Stream[*ScopedAccessChecker], decisionFn func(*ScopedAccessChecker) (D, error)) (D, error) {
+	for checker, err := range checkers {
+		if err != nil {
+			return *new(D), trace.Wrap(err)
+		}
+
+		result, err := decisionFn(checker)
+		switch {
+		case err == nil:
+			return result, nil
+		case IsAccessExplicitlyDenied(err):
+			return *new(D), trace.Wrap(err)
+		default:
+			// implicit deny, continue to the next check
+			continue
+		}
+	}
+
+	return *new(D), trace.AccessDenied("access denied (scoped)")
+}
+
+// scopedAccessCheckerBuilder is a helper that builds scoped access checkers.
+type scopedAccessCheckerBuilder struct {
+	info         *AccessInfo
+	localCluster string
+	reader       ScopedRoleReader
+}
+
+// Check verifies that the builder was provided will all necessary parameters and that they are well-formed.
+func (b *scopedAccessCheckerBuilder) Check() error {
+	if b.reader == nil {
+		return trace.BadParameter("cannot create scoped access checkers without a scoped role reader")
+	}
+
+	if b.localCluster == "" {
+		return trace.BadParameter("cannot create scoped access checkers without a local cluster name")
+	}
+
+	if b.info.ScopePin == nil {
+		return trace.BadParameter("cannot create scoped access checkers for unscoped identity")
+	}
+
+	if len(b.info.AllowedResourceIDs) != 0 {
+		return trace.BadParameter("cannot create scoped access checkers for identity with active resource IDs")
+	}
+
+	// validate that the scope pin is well-formed
+	if err := pinning.WeakValidate(b.info.ScopePin); err != nil {
+		return trace.Errorf("cannot create scoped access checkers: %w", err)
+	}
+
+	return nil
+}
+
+func (b *scopedAccessCheckerBuilder) newCheckerAtScope(ctx context.Context, scope string) (*ScopedAccessChecker, error) {
+	// TODO(fspmarshall/scopes): implement the ability to pull already loaded roles from parent checkers
+	// in order to reduce redunant role fetches.
+
+	// validate that the target scope is compatible with the scope pin. note that this check is conceptually
+	// distinct from checking whether or not the pinned scope permits access to resources at the target scope.
+	// scope pinning rules disallow access to resources that are not equivalent or descendant to the pinned
+	// scope, but during access evaluation we must create checkers for all parent scopes as well. this check
+	// just verifies that we aren't creating a checker for an *orthogonal* scope. a full access-control check
+	// implementation must use [ScopedAccessCheckerContext.CheckersForResourceScope] in order to ensure that
+	// pinning is properly enforced for the resource scope.
+	if !pinning.PinCompatibleWithPolicyScope(b.info.ScopePin, scope) {
+		return nil, trace.AccessDenied("an identity pinned to scope %q cannot inform access decisions at scope %q", b.info.ScopePin.GetScope(), scope)
+	}
+
+	// fetch all assigned scoped roles and convert them to classic roles to drive the underlying access checks.
+	// we need to use the unchecked variant of assignments for resource scope because the standard variant
+	// refuses to produce an iterator for a scope that is a parent of the pinned scope, and this method will
+	// get called to build parent checkers as part of legitimate access checks. it is the responsibility of the
+	// caller of this method to determine that it is being used in a context that respects correct pinning rules.
+	var roles []types.Role
+	for scope, assigned := range pinning.AssignmentsForResourceScopeUnchecked(b.info.ScopePin, scope) {
+		if len(assigned.GetRoles()) == 0 {
+			continue
+		}
+
+		rolesForScope, err := fetchAndConvertScopedRoles(ctx, scope, assigned.GetRoles(), b.reader)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		roles = append(roles, rolesForScope...)
+	}
+
+	checker := newAccessChecker(b.info, b.localCluster, NewRoleSet(roles...))
+
+	return &ScopedAccessChecker{
+		scope:   scope,
+		checker: checker,
+	}, nil
+}
+
+// ScopedAccessChecker is similar to AccessChecker, but performs scoped checks. Note that usage patterns differ with
+// scoped access checks in comparison to standard access checkers since scoped access checkers can be set up "at"
+// various scopes, and the scope of subsequent checks may depend on the scope at which an allow was reached in a
+// previous check. For example, if an allow decision was reached for ssh access at a particular node, then checks for
+// parameters (e.g. x11 forwarding) must be performed at that same scope, even if that scope is a parent of the
+// node's scope rather than the node's scope itself. On the other hand, a ListNodes operation should have read
+// permssions for each individual node evaluated starting from the root scope, and descending to the node's scope if
+// necessary. In general, a decision *about* access to a resource always happens at the highest scope along the
+// resource's scope path at which primary access to the resource is allowed.
+type ScopedAccessChecker struct {
+	scope   string
+	checker *accessChecker
+}
+
+// RiskyNewScopedAccessCheckerAtScope creates a scoped access checker at the specified scope. Note that creating a scoped
+// access checker at a specific target scope rather than using [ScopedAccessCheckerContext] is typically incorrect as it
+// bypasses scope pin enforcement. This function exists solely to support a few niche use-cases where standard scope pinning
+// behavior is not applicable.
+func RiskyNewScopedAccessCheckerAtScope(ctx context.Context, scope string, info *AccessInfo, localCluster string, reader ScopedRoleReader) (*ScopedAccessChecker, error) {
+	builder := scopedAccessCheckerBuilder{
+		info:         info,
+		localCluster: localCluster,
+		reader:       reader,
+	}
+
+	if err := builder.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return builder.newCheckerAtScope(ctx, scope)
+}
+
+// Scope returns the scope "at" which the checker was created. A scoped access checker created at a given scope includes
+// all scoped roles assigned to the user at that scope, and all ancestral scopes.
+func (c *ScopedAccessChecker) Scope() string {
+	return c.scope
+}
+
+// ScopePin returns the scope pin that this checker was created from.
+func (c *ScopedAccessChecker) ScopePin() *scopesv1.Pin {
+	return c.checker.info.ScopePin
+}
+
+// Traits returns the set of user traits.
+func (c *ScopedAccessChecker) Traits() wrappers.Traits {
+	// identical in scoped/unscoped contexts generally (there is no concept of
+	// scoped traits currently, and none is planned or would be feasible at least
+	// until we've fully migrated to PDP and deprecated certificate-based traits).
+	return c.checker.Traits()
+}
+
+// CheckAccessToRules verifies that *all* of a series of verbs are permitted for the specified resource. This function differs
+// from the unscoped AccessChecker.CheckAccessToRule in a number of ways. It does not support advanced context-based features
+// or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.
+func (c *ScopedAccessChecker) CheckAccessToRules(resource string, verbs ...string) error {
+	if len(verbs) == 0 {
+		return trace.AccessDenied("malformed rule check, no verbs provided (this is a bug)")
+	}
+
+	// scoped roles currently do not support any rule-context features.
+	ctx := &Context{}
+
+	for _, verb := range verbs {
+		if err := c.checker.CheckAccessToRule(ctx, apidefaults.Namespace, resource, verb); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// CheckAccessToRemoteCluster checks access to remote cluster
+func (c *ScopedAccessChecker) CheckAccessToRemoteCluster(cluster types.RemoteCluster) error {
+	// remote cluster access is never permitted for scoped identities
+	// NOTE: it is unclear whether or not this method should even be implemented for the scoped access checker. it may be more
+	// sensible to force outer enforcement logic to grapple with the fact that a scoped checker does not support remote clusters
+	// at the type-level. this has been implemented experimentally to explore the pattern of having the scoped access checker
+	// implement methods that always deny for unsupported features.
+	return trace.AccessDenied("remote cluster access is not permitted for scoped identities")
+}
+
+// CheckLoginDuration checks if role set can login up to given duration and
+// returns a combined list of allowed logins.
+func (c *ScopedAccessChecker) CheckLoginDuration(ttl time.Duration) ([]string, error) {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.CheckLoginDuration(ttl)
+}
+
+// AdjustSessionTTL will reduce the requested ttl to lowest max allowed TTL
+// for this role set, otherwise it returns ttl unchanged
+func (c *ScopedAccessChecker) AdjustSessionTTL(ttl time.Duration) time.Duration {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.AdjustSessionTTL(ttl)
+}
+
+// PrivateKeyPolicy returns the enforced private key policy for this role set,
+// or the provided defaultPolicy - whichever is stricter.
+func (c *ScopedAccessChecker) PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) (keys.PrivateKeyPolicy, error) {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.PrivateKeyPolicy(defaultPolicy)
+}
+
+// PinSourceIP forces the same client IP for certificate generation and SSH usage
+func (c *ScopedAccessChecker) PinSourceIP() bool {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.PinSourceIP()
+}
+
+// CanPortForward returns true if this RoleSet can forward ports.
+func (c *ScopedAccessChecker) CanPortForward() bool {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+
+	// NOTE: internally this method relies upon the SSHPortForwardMode() method. if future work
+	// on the scoped access checker causes us to change the behavior of that method, we will
+	// need to rework this method as well to ensure that it behaves consistently.
+	return c.checker.CanPortForward()
+}
+
+// CanForwardAgents returns true if this role set offers capability to forward
+// agents.
+func (c *ScopedAccessChecker) CanForwardAgents() bool {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.CanForwardAgents()
+}
+
+// PermitX11Forwarding returns true if this RoleSet allows X11 Forwarding.
+func (c *ScopedAccessChecker) PermitX11Forwarding() bool {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.PermitX11Forwarding()
+}
+
+// LockingMode returns the locking mode to apply with this checker.
+func (c *ScopedAccessChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	// the naive implementation of this method for scopes may have problematic interactions with
+	// cert parameter generation. see ../scopes/access/compat.go for more detailed discussion.
+	return c.checker.LockingMode(defaultMode)
+}
+
+// AccessInfo returns the AccessInfo that this access checker is based on.
+func (c *ScopedAccessChecker) AccessInfo() *AccessInfo {
+	return c.checker.info
+}
+
+// fetchAndConvertScopedRoles fetches scoped roles by name and converts them to classic roles.
+func fetchAndConvertScopedRoles(ctx context.Context, scope string, names []string, reader ScopedRoleReader) ([]types.Role, error) {
+	roles := make([]types.Role, 0, len(names))
+	for _, name := range names {
+		rsp, err := reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+			Name: name,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		role, err := scopedaccess.ScopedRoleToRole(rsp.Role, scope)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// TODO(fspmarshall): figure out how/when we want to support trait interpolation in scoped
+		// roles. When we do, that will likely need to be done here. Wether we should perform trait
+		// interpolation on the per-conversion scoped role and add support piecemeal, or inherit
+		// identical trait interpolation from classic role behavior isn't clear yet, so at this
+		// stage we're just opting to skip entirely.
+
+		roles = append(roles, role)
+	}
+
+	return roles, nil
+}

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -1,0 +1,102 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/api/constants"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/keys"
+)
+
+// CommonAccessChecker defines the common methods that are identical across both scoped and unscoped access checkers.
+type CommonAccessChecker interface {
+	AccessInfo() *AccessInfo
+	Traits() wrappers.Traits
+	CheckLoginDuration(ttl time.Duration) ([]string, error)
+	AdjustSessionTTL(ttl time.Duration) time.Duration
+	PrivateKeyPolicy(defaultPolicy keys.PrivateKeyPolicy) (keys.PrivateKeyPolicy, error)
+	PinSourceIP() bool
+	CanPortForward() bool
+	CanForwardAgents() bool
+	PermitX11Forwarding() bool
+	LockingMode(defaultMode constants.LockingMode) constants.LockingMode
+}
+
+// ScopedAccessCheckerSubset defines the methods that are specific to scoped access checkers.
+type ScopedAccessCheckerSubset interface {
+	ScopePin() *scopesv1.Pin
+}
+
+// UnscopedAccessCheckerSubset defines the methods that are specific to unscoped access checkers.
+type UnscopedAccessCheckerSubset interface {
+	RoleNames() []string
+	CertificateFormat() string
+	GetAllowedResourceIDs() []types.ResourceID
+	CertificateExtensions() []*types.CertExtension
+	CheckAccessToRemoteCluster(cluster types.RemoteCluster) error
+	CheckKubeGroupsAndUsers(ttl time.Duration, overrideTTL bool, matchers ...RoleMatcher) (groups []string, users []string, err error)
+	CheckDatabaseNamesAndUsers(ttl time.Duration, overrideTTL bool) (names []string, users []string, err error)
+	CheckAWSRoleARNs(ttl time.Duration, overrideTTL bool) ([]string, error)
+	CheckAzureIdentities(ttl time.Duration, overrideTTL bool) ([]string, error)
+	CheckGCPServiceAccounts(ttl time.Duration, overrideTTL bool) ([]string, error)
+}
+
+// SplitAccessChecker is used in logic that needs to branch based on whether it is operating on a scoped or unscoped access checker. It
+// provides a Common interface that is always present, and one of either a Scoped or Unscoped interface that is present depending on
+// which underlying access checker is being used. If a method that previously existed on one of the Subset interfaces is implemented
+// by the second checker and moved to the Common interface, then the it should be removed from the Subset interface in order to ensure
+// that we don't continue to accidentally call it on the old location.
+type SplitAccessChecker struct {
+	common   CommonAccessChecker
+	unscoped UnscopedAccessCheckerSubset
+	scoped   ScopedAccessCheckerSubset
+}
+
+func NewUnscopedSplitAccessChecker(checker AccessChecker) *SplitAccessChecker {
+	return &SplitAccessChecker{
+		common:   checker,
+		unscoped: checker,
+	}
+}
+
+func NewScopedSplitAccessChecker(checker *ScopedAccessChecker) *SplitAccessChecker {
+	return &SplitAccessChecker{
+		common: checker,
+		scoped: checker,
+	}
+}
+
+// Common gets the common access checker interface that is shared between both scoped and unscoped access checkers.
+func (c *SplitAccessChecker) Common() CommonAccessChecker {
+	return c.common
+}
+
+// Unscoped gets the unscoped access checker interface if it is present.
+func (c *SplitAccessChecker) Unscoped() (checker UnscopedAccessCheckerSubset, ok bool) {
+	return c.unscoped, c.unscoped != nil
+}
+
+// Scoped gets the scoped access checker interface if it is present.
+func (c *SplitAccessChecker) Scoped() (checker ScopedAccessCheckerSubset, ok bool) {
+	return c.scoped, c.scoped != nil
+}

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -774,7 +774,7 @@ func (c *UnifiedResourceCache) getGitServers(ctx context.Context) (all []types.S
 }
 
 // read applies the supplied closure to either the primary tree or the ttl-based fallback tree depending on
-// wether or not the cache is currently healthy.  locking is handled internally and the passed-in tree should
+// whether or not the cache is currently healthy.  locking is handled internally and the passed-in tree should
 // not be accessed after the closure completes.
 func (c *UnifiedResourceCache) read(ctx context.Context, fn func(cache *UnifiedResourceCache) error) error {
 	c.rw.RLock()

--- a/lib/utils/once/keyedvalue.go
+++ b/lib/utils/once/keyedvalue.go
@@ -1,0 +1,73 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package once
+
+import (
+	"context"
+	"sync"
+)
+
+type entry[V any] struct {
+	value V
+	err   error
+	ready chan struct{}
+}
+
+// KeyedValue provides a keyed, fallible, and context-aware equivalent to [sync.OnceValue]. the
+// wrapped function is called exactly once for a given key and the result is cached indefinitely.
+// canceling the context passed to the returned closure unblocks the waiting caller but does not cause
+// cancellation of inflight calls to the wrapped function. the returned cancel function may optionally
+// be called to signal cancellation to inflight and future calls of the wrapped function.
+func KeyedValue[K comparable, V any](fn func(context.Context, K) (V, error)) (func(context.Context, K) (V, error), context.CancelFunc) {
+
+	entries := make(map[K]*entry[V])
+	var mu sync.Mutex
+
+	closeContext, cancel := context.WithCancel(context.Background())
+
+	ensure := func(key K) *entry[V] {
+		mu.Lock()
+		defer mu.Unlock()
+
+		e, ok := entries[key]
+		if ok {
+			return e
+		}
+
+		e = &entry[V]{ready: make(chan struct{})}
+		entries[key] = e
+
+		go func() {
+			defer close(e.ready)
+			e.value, e.err = fn(closeContext, key)
+		}()
+		return e
+	}
+
+	return func(ctx context.Context, key K) (V, error) {
+		e := ensure(key)
+
+		select {
+		case <-e.ready:
+			return e.value, e.err
+		case <-ctx.Done():
+			return *new(V), ctx.Err()
+		}
+	}, cancel
+}

--- a/lib/utils/once/keyedvalue_test.go
+++ b/lib/utils/once/keyedvalue_test.go
@@ -1,0 +1,117 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package once
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeyedValue verifies the basic expected function of KeyedValue.
+func TestKeyedValue(t *testing.T) {
+
+	var callsMu sync.Mutex
+	calls := make(map[int]int)
+
+	fn, cancel := KeyedValue(func(ctx context.Context, key int) (string, error) {
+		callsMu.Lock()
+		defer callsMu.Unlock()
+		calls[key]++
+		return fmt.Sprintf("value-%d", key), nil
+	})
+	defer cancel()
+
+	results := make(chan struct {
+		key int
+		val string
+		err error
+	})
+	for i := 0; i < 16; i++ {
+		key := i % 2
+		go func() {
+			for j := 0; j < 16; j++ {
+				val, err := fn(context.Background(), key)
+				results <- struct {
+					key int
+					val string
+					err error
+				}{key, val, err}
+			}
+		}()
+	}
+
+	for i := 0; i < 256; i++ {
+		res := <-results
+		require.NoError(t, res.err)
+		require.Equal(t, fmt.Sprintf("value-%d", res.key), res.val)
+	}
+
+	callsMu.Lock()
+	require.Equal(t, map[int]int{0: 1, 1: 1}, calls)
+	callsMu.Unlock()
+}
+
+// TestKeyedValueCancellation verifies that KeyedValue respects caller context cancellation
+// and that the cancel function returned by KeyedValue causes cancellation of inflight
+// calls to the wrapped function.
+func TestKeyedValueCancellation(t *testing.T) {
+	canceledInner := errors.New("inner-function-canceled")
+
+	unblock := make(chan struct{}, 1)
+
+	fn, cancelInner := KeyedValue(func(ctx context.Context, key int) (string, error) {
+		select {
+		case <-unblock:
+			return fmt.Sprintf("value-%d", key), nil
+		case <-ctx.Done():
+			return "", canceledInner
+		}
+	})
+	defer cancelInner()
+
+	// verify normal operation
+	unblock <- struct{}{}
+	val, err := fn(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, "value-1", val)
+
+	// verify cancellation of caller context
+	tctx, cancel := context.WithTimeout(context.Background(), 1)
+	defer cancel()
+	val, err = fn(tctx, 2)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Empty(t, val)
+
+	// unblock the inner function and verify it completes normally
+	unblock <- struct{}{}
+	val, err = fn(context.Background(), 2)
+	require.NoError(t, err)
+	require.Equal(t, "value-2", val)
+
+	// verify cancellation of the inner function via the cancel function
+	cancelInner()
+	val, err = fn(context.Background(), 3)
+	require.ErrorIs(t, err, canceledInner)
+	require.Empty(t, val)
+}

--- a/lib/versioncontrol/target.go
+++ b/lib/versioncontrol/target.go
@@ -148,7 +148,7 @@ func (t Target) SecurityPatch() bool {
 }
 
 // SecurityPatchAltOf performs a bidirectional check to see if this target and another
-// are security patch alternates (i.e. wether or not they provide the same security fix).
+// are security patch alternates (i.e. whether or not they provide the same security fix).
 func (t Target) SecurityPatchAltOf(other Target) bool {
 	if !t.Ok() || !other.Ok() {
 		return false

--- a/lib/versioncontrol/upgradewindow/upgradewindow.go
+++ b/lib/versioncontrol/upgradewindow/upgradewindow.go
@@ -50,7 +50,7 @@ const (
 type ExportFunc func(ctx context.Context, req proto.ExportUpgradeWindowsRequest) (proto.ExportUpgradeWindowsResponse, error)
 
 // contextLike lets us abstract over the difference between basic contexts and context-like values such
-// as control stream senders or resource watchers. the exporter uses a contextLike value to decide wether
+// as control stream senders or resource watchers. the exporter uses a contextLike value to decide whether
 // or not auth connectivity appears healthy. during normal runtime, we end up using the inventory control
 // stream send handle.
 type contextLike interface {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -886,7 +886,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	// Returns the CA Certs
 	// Deprecated, use the `webapi/auth/export` endpoint.
-	// Returning other clusters (trusted cluster) CA certs would leak wether the TrustedCluster exists or not.
+	// Returning other clusters (trusted cluster) CA certs would leak whether the TrustedCluster exists or not.
 	// Given that this is a public/unauthorized endpoint, we should refrain from exposing that kind of information.
 	h.GET("/webapi/sites/:site/auth/export", h.authExportPublic)
 	h.GET("/webapi/auth/export", h.authExportPublic)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -959,6 +959,7 @@ func (s *sessionCache) AuthenticateSSHUser(
 ) (*authclient.SSHLoginResponse, error) {
 	authReq := authclient.AuthenticateUserRequest{
 		Username:       c.User,
+		Scope:          c.Scope,
 		ClientMetadata: clientMeta,
 		SSHPublicKey:   c.UserPublicKeys.SSHPubKey,
 		TLSPublicKey:   c.UserPublicKeys.TLSPubKey,


### PR DESCRIPTION
Scope pinning is the process of locking a certificate to a specific target scope such that the certificate is only usable for access to resources subject to that scope, and only conveys the set of scoped privileges relevant to said access.

This PR introduces the core logic related to generation of scope-pinned certificates, as well as various helpers/tweaks intended to support the minimum functional usecase of being able to perform a standard `tsh login` using scopes.

As it stands, scope pinned certificates aren't really usable for anything as scoped roles don't convey any additional privileges beyond the default implicit privilege set, and no significant APIs have been updated to support scoped privileges.  This PR represents the last of the pre-requisite work before we can start adding scoped privileges and making individual APIs scope-aware.  As a proof of concept, and because it is depended upon by `tsh login` functionality, the `GetCertAuthorities` method was updated to support scoped identities.

In addition to scope pinned certs, this PR introduces a set of related utilities for handling scoped identities/privileges:
- `services.ScopedAccessChecker`: A scope-aware direct equivalent to the `AccessChecker` type (though note that high-level usage varies significantly).
- `services.SplitAccessChecker`: A wrapper type for use by logic that accepts either a scoped or unscoped access checker.
- `services.ScopedAccessCheckerContext`: The top-level type from which scoped access checkers are generated.  This is a key difference between scoped and unscoped access checks.  Scoped access checks are performed in a descending sequence from the root scope to the scope of the resource against which access is being attempted (e.g. a resource at scope `/aa/bb` may be authorized by assignments at `/`, `/aa`, or `/aa/bb`, which are conceptually distinct decisions).
- `authz.ScopedAuthorizer`/`authz.ScopedContext`: A wrapper around `authz.Authorizer` that provides rudimentary scoped identity support.

Note that all of the above are fairly experimental patterns and subject to significant churn as we start building out scoped privileges/APIs and learn more about how to make them ergonomic and functional.  In particular, I am dissatisfied with the current `authz.ScopedContext`/`services.ScopedAccessCheckerContext` pattern.  I think we're going to need better polymorphism at that level to ensure that complex methods that need to support scoped and unscoped privileges don't end up with completely bifurcated access-control implementations.

This PR also makes some minor fixes/tweaks, including disallowing capital letters in scope segments (judged too easy to abuse/misuse), and fixing a failure to close the scoped access cache which was resulting in excess load/spam during tests.

This PR is a direct follow-up to https://github.com/gravitational/teleport/pull/58123.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).