### PR TITLE
Remove outdated SSH language in the SSO guide

### DIFF
--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Single Sign-On
-description: How to set up single sign-on (SSO) for SSH using Teleport
+description: How to set up single sign-on (SSO) using Teleport
 labels:
  - conceptual
  - zero-trust
@@ -578,12 +578,12 @@ $ tsh --proxy=proxy.example.com login --auth=local --user=admin
 ```
 
 Refer to the following guides to configure authentication connectors of both
-SAML and OIDC types:
+SAML and OIDC types for your IdP:
 
-- [SSH Authentication with Okta](okta.mdx)
-- [SSH Authentication with OneLogin](one-login.mdx)
-- [SSH Authentication with ADFS](adfs.mdx)
-- [SSH Authentication with OAuth2 / OpenID Connect](oidc.mdx)
+- [Okta](okta.mdx)
+- [OneLogin](one-login.mdx)
+- [ADFS](adfs.mdx)
+- [OAuth2 / OpenID Connect](oidc.mdx)
 
 ## SSO customization
 


### PR DESCRIPTION
Closes #58410

This guide includes some language that implies that SSO is a form of authentication for SSH. While this was true for early versions of Teleport, when we emphasized access to servers using SSH certificates, Teleport now supports a variety of protocols and infrastructure resources.