### PR TITLE
Add the events renderer for the session timeline

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import {
+  SessionRecordingEventType,
+  SessionRecordingMetadata,
+} from 'teleport/services/recordings';
+import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
+import { darkTheme } from 'teleterm/ui/ThemeProvider/theme';
+
+import {
+  EVENT_ROW_HEIGHT,
+  EVENT_SECTION_PADDING,
+  LEFT_PADDING,
+  RULER_HEIGHT,
+} from '../constants';
+import { EventsRenderer } from './EventsRenderer';
+
+const mockMetadata: SessionRecordingMetadata = {
+  startTime: 1609459200, // Jan 1, 2021
+  endTime: 1609462800, // Jan 1, 2021
+  duration: 3600000, // 1 hour in milliseconds
+  user: 'testuser',
+  resourceName: 'test-server',
+  clusterName: 'test-cluster',
+  events: [],
+  startCols: 80,
+  startRows: 24,
+  type: 'ssh',
+};
+
+function createRenderer(metadata?: Partial<SessionRecordingMetadata>) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const renderer = new EventsRenderer(ctx, darkTheme, {
+    ...mockMetadata,
+    ...metadata,
+  });
+
+  return { ctx, renderer };
+}
+
+describe('EventsRenderer', () => {
+  describe('event row creation', () => {
+    it('should place non-overlapping events in the same row', () => {
+      const { renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 1000,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 1500,
+            endTime: 2500,
+            user: 'bob',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 3000,
+            endTime: 4000,
+            user: 'charlie',
+          },
+        ],
+      });
+
+      expect(renderer.getHeight()).toBe(
+        EVENT_ROW_HEIGHT + EVENT_SECTION_PADDING
+      );
+    });
+
+    it('should create multiple rows for overlapping events', () => {
+      const { renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 2000,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 1000,
+            endTime: 3000,
+            user: 'bob',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 1500,
+            endTime: 3500,
+            user: 'charlie',
+          },
+        ],
+      });
+
+      expect(renderer.getHeight()).toBe(
+        3 * EVENT_ROW_HEIGHT + EVENT_SECTION_PADDING
+      );
+    });
+
+    it('should filter out resize events', () => {
+      const { renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Resize,
+            startTime: 0,
+            endTime: 1000,
+            cols: 100,
+            rows: 30,
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 500,
+            endTime: 1500,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Resize,
+            startTime: 2000,
+            endTime: 3000,
+            cols: 120,
+            rows: 40,
+          },
+        ],
+      });
+
+      expect(renderer.getHeight()).toBe(
+        EVENT_ROW_HEIGHT + EVENT_SECTION_PADDING
+      );
+    });
+  });
+
+  describe('position calculation', () => {
+    it('should calculate correct positions for events', () => {
+      const { renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 2500,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 5000,
+            endTime: 7500,
+            user: 'bob',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const rowsWithPositions = renderer.getRowsWithPositions();
+
+      expect(rowsWithPositions).toHaveLength(1);
+      expect(rowsWithPositions[0]).toHaveLength(2);
+
+      expect(rowsWithPositions[0][0].startPosition).toBe(LEFT_PADDING);
+      expect(rowsWithPositions[0][0].endPosition).toBe(LEFT_PADDING + 250);
+
+      expect(rowsWithPositions[0][1].startPosition).toBe(LEFT_PADDING + 500);
+      expect(rowsWithPositions[0][1].endPosition).toBe(LEFT_PADDING + 750);
+    });
+
+    it('should measure the text of each event', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Inactivity,
+            startTime: 0,
+            endTime: 3000,
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 4000,
+            endTime: 5000,
+            user: 'verylongusername',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const events = ctx.__getEvents();
+      const measureTextEvents = events.filter(
+        call => call.type === 'measureText'
+      );
+
+      expect(measureTextEvents[0].props.text).toBe('Inactivity for 3s');
+      expect(measureTextEvents[1].props.text).toBe('verylongusername joined');
+    });
+  });
+
+  describe('visibility', () => {
+    it('should only render visible events', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 20000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 1000,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 10000,
+            endTime: 11000,
+            user: 'bob',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 19000,
+            endTime: 20000,
+            user: 'charlie',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(2000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 100,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const drawCalls = ctx.__getDrawCalls();
+      const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+      expect(fillTextCalls).toHaveLength(1);
+      expect(fillTextCalls[0].props.text).toBe('alice joined');
+    });
+
+    it('should include events partially visible in viewport', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 20000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 1000,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 10000,
+            endTime: 11000,
+            user: 'bob',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 19000,
+            endTime: 20000,
+            user: 'charlie',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 550,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const drawCalls = ctx.__getDrawCalls();
+      const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+      expect(fillTextCalls).toHaveLength(2);
+      expect(fillTextCalls[0].props.text).toBe('alice joined');
+      expect(fillTextCalls[1].props.text).toBe('bob joined');
+    });
+  });
+
+  describe('event rendering', () => {
+    it('should render inactivity events with duration text', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Inactivity,
+            startTime: 1000,
+            endTime: 6000,
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 1200,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const drawCalls = ctx.__getDrawCalls();
+      const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+      expect(fillTextCalls).toHaveLength(1);
+      expect(fillTextCalls[0].props.text).toBe('Inactivity for 5s');
+    });
+
+    it('should constrain text within event bounds', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 1000,
+            endTime: 1100,
+            user: 'verylongusernamethatoverflows',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 1200,
+        offset: -100,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const drawCalls = ctx.__getDrawCalls();
+      const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+      expect(fillTextCalls).toHaveLength(1);
+
+      // text should be rendered within event bounds
+      // event starts at 1000ms which is 10% of 1000px
+      // so event starts at 100px + LEFT_PADDING
+      // text should not start before that
+
+      const textX = fillTextCalls[0].props.x;
+      const eventStartX = LEFT_PADDING + (1000 / 10000) * 1000;
+
+      expect(textX).toBeGreaterThanOrEqual(eventStartX);
+    });
+
+    it('should position events at correct Y coordinate for each row', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 2000,
+            user: 'alice',
+          },
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 1000,
+            endTime: 3000,
+            user: 'bob',
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 1200,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const events = ctx.__getEvents();
+      const roundRectEvents = events.filter(e => e.type === 'roundRect');
+
+      expect(roundRectEvents).toHaveLength(2);
+
+      // first event should be in first row
+      expect(roundRectEvents[0].props.y).toBe(
+        EVENT_SECTION_PADDING + RULER_HEIGHT
+      );
+      // second event should be in second row
+      expect(roundRectEvents[1].props.y).toBe(
+        EVENT_SECTION_PADDING + EVENT_ROW_HEIGHT + RULER_HEIGHT
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty events array', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [],
+      });
+
+      expect(renderer.getHeight()).toBe(EVENT_SECTION_PADDING);
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 1200,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const drawCalls = ctx.__getDrawCalls();
+
+      expect(drawCalls).toHaveLength(0);
+    });
+
+    it('should handle very long event titles', () => {
+      const { ctx, renderer } = createRenderer({
+        duration: 10000,
+        events: [
+          {
+            type: SessionRecordingEventType.Join,
+            startTime: 0,
+            endTime: 100,
+            user: 'a'.repeat(100),
+          },
+        ],
+      });
+
+      renderer.setTimelineWidth(1000);
+      renderer.calculate();
+
+      const renderContext: TimelineRenderContext = {
+        containerWidth: 1200,
+        offset: 0,
+        containerHeight: 200,
+        eventsHeight: renderer.getHeight(),
+      };
+
+      renderer._render(renderContext);
+
+      const events = ctx.__getEvents();
+
+      const roundRectCalls = events.filter(call => call.type === 'roundRect');
+
+      expect(roundRectCalls).toHaveLength(1);
+
+      // the event should be the width of the text plus padding
+      const textMetrics = ctx.measureText('a'.repeat(100) + ' joined');
+      const eventWidth = textMetrics.width + 16; // 8px padding on each side
+
+      expect(roundRectCalls[0].props.width).toBeLessThanOrEqual(eventWidth);
+    });
+  });
+});

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.test.ts
@@ -18,12 +18,13 @@
 
 import 'jest-canvas-mock';
 
