### PR TITLE
[v18] MWI: Allow configuration of default namespace for `kubernetes/v2` service

### DIFF
--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -216,14 +216,14 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 	}
 	defer impersonatedClient.Close()
 
-	clusters, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
+	matches, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var clusterNames []string
-	for _, c := range clusters {
-		clusterNames = append(clusterNames, c.GetName())
+	for _, m := range matches {
+		clusterNames = append(clusterNames, m.cluster.GetName())
 	}
 	clusterNames = utils.Deduplicate(clusterNames)
 

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -166,14 +166,27 @@ func (s *OutputV2Service) generate(ctx context.Context) error {
 	}
 	defer impersonatedClient.Close()
 
-	clusters, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
+	matches, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	var clusterNames []string
-	for _, c := range clusters {
-		clusterNames = append(clusterNames, c.GetName())
+	for _, m := range matches {
+		clusterNames = append(clusterNames, m.cluster.GetName())
+	}
+	defaultNamespaces := map[string]string{}
+	for _, m := range matches {
+		if m.selector.DefaultNamespace != "" {
+			if _, ok := defaultNamespaces[m.cluster.GetName()]; ok {
+				s.log.WarnContext(
+					ctx,
+					"Multiple selectors match the same cluster with different default namespaces configured, last definition will take priority",
+					"cluster", m.cluster.GetName(),
+				)
+			}
+			defaultNamespaces[m.cluster.GetName()] = m.selector.DefaultNamespace
+		}
 	}
 
 	clusterNames = utils.Deduplicate(clusterNames)
@@ -211,6 +224,7 @@ func (s *OutputV2Service) generate(ctx context.Context) error {
 		credentials:            keyRing,
 		teleportClusterName:    proxyPong.ClusterName,
 		kubernetesClusterNames: clusterNames,
+		defaultNamespaces:      defaultNamespaces,
 	}
 
 	return trace.Wrap(s.render(ctx, status, id.Get(), hostCAs))
@@ -224,6 +238,9 @@ type kubernetesStatusV2 struct {
 	tlsServerName          string
 	credentials            *libclient.KeyRing
 	kubernetesClusterNames []string
+	// defaultNamespace is map of the cluster name to the default namespace
+	// which should be used for that cluster.
+	defaultNamespaces map[string]string
 }
 
 // queryKubeClustersByLabels fetches a list of Kubernetes clusters matching the
@@ -249,13 +266,18 @@ func queryKubeClustersByLabels(ctx context.Context, clt apiclient.GetResourcesCl
 	return clusters, nil
 }
 
+type selectorMatch struct {
+	selector *KubernetesSelector
+	cluster  types.KubeCluster
+}
+
 // fetchAllMatchingKubeClusters returns a list of all clusters matching the
 // given selectors.
-func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResourcesClient, selectors []*KubernetesSelector) ([]types.KubeCluster, error) {
+func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResourcesClient, selectors []*KubernetesSelector) ([]selectorMatch, error) {
 	ctx, span := tracer.Start(ctx, "findAllMatchingKubeClusters")
 	defer span.End()
 
-	clusters := []types.KubeCluster{}
+	matches := []selectorMatch{}
 	for _, selector := range selectors {
 		if selector.Name != "" {
 			cluster, err := getKubeCluster(ctx, clt, selector.Name)
@@ -264,7 +286,10 @@ func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResource
 				return nil, trace.Wrap(err, "unable to fetch cluster %q by name", selector.Name)
 			}
 
-			clusters = append(clusters, cluster)
+			matches = append(matches, selectorMatch{
+				selector: selector,
+				cluster:  cluster,
+			})
 			continue
 		}
 
@@ -278,11 +303,15 @@ func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResource
 			// clusters are returned.)
 			return nil, trace.Wrap(err, "unable to fetch clusters with labels %v", selector.Labels)
 		}
-
-		clusters = append(clusters, labeledClusters...)
+		for _, cluster := range labeledClusters {
+			matches = append(matches, selectorMatch{
+				selector: selector,
+				cluster:  cluster,
+			})
+		}
 	}
 
