### PR TITLE
[v17] Move the Identity Center integration docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1472,22 +1472,22 @@
     },
     {
       "source": "/admin-guides/management/guides/aws-iam-identity-center/",
-      "destination": "/zero-trust-access/management/guides/aws-iam-identity-center/",
+      "destination": "/identity-governance/aws-iam-identity-center/",
       "permanent": true
     },
     {
       "source": "/admin-guides/management/guides/aws-iam-identity-center/guide/",
-      "destination": "/zero-trust-access/management/guides/aws-iam-identity-center/guide/",
+      "destination": "/identity-governance/aws-iam-identity-center/guide/",
       "permanent": true
     },
     {
       "source": "/admin-guides/management/guides/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport/",
-      "destination": "/zero-trust-access/management/guides/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport/",
+      "destination": "/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport/",
       "permanent": true
     },
     {
       "source": "/admin-guides/management/guides/aws-iam-identity-center/using-aws-cli/",
-      "destination": "/zero-trust-access/management/guides/aws-iam-identity-center/using-aws-cli/",
+      "destination": "/identity-governance/aws-iam-identity-center/using-aws-cli/",
       "permanent": true
     },
     {
@@ -1573,6 +1573,26 @@
     {
       "source": "/admin-guides/migrate-plans/",
       "destination": "/migrate-plans/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/aws-iam-identity-center/",
+      "destination": "/identity-governance/aws-iam-identity-center/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/aws-iam-identity-center/guide/",
+      "destination": "/identity-governance/aws-iam-identity-center/guide/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport/",
+      "destination": "/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/aws-iam-identity-center/using-aws-cli/",
+      "destination": "/identity-governance/aws-iam-identity-center/using-aws-cli/",
       "permanent": true
     }
   ]

--- a/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
@@ -14,9 +14,9 @@ With the AWS Identity Center integration, you can manage AWS access by granting 
 
 ## How it works
 
-The Identity Center integration builds on top of Teleport's [role-based access controls](../../../../zero-trust-access/access-controls/guides/guides.mdx),
-[just-in-time Access Requests](../../../../identity-governance/access-requests/access-requests.mdx)
-and [Access Lists](../../../../identity-governance/access-lists/access-lists.mdx) to manage
+The Identity Center integration builds on top of Teleport's [role-based access controls](../../index.mdx),
+[just-in-time Access Requests](../access-requests/access-requests.mdx)
+and [Access Lists](../access-lists/access-lists.mdx) to manage
 the creation and deletion of Identity Center _Account Assignments_. 
 
 An _account assignment_ is the combination of a specific AWS Permission Set on a 

--- a/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
@@ -31,16 +31,16 @@ identity source.
 As such, we recommend ensuring that all Identity Center users have access to
 your Teleport cluster before turning the integration on to avoid access
 interruption. If your Identity Center already uses external identity source,
-you can configure the corresponding [SSO connector](../../../../zero-trust-access/sso/sso.mdx)
+you can configure the corresponding [SSO connector](../../zero-trust-access/sso/sso.mdx)
 in Teleport or, if you're using Okta, enable the
-[Okta integration](../../../../identity-governance/okta/okta.mdx).
+[Okta integration](../okta/okta.mdx).
 
 ## Step 1/6. Configure AWS integration
 
 To get started, navigate to the "Add new integration" page in your Teleport
 cluster control panel and select "AWS Identity Center".
 
-![Pick Identity Center integration](../../../../../img/identity-center/ic-pick-integration.png)
+![Pick Identity Center integration](../../../img/identity-center/ic-pick-integration.png)
 
 Next, you will generate a script that creates an AWS IAM role for the
 integration.
