### PR TITLE
Add an interactive timeline to session recordings

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
@@ -1,0 +1,427 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type MouseEvent,
+  type RefObject,
+} from 'react';
+import styled, { useTheme } from 'styled-components';
+import { useDebounceCallback } from 'usehooks-ts';
+
+import { useLocalStorage } from 'shared/hooks/useLocalStorage';
+
+import type {
+  SessionRecordingMetadata,
+  SessionRecordingThumbnail,
+} from 'teleport/services/recordings';
+import { KeysEnum } from 'teleport/services/storageService';
+
+import { TimelineRenderer } from './renderers/TimelineRenderer';
+import { ResizeHandle } from './ResizeHandle';
+import { useCursor } from './useCursor';
+import {
+  calculateAutoScrollOffset,
+  calculateNextUserControlled,
+  shouldAutoScroll,
+} from './utils';
+
+interface RecordingTimelineProps {
+  frames: SessionRecordingThumbnail[];
+  metadata: SessionRecordingMetadata;
+  onTimeChange: (time: number) => void;
+  showAbsoluteTime: boolean;
+  ref: RefObject<RecordingTimelineHandle>;
+}
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const Canvas = styled.canvas`
+  background: ${p => p.theme.colors.sessionRecordingTimeline.background};
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  will-change: transform;
+  transform: translateZ(0);
+`;
+
+const Cursor = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: ${p => p.theme.colors.sessionRecordingTimeline.cursor};
+  z-index: 1;
+  pointer-events: none;
+  will-change: transform;
+  display: none;
+`;
+
+export interface RecordingTimelineHandle {
+  moveToTime: (time: number, force?: boolean) => void;
+}
+
+const defaultHeight = 235;
+const minHeight = 200;
+const maxHeight = 500;
+
+function scaleCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  options?: CanvasRenderingContext2DSettings
+) {
+  const dpr = window.devicePixelRatio || 1;
+
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+
+  const ctx = canvas.getContext('2d', options);
+
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  ctx.scale(dpr, dpr);
+
+  return ctx;
+}
+
+export function RecordingTimeline({
+  frames,
+  metadata,
+  onTimeChange,
+  showAbsoluteTime,
+  ref,
+}: RecordingTimelineProps) {
+  const theme = useTheme();
+
+  const [height, setHeight] = useLocalStorage(
+    KeysEnum.SESSION_RECORDING_TIMELINE_HEIGHT,
+    defaultHeight
+  );
+
+  const timeRef = useRef(0);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cursorRef = useRef<HTMLDivElement | null>(null);
+  const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
+  const rendererRef = useRef<TimelineRenderer | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !canvasRef.current) {
+      return;
+    }
+
+    const { clientWidth: containerWidth, clientHeight: containerHeight } =
+      containerRef.current;
+
+    if (rendererRef.current) {
+      rendererRef.current.destroy();
+      rendererRef.current = null;
+    }
+
+    ctxRef.current = scaleCanvas(
+      canvasRef.current,
+      containerWidth,
+      containerHeight,
+      {
+        alpha: false,
+        desynchronized: true,
+        willReadFrequently: true,
+      }
+    );
+
+    ctxRef.current.imageSmoothingEnabled = false;
+    ctxRef.current.textRendering = 'optimizeLegibility';
+
+    ctxRef.current.fillStyle = theme.colors.sessionRecordingTimeline.background;
+    ctxRef.current.fillRect(0, 0, containerWidth, containerHeight);
+
+    rendererRef.current = new TimelineRenderer(
+      ctxRef.current,
+      metadata,
+      frames,
+      theme,
+      containerWidth,
+      containerHeight
+    );
+  }, [frames, metadata, theme]);
+
+  useEffect(() => {
+    if (!rendererRef.current) {
+      return;
+    }
+
+    rendererRef.current.setShowAbsoluteTime(showAbsoluteTime);
+  }, [showAbsoluteTime]);
+
+  useEffect(() => {
+    if (!canvasRef.current) {
+      return;
+    }
+
+    function handleWheel(event: WheelEvent) {
+      if (!rendererRef.current) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const renderer = rendererRef.current;
+
+      if (event.metaKey || event.ctrlKey) {
+        const ZOOM_SENSITIVITY = 0.002;
+        const deltaZoom = -event.deltaY * ZOOM_SENSITIVITY;
+
+        renderer.accumulateZoom(event.clientX, deltaZoom);
+      } else if (event.shiftKey && event.deltaY !== 0) {
+        renderer.accumulatePan(event.deltaY);
+      } else if (!event.shiftKey && event.deltaX !== 0) {
+        renderer.accumulatePan(event.deltaX);
+      }
+    }
+
+    const container = canvasRef.current;
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
+
+  const updateImages = useCallback(() => {
+    if (!rendererRef.current) {
+      return;
+    }
+
+    rendererRef.current.recreateImages();
+    rendererRef.current.render();
+  }, []);
+
+  const debouncedUpdateImages = useDebounceCallback(updateImages);
+
+  const handleHeightChange = useCallback(
+    (newHeight: number) => {
+      if (!canvasRef.current || !ctxRef.current || !rendererRef.current) {
+        return;
+      }
+
+      setHeight(newHeight);
+
+      const dpr = window.devicePixelRatio || 1;
+
+      canvasRef.current.height = newHeight * dpr;
+
+      canvasRef.current.style.height = `${newHeight}px`;
+
+      ctxRef.current.scale(dpr, dpr);
+
+      rendererRef.current.setHeight(newHeight);
+
+      // the thumbnails need to be recreated on height change (as they are already rendered at
+      // the previous height on an offscreen canvas), so we need to call recreateVisibleImages so
+      // that we don't recreate all of them at once and hang the UI
+      rendererRef.current.recreateVisibleImages();
+
+      // debounce updating the rest of the images to avoid hanging the UI
+      // when resizing the timeline to a larger height
+      debouncedUpdateImages();
+    },
+    [debouncedUpdateImages, setHeight]
+  );
+
+  const {
+    handleMouseEnter,
+    handleMouseLeave,
+    handleMouseMove,
+    isInteractingRef,
+  } = useCursor({
+    containerRef,
+    cursorRef,
+  });
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLCanvasElement>) => {
+      if (!canvasRef.current || !rendererRef.current) {
+        return;
+      }
+
+      const time = rendererRef.current.getTimeAtX(
+        event.clientX - canvasRef.current.getBoundingClientRect().left
+      );
+
+      onTimeChange(time);
+    },
+    [onTimeChange]
+  );
+
+  const moveToTime = useCallback(
+    (time: number, force?: boolean) => {
+      if (!rendererRef.current || !containerRef.current) {
+        return;
+      }
+
+      timeRef.current = time;
+
+      const renderer = rendererRef.current;
+      const containerWidth = containerRef.current.offsetWidth;
+
+      // Calculate timeline width based on duration and zoom
+      const pixelsPerMs = 0.1;
+      const baseTimelineWidth = metadata.duration * pixelsPerMs;
+      const timelineWidth = baseTimelineWidth * renderer.getZoom();
+
+      // Calculate time position on the timeline
+      const timePosition = (time / metadata.duration) * timelineWidth;
+      const relativePosition = timePosition + renderer.getOffset();
+
+      // Check if we should auto-scroll
+      const isUserControlled = renderer.getIsUserControlled();
+      const newUserControlled = calculateNextUserControlled(
+        relativePosition,
+        containerWidth,
+        isInteractingRef.current,
+        isUserControlled
+      );
+
+      if (newUserControlled !== isUserControlled) {
+        renderer.setIsUserControlled(newUserControlled);
+      }
+
+      if (
+        force ||
+        shouldAutoScroll(
+          relativePosition,
+          containerWidth,
+          isInteractingRef.current,
+          newUserControlled
+        )
+      ) {
+        const newOffset = calculateAutoScrollOffset(
+          timePosition,
+          relativePosition,
+          containerWidth,
+          timelineWidth,
+          force
+        );
+
+        renderer.setOffset(newOffset);
+      }
+
+      renderer.setCurrentTime(time);
+    },
+    [metadata.duration, isInteractingRef]
+  );
+
+  useImperativeHandle(ref, () => ({
+    moveToTime,
+  }));
+
+  const previousContainerWidth = useRef(0);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    // not using useResizeObserver here as it returns a RefCallback instead of a RefObject
+    const observer = new ResizeObserver(([box]) => {
+      if (!canvasRef.current || !rendererRef.current) {
+        return;
+      }
+
+      const { blockSize: height, inlineSize: width } = box.contentBoxSize[0];
+
+      const canvas = canvasRef.current;
+      if (!ctxRef.current) {
+        return;
+      }
+
+      const imageData = ctxRef.current.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+
+      ctxRef.current.scale(dpr, dpr);
+      ctxRef.current.putImageData(imageData, 0, 0);
+
+      const sameWidth = width === previousContainerWidth.current;
+
+      if (!sameWidth) {
+        previousContainerWidth.current = width;
+
+        rendererRef.current.setWidth(width);
+      }
+    });
+
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <Container style={{ height: `${height}px` }} ref={containerRef}>
+      <ResizeHandle
+        onChange={handleHeightChange}
+        height={height}
+        defaultHeight={defaultHeight}
+        minHeight={minHeight}
+        maxHeight={maxHeight}
+      />
+
+      <Cursor ref={cursorRef} />
+
+      <Canvas
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onMouseMove={handleMouseMove}
+        width="100%"
+        ref={canvasRef}
+      />
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
@@ -67,7 +67,7 @@ const Canvas = styled.canvas`
   bottom: 0;
   width: 100%;
   will-change: transform;
