### PR TITLE
Fix no-restricted-imports ESLint rule, report unused disable directives

### DIFF
--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -27,6 +27,21 @@ import unusedImportsPlugin from 'eslint-plugin-unused-imports';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+const commonNoRestrictedImportsPaths = [
+  {
+    name: 'usehooks-ts',
+    importNames: ['useResizeObserver'],
+    message:
+      "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead.",
+  },
+  {
+    name: 'usehooks-ts',
+    importNames: ['useCopyToClipboard'],
+    message:
+      "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead.",
+  },
+];
+
 export default tseslint.config(
   {
     // Citing from the ESLint docs:
@@ -194,6 +209,7 @@ export default tseslint.config(
               group: ['teleport/*', 'e-teleport/*', 'teleterm/*'],
             },
           ],
+          paths: commonNoRestrictedImportsPaths,
         },
       ],
     },
@@ -209,6 +225,7 @@ export default tseslint.config(
               group: ['e-teleport/*', 'teleterm/*'],
             },
           ],
+          paths: commonNoRestrictedImportsPaths,
         },
       ],
     },
@@ -224,6 +241,7 @@ export default tseslint.config(
               group: ['teleterm/*'],
             },
           ],
+          paths: commonNoRestrictedImportsPaths,
         },
       ],
     },
@@ -239,37 +257,20 @@ export default tseslint.config(
               group: ['teleport/*', 'e-teleport/*'],
             },
           ],
+          paths: commonNoRestrictedImportsPaths,
         },
       ],
     },
   },
 
