### PR TITLE
Add the frames renderer for the session timeline

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
@@ -92,13 +92,11 @@ async function createRenderer(
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d')!;
 
-  function imageLoader() {
-    return new Promise<LoadedImageResult>(resolve => {
-      const canvas = new OffscreenCanvas(frameWidth, frameHeight);
-      const img = new Image();
+  function imageLoader(): Promise<LoadedImageResult> {
+    const canvas = new OffscreenCanvas(frameWidth, frameHeight);
+    const img = new Image();
 
-      resolve({ canvas, img });
-    });
+    return Promise.resolve({ canvas, img });
   }
 
   const renderer = new FramesRenderer(

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import { darkTheme } from 'design/theme';
+
+import { SessionRecordingThumbnail } from 'teleport/services/recordings';
+import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
+
+import { FramesRenderer } from './FramesRenderer';
+
+// Mock the SVG utilities
+jest.mock('teleport/SessionRecordings/svg', () => ({
+  generateTerminalSVGStyleTag: jest.fn(() => '<style></style>'),
+  injectSVGStyles: jest.fn(svg => svg),
+  svgToDataURIBase64: jest.fn(svg => `data:image/svg+xml;base64,${svg}`),
+}));
+
+beforeEach(() => {
+  Object.defineProperty(window, 'devicePixelRatio', {
+    writable: true,
+    configurable: true,
+    value: 1,
+  });
+
+  global.OffscreenCanvas = jest.fn().mockImplementation((width, height) => {
+    const canvas = document.createElement('canvas');
+
+    canvas.width = width;
+    canvas.height = height;
+
+    return canvas;
+  });
+});
+
+afterEach(() => {
+  global.OffscreenCanvas = undefined;
+});
+
+function createThumbnail(
+  svg: string,
+  cols: number,
+  rows: number,
+  startOffset: number,
+  cursorX = 0,
+  cursorY = 0
+): SessionRecordingThumbnail {
+  return {
+    svg,
+    startOffset,
+    endOffset: startOffset + 1000,
+    cols,
+    rows,
+    cursorX,
+    cursorY,
+    cursorVisible: true,
+  };
+}
+
+const mockFrames: SessionRecordingThumbnail[] = [
+  createThumbnail('<svg>frame1</svg>', 80, 24, 0),
+  createThumbnail('<svg>frame2</svg>', 100, 30, 1000),
+  createThumbnail('<svg>frame3</svg>', 120, 40, 2000),
+  createThumbnail('<svg>frame4</svg>', 80, 24, 3000),
+];
+
+async function createRenderer(
+  frames: SessionRecordingThumbnail[] = mockFrames,
+  timelineWidth = 1000,
+  duration = 5000,
+  initialHeight = 200,
+  eventsHeight = 50,
+  frameWidth = 200,
+  frameHeight = 50
+) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const renderer = new FramesRenderer(
+    ctx,
+    darkTheme,
+    duration,
+    frames,
+    initialHeight,
+    eventsHeight
+  );
+
+  renderer.setTimelineWidth(timelineWidth);
+  renderer.calculate();
+
+  jest
+    .spyOn(
+      // hack to be able to spy on a private method
+      // jest cannot load images in tests so we mock this method
+      renderer as unknown as {
+        loadImage: (
+          frame: SessionRecordingThumbnail
+        ) => Promise<OffscreenCanvas>;
+      },
+      'loadImage'
+    )
+    .mockImplementation(async frame => {
+      const canvas = new OffscreenCanvas(frameWidth, frameHeight);
+
+      renderer['loadedImages'].set(frame.id, canvas);
+
+      return canvas;
+    });
+
+  await renderer.loadVisibleFrames(0, timelineWidth);
+
+  const renderContext: TimelineRenderContext = {
+    containerWidth: timelineWidth,
+    offset: 0,
+    containerHeight: initialHeight,
+    eventsHeight: eventsHeight,
+  };
+
+  renderer._render(renderContext);
+
+  return { ctx, renderer };
+}
+
+function getDrawImageCalls(ctx: CanvasRenderingContext2D) {
+  return ctx.__getDrawCalls().filter(call => call.type === 'drawImage');
+}
+
+test('should calculate frame positions correctly', async () => {
+  const { ctx } = await createRenderer();
+
+  const drawImageCalls = getDrawImageCalls(ctx);
+
+  expect(drawImageCalls).toHaveLength(4);
+
+  expect(drawImageCalls[0].props.dx).toBe(24); // left padding
+  expect(drawImageCalls[1].props.dx).toBe(224); // 24 + 200
+  expect(drawImageCalls[2].props.dx).toBe(424); // 224 + 200
+  expect(drawImageCalls[3].props.dx).toBe(800); // last frame at end of timeline, 1000 - 200
+});
+
+test('should skip frames that would overlap at current zoom', async () => {
+  const closeFrames: SessionRecordingThumbnail[] = [
+    createThumbnail('<svg>1</svg>', 80, 24, 0),
+    createThumbnail('<svg>2</svg>', 80, 24, 10),
+    createThumbnail('<svg>3</svg>', 80, 24, 20),
+    createThumbnail('<svg>4</svg>', 80, 24, 500),
+    createThumbnail('<svg>5</svg>', 80, 24, 990),
+  ];
+
+  const { ctx } = await createRenderer(closeFrames, 550);
+
+  const drawImageCalls = getDrawImageCalls(ctx);
+
+  expect(drawImageCalls).toHaveLength(2);
+
+  expect(drawImageCalls[0].props.dx).toBe(24); // first frame, should be drawn at left padding
+  expect(drawImageCalls[1].props.dx).toBe(350); // fourth frame
+});
+
+test('should only render visible frames', async () => {
+  const { ctx } = await createRenderer(mockFrames, 500);
+
+  const drawImageCalls = getDrawImageCalls(ctx);
+
+  expect(drawImageCalls).toHaveLength(2);
+
+  expect(drawImageCalls[0].props.dx).toBe(24); // left padding
+  expect(drawImageCalls[1].props.dx).toBe(224); // 24 + 200
+});
+
+test('should calculate the frames at the current zoom level', async () => {
+  const { renderer } = await createRenderer();
+
+  const framesAtCurrentZoom = renderer.getFramesAtCurrentZoom();
+
+  expect(framesAtCurrentZoom).toHaveLength(4);
+
+  renderer.setTimelineWidth(400);
+
+  const framesAtNewZoom = renderer.getFramesAtCurrentZoom();
+
+  expect(framesAtNewZoom).toHaveLength(2);
+});

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.test.ts
@@ -23,7 +23,7 @@ import { darkTheme } from 'design/theme';
 import { SessionRecordingThumbnail } from 'teleport/services/recordings';
 import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
 
-import { FramesRenderer } from './FramesRenderer';
+import { FramesRenderer, type ThumbnailWithId } from './FramesRenderer';
 
 // Mock the SVG utilities
 jest.mock('teleport/SessionRecordings/svg', () => ({
@@ -109,9 +109,7 @@ async function createRenderer(
       // hack to be able to spy on a private method
       // jest cannot load images in tests so we mock this method
       renderer as unknown as {
-        loadImage: (
-          frame: SessionRecordingThumbnail
-        ) => Promise<OffscreenCanvas>;
+        loadImage: (frame: ThumbnailWithId) => Promise<OffscreenCanvas>;
       },
       'loadImage'
     )

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
@@ -38,7 +38,7 @@ import {
   type TimelineRenderContext,
 } from './TimelineCanvasRenderer';
 
-interface ThumbnailWithId extends SessionRecordingThumbnail {
+export interface ThumbnailWithId extends SessionRecordingThumbnail {
   id: string;
 }
 

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
@@ -1,0 +1,419 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DefaultTheme } from 'styled-components';
+
+import type { SessionRecordingThumbnail } from 'teleport/services/recordings';
+import {
+  generateTerminalSVGStyleTag,
+  injectSVGStyles,
+  svgToDataURIBase64,
+} from 'teleport/SessionRecordings/svg';
+import { calculateThumbnailViewport } from 'teleport/SessionRecordings/view/Timeline/utils';
+
+import {
+  DEFAULT_FRAME_HEIGHT,
+  DEFAULT_MAX_FRAME_WIDTH,
+  EVENT_SECTION_PADDING,
+  LEFT_PADDING,
+  RULER_HEIGHT,
+} from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+interface ThumbnailWithId extends SessionRecordingThumbnail {
+  id: string;
+}
+
+interface ThumbnailWithPosition extends ThumbnailWithId {
+  index: number;
+  position: number;
+  width: number;
+  isEnd: boolean;
+}
+
+/**
+ * FramesRenderer renders every frame it can at the current zoom level.
+ * It skips frames that would overlap with the previous frame to avoid clutter.
+ * It always renders the last frame to ensure the end of the recording is visible.
+ *
+ * It renders frames onto offscreen canvases to avoid doing expensive image processing
+ * on the main canvas during every render cycle. It only processes images when they
+ * are loaded or when the theme changes.
+ *
+ * It uses binary search to quickly find the first frame that is visible in the current
+ * viewport, then iterates from there to find all visible frames.
+ */
+export class FramesRenderer extends TimelineCanvasRenderer {
+  private readonly frames: ThumbnailWithId[] = [];
+  private framesAtCurrentZoom: ThumbnailWithPosition[] = [];
+
+  private frameHeight = 0;
+  private maxFrameWidth = 0;
+
+  private loadedImageElements = new Map<string, HTMLImageElement>();
+  private loadedImages = new Map<string, OffscreenCanvas>();
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    duration: number,
+    frames: SessionRecordingThumbnail[],
+    initialHeight: number,
+    eventsHeight: number
+  ) {
+    super(ctx, theme, duration);
+
+    const svgTheme = generateTerminalSVGStyleTag(theme);
+
+    this.frameHeight =
+      initialHeight - eventsHeight - RULER_HEIGHT - EVENT_SECTION_PADDING * 2;
+
+    this.maxFrameWidth =
+      (DEFAULT_MAX_FRAME_WIDTH / DEFAULT_FRAME_HEIGHT) * initialHeight;
+
+    this.frames = frames.map((frame, index) => ({
+      ...frame,
+      id: `frame-${index}`,
+      svg: svgToDataURIBase64(injectSVGStyles(frame.svg, svgTheme)),
+    }));
+
+    this.setHeight(initialHeight, eventsHeight);
+  }
+
+  _render({ containerWidth, eventsHeight, offset }: TimelineRenderContext) {
+    const framesToRender = this.getVisibleFrames(offset, containerWidth);
+
+    for (let i = 0; i < framesToRender.length; i++) {
+      const frame = framesToRender[i];
+      const img = this.loadedImages.get(frame.id);
+
+      if (img) {
+        this.ctx.drawImage(
+          img,
+          frame.position,
+          eventsHeight + EVENT_SECTION_PADDING + RULER_HEIGHT,
+          frame.width,
+          this.frameHeight
+        );
+      }
+    }
+  }
+
+  // calculate determines which frames to show at the current zoom level,
+  // and their positions.
+  calculate() {
+    const framesWithPositions: ThumbnailWithPosition[] = [];
+
+    for (let i = 0; i < this.frames.length; i++) {
+      const frame = this.frames[i];
+      const frameAspectRatio = frame.cols / frame.rows;
+
+      const calculatedWidth = Math.ceil(this.frameHeight * frameAspectRatio);
+      const frameWidth = Math.min(calculatedWidth, this.maxFrameWidth);
+
+      const position =
+        (frame.startOffset / this.duration) * this.timelineWidth + LEFT_PADDING;
+
+      framesWithPositions.push({
+        ...frame,
+        index: i,
+        isEnd: i === this.frames.length - 1,
+        position,
+        width: frameWidth,
+      });
+    }
+
+    const framesAtZoom: ThumbnailWithPosition[] = [];
+
+    for (const frame of framesWithPositions) {
+      if (framesAtZoom.length === 0) {
+        framesAtZoom.push(frame);
+
+        continue;
+      }
+
+      const lastFrame = framesAtZoom[framesAtZoom.length - 1];
+      const lastFrameEnd = lastFrame.position + lastFrame.width;
+
+      if (frame.isEnd || frame.position >= lastFrameEnd - 1) {
+        framesAtZoom.push(frame);
+      }
+    }
+
+    this.framesAtCurrentZoom = framesAtZoom;
+  }
+
+  getFramesAtCurrentZoom() {
+    return this.framesAtCurrentZoom;
+  }
+
+  destroy() {
+    this.framesAtCurrentZoom = [];
+    this.loadedImageElements.clear();
+  }
+
+  // loadNonVisibleFrames loads all frames that are not currently visible.
+  // This is useful for preloading frames in the background.
+  loadNonVisibleFrames(): Promise<OffscreenCanvas[]> {
+    const nonVisibleFrames = this.frames.filter(
+      frame => !this.loadedImages.has(frame.id)
+    );
+
+    return Promise.all(nonVisibleFrames.map(frame => this.loadImage(frame)));
+  }
+
+  // loadVisibleFrames loads only the frames that are currently visible in the viewport.
+  loadVisibleFrames(
+    offset: number,
+    containerWidth: number
+  ): Promise<OffscreenCanvas[]> {
+    const visibleFrames = this.getVisibleFrames(offset, containerWidth);
+
+    return Promise.all(visibleFrames.map(frame => this.loadImage(frame)));
+  }
+
+  // recreateImages redraws all loaded images, useful for when the height changes (as the
+  // height/width and zoom of the thumbnail changes).
+  recreateImages(render: () => void) {
+    for (const frame of this.frames) {
+      const img = this.loadedImageElements.get(frame.id);
+      const existingCanvas = this.loadedImages.get(frame.id);
+
+      if (img && existingCanvas) {
+        const newCanvas = new OffscreenCanvas(img.width, img.height);
+
+        this.drawFrame(frame, newCanvas, img);
+
+        render();
+      }
+    }
+  }
+
+  // recreateVisibleImages redraws only the loaded images that are currently visible.
+  recreateVisibleImages(
+    offset: number,
+    containerWidth: number,
+    render: () => void
+  ) {
+    const visibleFrames = this.getVisibleFrames(offset, containerWidth);
+
+    for (const frame of visibleFrames) {
+      const img = this.loadedImageElements.get(frame.id);
+      const canvas = this.loadedImages.get(frame.id);
+
+      if (img && canvas) {
+        this.drawFrame(frame, canvas, img);
+
+        render();
+      }
+    }
+  }
+
+  setHeight(height: number, eventsHeight: number) {
+    this.frameHeight =
+      height - eventsHeight - RULER_HEIGHT - EVENT_SECTION_PADDING * 2;
+
+    this.maxFrameWidth =
+      (DEFAULT_MAX_FRAME_WIDTH / DEFAULT_FRAME_HEIGHT) * height;
+  }
+
+  private binarySearchFrameIndex(position: number): number {
+    let left = 0;
+    let right = this.framesAtCurrentZoom.length - 1;
+    let result = 0;
+
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2);
+      const frame = this.framesAtCurrentZoom[mid];
+
+      if (frame.position <= position) {
+        result = mid;
+        left = mid + 1;
+      } else {
+        right = mid - 1;
+      }
+    }
+
+    return Math.max(0, result - 1);
+  }
+
+  private getVisibleFrames(
+    offset: number,
+    containerWidth: number
+  ): ThumbnailWithPosition[] {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const frames: ThumbnailWithPosition[] = [];
+    const startIndex = this.binarySearchFrameIndex(visibleStart);
+
+    for (let i = startIndex; i < this.framesAtCurrentZoom.length; i++) {
+      const frame = this.framesAtCurrentZoom[i];
+
+      if (frame.isEnd) {
+        if (frame.position < visibleEnd + frame.width) {
+          const frameBefore = frames.find(
+            f => f.position + f.width > visibleEnd - 100 - frame.width
+          );
+
+          if (!frameBefore) {
+            frames.push({
+              ...frame,
+              position: visibleEnd - 100 - frame.width,
+            });
+          }
+
+          continue;
+        }
+
+        continue;
+      }
+
+      if (frame.position > visibleEnd) {
+        break;
+      }
+
+      const frameEnd = frame.position + frame.width;
+
+      if (frameEnd >= visibleStart) {
+        frames.push(frame);
+      }
+    }
+
+    return frames;
+  }
+
+  // drawFrame draws a single frame onto an offscreen canvas, scaling and cropping
+  // the image to fit the desired dimensions while maintaining aspect ratio.
+  private drawFrame(
+    frame: ThumbnailWithId,
+    canvas: OffscreenCanvas,
+    image: HTMLImageElement
+  ) {
+    const frameAspectRatio = frame.cols / frame.rows;
+    const calculatedWidth = Math.ceil(this.frameHeight * frameAspectRatio);
+    const width = Math.min(calculatedWidth, this.maxFrameWidth);
+    const height = this.frameHeight;
+
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      throw new Error('Failed to get offscreen canvas context');
+    }
+
+    ctx.scale(dpr, dpr);
+
+    ctx.save();
+
+    // Calculate viewport position
+    const viewport = calculateThumbnailViewport(
+      frame,
+      image.width,
+      image.height
+    );
+
+    // Calculate source dimensions maintaining aspect ratio
+    const imageAspect = image.width / image.height;
+    const canvasAspect = width / height;
+
+    let adjustedSourceWidth = viewport.sourceWidth;
+    let adjustedSourceHeight = viewport.sourceHeight;
+
+    // Adjust source dimensions to match canvas aspect ratio
+    if (imageAspect > canvasAspect) {
+      // Image is wider - adjust width
+      const adjustedFullWidth = image.height * canvasAspect;
+      adjustedSourceWidth = adjustedFullWidth / viewport.zoomLevel;
+    } else {
+      // Image is taller - adjust height
+      const adjustedFullHeight = image.width / canvasAspect;
+      adjustedSourceHeight = adjustedFullHeight / viewport.zoomLevel;
+    }
+
+    const borderRadius = 12;
+
+    // Create clipping path for rounded corners
+    ctx.beginPath();
+    ctx.roundRect(0, 0, width, height, borderRadius);
+    ctx.clip();
+
+    // Draw the image
+    ctx.drawImage(
+      image,
+      viewport.sourceX,
+      viewport.sourceY,
+      adjustedSourceWidth,
+      adjustedSourceHeight,
+      0,
+      0,
+      width,
+      height
+    );
+
+    ctx.restore();
+
+    // Draw border
+    ctx.save();
+    ctx.strokeStyle = this.theme.colors.sessionRecordingTimeline.frameBorder;
+    ctx.lineWidth = 1;
+
+    ctx.beginPath();
+
+    // Adjust border position by 0.5px to ensure it's fully visible
+    ctx.roundRect(0.5, 0.5, width - 1, height - 1, borderRadius);
+    ctx.stroke();
+
+    ctx.restore();
+
+    this.loadedImages.set(frame.id, canvas);
+  }
+
+  // loadImage loads a data URI SVG string and draws it onto an offscreen canvas.
+  private loadImage(frame: ThumbnailWithId): Promise<OffscreenCanvas> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+
+      img.onload = () => {
+        try {
+          const offscreen = new OffscreenCanvas(img.width, img.height);
+
+          this.drawFrame(frame, offscreen, img);
+          this.loadedImageElements.set(frame.id, img);
+
+          resolve(offscreen);
+        } catch {
+          reject(new Error(`Failed to process image for frame ${frame.id}`));
+        }
+      };
+
+      img.onerror = () => {
+        reject(new Error(`Failed to load image for frame ${frame.id}`));
+      };
+
+      img.src = frame.svg;
+    });
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/FramesRenderer.ts
@@ -260,8 +260,8 @@ export class FramesRenderer extends TimelineCanvasRenderer {
     offset: number,
     containerWidth: number
   ): ThumbnailWithPosition[] {
-    const visibleStart = -offset - 100;
-    const visibleEnd = -offset + containerWidth + 100;
+    const visibleStart = -offset;
+    const visibleEnd = -offset + containerWidth;
 
     const frames: ThumbnailWithPosition[] = [];
     const startIndex = this.binarySearchFrameIndex(visibleStart);
@@ -270,22 +270,27 @@ export class FramesRenderer extends TimelineCanvasRenderer {
       const frame = this.framesAtCurrentZoom[i];
 
       if (frame.isEnd) {
+        // check if the end frame is within the visible area + its width
         if (frame.position < visibleEnd + frame.width) {
+          // check if there's a gap between the last visible frame and where the end frame would be pinned
+          // if so, pin the end frame to the right edge of the visible area
+          // this is because the position of the end frame would always position it off the end of the timeline
+          // as it starts at the end of the recording
           const frameBefore = frames.find(
-            f => f.position + f.width > visibleEnd - 100 - frame.width
+            f => f.position + f.width > visibleEnd - frame.width
           );
 
           if (!frameBefore) {
             frames.push({
               ...frame,
-              position: visibleEnd - 100 - frame.width,
+              position: visibleEnd - frame.width,
             });
           }
 
-          continue;
+          break;
         }
 
-        continue;
+        break;
       }
 
       if (frame.position > visibleEnd) {

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
@@ -1,0 +1,87 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import type { SessionRecordingThumbnail } from 'teleport/services/recordings';
+
+const zoomLevelWithCursor = 2;
+const zoomLevelWithoutCursor = 1;
+
+// calculateThumbnailViewport calculates the portion of the thumbnail image to display
+// based on the cursor position and whether the cursor is visible.
+// It returns the source coordinates and dimensions to be used in drawing the image,
+// as well as the zoom level applied.
+export function calculateThumbnailViewport(
+  thumbnail: SessionRecordingThumbnail,
+  width: number,
+  height: number
+) {
+  // Use different zoom levels based on cursor visibility
+  const zoomLevel = thumbnail.cursorVisible
+    ? zoomLevelWithCursor
+    : zoomLevelWithoutCursor;
+
+  const visibleWidthPercent = 100 / zoomLevel;
+  const visibleHeightPercent = 100 / zoomLevel;
+
+  let bgPosX: number;
+  let bgPosY: number;
+
+  if (thumbnail.cursorVisible) {
+    // Calculate cursor position as percentage
+    const cursorPercentX = (thumbnail.cursorX / thumbnail.cols) * 100;
+    const cursorPercentY = (thumbnail.cursorY / thumbnail.rows) * 100;
+
+    // Calculate the top-left position percentage to center on cursor
+    bgPosX = Math.max(
+      0,
+      Math.min(
+        100 - visibleWidthPercent,
+        cursorPercentX - visibleWidthPercent / 2
+      )
+    );
+    bgPosY = Math.max(
+      0,
+      Math.min(
+        100 - visibleHeightPercent,
+        cursorPercentY - visibleHeightPercent / 2
+      )
+    );
+  } else {
+    // Center the viewport when cursor is not visible
+    bgPosX = (100 - visibleWidthPercent) / 2;
+    bgPosY = (100 - visibleHeightPercent) / 2;
+  }
+
+  // Calculate source dimensions
+  const sourceWidth = width / zoomLevel;
+  const sourceHeight = height / zoomLevel;
+
+  // Convert percentages to pixel coordinates on the source image
+  const maxSourceX = width - sourceWidth;
+  const maxSourceY = height - sourceHeight;
+
+  const sourceX = (bgPosX / (100 - visibleWidthPercent)) * maxSourceX || 0;
+  const sourceY = (bgPosY / (100 - visibleHeightPercent)) * maxSourceY || 0;
+
+  return {
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    zoomLevel,
+  };
+}


### PR DESCRIPTION
This adds the frames renderer. This is responsible for drawing all the visible frames at the current zoom/offset

This was really hard to write tests for without exposing more of the private interface. `jest-canvas-mock` isn't great because it ignores the width/height passed into `drawImage` and will always log the `drawImage` call as the image's width/height, so I couldn't add tests for ensuring that the frames are rendered at the right dimensions. Let me know if you can think of any more tests to add.

<img width="1524" height="324" alt="image" src="https://github.com/user-attachments/assets/a0313b4f-538c-472f-aec7-8d447c21f78b" />