-  transform: translateZ(0);
+  transform: translateZ(0); // force the browser to use the GPU for rendering
 `;
 
 const Cursor = styled.div`

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/ResizeHandle.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/ResizeHandle.tsx
@@ -1,0 +1,150 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import styled from 'styled-components';
+
+import { useStateRef } from 'shared/hooks';
+
+const ResizeHandleLine = styled.div<{ active: boolean }>`
+  position: absolute;
+  height: ${p => (p.active ? 2 : 1)}px;
+  background: ${p =>
+    p.active
+      ? p.theme.colors.sessionRecordingTimeline.border.hover
+      : p.theme.colors.sessionRecordingTimeline.border.default};
+  top: 50%;
+  left: 0;
+  right: 0;
+  z-index: 1;
+`;
+
+const Container = styled.div`
+  --height: 14px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  cursor: ns-resize;
+  height: var(--height);
+  user-select: none;
+  z-index: 2;
+
+  &:hover ${ResizeHandleLine} {
+    background: ${p => p.theme.colors.sessionRecordingTimeline.border.hover};
+    height: 2px;
+  }
+`;
+
+interface ResizeHandleProps {
+  onChange: (newHeight: number) => void;
+  height: number;
+  defaultHeight: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+export function ResizeHandle({
+  onChange,
+  height,
+  defaultHeight,
+  minHeight,
+  maxHeight,
+}: ResizeHandleProps) {
+  const [isResizing, isResizingRef, setIsResizing] = useStateRef(false);
+
+  const heightRef = useRef(defaultHeight);
+  const initialMouseY = useRef<number>(0);
+
+  const handleMouseDown = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      document.body.style.cursor = 'ns-resize';
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      setIsResizing(true);
+
+      heightRef.current = height;
+      initialMouseY.current = e.clientY;
+    },
+    [height, setIsResizing]
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    document.body.style.cursor = 'default';
+
+    onChange(defaultHeight);
+  }, [onChange, defaultHeight]);
+
+  useEffect(() => {
+    function handleMouseMove(event: MouseEvent) {
+      if (!isResizingRef.current) {
+        return;
+      }
+
+      const deltaY = initialMouseY.current - event.clientY;
+      const newHeight = heightRef.current + deltaY;
+
+      const clampedHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
+
+      onChange(clampedHeight);
+    }
+
+    function handleMouseUp() {
+      if (!isResizingRef.current) {
+        return;
+      }
+
+      document.body.style.cursor = 'default';
+
+      window.setTimeout(() => {
+        setIsResizing(false);
+      }, 100);
+    }
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.body.style.cursor = 'default';
+
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+
+      setIsResizing(false);
+    };
+  }, [isResizingRef, maxHeight, minHeight, onChange, setIsResizing]);
+
+  return (
+    <Container
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+      style={{
+        transform: `translateY(calc(${height * -1}px + var(--height) / 2))`,
+      }}
+    >
+      <ResizeHandleLine active={isResizing} />
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/useCursor.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/useCursor.ts
@@ -1,0 +1,99 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useRef, type MouseEvent, type RefObject } from 'react';
+
+interface UseCursorOptions {
+  containerRef: RefObject<HTMLElement>;
+  cursorRef: RefObject<HTMLElement>;
+}
+
+const INTERACTION_TIMEOUT = 300;
+
+/**
+ * useCursor is a hook that provides mouse event handlers to manage a custom cursor element within a container.
+ * It tracks whether the user is interacting with the container and updates the cursor's position accordingly.
+ * It returns a ref for accessing the interaction state.
+ */
+export function useCursor({ containerRef, cursorRef }: UseCursorOptions) {
+  const isInteractingRef = useRef(false);
+  const interactionTimeoutRef = useRef<null | number>(null);
+
+  const handleInteractionStart = useCallback(() => {
+    isInteractingRef.current = true;
+
+    if (interactionTimeoutRef.current) {
+      window.clearTimeout(interactionTimeoutRef.current);
+    }
+  }, []);
+
+  const handleInteractionEnd = useCallback(() => {
+    interactionTimeoutRef.current = window.setTimeout(() => {
+      isInteractingRef.current = false;
+    }, INTERACTION_TIMEOUT);
+  }, []);
+
+  const handleMouseEnter = useCallback(
+    (event: MouseEvent) => {
+      if (!cursorRef.current || !containerRef.current) {
+        return;
+      }
+
+      handleInteractionStart();
+
+      const x =
+        event.clientX - containerRef.current.getBoundingClientRect().left;
+
+      cursorRef.current.style.display = 'block';
+      cursorRef.current.style.transform = `translateX(${x}px) translateZ(0)`;
+    },
+    [handleInteractionStart, containerRef, cursorRef]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (!cursorRef.current) {
+      return;
+    }
+
+    handleInteractionEnd();
+
+    cursorRef.current.style.display = 'none';
+  }, [cursorRef, handleInteractionEnd]);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!cursorRef.current || !containerRef.current) {
+        return;
+      }
+
+      handleInteractionStart();
+
+      const x = e.clientX - containerRef.current.getBoundingClientRect().left;
+
+      cursorRef.current.style.transform = `translateX(${x}px) translateZ(0)`;
+    },
+    [containerRef, cursorRef, handleInteractionStart]
+  );
+
+  return {
+    handleMouseEnter,
+    handleMouseLeave,
+    handleMouseMove,
+    isInteractingRef,
+  };
+}

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/utils.ts
@@ -17,13 +17,17 @@
  */
 import type { SessionRecordingThumbnail } from 'teleport/services/recordings';
 
+import { LEFT_PADDING } from './constants';
+
 const zoomLevelWithCursor = 2;
 const zoomLevelWithoutCursor = 1;
 
-// calculateThumbnailViewport calculates the portion of the thumbnail image to display
-// based on the cursor position and whether the cursor is visible.
-// It returns the source coordinates and dimensions to be used in drawing the image,
-// as well as the zoom level applied.
+/**
+ * calculateThumbnailViewport calculates the portion of the thumbnail image to display
+ * based on the cursor position and whether the cursor is visible.
+ * It returns the source coordinates and dimensions to be used in drawing the image,
+ * as well as the zoom level applied.
+ */
 export function calculateThumbnailViewport(
   thumbnail: SessionRecordingThumbnail,
   width: number,
@@ -84,4 +88,149 @@ export function calculateThumbnailViewport(
     sourceHeight,
     zoomLevel,
   };
+}
+
+// Edge threshold in pixels to determine when the time indicator is near the edge
+// of the container and should trigger auto-scrolling behavior.
+const EDGE_THRESHOLD = 100;
+// Visibility buffer in pixels to determine when the time indicator is considered
+// fully visible within the container.
+const VISIBILITY_BUFFER = 50;
+
+/**
+ * calculateNextUserControlled determines whether the user is currently controlling
+ * the timeline's scroll position based on the position of the time indicator,
+ * the container width, and whether the user is actively interacting with the timeline.
+ *
+ * It returns a boolean indicating if the user is in control of the scroll position.
+ *
+ * @param relativePosition - The current position of the time indicator relative to the container.
+ * @param containerWidth - The width of the timeline container.
+ * @param isInteracting - Whether the user is currently interacting with the timeline (e.g., dragging).
+ * @param currentUserControlled - The current state of user control over the timeline.
+ * @returns boolean - True if the user is controlling the timeline, false otherwise.
+ */
+export function calculateNextUserControlled(
+  relativePosition: number,
+  containerWidth: number,
+  isInteracting: boolean,
+  currentUserControlled: boolean
+) {
+  if (isInteracting) {
+    return currentUserControlled;
+  }
+
+  const isIndicatorFullyVisible =
+    relativePosition >= VISIBILITY_BUFFER &&
+    relativePosition <= containerWidth - VISIBILITY_BUFFER;
+
+  const isIndicatorPartiallyVisible =
+    relativePosition >= -EDGE_THRESHOLD &&
+    relativePosition <= containerWidth + EDGE_THRESHOLD;
+
+  const isApproachingRightEdge =
+    relativePosition > containerWidth - EDGE_THRESHOLD &&
+    relativePosition <= containerWidth;
+
+  const isApproachingLeftEdge =
+    relativePosition < EDGE_THRESHOLD && relativePosition >= 0;
+
+  // User manually scrolled away from the progress line
+  if (!isIndicatorPartiallyVisible) {
+    return true;
+  }
+
+  // Progress line is fully visible, user control can be disabled
+  if (isIndicatorFullyVisible) {
+    return false;
+  }
+
+  // If user was controlling and line is approaching edge, give back control to auto-scroll
+  if (
+    currentUserControlled &&
+    (isApproachingRightEdge || isApproachingLeftEdge)
+  ) {
+    return false;
+  }
+
+  return currentUserControlled;
+}
+
+/**
+ * shouldAutoScroll determines whether the timeline should auto-scroll
+ * based on the position of the time indicator, the container width,
+ * and whether the user is interacting with the timeline or has manual control.
+ *
+ * @param relativePosition - The current position of the time indicator relative to the container.
+ * @param containerWidth - The width of the timeline container.
+ * @param isInteracting - Whether the user is currently interacting with the timeline (e.g., dragging).
+ * @param isUserControlled - Whether the user has manual control over the timeline's scroll position.
+ */
+export function shouldAutoScroll(
+  relativePosition: number,
+  containerWidth: number,
+  isInteracting: boolean,
+  isUserControlled: boolean
+) {
+  if (isInteracting || isUserControlled) {
+    return false;
+  }
+
+  const shouldJumpForward = relativePosition > containerWidth - EDGE_THRESHOLD;
+  const shouldJumpBackward = relativePosition < 0;
+
+  return shouldJumpForward || shouldJumpBackward;
+}
+
+/**
+ * calculateAutoScrollOffset computes the new offset needed to auto-scroll the timeline
+ * to keep the time indicator within the visible area of the container.
+ * It takes into account the current position of the time indicator,
+ * the container width, the total timeline width, and whether to force the scroll.
+ *
+ * @param timePosition - The current position of the time indicator in pixels.
+ * @param relativePosition - The position of the time indicator relative to the container.
+ * @param containerWidth - The width of the timeline container in pixels.
+ * @param timelineWidth - The total width of the timeline in pixels.
+ * @param force - Whether to force the scroll regardless of the current position.
+ *
+ * @returns number - The new offset to apply to the timeline for auto-scrolling.
+ */
+export function calculateAutoScrollOffset(
+  timePosition: number,
+  relativePosition: number,
+  containerWidth: number,
+  timelineWidth: number,
+  force?: boolean
+) {
+  const totalWidth = timelineWidth + LEFT_PADDING;
+  const maxOffset = 0;
+  const minOffset = Math.min(0, containerWidth - totalWidth);
+
+  if (force) {
+    const targetRelativePosition = LEFT_PADDING + VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  if (relativePosition > containerWidth - EDGE_THRESHOLD) {
+    const targetRelativePosition = LEFT_PADDING + VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    if (newOffset < minOffset) {
+      return minOffset;
+    }
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  if (relativePosition < 0) {
+    const targetRelativePosition = containerWidth - VISIBILITY_BUFFER;
+    const newOffset = targetRelativePosition - timePosition;
+
+    return Math.max(minOffset, Math.min(maxOffset, newOffset));
+  }
+
+  return 0;
 }


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/58433 and https://github.com/gravitational/teleport/pull/58439

This adds the actual session timeline to the UI

<img width="1800" height="405" alt="image" src="https://github.com/user-attachments/assets/8d050b61-8f3b-4591-88c3-9ee41b888100" />

<img width="1800" height="425" alt="image" src="https://github.com/user-attachments/assets/0cdda7fe-a134-4143-bebd-0aae16c1f9e3" />

<img width="1446" height="1209" alt="image" src="https://github.com/user-attachments/assets/71f3571b-c463-432b-b50a-444a6cc857a0" />

changelog: New session recordings now display an interactive timeline for faster navigation