### PR TITLE
Add documentation for `default_namespace` configuration option

### DIFF
--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -343,6 +343,14 @@ selectors:
   # name includes an exact match by name. Note that wildcards are not currently
   # supported. Multiple name selectors can be specified if desired.
   - name: foo
+    # default_namespace is the namespace that should be configured for the
+    # context within the kubeconfig. This will be the namespace used by
+    # `kubectl`/SDK if the user has not explicitly provided one.
+    #
+    # If unspecified, no default namespace is set within the kubeconfig and
+    # `kubectl`/SDKs will use default based on their own login - which is often
+    # to select the `default` namespace.
+    default_namespace: my-namespace
   # labels include all clusters matching all of these labels. Multiple label
   # selectors can be provided if needed.
   - labels:

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -348,7 +348,7 @@ selectors:
     # `kubectl`/SDK if the user has not explicitly provided one.
     #
     # If unspecified, no default namespace is set within the kubeconfig and
-    # `kubectl`/SDKs will use default based on their own login - which is often
+    # `kubectl`/SDKs will use default based on their own logic - which is often
     # to select the `default` namespace.
     default_namespace: my-namespace
   # labels include all clusters matching all of these labels. Multiple label


### PR DESCRIPTION
Adds documentation for https://github.com/gravitational/teleport/pull/58393

DNM until feature is merged, do not merge backports until feature is released.