@@ -83,21 +83,21 @@ iam:ListRoles
 ```
 </details>
 
-![Configure AWS integration](../../../../../img/identity-center/ic-step1.1.png)
+![Configure AWS integration](../../../img/identity-center/ic-step1.1.png)
 
 Enter required information such as Identity Center region, ARN and integration
 name, and execute the generated command in the Cloud Shell.
 
 After the script has run, fill out the ARN for the role created by the script.
 
-![Run script for AWS integration](../../../../../img/identity-center/ic-step1.2.png)
+![Run script for AWS integration](../../../img/identity-center/ic-step1.2.png)
 
 ## Step 2/6. Preview AWS resources
 
 On the next step, you are presented with the list of AWS accounts, groups, and
 permission sets that Teleport was able to find in your Identity Center.
 
-![Preview AWS resources](../../../../../img/identity-center/ic-step2.png)
+![Preview AWS resources](../../../img/identity-center/ic-step2.png)
 
 Pick the default owners that should be assigned to the Access Lists in Teleport.
 These resources will be imported into Teleport once the plugin is installed.
@@ -109,21 +109,21 @@ After this step, Teleport will become your Identity Center's identity provider.
 
 To avoid access interruptions, we recommend making sure that all existing
 Identity Center users have access to your Teleport cluster by, for example, using
-the same [IdP](../../../../zero-trust-access/sso/sso.mdx) as your current Identity Center
+the same [IdP](../../zero-trust-access/sso/sso.mdx) as your current Identity Center
 external identity source.
 </Admonition>
 
 Follow the instructions to change your Identity Center's identity source to
 Teleport.
 
-![Configure identity source](../../../../../img/identity-center/ic-step3.png)
+![Configure identity source](../../../img/identity-center/ic-step3.png)
 
 ## Step 4/6. Enable SCIM
 
 The final step is to enable the SCIM endpoint in your Identity Center to
 allow Teleport to push user and group changes.
 
-![Enable SCIM](../../../../../img/identity-center/ic-step4.png)
+![Enable SCIM](../../../img/identity-center/ic-step4.png)
 
 Make sure to test SCIM connection after enabling it.
 
@@ -136,7 +136,7 @@ your Identity Center groups have been imported.
 It may take a few minutes for the initial sync to complete.
 </Admonition>
 
-![Access Lists view](../../../../../img/identity-center/ic-lists.png)
+![Access Lists view](../../../img/identity-center/ic-lists.png)
 
 Imported Access Lists should show the same members as their corresponding
 Identity Center groups.
@@ -146,7 +146,7 @@ Identity Center groups.
 Once the integration is up and running, you will see an application named
 `aws-identity-center` among your resources:
 
-![Connect to AWS SSO portal](../../../../../img/identity-center/ic-app.png)
+![Connect to AWS SSO portal](../../../img/identity-center/ic-app.png)
 
 Clicking the "Log In" button for this app takes you to your Identity Center
 SSO start page which you can use to pick a role and connect to your AWS account
@@ -210,7 +210,7 @@ selecting from the Permission Sets available to each AWS Account. Users
 can mix Permission Sets from multiple AWS Accounts, and even include other 
 Teleport-managed resources if necessary.
 
-![Selecting Identity Center resources](../../../../../img/identity-center/ic-select-ps.png)
+![Selecting Identity Center resources](../../../img/identity-center/ic-select-ps.png)
 
 Once the used has selected their desired Account Assignments, the Access Request
 submission and review process is the same as for any other Teleport-managed
@@ -222,7 +222,7 @@ Access Request expires.
 The user can access their temporary AWS Accounts and Roles from within Teleport
 by assuming the Access Request roles. 
 
-![Assumed Role granting Identity Center Account Assignments](../../../../../img/identity-center/ic-role-assumed.png)
+![Assumed Role granting Identity Center Account Assignments](../../../img/identity-center/ic-role-assumed.png)
 
 <Admonition type="warning">
 The AWS Account Assignments will exist for the lifetime of the Access Request,
@@ -243,7 +243,7 @@ If a user requests access to Account Assignments that can also be granted via an
 existing Access List, Teleport will offer the reviewer the option of *promoting*
 the Access Request to long-term access.
 
-![Promoting Access Request](../../../../../img/identity-center/ic-promote.png)
+![Promoting Access Request](../../../img/identity-center/ic-promote.png)
 
 When an Access Request is promoted to long-term access, the requesting user is
 added to the targeted Access List. This membership change is propagated to the
@@ -284,7 +284,7 @@ among their role grants to Identity Center.
 ### How does it work with nested Access Lists?
 
 Identity Center does not support nested groups. As such, Teleport recursively 
-flattens any [nested Access Lists](../../../../identity-governance/access-lists/nested-access-lists.mdx)
+flattens any [nested Access Lists](../access-lists/nested-access-lists.mdx)
 into a single Identity Center group containing all members reachable from the 
 top-level Access List.
 
@@ -324,10 +324,11 @@ Provider and its role from your AWS IAM console as well.
 ## Next steps
 
 - Take a deeper dive into fundamental Teleport concepts used in Identity Center
-  integration such as [RBAC](../../../../zero-trust-access/access-controls/guides/guides.mdx),
-  [JIT Access Requests](../../../../identity-governance/access-requests/access-requests.mdx),
-  [Access Lists](../../../../identity-governance/access-lists/access-lists.mdx) 
-  and the [Teleport SAML IdP](../../../../identity-governance/idps/idps.mdx).
-- Learn how to enable the [Okta integration](../../../../identity-governance/okta/okta.mdx)
+  integration such as
+  [RBAC](../../zero-trust-access/access-controls/access-controls.mdx),
+  [JIT Access Requests](../access-requests/access-requests.mdx),
+  [Access Lists](../access-lists/access-lists.mdx)
+  and the [Teleport SAML IdP](../idps/idps.mdx).
+- Learn how to enable the [Okta integration](../okta/okta.mdx)
   to sync apps, users and groups from Okta in conjunction with Identity Center
   integration.

--- a/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -55,7 +55,7 @@ configured as the identity source and you may decide to fully switch the control
 
 This is our starting configuration: Okta as sole Identity Source for Identity Center.
 
-![Migration Starting Point](../../../../../img/identity-center/ic-migrate-start.png)
+![Migration Starting Point](../../../img/identity-center/ic-migrate-start.png)
 
 ### Midway
 
@@ -69,7 +69,7 @@ Okta to Teleport. At this stage:
  - Teleport controls Identity Center group account assignments for the Identity Center groups under its control.
  - Teleport controls direct Identity Center user account assignments for the Identity Center users under its control.
 
-![Migration Mid Point](../../../../../img/identity-center/ic-migrate-mid.png)
+![Migration Mid Point](../../../img/identity-center/ic-migrate-mid.png)
 
 ### Ending point
 
@@ -77,13 +77,13 @@ Once Teleport is in control of all the users and groups you want to provision
 into Identity Center, the Okta Provisioning and Push Groups functions can be
 retired, leaving Okta only providing SSO login.
 
-![Migration End Point](../../../../../img/identity-center/ic-migrate-end.png)
+![Migration End Point](../../../img/identity-center/ic-migrate-end.png)
 
 
 ## Step 1/7. Install Okta SAML connector
 
 Install Okta SAML connector into Teleport as per the Teleport
-[Okta as an SSO provider](../../../../zero-trust-access/sso/okta.mdx) guide.
+[Okta as an SSO provider](../../zero-trust-access/sso/okta.mdx) guide.
 
 <Admonition type="note">
  For the integration to function properly, both AWS IAM Identity Center and Teleport must view the

--- a/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
@@ -196,9 +196,10 @@ where `${SSO_SESSION_NAME}` is the name of your configured SSO session.
 
 - Learn how to request [Just-in-Time access to an Account Assignment](./guide.mdx#just-in-time-access-with-resource-access-requests).
 - Take a deeper dive into fundamental Teleport concepts used in Identity Center
-  integration such as [RBAC](../../../../zero-trust-access/access-controls/guides/guides.mdx),
-  [JIT Access Requests](../../../../identity-governance/access-requests/access-requests.mdx), and 
-  [Access Lists](../../../../identity-governance/access-lists/access-lists.mdx).
+  integration such as
+  [RBAC](../../zero-trust-access/access-controls/access-controls.mdx),
+  [JIT Access Requests](../access-requests/access-requests.mdx), and
+  [Access Lists](../access-lists/access-lists.mdx).
 - Learn how Teleport uses RBAC, JIT Access Requests and Access Lists to manage AWS
   Identity Center Account Assignments in the [AWS IAM Identity Center guide](./aws-iam-identity-center.mdx)
 


### PR DESCRIPTION
Backports #56940

Closes #56851

Include these in the Identity Governance section, since the Identity Center feature falls under this product.