### PR TITLE
Add the time markers renderer for the session timeline

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import { darkTheme } from 'design/theme';
+
+import { SessionRecordingMetadata } from 'teleport/services/recordings';
+import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
+
+import { TimeMarkersRenderer } from './TimeMarksRenderer';
+
+const mockMetadata: SessionRecordingMetadata = {
+  startTime: 1609459200000, // Jan 1, 2021 12:00:00 AM UTC
+  endTime: 1609462800000, // Jan 1, 2021 1:00:00 AM UTC
+  duration: 3600000, // 1 hour in milliseconds
+  user: 'testuser',
+  resourceName: 'test-server',
+  clusterName: 'test-cluster',
+  events: [],
+  startCols: 80,
+  startRows: 24,
+  type: 'ssh',
+};
+
+function createRenderer(metadata?: Partial<SessionRecordingMetadata>) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const renderer = new TimeMarkersRenderer(ctx, darkTheme, {
+    ...mockMetadata,
+    ...metadata,
+  });
+
+  return { ctx, renderer };
+}
+
+describe('time marker intervals', () => {
+  it('should render 10 second intervals at low zoom', () => {
+    const { ctx, renderer } = createRenderer({
+      duration: 60 * 1000, // 1 minute
+    });
+
+    renderer.setTimelineWidth(500); // low zoom level
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 600,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // At low zoom, should show 10 second intervals: 0:00, 0:10, 0:20, 0:30, 0:40, 0:50, 1:00
+    expect(fillTextCalls).toHaveLength(7);
+    expect(fillTextCalls[0].props.text).toBe('0:00');
+    expect(fillTextCalls[1].props.text).toBe('0:10');
+    expect(fillTextCalls[2].props.text).toBe('0:20');
+    expect(fillTextCalls[3].props.text).toBe('0:30');
+    expect(fillTextCalls[4].props.text).toBe('0:40');
+    expect(fillTextCalls[5].props.text).toBe('0:50');
+    expect(fillTextCalls[6].props.text).toBe('1:00');
+  });
+
+  it('should render 5 second intervals at medium zoom', () => {
+    const { ctx, renderer } = createRenderer({
+      duration: 60 * 1000, // 1 minute
+    });
+
+    renderer.setTimelineWidth(2000); // medium zoom level
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 2100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // At medium zoom, should show 5 second intervals
+    expect(fillTextCalls).toHaveLength(13);
+    expect(fillTextCalls[0].props.text).toBe('0:00');
+    expect(fillTextCalls[1].props.text).toBe('0:05');
+    expect(fillTextCalls[2].props.text).toBe('0:10');
+    expect(fillTextCalls[6].props.text).toBe('0:30');
+    expect(fillTextCalls[12].props.text).toBe('1:00');
+  });
+
+  it('should render 1 second intervals at high zoom', () => {
+    const { ctx, renderer } = createRenderer({
+      duration: 10000, // 10 seconds
+    });
+
+    renderer.setTimelineWidth(2500); // high zoom level
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 2600,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // At high zoom, should show 1-second intervals
+    expect(fillTextCalls).toHaveLength(11);
+
+    expect(fillTextCalls[0].props.text).toBe('0:00');
+    expect(fillTextCalls[1].props.text).toBe('0:01');
+    expect(fillTextCalls[2].props.text).toBe('0:02');
+    expect(fillTextCalls[5].props.text).toBe('0:05');
+    expect(fillTextCalls[10].props.text).toBe('0:10');
+  });
+});
+
+describe('absolute time display', () => {
+  it('should show absolute time for minute markers when enabled', () => {
+    const { ctx, renderer } = createRenderer({
+      startTime: 1609459200000, // Jan 1, 2021 12:00:00 AM UTC
+      duration: 3 * 60 * 1000, // 3 minutes
+    });
+
+    renderer.setTimelineWidth(2000);
+    renderer.setShowAbsoluteTime(true);
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 2100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // Should show absolute time for minute markers (0:00, 1:00, 2:00, 3:00)
+    // and relative time for 5 second intervals between them
+    const minuteMarkers = fillTextCalls.filter(
+      (call, index) => index % 12 === 0 // Every 12th marker is a minute marker (60s / 5s interval)
+    );
+
+    // The absolute time should be shown in 12-hour format
+    // Starting at midnight UTC
+    expect(minuteMarkers[0].props.text).toBe('12:00am');
+    expect(minuteMarkers[1].props.text).toBe('12:01am');
+    expect(minuteMarkers[2].props.text).toBe('12:02am');
+    expect(minuteMarkers[3].props.text).toBe('12:03am');
+
+    const nonMinuteMarkers = fillTextCalls.filter(
+      (call, index) => index % 12 !== 0
+    );
+
+    // Non-minute markers should show relative time
+    expect(nonMinuteMarkers[0].props.text).toBe('0:05');
+    expect(nonMinuteMarkers[1].props.text).toBe('0:10');
+    expect(nonMinuteMarkers[2].props.text).toBe('0:15');
+    expect(nonMinuteMarkers[3].props.text).toBe('0:20');
+  });
+
+  it('should show relative time when absolute time is disabled', () => {
+    const { ctx, renderer } = createRenderer({
+      startTime: new Date('2021-01-01T00:00:00Z').getTime(),
+      duration: 3 * 60 * 1000, // 3 minutes
+    });
+
+    renderer.setTimelineWidth(2000);
+    renderer.setShowAbsoluteTime(false);
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 2100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // All markers should show relative time
+    expect(fillTextCalls[0].props.text).toBe('0:00');
+    expect(fillTextCalls[12].props.text).toBe('1:00');
+    expect(fillTextCalls[24].props.text).toBe('2:00');
+    expect(fillTextCalls[36].props.text).toBe('3:00');
+  });
+
+  it('should handle PM times correctly', () => {
+    const { ctx, renderer } = createRenderer({
+      startTime: new Date('2021-01-01T12:00:00Z').getTime(),
+      duration: 2 * 60 * 1000, // 2 minutes
+    });
+
+    renderer.setTimelineWidth(2000);
+    renderer.setShowAbsoluteTime(true);
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 2100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    const minuteMarkers = fillTextCalls.filter(
+      (call, index) => index % 12 === 0
+    );
+
+    expect(minuteMarkers[0].props.text).toBe('12:00pm');
+    expect(minuteMarkers[1].props.text).toBe('12:01pm');
+    expect(minuteMarkers[2].props.text).toBe('12:02pm');
+  });
+});
+
+describe('visibility', () => {
+  it('should only render visible time markers', () => {
+    const { ctx, renderer } = createRenderer({
+      duration: 60 * 1000, // 1 minute
+    });
+
+    renderer.setTimelineWidth(6000); // very high zoom
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 500,
+      offset: -1000, // scrolled to show markers around 10 seconds
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // Should only render markers visible in the viewport (with 100px buffer)
+    // At this zoom and offset, should see markers starting from 9 seconds
+    expect(fillTextCalls.length).toBe(8); // 9s, 10s, 11s, 12s, 13s, 14s, 15s, 16s
+
+    // Check that we're seeing markers in the expected range
+    const visibleTexts = fillTextCalls.map(call => call.props.text);
+
+    expect(visibleTexts[0]).toBe('0:09');
+    expect(visibleTexts[visibleTexts.length - 1]).toBe('0:16');
+  });
+});
+
+describe('sub-tick rendering', () => {
+  it('should render sub-ticks between main markers at high zoom', () => {
+    const { ctx, renderer } = createRenderer({
+      duration: 10 * 1000, // 10 seconds
+    });
+
+    renderer.setTimelineWidth(3000); // high zoom to get many sub-ticks
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 3100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+
+    // Count fillRect calls that are sub-ticks (height 4 or 6)
+    const subTickCalls = drawCalls.filter(
+      call =>
+        call.type === 'fillRect' &&
+        (call.props.height === 4 || call.props.height === 6)
+    );
+
+    // At high zoom, should have multiple sub-ticks between main markers
+    expect(subTickCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -192,11 +192,5 @@ function formatRelativeTime(seconds: number) {
 function formatAbsoluteTime(timestamp: number) {
   const date = new Date(timestamp);
 
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-
-  const period = hours >= 12 ? 'pm' : 'am';
-  const displayHours = hours % 12 || 12;
-
-  return `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
+  return date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
 }

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -191,5 +191,5 @@ function formatRelativeTime(seconds: number) {
 function formatAbsoluteTime(timestamp: number) {
   const date = new Date(timestamp);
 
-  return date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -101,7 +101,6 @@ export class TimeMarkersRenderer extends TimelineCanvasRenderer {
 
     if (pixelsPerSecond < 10) interval = 10000;
     else if (pixelsPerSecond < 50) interval = 5000;
-    else if (pixelsPerSecond > 200) interval = 1000;
 
     for (let time = 0; time < this.duration + interval; time += interval) {
       // if show absolute time is enabled, change the 0:00, 1:00, etc, labels to absolute time

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -191,5 +191,8 @@ function formatRelativeTime(seconds: number) {
 function formatAbsoluteTime(timestamp: number) {
   const date = new Date(timestamp);
 
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return date
+    .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    .replace(' AM', 'am')
+    .replace(' PM', 'pm');
 }

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimeMarksRenderer.ts
@@ -1,0 +1,202 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DefaultTheme } from 'styled-components';
+
+import type { SessionRecordingMetadata } from 'teleport/services/recordings';
+
+import { CANVAS_FONT, LEFT_PADDING } from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+interface SubTick {
+  height: number;
+  position: number;
+}
+
+interface TimeMarker {
+  absolute: boolean;
+  label: string;
+  position: number;
+  time: number;
+}
+
+export class TimeMarkersRenderer extends TimelineCanvasRenderer {
+  private subTicks: SubTick[] = [];
+  private timeMarkers: TimeMarker[] = [];
+  private showAbsoluteTime = false;
+
+  private readonly startTime: number;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+    this.startTime = metadata.startTime;
+  }
+
+  _render({ containerWidth, offset }: TimelineRenderContext) {
+    const { markers, subTicks } = this.getVisibleTimeMarkers(
+      offset,
+      containerWidth
+    );
+
+    this.ctx.font = `10px ${CANVAS_FONT}`;
+
+    for (const marker of markers) {
+      const textWidth = this.ctx.measureText(marker.label).width;
+      const x = marker.position + LEFT_PADDING;
+
+      this.ctx.fillStyle =
+        this.theme.colors.sessionRecordingTimeline.timeMarks.primary;
+      this.ctx.fillRect(x, 0, 1, 10);
+
+      if (marker.absolute) {
+        this.ctx.font = `bold 10px ${CANVAS_FONT}`;
+      }
+
+      this.ctx.fillStyle = marker.absolute
+        ? this.theme.colors.sessionRecordingTimeline.timeMarks.absolute
+        : this.theme.colors.sessionRecordingTimeline.timeMarks.text;
+
+      this.ctx.fillText(marker.label, x - textWidth / 2, 24);
+
+      if (marker.absolute) {
+        this.ctx.font = `10px ${CANVAS_FONT}`;
+      }
+    }
+
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.timeMarks.secondary;
+
+    for (const tick of subTicks) {
+      this.ctx.fillRect(tick.position + LEFT_PADDING, 0, 1, tick.height);
+    }
+  }
+
+  calculate() {
+    const markers: TimeMarker[] = [];
+
+    let interval = 1000;
+    let pixelsPerSecond = (this.timelineWidth / this.duration) * 1000;
+
+    if (pixelsPerSecond < 10) interval = 10000;
+    else if (pixelsPerSecond < 50) interval = 5000;
+    else if (pixelsPerSecond > 200) interval = 1000;
+
+    for (let time = 0; time < this.duration + interval; time += interval) {
+      // if show absolute time is enabled, change the 0:00, 1:00, etc, labels to absolute time
+      const absolute = this.showAbsoluteTime && (time / 1000) % 60 === 0;
+      const label = absolute
+        ? formatAbsoluteTime(this.startTime + time)
+        : formatRelativeTime(time / 1000);
+
+      markers.push({
+        absolute,
+        label,
+        position: (time / this.duration) * this.timelineWidth,
+        time,
+      });
+    }
+
+    const subTicks: SubTick[] = [];
+
+    const markerSpacing = (interval / this.duration) * this.timelineWidth;
+
+    let numSubticks = 0;
+    if (markerSpacing > 300) numSubticks = 9;
+    else if (markerSpacing > 200) numSubticks = 7;
+    else if (markerSpacing > 150) numSubticks = 4;
+    else if (markerSpacing > 100) numSubticks = 3;
+    else if (markerSpacing > 50) numSubticks = 1;
+
+    for (let i = 0; i < markers.length - 1; i++) {
+      const currentMarker = markers[i];
+
+      for (let j = 1; j <= numSubticks; j++) {
+        const fraction = j / (numSubticks + 1);
+        const position = currentMarker.position + markerSpacing * fraction;
+
+        let height = 4;
+        if (numSubticks % 2 === 1) {
+          height = j === Math.ceil(numSubticks / 2) ? 6 : 4;
+        } else {
+          const mid1 = numSubticks / 2;
+          const mid2 = mid1 + 1;
+          height = j === mid1 || j === mid2 ? 6 : 4;
+        }
+
+        subTicks.push({ height, position });
+      }
+    }
+
+    this.timeMarkers = markers;
+    this.subTicks = subTicks;
+  }
+
+  setShowAbsoluteTime(show: boolean) {
+    this.showAbsoluteTime = show;
+
+    this.calculate();
+  }
+
+  private getVisibleTimeMarkers(offset: number, containerWidth: number) {
+    const visibleStart = -offset - 100;
+    const visibleEnd = -offset + containerWidth + 100;
+
+    const visibleMarkers: TimeMarker[] = [];
+    const visibleSubTicks: SubTick[] = [];
+
+    for (const marker of this.timeMarkers) {
+      if (marker.position >= visibleStart && marker.position <= visibleEnd) {
+        visibleMarkers.push(marker);
+      }
+    }
+
+    for (const subTick of this.subTicks) {
+      if (subTick.position >= visibleStart && subTick.position <= visibleEnd) {
+        visibleSubTicks.push(subTick);
+      }
+    }
+
+    return { markers: visibleMarkers, subTicks: visibleSubTicks };
+  }
+}
+
+function formatRelativeTime(seconds: number) {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function formatAbsoluteTime(timestamp: number) {
+  const date = new Date(timestamp);
+
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  const period = hours >= 12 ? 'pm' : 'am';
+  const displayHours = hours % 12 || 12;
+
+  return `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
+}


### PR DESCRIPTION
This adds the renderer responsible for rendering time marks on the session timeline.

<img width="771" height="55" alt="image" src="https://github.com/user-attachments/assets/c50971a9-220b-4028-b0ad-ef6aa5dce94c" />
