### PR TITLE
dependabot: Add node-gyp and node-pty to the electron group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -239,15 +239,18 @@ updates:
       - 'ui'
       - 'no-changelog'
     groups:
+      # These packages are either directly involved in the process of building Teleport Connect or
+      # they make use of native dependencies. Verifying that updating them didn't break anything
+      # involves making a tag build.
       electron:
         patterns:
           - 'electron*'
+          - node-gyp
+          - node-pty
       ui:
         update-types:
           - 'minor'
           - 'patch'
-        exclude-patterns:
-          - 'electron*'
     open-pull-requests-limit: 20
   - package-ecosystem: github-actions
     directory: '/.github/workflows'


### PR DESCRIPTION
I intend to merge this on Sunday to trigger Dependabot as close to September 1st as possible.