### PR TITLE
Enable merge_group trigger for CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -7,6 +7,11 @@ on:
     types:
       - opened
       - synchronize # Run on any diff changes to the PR (e.g. code updates)
+  # merge_group will allow this workflow to be triggered when in merge queue.
+  # The job will end up being skipped due to conditionals below. This will be considered a "Success" 
+  # for the required check as the workflow was triggered but the job was skipped due to conditionals
+  # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  merge_group:
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: read


### PR DESCRIPTION
Enabling the merge_group trigger for the CLA Assistant workflow. This should allow the checks to pass in the merge queue. Previously, since it wouldn't run the check would show "Pending" and the commit would stall in the merge queue indefinitely.

The workflow will now trigger on merge_group, however the actual job will skip. For the purposes of required status checks, this will count as a "Success". See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks