### PR TITLE
docs: clarify cluster upgrade process

### DIFF
--- a/docs/pages/includes/compatibility.mdx
+++ b/docs/pages/includes/compatibility.mdx
@@ -15,4 +15,4 @@ apply:
   compatible with an 17.x.x Auth Service.
 - Auth Service instances should always be the first component of the cluster that
   is upgraded, and you must upgrade all Auth Service instances to the target version
-  before proceeding to upgrade Proxy Service instances and other agents.
+  before proceeding to upgrade Proxy Service instances, other agents, and client tools (tsh, tctl, tbot, Connect, etc).

--- a/docs/pages/includes/compatibility.mdx
+++ b/docs/pages/includes/compatibility.mdx
@@ -4,12 +4,15 @@ When running multiple `teleport` binaries within a cluster, the following rules
 apply:
 
 - Servers support clients that are one major version behind, but do not support
-  clients that are on a newer major version. For example, an 8.x.x Proxy Service
-  instance is compatible with 7.x.x agents and 7.x.x `tsh`, but we don't
-  guarantee that a 9.x.x agent will work with an 8.x.x Proxy Service instance.
-  This also means you must not attempt to upgrade from 6.x.x straight to 8.x.x.
-  You must upgrade to 7.x.x first.
+  clients that are on a newer major version. For example, an 17.x.x Proxy
+  Service instance is compatible with 16.x.x agents and 16.x.x `tsh`, but a
+  17.x.x agent will not work with an 16.x.x Proxy Service instance. This also
+  means you must not attempt to upgrade from 16.x.x straight to 18.x.x. You must
+  upgrade to 17.x.x first.
 - Proxy Service instances and agents do not support Auth Service instances that
   are on an older major version, and will fail to connect to older Auth Service
-  instances by default. For example, an 8.x.x Proxy Service or agent is not
-  compatible with an 7.x.x Auth Service.
+  instances by default. For example, an 18.x.x Proxy Service or agent is not
+  compatible with an 17.x.x Auth Service.
+- Auth Service instances should always be the first component of the cluster that
+  is upgraded, and you must upgrade all Auth Service instances to the target version
+  before proceeding to upgrade Proxy Service instances and other agents.

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -17,13 +17,22 @@ Teleport cluster while preserving compatibility.
 
 (!docs/pages/includes/compatibility.mdx!)
 
+You can think of Teleport cluster components in three tiers:
+1. The Auth Service is expected to be the newest component in the cluster.
+   For this reason it should always be the first component that is upgraded.
+2. The Proxy Service is expected to run a version less than or equal to the
+   Auth Service. The Proxy Service should never run a version newer than the
+   Auth Service.
+3. Other Teleport agents (SSH Service, Database Service, etc.) should always
+   run a version less than or equal to the Proxy Service.
+
 In Teleport Enterprise Cloud, we manage the Auth Service and Proxy Service for
 you. You can determine the current version of these services by running the
 following command, where `mytenant` is the name of your Teleport Enterprise
 Cloud tenant:
 
 ```code
-$ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'
+$ curl -s https://mytenant.teleport.sh/webapi/find | jq '.server_version'
 ```
 
 ## Upgrading a self-hosted Teleport cluster

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -47,7 +47,7 @@ Teleport cluster.
 1. Upgrade all **Auth Service** instances to the **target version first**.
    Auth Service instances may be upgraded in any sequence or at the same time. After
    the upgrade **confirm** that the cluster is in a healthy state before continuing.
-1. After all Auth Service instances are running the tareget version, upgrade Proxy Service instances
+1. After all Auth Service instances are running the target version, upgrade Proxy Service instances
    to the same version as the Auth Service. Proxy Service instances are
    stateless and can be upgraded in any sequence or at the same time. After the
    upgrade **confirm** that the cluster is in a healthy state before continuing.

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -35,9 +35,9 @@ Teleport cluster.
 <Admonition type="warning">
   If you are upgrading more then one major version, you must repeat the
   following steps for each major version until you reach your target version.
-  For example, if your cluster is on v10 and you wish to upgrade to v13, you
-  must first follow the sequence below for v11, then v12, before finally upgrading
-  to v13. You must not upgrade directly from v10 to v13.
+  For example, if your cluster is on v15 and you wish to upgrade to v18, you
+  must first follow the sequence below for v16, then v17, before finally upgrading
+  to v18. You must not upgrade directly from v15 to v18.
 </Admonition>
 
 1. Back up your Teleport cluster state as a precaution against any unforeseen
@@ -47,14 +47,19 @@ Teleport cluster.
 1. Upgrade all **Auth Service** instances to the **target version first**.
    Auth Service instances may be upgraded in any sequence or at the same time. After
    the upgrade **confirm** that the cluster is in a healthy state before continuing.
-1. Upgrade Proxy Service instances to the same version as the Auth
-   Service. Proxy Service instances are stateless and can be upgraded in any
-   sequence or at the same time. After the upgrade **confirm** that the cluster
-   is in a healthy state before continuing.
-1. Upgrade your Teleport Agents to the same version as the Auth Service.
-   You can upgrade resource agents in any sequence or at the same time. After the
+1. After all Auth Service instances are running the tareget version, upgrade Proxy Service instances
+   to the same version as the Auth Service. Proxy Service instances are
+   stateless and can be upgraded in any sequence or at the same time. After the
    upgrade **confirm** that the cluster is in a healthy state before continuing.
+1. After all Proxy Service instances are running the target version, upgrade
+   your Teleport Agents to the same version as the Auth Service. You can upgrade
+   agents in any sequence or at the same time. After the upgrade **confirm**
+   that the cluster is in a healthy state before continuing.
 1. Upgrade your Teleport clients and plugins (tctl, tsh, tbot, terraform-provider, event-handler, etc.).
+
+By following this process, your agents will never get ahead of your control
+plane components (even within the same major/patch version), ensuring that all
+expected APIs and migrations will be available by the time the agents upgrade.
 
 ## Upgrading multiple Teleport clusters
 


### PR DESCRIPTION
When we removed the requirement to scale auth servers down to 1 instance as part of cluster upgrades, we placed new rules on agent upgrades. This docs change attempts to clatify the requirements, namely that agents don't get ahead of proxy/auth.

- Auth servers must be upgraded first. You can upgrade them as quickly or slowly as you want, but don't start upgrading other components until all auth servers are running the new version.
- Proxy servers get updated next. Upgrade them to the same version that auth was just updated to.
- Agents get upgraded only after auth and proxy are all running the new version. Same thing goes here - the agent should be upgraded to the same version that you just upgraded the control plane to.