### PR TITLE
[v17] Allow `"*"` in `kubernetes_users`

### DIFF
--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -313,8 +313,8 @@ determines this from the `kubernetes_users` and `kubernetes_groups` fields in a
 user's roles.
 
 If a user has exactly one value in `kubernetes_users`, the Teleport Kubernetes
-Service impersonates that user. If there are no values in `kubernetes_users`,
-the Kubernetes Service uses the user's Teleport username.
+Service impersonates that user. If there are no values or a wildcard (`*`) in
+`kubernetes_users`, the Kubernetes Service uses the user's Teleport username.
 
 The Kubernetes Service will deny a request if a user has multiple
 `kubernetes_users` and has not specified one when authenticating to a cluster
@@ -322,6 +322,16 @@ The Kubernetes Service will deny a request if a user has multiple
 
 If the user has not specified a Kubernetes group to impersonate, the Kubernetes
 Service uses all values within `kubernetes_groups`.
+
+<Admonition type="warning">
+    When impersonating a less privileged user, remember that unless you're
+    also manually impersonating specific groups (e.g. using `--as-groups` flag),
+    the Kubernetes Service will automatically impersonate any groups within
+    `kubernetes_groups`.
+
+    This can be confusing because you will have the combined permissions of both
+    the user and any automatically-impersonated groups.
+</Admonition>
 
 With the `kube-access` role above, after you authenticate to Teleport, the
 Kubernetes Service uses impersonation headers to forward requests to the API

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -248,7 +248,7 @@ func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.He
 		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
 	restConfig := details.getKubeRestConfig()
-	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, headers)
+	kubeUser, kubeGroups, err := computeImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -479,7 +479,7 @@ func (c *authContext) key() string {
 func (c *authContext) eventClusterMeta(req *http.Request) apievents.KubernetesClusterMetadata {
 	var kubeUsers, kubeGroups []string
 
-	if impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(c.kubeUsers, c.kubeGroups, req.Header); err == nil {
+	if impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(c.kubeUsers, c.kubeGroups, c.User.GetName(), req.Header); err == nil {
 		kubeUsers = []string{impersonateUser}
 		kubeGroups = impersonateGroups
 	} else {
@@ -1939,7 +1939,7 @@ func setupImpersonationHeaders(sess *clusterSession, headers http.Header) error 
 		return nil
 	}
 
-	impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, headers)
+	impersonateUser, impersonateGroups, err := computeImpersonatedPrincipals(sess.kubeUsers, sess.kubeGroups, sess.User.GetName(), headers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1978,7 +1978,9 @@ func copyImpersonationHeaders(dst, src http.Header) {
 // received in the `Impersonate-User` and `Impersonate-Groups` headers and the
 // allowed values. If the user didn't specify any user and groups to impersonate,
 // Teleport will use every group the user is allowed to impersonate.
-func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, headers http.Header) (string, []string, error) {
+func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, username string, headers http.Header) (string, []string, error) {
+	_, hasUserWildcard := kubeUsers[types.Wildcard]
+
 	var impersonateUser string
 	var impersonateGroups []string
 	for header, values := range headers {
@@ -2003,7 +2005,7 @@ func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, he
 			}
 			impersonateUser = values[0]
 
-			if _, ok := kubeUsers[impersonateUser]; !ok {
+			if _, ok := kubeUsers[impersonateUser]; !ok && !hasUserWildcard {
 				return "", nil, trace.AccessDenied("%v, user header %q is not allowed in roles", ImpersonationRequestDeniedMessage, impersonateUser)
 			}
 		case ImpersonateGroupHeader:
@@ -2037,20 +2039,24 @@ func computeImpersonatedPrincipals(kubeUsers, kubeGroups map[string]struct{}, he
 	// link the user identity with the IAM role, for example `IAM#{{external.email}}`
 	//
 	if impersonateUser == "" {
-		switch len(kubeUsers) {
-		// this is currently not possible as kube users have at least one
-		// user (user name), but in case if someone breaks it, catch here
-		case 0:
-			return "", nil, trace.AccessDenied("assumed at least one user to be present")
-		// if there is deterministic choice, make it to improve user experience
-		case 1:
-			for user := range kubeUsers {
-				impersonateUser = user
-				break
+		if hasUserWildcard {
+			impersonateUser = username
+		} else {
+			switch len(kubeUsers) {
+			// this is currently not possible as kube users have at least one
+			// user (user name), but in case if someone breaks it, catch here
+			case 0:
+				return "", nil, trace.AccessDenied("assumed at least one user to be present")
+			// if there is deterministic choice, make it to improve user experience
+			case 1:
+				for user := range kubeUsers {
+					impersonateUser = user
+					break
+				}
+			default:
+				return "", nil, trace.AccessDenied(
+					"please select a user to impersonate, refusing to select a user due to several kubernetes_users set up for this user")
 			}
-		default:
-			return "", nil, trace.AccessDenied(
-				"please select a user to impersonate, refusing to select a user due to several kubernetes_users set up for this user")
 		}
 	}
 

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -617,6 +617,7 @@ func deleteResources[T kubeObjectInterface](
 
 		impersonatedUsers, impersonatedGroups, err := computeImpersonatedPrincipals(
 			utils.StringsSet(allowedKubeUsers), utils.StringsSet(allowedKubeGroups),
+			params.authCtx.User.GetName(),
 			params.header,
 		)
 		if err != nil {


### PR DESCRIPTION
Backport #58282 to branch/v17

changelog: Support setting `"*"` in role `kubernetes_users`
