### PR TITLE
Device Trust UI: Add Intune next to Jamf in empty state

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
@@ -236,42 +236,42 @@ export const fakeItems: TrustedDevice[] = [
     assetTag: 'FWPGP915V',
     osType: 'macOS',
     enrollStatus: 'enrolled',
-    owner: 'mykel',
+    owner: 'alice',
   },
   {
     id: 'M7XJR4GK8823',
     assetTag: 'M7XJR4GK8823',
     osType: 'Windows',
     enrollStatus: 'enrolled',
-    owner: 'lila',
+    owner: 'bob',
   },
   {
     id: 'L2FQZ9VH4466',
     assetTag: 'L2FQZ9VH4466',
     osType: 'Linux',
     enrollStatus: 'enrolled',
-    owner: 'bart',
+    owner: 'charlie',
   },
   {
     id: 'N8EYW1DP7732',
     assetTag: 'N8EYW1DP7732',
     osType: 'Linux',
     enrollStatus: 'not enrolled',
-    owner: 'rafao',
+    owner: '',
   },
   {
     id: 'K5BHP6CT5598',
     assetTag: 'K5BHP6CT5598',
     osType: 'Windows',
     enrollStatus: 'not enrolled',
-    owner: 'gzz',
+    owner: '',
   },
   {
     id: 'Y3RSL7FJ2104',
     assetTag: 'Y3RSL7FJ2104',
     osType: 'macOS',
     enrollStatus: 'enrolled',
-    owner: 'ryry',
+    owner: 'dan',
   },
 ];
 
@@ -292,7 +292,7 @@ const auditEvents = [
     code: 'TC000I',
     event: 'cert.create',
     identity: {
-      user: 'lisa',
+      user: 'charlie',
     },
     time: '2024-02-04T19:43:23.529Z',
   },
@@ -303,14 +303,14 @@ const auditEvents = [
     success: true,
     time: '2024-02-04T19:43:22.529Z',
     uid: 'fa279611-91d8-47b5-9fad-b8ea3e5286e0',
-    user: 'lisa',
+    user: 'charlie',
   },
   {
     cert_type: 'user',
     code: 'TC000I',
     event: 'cert.create',
     identity: {
-      user: 'isabelle',
+      user: 'dan',
     },
     time: '2024-02-04T19:43:21.529Z',
   },
@@ -319,7 +319,7 @@ const auditEvents = [
     code: 'T1016I',
     time: '2024-02-04T19:43:20.529Z',
     uid: '815bbcf4-fb05-4e08-917c-7259e9332d69',
-    user: 'isabelle',
+    user: 'dan',
   },
 ].map(makeEvent);
 

