### PR TITLE
fix: cgroup leak when eBPF recording enabled

### DIFF
--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -260,8 +260,8 @@ func (s *Service) cleanupHierarchy() error {
 		}
 	}
 
-	err = s.Remove("")
-	if err != nil {
+	// Remove root cgroup
+	if err := s.Remove("."); err != nil {
 		logger.ErrorContext(context.TODO(), "Failed to remove root cgroup.", "error", err)
 		return trace.Wrap(err)
 	}

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -260,6 +260,12 @@ func (s *Service) cleanupHierarchy() error {
 		}
 	}
 
+	err = s.Remove("")
+	if err != nil {
+		logger.ErrorContext(context.TODO(), "Failed to remove root cgroup.", "error", err)
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -147,8 +147,6 @@ func TestRootCleanup(t *testing.T) {
 		MountPath: dir,
 	})
 	require.NoError(t, err)
-	const skipUnmount = false
-	defer service.Close(skipUnmount)
 
 	// Create fake session ID and cgroup.
 	sessionID := uuid.New().String()
@@ -162,6 +160,9 @@ func TestRootCleanup(t *testing.T) {
 	// Make sure the cgroup no longer exists.
 	cgroupPath := filepath.Join(service.teleportRoot, sessionID)
 	require.NoDirExists(t, cgroupPath)
+
+	err = service.unmount()
+	require.NoError(t, err)
 }
 
 // TestRootSkipUnmount checks that closing the service with skipUnmount set to

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -189,16 +190,36 @@ func TestRootSkipUnmount(t *testing.T) {
 	const skipUnmount = true
 	require.NoError(t, service.Close(skipUnmount))
 
-	require.DirExists(t, service.teleportRoot)
+	// Check whether cgroup mount path is indeed mounted as cgroup
+	isCgroupMounted, err := isCgroupDir(service.MountPath)
+	require.NoError(t, err)
+	require.True(t, isCgroupMounted)
+
+	require.DirExists(t, service.MountPath)
 	require.NoDirExists(t, filepath.Join(service.teleportRoot, sessionID))
 
 	require.NoError(t, service.unmount())
-
-	require.NoDirExists(t, service.teleportRoot)
+	
+	// Check whether cgroup mount path is no longer mounted as cgroup
+	isCgroupMounted, err = isCgroupDir(service.MountPath)
+	require.NoError(t, err)
+	require.False(t, isCgroupMounted)
 }
 
 // isRoot returns a boolean if the test is being run as root or not. Tests
 // for this package must be run as root.
 func isRoot() bool {
 	return os.Geteuid() == 0
+}
+
+// https://elixir.bootlin.com/linux/v6.16.6/source/include/uapi/linux/magic.h#L71
+const CGROUP2_SUPER_MAGIC = 0x63677270
+
+func isCgroupDir(path string) (bool, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return false, err
+	}
+
+	return st.Type == CGROUP2_SUPER_MAGIC, nil
 }

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -200,7 +200,7 @@ func TestRootSkipUnmount(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(service.teleportRoot, sessionID))
 
 	require.NoError(t, service.unmount())
-	
+
 	// Check whether cgroup mount path is no longer mounted as cgroup
 	isCgroupMounted, err = isCgroupDir(service.MountPath)
 	require.NoError(t, err)
@@ -213,14 +213,11 @@ func isRoot() bool {
 	return os.Geteuid() == 0
 }
 
-// https://elixir.bootlin.com/linux/v6.16.6/source/include/uapi/linux/magic.h#L71
-const CGROUP2_SUPER_MAGIC = 0x63677270
-
 func isCgroupDir(path string) (bool, error) {
 	var st unix.Statfs_t
 	if err := unix.Statfs(path, &st); err != nil {
 		return false, err
 	}
 
-	return st.Type == CGROUP2_SUPER_MAGIC, nil
+	return st.Type == unix.CGROUP2_SUPER_MAGIC, nil
 }


### PR DESCRIPTION
Hey! 

Stumbled on a bug - Teleport tries to manage cgroups and fails to clean up properly. This would be a minor issue if, for example, it only created one cgroup for its operation. But it creates a new one on every restart.

The situation: a machine with a direct connection had its IP changed, and now Teleport cannot bind to the requested `listen_addr`, which results in the service restarting constantly.

<img width="1653" height="559" alt="image" src="https://github.com/user-attachments/assets/6e85e6f8-4914-4ff9-8d56-e84d00e44378" />

Because of that, a new cgroup gets allocated every few seconds, each consuming ~500K of RAM (RestartSec=5, so ~8GB of RAM a day). You can't find this leaked memory in `/proc/meminfo` or with `slabtop` - it took a good hour to debug the issue when I first encountered it. 

I think I patched the problem in the PR, but I am not sure whether my solution is totally correct. However, it does fix the problem at hand.