### PR TITLE
Remove redundant type args from fetchers

### DIFF
--- a/lib/srv/discovery/fetchers/db/azure_dbserver.go
+++ b/lib/srv/discovery/fetchers/db/azure_dbserver.go
@@ -31,12 +31,12 @@ import (
 
 // newAzureMySQLFetcher creates a fetcher for Azure MySQL.
 func newAzureMySQLFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*azure.DBServer, azure.DBServersClient](config, &azureDBServerPlugin{})
+	return newAzureFetcher(config, &azureDBServerPlugin{})
 }
 
 // newAzureMySQLFetcher creates a fetcher for Azure PostgreSQL.
 func newAzurePostgresFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*azure.DBServer, azure.DBServersClient](config, &azureDBServerPlugin{})
+	return newAzureFetcher(config, &azureDBServerPlugin{})
 }
 
 // azureDBServerPlugin implements azureFetcherPlugin for MySQL and PostgreSQL.

--- a/lib/srv/discovery/fetchers/db/azure_dbserver_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_dbserver_test.go
@@ -50,8 +50,8 @@ func TestAzureDBServerFetchers(t *testing.T) {
 		subscription2 = "sub2"
 	)
 
-	azureSub1 := makeAzureSubscription(t, subscription1)
-	azureSub2 := makeAzureSubscription(t, subscription2)
+	azureSub1 := makeAzureSubscription(subscription1)
+	azureSub2 := makeAzureSubscription(subscription2)
 
 	azMySQLServer1, azMySQLDB1 := makeAzureMySQLServer(t, "server-1", subscription1, group1, eastus, map[string]string{"env": "prod"})
 	azMySQLServer2, _ := makeAzureMySQLServer(t, "server-2", subscription1, group1, eastus, map[string]string{"env": "dev"})
@@ -307,7 +307,7 @@ func TestAzureDBServerFetchers(t *testing.T) {
 	}
 }
 
