### PR TITLE
Support kubernetes sessions with the new metadata/thumbnails/timeline

### DIFF
--- a/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata.pb.go
+++ b/api/gen/proto/go/teleport/recordingmetadata/v1/recordingmetadata.pb.go
@@ -46,6 +46,8 @@ const (
 	SessionRecordingType_SESSION_RECORDING_TYPE_UNSPECIFIED SessionRecordingType = 0
 	// SessionRecordingTypeSsh is an interactive SSH session recording.
 	SessionRecordingType_SESSION_RECORDING_TYPE_SSH SessionRecordingType = 1
+	// SessionRecordingTypeKubernetes is an interactive Kubernetes session recording.
+	SessionRecordingType_SESSION_RECORDING_TYPE_KUBERNETES SessionRecordingType = 2
 )
 
 // Enum value maps for SessionRecordingType.
@@ -53,10 +55,12 @@ var (
 	SessionRecordingType_name = map[int32]string{
 		0: "SESSION_RECORDING_TYPE_UNSPECIFIED",
 		1: "SESSION_RECORDING_TYPE_SSH",
+		2: "SESSION_RECORDING_TYPE_KUBERNETES",
 	}
 	SessionRecordingType_value = map[string]int32{
 		"SESSION_RECORDING_TYPE_UNSPECIFIED": 0,
 		"SESSION_RECORDING_TYPE_SSH":         1,
+		"SESSION_RECORDING_TYPE_KUBERNETES":  2,
 	}
 )
 
@@ -626,10 +630,11 @@ const file_teleport_recordingmetadata_v1_recordingmetadata_proto_rawDesc = "" +
 	"\fstart_offset\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\vstartOffset\x128\n" +
 	"\n" +
 	"end_offset\x18\a \x01(\v2\x19.google.protobuf.DurationR\tendOffset\x12%\n" +
-	"\x0ecursor_visible\x18\b \x01(\bR\rcursorVisible*^\n" +
+	"\x0ecursor_visible\x18\b \x01(\bR\rcursorVisible*\x85\x01\n" +
 	"\x14SessionRecordingType\x12&\n" +
 	"\"SESSION_RECORDING_TYPE_UNSPECIFIED\x10\x00\x12\x1e\n" +
