### PR TITLE
Do not add certificates to a 1password ssh-agent

### DIFF
--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -89,10 +89,10 @@ func agentIsPresent() bool {
 
 // agentSupportsSSHCertificates checks if the running agent supports SSH certificates.
 // This detection implementation is as described in RFD 18 and works by simply checking for
-// presence of gpg-agent which is a common agent known to not support SSH certificates.
+// presence of gpg-agent or 1password which are common agents known to not support SSH certificates.
 func agentSupportsSSHCertificates() bool {
 	agent := os.Getenv(teleport.SSHAuthSock)
-	return !strings.Contains(agent, "gpg-agent")
+	return !strings.Contains(agent, "gpg-agent") || !strings.Contains(agent, "1password")
 }
 
 func shouldAddKeysToAgent(addKeysToAgent string) bool {


### PR DESCRIPTION
This is in-line with the approach outlined in [RFD 0018](https://github.com/gravitational/teleport/blob/master/rfd/0018-agent-loading.md), where gpg-agent sockets are skipped.

Fixes the most common cause of https://github.com/gravitational/teleport/issues/22326 without requiring users to set environment variables everywhere.