-	return clusters, nil
+	return matches, nil
 }
 
 func (s *OutputV2Service) render(
@@ -431,6 +460,9 @@ func generateKubeConfigV2WithPlugin(ks *kubernetesStatusV2, destPath string, exe
 			Cluster:  contextName,
 			AuthInfo: ks.teleportClusterName,
 		}
+		if ns, ok := ks.defaultNamespaces[cluster]; ok {
+			config.Contexts[contextName].Namespace = ns
+		}
 
 		// Always set the current context to the first-matched cluster. This
 		// won't be perfectly consistent if the first selector uses labels, so
@@ -477,6 +509,9 @@ func generateKubeConfigV2WithoutPlugin(ks *kubernetesStatusV2) (*clientcmdapi.Co
 		config.Contexts[contextName] = &clientcmdapi.Context{
 			Cluster:  contextName,
 			AuthInfo: ks.teleportClusterName,
+		}
+		if ns, ok := ks.defaultNamespaces[cluster]; ok {
+			config.Contexts[contextName].Namespace = ns
 		}
 
 		if i == 0 {

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -140,6 +140,10 @@ type KubernetesSelector struct {
 	Name string `yaml:"name,omitempty"`
 
 	Labels map[string]string `yaml:"labels,omitempty"`
+	
+	// DefaultNamespace specifies the default namespace that should be set in
+	// the resulting kubeconfig context for clusters yielded by this selector.
+	DefaultNamespace string `yaml:"default_namespace,omitempty"`
 }
 
 // String returns a human-readable representation of the selector for logs.

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -140,7 +140,7 @@ type KubernetesSelector struct {
 	Name string `yaml:"name,omitempty"`
 
 	Labels map[string]string `yaml:"labels,omitempty"`
-	
+
 	// DefaultNamespace specifies the default namespace that should be set in
 	// the resulting kubeconfig context for clusters yielded by this selector.
 	DefaultNamespace string `yaml:"default_namespace,omitempty"`

--- a/lib/tbot/services/k8s/output_v2_config_test.go
+++ b/lib/tbot/services/k8s/output_v2_config_test.go
@@ -49,6 +49,7 @@ func TestKubernetesV2Output_YAML(t *testing.T) {
 						Labels: map[string]string{
 							"foo": "bar",
 						},
+						DefaultNamespace: "foo-namespace",
 					},
 				},
 				CredentialLifetime: bot.CredentialLifetime{

--- a/lib/tbot/services/k8s/output_v2_test.go
+++ b/lib/tbot/services/k8s/output_v2_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apiclient "github.com/gravitational/teleport/api/client"
@@ -129,18 +130,23 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 		selectors            []*KubernetesSelector
 		expectError          require.ErrorAssertionFunc
 		expectedClusterNames []string
+		wantNamespaces       map[string]string
 	}{
 		{
 			name: "matches by name",
 			selectors: []*KubernetesSelector{
 				{
-					Name: "a",
+					Name:             "a",
+					DefaultNamespace: "a selector",
 				},
 				{
 					Name: "c",
 				},
 			},
 			expectedClusterNames: []string{"a", "c"},
+			wantNamespaces: map[string]string{
+				"a": "a selector",
+			},
 		},
 		{
 			name: "errors when direct lookup fails",
@@ -160,9 +166,14 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "1",
 					},
+					DefaultNamespace: "my-namespace",
 				},
 			},
 			expectedClusterNames: []string{"b", "c"},
+			wantNamespaces: map[string]string{
+				"b": "my-namespace",
+				"c": "my-namespace",
+			},
 		},
 		{
 			name: "matches with complex label selector",
@@ -175,6 +186,7 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 				},
 			},
 			expectedClusterNames: []string{"c"},
+			wantNamespaces:       map[string]string{},
 		},
 		{
 			name: "matches with multiple selectors",
@@ -183,6 +195,7 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "1",
 					},
+					DefaultNamespace: "bar",
 				},
 				{
 					Labels: map[string]string{
@@ -194,6 +207,10 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 				},
 			},
 			expectedClusterNames: []string{"a", "b", "c", "d"},
+			wantNamespaces: map[string]string{
+				"b": "bar",
+				"c": "bar",
+			},
 		},
 	}
 
@@ -207,15 +224,21 @@ func TestKubernetesV2OutputService_fetch(t *testing.T) {
 
 				var names []string
 				for _, match := range matches {
-					names = append(names, match.GetName())
+					names = append(names, match.cluster.GetName())
 				}
 
 				// `generate()` dedupes downstream, so we'll replicate that
 				// here, otherwise we might see duplicates if some label
 				// selectors overlap.
 				names = apiutils.Deduplicate(names)
-
-				require.ElementsMatch(t, tt.expectedClusterNames, names)
+				assert.ElementsMatch(t, tt.expectedClusterNames, names)
+				namespaces := make(map[string]string)
+				for _, match := range matches {
+					if match.selector.DefaultNamespace != "" {
+						namespaces[match.cluster.GetName()] = match.selector.DefaultNamespace
+					}
+				}
+				assert.Equal(t, tt.wantNamespaces, namespaces)
 			}
 		})
 	}

--- a/lib/tbot/services/k8s/output_v2_test.go
+++ b/lib/tbot/services/k8s/output_v2_test.go
@@ -305,10 +305,13 @@ func TestKubernetesV2OutputService_render(t *testing.T) {
 			require.NoError(t, err)
 			status := &kubernetesStatusV2{
 				kubernetesClusterNames: []string{"a", "b", "c"},
-				teleportClusterName:    mockClusterName,
-				tlsServerName:          client.GetKubeTLSServerName(mockClusterName),
-				credentials:            keyRing,
-				clusterAddr:            fmt.Sprintf("https://%s:443", mockClusterName),
+				defaultNamespaces: map[string]string{
+					"a": "namespace-a",
+				},
+				teleportClusterName: mockClusterName,
+				tlsServerName:       client.GetKubeTLSServerName(mockClusterName),
+				credentials:         keyRing,
+				clusterAddr:         fmt.Sprintf("https://%s:443", mockClusterName),
 			}
 
 			err = svc.render(

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/absolute_path/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/absolute_path/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/exec_plugin_disabled/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/exec_plugin_disabled/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/relative_path/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/relative_path/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2Output_YAML/full.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2Output_YAML/full.golden
@@ -6,5 +6,6 @@ selectors:
   - name: foo
   - labels:
       foo: bar
+    default_namespace: foo-namespace
 credential_ttl: 1m0s
 renewal_interval: 30s


### PR DESCRIPTION
Backport #58393 to branch/v18

changelog: tbot now supports the configuration of a default namespace for kubeconfig files generated by the `kubernetes/v2` service.