-	"\x1aSESSION_RECORDING_TYPE_SSH\x10\x01BfZdgithub.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1;recordingmetadatav1b\x06proto3"
+	"\x1aSESSION_RECORDING_TYPE_SSH\x10\x01\x12%\n" +
+	"!SESSION_RECORDING_TYPE_KUBERNETES\x10\x02BfZdgithub.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1;recordingmetadatav1b\x06proto3"
 
 var (
 	file_teleport_recordingmetadata_v1_recordingmetadata_proto_rawDescOnce sync.Once

--- a/api/proto/teleport/recordingmetadata/v1/recordingmetadata.proto
+++ b/api/proto/teleport/recordingmetadata/v1/recordingmetadata.proto
@@ -62,6 +62,8 @@ enum SessionRecordingType {
   SESSION_RECORDING_TYPE_UNSPECIFIED = 0;
   // SessionRecordingTypeSsh is an interactive SSH session recording.
   SESSION_RECORDING_TYPE_SSH = 1;
+  // SessionRecordingTypeKubernetes is an interactive Kubernetes session recording.
+  SESSION_RECORDING_TYPE_KUBERNETES = 2;
 }
 
 // SessionRecordingMetadata contains metadata for a session recording.

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -220,9 +220,14 @@ loop:
 				metadata.ClusterName = e.ClusterName
 				metadata.User = e.User
 
-				if e.Protocol == events.EventProtocolSSH {
+				switch e.Protcol {
+				case events.EventProtocolSSH:
 					metadata.ResourceName = e.ServerHostname
 					metadata.Type = pb.SessionRecordingType_SESSION_RECORDING_TYPE_SSH
+
+				case events.EventProtocolKube:
+					metadata.ResourceName = e.KubernetesCluster
+					metadata.Type = pb.SessionRecordingType_SESSION_RECORDING_TYPE_KUBERNETES
 				}
 
 				metadata.StartCols = int32(size.W)

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -220,7 +220,7 @@ loop:
 				metadata.ClusterName = e.ClusterName
 				metadata.User = e.User
 
-				switch e.Protcol {
+				switch e.Protocol {
 				case events.EventProtocolSSH:
 					metadata.ResourceName = e.ServerHostname
 					metadata.Type = pb.SessionRecordingType_SESSION_RECORDING_TYPE_SSH

--- a/lib/web/recordingmetadata.go
+++ b/lib/web/recordingmetadata.go
@@ -230,6 +230,8 @@ func pbTypeToString(t recordingmetadatav1.SessionRecordingType) string {
 	switch t {
 	case recordingmetadatav1.SessionRecordingType_SESSION_RECORDING_TYPE_SSH:
 		return "ssh"
+	case recordingmetadatav1.SessionRecordingType_SESSION_RECORDING_TYPE_KUBERNETES:
+		return "k8s"
 	default:
 		return "unknown"
 	}

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -62,6 +62,8 @@ export interface RecordingItemProps {
   viewMode: ViewMode;
 }
 
+const recordingTypesWithThumbnails: RecordingType[] = ['ssh', 'k8s'];
+
 export function RecordingItem({
   actionSlot,
   density,
@@ -94,7 +96,9 @@ export function RecordingItem({
     [actionSlot, recording.sid]
   );
 
-  const hasThumbnail = recording.recordingType === 'ssh';
+  const hasThumbnail = recordingTypesWithThumbnails.includes(
+    recording.recordingType
+  );
 
   return (
     <RecordingItemContainer

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
@@ -69,7 +69,7 @@ export function RecordingWithMetadata({
           clusterId={clusterId}
           sessionId={sessionId}
           durationMs={data.metadata.duration}
-          recordingType="ssh"
+          recordingType={data.metadata.recordingType}
           onToggleSidebar={toggleSidebar}
         />
       </Player>

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
@@ -69,7 +69,7 @@ export function RecordingWithMetadata({
           clusterId={clusterId}
           sessionId={sessionId}
           durationMs={data.metadata.duration}
-          recordingType={data.metadata.recordingType}
+          recordingType={data.metadata.type}
           onToggleSidebar={toggleSidebar}
         />
       </Player>

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -154,7 +154,7 @@ test('renders non-SSH recordings correctly', async () => {
         sid: 'test-session',
       },
       {
-        recordingType: 'k8s',
+        recordingType: 'desktop',
         durationMs: 3600000,
       }
     )

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -145,7 +145,7 @@ test('renders the duration correctly', async () => {
 });
 
 test('renders non-SSH recordings correctly', async () => {
-  server.use(createMetadataHandler({ ...mockMetadata, type: 'k8s' }, []));
+  server.use(createMetadataHandler({ ...mockMetadata, type: 'desktop' }, []));
 
   setupTest(
     cfg.getPlayerRoute(

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -162,7 +162,7 @@ test('renders non-SSH recordings correctly', async () => {
 
   expect(
     await screen.findByText(
-      'RecordingPlayer: test-cluster/test-session/3600000/k8s'
+      'RecordingPlayer: test-cluster/test-session/3600000/desktop'
     )
   ).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -39,6 +39,8 @@ import {
 
 const validRecordingTypes = ['ssh', 'k8s', 'desktop', 'database'];
 
+const recordingTypesWithMetadata: RecordingType[] = ['ssh', 'k8s'];
+
 interface ViewSessionRecordingRouteProps {
   summarySlot?: SummarySlot;
 }
@@ -87,7 +89,7 @@ export function ViewSessionRecordingRoute({
     );
   }
 
-  if (recordingType === 'ssh') {
+  if (recordingTypesWithMetadata.includes(recordingType)) {
     // If the recording type is SSH, try to load the session metadata (ViewTerminalRecording)
     // and render the SSH player with the session metadata/summary.
     // If that errors (such as during a proxy upgrade), we fall back to the


### PR DESCRIPTION
As kubernetes sessions work the same was as SSH sessions, this just finishes up a bit of the wiring to make the new thumbnails/metadata/timeline feature work with kubernetes sessions as well.