### PR TITLE
Fix proxy hanging waiting for keyboard layout

### DIFF
--- a/web/packages/shared/components/CanvasRenderer.tsx
+++ b/web/packages/shared/components/CanvasRenderer.tsx
@@ -99,7 +99,11 @@ export const CanvasRenderer = forwardRef<
   }, []);
 
   useEffect(() => {
-    if (!onResize) {
+    if (
+      !onResize ||
+      // Only send resize events when the canvas is visible (i.e. the connection is active).
+      props.hidden
+    ) {
       return;
     }
 
@@ -118,7 +122,7 @@ export const CanvasRenderer = forwardRef<
       debouncedOnResize.cancel();
       observer.disconnect();
     };
-  }, [onResize]);
+  }, [onResize, props.hidden]);
 
   // Wheel events must be registered on a ref because React's onWheel
   // uses a passive listener, so handlers are not able to call of e.preventDefault() on it.

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -194,6 +194,16 @@ export class TdpClient extends EventEmitter<EventMap> {
     // avoids the connection crashing.
     if (options.keyboardLayout !== undefined && options.keyboardLayout !== 0) {
       this.sendClientKeyboardLayout(options.keyboardLayout);
+    } else {
+      // The proxy expects two messasges (client screen spec and keyboard layout)
+      // before it will initialise the connection to WDS. If no keyboard layout
+      // is sent, the proxy will hang waiting for a second message that won't
+      // arrive. To get around this we send another client screen spec.
+      // TODO (danielashare): Remove this once proxy doesn't block on
+      // keyboardLayout.
+      if (options.screenSpec) {
+        this.sendClientScreenSpec(options.screenSpec);
+      }
     }
 
     let processingError: Error | undefined;


### PR DESCRIPTION
This temporarily patches an issue that would cause the proxy to wait for a keyboard layout message that would never arrive, and thus blocks the proxy from making  a connection to the WDS.

changelog: Fixed an issue introduced in v18.1.5 that caused desktop connection attempts to stall on the loading screen.