### PR TITLE
Don't display links in Markdown unless explicitly enabled

### DIFF
--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -63,7 +63,7 @@ const parsers: MarkdownParser[] = [
     render: (activeParsers, content, key) => <code key={key}>{content}</code>,
   },
   {
-    condition: (opts: MarkdownOptions) => opts.enableLinks,
+    condition: (opts: MarkdownOptions) => !!opts.enableLinks,
     pattern: /\[(?<content>[^\]]*)](?:\((?<url>https?:\/\/[^)]+|[^:)]+)\))?/,
     render: (activeParsers, content, key, url) => (
       <StyledLink key={key} href={url}>

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -19,9 +19,23 @@
 import { createElement, useMemo, type ReactNode } from 'react';
 import styled from 'styled-components';
 
+export interface MarkdownOptions {
+  /**
+   * `true` if links should be rendered. Defaults to `false` to protect from
+   * rendering untrusted content posing as Teleport-approved link.
+   */
+  enableLinks?: boolean;
+}
+
 interface MarkdownParser {
+  condition?: (opts: MarkdownOptions) => boolean;
   pattern: RegExp;
-  render: (content: string, key: string, url?: string) => React.ReactNode;
+  render: (
+    activeParsers: MarkdownParser[],
+    content: string,
+    key: string,
+    url?: string
+  ) => React.ReactNode;
 }
 
 interface EarliestMatch {
@@ -40,23 +54,26 @@ const StyledLink = styled.a`
 const parsers: MarkdownParser[] = [
   {
     pattern: /\*\*(?<content>[^*]+?)\*\*/,
-    render: (content, key) => <strong key={key}>{parseLine(content)}</strong>,
+    render: (activeParsers, content, key) => (
+      <strong key={key}>{parseLine(activeParsers, content)}</strong>
+    ),
   },
   {
     pattern: /`(?<content>[^`]+)`/,
-    render: (content, key) => <code key={key}>{content}</code>,
+    render: (activeParsers, content, key) => <code key={key}>{content}</code>,
   },
   {
+    condition: (opts: MarkdownOptions) => opts.enableLinks,
     pattern: /\[(?<content>[^\]]*)](?:\((?<url>https?:\/\/[^)]+|[^:)]+)\))?/,
-    render: (content, key, url) => (
+    render: (activeParsers, content, key, url) => (
       <StyledLink key={key} href={url}>
-        {parseLine(content)}
+        {parseLine(activeParsers, content)}
       </StyledLink>
     ),
   },
 ];
 
-function parseLine(line: string): ReactNode[] {
+function parseLine(activeParsers: MarkdownParser[], line: string): ReactNode[] {
   const items: ReactNode[] = [];
 
   let remaining = line;
@@ -66,7 +83,7 @@ function parseLine(line: string): ReactNode[] {
   while (remaining.length > 0) {
     let earliestMatch: EarliestMatch | null = null;
 
-    for (const parser of parsers) {
+    for (const parser of activeParsers) {
       if (parser.pattern.test(remaining)) {
         const match = parser.pattern.exec(remaining);
 
@@ -94,7 +111,12 @@ function parseLine(line: string): ReactNode[] {
     key += 1;
 
     items.push(
-      parser.render(match.groups!.content, `inline-${key}`, match.groups?.url)
+      parser.render(
+        activeParsers,
+        match.groups!.content,
+        `inline-${key}`,
+        match.groups?.url
+      )
     );
 
     remaining = remaining.substring(match.index + match[0].length);
@@ -107,7 +129,19 @@ const headerRegex = /^(?<hashes>#{1,6})\s*(?<content>.*)$/;
 
 const MAX_ITERATIONS = 10000;
 
-function processMarkdown(text: string) {
+/**
+ * Turns a Markdown string into a list of React nodes. CAUTION: this function
+ * may handle untrusted user input, so think twice before extending it! If you
+ * extend it with something that may possibly cause a security issue if
+ * rendered, make sure to only enable it if a certain option is turned on and
+ * default to disabling it.
+ */
+function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
+  const activeParsers = parsers.filter(p => {
+    if (!p.condition) return true;
+    return p.condition(options);
+  });
+
   const lines = text.split('\n');
 
   const items: ReactNode[] = [];
@@ -152,7 +186,9 @@ function processMarkdown(text: string) {
       const startI = i;
 
       while (i < lines.length && lines[i].trimStart().startsWith('- ')) {
-        listItems.push(<li key={i}>{parseLine(lines[i].substring(2))}</li>);
+        listItems.push(
+          <li key={i}>{parseLine(activeParsers, lines[i].substring(2))}</li>
+        );
 
         i += 1;
 
@@ -188,7 +224,11 @@ function processMarkdown(text: string) {
     }
 
     if (paragraphLines.length > 0) {
-      items.push(<p key={`p-${i}`}>{parseLine(paragraphLines.join(' '))}</p>);
+      items.push(
+        <p key={`p-${i}`}>
+          {parseLine(activeParsers, paragraphLines.join(' '))}
+        </p>
+      );
     }
 
     if (i === startI) {
@@ -199,10 +239,13 @@ function processMarkdown(text: string) {
   return items;
 }
 
-interface MarkdownProps {
+export interface MarkdownProps extends MarkdownOptions {
   text: string;
 }
 
-export function Markdown({ text }: MarkdownProps) {
-  return useMemo(() => processMarkdown(text), [text]);
+export function Markdown({ text, ...options }: MarkdownProps) {
+  return useMemo(
+    () => processMarkdown(text, options),
+    [text, ...Object.values(options)]
+  );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -189,6 +189,11 @@ test('renders rds impacts', async () => {
     header: ['Name'],
     rows: [['i-016e32a5882f5ee81'], ['i-065818031835365cc']],
   });
+  const link = screen.getByRole('link', { name: 'IAM authentication' });
+  expect(link).toHaveAttribute(
+    'href',
+    'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html'
+  );
   jest.resetAllMocks();
 });
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -171,7 +171,7 @@ export function Task({
       <H3 my={2} style={{ overflow: 'unset' }}>
         Details
       </H3>
-      <Markdown text={taskAttempt.data.description} />
+      <Markdown text={taskAttempt.data.description} enableLinks />
       <H3 my={2} style={{ overflow: 'unset' }}>
         Impacted instances ({Object.keys(impacts).length})
       </H3>


### PR DESCRIPTION
This is to prevent displaying links from user-generated content inside session recording summaries. These could potentially be clicked by unsuspecting users, leading them to a malicious site.