### PR TITLE
[v18] Forcibly exit VNet admin process if network stack doesn't shut down after timeout

### DIFF
--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -127,18 +127,16 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 	case err := <-done:
 		return trace.Wrap(err, "running VNet admin process")
 	case <-ctx.Done():
-		timer := time.NewTimer(5 * time.Second)
-		defer timer.Stop()
+	}
 
-		select {
-		case <-done:
-			// network stack exited cleanly within timeout
-			return trace.Wrap(err, "running VNet admin process")
-		case <-timer.C:
-			log.ErrorContext(ctx, "VNet admin process did not exit within 5 seconds, forcing shutdown.")
-			os.Exit(1)
-			return nil
-		}
+	select {
+	case err := <-done:
+		// network stack exited cleanly within timeout
+		return trace.Wrap(err, "running VNet admin process")
+	case <-time.After(10 * time.Second):
+		log.ErrorContext(ctx, "VNet admin process did not exit within 10 seconds, forcing shutdown.")
+		os.Exit(1)
+		return nil
 	}
 }
 

--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -90,18 +90,21 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
+		defer log.InfoContext(ctx, "Network stack terminated.")
 		if err := networkStack.run(ctx); err != nil {
 			return trace.Wrap(err, "running network stack")
 		}
 		return errors.New("network stack terminated")
 	})
 	g.Go(func() error {
+		defer log.InfoContext(ctx, "OS configuration loop exited.")
 		if err := osConfigurator.runOSConfigurationLoop(ctx); err != nil {
 			return trace.Wrap(err, "running OS configuration loop")
 		}
 		return errors.New("OS configuration loop terminated")
 	})
 	g.Go(func() error {
+		defer log.InfoContext(ctx, "Ping loop exited.")
 		tick := time.Tick(time.Second)
 		for {
 			select {


### PR DESCRIPTION
Backport #58298 to branch/v18

changelog: Fixed an issue where VNet could not start because of "VNet is already running" error
