### PR TITLE
Add variadic opts and managed device methods to `lib/msgraph.Client`

### DIFF
--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -154,7 +154,7 @@ func NewClient(cfg Config) (*Client, error) {
 
 // request is the base function for HTTP API calls.
 // It implements retry handling in case of API throttling, see [https://learn.microsoft.com/en-us/graph/throttling].
-func (c *Client) request(ctx context.Context, method string, uri string, header map[string]string, payload []byte) (*http.Response, error) {
+func (c *Client) request(ctx context.Context, method string, uri string, header http.Header, payload []byte) (*http.Response, error) {
 	var body io.ReadSeeker = nil
 	if len(payload) > 0 {
 		body = bytes.NewReader(payload)
@@ -164,8 +164,12 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	for key := range header {
+		req.Header.Set(key, header.Get(key))
+	}
+
 	if body != nil {
-		req.Header.Add("Content-Type", "application/json")
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	token, err := c.tokenProvider.GetToken(ctx, policy.TokenRequestOptions{
@@ -174,10 +178,7 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to get azure authentication token")
 	}
-	req.Header.Add("Authorization", "Bearer "+token.Token)
-	for i := range header {
-		req.Header.Add(i, header[i])
-	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
 
 	const maxRetries = 5
 	var retryAfter time.Duration

--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -165,7 +165,9 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 		return nil, trace.Wrap(err)
 	}
 	for key := range header {
-		req.Header.Set(key, header.Get(key))
+		for _, value := range header.Values(key) {
+			req.Header.Add(key, value)
+		}
 	}
 
 	if body != nil {

--- a/lib/msgraph/managed_device.go
+++ b/lib/msgraph/managed_device.go
@@ -19,7 +19,11 @@ package msgraph
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/gravitational/trace"
 )
 
 // ManagedDevice represents a device from Intune's inventory.
@@ -63,4 +67,13 @@ func WithLastSyncDateTimeGt(lastSyncDateTime time.Time) IterateOpt {
 		// https://learn.microsoft.com/en-us/graph/filter-query-parameter
 		ic.filter = fmt.Sprintf("lastSyncDateTime gt %s", lastSyncDateTime.UTC().Format(time.RFC3339))
 	}
+}
+
+// GetManagedDevice returns a single managed device.
+// https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-get?view=graph-rest-1.0
+func (c *Client) GetManagedDevice(ctx context.Context, id string) (*ManagedDevice, error) {
+	uri := c.endpointURI("deviceManagement", "managedDevices", id)
+	uri.RawQuery = url.Values{"$select": {selectManagedDevice}}.Encode()
+	out, err := roundtrip[*ManagedDevice](ctx, c, http.MethodGet, uri.String(), nil)
+	return out, trace.Wrap(err)
 }

--- a/lib/msgraph/managed_device.go
+++ b/lib/msgraph/managed_device.go
@@ -1,0 +1,66 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package msgraph
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ManagedDevice represents a device from Intune's inventory.
+type ManagedDevice struct {
+	// ID is the unique ID of the device within Intune.
+	ID string `json:"id"`
+	// LastSyncDateTime is the time that the device last completed a successful sync with Intune.
+	LastSyncDateTime time.Time `json:"lastSyncDateTime"`
+	// DeviceRegistrationState describes whether a device was fully enrolled within Intune.
+	// Possible values are: notRegistered, registered, revoked, keyConflict, approvalPending,
+	// certificateReset, notRegisteredPendingEnrollment, unknown.
+	DeviceRegistrationState string `json:"deviceRegistrationState"`
+	SerialNumber            string `json:"serialNumber"`
+	Model                   string `json:"model"`
+	// OperatingSystem is the OS of the device, e.g. "Windows", "macOS", "Linux (ubuntu)".
+	OperatingSystem string `json:"operatingSystem"`
+	// OSVersion is the version of the OS, e.g. "10.0.26100.4351" (Windows), "15.5 (24F74)" (macOS),
+	// "24.04" (Linux).
+	OSVersion string `json:"osVersion"`
+}
+
+// selectManagedDevice is the value for the $select query param when fetching managed devices so
+// that the client fetches only the fields that it needs.
+const selectManagedDevice = "id,lastSyncDateTime,deviceRegistrationState,operatingSystem,serialNumber,model,osVersion"
+
+// IterateManagedDevicePages iterates over managed devices, returning them page by page.
+// https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list?view=graph-rest-1.0
+func (c *Client) IterateManagedDevicePages(ctx context.Context, f func(mds []*ManagedDevice) bool, iterateOpts ...IterateOpt) error {
+	iterateOpts = append(iterateOpts, WithSelect(selectManagedDevice))
+	return iteratePage(c, ctx, "deviceManagement/managedDevices", f, iterateOpts...)
+}
+
+// WithLastSyncDateTimeGt filters the result to only those whose lastSyncDateTime is greater than
+// the given time.
+func WithLastSyncDateTimeGt(lastSyncDateTime time.Time) IterateOpt {
+	return func(ic *iterateConfig) {
+		if lastSyncDateTime.IsZero() {
+			return
+		}
+		// As noted in the docs, DateTimeOffset values aren't enclosed in quotes in $filter expressions.
+		// https://learn.microsoft.com/en-us/graph/filter-query-parameter
+		ic.filter = fmt.Sprintf("lastSyncDateTime gt %s", lastSyncDateTime.UTC().Format(time.RFC3339))
+	}
+}

--- a/lib/msgraph/paginated.go
+++ b/lib/msgraph/paginated.go
@@ -135,6 +135,24 @@ func iterateSimple[T any](c *Client, ctx context.Context, endpoint string, f fun
 	return trace.Wrap(itErr)
 }
 
+func iteratePage[T any](c *Client, ctx context.Context, endpoint string, f func([]T) bool, iterateOpts ...IterateOpt) error {
+	var err error
+	itErr := c.iterate(ctx, endpoint, func(msg json.RawMessage) bool {
+		var page []T
+		if err = json.Unmarshal(msg, &page); err != nil {
+			return false
+		}
+		if !f(page) {
+			return false
+		}
+		return true
+	}, iterateOpts...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(itErr)
+}
+
 // iterate implements pagination for "list" endpoints.
 func (c *Client) iterate(ctx context.Context, endpoint string, f func(json.RawMessage) bool, iterateOpts ...IterateOpt) error {
 	ic := c.newIterateConfig()

--- a/lib/msgraph/paginated.go
+++ b/lib/msgraph/paginated.go
@@ -31,10 +31,93 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+type iterateConfig struct {
+	// filter is the $filter query param.
+	// https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
+	filter string
+	// top is the $top query param.
+	// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#top
+	top int
+	// selector is the $select query param.
+	// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#select
+	selector string
+	// header includes headers that are going to be set during iteration.
+	header http.Header
+	// count is the $count query param.
+	// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#count
+	count bool
+}
+
+func (ic *iterateConfig) query() url.Values {
+	q := make(url.Values)
+	if ic.filter != "" {
+		q.Set("$filter", ic.filter)
+	}
+	if ic.top > 0 {
+		q.Set("$top", strconv.Itoa(ic.top))
+	}
+	if ic.selector != "" {
+		q.Set("$select", ic.selector)
+	}
+	if ic.count {
+		q.Set("$count", "true")
+	}
+	return q
+}
+
+func (c *Client) newIterateConfig() *iterateConfig {
+	return &iterateConfig{
+		top:    c.pageSize,
+		header: make(http.Header),
+	}
+}
+
+// IterateOpt is a function that can be passed to [Client] methods that iterate over API results.
+type IterateOpt func(*iterateConfig)
+
+// WithFilter sets the $filter query param.
+// https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
+func WithFilter(filter string) IterateOpt {
+	return func(ic *iterateConfig) {
+		ic.filter = filter
+	}
+}
+
+// WithTop sets the $top query param. It overrides the default page size set in [Config].
+// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#top
+func WithTop(top int) IterateOpt {
+	return func(ic *iterateConfig) {
+		ic.top = top
+	}
+}
+
+// WithSelect sets the $select query param.
+// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#select
+func WithSelect(s string) IterateOpt {
+	return func(ic *iterateConfig) {
+		ic.selector = s
+	}
+}
+
+// WithCount sets the $count query param.
+// https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#count
+func WithCount() IterateOpt {
+	return func(ic *iterateConfig) {
+		ic.count = true
+	}
+}
+
+// WithHeader sets the value of a specific header.
+func WithHeader(key, value string) IterateOpt {
+	return func(ic *iterateConfig) {
+		ic.header.Set(key, value)
+	}
+}
+
 // iterateSimple implements pagination for "simple" object lists, where additional logic isn't needed
-func iterateSimple[T any](c *Client, ctx context.Context, endpoint string, f func(*T) bool) error {
+func iterateSimple[T any](c *Client, ctx context.Context, endpoint string, f func(*T) bool, iterateOpts ...IterateOpt) error {
 	var err error
-	itErr := c.iterate(ctx, endpoint, nil /* query */, nil /* optional header */, func(msg json.RawMessage) bool {
+	itErr := c.iterate(ctx, endpoint, func(msg json.RawMessage) bool {
 		var page []T
 		if err = json.Unmarshal(msg, &page); err != nil {
 			return false
@@ -45,7 +128,7 @@ func iterateSimple[T any](c *Client, ctx context.Context, endpoint string, f fun
 			}
 		}
 		return true
-	})
+	}, iterateOpts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -53,18 +136,20 @@ func iterateSimple[T any](c *Client, ctx context.Context, endpoint string, f fun
 }
 
 // iterate implements pagination for "list" endpoints.
-func (c *Client) iterate(ctx context.Context, endpoint string, query url.Values, header map[string]string, f func(json.RawMessage) bool) error {
+func (c *Client) iterate(ctx context.Context, endpoint string, f func(json.RawMessage) bool, iterateOpts ...IterateOpt) error {
+	ic := c.newIterateConfig()
+	for _, opt := range iterateOpts {
+		opt(ic)
+	}
+
 	uri := *c.baseURL
 	uri.Path = path.Join(uri.Path, endpoint)
-	pageSize := strconv.Itoa(c.pageSize)
-	if query == nil {
-		query = make(url.Values)
-	}
-	query.Add("$top", pageSize)
-	uri.RawQuery = query.Encode()
+
+	uri.RawQuery = ic.query().Encode()
+
 	uriString := uri.String()
 	for uriString != "" {
-		resp, err := c.request(ctx, http.MethodGet, uriString, header, nil /* payload */)
+		resp, err := c.request(ctx, http.MethodGet, uriString, ic.header, nil /* payload */)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -122,7 +207,7 @@ func (c *Client) IterateServicePrincipals(ctx context.Context, f func(principal 
 // Ref: [https://learn.microsoft.com/en-us/graph/api/group-list-members].
 func (c *Client) IterateGroupMembers(ctx context.Context, groupID string, f func(GroupMember) bool) error {
 	var err error
-	itErr := c.iterate(ctx, path.Join("groups", groupID, "members"), nil /* query */, nil /* optional header */, func(msg json.RawMessage) bool {
+	itErr := c.iterate(ctx, path.Join("groups", groupID, "members"), func(msg json.RawMessage) bool {
 		var page []json.RawMessage
 		if err = json.Unmarshal(msg, &page); err != nil {
 			return false
@@ -175,12 +260,10 @@ func (c *Client) IterateUsersTransitiveMemberOf(ctx context.Context, userID, gro
 	// "ConsistencyLevel: eventual" header set when using
 	// advanced query parameter such as $filter.
 	// https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http#legend
-	query := url.Values{
-		"$select": {"id"},
-		"$count":  {"true"},
-	}
-	header := map[string]string{
-		"ConsistencyLevel": "eventual",
+	iterateOpts := []IterateOpt{
+		WithSelect("id"),
+		WithCount(),
+		WithHeader("ConsistencyLevel", "eventual"),
 	}
 
 	endpoint := path.Join("users", userID, "transitiveMemberOf")
@@ -191,13 +274,13 @@ func (c *Client) IterateUsersTransitiveMemberOf(ctx context.Context, userID, gro
 		endpoint = path.Join(endpoint, graphNamespaceDirectoryRoles)
 	case types.EntraIDSecurityGroups:
 		endpoint = path.Join(endpoint, graphNamespaceGroups)
-		query.Add("$filter", securityGroupsFilter)
+		iterateOpts = append(iterateOpts, WithFilter(securityGroupsFilter))
 	default:
 		return trace.BadParameter("unexpected group type %q received, expected types are %q", groupType, types.EntraIDGroupsTypes)
 	}
 
 	var err error
-	itErr := c.iterate(ctx, endpoint, query, header, func(msg json.RawMessage) bool {
+	itErr := c.iterate(ctx, endpoint, func(msg json.RawMessage) bool {
 		var page []Group
 		if err = json.Unmarshal(msg, &page); err != nil {
 			return false
@@ -208,7 +291,7 @@ func (c *Client) IterateUsersTransitiveMemberOf(ctx context.Context, userID, gro
 			}
 		}
 		return true
-	})
+	}, iterateOpts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR converts the existing callsites of `lib/msgraph.Client.iterate` to use variadic opts. It also adds methods for fetching managed devices that I'll need in `e/lib/intune`.

The new methods are used in https://github.com/gravitational/teleport.e/pull/7174.