-func makeAzureSubscription(t *testing.T, subID string) *armsubscription.Subscription {
+func makeAzureSubscription(subID string) *armsubscription.Subscription {
 	return &armsubscription.Subscription{
 		SubscriptionID: &subID,
 		State:          to.Ptr(armsubscription.SubscriptionStateEnabled),

--- a/lib/srv/discovery/fetchers/db/azure_managed_sql.go
+++ b/lib/srv/discovery/fetchers/db/azure_managed_sql.go
@@ -32,7 +32,7 @@ import (
 
 // newAzureManagedSQLServerFetcher creates a fetcher for Azure SQL Servers.
 func newAzureManagedSQLServerFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*armsql.ManagedInstance, azure.ManagedSQLServerClient](config, &azureManagedSQLServerFetcher{})
+	return newAzureFetcher(config, &azureManagedSQLServerFetcher{})
 }
 
 // azureManagedSQLServerFetcher implements azureFetcherPlugin for Azure Managed

--- a/lib/srv/discovery/fetchers/db/azure_managed_sql_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_managed_sql_test.go
@@ -19,7 +19,6 @@
 package db
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -35,6 +34,7 @@ func TestSQLManagedServerFetcher(t *testing.T) {
 	fetcher := &azureManagedSQLServerFetcher{}
 
 	t.Run("NewDatabaseFromServer", func(t *testing.T) {
+		ctx := t.Context()
 		// List of provisioning states that are used to identify a database is
 		// available and can be discovered.
 		availableStates := []armsql.ManagedInstancePropertiesProvisioningState{
@@ -47,7 +47,7 @@ func TestSQLManagedServerFetcher(t *testing.T) {
 		// For available states, it should return a parsed database.
 		for _, state := range availableStates {
 			t.Run(string(state), func(t *testing.T) {
-				require.NotNil(t, fetcher.NewDatabaseFromServer(context.Background(), makeManagedSQLInstance(state), logger), "expected to have a database, but got nil")
+				require.NotNil(t, fetcher.NewDatabaseFromServer(ctx, makeManagedSQLInstance(state), logger), "expected to have a database, but got nil")
 			})
 		}
 
@@ -59,14 +59,14 @@ func TestSQLManagedServerFetcher(t *testing.T) {
 			}
 
 			t.Run(string(state), func(t *testing.T) {
-				require.Nil(t, fetcher.NewDatabaseFromServer(context.Background(), makeManagedSQLInstance(state), logger), "expected to have nil, but got a database")
+				require.Nil(t, fetcher.NewDatabaseFromServer(ctx, makeManagedSQLInstance(state), logger), "expected to have nil, but got a database")
 			})
 		}
 
 		t.Run("RandomState", func(t *testing.T) {
 			require.NotNil(t,
 				fetcher.NewDatabaseFromServer(
-					context.Background(),
+					ctx,
 					makeManagedSQLInstance("RandomState"),
 					logger,
 				),

--- a/lib/srv/discovery/fetchers/db/azure_mysql_flex.go
+++ b/lib/srv/discovery/fetchers/db/azure_mysql_flex.go
@@ -32,7 +32,7 @@ import (
 
 // newAzureMySQLFlexServerFetcher creates a fetcher for Azure MySQL Flexible server.
 func newAzureMySQLFlexServerFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*armmysqlflexibleservers.Server, azure.MySQLFlexServersClient](config, &azureMySQLFlexServerFetcher{})
+	return newAzureFetcher(config, &azureMySQLFlexServerFetcher{})
 }
 
 // azureMySQLFlexServerFetcher implements azureFetcherPlugin for Azure MySQL Flexible server.

--- a/lib/srv/discovery/fetchers/db/azure_mysql_flex_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_mysql_flex_test.go
@@ -37,7 +37,7 @@ import (
 func TestAzureMySQLFlexFetchers(t *testing.T) {
 	t.Parallel()
 
-	azureSub := makeAzureSubscription(t, "sub123")
+	azureSub := makeAzureSubscription("sub123")
 	azMySQLFlexServer, azMySQLFlexDB := makeAzureMySQLFlexServer(t, "mysql-flex", "sub123", "group 1", "East US", map[string]string{"env": "prod"})
 	azureMatchers := []types.AzureMatcher{{
 		Types:        []string{types.AzureMatcherMySQL},

--- a/lib/srv/discovery/fetchers/db/azure_postgres_flex.go
+++ b/lib/srv/discovery/fetchers/db/azure_postgres_flex.go
@@ -32,7 +32,7 @@ import (
 
 // newAzurePostgresFlexServerFetcher creates a fetcher for Azure PostgreSQL Flexible server.
 func newAzurePostgresFlexServerFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*armpostgresqlflexibleservers.Server, azure.PostgresFlexServersClient](config, &azurePostgresFlexServerFetcher{})
+	return newAzureFetcher(config, &azurePostgresFlexServerFetcher{})
 }
 
 // newAzurePostgresFlexServerFetcher implements azureFetcherPlugin for Azure PostgreSQL Flexible server.

--- a/lib/srv/discovery/fetchers/db/azure_postgres_flex_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_postgres_flex_test.go
@@ -37,7 +37,7 @@ import (
 func TestAzurePostgresFlexFetchers(t *testing.T) {
 	t.Parallel()
 
-	azureSub := makeAzureSubscription(t, "sub123")
+	azureSub := makeAzureSubscription("sub123")
 	azPostgresFlexServer, azPostgresFlexDB := makeAzurePostgresFlexServer(t, "postgres-flex", "sub123", "group 1", "East US", map[string]string{"env": "prod"})
 	azureMatchers := []types.AzureMatcher{{
 		Types:        []string{types.AzureMatcherPostgres},

--- a/lib/srv/discovery/fetchers/db/azure_redis.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis.go
@@ -32,7 +32,7 @@ import (
 
 // newAzureRedisFetcher creates a fetcher for Azure Redis.
 func newAzureRedisFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*armredis.ResourceInfo, azure.RedisClient](config, &azureRedisPlugin{})
+	return newAzureFetcher(config, &azureRedisPlugin{})
 }
 
 // azureRedisPlugin implements azureFetcherPlugin for Azure Redis.

--- a/lib/srv/discovery/fetchers/db/azure_redis_enterprise.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis_enterprise.go
@@ -32,7 +32,7 @@ import (
 
 // newAzureRedisEnterpriseFetcher creates a fetcher for Azure Redis Enterprise.
 func newAzureRedisEnterpriseFetcher(config azureFetcherConfig) (common.Fetcher, error) {
-	return newAzureFetcher[*azure.RedisEnterpriseDatabase, azure.RedisEnterpriseClient](config, &azureRedisEnterprisePlugin{})
+	return newAzureFetcher(config, &azureRedisEnterprisePlugin{})
 }
 
 type azureRedisEnterprisePlugin struct{}

--- a/lib/srv/discovery/fetchers/db/azure_redis_test.go
+++ b/lib/srv/discovery/fetchers/db/azure_redis_test.go
@@ -39,7 +39,7 @@ import (
 func TestAzureRedisFetchers(t *testing.T) {
 	t.Parallel()
 
-	azureSub := makeAzureSubscription(t, "sub")
+	azureSub := makeAzureSubscription("sub")
 
 	// Note that the Azure Redis APIs may return location in their display
 	// names (eg. "East US"). The Azure fetcher should normalize location names

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -19,7 +19,6 @@
 package db
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -65,7 +64,7 @@ func mustMakeAWSFetchers(t *testing.T, cfg AWSFetcherFactoryConfig, matchers []t
 
 	fetcherFactory, err := NewAWSFetcherFactory(cfg)
 	require.NoError(t, err)
-	fetchers, err := fetcherFactory.MakeFetchers(context.Background(), matchers, discoveryConfigName)
+	fetchers, err := fetcherFactory.MakeFetchers(t.Context(), matchers, discoveryConfigName)
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 
@@ -95,7 +94,7 @@ func mustGetDatabases(t *testing.T, fetchers []common.Fetcher) types.Databases {
 
 	var all types.Databases
 	for _, fetcher := range fetchers {
-		resources, err := fetcher.Get(context.TODO())
+		resources, err := fetcher.Get(t.Context())
 		require.NoError(t, err)
 
 		databases, err := resources.AsDatabases()


### PR DESCRIPTION
This PR just removes some redundant types that gopls keeps underlining as "redundant".