### PR TITLE
docs: update linux distro refs in ssh getting started

### DIFF
--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -39,8 +39,8 @@ that a user intends to access.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- One host running a Linux environment (such as Ubuntu 20.04, CentOS 8.0, or
-  Debian 10). This will serve as a Teleport Node.
+- One host running a Linux environment (such as Amazon Linux, Ubuntu, CentOS Stream, or
+  Debian). This will serve as a Teleport Node.
 - (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/permission-warning.mdx!)


### PR DESCRIPTION
This referred to EOL linux distros (CentOS updated to CentOS Streams) or versions. Updating to not include specific versions and add in Amazon Linux.