--- a/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
@@ -22,12 +22,12 @@ import styled from 'styled-components';
 
 import {
   Box,
-  ButtonPrimary,
   ButtonSecondary,
   Flex,
   H1,
   H2,
   H3,
+  MenuItem,
   P1,
   P2,
   ResourceIcon,
@@ -46,6 +46,7 @@ import {
   FeatureContainer,
   FeatureSlider,
 } from 'shared/components/EmptyState/EmptyState';
+import { MenuButton } from 'shared/components/MenuAction';
 import { pluralize } from 'shared/utils/text';
 
 import {
@@ -123,7 +124,7 @@ export const EmptyList = ({
             isSliding={!!intervalId}
             onClick={() => handleOnClick(3)}
             title="Integrates with your MDM"
-            description="Auto-enroll and sync device registry from Jamf."
+            description="Auto-enroll and sync device registry from Jamf&nbsp;Pro or&nbsp;Microsoft&nbsp;Intune."
           />
         </Box>
         <Box>
@@ -146,21 +147,22 @@ export const EmptyList = ({
           )}
           {currIndex === 3 && (
             <FadedTable>
-              <Flex flexDirection="column" justifyContent="center">
-                <JamfCard margin="auto" mb={4}>
-                  <ResourceIcon height="20px" width="20px" name="jamf" />
-                  {/* purposefully "creating" the text ourselves to avoid having a light and dark logo just for text */}
-                  <Text
-                    css={`
-                      font-size: 28px;
-                      line-height: 30px;
-                    `}
-                    ml={3}
-                  >
-                    jamf
-                  </Text>
-                </JamfCard>
-                <Flex justifyContent="center" gap={4}>
+              <Flex
+                flexDirection="column"
+                justifyContent="center"
+                gap={iconGap}
+              >
+                <Flex gap={iconGap}>
+                  <MdmCard>
+                    <ResourceIcon height="20px" width="20px" name="jamf" />
+                    <MdmText>Jamf Pro</MdmText>
+                  </MdmCard>
+                  <MdmCard>
+                    <ResourceIcon height="20px" width="20px" name="intune" />
+                    <MdmText>Microsoft Intune</MdmText>
+                  </MdmCard>
+                </Flex>
+                <Flex justifyContent="center" gap={iconGap}>
                   <IconCard>
                     <Password />
                   </IconCard>
@@ -197,17 +199,30 @@ export const EmptyList = ({
         >
           {isEnterprise ? (
             <>
-              <ButtonPrimary
-                width="280px"
-                as={Link}
-                to={cfg.getIntegrationEnrollRoute('jamf')}
-                size="large"
+              <MenuButton
+                buttonText="Get Started with an MDM"
+                buttonProps={{
+                  size: 'large',
+                  intent: 'primary',
+                  fill: 'filled',
+                  color: 'text.primaryInverse',
+                  width: '280px',
+                }}
               >
-                Get Started with JAMF
-              </ButtonPrimary>
+                <MenuItem as={Link} to={cfg.getIntegrationEnrollRoute('jamf')}>
+                  Jamf Pro
+                </MenuItem>
+                <MenuItem
+                  as={Link}
+                  to={cfg.getIntegrationEnrollRoute('intune')}
+                >
+                  Microsoft Intune
+                </MenuItem>
+              </MenuButton>
+
               <ButtonSecondary
                 as="a"
-                href="https://goteleport.com/docs/admin-guides/access-controls/device-trust/jamf-integration/"
+                href="https://goteleport.com/docs/identity-governance/device-trust/"
                 target="_blank"
                 width="280px"
                 size="large"
@@ -229,6 +244,8 @@ export const EmptyList = ({
     </Box>
   );
 };
+
+const iconGap = 4;
 
 export const fakeItems: TrustedDevice[] = [
   {
@@ -467,12 +484,17 @@ const PreviewBox = styled(Box)`
   border-radius: ${p => p.theme.radii[3]}px;
 `;
 
-const JamfCard = styled(Flex)`
-  justify-content: center;
-  align-items: center;
-  padding: ${p => p.theme.space[5]}px;
-  border-radius: ${p => p.theme.radii[3]}px;
-  background-color: ${p => p.theme.colors.levels.surface};
+const MdmCard = styled(Flex).attrs({
+  justifyContent: 'center',
+  alignItems: 'center',
+  p: 5,
+  borderRadius: 3,
+  backgroundColor: 'levels.surface',
+  gap: 3,
+})``;
+
+const MdmText = styled(Text).attrs({ fontSize: '28px' })`
+  line-height: 30px;
 `;
 
 const IconCard = styled(Flex)`


### PR DESCRIPTION
* The example device list was changed so that it doesn't list owners next to devices that are not enrolled, as this state is not possible in a real app.
   * The names in the table were updated to classic Alice & Bob names, as well as were made to match the names in the third subsection with the audit log.
* The fake jamf logo was changed to spell Jamf Pro (the actual product name). This is so that we can have some text next to both logos and it doesn't look as weird as it would if one was a stylized "jamf" and the other was "Microsoft Intune".
* The button that directed the user towards the Jamf plugin was changed to a button menu from which the user can select either Jamf or Intune.
   * If the new integration page supported filtering, we could maybe have a single button with a filter for a certain plugin type. But it doesn't support filtering today, so I figured out that a button menu is best we can do right now.
* The link to docs was updated to point to the main Device Trust docs page instead of the Jamf integration docs. [In an updated version](https://github.com/gravitational/teleport/pull/58264), that docs page is going to link to both integrations.

https://localhost:9002/?path=/story/teleporte-devicetrust--empty-no-cta

| Before | After |
| --- | --- |
| <img width="1304" height="689" alt="before-devices-list" src="https://github.com/user-attachments/assets/ea81f537-79ec-4839-8c0e-546e4718998d" /> | <img width="1304" height="689" alt="after-devices-list" src="https://github.com/user-attachments/assets/35d09d4d-2d9a-4798-b679-b3836d591ec9" /> |
| <img width="1304" height="689" alt="before-mdm" src="https://github.com/user-attachments/assets/331d9899-5282-490d-b0e1-d89506a64ea0" /> | <img width="1304" height="689" alt="after-mdm" src="https://github.com/user-attachments/assets/9b671572-1396-4dff-bd80-c6a582259a5e" /> |