### PR TITLE
Remove temporary AWS IC APIs

### DIFF
--- a/lib/cache/identitycenter.go
+++ b/lib/cache/identitycenter.go
@@ -94,18 +94,6 @@ func (c *Cache) ListIdentityCenterAccounts(ctx context.Context, pageSize int, pa
 	ctx, span := c.Tracer.Start(ctx, "cache/ListIdentityCenterAccounts")
 	defer span.End()
 
-	accounts, next, err := c.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	return accounts, next, nil
-}
-
-func (c *Cache) ListIdentityCenterAccounts2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.Account, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListIdentityCenterAccounts2")
-	defer span.End()
-
 	rg, err := acquireReadGuard(c, c.collections.identityCenterAccounts)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -113,7 +101,7 @@ func (c *Cache) ListIdentityCenterAccounts2(ctx context.Context, pageSize int, p
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		accounts, next, err := c.Config.IdentityCenter.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
+		accounts, next, err := c.Config.IdentityCenter.ListIdentityCenterAccounts(ctx, pageSize, pageToken)
 		return accounts, next, trace.Wrap(err)
 	}
 
@@ -291,19 +279,11 @@ func (c *Cache) ListPrincipalAssignments(ctx context.Context, pageSize int, page
 	ctx, span := c.Tracer.Start(ctx, "cache/ListPrincipalAssignments")
 	defer span.End()
 
-	out, next, err := c.ListPrincipalAssignments2(ctx, pageSize, pageToken)
-	return out, next, trace.Wrap(err)
-}
-
-func (c *Cache) ListPrincipalAssignments2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListPrincipalAssignments")
-	defer span.End()
-
 	lister := genericLister[*identitycenterv1.PrincipalAssignment, identityCenterPrincipalAssignmentIndex]{
 		cache:        c,
 		collection:   c.collections.identityCenterPrincipalAssignments,
 		index:        identityCenterPrincipalAssignmentNameIndex,
-		upstreamList: c.Config.IdentityCenter.ListPrincipalAssignments2,
+		upstreamList: c.Config.IdentityCenter.ListPrincipalAssignments,
 		nextToken: func(t *identitycenterv1.PrincipalAssignment) string {
 			return t.GetMetadata().GetName()
 		},

--- a/lib/cache/identitycenter_test.go
+++ b/lib/cache/identitycenter_test.go
@@ -56,20 +56,20 @@ func TestIdentityCenterAccount(t *testing.T) {
 			return newIdentityCenterAccount(s), nil
 		},
 		create: func(ctx context.Context, item *identitycenterv1.Account) error {
-			_, err := fixturePack.identityCenter.CreateIdentityCenterAccount2(ctx, item)
+			_, err := fixturePack.identityCenter.CreateIdentityCenterAccount(ctx, item)
 			return trace.Wrap(err)
 		},
 		update: func(ctx context.Context, item *identitycenterv1.Account) error {
-			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccount2(ctx, item)
+			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccount(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.identityCenter.ListIdentityCenterAccounts2,
+		list: fixturePack.identityCenter.ListIdentityCenterAccounts,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteIdentityCenterAccount(
 				ctx, services.IdentityCenterAccountID(id)))
 		},
 		deleteAll: fixturePack.identityCenter.DeleteAllIdentityCenterAccounts,
-		cacheList: fixturePack.cache.ListIdentityCenterAccounts2,
+		cacheList: fixturePack.cache.ListIdentityCenterAccounts,
 		cacheGet:  fixturePack.cache.GetIdentityCenterAccount,
 	}, withSkipPaginationTest())
 }
@@ -111,14 +111,14 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 			_, err := fixturePack.identityCenter.UpdatePrincipalAssignment(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.identityCenter.ListPrincipalAssignments2,
+		list: fixturePack.identityCenter.ListPrincipalAssignments,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeletePrincipalAssignment(ctx, services.PrincipalAssignmentID(id)))
 		},
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAllPrincipalAssignments(ctx))
 		},
