### PR TITLE
Add the resize events renderer for the session timeline

### DIFF
--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -512,6 +512,7 @@ const colors: ThemeColors = {
         text: 'rgba(255, 255, 255, 0.6)',
       },
       resize: {
+        semiBackground: 'rgba(0, 0, 0, 0.8)',
         background: '#26323c',
         border: '#86c4ed',
         text: '#86c4ed',

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -520,6 +520,7 @@ const colors: ThemeColors = {
         text: 'rgba(255, 255, 255, 0.6)',
       },
       resize: {
+        semiBackground: 'rgba(0, 0, 0, 0.8)',
         background: '#26323c',
         border: '#86c4ed',
         text: '#86c4ed',

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -515,6 +515,7 @@ const colors: ThemeColors = {
         text: 'rgba(0, 0, 0, 0.6)',
       },
       resize: {
+        semiBackground: 'rgba(0, 0, 0, 0.8)',
         border: '#26323c',
         background: '#86c4ed',
         text: '#26323c',

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -243,6 +243,7 @@ export type ThemeColors = {
         text: string;
       };
       resize: {
+        semiBackground: string;
         background: string;
         border: string;
         text: string;

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import { darkTheme } from 'design/theme';
+
+import {
+  SessionRecordingEventType,
+  SessionRecordingMetadata,
+  SessionRecordingResizeEvent,
+} from 'teleport/services/recordings';
+import type { TimelineRenderContext } from 'teleport/SessionRecordings/view/Timeline/renderers/TimelineCanvasRenderer';
+
+import { ResizeEventsRenderer } from './ResizeEventsRenderer';
+
+// TODO(ryan): share some common mocks between all tests once everything is merged
+const mockMetadata: SessionRecordingMetadata = {
+  startTime: 1609459200000, // Jan 1, 2021 12:00:00 AM UTC
+  endTime: 1609462800000, // Jan 1, 2021 1:00:00 AM UTC
+  duration: 3600000, // 1 hour in milliseconds
+  user: 'testuser',
+  resourceName: 'test-server',
+  clusterName: 'test-cluster',
+  events: [],
+  startCols: 80,
+  startRows: 24,
+  type: 'ssh',
+};
+
+function createRenderer(
+  metadata?: Partial<SessionRecordingMetadata>,
+  events?: SessionRecordingResizeEvent[]
+) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const renderer = new ResizeEventsRenderer(ctx, darkTheme, {
+    ...mockMetadata,
+    events: events || [],
+    ...metadata,
+  });
+
+  return { ctx, renderer };
+}
+
+function createResizeEvent(
+  startTime: number,
+  cols: number,
+  rows: number,
+  endTime?: number
+): SessionRecordingResizeEvent {
+  return {
+    type: SessionRecordingEventType.Resize,
+    startTime,
+    endTime: endTime || 0,
+    cols,
+    rows,
+  };
+}
+
+describe('resize event calculation', () => {
+  it('should calculate end times for resize events', () => {
+    const events = [
+      createResizeEvent(0, 80, 24),
+      createResizeEvent(10000, 100, 30),
+      createResizeEvent(20000, 120, 40),
+    ];
+
+    const { renderer } = createRenderer(
+      {
+        duration: 30 * 1000, // 30 seconds
+      },
+      events
+    );
+
+    renderer.calculate();
+
+    // Check that events have proper end times
+    // First event ends at second event start - 1
+    // Second event ends at third event start - 1
+    // Third event ends at duration
+
+    const allEvents = renderer.getAllEvents();
+    expect(allEvents[0].endTime).toBe(9999);
+    expect(allEvents[1].endTime).toBe(19999);
+    expect(allEvents[2].endTime).toBe(30000);
+  });
+
+  it('should calculate text metrics and positions', () => {
+    const events = [createResizeEvent(5000, 120, 40)];
+
+    const { ctx, renderer } = createRenderer(
+      {
+        duration: 10 * 1000, // 10 seconds
+      },
+      events
+    );
+
+    renderer.setTimelineWidth(1000);
+    renderer.calculate();
+
+    const allEvents = renderer.getAllEvents();
+
+    const expectedWidth = ctx.measureText('120x40').width;
+
+    expect(allEvents[0].title).toBe('120x40');
+    expect(allEvents[0].startPosition).toBeDefined();
+    expect(allEvents[0].endPosition).toBeDefined();
+    expect(allEvents[0].textMetrics).toBeDefined();
+    expect(allEvents[0].textMetrics.width).toBe(expectedWidth);
+  });
+
+  it('should assign events to rows to avoid overlap', () => {
+    const events = [
+      createResizeEvent(0, 80, 24),
+      createResizeEvent(5000, 100, 30),
+      createResizeEvent(5010, 120, 40),
+      createResizeEvent(15000, 140, 50),
+    ];
+
+    const { renderer } = createRenderer(
+      {
+        duration: 20 * 1000, // 20 seconds
+      },
+      events
+    );
+
+    renderer.setTimelineWidth(100);
+    renderer.calculate();
+
+    const allEvents = renderer.getAllEvents();
+
+    expect(allEvents[0].originalRow).toBe(0);
+    expect(allEvents[1].originalRow).toBe(1);
+    expect(allEvents[2].originalRow).toBe(0);
+    expect(allEvents[3].originalRow).toBe(0);
+
+    // Check that overlapping events are not in the same row
+    const rows = new Map<number, any[]>();
+    for (const event of allEvents) {
+      if (!rows.has(event.originalRow)) {
+        rows.set(event.originalRow, []);
+      }
+
+      rows.get(event.originalRow).push(event);
+    }
+
+    // Verify no overlap within each row
+    for (const [, eventsInRow] of rows) {
+      for (let i = 0; i < eventsInRow.length - 1; i++) {
+        for (let j = i + 1; j < eventsInRow.length; j++) {
+          const event1 = eventsInRow[i];
+          const event2 = eventsInRow[j];
+
+          const hasOverlap =
+            event1.startPosition <
+              event2.startPosition + event2.textMetrics.width &&
+            event2.startPosition <
+              event1.startPosition + event1.textMetrics.width;
+
+          expect(hasOverlap).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe('resize event rendering', () => {
+  it('should render resize events within visible area', () => {
+    const events = [
+      createResizeEvent(5000, 80, 24),
+      createResizeEvent(15000, 100, 30),
+    ];
+
+    const { ctx, renderer } = createRenderer(
+      {
+        duration: 20 * 1000, // 20 seconds
+      },
+      events
+    );
+
+    renderer.setTimelineWidth(1000);
+    renderer.calculate();
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 1100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+
+    // Should render text for both resize events
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    expect(fillTextCalls).toHaveLength(2);
+    expect(fillTextCalls[0].props.text).toBe('80x24');
+    expect(fillTextCalls[1].props.text).toBe('100x30');
+
+    const ctxEvents = ctx.__getEvents();
+    const roundRects = ctxEvents.filter(e => e.type === 'roundRect');
+
+    expect(roundRects).toHaveLength(2 * 2); // Each event has two roundRects (background and border)
+  });
+
+  it('should only render events within view buffer', () => {
+    const events = [
+      createResizeEvent(0, 80, 24),
+      createResizeEvent(50000, 100, 30), // Far offscreen
+      createResizeEvent(10000, 120, 40),
+    ];
+
+    const { ctx, renderer } = createRenderer(
+      {
+        duration: 60 * 1000, // 60 seconds
+      },
+      events
+    );
+
+    renderer.setTimelineWidth(1000);
+    renderer.calculate();
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 200,
+      offset: 0, // Viewing start of timeline
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const drawCalls = ctx.__getDrawCalls();
+    const fillTextCalls = drawCalls.filter(call => call.type === 'fillText');
+
+    // Should only render first and third events (second is far offscreen)
+    expect(fillTextCalls).toHaveLength(2);
+    expect(fillTextCalls[0].props.text).toBe('80x24');
+    expect(fillTextCalls[1].props.text).toBe('120x40');
+  });
+
+  it('should render vertical lines connecting events to timeline', () => {
+    const events = [createResizeEvent(5000, 80, 24)];
+
+    const { ctx, renderer } = createRenderer(
+      {
+        duration: 10000, // 10 seconds
+      },
+      events
+    );
+
+    renderer.setTimelineWidth(1000);
+    renderer.calculate();
+
+    const renderContext: TimelineRenderContext = {
+      containerWidth: 1100,
+      offset: 0,
+      containerHeight: 200,
+      eventsHeight: 100,
+    };
+
+    renderer._render(renderContext);
+
+    const paths = ctx.__getPath();
+
+    expect(paths).toHaveLength(3);
+
+    expect(paths[0].type).toBe('beginPath');
+    expect(paths[1].type).toBe('moveTo');
+
+    const moveToX = paths[1].props.x;
+    const moveToY = paths[1].props.y;
+
+    expect(paths[2].type).toBe('lineTo');
+    expect(paths[2].props.x).toBe(moveToX);
+    expect(paths[2].props.y).toBeGreaterThan(moveToY);
+  });
+});

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -320,9 +320,7 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
     const viewEnd = -offset + containerWidth;
 
     const activeEvents = this.allEvents.filter(
-      event =>
-        event.endPosition > viewStart &&
-        event.startPosition < viewEnd
+      event => event.endPosition > viewStart && event.startPosition < viewEnd
     );
 
     const sortedEvents = activeEvents.toSorted(

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -326,7 +326,7 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
         event.startPosition < viewEnd + buffer
     );
 
-    const sortedEvents = [...activeEvents].toSorted(
+    const sortedEvents = activeEvents.toSorted(
       (a, b) => a.startPosition - b.startPosition
     );
 

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -1,0 +1,528 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { DefaultTheme } from 'styled-components';
+
+import {
+  SessionRecordingEventType,
+  type SessionRecordingMetadata,
+  type SessionRecordingResizeEvent,
+} from 'teleport/services/recordings';
+
+import { LEFT_PADDING } from '../constants';
+import {
+  TimelineCanvasRenderer,
+  type TimelineRenderContext,
+} from './TimelineCanvasRenderer';
+
+interface EventWithCalculatedPosition {
+  event: ResizeTimelineEventPositioned;
+  row: number;
+  y: number;
+}
+
+interface LineSegment {
+  end: number;
+  start: number;
+}
+
+interface ResizeTimelineEventPositioned extends SessionRecordingResizeEvent {
+  title: string;
+  endPosition: number;
+  originalRow: number;
+  startPosition: number;
+  textMetrics: TextMetrics;
+}
+
+function calculateEventEndTimes(
+  resizeEvents: SessionRecordingResizeEvent[],
+  duration: number
+) {
+  const events: SessionRecordingResizeEvent[] = [];
+
+  for (const event of resizeEvents) {
+    const lastResizeEvent = events.findLast(e => e.startTime < event.startTime);
+
+    if (lastResizeEvent) {
+      lastResizeEvent.endTime = event.startTime - 1;
+    }
+
+    events.push(event);
+  }
+
+  const lastResizeEvent = events.findLast(
+    e => e.type === SessionRecordingEventType.Resize
+  );
+
+  if (lastResizeEvent) {
+    lastResizeEvent.endTime = duration;
+  }
+
+  return events;
+}
+
+const TEXT_PADDING_X = 8;
+const TEXT_PADDING_Y = 3.5;
+const ROW_HEIGHT = 20;
+const BORDER_RADIUS = 6;
+
+/**
+ * ResizeEventsRenderer is responsible for rendering terminal resize events on the timeline,
+ * in the bottom left.
+ *
+ * It renders the size in a mono font, `ColsxRows`, inside a rounded rectangle with a semi-transparent background.
+ * The resize events will move along with the timeline as the user scrolls, until it encounters another
+ * resize event, at which point that resize event will "push" the previous event out of the way.
+ *
+ * If there are multiple resize events that would overlap, they will be stacked vertically.
+ * Each event will have a line connecting it to the bottom of the timeline, unless that line
+ * would intersect with another event's box, in which case the line will stop just before the box.
+ */
+export class ResizeEventsRenderer extends TimelineCanvasRenderer {
+  private allEvents: ResizeTimelineEventPositioned[] = [];
+  private readonly resizeEvents: SessionRecordingResizeEvent[] = [];
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    theme: DefaultTheme,
+    metadata: SessionRecordingMetadata
+  ) {
+    super(ctx, theme, metadata.duration);
+
+    this.resizeEvents = calculateEventEndTimes(
+      metadata.events.filter(
+        event => event.type === SessionRecordingEventType.Resize
+      ),
+      metadata.duration
+    );
+  }
+
+  _render({ containerHeight, containerWidth, offset }: TimelineRenderContext) {
+    const eventsWithPositions = this.getEventPositions(
+      offset,
+      containerWidth,
+      containerHeight
+    );
+
+    console.log('Rendering resize events:', eventsWithPositions);
+
+    for (const { event, row, y } of eventsWithPositions) {
+      this.renderEvent(
+        event,
+        containerHeight,
+        offset,
+        row,
+        y,
+        eventsWithPositions
+      );
+    }
+  }
+
+  // calculate determines the position of each resize event on the timeline,
+  // and how many rows are needed to display them without overlap.
+  // It also calculates the text metrics for each event title.
+  calculate() {
+    this.allEvents = [];
+
+    for (let i = 0; i < this.resizeEvents.length; i++) {
+      const event = this.resizeEvents[i];
+
+      const startPosition =
+        (event.startTime / this.duration) * this.timelineWidth + LEFT_PADDING;
+      const endPosition =
+        (event.endTime / this.duration) * this.timelineWidth + LEFT_PADDING;
+
+      this.ctx.save();
+
+      this.ctx.font = `bold 10px ${this.theme.fonts.mono}`;
+
+      const title = `${event.cols}x${event.rows}`;
+
+      const textMetrics = this.ctx.measureText(title);
+
+      this.ctx.restore();
+
+      this.allEvents.push({
+        ...event,
+        title,
+        endPosition,
+        originalRow: 0,
+        startPosition,
+        textMetrics,
+      });
+    }
+
+    const rows: ResizeTimelineEventPositioned[][] = [];
+
+    // calculate the rows for each event, starting from the last event
+    // this ensures that events stack upwards and to the right
+    for (let i = this.allEvents.length - 1; i >= 0; i--) {
+      const event = this.allEvents[i];
+      let placed = false;
+
+      for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+        // check for overlap with existing events in this row
+        const hasOverlap = rows[rowIndex].some(
+          existingEvent =>
+            existingEvent.startPosition <
+              event.startPosition + event.textMetrics.width &&
+            event.startPosition <
+              existingEvent.startPosition + existingEvent.textMetrics.width
+        );
+
+        if (!hasOverlap) {
+          // no overlap, place the event in this row
+          event.originalRow = rowIndex;
+          rows[rowIndex].push(event);
+
+          placed = true;
+
+          break;
+        }
+      }
+
+      if (!placed) {
+        // no suitable row found, create a new row
+        event.originalRow = rows.length;
+        rows.push([event]);
+      }
+    }
+  }
+
+  getAllEvents() {
+    return this.allEvents;
+  }
+
+  // calculateLineSegments calculates the segments of the vertical line that connects
+  // the event box to the bottom of the timeline, avoiding intersections with other event boxes.
+  calculateLineSegments(
+    lineX: number,
+    lineStartY: number,
+    lineEndY: number,
+    rowIndex: number,
+    currentEvent: ResizeTimelineEventPositioned,
+    offset: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): LineSegment[] {
+    let segments: LineSegment[] = [{ end: lineEndY, start: lineStartY }];
+
+    for (const eventPos of allEvents) {
+      const { event: otherEvent, row: otherRow, y: otherY } = eventPos;
+
+      // Skip the current event and events in the same or lower rows
+      if (otherEvent === currentEvent || otherRow >= rowIndex) {
+        continue;
+      }
+
+      const textPadding = TEXT_PADDING_X;
+
+      // Calculate the bounding box of the other event
+      // Adjust for the current offset to determine visibility
+      // If the other event is partially off-screen, adjust the text offset accordingly
+      // This ensures the bounding box is accurate even when the timeline is scrolled
+      // and the event is not fully visible
+
+      const visibleStart = Math.max(otherEvent.startPosition, -offset);
+      const defaultTextOffset = Math.max(
+        visibleStart - otherEvent.startPosition + textPadding,
+        textPadding
+      );
+
+      const width = otherEvent.endPosition - otherEvent.startPosition;
+      let textOffset = defaultTextOffset;
+
+      if (otherEvent.textMetrics.width > 0) {
+        const maxTextOffset = Math.max(
+          textPadding,
+          width - otherEvent.textMetrics.width - textPadding
+        );
+        textOffset = Math.min(defaultTextOffset, maxTextOffset);
+      }
+
+      const otherX = otherEvent.startPosition + textOffset;
+      const otherTextWidth = otherEvent.textMetrics.width;
+
+      const otherRectX = otherX - TEXT_PADDING_X;
+      const otherRectWidth = otherTextWidth + TEXT_PADDING_X * 2;
+
+      const otherTextHeight =
+        otherEvent.textMetrics.actualBoundingBoxAscent +
+        otherEvent.textMetrics.actualBoundingBoxDescent;
+      const otherRectY =
+        otherY -
+        otherEvent.textMetrics.actualBoundingBoxAscent -
+        TEXT_PADDING_Y;
+      const otherRectHeight = otherTextHeight + TEXT_PADDING_Y * 2;
+
+      // Check if the vertical line intersects with the other event's bounding box
+      if (
+        lineX >= otherRectX &&
+        lineX <= otherRectX + otherRectWidth &&
+        lineStartY <= otherRectY + otherRectHeight &&
+        lineEndY >= otherRectY
+      ) {
+        const newSegments: LineSegment[] = [];
+
+        for (const segment of segments) {
+          // If the segment intersects with the other event's bounding box, split it
+          if (segment.start < otherRectY && segment.end > otherRectY) {
+            newSegments.push({ end: otherRectY, start: segment.start });
+          }
+
+          // If the segment intersects with the bottom of the other event's bounding box, split it
+          if (
+            segment.start < otherRectY + otherRectHeight &&
+            segment.end > otherRectY + otherRectHeight
+          ) {
+            newSegments.push({
+              end: segment.end,
+              start: otherRectY + otherRectHeight,
+            });
+          }
+
+          // If the segment is completely above or below the other event's bounding box, keep it as is
+          if (
+            segment.start >= otherRectY + otherRectHeight ||
+            segment.end <= otherRectY
+          ) {
+            newSegments.push(segment);
+          }
+        }
+
+        segments = newSegments;
+      }
+    }
+
+    return segments;
+  }
+
+  // getEventPositions filters and positions events based on the current view offset and container size.
+  // It returns events that are within the visible area plus a buffer, and assigns them to rows to avoid overlap.
+  private getEventPositions(
+    offset: number,
+    containerWidth: number,
+    containerHeight: number
+  ): EventWithCalculatedPosition[] {
+    const viewStart = -offset;
+    const viewEnd = -offset + containerWidth;
+    const buffer = containerWidth / 2;
+
+    const activeEvents = this.allEvents.filter(
+      event =>
+        event.endPosition > viewStart - buffer &&
+        event.startPosition < viewEnd + buffer
+    );
+
+    const sortedEvents = [...activeEvents].toSorted(
+      (a, b) => a.startPosition - b.startPosition
+    );
+
+    const eventsWithPositions: EventWithCalculatedPosition[] = [];
+    const rowEndPositions = new Map<number, number>();
+
+    for (const event of sortedEvents) {
+      const baseRow = event.originalRow;
+
+      let targetRow = baseRow;
+
+      const padding = 10;
+
+      for (let i = 0; i < baseRow; i++) {
+        const rowEnd = rowEndPositions.get(i) ?? -Infinity;
+
+        console.log('checking row', i, 'end', rowEnd);
+
+        // Check if the event can fit in this row without overlapping
+        if (event.startPosition >= rowEnd + padding) {
+          targetRow = i;
+
+          break;
+        }
+      }
+
+      const y = this.getYForRow(targetRow, containerHeight);
+
+      console.log('setting row to', targetRow, 'y:', y);
+
+      eventsWithPositions.push({
+        event,
+        row: targetRow,
+        y,
+      });
+
+      rowEndPositions.set(targetRow, event.endPosition);
+    }
+
+    return eventsWithPositions;
+  }
+
+  private getYForRow(row: number, containerHeight: number): number {
+    const bottom = containerHeight - 10;
+
+    return bottom - row * ROW_HEIGHT;
+  }
+
+  private renderEvent(
+    event: ResizeTimelineEventPositioned,
+    containerHeight: number,
+    offset: number,
+    row: number,
+    y: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): void {
+    const textPadding = 8;
+    const visibleStart = Math.max(event.startPosition, -offset);
+    const defaultTextOffset = Math.max(
+      visibleStart - event.startPosition + textPadding,
+      textPadding
+    );
+
+    const width = event.endPosition - event.startPosition;
+    let textOffset = defaultTextOffset;
+
+    if (event.textMetrics.width > 0) {
+      const maxTextOffset = Math.max(
+        textPadding,
+        width - event.textMetrics.width - textPadding
+      );
+      textOffset = Math.min(defaultTextOffset, maxTextOffset);
+    }
+
+    const x = event.startPosition + textOffset;
+
+    this.renderResizeEventBox(event, x, y);
+    this.renderResizeEventText(event, x, y);
+    this.renderResizeEventLine(
+      event,
+      x,
+      y,
+      containerHeight,
+      offset,
+      row,
+      allEvents
+    );
+  }
+
+  private renderResizeEventBox(
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number
+  ): void {
+    const textWidth = event.textMetrics.width;
+    const textHeight =
+      event.textMetrics.actualBoundingBoxAscent +
+      event.textMetrics.actualBoundingBoxDescent;
+
+    const rectX = x - TEXT_PADDING_X;
+    const rectY =
+      y - event.textMetrics.actualBoundingBoxAscent - TEXT_PADDING_Y;
+    const rectWidth = textWidth + TEXT_PADDING_X * 2;
+    const rectHeight = textHeight + TEXT_PADDING_Y * 2;
+
+    this.ctx.save();
+
+    // Draw semi-transparent background for better readability
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.semiBackground;
+    this.ctx.beginPath();
+    this.ctx.roundRect(rectX, rectY, rectWidth, rectHeight, BORDER_RADIUS);
+    this.ctx.fill();
+
+    // Draw main box with shadow
+    this.ctx.shadowColor = 'rgba(0, 0, 0, .05)';
+    this.ctx.shadowBlur = 4;
+    this.ctx.shadowOffsetX = 0;
+    this.ctx.shadowOffsetY = 0;
+
+    // Main box background and border
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.background;
+    this.ctx.beginPath();
+    this.ctx.roundRect(rectX, rectY, rectWidth, rectHeight, BORDER_RADIUS);
+    this.ctx.fill();
+    this.ctx.strokeStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.border;
+    this.ctx.lineWidth = 1.5;
+    this.ctx.stroke();
+
+    this.ctx.restore();
+  }
+
+  private renderResizeEventLine(
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number,
+    containerHeight: number,
+    offset: number,
+    rowIndex: number,
+    allEvents: EventWithCalculatedPosition[]
+  ): void {
+    const textWidth = event.textMetrics.width;
+    const textHeight =
+      event.textMetrics.actualBoundingBoxAscent +
+      event.textMetrics.actualBoundingBoxDescent;
+
+    const rectY =
+      y - event.textMetrics.actualBoundingBoxAscent - TEXT_PADDING_Y;
+    const rectHeight = textHeight + TEXT_PADDING_Y * 2;
+
+    const lineX = x + textWidth / 2;
+    const lineStartY = rectY + rectHeight;
+    const lineEndY = containerHeight;
+
+    this.ctx.save();
+
+    this.ctx.strokeStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.border;
+    this.ctx.lineWidth = 1.5;
+
+    const segments = this.calculateLineSegments(
+      lineX,
+      lineStartY,
+      lineEndY,
+      rowIndex,
+      event,
+      offset,
+      allEvents
+    );
+
+    for (const segment of segments) {
+      this.ctx.beginPath();
+      this.ctx.moveTo(lineX, segment.start);
+      this.ctx.lineTo(lineX, segment.end);
+      this.ctx.stroke();
+    }
+
+    this.ctx.restore();
+  }
+
+  private renderResizeEventText(
+    event: ResizeTimelineEventPositioned,
+    x: number,
+    y: number
+  ): void {
+    this.ctx.save();
+
+    this.ctx.fillStyle =
+      this.theme.colors.sessionRecordingTimeline.events.resize.text;
+    this.ctx.font = `bold 10px ${this.theme.fonts.mono}`;
+
+    this.ctx.fillText(event.title, x, y);
+    this.ctx.restore();
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -310,7 +310,7 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
   }
 
   // getEventPositions filters and positions events based on the current view offset and container size.
-  // It returns events that are within the visible area plus a buffer, and assigns them to rows to avoid overlap.
+  // It returns events that are within the visible area and assigns them to rows to avoid overlap.
   private getEventPositions(
     offset: number,
     containerWidth: number,
@@ -318,12 +318,11 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
   ): EventWithCalculatedPosition[] {
     const viewStart = -offset;
     const viewEnd = -offset + containerWidth;
-    const buffer = containerWidth / 2;
 
     const activeEvents = this.allEvents.filter(
       event =>
-        event.endPosition > viewStart - buffer &&
-        event.startPosition < viewEnd + buffer
+        event.endPosition > viewStart &&
+        event.startPosition < viewEnd
     );
 
     const sortedEvents = activeEvents.toSorted(

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/ResizeEventsRenderer.ts
@@ -119,8 +119,6 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
       containerHeight
     );
 
-    console.log('Rendering resize events:', eventsWithPositions);
-
     for (const { event, row, y } of eventsWithPositions) {
       this.renderEvent(
         event,
@@ -345,8 +343,6 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
       for (let i = 0; i < baseRow; i++) {
         const rowEnd = rowEndPositions.get(i) ?? -Infinity;
 
-        console.log('checking row', i, 'end', rowEnd);
-
         // Check if the event can fit in this row without overlapping
         if (event.startPosition >= rowEnd + padding) {
           targetRow = i;
@@ -356,8 +352,6 @@ export class ResizeEventsRenderer extends TimelineCanvasRenderer {
       }
 
       const y = this.getYForRow(targetRow, containerHeight);
-
-      console.log('setting row to', targetRow, 'y:', y);
 
       eventsWithPositions.push({
         event,


### PR DESCRIPTION
This adds the resize events renderer for the session timeline

It's responsible for rendering the current size of the terminal in the bottom left (or along the timeline where it occurs) - it will stick to the bottom left as long as it's the correct resize event for that moment in time. If another event comes along, it will "push" the previous event out of the way and take its place.

<img width="333" height="333" alt="image" src="https://github.com/user-attachments/assets/35fa91be-ab82-43c3-b625-57b9486514c2" />
