### PR TITLE
Update terminology in lib/reversetunnel

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -16,10 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Package reversetunnel sets up persistent reverse tunnel
-// between remote site and teleport proxy, when site agents
-// dial to teleport proxy's socket and teleport proxy can connect
-// to any server through this tunnel.
+// Package reversetunnel sets up persistent reverse tunnels
+// from proxies in leaf clusters and agents in the local cluster
+// with the local cluster proxy.
 package reversetunnel
 
 import (

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -49,10 +49,11 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-// remoteSite is a remote site that established the inbound connection to
-// the local reverse tunnel server, and now it can provide access to the
-// cluster behind it.
-type remoteSite struct {
+// leafCluster is a leaf cluster is a Teleport cluster that has established
+// trust with the local Teleport cluster. Access to resources in the
+// leaf cluster can be facilitated by the local cluster via the inbound connection
+// to the local reverse tunnel server
+type leafCluster struct {
 	sync.RWMutex
 
 	logger      *slog.Logger
@@ -76,17 +77,16 @@ type remoteSite struct {
 	// localClient provides access to the Auth Server API of the cluster
 	// within which reversetunnelclient.Server is running.
 	localClient authclient.ClientI
-	// remoteClient provides access to the Auth Server API of the remote cluster that
-	// this site belongs to.
-	remoteClient authclient.ClientI
-	// localAccessPoint provides access to a cached subset of the Auth Server API of
+	// leafClient provides access to the Auth Server API of the associated leaf cluster.
+	leafClient authclient.ClientI
+	// localCache provides access to a cached subset of the Auth Server API of
 	// the local cluster.
-	localAccessPoint authclient.ProxyAccessPoint
-	// remoteAccessPoint provides access to a cached subset of the Auth Server API of
-	// the remote cluster this site belongs to.
-	remoteAccessPoint authclient.RemoteProxyAccessPoint
+	localCache authclient.ProxyAccessPoint
+	// leafCache provides access to a cached subset of the Auth Server API of
+	// the remote cluster.
+	leafCache authclient.RemoteProxyAccessPoint
 
-	// nodeWatcher provides access the node set for the remote site
+	// nodeWatcher provides access the node set for the leaf cluster.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
 	// remoteCA is the last remote certificate authority recorded by the client.
@@ -104,7 +104,7 @@ type remoteSite struct {
 	proxySyncInterval time.Duration
 }
 
-func (s *remoteSite) getRemoteClient() (authclient.ClientI, bool, error) {
+func (s *leafCluster) getLeafClient() (authclient.ClientI, bool, error) {
 	// check if all cert authorities are initiated and if everything is OK
 	ca, err := s.srv.localAccessPoint.GetCertAuthority(s.ctx, types.CertAuthID{Type: types.HostCA, DomainName: s.domainName}, false)
 	if err != nil {
@@ -116,10 +116,10 @@ func (s *remoteSite) getRemoteClient() (authclient.ClientI, bool, error) {
 	// The fact that cluster has keys to remote CA means that the key exchange
 	// has completed.
 
-	s.logger.DebugContext(s.ctx, "Using TLS client to remote cluster")
+	s.logger.DebugContext(s.ctx, "Using TLS client to leaf cluster")
 	tlsConfig := utils.TLSConfig(s.srv.ClientTLSCipherSuites)
 	// encode the name of this cluster to identify this cluster,
-	// connecting to the remote one (it is used to find the right certificate
+	// connecting to the leaf cluster (it is used to find the right certificate
 	// authority to verify)
 	tlsConfig.ServerName = apiutils.EncodeClusterName(s.srv.ClusterName)
 	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -151,45 +151,45 @@ func (s *remoteSite) getRemoteClient() (authclient.ClientI, bool, error) {
 	return clt, false, nil
 }
 
-func (s *remoteSite) authServerContextDialer(ctx context.Context, network, address string) (net.Conn, error) {
+func (s *leafCluster) authServerContextDialer(ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := s.DialAuthServer(reversetunnelclient.DialParams{})
 	return conn, err
 }
 
 // GetTunnelsCount always returns 0 for local cluster
-func (s *remoteSite) GetTunnelsCount() int {
+func (s *leafCluster) GetTunnelsCount() int {
 	return s.connectionCount()
 }
 
-func (s *remoteSite) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
-	return s.remoteAccessPoint, nil
+func (s *leafCluster) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
+	return s.leafCache, nil
 }
 
-// NodeWatcher returns the services.NodeWatcher for the remote cluster.
-func (s *remoteSite) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+// NodeWatcher returns the services.NodeWatcher for the leaf cluster.
+func (s *leafCluster) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return s.nodeWatcher, nil
 }
 
-// GitServerWatcher returns the Git server watcher for the remote cluster.
-func (s *remoteSite) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
-	return nil, trace.NotImplemented("GitServerWatcher not implemented for remoteSite")
+// GitServerWatcher returns the Git server watcher for the leaf cluster.
+func (s *leafCluster) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+	return nil, trace.NotImplemented("GitServerWatcher not implemented for leafCluster")
 }
 
-func (s *remoteSite) GetClient() (authclient.ClientI, error) {
-	return s.remoteClient, nil
+func (s *leafCluster) GetClient() (authclient.ClientI, error) {
+	return s.leafClient, nil
 }
 
-func (s *remoteSite) String() string {
-	return fmt.Sprintf("remoteSite(%v)", s.domainName)
+func (s *leafCluster) String() string {
+	return fmt.Sprintf("leafCluster(%v)", s.domainName)
 }
 
-func (s *remoteSite) connectionCount() int {
+func (s *leafCluster) connectionCount() int {
 	s.RLock()
 	defer s.RUnlock()
 	return len(s.connections)
 }
 
-func (s *remoteSite) HasValidConnections() bool {
+func (s *leafCluster) HasValidConnections() bool {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -201,8 +201,8 @@ func (s *remoteSite) HasValidConnections() bool {
 	return false
 }
 
-// Close closes remote cluster connections
-func (s *remoteSite) Close() error {
+// Close closes leaf cluster connections
+func (s *leafCluster) Close() error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -215,8 +215,8 @@ func (s *remoteSite) Close() error {
 		}
 	}
 	s.connections = []*remoteConn{}
-	if s.remoteAccessPoint != nil {
-		if err := s.remoteAccessPoint.Close(); err != nil {
+	if s.leafCache != nil {
+		if err := s.leafCache.Close(); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -224,15 +224,15 @@ func (s *remoteSite) Close() error {
 	return trace.NewAggregate(errors...)
 }
 
-// IsClosed reports whether this remoteSite has been closed.
-func (s *remoteSite) IsClosed() bool {
+// IsClosed reports whether this leafCluster has been closed.
+func (s *leafCluster) IsClosed() bool {
 	return s.ctx.Err() != nil
 }
 
 // nextConn returns next connection that is ready
 // and has not been marked as invalid
 // it will close connections marked as invalid
-func (s *remoteSite) nextConn() (*remoteConn, error) {
+func (s *leafCluster) nextConn() (*remoteConn, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -259,7 +259,7 @@ func (s *remoteSite) nextConn() (*remoteConn, error) {
 
 // removeInvalidConns removes connections marked as invalid,
 // it should be called only under write lock
-func (s *remoteSite) removeInvalidConns() {
+func (s *leafCluster) removeInvalidConns() {
 	// for first pass, do nothing if no connections are marked
 	count := 0
 	for _, conn := range s.connections {
@@ -286,9 +286,9 @@ func (s *remoteSite) removeInvalidConns() {
 	s.connections = conns
 }
 
-// addConn helper adds a new active remote cluster connection to the list
+// addConn helper adds a new active leaf cluster connection to the list
 // of such connections
-func (s *remoteSite) addConn(conn net.Conn, sconn ssh.Conn) (*remoteConn, error) {
+func (s *leafCluster) addConn(conn net.Conn, sconn ssh.Conn) (*remoteConn, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -306,7 +306,7 @@ func (s *remoteSite) addConn(conn net.Conn, sconn ssh.Conn) (*remoteConn, error)
 	return rconn, nil
 }
 
-func (s *remoteSite) adviseReconnect(ctx context.Context) {
+func (s *leafCluster) adviseReconnect(ctx context.Context) {
 	wg := &sync.WaitGroup{}
 
 	s.RLock()
@@ -335,7 +335,7 @@ func (s *remoteSite) adviseReconnect(ctx context.Context) {
 	}
 }
 
-func (s *remoteSite) GetStatus() string {
+func (s *leafCluster) GetStatus() string {
 	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return teleport.RemoteClusterStatusOffline
@@ -343,19 +343,19 @@ func (s *remoteSite) GetStatus() string {
 	return services.TunnelConnectionStatus(s.clock, connInfo, s.offlineThreshold)
 }
 
-func (s *remoteSite) copyConnInfo() types.TunnelConnection {
+func (s *leafCluster) copyConnInfo() types.TunnelConnection {
 	s.RLock()
 	defer s.RUnlock()
 	return s.connInfo.Clone()
 }
 
-func (s *remoteSite) setLastConnInfo(connInfo types.TunnelConnection) {
+func (s *leafCluster) setLastConnInfo(connInfo types.TunnelConnection) {
 	s.Lock()
 	defer s.Unlock()
 	s.lastConnInfo = connInfo.Clone()
 }
 
-func (s *remoteSite) getLastConnInfo() (types.TunnelConnection, error) {
+func (s *leafCluster) getLastConnInfo() (types.TunnelConnection, error) {
 	s.RLock()
 	defer s.RUnlock()
 	if s.lastConnInfo == nil {
@@ -364,12 +364,12 @@ func (s *remoteSite) getLastConnInfo() (types.TunnelConnection, error) {
 	return s.lastConnInfo.Clone(), nil
 }
 
-func (s *remoteSite) registerHeartbeat(t time.Time) {
+func (s *leafCluster) registerHeartbeat(t time.Time) {
 	connInfo := s.copyConnInfo()
 	connInfo.SetLastHeartbeat(t)
 	connInfo.SetExpiry(s.clock.Now().Add(s.offlineThreshold))
 	s.setLastConnInfo(connInfo)
-	err := s.localAccessPoint.UpsertTunnelConnection(connInfo)
+	err := s.localCache.UpsertTunnelConnection(connInfo)
 	if err != nil {
 		s.logger.WarnContext(s.ctx, "Failed to register heartbeat", "error", err)
 	}
@@ -377,8 +377,8 @@ func (s *remoteSite) registerHeartbeat(t time.Time) {
 
 // deleteConnectionRecord deletes connection record to let know peer proxies
 // that this node lost the connection and needs to be discovered
-func (s *remoteSite) deleteConnectionRecord() {
-	if err := s.localAccessPoint.DeleteTunnelConnection(s.connInfo.GetClusterName(), s.connInfo.GetName()); err != nil {
+func (s *leafCluster) deleteConnectionRecord() {
+	if err := s.localCache.DeleteTunnelConnection(s.connInfo.GetClusterName(), s.connInfo.GetName()); err != nil {
 		s.logger.WarnContext(s.ctx, "Failed to delete tunnel connection", "error", err)
 	}
 }
@@ -386,7 +386,7 @@ func (s *remoteSite) deleteConnectionRecord() {
 // fanOutProxies is a non-blocking call that puts the new proxies
 // list so that remote connection can notify the remote agent
 // about the list update
-func (s *remoteSite) fanOutProxies(proxies []types.Server) {
+func (s *leafCluster) fanOutProxies(proxies []types.Server) {
 	s.Lock()
 	defer s.Unlock()
 	for _, conn := range s.connections {
@@ -397,7 +397,7 @@ func (s *remoteSite) fanOutProxies(proxies []types.Server) {
 // handleHeartbeat receives heartbeat messages from the connected agent
 // if the agent has missed several heartbeats in a row, Proxy marks
 // the connection as invalid.
-func (s *remoteSite) handleHeartbeat(ctx context.Context, conn *remoteConn, ch ssh.Channel, reqC <-chan *ssh.Request) {
+func (s *leafCluster) handleHeartbeat(ctx context.Context, conn *remoteConn, ch ssh.Channel, reqC <-chan *ssh.Request) {
 	logger := s.logger.With(
 		"server_id", conn.nodeID,
 		"addr", logutils.StringerAttr(conn.conn.RemoteAddr()),
@@ -419,11 +419,11 @@ func (s *remoteSite) handleHeartbeat(ctx context.Context, conn *remoteConn, ch s
 		logger.InfoContext(ctx, "Cluster connection closed")
 
 		if err := conn.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
-			logger.WarnContext(ctx, "Failed to close remote connection for remote site", "error", err)
+			logger.WarnContext(ctx, "Failed to close connection for leaf cluster", "error", err)
 		}
 
-		if err := s.srv.onSiteTunnelClose(s); err != nil {
-			logger.WarnContext(ctx, "Failed to close remote site", "error", err)
+		if err := s.srv.onClusterTunnelClose(s); err != nil {
+			logger.WarnContext(ctx, "Failed to clean up leaf cluster resources", "error", err)
 		}
 	}()
 
@@ -522,11 +522,11 @@ func (s *remoteSite) handleHeartbeat(ctx context.Context, conn *remoteConn, ch s
 	}
 }
 
-func (s *remoteSite) GetName() string {
+func (s *leafCluster) GetName() string {
 	return s.domainName
 }
 
-func (s *remoteSite) GetLastConnected() time.Time {
+func (s *leafCluster) GetLastConnected() time.Time {
 	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return time.Time{}
@@ -534,7 +534,7 @@ func (s *remoteSite) GetLastConnected() time.Time {
 	return connInfo.GetLastHeartbeat()
 }
 
-func (s *remoteSite) compareAndSwapCertAuthority(ca types.CertAuthority) error {
+func (s *leafCluster) compareAndSwapCertAuthority(ca types.CertAuthority) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -549,26 +549,26 @@ func (s *remoteSite) compareAndSwapCertAuthority(ca types.CertAuthority) error {
 		return nil
 	}
 	s.remoteCA = ca
-	return trace.CompareFailed("remote certificate authority rotation has been updated")
+	return trace.CompareFailed("leaf cluster certificate authority rotation has been updated")
 }
 
-func (s *remoteSite) updateCertAuthorities(retry retryutils.Retry, remoteWatcher *services.CertAuthorityWatcher, remoteVersion string) {
-	defer remoteWatcher.Close()
+func (s *leafCluster) updateCertAuthorities(retry retryutils.Retry, leafClusterWatcher *services.CertAuthorityWatcher, leafClusterVersion string) {
+	defer leafClusterWatcher.Close()
 
 	for {
-		err := s.watchCertAuthorities(remoteWatcher, remoteVersion)
+		err := s.watchCertAuthorities(leafClusterWatcher, leafClusterVersion)
 		if err != nil {
 			switch {
 			case trace.IsNotFound(err):
-				s.logger.DebugContext(s.ctx, "Remote cluster does not support cert authorities rotation yet")
+				s.logger.DebugContext(s.ctx, "Leaf cluster does not support cert authorities rotation yet")
 			case trace.IsCompareFailed(err):
-				s.logger.InfoContext(s.ctx, "Remote cluster has updated certificate authorities, going to force reconnect")
-				if err := s.srv.onSiteTunnelClose(&alwaysClose{Cluster: s}); err != nil {
-					s.logger.WarnContext(s.ctx, "Failed to close remote site", "error", err)
+				s.logger.InfoContext(s.ctx, "Leaf cluster has updated certificate authorities, going to force reconnect")
+				if err := s.srv.onClusterTunnelClose(&alwaysClose{Cluster: s}); err != nil {
+					s.logger.WarnContext(s.ctx, "Failed to clean up leaf cluster resources", "error", err)
 				}
 				return
 			case trace.IsConnectionProblem(err):
-				s.logger.DebugContext(s.ctx, "Remote cluster is offline")
+				s.logger.DebugContext(s.ctx, "Leaf cluster is offline")
 			default:
 				s.logger.WarnContext(s.ctx, "Could not perform cert authorities update", "error", err)
 			}
@@ -585,7 +585,7 @@ func (s *remoteSite) updateCertAuthorities(retry retryutils.Retry, remoteWatcher
 	}
 }
 
-func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityWatcher, remoteVersion string) error {
+func (s *leafCluster) watchCertAuthorities(leafClusterWatcher *services.CertAuthorityWatcher, leafClusterVersion string) error {
 	filter := types.CertAuthorityFilter{
 		types.HostCA:     s.srv.ClusterName,
 		types.UserCA:     s.srv.ClusterName,
@@ -602,7 +602,7 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 		}
 	}()
 
-	remoteWatch, err := remoteWatcher.Subscribe(
+	leafWatch, err := leafClusterWatcher.Subscribe(
 		s.ctx,
 		types.CertAuthorityFilter{
 			types.HostCA: s.domainName,
@@ -612,8 +612,8 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 		return trace.Wrap(err)
 	}
 	defer func() {
-		if err := remoteWatch.Close(); err != nil {
-			s.logger.WarnContext(s.ctx, "Failed to close remote ca watcher subscription", "error", err)
+		if err := leafWatch.Close(); err != nil {
+			s.logger.WarnContext(s.ctx, "Failed to close leaf cluster ca watcher subscription", "error", err)
 		}
 	}()
 
@@ -623,54 +623,54 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 			Type:       caType,
 			DomainName: clusterName,
 		}
-		ca, err := s.localAccessPoint.GetCertAuthority(s.ctx, caID, false)
+		ca, err := s.localCache.GetCertAuthority(s.ctx, caID, false)
 		if err != nil {
 			return trace.Wrap(err, "failed to get local cert authority")
 		}
-		if err := s.remoteClient.RotateExternalCertAuthority(s.ctx, ca); err != nil {
+		if err := s.leafClient.RotateExternalCertAuthority(s.ctx, ca); err != nil {
 			return trace.Wrap(err, "failed to push local cert authority")
 		}
 		s.logger.DebugContext(s.ctx, "Pushed local cert authority", "cert_authority", logutils.StringerAttr(caID))
 		localCAs[caType] = ca
 	}
 
-	remoteCA, err := s.remoteAccessPoint.GetCertAuthority(s.ctx, types.CertAuthID{
+	remoteCA, err := s.leafCache.GetCertAuthority(s.ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: s.domainName,
 	}, false)
 	if err != nil {
-		return trace.Wrap(err, "failed to get remote cert authority")
+		return trace.Wrap(err, "failed to get leaf cluster cert authority")
 	}
 	if remoteCA.GetName() != s.domainName || remoteCA.GetType() != types.HostCA {
-		return trace.BadParameter("received wrong CA, expected remote host CA, got %v", remoteCA.GetID())
+		return trace.BadParameter("received wrong CA, expected leaf cluster host CA, got %v", remoteCA.GetID())
 	}
 
-	maybeUpsertRemoteCA := func(remoteCA types.CertAuthority) error {
-		oldRemoteCA, err := s.localAccessPoint.GetCertAuthority(s.ctx, types.CertAuthID{
+	maybeUpsertLeafClusterCA := func(leafClusterCA types.CertAuthority) error {
+		oldLeafClusterCA, err := s.localCache.GetCertAuthority(s.ctx, types.CertAuthID{
 			Type:       types.HostCA,
-			DomainName: remoteCA.GetClusterName(),
+			DomainName: leafClusterCA.GetClusterName(),
 		}, false)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 
 		// if CA is changed or does not exist, update backend
-		if err != nil || !services.CertAuthoritiesEquivalent(oldRemoteCA, remoteCA) {
-			s.logger.DebugContext(s.ctx, "Ingesting remote cert authority", "cert_authority", logutils.StringerAttr(remoteCA.GetID()))
-			if err := s.localClient.UpsertCertAuthority(s.ctx, remoteCA); err != nil {
+		if err != nil || !services.CertAuthoritiesEquivalent(oldLeafClusterCA, leafClusterCA) {
+			s.logger.DebugContext(s.ctx, "Ingesting leaf cluster cert authority", "cert_authority", logutils.StringerAttr(leafClusterCA.GetID()))
+			if err := s.localClient.UpsertCertAuthority(s.ctx, leafClusterCA); err != nil {
 				return trace.Wrap(err)
 			}
 		}
 
-		// keep track of when the remoteSite needs to reconnect
-		if err := s.compareAndSwapCertAuthority(remoteCA); err != nil {
+		// keep track of when the leaf cluster should reconnect
+		if err := s.compareAndSwapCertAuthority(leafClusterCA); err != nil {
 			return trace.Wrap(err)
 		}
 
 		return nil
 	}
 
-	if err := maybeUpsertRemoteCA(remoteCA); err != nil {
+	if err := maybeUpsertLeafClusterCA(remoteCA); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -682,9 +682,9 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 		case <-localWatch.Done():
 			s.logger.WarnContext(s.ctx, "Local CertAuthority watcher subscription has closed")
 			return fmt.Errorf("local ca watcher for cluster %s has closed", s.srv.ClusterName)
-		case <-remoteWatch.Done():
-			s.logger.WarnContext(s.ctx, "Remote CertAuthority watcher subscription has closed")
-			return fmt.Errorf("remote ca watcher for cluster %s has closed", s.domainName)
+		case <-leafWatch.Done():
+			s.logger.WarnContext(s.ctx, "Leaf Cluster CertAuthority watcher subscription has closed")
+			return fmt.Errorf("leaf cluster ca watcher for cluster %s has closed", s.domainName)
 		case evt := <-localWatch.Events():
 			switch evt.Type {
 			case types.OpPut:
@@ -703,14 +703,14 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 				// CheckAndSetDefaults
 				// TODO(espadolini): figure out who should be responsible for validating the CA *once*
 				newCA = newCA.Clone()
-				if err := s.remoteClient.RotateExternalCertAuthority(s.ctx, newCA); err != nil {
+				if err := s.leafClient.RotateExternalCertAuthority(s.ctx, newCA); err != nil {
 					s.logger.WarnContext(s.ctx, "Failed to rotate external ca", "error", err)
 					return trace.Wrap(err)
 				}
 
 				localCAs[newCA.GetType()] = newCA
 			}
-		case evt := <-remoteWatch.Events():
+		case evt := <-leafWatch.Events():
 			switch evt.Type {
 			case types.OpPut:
 				remoteCA, ok := evt.Resource.(types.CertAuthority)
@@ -720,7 +720,7 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 
 				// the CA might not be trusted but the watcher's fanout logic is
 				// local, so this is ok
-				if err := maybeUpsertRemoteCA(remoteCA); err != nil {
+				if err := maybeUpsertLeafClusterCA(remoteCA); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -728,8 +728,8 @@ func (s *remoteSite) watchCertAuthorities(remoteWatcher *services.CertAuthorityW
 	}
 }
 
-func (s *remoteSite) updateLocks(retry retryutils.Retry) {
-	s.logger.DebugContext(s.ctx, "Watching for remote lock changes")
+func (s *leafCluster) updateLocks(retry retryutils.Retry) {
+	s.logger.DebugContext(s.ctx, "Watching for leaf cluster lock changes")
 
 	for {
 		startedWaiting := s.clock.Now()
@@ -744,17 +744,17 @@ func (s *remoteSite) updateLocks(retry retryutils.Retry) {
 		if err := s.watchLocks(); err != nil {
 			switch {
 			case trace.IsNotImplemented(err):
-				s.logger.DebugContext(s.ctx, "Remote cluster does not support locks yet", "cluster", s.domainName)
+				s.logger.DebugContext(s.ctx, "Leaft cluster does not support locks yet", "cluster", s.domainName)
 			case trace.IsConnectionProblem(err):
-				s.logger.DebugContext(s.ctx, "Remote cluster is offline", "cluster", s.domainName)
+				s.logger.DebugContext(s.ctx, "Leaf cluster is offline", "cluster", s.domainName)
 			default:
-				s.logger.WarnContext(s.ctx, "Could not update remote locks", "error", err)
+				s.logger.WarnContext(s.ctx, "Could not update leaf cluster locks", "error", err)
 			}
 		}
 	}
 }
 
-func (s *remoteSite) watchLocks() error {
+func (s *leafCluster) watchLocks() error {
 	watcher, err := s.srv.LockWatcher.Subscribe(s.ctx)
 	if err != nil {
 		s.logger.ErrorContext(s.ctx, "Failed to subscribe to LockWatcher", "error", err)
@@ -777,7 +777,7 @@ func (s *remoteSite) watchLocks() error {
 			switch evt.Type {
 			case types.OpPut, types.OpDelete:
 				locks := s.srv.LockWatcher.GetCurrent()
-				if err := s.remoteClient.ReplaceRemoteLocks(s.ctx, s.srv.ClusterName, locks); err != nil {
+				if err := s.leafClient.ReplaceRemoteLocks(s.ctx, s.srv.ClusterName, locks); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -785,7 +785,7 @@ func (s *remoteSite) watchLocks() error {
 	}
 }
 
-func (s *remoteSite) DialAuthServer(params reversetunnelclient.DialParams) (net.Conn, error) {
+func (s *leafCluster) DialAuthServer(params reversetunnelclient.DialParams) (net.Conn, error) {
 	conn, err := s.connThroughTunnel(&sshutils.DialReq{
 		Address:       constants.RemoteAuthServer,
 		ClientSrcAddr: stringOrEmpty(params.From),
@@ -795,14 +795,14 @@ func (s *remoteSite) DialAuthServer(params reversetunnelclient.DialParams) (net.
 }
 
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
-// located in a remote connected site, the connection goes through the
+// located in a leaf cluster, the connection goes through the
 // reverse proxy tunnel.
-func (s *remoteSite) Dial(params reversetunnelclient.DialParams) (net.Conn, error) {
+func (s *leafCluster) Dial(params reversetunnelclient.DialParams) (net.Conn, error) {
 	if params.TargetServer == nil && params.ConnType == types.NodeTunnel {
 		return nil, trace.BadParameter("target server is required for teleport nodes")
 	}
 
-	localRecCfg, err := s.localAccessPoint.GetSessionRecordingConfig(s.ctx)
+	localRecCfg, err := s.localCache.GetSessionRecordingConfig(s.ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -812,15 +812,15 @@ func (s *remoteSite) Dial(params reversetunnelclient.DialParams) (net.Conn, erro
 	}
 
 	if params.ConnType == types.NodeTunnel {
-		// If the remote cluster is recording at the proxy we need to respect
+		// If the leaf cluster is recording at the proxy we need to respect
 		// that and forward and record the session. We will be connecting
-		// to the node without connecting through the remote proxy, so the
-		// session won't have a chance to get recorded at the remote proxy.
-		remoteRecCfg, err := s.remoteAccessPoint.GetSessionRecordingConfig(s.ctx)
+		// to the node without connecting through the leaf proxy, so the
+		// session won't have a chance to get recorded at the leaf proxy.
+		leafClusterRecCfg, err := s.leafCache.GetSessionRecordingConfig(s.ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if services.IsRecordAtProxy(remoteRecCfg.GetMode()) {
+		if services.IsRecordAtProxy(leafClusterRecCfg.GetMode()) {
 			return s.dialAndForward(params)
 		}
 	}
@@ -829,7 +829,7 @@ func (s *remoteSite) Dial(params reversetunnelclient.DialParams) (net.Conn, erro
 	return s.DialTCP(params)
 }
 
-func (s *remoteSite) DialTCP(params reversetunnelclient.DialParams) (net.Conn, error) {
+func (s *leafCluster) DialTCP(params reversetunnelclient.DialParams) (net.Conn, error) {
 	s.logger.DebugContext(s.ctx, "Initiating dial request",
 		"source_addr", logutils.StringerAttr(params.From),
 		"target_addr", logutils.StringerAttr(params.To),
@@ -852,7 +852,7 @@ func (s *remoteSite) DialTCP(params reversetunnelclient.DialParams) (net.Conn, e
 	return conn, nil
 }
 
-func (s *remoteSite) dialAndForward(params reversetunnelclient.DialParams) (_ net.Conn, retErr error) {
+func (s *leafCluster) dialAndForward(params reversetunnelclient.DialParams) (_ net.Conn, retErr error) {
 	if params.GetUserAgent == nil && !params.TargetServer.IsOpenSSHNode() {
 		return nil, trace.BadParameter("user agent getter is required for teleport nodes")
 	}
@@ -899,7 +899,7 @@ func (s *remoteSite) dialAndForward(params reversetunnelclient.DialParams) (_ ne
 	// once conn is closed.
 	serverConfig := forward.ServerConfig{
 		LocalAuthClient:          s.localClient,
-		TargetClusterAccessPoint: s.remoteAccessPoint,
+		TargetClusterAccessPoint: s.leafCache,
 		UserAgent:                userAgent,
 		AgentlessSigner:          params.AgentlessSigner,
 		TargetConn:               targetConn,
@@ -924,14 +924,14 @@ func (s *remoteSite) dialAndForward(params reversetunnelclient.DialParams) (_ ne
 		Clock:                    s.clock,
 		EICESigner:               s.srv.EICESigner,
 	}
-	remoteServer, err := forward.New(serverConfig)
+	forwardingServer, err := forward.New(serverConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	go remoteServer.Serve()
+	go forwardingServer.Serve()
 
 	// Return a connection to the forwarding server.
-	conn, err := remoteServer.Dial()
+	conn, err := forwardingServer.Dial()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -963,13 +963,13 @@ func UseTunnel(logger *slog.Logger, c *sshutils.ChConn) bool {
 	}
 }
 
-func (s *remoteSite) connThroughTunnel(req *sshutils.DialReq) (*sshutils.ChConn, error) {
-	s.logger.DebugContext(s.ctx, "Requesting connection in remote cluster.",
+func (s *leafCluster) connThroughTunnel(req *sshutils.DialReq) (*sshutils.ChConn, error) {
+	s.logger.DebugContext(s.ctx, "Requesting connection in leaf cluster.",
 		"target_address", req.Address,
 		"target_server_id", req.ServerID,
 	)
 
-	// Loop through existing remote connections and try and establish a
+	// Loop through existing leaf cluster connections and try and establish a
 	// connection over the "reverse tunnel".
 	var conn *sshutils.ChConn
 	var err error
@@ -978,7 +978,7 @@ func (s *remoteSite) connThroughTunnel(req *sshutils.DialReq) (*sshutils.ChConn,
 		if err == nil {
 			return conn, nil
 		}
-		s.logger.WarnContext(s.ctx, "Request for connection to remote site failed", "error", err)
+		s.logger.WarnContext(s.ctx, "Request for connection to leaf cluster failed", "error", err)
 	}
 
 	// Didn't connect and no error? This means we didn't have any connected
@@ -994,7 +994,7 @@ func (s *remoteSite) connThroughTunnel(req *sshutils.DialReq) (*sshutils.ChConn,
 	return nil, err
 }
 
-func (s *remoteSite) chanTransportConn(req *sshutils.DialReq) (*sshutils.ChConn, error) {
+func (s *leafCluster) chanTransportConn(req *sshutils.DialReq) (*sshutils.ChConn, error) {
 	rconn, err := s.nextConn()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -35,145 +35,144 @@ import (
 	"github.com/gravitational/teleport/lib/services/readonly"
 )
 
-func newClusterPeers(clusterName string) *clusterPeers {
-	return &clusterPeers{
+func newExpectedLeafClusters(clusterName string) *expectedLeafClusters {
+	return &expectedLeafClusters{
 		clusterName: clusterName,
-		peers:       make(map[string]*clusterPeer),
+		clusters:    make(map[string]*expectedLeafCluster),
 	}
 }
 
-// clusterPeers is a collection of cluster peers to a given cluster
-type clusterPeers struct {
+// expectedLeafClusters is a collection of placeholders for a given cluster.
+type expectedLeafClusters struct {
 	clusterName string
-	peers       map[string]*clusterPeer
+	clusters    map[string]*expectedLeafCluster
 }
 
-func (p *clusterPeers) GetTunnelsCount() int {
-	return len(p.peers)
+func (p *expectedLeafClusters) GetTunnelsCount() int {
+	return len(p.clusters)
 }
 
-func (p *clusterPeers) pickPeer() (*clusterPeer, error) {
-	var currentPeer *clusterPeer
-	for _, peer := range p.peers {
-		if currentPeer == nil || peer.getConnInfo().GetLastHeartbeat().After(currentPeer.getConnInfo().GetLastHeartbeat()) {
-			currentPeer = peer
+func (p *expectedLeafClusters) pickCluster() (*expectedLeafCluster, error) {
+	var currentCluster *expectedLeafCluster
+	for _, cluster := range p.clusters {
+		if currentCluster == nil || cluster.getConnInfo().GetLastHeartbeat().After(currentCluster.getConnInfo().GetLastHeartbeat()) {
+			currentCluster = cluster
 		}
 	}
-	if currentPeer == nil {
-		return nil, trace.NotFound("no active peers found for %v", p.clusterName)
+	if currentCluster == nil {
+		return nil, trace.NotFound("no active clusters found for %v", p.clusterName)
 	}
-	return currentPeer, nil
+	return currentCluster, nil
 }
 
-func (p *clusterPeers) updatePeer(conn types.TunnelConnection) bool {
-	peer, ok := p.peers[conn.GetName()]
+func (p *expectedLeafClusters) updateCluster(conn types.TunnelConnection) bool {
+	cluster, ok := p.clusters[conn.GetName()]
 	if !ok {
 		return false
 	}
-	peer.setConnInfo(conn)
+	cluster.setConnInfo(conn)
 	return true
 }
 
-func (p *clusterPeers) addPeer(peer *clusterPeer) {
-	p.peers[peer.getConnInfo().GetName()] = peer
+func (p *expectedLeafClusters) addCluster(cluster *expectedLeafCluster) {
+	p.clusters[cluster.getConnInfo().GetName()] = cluster
 }
 
-func (p *clusterPeers) removePeer(connInfo types.TunnelConnection) {
-	delete(p.peers, connInfo.GetName())
+func (p *expectedLeafClusters) removeCluster(connInfo types.TunnelConnection) {
+	delete(p.clusters, connInfo.GetName())
 }
 
-func (p *clusterPeers) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return peer.CachingAccessPoint()
+	return cluster.CachingAccessPoint()
 }
 
-func (p *clusterPeers) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return peer.NodeWatcher()
+	return cluster.NodeWatcher()
 }
 
-func (p *clusterPeers) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return peer.GitServerWatcher()
+	return cluster.GitServerWatcher()
 }
 
-func (p *clusterPeers) GetClient() (authclient.ClientI, error) {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) GetClient() (authclient.ClientI, error) {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return peer.GetClient()
+	return cluster.GetClient()
 }
 
-func (p *clusterPeers) String() string {
-	return fmt.Sprintf("clusterPeer(%v)", p.clusterName)
+func (p *expectedLeafClusters) String() string {
+	return fmt.Sprintf("expectedLeafClusters(%v)", p.clusterName)
 }
 
-func (p *clusterPeers) GetStatus() string {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) GetStatus() string {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return teleport.RemoteClusterStatusOffline
 	}
-	return peer.GetStatus()
+	return cluster.GetStatus()
 }
 
-func (p *clusterPeers) GetName() string {
+func (p *expectedLeafClusters) GetName() string {
 	return p.clusterName
 }
 
-func (p *clusterPeers) GetLastConnected() time.Time {
-	peer, err := p.pickPeer()
+func (p *expectedLeafClusters) GetLastConnected() time.Time {
+	cluster, err := p.pickCluster()
 	if err != nil {
 		return time.Time{}
 	}
-	return peer.GetLastConnected()
+	return cluster.GetLastConnected()
 }
 
-func (p *clusterPeers) DialAuthServer(reversetunnelclient.DialParams) (net.Conn, error) {
+func (p *expectedLeafClusters) DialAuthServer(reversetunnelclient.DialParams) (net.Conn, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial to auth server, this proxy has not been discovered yet, try again later")
 }
 
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
-// located in a remote connected site, the connection goes through the
+// located in a leaf cluster, the connection goes through the
 // reverse proxy tunnel.
-func (p *clusterPeers) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
+func (p *expectedLeafClusters) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return p.DialTCP(params)
 }
 
-func (p *clusterPeers) DialTCP(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
+func (p *expectedLeafClusters) DialTCP(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 
-// IsClosed always returns false because clusterPeers is never closed.
-func (p *clusterPeers) IsClosed() bool { return false }
+// IsClosed always returns false because expectedLeafCluster is never closed.
+func (p *expectedLeafClusters) IsClosed() bool { return false }
 
-// Close always returns nil because a clusterPeers isn't closed.
-func (p *clusterPeers) Close() error { return nil }
+// Close is noop.
+func (p *expectedLeafClusters) Close() error { return nil }
 
-// newClusterPeer returns new cluster peer
-func newClusterPeer(srv *server, connInfo types.TunnelConnection, offlineThreshold time.Duration) (*clusterPeer, error) {
-	clusterPeer := &clusterPeer{
+// newExpectedLeafCluster returns new cluster placeholder.
+func newExpectedLeafCluster(srv *server, connInfo types.TunnelConnection, offlineThreshold time.Duration) *expectedLeafCluster {
+	return &expectedLeafCluster{
 		srv:              srv,
 		connInfo:         connInfo,
 		clock:            clockwork.NewRealClock(),
 		offlineThreshold: offlineThreshold,
 	}
 
-	return clusterPeer, nil
 }
 
-// clusterPeer is a remote cluster that has established
-// a tunnel to the peers
-type clusterPeer struct {
+// expectedLeafCluster represents a connection to a leaf
+// cluster that has yet to register any tunnels
+type expectedLeafCluster struct {
 	mu       sync.Mutex
 	connInfo types.TunnelConnection
 	srv      *server
@@ -186,66 +185,66 @@ type clusterPeer struct {
 	offlineThreshold time.Duration
 }
 
-func (s *clusterPeer) getConnInfo() types.TunnelConnection {
+func (s *expectedLeafCluster) getConnInfo() types.TunnelConnection {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.connInfo
 }
 
-func (s *clusterPeer) setConnInfo(ci types.TunnelConnection) {
+func (s *expectedLeafCluster) setConnInfo(ci types.TunnelConnection) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.connInfo = ci
 }
 
-func (s *clusterPeer) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
+func (s *expectedLeafCluster) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+func (s *expectedLeafCluster) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch node watcher, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
+func (s *expectedLeafCluster) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch git server watcher, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) GetClient() (authclient.ClientI, error) {
+func (s *expectedLeafCluster) GetClient() (authclient.ClientI, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to fetch client, this proxy %v has not been discovered yet, try again later", s)
 }
 
-func (s *clusterPeer) String() string {
+func (s *expectedLeafCluster) String() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return fmt.Sprintf("clusterPeer(%v)", s.connInfo)
+	return fmt.Sprintf("expectedLeafCluster(%v)", s.connInfo)
 }
 
-func (s *clusterPeer) GetStatus() string {
+func (s *expectedLeafCluster) GetStatus() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return services.TunnelConnectionStatus(s.clock, s.connInfo, s.offlineThreshold)
 }
 
-func (s *clusterPeer) GetName() string {
+func (s *expectedLeafCluster) GetName() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.connInfo.GetClusterName()
 }
 
-func (s *clusterPeer) GetLastConnected() time.Time {
+func (s *expectedLeafCluster) GetLastConnected() time.Time {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.connInfo.GetLastHeartbeat()
 }
 
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
-// located in a remote connected site, the connection goes through the
+// located in a leaf clsuter, the connection goes through the
 // reverse proxy tunnel.
-func (s *clusterPeer) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
+func (s *expectedLeafCluster) Dial(params reversetunnelclient.DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy %v has not been discovered yet, try again later", s)
 }
 
-// Close closes cluster peer connections
-func (s *clusterPeer) Close() error {
+// Close is a noop.
+func (s *expectedLeafCluster) Close() error {
 	return nil
 }

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -97,15 +97,15 @@ type server struct {
 	srv     *sshutils.Server
 	limiter *limiter.Limiter
 
-	// remoteSites is the list of connected remote clusters
-	remoteSites []*remoteSite
+	// leafClusters is the list of connected leaf clusters
+	leafClusters []*leafCluster
 
-	// localSite is the  local (our own cluster) tunnel client.
-	localSite *localSite
+	// localCluster is the local Teleport cluster.
+	localCluster *localCluster
 
-	// clusterPeers is a map of clusters connected to peer proxies
+	// expectedLeafClusters is a map of clusters connected to peer proxies
 	// via reverse tunnels
-	clusterPeers map[string]*clusterPeers
+	expectedLeafClusters map[string]*expectedLeafClusters
 
 	// cancel function will cancel the
 	cancel context.CancelFunc
@@ -164,7 +164,7 @@ type Config struct {
 	// problems.
 	LocalAccessPoint authclient.ProxyAccessPoint
 	// NewCachingAccessPoint returns new caching access points
-	// per remote cluster
+	// per leaf cluster
 	NewCachingAccessPoint authclient.NewRemoteProxyCachingAccessPoint
 	// Context is a signaling context
 	Context context.Context
@@ -354,26 +354,24 @@ func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 	}
 
 	srv := &server{
-		Config:           cfg,
-		localAuthClient:  cfg.LocalAuthClient,
-		localAccessPoint: cfg.LocalAccessPoint,
-		limiter:          cfg.Limiter,
-		ctx:              ctx,
-		cancel:           cancel,
-		proxyWatcher:     proxyWatcher,
-		clusterPeers:     make(map[string]*clusterPeers),
-		logger:           cfg.Logger,
-		offlineThreshold: offlineThreshold,
-		proxySigner:      cfg.PROXYSigner,
-		gitKeyManager:    gitKeyManager,
+		Config:               cfg,
+		localAuthClient:      cfg.LocalAuthClient,
+		localAccessPoint:     cfg.LocalAccessPoint,
+		limiter:              cfg.Limiter,
+		ctx:                  ctx,
+		cancel:               cancel,
+		proxyWatcher:         proxyWatcher,
+		expectedLeafClusters: make(map[string]*expectedLeafClusters),
+		logger:               cfg.Logger,
+		offlineThreshold:     offlineThreshold,
+		proxySigner:          cfg.PROXYSigner,
+		gitKeyManager:        gitKeyManager,
 	}
 
-	localSite, err := newLocalSite(srv, cfg.ClusterName, cfg.LocalAuthAddresses)
+	srv.localCluster, err = newLocalCluster(srv, cfg.ClusterName, cfg.LocalAuthAddresses)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	srv.localSite = localSite
 
 	s, err := sshutils.NewServer(
 		teleport.ComponentReverseTunnelServer,
@@ -410,15 +408,15 @@ func remoteClustersMap(rc []types.RemoteCluster) map[string]types.RemoteCluster 
 	return out
 }
 
-// disconnectClusters disconnects reverse tunnel connections from remote clusters
+// disconnectClusters disconnects reverse tunnel connections from leaf clusters
 // that were deleted from the local cluster side and cleans up in memory objects.
 // In this case all local trust has been deleted, so all the tunnel connections have to be dropped.
-func (s *server) disconnectClusters(connectedRemoteClusters []*remoteSite, remoteMap map[string]types.RemoteCluster) error {
-	for _, cluster := range connectedRemoteClusters {
+func (s *server) disconnectClusters(connectedLeafClusters []*leafCluster, remoteMap map[string]types.RemoteCluster) error {
+	for _, cluster := range connectedLeafClusters {
 		if _, ok := remoteMap[cluster.GetName()]; !ok {
-			s.logger.InfoContext(s.ctx, "Remote cluster has been deleted, disconnecting it from the proxy", "remote_cluster", cluster.GetName())
-			if err := s.onSiteTunnelClose(&alwaysClose{Cluster: cluster}); err != nil {
-				s.logger.DebugContext(s.ctx, "Failure closing cluster", "remote_cluster", cluster.GetName(), "error", err)
+			s.logger.InfoContext(s.ctx, "Leaf cluster has been deleted, disconnecting it from the proxy", "leaf_cluster", cluster.GetName())
+			if err := s.onClusterTunnelClose(&alwaysClose{Cluster: cluster}); err != nil {
+				s.logger.DebugContext(s.ctx, "Failure closing cluster", "leaf_cluster", cluster.GetName(), "error", err)
 			}
 			remoteClustersStats.DeleteLabelValues(cluster.GetName())
 		}
@@ -430,8 +428,8 @@ func (s *server) periodicFunctions() {
 	ticker := time.NewTicker(defaults.ResyncInterval)
 	defer ticker.Stop()
 
-	if err := s.fetchClusterPeers(); err != nil {
-		s.logger.WarnContext(s.Context, "Failed to fetch cluster peers", "error", err)
+	if err := s.fetchExpectedLeafClusters(); err != nil {
+		s.logger.WarnContext(s.Context, "Failed to fetch expected leaf cluster", "error", err)
 	}
 	for {
 		select {
@@ -442,11 +440,11 @@ func (s *server) periodicFunctions() {
 		case proxies := <-s.proxyWatcher.ResourcesC:
 			s.fanOutProxies(proxies)
 		case <-ticker.C:
-			if err := s.fetchClusterPeers(); err != nil {
-				s.logger.WarnContext(s.ctx, "Failed to fetch cluster peers", "error", err)
+			if err := s.fetchExpectedLeafClusters(); err != nil {
+				s.logger.WarnContext(s.ctx, "Failed to fetch expected leaf clusters", "error", err)
 			}
 
-			connectedRemoteClusters := s.getRemoteClusters()
+			connectedRemoteClusters := s.getLeafClusters()
 
 			remoteClusters, err := s.localAccessPoint.GetRemoteClusters(s.ctx)
 			if err != nil {
@@ -466,12 +464,12 @@ func (s *server) periodicFunctions() {
 	}
 }
 
-// fetchClusterPeers pulls back all proxies that have registered themselves
+// fetchExpectedLeafClusters pulls back all proxies that have registered themselves
 // (created a services.TunnelConnection) in the backend and compares them to
 // what was found in the previous iteration and updates the in-memory cluster
-// peer map. This map is used later by Cluster(s) to return either local or
-// remote site, or if no match, a cluster peer.
-func (s *server) fetchClusterPeers() error {
+// placeholders. This map is used later by Cluster(s) to return either local or
+// leaf cluster, or if no match, a placeholder.
+func (s *server) fetchExpectedLeafClusters() error {
 	conns, err := s.LocalAccessPoint.GetAllTunnelConnections()
 	if err != nil {
 		return trace.Wrap(err)
@@ -497,18 +495,18 @@ func (s *server) fetchClusterPeers() error {
 	}
 	existingConns := s.existingConns()
 	connsToAdd, connsToUpdate, connsToRemove := s.diffConns(newConns, existingConns)
-	s.removeClusterPeers(connsToRemove)
-	s.updateClusterPeers(connsToUpdate)
-	return s.addClusterPeers(connsToAdd)
+	s.removeExpectedLeafCluster(connsToRemove)
+	s.updateExpectedLeafClusters(connsToUpdate)
+	return s.addExpectedLeafClusters(connsToAdd)
 }
 
-func (s *server) reportClusterStats(connectedRemoteClusters []*remoteSite, remoteMap map[string]types.RemoteCluster) error {
+func (s *server) reportClusterStats(connectedRemoteClusters []*leafCluster, remoteMap map[string]types.RemoteCluster) error {
 	// zero out counters for remote clusters that have a
-	// resource in the backend but no associated remoteSite
+	// resource in the backend but no associated cluster
 	for cluster := range remoteMap {
 		var exists bool
-		for _, site := range connectedRemoteClusters {
-			if site.GetName() == cluster {
+		for _, connectedCluster := range connectedRemoteClusters {
+			if connectedCluster.GetName() == cluster {
 				exists = true
 				break
 			}
@@ -520,8 +518,8 @@ func (s *server) reportClusterStats(connectedRemoteClusters []*remoteSite, remot
 	}
 
 	// update the counters for any remote clusters that have
-	// both a resource in the backend AND an associated remote
-	// site with connections
+	// both a resource in the backend AND an associated leaf cluster
+	// with connections
 	for _, cluster := range connectedRemoteClusters {
 		rc, ok := remoteMap[cluster.GetName()]
 		if !ok {
@@ -539,59 +537,55 @@ func (s *server) reportClusterStats(connectedRemoteClusters []*remoteSite, remot
 	return nil
 }
 
-func (s *server) addClusterPeers(conns map[string]types.TunnelConnection) error {
+func (s *server) addExpectedLeafClusters(conns map[string]types.TunnelConnection) error {
 	for key := range conns {
 		connInfo := conns[key]
-		peer, err := newClusterPeer(s, connInfo, s.offlineThreshold)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		s.addClusterPeer(peer)
+		s.addExpectedLeafCluster(newExpectedLeafCluster(s, connInfo, s.offlineThreshold))
 	}
 	return nil
 }
 
-func (s *server) updateClusterPeers(conns map[string]types.TunnelConnection) {
+func (s *server) updateExpectedLeafClusters(conns map[string]types.TunnelConnection) {
 	for key := range conns {
 		connInfo := conns[key]
-		s.updateClusterPeer(connInfo)
+		s.updateExpectedLeafCluster(connInfo)
 	}
 }
 
-func (s *server) addClusterPeer(peer *clusterPeer) {
+func (s *server) addExpectedLeafCluster(cluster *expectedLeafCluster) {
 	s.Lock()
 	defer s.Unlock()
-	clusterName := peer.connInfo.GetClusterName()
-	peers, ok := s.clusterPeers[clusterName]
+	clusterName := cluster.connInfo.GetClusterName()
+	clusters, ok := s.expectedLeafClusters[clusterName]
 	if !ok {
-		peers = newClusterPeers(clusterName)
-		s.clusterPeers[clusterName] = peers
+		clusters = newExpectedLeafClusters(clusterName)
+		s.expectedLeafClusters[clusterName] = clusters
 	}
-	peers.addPeer(peer)
+	clusters.addCluster(cluster)
 }
 
-func (s *server) updateClusterPeer(conn types.TunnelConnection) bool {
+func (s *server) updateExpectedLeafCluster(conn types.TunnelConnection) bool {
 	s.Lock()
 	defer s.Unlock()
 	clusterName := conn.GetClusterName()
-	peers, ok := s.clusterPeers[clusterName]
+	clusters, ok := s.expectedLeafClusters[clusterName]
 	if !ok {
 		return false
 	}
-	return peers.updatePeer(conn)
+	return clusters.updateCluster(conn)
 }
 
-func (s *server) removeClusterPeers(conns []types.TunnelConnection) {
+func (s *server) removeExpectedLeafCluster(conns []types.TunnelConnection) {
 	s.Lock()
 	defer s.Unlock()
 	for _, conn := range conns {
-		peers, ok := s.clusterPeers[conn.GetClusterName()]
+		clusters, ok := s.expectedLeafClusters[conn.GetClusterName()]
 		if !ok {
-			s.logger.WarnContext(s.ctx, "failed to remove missing cluster peer", "tunnel_connection", logutils.StringerAttr(conn))
+			s.logger.WarnContext(s.ctx, "failed to remove missing expected leaf cluster", "tunnel_connection", logutils.StringerAttr(conn))
 			continue
 		}
-		peers.removePeer(conn)
-		s.logger.DebugContext(s.ctx, "Removed cluster peer", "tunnel_connection", logutils.StringerAttr(conn))
+		clusters.removeCluster(conn)
+		s.logger.DebugContext(s.ctx, "Removed expected cluster", "tunnel_connection", logutils.StringerAttr(conn))
 	}
 }
 
@@ -599,8 +593,8 @@ func (s *server) existingConns() map[string]types.TunnelConnection {
 	s.RLock()
 	defer s.RUnlock()
 	conns := make(map[string]types.TunnelConnection)
-	for _, peers := range s.clusterPeers {
-		for _, cluster := range peers.peers {
+	for _, clusters := range s.expectedLeafClusters {
+		for _, cluster := range clusters.clusters {
 			conns[cluster.connInfo.GetName()] = cluster.connInfo
 		}
 	}
@@ -652,12 +646,12 @@ func (s *server) DrainConnections(ctx context.Context) error {
 	// Ensure listener is closed before sending reconnects.
 	err := s.srv.Close()
 	s.RLock()
-	s.logger.DebugContext(ctx, "Advising reconnect to local site", "local_site", s.localSite.GetName())
-	go s.localSite.adviseReconnect(ctx)
+	s.logger.DebugContext(ctx, "Advising reconnect to local cluster", "local_cluster", s.localCluster.GetName())
+	go s.localCluster.adviseReconnect(ctx)
 
-	for _, site := range s.remoteSites {
-		s.logger.DebugContext(ctx, "Advising reconnect to remote site", "remote_site", site.GetName())
-		go site.adviseReconnect(ctx)
+	for _, cluster := range s.leafClusters {
+		s.logger.DebugContext(ctx, "Advising reconnect to leaf cluster", "leaf_cluster", cluster.GetName())
+		go cluster.adviseReconnect(ctx)
 	}
 	s.RUnlock()
 
@@ -856,8 +850,8 @@ func (s *server) handleNewService(ctx context.Context, role types.SystemRole, co
 }
 
 func (s *server) handleNewCluster(ctx context.Context, conn net.Conn, sshConn *ssh.ServerConn, nch ssh.NewChannel) {
-	// add the incoming site (cluster) to the list of active connections:
-	site, remoteConn, err := s.upsertRemoteCluster(conn, sshConn)
+	// add the incoming cluster to the list of active connections:
+	cluster, remoteConn, err := s.upsertRemoteCluster(conn, sshConn)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to upsert remote cluster connection", "error", err)
 		s.rejectRequest(nch, ssh.ConnectionFailed, "failed to accept incoming cluster connection")
@@ -870,7 +864,7 @@ func (s *server) handleNewCluster(ctx context.Context, conn net.Conn, sshConn *s
 		sshConn.Close()
 		return
 	}
-	go site.handleHeartbeat(ctx, remoteConn, ch, req)
+	go cluster.handleHeartbeat(ctx, remoteConn, ch, req)
 }
 
 func (s *server) requireLocalAgentForConn(sconn *ssh.ServerConn, connType types.TunnelType) error {
@@ -880,7 +874,7 @@ func (s *server) requireLocalAgentForConn(sconn *ssh.ServerConn, connType types.
 		return trace.BadParameter("empty cluster name")
 	}
 
-	if s.localSite.domainName == clusterName {
+	if s.localCluster.domainName == clusterName {
 		return nil
 	}
 
@@ -1003,7 +997,7 @@ func (s *server) checkClientCert(user string, clusterName string, cert *ssh.Cert
 	return nil
 }
 
-func (s *server) upsertServiceConn(conn net.Conn, sconn *ssh.ServerConn, connType types.TunnelType) (*localSite, *remoteConn, error) {
+func (s *server) upsertServiceConn(conn net.Conn, sconn *ssh.ServerConn, connType types.TunnelType) (*localCluster, *remoteConn, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -1016,15 +1010,15 @@ func (s *server) upsertServiceConn(conn net.Conn, sconn *ssh.ServerConn, connTyp
 		return nil, nil, trace.BadParameter("host id not found")
 	}
 
-	rconn, err := s.localSite.addConn(nodeID, connType, conn, sconn)
+	rconn, err := s.localCluster.addConn(nodeID, connType, conn, sconn)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	return s.localSite, rconn, nil
+	return s.localCluster, rconn, nil
 }
 
-func (s *server) upsertRemoteCluster(conn net.Conn, sshConn *ssh.ServerConn) (*remoteSite, *remoteConn, error) {
+func (s *server) upsertRemoteCluster(conn net.Conn, sshConn *ssh.ServerConn) (*leafCluster, *remoteConn, error) {
 	domainName := sshConn.Permissions.Extensions[extAuthority]
 	if strings.TrimSpace(domainName) == "" {
 		return nil, nil, trace.BadParameter("cannot create reverse tunnel: empty cluster name")
@@ -1033,54 +1027,54 @@ func (s *server) upsertRemoteCluster(conn net.Conn, sshConn *ssh.ServerConn) (*r
 	s.Lock()
 	defer s.Unlock()
 
-	var site *remoteSite
-	for _, st := range s.remoteSites {
+	var cluster *leafCluster
+	for _, st := range s.leafClusters {
 		if st.domainName == domainName {
-			site = st
+			cluster = st
 			break
 		}
 	}
 	var err error
 	var remoteConn *remoteConn
-	if site != nil {
-		if remoteConn, err = site.addConn(conn, sshConn); err != nil {
+	if cluster != nil {
+		if remoteConn, err = cluster.addConn(conn, sshConn); err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 	} else {
-		site, err = newRemoteSite(s, domainName, sshConn.Conn)
+		cluster, err = newLeafCluster(s, domainName, sshConn.Conn)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		if remoteConn, err = site.addConn(conn, sshConn); err != nil {
+		if remoteConn, err = cluster.addConn(conn, sshConn); err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		s.remoteSites = append(s.remoteSites, site)
+		s.leafClusters = append(s.leafClusters, cluster)
 	}
-	site.logger.InfoContext(s.ctx, "Processed inbound connection from remote cluster",
+	cluster.logger.InfoContext(s.ctx, "Processed inbound connection from remote cluster",
 		"source_addr", logutils.StringerAttr(conn.RemoteAddr()),
-		"tunnel_count", len(s.remoteSites),
+		"tunnel_count", len(s.leafClusters),
 	)
 	// treat first connection as a registered heartbeat,
 	// otherwise the connection information will appear after initial
 	// heartbeat delay
-	go site.registerHeartbeat(s.Clock.Now())
-	return site, remoteConn, nil
+	go cluster.registerHeartbeat(s.Clock.Now())
+	return cluster, remoteConn, nil
 }
 
 func (s *server) Clusters(context.Context) ([]reversetunnelclient.Cluster, error) {
 	s.RLock()
 	defer s.RUnlock()
-	out := make([]reversetunnelclient.Cluster, 0, len(s.remoteSites)+len(s.clusterPeers)+1)
-	out = append(out, s.localSite)
+	out := make([]reversetunnelclient.Cluster, 0, len(s.leafClusters)+len(s.expectedLeafClusters)+1)
+	out = append(out, s.localCluster)
 
 	haveLocalConnection := make(map[string]bool)
-	for i := range s.remoteSites {
-		site := s.remoteSites[i]
-		haveLocalConnection[site.GetName()] = true
-		out = append(out, site)
+	for i := range s.leafClusters {
+		cluster := s.leafClusters[i]
+		haveLocalConnection[cluster.GetName()] = true
+		out = append(out, cluster)
 	}
-	for i := range s.clusterPeers {
-		cluster := s.clusterPeers[i]
+	for i := range s.expectedLeafClusters {
+		cluster := s.expectedLeafClusters[i]
 		if _, ok := haveLocalConnection[cluster.GetName()]; !ok {
 			out = append(out, cluster)
 		}
@@ -1088,36 +1082,31 @@ func (s *server) Clusters(context.Context) ([]reversetunnelclient.Cluster, error
 	return out, nil
 }
 
-func (s *server) getRemoteClusters() []*remoteSite {
+func (s *server) getLeafClusters() []*leafCluster {
 	s.RLock()
 	defer s.RUnlock()
-	out := make([]*remoteSite, len(s.remoteSites))
-	copy(out, s.remoteSites)
+	out := make([]*leafCluster, len(s.leafClusters))
+	copy(out, s.leafClusters)
 	return out
 }
 
-// Cluster returns the Cluster with the matching name. The first attempt
-// is to find and return a remote site and that is what is returned if a remote agent has
-// connected to this proxy. Next we loop over local sites and try and try and
-// return a local site. If that fails, we return a cluster peer. This happens
-// when you hit proxy that has never had an agent connect to it. If you end up
-// with a cluster peer your best bet is to wait until the agent has discovered
-// all proxies behind a load balancer. Note, the cluster peer is a
-// services.TunnelConnection that was created by another proxy.
+// Cluster returns the [reversetunnelclient.Cluster] with the matching name. If
+// the name does not match the local cluster or any connected leaf clusters, then a placeholder
+// cluster is returned.
 func (s *server) Cluster(_ context.Context, name string) (reversetunnelclient.Cluster, error) {
 	s.RLock()
 	defer s.RUnlock()
-	if s.localSite.GetName() == name {
-		return s.localSite, nil
+	if s.localCluster.GetName() == name {
+		return s.localCluster, nil
 	}
-	for i := range s.remoteSites {
-		if s.remoteSites[i].GetName() == name {
-			return s.remoteSites[i], nil
+	for i := range s.leafClusters {
+		if s.leafClusters[i].GetName() == name {
+			return s.leafClusters[i], nil
 		}
 	}
-	for i := range s.clusterPeers {
-		if s.clusterPeers[i].GetName() == name {
-			return s.clusterPeers[i], nil
+	for i := range s.expectedLeafClusters {
+		if s.expectedLeafClusters[i].GetName() == name {
+			return s.expectedLeafClusters[i], nil
 		}
 	}
 	return nil, trace.NotFound("cluster %q is not found", name)
@@ -1128,8 +1117,8 @@ func (s *server) GetProxyPeerClient() *peer.Client {
 	return s.PeerClient
 }
 
-// alwaysClose forces onSiteTunnelClose to remove and close
-// the site by always returning false from HasValidConnections.
+// alwaysClose forces onClusterTunnelClose to remove and close
+// the cluster by always returning false from HasValidConnections.
 type alwaysClose struct {
 	reversetunnelclient.Cluster
 }
@@ -1138,33 +1127,33 @@ func (a *alwaysClose) HasValidConnections() bool {
 	return false
 }
 
-// siteCloser is used by onSiteTunnelClose to determine if a site should be closed
+// clusterCloser is used by onClusterTunnelClose to determine if a cluster should be closed
 // when a tunnel is closed
-type siteCloser interface {
+type clusterCloser interface {
 	GetName() string
 	HasValidConnections() bool
 	io.Closer
 }
 
-// onSiteTunnelClose will close and stop tracking the site with the given name
+// onClusterTunnelClose will close and stop tracking the cluster with the given name
 // if it has 0 active tunnels. This is done here to ensure that no new tunnels
-// can be established while cleaning up a site.
-func (s *server) onSiteTunnelClose(site siteCloser) error {
+// can be established while cleaning up a cluster.
+func (s *server) onClusterTunnelClose(cluster clusterCloser) error {
 	s.Lock()
 	defer s.Unlock()
 
-	if site.HasValidConnections() {
+	if cluster.HasValidConnections() {
 		return nil
 	}
 
-	for i := range s.remoteSites {
-		if s.remoteSites[i].domainName == site.GetName() {
-			s.remoteSites = append(s.remoteSites[:i], s.remoteSites[i+1:]...)
-			return trace.Wrap(site.Close())
+	for i := range s.leafClusters {
+		if s.leafClusters[i].domainName == cluster.GetName() {
+			s.leafClusters = append(s.leafClusters[:i], s.leafClusters[i+1:]...)
+			return trace.Wrap(cluster.Close())
 		}
 	}
 
-	return trace.NotFound("site %q is not found", site.GetName())
+	return trace.NotFound("cluster %q is not found", cluster.GetName())
 }
 
 // fanOutProxies is a non-blocking call that updated the watches proxies
@@ -1172,9 +1161,9 @@ func (s *server) onSiteTunnelClose(site siteCloser) error {
 func (s *server) fanOutProxies(proxies []types.Server) {
 	s.Lock()
 	defer s.Unlock()
-	s.localSite.fanOutProxies(proxies)
+	s.localCluster.fanOutProxies(proxies)
 
-	for _, cluster := range s.remoteSites {
+	for _, cluster := range s.leafClusters {
 		cluster.fanOutProxies(proxies)
 	}
 }
@@ -1192,8 +1181,8 @@ func (s *server) TrackUserConnection() (release func()) {
 	return s.srv.TrackUserConnection()
 }
 
-// newRemoteSite helper creates and initializes 'remoteSite' instance
-func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite, error) {
+// newLeafCluster helper creates and initializes a leafCluster instance
+func newLeafCluster(srv *server, domainName string, sconn ssh.Conn) (*leafCluster, error) {
 	connInfo, err := types.NewTunnelConnection(
 		fmt.Sprintf("%v-%v", srv.ID, domainName),
 		types.TunnelConnectionSpecV2{
@@ -1213,7 +1202,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 			cancel()
 		}
 	}()
-	remoteSite := &remoteSite{
+	leaf := &leafCluster{
 		srv:        srv,
 		domainName: domainName,
 		connInfo:   connInfo,
@@ -1230,25 +1219,25 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 
 	// configure access to the full Auth Server API and the cached subset for
 	// the local cluster within which reversetunnelclient.Server is running.
-	remoteSite.localClient = srv.localAuthClient
-	remoteSite.localAccessPoint = srv.localAccessPoint
+	leaf.localClient = srv.localAuthClient
+	leaf.localCache = srv.localAccessPoint
 
-	clt, _, err := remoteSite.getRemoteClient()
+	clt, _, err := leaf.getLeafClient()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteSite.remoteClient = clt
+	leaf.leafClient = clt
 
-	remoteVersion, err := getRemoteAuthVersion(closeContext, sconn)
+	version, err := getLeafClusterAuthVersion(closeContext, sconn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	accessPoint, err := createRemoteAccessPoint(srv, clt, domainName)
+	accessPoint, err := createLeafClusterCache(srv, clt, domainName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteSite.remoteAccessPoint = accessPoint
+	leaf.leafCache = accessPoint
 	nodeWatcher, err := services.NewNodeWatcher(closeContext, services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component:    srv.Component,
@@ -1261,16 +1250,16 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteSite.nodeWatcher = nodeWatcher
+	leaf.nodeWatcher = nodeWatcher
 	// instantiate a cache of host certificates for the forwarding server. the
-	// certificate cache is created in each site (instead of creating it in
+	// certificate cache is created in each cluster (instead of creating it in
 	// reversetunnel.server and passing it along) so that the host certificate
 	// is signed by the correct certificate authority.
 	certificateCache, err := newHostCertificateCache(srv.localAuthClient, srv.localAccessPoint, srv.Clock)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteSite.certificateCache = certificateCache
+	leaf.certificateCache = certificateCache
 
 	caRetry, err := retryutils.NewLinear(retryutils.LinearConfig{
 		First:  retryutils.HalfJitter(srv.Config.PollingPeriod),
@@ -1283,12 +1272,12 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		return nil, trace.Wrap(err)
 	}
 
-	remoteWatcher, err := services.NewCertAuthorityWatcher(srv.ctx, services.CertAuthorityWatcherConfig{
+	leafClusterWatcher, err := services.NewCertAuthorityWatcher(srv.ctx, services.CertAuthorityWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentProxy,
 			Logger:    srv.logger,
 			Clock:     srv.Clock,
-			Client:    remoteSite.remoteAccessPoint,
+			Client:    leaf.leafCache,
 		},
 		Types: []types.CertAuthType{types.HostCA},
 	})
@@ -1297,7 +1286,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	}
 
 	go func() {
-		remoteSite.updateCertAuthorities(caRetry, remoteWatcher, remoteVersion)
+		leaf.updateCertAuthorities(caRetry, leafClusterWatcher, version)
 	}()
 
 	lockRetry, err := retryutils.NewLinear(retryutils.LinearConfig{
@@ -1311,14 +1300,14 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		return nil, trace.Wrap(err)
 	}
 
-	go remoteSite.updateLocks(lockRetry)
-	return remoteSite, nil
+	go leaf.updateLocks(lockRetry)
+	return leaf, nil
 }
 
-// createRemoteAccessPoint creates a new access point for the remote cluster.
-func createRemoteAccessPoint(srv *server, clt authclient.ClientI, domainName string) (authclient.RemoteProxyAccessPoint, error) {
-	// Configure access to the cached subset of the Auth Server API of the remote
-	// cluster this remote site provides access to.
+// createLeafClusterCache creates a new cache for the leaf cluster.
+func createLeafClusterCache(srv *server, clt authclient.ClientI, domainName string) (authclient.RemoteProxyAccessPoint, error) {
+	// Configure access to the cached subset of the Auth Server API of the leaf
+	// cluster this leaf cluster provides access to.
 	accessPoint, err := srv.Config.NewCachingAccessPoint(clt, []string{"reverse", domainName})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1327,8 +1316,8 @@ func createRemoteAccessPoint(srv *server, clt authclient.ClientI, domainName str
 	return accessPoint, nil
 }
 
-// getRemoteAuthVersion sends a version request to the remote agent.
-func getRemoteAuthVersion(ctx context.Context, sconn ssh.Conn) (string, error) {
+// getLeafClusterAuthVersion sends a version request to the leaf cluster.
+func getLeafClusterAuthVersion(ctx context.Context, sconn ssh.Conn) (string, error) {
 	errorCh := make(chan error, 1)
 	versionCh := make(chan string, 1)
 

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -389,7 +389,7 @@ func (p *transport) handleChannelRequests(closeContext context.Context, useTunne
 	}
 }
 
-// getConn checks if the local site holds a connection to the target host,
+// getConn checks if the local cluster holds a connection to the target host,
 // and if it does, attempts to dial through the tunnel. Otherwise directly
 // dials to host.
 func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, error) {
@@ -442,12 +442,12 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 	return conn, true, nil
 }
 
-// tunnelDial looks up the search names in the local site for a matching tunnel
+// tunnelDial looks up the search names in the local cluster for a matching tunnel
 // connection. If a connection exists, it's used to dial through the tunnel.
 func (p *transport) tunnelDial(ctx context.Context, r *sshutils.DialReq) (net.Conn, error) {
-	// Extract the local site from the tunnel server. If no tunnel server
+	// Extract the local cluster from the tunnel server. If no tunnel server
 	// exists, then exit right away this code may be running outside of a
-	// remote site.
+	// leaf cluster.
 	if p.reverseTunnelServer == nil {
 		return nil, trace.NotFound("not found")
 	}
@@ -455,7 +455,7 @@ func (p *transport) tunnelDial(ctx context.Context, r *sshutils.DialReq) (net.Co
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	localCluster, ok := cluster.(*localSite)
+	localCluster, ok := cluster.(*localCluster)
 	if !ok {
 		return nil, trace.BadParameter("did not find local cluster, found %T", cluster)
 	}


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/19164.

This change addresses the following point from the linked issue:

> The root/leaf terminology used in describing cluster relationships is absent from much of lib/reversetunnel. A lot of types/comments/messages could benefit from naming reworks to better explain exactly what they are using the current terminology (sites -> clusters, remote site -> leaf cluster, cluster peer -> expected leaf cluster, remote access point -> leaf cluster cache, etc...).


All variables, comments, types in the reversetunnel package which match any of the above verbiage has been translated as recommended. Additionally the localsite.go and remotsite.go files have been renamed to local_cluster.go and remote_cluster.go.