### PR TITLE
Docs: Fix step numbers and "How it works" sections

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -9,6 +9,18 @@ labels:
 This guide shows you how to configure Teleport to automatically enroll EC2
 instances in your cluster, with permissions configured by Teleport.
 
+## How it works
+
+The Teleport Discovery Service runs on an EC2 instance and queries the AWS API
+to list instances in your AWS account. For any new EC2 instance that you deploy,
+the Discovery Service uses AWS Systems Manager to install Teleport on the
+instance and join it to the cluster as a Teleport-protected server. `teleport`
+commands allow you to create IAM policies that enable the Discovery Service to
+enroll EC2 instances as servers in your Teleport cluster.
+
+To manual configure IAM policies and SSM documents instead, read [Manual EC2
+Auto-Discovery Configuration](ec2-discovery-guided.mdx).
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -9,6 +9,18 @@ labels:
 This guide shows you how to configure Teleport to automatically enroll EC2
 instances in your cluster, with permissions configured manually.
 
+## How it works
+
+The Teleport Discovery Service runs on an EC2 instance and queries the AWS API
+to list instances in your AWS account. For any new EC2 instance that you deploy,
+the Discovery Service uses AWS Systems Manager (SSM) to install Teleport on the
+instance and join it to the cluster as a Teleport-protected server. In addition
+to deploying the Teleport Discovery Service, the procedure shown in this guide
+includes manually editing IAM policies and SSM documents.
+
+To automatically bootstrap IAM policies instead, read [Guided EC2 Auto-Discovery
+Configuration](ec2-discovery-guided.mdx).
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/entra-id/configure-access.mdx
+++ b/docs/pages/identity-governance/entra-id/configure-access.mdx
@@ -46,7 +46,7 @@ read and write Auth Connector, plugins, roles and Access Lists.
 - For demonstration, this guide references a Grafana application. You may use any other 
 [resource](../../enroll-resources/enroll-resources.mdx) type to get started. 
 
-## Step 1/4. Create groups in Entra ID
+## Step 1/3. Create groups in Entra ID
 
 <Admonition type="info" title="New Group">
   You may skip this step if you are using an existing Entra ID 
@@ -66,7 +66,7 @@ Every 5 minutes, Teleport imports groups from Entra ID and creates
 an Access List for each of the imported groups. Teleport will also preserve respective 
 group members as an Access List member.
 
-## Step 2/4. Create roles in Teleport
+## Step 2/3. Create roles in Teleport
 
 First, create a role template that grants access to Grafana. 
 
@@ -124,7 +124,7 @@ spec:
   rule if you are following through this guide with a different kind of resource.  
 </Admonition>
 
-## Step 3/4. Create a Nested Access List
+## Step 3/3. Create a Nested Access List
 
 Assuming Teleport has already imported new groups we created in Entra ID, 
 we will now create new Access Lists for short-term (Just-In-Time) 

--- a/docs/pages/identity-governance/entra-id/getting-started.mdx
+++ b/docs/pages/identity-governance/entra-id/getting-started.mdx
@@ -12,6 +12,8 @@ This guide shows how to configure Entra ID integration in a guided configuration
 Teleport will generate a script that will configure your Entra ID tenant with the 
 properties required for the Teleport Entra ID integration.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - Your user must have privileged administrator permissions in the Microsoft Entra ID tenant.

--- a/docs/pages/identity-governance/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/entra-id/manual-installation.mdx
@@ -11,6 +11,8 @@ See [getting started with Entra ID integration](getting-started.mdx) for a guide
 
 The set up is based on the [OIDC IdP authentication method](entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - Teleport Identity Governance enabled for your Teleport cluster.

--- a/docs/pages/zero-trust-access/management/guides/scim/sailpoint.mdx
+++ b/docs/pages/zero-trust-access/management/guides/scim/sailpoint.mdx
@@ -7,6 +7,8 @@ description: How to Configure SCIM Connector in SailPoint to manage Access List 
 SailPoint provides a SCIM identity management connector that allows you to manage Teleport Access List membership
 through SailPoint IdentityNow or SailPoint IdentityIQ.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 - Teleport SCIM plugin setup: [SCIM Plugin Installation](./scim.mdx)
 

--- a/docs/pages/zero-trust-access/management/guides/scim/scim.mdx
+++ b/docs/pages/zero-trust-access/management/guides/scim/scim.mdx
@@ -103,7 +103,7 @@ Click **Continue** to proceed to the **SCIM Credentials** screen.
 - Copy the **Client ID**, **Client Secret**, and **Base URL** — you'll use them
   when configuring your Identity Provider in the next step.
 
-### Step 3/3. Configure SCIM integration with your Identity Management SCIM provider
+## Step 3/3. Configure SCIM integration with your Identity Management SCIM provider
 
 SCIM configuration may differ depending on your IdP. The integration has been officially tested with the following providers:
 

--- a/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
@@ -35,7 +35,7 @@ for any Teleport-protected resource.
   started guide for [server
   access](../../enroll-resources/server-access/getting-started.mdx).
 
-## Step 1/2. Enroll resources with labels
+## Step 1/3. Enroll resources with labels
 
 In this section, you will enroll two servers with your Teleport cluster. One
 server will have the `env:local-dev` label and the other will have the


### PR DESCRIPTION
The Vale prose linter used to check docs pages for the following structural qualities in how-to guides:

- Correct step numbering.
- A "How it works" section providing an architectural overview, preventing newer users from getting lost and allowing users with knowledge of Teleport architecture to anticipate the steps within the guide.

Since the Vale linter used the `raw` scope, rather than a parsed Markdown AST, there was no way for a docs page to disable these linters in edge cases using comments. By making the structure `remark` linters, we can allow users to ignore them if they need to, while also taking advantage of unit testing for the linter code.

This change anticipates the new `remark` linters by editing the documentation content to:

- Fix step numbering in the Entra ID config guide, SCIM guide, and role demo.
- Add "How it works" sections to EC2 discovery guides.
- Ignore the "How it works" linter in three guides. These guides could use an architectural overview, but for now, we can ignore the linter so we can add it for new guides.