-  /*
-   * Restricted hook imports
-   *
-   * We already have our own, Electron and browser safe hooks, so we don't want any usage of the equivalent
-   * hooks from `usehooks-ts`
-   */
   {
-    files: ['e/web/**/*.{ts,tsx,js,jsx}', 'web/packages/**/*.{ts,tsx,js,jsx}'],
+    // Anything but the packages which have more specific patterns written out above.
+    files: ['web/packages/!(teleterm|teleport|shared)/**/*.{ts,tsx,js,jsx}'],
     rules: {
       'no-restricted-imports': [
         'error',
         {
-          paths: [
-            {
-              name: 'usehooks-ts',
-              importNames: ['useResizeObserver'],
-              message:
-                "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead.",
-            },
-            {
-              name: 'usehooks-ts',
-              importNames: ['useCopyToClipboard'],
-              message:
-                "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead.",
-            },
-          ],
+          paths: commonNoRestrictedImportsPaths,
         },
       ],
     },

--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -57,6 +57,7 @@ export default tseslint.config(
     // And just to be future-proof we specify other non-default extensions used in the project.
     files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.jsx'],
   },
+  { linterOptions: { reportUnusedDisableDirectives: 'error' } },
   {
     ignores: [
       '**/dist/**',

--- a/web/packages/build/jest/jest.d.ts
+++ b/web/packages/build/jest/jest.d.ts
@@ -18,7 +18,6 @@
 
 // Ignore no-empty-interface in order to explicitly follow the types from Jest docs.
 // Otherwise ESLint would autofix them.
-/* eslint-disable @typescript-eslint/no-empty-interface */
 
 // https://jestjs.io/docs/27.x/expect#expectextendmatchers
 // https://redd.one/blog/practical-guide-to-custom-jest-matchers

--- a/web/packages/shared/components/AnimatedTerminal/content.ts
+++ b/web/packages/shared/components/AnimatedTerminal/content.ts
@@ -63,7 +63,6 @@ export async function* createTerminalContent(
     yield buffer;
   }
 
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     if (lineIndex < lines.length) {
       if (!lines[lineIndex].isCommand) {

--- a/web/packages/shared/utils/saveOnDisk.test.ts
+++ b/web/packages/shared/utils/saveOnDisk.test.ts
@@ -27,7 +27,6 @@ test('saveOnDisk', async () => {
   jest.spyOn(document.body, 'appendChild').mockImplementation();
   jest.spyOn(document.body, 'removeChild').mockImplementation();
   const blob = jest.spyOn(global, 'Blob').mockImplementation();
-  // eslint-disable-next-line jest/prefer-spy-on
   window.URL.createObjectURL = jest.fn();
 
   saveOnDisk('testcontent', 'testfile.txt', 'plain/text');

--- a/web/packages/teleport/src/services/auth/auth.test.ts
+++ b/web/packages/teleport/src/services/auth/auth.test.ts
@@ -20,8 +20,6 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import auth from 'teleport/services/auth';
 
-/* eslint-disable jest/no-conditional-expect */
-
 describe('services/auth', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/web/packages/teleterm/src/mainProcess/agentDownloader/agentDownloader.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentDownloader/agentDownloader.test.ts
@@ -63,7 +63,6 @@ const LATEST_TELEPORT_VERSIONS_MOCK = [
 beforeAll(() => {
   Logger.init(new NullService());
   // (Cannot spy the fetch property because it is not a function; undefined given instead)
-  // eslint-disable-next-line jest/prefer-spy-on
   global.fetch = jest.fn().mockImplementation(() =>
     Promise.resolve({
       ok: true,

--- a/web/packages/teleterm/src/ui/uri.test.ts
+++ b/web/packages/teleterm/src/ui/uri.test.ts
@@ -89,9 +89,7 @@ describe('getKubeResourceNamespaceUri', () => {
     },
   ];
 
-  /* eslint-disable jest/no-conditional-expect */
   test.each(tests)('$name', ({ input, output }) => {
     expect(routing.getKubeResourceNamespaceUri(input)).toEqual(output);
   });
-  /* eslint-enable jest/no-conditional-expect */
 });


### PR DESCRIPTION
* teleport.e counterpart: https://github.com/gravitational/teleport.e/pull/7142

https://github.com/gravitational/teleport/pull/58341 added some more no-restricted-imports rules for usehooks-ts to the ESLint config. However, because of how rule config merging works, this ended up overwriting previous rules.

> When more than one configuration object specifies the same rule, the rule configuration is merged with the later object taking precedence over any previous objects.

https://eslint.org/docs/latest/use/configure/rules#using-configuration-files

<details>
<summary>Effective ESLint config before</summary>

```
$ pnpm exec eslint --print-config web/packages/shared/components/UnifiedResources/UnifiedResources.tsx | rg no-restricted-imports -A 30
    "no-restricted-imports": [
      2,
      {
        "paths": [
          {
            "name": "usehooks-ts",
            "importNames": [
              "useResizeObserver"
            ],
            "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
          },
          {
            "name": "usehooks-ts",
            "importNames": [
              "useCopyToClipboard"
            ],
            "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
          }
        ]
      }
    ]
  },
```
</details>

This PR updates the config for that rule, making sure that both the previous and current no-restricted-imports rules are in effect. In addition, it enables `reportUnusedDisableDirectives` which would've caught the regression from https://github.com/gravitational/teleport/pull/58341.

<details>
<summary>Effective ESLint config after</summary>

```
$ pnpm exec eslint --print-config web/packages/shared/components/UnifiedResources/UnifiedResources.tsx | rg no-restricted-imports -A 30
    "no-restricted-imports": [
      2,
      {
        "patterns": [
          {
            "group": [
              "teleport/*",
              "e-teleport/*",
              "teleterm/*"
            ]
          }
        ],
        "paths": [
          {
            "name": "usehooks-ts",
            "importNames": [
              "useResizeObserver"
            ],
            "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
          },
          {
            "name": "usehooks-ts",
            "importNames": [
              "useCopyToClipboard"
            ],
            "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
          }
        ]
      }
    ]
  },
$ pnpm exec eslint --print-config web/packages/build/jest/setupTests.ts  | rg no-restricted-imports -A 30
    "no-restricted-imports": [
      2,
      {
        "paths": [
          {
            "name": "usehooks-ts",
            "importNames": [
              "useResizeObserver"
            ],
            "message": "Use 'useResizeObserver' from 'design/utils/useResizeObserver' instead."
          },
          {
            "name": "usehooks-ts",
            "importNames": [
              "useCopyToClipboard"
            ],
            "message": "Use 'copyToClipboard' from 'design/utils/copyToClipboard' instead."
          }
        ]
      }
    ]
  },
```

</details>