+import { darkTheme } from 'design/theme';
+
 import {
   SessionRecordingEventType,
   SessionRecordingMetadata,
 } from 'teleport/services/recordings';
 import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
-import { darkTheme } from 'teleterm/ui/ThemeProvider/theme';
 
 import {
   EVENT_ROW_HEIGHT,

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
@@ -79,11 +79,13 @@ const EVENT_RADIUS = 8;
 const TEXT_PADDING = 8;
 const EVENT_HEIGHT = 24;
 
-// EventsRenderer renders each "event" that happens in a session recording, i.e. inactivity,
-// or if a user has joined. It does not render resize events, that is handled by a different renderer.
-//
-// Events are shown between the start time and end time of the event. The text in the event
-// scrolls along with the timeline, but is constrained to the event box.
+/**
+ * EventsRenderer renders each "event" that happens in a session recording, i.e. inactivity,
+ * or if a user has joined. It does not render resize events, that is handled by a different renderer.
+ *
+ * Events are shown between the start time and end time of the event. The text in the event
+ * scrolls along with the timeline, but is constrained to the event box.
+ */
 export class EventsRenderer extends TimelineCanvasRenderer {
   private height = 0;
   // rows are computed on creation, containing information such as text width to avoid

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/EventsRenderer.ts
@@ -1,0 +1,274 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DefaultTheme } from 'styled-components';
+
+import {
+  SessionRecordingEventType,
+  type SessionRecordingEvent,
+  type SessionRecordingMetadata,
+} from 'teleport/services/recordings';
+import { formatSessionRecordingDuration } from 'teleport/SessionRecordings/list/RecordingItem';
+
+import {
+  CANVAS_FONT,
+  EVENT_ROW_HEIGHT,
+  EVENT_SECTION_PADDING,
+  LEFT_PADDING,
+  RULER_HEIGHT,
+} from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+export type EventRow = TimelineEventMeasured[];
+
+export type EventRowWithPositions = TimelineEventPositioned[];
+
+type TimelineEventMeasured = SessionRecordingEvent & {
+  title: string;
+  textMetrics: TextMetrics;
+};
+
+type TimelineEventPositioned = TimelineEventMeasured & {
+  endPosition: number;
+  startPosition: number;
+};
+
+function getEventStyles(theme: DefaultTheme, type: SessionRecordingEventType) {
+  switch (type) {
+    case SessionRecordingEventType.Inactivity:
+      return theme.colors.sessionRecordingTimeline.events.inactivity;
+    case SessionRecordingEventType.Resize:
+      return theme.colors.sessionRecordingTimeline.events.resize;
+    case SessionRecordingEventType.Join:
+      return theme.colors.sessionRecordingTimeline.events.join;
+    default:
+      return theme.colors.sessionRecordingTimeline.events.default;
+  }
+}
+
+function getEventTitle(event: SessionRecordingEvent) {
+  switch (event.type) {
+    case SessionRecordingEventType.Inactivity:
+      return `Inactivity for ${formatSessionRecordingDuration(event.endTime - event.startTime)}`;
+    case SessionRecordingEventType.Join:
+      return `${event.user} joined`;
+    default:
+      return 'Event';
+  }
+}
+
+const EVENT_RADIUS = 8;
+const TEXT_PADDING = 8;
+const EVENT_HEIGHT = 24;
+
+// EventsRenderer renders each "event" that happens in a session recording, i.e. inactivity,
+// or if a user has joined. It does not render resize events, that is handled by a different renderer.
+//
+// Events are shown between the start time and end time of the event. The text in the event
+// scrolls along with the timeline, but is constrained to the event box.
+export class EventsRenderer extends TimelineCanvasRenderer {
+  private height = 0;
+  // rows are computed on creation, containing information such as text width to avoid
+  // measuring text during render.
+  private rows: EventRow[] = [];
+  // rowsWithPositions are computed after calculate() is called, containing the position
+  // of each event in the timeline, along with text metrics to avoid measuring text during render
+  private rowsWithPositions: EventRowWithPositions[] = [];
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+
+    this.createEventRows(metadata.events);
+  }
+
+  _render({ containerWidth, offset }: TimelineRenderContext) {
+    const eventRows = this.getVisibleEvents(offset, containerWidth);
+
+    for (const [index, row] of eventRows.entries()) {
+      for (const event of row) {
+        const startX = event.startPosition;
+        const endX = event.endPosition;
+        this.ctx.save();
+
+        const x = startX;
+
+        const y =
+          EVENT_SECTION_PADDING + index * EVENT_ROW_HEIGHT + RULER_HEIGHT;
+
+        // calculate the minimum width of the event box from the text width + padding
+        const textWidth = event.textMetrics.width;
+        const minWidth = textWidth + 2 * TEXT_PADDING;
+
+        const width = Math.max(endX - startX, minWidth);
+
+        const styles = getEventStyles(this.theme, event.type);
+
+        this.ctx.fillStyle = styles.background;
+        this.ctx.beginPath();
+
+        this.ctx.roundRect(x, y, width, EVENT_HEIGHT, EVENT_RADIUS);
+        this.ctx.fill();
+
+        this.ctx.fillStyle = styles.text;
+
+        this.ctx.font = `bold 12px ${CANVAS_FONT}`;
+
+        // Calculate text position and constrain it within the event box.
+        const textHeight =
+          event.textMetrics.actualBoundingBoxAscent +
+          event.textMetrics.actualBoundingBoxDescent;
+
+        const textPadding = 8;
+        const visibleStart = Math.max(startX, -offset);
+        const defaultTextOffset = Math.max(
+          visibleStart - startX + textPadding,
+          textPadding
+        );
+
+        let textOffset = defaultTextOffset;
+
+        if (textWidth > 0) {
+          // Ensure the text does not overflow the event box.
+          const maxTextOffset = Math.max(
+            textPadding,
+            width - textWidth - textPadding
+          );
+          textOffset = Math.min(defaultTextOffset, maxTextOffset);
+        }
+
+        const textY =
+          y +
+          (EVENT_HEIGHT - textHeight) / 2 +
+          event.textMetrics.actualBoundingBoxAscent;
+
+        this.ctx.fillText(event.title, x + textOffset, textY + 1);
+
+        this.ctx.restore();
+      }
+    }
+  }
+
+  // calculate calculates the positions of each event in the timeline, along with the
+  // text metrics for each event title (to avoid measuring text during render).
+  calculate() {
+    const eventRowsWithPositions: EventRowWithPositions[] = [];
+
+    for (let i = 0; i < this.rows.length; i++) {
+      const row = this.rows[i];
+      const positionedRow: EventRowWithPositions = [];
+
+      for (const event of row) {
+        const startPosition =
+          LEFT_PADDING + (event.startTime / this.duration) * this.timelineWidth;
+        const endPosition =
+          LEFT_PADDING + (event.endTime / this.duration) * this.timelineWidth;
+
+        positionedRow.push({
+          ...event,
+          endPosition,
+          startPosition,
+        });
+      }
+
+      eventRowsWithPositions.push(positionedRow);
+    }
+
+    this.rowsWithPositions = eventRowsWithPositions;
+  }
+
+  getHeight() {
+    return this.height;
+  }
+
+  getRowsWithPositions() {
+    return this.rowsWithPositions;
+  }
+
+  private createEventRows(events: SessionRecordingEvent[]) {
+    const sortedEvents = [...events].sort((a, b) => a.startTime - b.startTime);
+    const rows: EventRow[] = [];
+
+    for (const event of sortedEvents) {
+      if (event.type === SessionRecordingEventType.Resize) {
+        continue;
+      }
+
+      let placed = false;
+
+      const title = getEventTitle(event);
+
+      for (const row of rows) {
+        const lastEventInRow = row[row.length - 1];
+
+        if (lastEventInRow.endTime <= event.startTime) {
+          const textMetrics = this.ctx.measureText(title);
+
+          row.push({ ...event, textMetrics, title });
+
+          placed = true;
+          break;
+        }
+      }
+
+      if (!placed) {
+        const textMetrics = this.ctx.measureText(title);
+
+        rows.push([{ ...event, textMetrics, title }]);
+      }
+    }
+
+    this.rows = rows;
+    this.height = this.rows.length * EVENT_ROW_HEIGHT + EVENT_SECTION_PADDING;
+  }
+
+  private getVisibleEvents(
+    offset: number,
+    containerWidth: number
+  ): EventRowWithPositions[] {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const visibleRows: EventRowWithPositions[] = [];
+
+    for (const row of this.rowsWithPositions) {
+      const visibleRow: EventRowWithPositions = [];
+
+      for (const event of row) {
+        if (
+          event.startPosition <= visibleEnd &&
+          event.endPosition >= visibleStart
+        ) {
+          visibleRow.push(event);
+        }
+      }
+
+      if (visibleRow.length > 0) {
+        visibleRows.push(visibleRow);
+      }
+    }
+
+    return visibleRows;
+  }
+}


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/58310

Adds the events renderer for the canvas timeline. This is responsible for rendering inactivity and join events

<img width="787" height="124" alt="image" src="https://github.com/user-attachments/assets/b0947baa-a57b-4722-8abb-8b1f91943ef3" />