-		cacheList: fixturePack.cache.ListPrincipalAssignments2,
+		cacheList: fixturePack.cache.ListPrincipalAssignments,
 		cacheGet: func(ctx context.Context, id string) (*identitycenterv1.PrincipalAssignment, error) {
 			r, err := fixturePack.cache.GetPrincipalAssignment(ctx, services.PrincipalAssignmentID(id))
 			return r, trace.Wrap(err)

--- a/lib/cache/provisioning.go
+++ b/lib/cache/provisioning.go
@@ -86,19 +86,11 @@ func (c *Cache) ListProvisioningStatesForAllDownstreams(ctx context.Context, pag
 	ctx, span := c.Tracer.Start(ctx, "cache/ListProvisioningStatesForAllDownstreams")
 	defer span.End()
 
-	out, next, err := c.ListProvisioningStatesForAllDownstreams2(ctx, pageSize, pageToken)
-	return out, next, trace.Wrap(err)
-}
-
-func (c *Cache) ListProvisioningStatesForAllDownstreams2(ctx context.Context, pageSize int, pageToken string) ([]*provisioningv1.PrincipalState, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListProvisioningStatesForAllDownstreams2")
-	defer span.End()
-
 	lister := genericLister[*provisioningv1.PrincipalState, principalStateIndex]{
 		cache:        c,
 		collection:   c.collections.provisioningStates,
 		index:        principalStateNameIndex,
-		upstreamList: c.Config.ProvisioningStates.ListProvisioningStatesForAllDownstreams2,
+		upstreamList: c.Config.ProvisioningStates.ListProvisioningStatesForAllDownstreams,
 		nextToken: func(t *provisioningv1.PrincipalState) string {
 			return t.GetMetadata().GetName()
 		},

--- a/lib/cache/provisioning_test.go
+++ b/lib/cache/provisioning_test.go
@@ -68,7 +68,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 			_, err := fixturePack.provisioningStates.UpdateProvisioningState(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams2,
+		list: fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteProvisioningState(
 				ctx, testDownstreamID, services.ProvisioningStateID(id)))
@@ -76,7 +76,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteAllProvisioningStates(ctx))
 		},
-		cacheList: fixturePack.cache.ListProvisioningStatesForAllDownstreams2,
+		cacheList: fixturePack.cache.ListProvisioningStatesForAllDownstreams,
 		cacheGet: func(ctx context.Context, id string) (*provisioningv1.PrincipalState, error) {
 			r, err := fixturePack.provisioningStates.GetProvisioningState(
 				ctx, testDownstreamID, services.ProvisioningStateID(id))

--- a/lib/services/identitycenter.go
+++ b/lib/services/identitycenter.go
@@ -63,7 +63,6 @@ type IdentityCenterAccountGetter interface {
 	// ListIdentityCenterAccounts provides a paged list of all known identity
 	// center accounts
 	ListIdentityCenterAccounts(context.Context, int, string) ([]*identitycenterv1.Account, string, error)
-	ListIdentityCenterAccounts2(context.Context, int, string) ([]*identitycenterv1.Account, string, error)
 
 	// GetIdentityCenterAccount fetches a specific Identity Center Account
 	GetIdentityCenterAccount(context.Context, string) (*identitycenterv1.Account, error)
@@ -76,12 +75,10 @@ type IdentityCenterAccounts interface {
 
 	// CreateIdentityCenterAccount creates a new Identity Center Account record
 	CreateIdentityCenterAccount(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
-	CreateIdentityCenterAccount2(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
 
 	// UpdateIdentityCenterAccount performs a conditional update on an Identity
 	// Center Account record, returning the updated record on success.
 	UpdateIdentityCenterAccount(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
-	UpdateIdentityCenterAccount2(context.Context, *identitycenterv1.Account) (*identitycenterv1.Account, error)
 
 	// UpsertIdentityCenterAccount performs an *unconditional* upsert on an
 	// Identity Center Account record, returning the updated record on success.
@@ -106,7 +103,6 @@ type IdentityCenterPrincipalAssignments interface {
 	// ListPrincipalAssignments lists all PrincipalAssignment records in the
 	// service
 	ListPrincipalAssignments(context.Context, int, string) ([]*identitycenterv1.PrincipalAssignment, string, error)
-	ListPrincipalAssignments2(context.Context, int, string) ([]*identitycenterv1.PrincipalAssignment, string, error)
 
 	// CreatePrincipalAssignment creates a new Principal Assignment record in
 	// the service from the supplied in-memory representation. Returns the
@@ -139,7 +135,6 @@ type PermissionSetID string
 type IdentityCenterPermissionSets interface {
 	// ListPermissionSets list the known Permission Sets
 	ListPermissionSets(context.Context, int, string) ([]*identitycenterv1.PermissionSet, string, error)
-	ListPermissionSets2(context.Context, int, string) ([]*identitycenterv1.PermissionSet, string, error)
 
 	// CreatePermissionSet creates a new PermissionSet record based on the
 	// supplied in-memory representation, returning the created record on
@@ -210,14 +205,22 @@ type IdentityCenterAccountAssignments interface {
 	// Account Assignment, returning the updated record on success.
 	UpdateIdentityCenterAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
 
-	// UpsertAccountAssignment performs an unconditional update on the supplied
+	// UpsertIdentityCenterAccountAssignment performs an unconditional update on the supplied
 	// Account Assignment, returning the updated record on success.
-	UpsertAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
+	UpsertIdentityCenterAccountAssignment(context.Context, *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error)
+
+	// DeleteIdentityCenterAccountAssignment deletes a specific account assignment
+	DeleteIdentityCenterAccountAssignment(context.Context, IdentityCenterAccountAssignmentID) error
+
+	// DeleteAllIdentityCenterAccountAssignments deletes all known account assignments
+	DeleteAllIdentityCenterAccountAssignments(context.Context) error
 
 	// DeleteAccountAssignment deletes a specific account assignment
+	// Deprecated: Prefer using DeleteIdentityCenterAccountAssignment
 	DeleteAccountAssignment(context.Context, IdentityCenterAccountAssignmentID) error
 
 	// DeleteAllAccountAssignments deletes all known account assignments
+	// Deprecated: Prefer using DeleteAllIdentityCenterAccountAssignment
 	DeleteAllAccountAssignments(context.Context) error
 }
 

--- a/lib/services/local/identitycenter.go
+++ b/lib/services/local/identitycenter.go
@@ -148,17 +148,6 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 // ListIdentityCenterAccounts provides a paged list of all AWS accounts known
 // to the Identity Center integration
 func (svc *IdentityCenterService) ListIdentityCenterAccounts(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.Account, string, error) {
-	accounts, nextPage, err := svc.ListIdentityCenterAccounts2(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	return accounts, nextPage, nil
-}
-
-// ListIdentityCenterAccounts2 provides a paged list of all AWS accounts known
-// to the Identity Center integration
-func (svc *IdentityCenterService) ListIdentityCenterAccounts2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.Account, string, error) {
 	accounts, nextPage, err := svc.accounts.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center assignment records")
@@ -169,15 +158,6 @@ func (svc *IdentityCenterService) ListIdentityCenterAccounts2(ctx context.Contex
 
 // CreateIdentityCenterAccount creates a new Identity Center Account record
 func (svc *IdentityCenterService) CreateIdentityCenterAccount(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
-	created, err := svc.CreateIdentityCenterAccount2(ctx, acct)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return created, nil
-}
-
-// CreateIdentityCenterAccount2 creates a new Identity Center Account record
-func (svc *IdentityCenterService) CreateIdentityCenterAccount2(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
 	created, err := svc.accounts.CreateResource(ctx, acct)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating identity center account")
@@ -197,16 +177,6 @@ func (svc *IdentityCenterService) GetIdentityCenterAccount(ctx context.Context, 
 // UpdateIdentityCenterAccount performs a conditional update on an Identity
 // Center Account record, returning the updated record on success.
 func (svc *IdentityCenterService) UpdateIdentityCenterAccount(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
-	updated, err := svc.UpdateIdentityCenterAccount2(ctx, acct)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return updated, nil
-}
-
-// UpdateIdentityCenterAccount2 performs a conditional update on an Identity
-// Center Account record, returning the updated record on success.
-func (svc *IdentityCenterService) UpdateIdentityCenterAccount2(ctx context.Context, acct *identitycenterv1.Account) (*identitycenterv1.Account, error) {
 	updated, err := svc.accounts.ConditionalUpdateResource(ctx, acct)
 	if err != nil {
 		return nil, trace.Wrap(err, "updating identity center account record")
@@ -238,15 +208,6 @@ func (svc *IdentityCenterService) DeleteAllIdentityCenterAccounts(ctx context.Co
 
 // ListPrincipalAssignments lists a page of PrincipalAssignment records in the service.
 func (svc *IdentityCenterService) ListPrincipalAssignments(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
-	resp, nextPage, err := svc.ListPrincipalAssignments2(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	return resp, nextPage, nil
-}
-
-// ListPrincipalAssignments2 lists a page of PrincipalAssignment records in the service.
-func (svc *IdentityCenterService) ListPrincipalAssignments2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PrincipalAssignment, string, error) {
 	resp, nextPage, err := svc.principalAssignments.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center assignment records")
@@ -306,16 +267,6 @@ func (svc *IdentityCenterService) DeleteAllPrincipalAssignments(ctx context.Cont
 
 // ListPermissionSets returns a page of known Permission Sets in the managed Identity Center
 func (svc *IdentityCenterService) ListPermissionSets(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PermissionSet, string, error) {
-	resp, nextPage, err := svc.ListPermissionSets2(ctx, pageSize, pageToken)
-	if err != nil {
-		return nil, "", trace.Wrap(err, "listing identity center permission set records")
-	}
-	return resp, nextPage, nil
-}
-
-// ListPermissionSets2 returns a page of known Permission Sets in the managed Identity Center
-func (svc *IdentityCenterService) ListPermissionSets2(ctx context.Context, pageSize int, pageToken string) ([]*identitycenterv1.PermissionSet, string, error) {
-
 	resp, nextPage, err := svc.permissionSets.ListResources(ctx, pageSize, pageToken)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing identity center permission set records")
@@ -372,17 +323,6 @@ func (svc *IdentityCenterService) ListIdentityCenterAccountAssignments(ctx conte
 	return assignments, nextPage, nil
 }
 
-// CreateAccountAssignment creates a new Account Assignment record in
-// the service from the supplied in-memory representation. Returns the
-// created record on success.
-func (svc *IdentityCenterService) CreateAccountAssignment(ctx context.Context, asmt services.IdentityCenterAccountAssignment) (services.IdentityCenterAccountAssignment, error) {
-	created, err := svc.CreateIdentityCenterAccountAssignment(ctx, asmt.AccountAssignment)
-	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
-	}
-	return services.IdentityCenterAccountAssignment{AccountAssignment: created}, nil
-}
-
 // CreateIdentityCenterAccountAssignment creates a new Account Assignment record in
 // the service from the supplied in-memory representation. Returns the
 // created record on success.
@@ -394,15 +334,6 @@ func (svc *IdentityCenterService) CreateIdentityCenterAccountAssignment(ctx cont
 	return created, nil
 }
 
-// GetAccountAssignment fetches a specific Account Assignment record.
-func (svc *IdentityCenterService) GetAccountAssignment(ctx context.Context, name services.IdentityCenterAccountAssignmentID) (services.IdentityCenterAccountAssignment, error) {
-	asmt, err := svc.GetIdentityCenterAccountAssignment(ctx, string(name))
-	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
-	}
-	return services.IdentityCenterAccountAssignment{AccountAssignment: asmt}, nil
-}
-
 // GetIdentityCenterAccountAssignment fetches a specific Account Assignment record.
 func (svc *IdentityCenterService) GetIdentityCenterAccountAssignment(ctx context.Context, name string) (*identitycenterv1.AccountAssignment, error) {
 	asmt, err := svc.accountAssignments.GetResource(ctx, name)
@@ -410,16 +341,6 @@ func (svc *IdentityCenterService) GetIdentityCenterAccountAssignment(ctx context
 		return nil, trace.Wrap(err, "fetching principal assignment")
 	}
 	return asmt, nil
-}
-
-// UpdateAccountAssignment performs a conditional update on the supplied
-// Account Assignment, returning the updated record on success.
-func (svc *IdentityCenterService) UpdateAccountAssignment(ctx context.Context, asmt services.IdentityCenterAccountAssignment) (services.IdentityCenterAccountAssignment, error) {
-	updated, err := svc.UpdateIdentityCenterAccountAssignment(ctx, asmt.AccountAssignment)
-	if err != nil {
-		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
-	}
-	return services.IdentityCenterAccountAssignment{AccountAssignment: updated}, nil
 }
 
 // UpdateIdentityCenterAccountAssignment performs a conditional update on the supplied
@@ -432,9 +353,9 @@ func (svc *IdentityCenterService) UpdateIdentityCenterAccountAssignment(ctx cont
 	return updated, nil
 }
 
-// UpsertAccountAssignment performs an unconditional upsert on the supplied
+// UpsertIdentityCenterAccountAssignment performs an unconditional upsert on the supplied
 // Account Assignment, returning the updated record on success.
-func (svc *IdentityCenterService) UpsertAccountAssignment(ctx context.Context, asmt *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error) {
+func (svc *IdentityCenterService) UpsertIdentityCenterAccountAssignment(ctx context.Context, asmt *identitycenterv1.AccountAssignment) (*identitycenterv1.AccountAssignment, error) {
 	updated, err := svc.accountAssignments.UpsertResource(ctx, asmt)
 	if err != nil {
 		return nil, trace.Wrap(err, "upserting principal assignment record")
@@ -443,11 +364,22 @@ func (svc *IdentityCenterService) UpsertAccountAssignment(ctx context.Context, a
 }
 
 // DeleteAccountAssignment deletes a specific account assignment
+// Deprecated: Prefer using DeleteIdentityCenterAccountAssignment
 func (svc *IdentityCenterService) DeleteAccountAssignment(ctx context.Context, name services.IdentityCenterAccountAssignmentID) error {
+	return trace.Wrap(svc.accountAssignments.DeleteResource(ctx, string(name)))
+}
+
+// DeleteAccountAssignment deletes a specific account assignment
+func (svc *IdentityCenterService) DeleteIdentityCenterAccountAssignment(ctx context.Context, name services.IdentityCenterAccountAssignmentID) error {
 	return trace.Wrap(svc.accountAssignments.DeleteResource(ctx, string(name)))
 }
 
 // DeleteAllAccountAssignments deletes all known account assignments
 func (svc *IdentityCenterService) DeleteAllAccountAssignments(ctx context.Context) error {
+	return trace.Wrap(svc.accountAssignments.DeleteAllResources(ctx))
+}
+
+// DeleteAllIdentityCenterAccountAssignments deletes all known account assignments
+func (svc *IdentityCenterService) DeleteAllIdentityCenterAccountAssignments(ctx context.Context) error {
 	return trace.Wrap(svc.accountAssignments.DeleteAllResources(ctx))
 }

--- a/lib/services/local/identitycenter_test.go
+++ b/lib/services/local/identitycenter_test.go
@@ -69,7 +69,7 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 			},
 			updateResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
 				acct := r.(*identitycenterv1.Account)
-				return svc.UpdateIdentityCenterAccount2(subtestCtx, acct)
+				return svc.UpdateIdentityCenterAccount(subtestCtx, acct)
 			},
 			upsertResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
 				acct := r.(*identitycenterv1.Account)
@@ -109,10 +109,10 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 			},
 			upsertResource: func(subtestCtx context.Context, svc services.IdentityCenter, r types.Resource153) (types.Resource153, error) {
 				asmt := r.(*identitycenterv1.AccountAssignment)
-				return svc.UpsertAccountAssignment(subtestCtx, asmt)
+				return svc.UpsertIdentityCenterAccountAssignment(subtestCtx, asmt)
 			},
 			deleteAllResources: func(subtestCtx context.Context, svc services.IdentityCenter) error {
-				return svc.DeleteAllAccountAssignments(subtestCtx)
+				return svc.DeleteAllIdentityCenterAccountAssignments(subtestCtx)
 			},
 		},
 		{
@@ -270,7 +270,7 @@ func TestIdentityCenterResourceCRUD(t *testing.T) {
 
 func makeTestIdentityCenterAccount(t *testing.T, ctx context.Context, svc services.IdentityCenter, id string) *identitycenterv1.Account {
 	t.Helper()
-	created, err := svc.CreateIdentityCenterAccount2(ctx, &identitycenterv1.Account{
+	created, err := svc.CreateIdentityCenterAccount(ctx, &identitycenterv1.Account{
 		Kind:     types.KindIdentityCenterAccount,
 		Version:  types.V1,
 		Metadata: &headerv1.Metadata{Name: id},

--- a/lib/services/local/provisioningstates.go
+++ b/lib/services/local/provisioningstates.go
@@ -151,22 +151,6 @@ func (ss *ProvisioningStateService) ListProvisioningStatesForAllDownstreams(
 	pageSize int,
 	token string,
 ) ([]*provisioningv1.PrincipalState, string, error) {
-	resp, nextPage, err := ss.ListProvisioningStatesForAllDownstreams2(ctx, pageSize, token)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	return resp, nextPage, nil
-}
-
-// ListProvisioningStatesForAllDownstreams2 lists all provisioning state records for all
-// downstream receivers. Note that the returned record names may not be unique
-// across all downstream receivers. Check the records' `DownstreamID` field
-// to disambiguate.
-func (ss *ProvisioningStateService) ListProvisioningStatesForAllDownstreams2(
-	ctx context.Context,
-	pageSize int,
-	token string,
-) ([]*provisioningv1.PrincipalState, string, error) {
 	resp, nextPage, err := ss.service.ListResources(ctx, pageSize, token)
 	if err != nil {
 		return nil, "", trace.Wrap(err, "listing provisioning state records")

--- a/lib/services/provisioningstates.go
+++ b/lib/services/provisioningstates.go
@@ -82,7 +82,6 @@ type ProvisioningStates interface {
 	// may not be unique across all downstream receivers. Check the records'
 	// `DownstreamID` field to disambiguate.
 	ListProvisioningStatesForAllDownstreams(context.Context, int, string) ([]*provisioningv1.PrincipalState, string, error)
-	ListProvisioningStatesForAllDownstreams2(context.Context, int, string) ([]*provisioningv1.PrincipalState, string, error)
 
 	// DeleteAllProvisioningStates deletes all provisioning state records for
 	// all downstream receivers.


### PR DESCRIPTION
This is the last leg in follow ups to https://github.com/gravitational/teleport/pull/56703. The temporary APIs have been replaced with their final variant now that teleport.e has been updated to call them.