### PR TITLE
Fix information in the tbot helm chart readme

### DIFF
--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -24,13 +24,11 @@ you use the `token` join method with this chart.
 ## Minimal configuration
 
 This basic configuration will write a Teleport identity file to a secret in
-the deployment namespace called `test-output`.
+the deployment namespace called `<helm-release-name>-out`. For example `tbot-out`.
 
 ```yaml
 clusterName: "test.teleport.sh"
 teleportProxyAddress: "test.teleport.sh:443"
-defaultOutput:
-  secretName: "test-output"
 token: "my-token"
 ```
 

--- a/examples/chart/tbot/.lint/simple.yaml
+++ b/examples/chart/tbot/.lint/simple.yaml
@@ -1,5 +1,3 @@
 clusterName: "test.teleport.sh"
 teleportProxyAddress: "test.teleport.sh:443"
-defaultOutput:
-  secretName: "test-output"
 token: "my-token"

--- a/examples/chart/tbot/README.md
+++ b/examples/chart/tbot/README.md
@@ -19,13 +19,11 @@ you use the `token` join method with this chart.
 ### Basic configuration
 
 This basic configuration will write a Teleport identity file to a secret in
-the deployment namespace called `test-output`.
+the deployment namespace called `<helm-release-name>-output`. For example `tbot-out`.
 
 ```yaml
 clusterName: "test.teleport.sh"
 teleportProxyAddress: "test.teleport.sh:443"
-defaultOutput:
-  secretName: "test-output"
 token: "my-token"
 ```
 

--- a/examples/chart/tbot/README.md
+++ b/examples/chart/tbot/README.md
@@ -19,7 +19,7 @@ you use the `token` join method with this chart.
 ### Basic configuration
 
 This basic configuration will write a Teleport identity file to a secret in
-the deployment namespace called `<helm-release-name>-output`. For example `tbot-out`.
+the deployment namespace called `<helm-release-name>-out`. For example `tbot-out`.
 
 ```yaml
 clusterName: "test.teleport.sh"


### PR DESCRIPTION

The secret name is set to `tbot.defaultOutputName` — [ref](https://github.com/gravitational/teleport/blob/v16.5.14/examples/chart/tbot/templates/_config.tpl#L40)

Which is set to `tbot.fullName` — [ref](https://github.com/gravitational/teleport/blob/v16.5.14/examples/chart/tbot/templates/_helpers.tpl#L55)

Note: `tbot.fullName` is currently a conditionless `define`, not an override. This means that, currently, output secret name cannot be overridden.