### PR TITLE
[v18] Forward MySQL attributes and capabilities to agent

### DIFF
--- a/lib/srv/db/mysql/engine_test.go
+++ b/lib/srv/db/mysql/engine_test.go
@@ -35,9 +35,11 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
 }

--- a/lib/srv/db/mysql/handshake.go
+++ b/lib/srv/db/mysql/handshake.go
@@ -1,0 +1,308 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysql
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/server"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
+)
+
+const (
+	// magicProxyReply is sent from proxy to the agent if, and only if, the proxy receives the agent's indication that it would like to handshake.
+	// to indicate that the
+	// proxy supports a full MySQL handshake and is waiting for the agent to
+	// initiate it.
+	// TODO(gavin): DELETE IN 21.0.0
+	magicProxyReply = "ready-for-handshake"
+	// emptyPassword is used as a fake credential because auth is already handled via mTLS.
+	emptyPassword = ""
+	// clientNameParamName defines the application name parameter name.
+	// This is used to set the session context's user agent.
+	//
+	// https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
+	clientNameParamName = "_client_name"
+	// handshakeModeEnvVar overrides the default MySQL handshake mode for the
+	// proxy and/or agent.
+	// Only exact string enum values are supported, see [handshakeMode].
+	handshakeModeEnvVar = "TELEPORT_MYSQL_DB_HANDSHAKE_MODE"
+)
+
+// handshakeMode determines the MySQL handshake behavior of the proxy or agent.
+type handshakeMode string
+
+// handshakeModeLogKey is the slog attribute key for handshake mode.
+const handshakeModeLogKey = "handshake_mode"
+
+const (
+	// handshakeWhenSupported makes the agent or proxy perform a MySQL handshake
+	// only when the other party supports a MySQL handshake. Handshake support
+	// is determined via a magic "OK" packet value sent by the agent and a
+	// corresponding magic proxy reply:
+	// +-------------------+                +----------------------+
+	// |  Teleport Proxy   |                |  Teleport DB Agent   |
+	// +-------------------+                +----------------------+
+	//            |                                    |
+	//            |--- Connect (reverse tunnel) ------>|
+	//            |                                    |
+	//            |<----------- OK packet -------------|
+	//            |                                    |
+	//            |      (If "magic" OK packet)        |
+	//         +------------------------------------------+
+	//         |  |                                    |  |
+	//         |  |--- "magic" reply ----------------->|  |
+	//         |  |                                    |  |
+	//         |  |<----- Init MySQL handshake --------|  |
+	//         |                                          |
+	//         +------------------------------------------+
+	// In v20 we can be sure that the proxy will support MySQL handshakes, so
+	// the agent can stop sending the OK packet to initiate a handshake and
+	// instead initiate a partial handshake with the proxy, dial the real
+	// database, and then complete the MySQL handshake with by sending OK.
+	// Since the agent will no longer have to send the initial OK packet, we
+	// will no longer have to worry about an older proxy telling the real client
+	// that the connection is ready without the proxy having completed a
+	// MySQL handshake with the agent first.
+	// This will allow us to forward client capabilities without mangling
+	// connection error propagation to the real client.
+	handshakeWhenSupported handshakeMode = "when_supported"
+	// handshakeAlways makes the agent or proxy unconditionally attempt a MySQL
+	// handshake after the proxy dials the agent, without waiting for the magic
+	// OK packet / proxy reply.
+	handshakeAlways handshakeMode = "always"
+	// handshakeDisabled disables MySQL handshake on the proxy or agent.
+	handshakeDisabled handshakeMode = "disabled"
+)
+
+func getHandshakeMode() handshakeMode {
+	switch handshakeMode(os.Getenv(handshakeModeEnvVar)) {
+	case handshakeWhenSupported, "":
+		// the default setting without env var override
+		return handshakeWhenSupported
+	case handshakeAlways:
+		return handshakeAlways
+	default:
+		return handshakeDisabled
+	}
+}
+
+// waitForAgent waits for the agent to indicate to the proxy that the connection
+// is ready.
+func waitForAgent(ctx context.Context, log *slog.Logger, mode handshakeMode, serviceConn net.Conn, handshakeOpts ...client.Option) error {
+	log = log.With(handshakeModeLogKey, mode)
+	if err := serviceConn.SetReadDeadline(time.Now().Add(2 * defaults.DatabaseConnectTimeout)); err != nil {
+		return trace.Wrap(err)
+	}
+	defer serviceConn.SetReadDeadline(time.Time{})
+
+	switch mode {
+	case handshakeDisabled:
+		log.DebugContext(ctx, "Waiting for OK packet from the database agent")
+		_, err := waitForOKPacket(serviceConn)
+		return trace.Wrap(err)
+	case handshakeWhenSupported:
+		bufConn := protocol.NewBufferedConn(ctx, serviceConn)
+		serviceConn = bufConn
+		isHandshakeV10, err := protocol.IsHandshakeV10Packet(bufConn)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if isHandshakeV10 {
+			log.DebugContext(ctx, "Received a handshake v10 packet")
+		} else {
+			log.DebugContext(ctx, "Waiting for magic OK packet from the database agent")
+			pkt, err := waitForOKPacket(serviceConn)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if !isMagicOKResult(pkt) {
+				return nil
+			}
+			if err := sendMagicProxyReply(serviceConn); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	case handshakeAlways:
+	}
+
+	log.DebugContext(ctx, "Performing a MySQL handshake with the database agent")
+	return trace.Wrap(handshakeWithAgent(ctx, serviceConn, handshakeOpts...))
+}
+
+// isMagicOKResult returns true if the OK packet received from the agent has
+// non-zero affected rows.
+// This method can be deleted after agents are updated to always initiate a
+// MySQL handshake without negotiating one with the magic OK packet.
+// TODO(gavin): DELETE IN 21.0.0
+func isMagicOKResult(packet *protocol.OK) bool {
+	return packet != nil && packet.HasAffectedRows()
+}
+
+func sendMagicProxyReply(conn net.Conn) error {
+	if _, err := conn.Write([]byte{byte(len(magicProxyReply))}); err != nil {
+		return trace.Wrap(err)
+	}
+	_, err := io.Copy(conn, strings.NewReader(magicProxyReply))
+	return trace.Wrap(err)
+}
+
+func handshakeWithAgent(ctx context.Context, serviceConn net.Conn, options ...client.Option) error {
+	_, err := client.ConnectWithDialer(ctx, "tcp", "stubAddr",
+		"stubUser",
+		emptyPassword,
+		"stubDB",
+		func(_ context.Context, _, _ string) (net.Conn, error) {
+			return serviceConn, nil
+		},
+		options...,
+	)
+	return trace.Wrap(err)
+}
+
+// notifyProxy notifies the proxy that the connection is ready on the agent side.
+func notifyProxy(ctx context.Context, log *slog.Logger, mode handshakeMode, proxyConn *server.Conn) error {
+	log = log.With(handshakeModeLogKey, mode)
+	// no matter the path we take, the client will expect the sequence number to
+	// start with zero as we enter the command phase, and a mismatch could cause
+	// sequence number errors
+	defer proxyConn.ResetSequence()
+	switch mode {
+	case handshakeDisabled:
+		// Send back OK packet to indicate auth/connect success. At this point
+		// the original client should consider the connection phase completed.
+		log.DebugContext(ctx, "Notifying the proxy of connection success with an empty OK packet")
+		return trace.Wrap(proxyConn.WriteOK(nil))
+	case handshakeWhenSupported:
+		log.DebugContext(ctx, "Sending a magic OK packet to the proxy to request a MySQL handshake")
+		if err := proxyConn.WriteOK(newMagicOKResult()); err != nil {
+			return trace.Wrap(err)
+		}
+		proxyConn.ResetSequence()
+		bufConn := protocol.NewBufferedConn(ctx, proxyConn.Conn.Conn)
+		proxyConn.Conn.Conn = bufConn
+		const magicReplyTimeout = 5 * time.Second
+		log.DebugContext(ctx, "Waiting for magic reply from the proxy",
+			"timeout", magicReplyTimeout,
+		)
+		found, err := waitForMagicProxyReply(bufConn, magicReplyTimeout)
+		if err != nil {
+			log.DebugContext(ctx, "The proxy did not reply to the request for a MySQL handshake, assuming that this proxy does not support MySQL handshakes",
+				"error", err,
+			)
+			return nil
+		}
+		if !found {
+			return nil
+		}
+	case handshakeAlways:
+	}
+
+	log.DebugContext(ctx, "Performing a MySQL handshake with the proxy")
+	return trace.Wrap(handshakeWithProxy(proxyConn))
+}
+
+// newMagicOKResult is sent by the DB agent to tell the proxy to tell the proxy
+// that the agent would like to perform a MySQL handshake.
+// The proxy checks for the magic OK packet to determine if it should perform a
+// full MySQL handshake to forward the real client's attributes and,
+// eventually, capabilities.
+// This ceremony is required for backwards compatibility, since we
+// historically only had the proxy wait for an "ok" packet without doing a
+// MySQL protocol handshake with the agent.
+// Any non-zero value for the OK packet's affected rows will work.
+// TODO(gavin): DELETE IN 20.0.0
+func newMagicOKResult() *mysql.Result {
+	return &mysql.Result{AffectedRows: 42}
+}
+
+// waitForMagicProxyReply peeks into the connection looking for the proxy reply,
+// returning true and advancing its connection reader if, and only if, the proxy
+// reply is found.
+// If an older proxy doesn't send the reply, then the bytes we peek into
+// will be from the real client. We could block indefinitely until the real
+// client sends some commands, but that would delay the session start event.
+// Normally, clients like libmysql will send some startup commands anyway, but
+// by enforcing a timeout we can be sure the session start event will be emitted
+// even if the client doesn't send any commands.
+// This is out of an abundance of caution - I can't actually foresee a problem
+// with delaying session start until the client sends some bytes, since the
+// client will be unable to do anything with the session otherwise.
+// TODO(gavin): DELETE IN 20.0.0
+func waitForMagicProxyReply(conn protocol.BufferedConn, timeout time.Duration) (found bool, err error) {
+	if timeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			return false, trace.Wrap(err)
+		}
+		defer conn.SetReadDeadline(time.Time{})
+	}
+	defer func() {
+		if err != nil && (errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, io.EOF)) {
+			err = nil
+		}
+	}()
+	payloadLen, err := conn.Peek(1)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	wantBytes := []byte(magicProxyReply)
+	if int(payloadLen[0]) != len(wantBytes) {
+		return false, nil
+	}
+	buf, err := conn.Peek(len(wantBytes) + 1)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if bytes.Equal(buf[1:], wantBytes) {
+		_, _ = conn.Discard(len(buf))
+		return true, nil
+	}
+	return false, nil
+}
+
+func handshakeWithProxy(proxyConn *server.Conn) error {
+	if err := proxyConn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return trace.Wrap(err)
+	}
+	defer proxyConn.SetReadDeadline(time.Time{})
+	if err := proxyConn.WriteInitialHandshake(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := proxyConn.ReadHandshakeResponse(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := proxyConn.WriteOK(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	proxyConn.ResetSequence()
+	return nil
+}

--- a/lib/srv/db/mysql/handshake_test.go
+++ b/lib/srv/db/mysql/handshake_test.go
@@ -1,0 +1,290 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysql
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
+)
+
+func TestSendMagicProxyReply(t *testing.T) {
+	conn := &bufferedTestConn{}
+	err := sendMagicProxyReply(conn)
+	require.NoError(t, err)
+	got, err := io.ReadAll(conn)
+	require.NoError(t, err)
+	require.Equal(t, []byte("\x13ready-for-handshake"), got)
+}
+
+func TestWaitForMagicProxyReply(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		desc       string
+		input      []byte
+		modifyConn func(t *testing.T, conn *fakeServerConn)
+		timeout    time.Duration
+		wantFound  bool
+		wantErr    error
+	}{
+		{
+			desc: "handles EOF when looking for length header",
+			modifyConn: func(t *testing.T, conn *fakeServerConn) {
+				conn.clt.Close()
+			},
+		},
+		{
+			desc:  "length header does not match",
+			input: []byte("\x12ready-for-handshake"),
+		},
+		{
+			desc:  "handles EOF when looking for payload",
+			input: []byte("\x13llama-lied"),
+			modifyConn: func(t *testing.T, conn *fakeServerConn) {
+				conn.clt.Close()
+			},
+		},
+		{
+			desc:  "payload doesnt match",
+			input: []byte("\x13llama-was-disguised"),
+		},
+		{
+			desc:      "found match",
+			input:     []byte("\x13ready-for-handshake"),
+			wantFound: true,
+		},
+		{
+			desc:    "handles timeout gracefully",
+			timeout: time.Millisecond * 100,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			conn := newFakeServerConn(t, test.input)
+			if test.modifyConn != nil {
+				test.modifyConn(t, conn)
+			}
+			bufConn := protocol.NewBufferedConn(ctx, conn)
+			found, err := waitForMagicProxyReply(bufConn, test.timeout)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantFound, found)
+			require.NoError(t, conn.clt.Close())
+			remaining, err := io.ReadAll(bufConn)
+			require.NoError(t, err)
+			if found {
+				require.Empty(t, remaining, "should discard the matched bytes")
+			} else {
+				want := test.input
+				if want == nil {
+					want = []byte{}
+				}
+				require.Equal(t, want, remaining, "should not advance the buffered conn reader if the proxy reply is not found")
+			}
+		})
+	}
+}
+
+func TestHandshakeModes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc               string
+		agentHandshakeMode handshakeMode
+		wantAgentError     string
+		proxyHandshakeMode handshakeMode
+		wantProxyError     string
+		wantHandshake      bool
+	}{
+		{
+			agentHandshakeMode: handshakeDisabled,
+			proxyHandshakeMode: handshakeDisabled,
+		},
+		{
+			agentHandshakeMode: handshakeWhenSupported,
+			proxyHandshakeMode: handshakeDisabled,
+		},
+		{
+			agentHandshakeMode: handshakeDisabled,
+			proxyHandshakeMode: handshakeWhenSupported,
+		},
+		{
+			agentHandshakeMode: handshakeWhenSupported,
+			proxyHandshakeMode: handshakeWhenSupported,
+			wantHandshake:      true,
+		},
+		{
+			agentHandshakeMode: handshakeAlways,
+			proxyHandshakeMode: handshakeWhenSupported,
+			wantHandshake:      true,
+		},
+		{
+			agentHandshakeMode: handshakeAlways,
+			proxyHandshakeMode: handshakeAlways,
+			wantHandshake:      true,
+		},
+		// always and disabled are not compatible
+		{
+			agentHandshakeMode: handshakeAlways,
+			wantAgentError:     "EOF",
+			proxyHandshakeMode: handshakeDisabled,
+			wantProxyError:     "expected OK or ERR packet",
+		},
+		{
+			agentHandshakeMode: handshakeDisabled,
+			proxyHandshakeMode: handshakeAlways,
+			wantProxyError:     "invalid protocol",
+		},
+		// proxy has to be upgraded last, it cant be changed to always
+		// handshake until all supported agents will always handshake
+		{
+			agentHandshakeMode: handshakeWhenSupported,
+			proxyHandshakeMode: handshakeAlways,
+			wantProxyError:     "invalid protocol",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("agent handshake %v proxy handshake %v", test.agentHandshakeMode, test.proxyHandshakeMode), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			agentProxyConn, proxyAgentConn := net.Pipe()
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			// agent
+			var agentMySQLServer *server.Conn
+			go func() {
+				defer wg.Done()
+				defer agentProxyConn.Close()
+				agentMySQLServer = makeProxyConn(agentProxyConn)
+				log := slog.With(teleport.ComponentKey, teleport.ComponentDatabase)
+				err := notifyProxy(ctx, log, test.agentHandshakeMode, agentMySQLServer)
+				if test.wantAgentError != "" {
+					assert.ErrorContains(t, err, test.wantAgentError)
+					return
+				}
+				if !assert.NoError(t, err) {
+					return
+				}
+				if test.wantHandshake {
+					assert.NotEmpty(t, agentMySQLServer.Attributes())
+					assert.Equal(t, "llama", agentMySQLServer.Attributes()["species"])
+				} else {
+					assert.Empty(t, agentMySQLServer.Attributes())
+				}
+				assert.Zero(t, agentMySQLServer.Sequence)
+				assertEmptyConn(t, agentMySQLServer.Conn)
+			}()
+
+			// proxy
+			go func() {
+				defer wg.Done()
+				defer proxyAgentConn.Close()
+				log := slog.With(teleport.ComponentKey, teleport.ComponentProxy)
+				err := waitForAgent(ctx, log, test.proxyHandshakeMode, proxyAgentConn, func(c *client.Conn) error {
+					c.SetAttributes(map[string]string{"species": "llama"})
+					return nil
+				})
+				if test.wantProxyError != "" {
+					assert.ErrorContains(t, err, test.wantProxyError)
+					return
+				}
+				if !assert.NoError(t, err) {
+					return
+				}
+				assertEmptyConn(t, proxyAgentConn)
+			}()
+
+			wg.Wait()
+		})
+	}
+}
+
+func assertEmptyConn(t *testing.T, conn net.Conn) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	defer conn.SetReadDeadline(time.Time{})
+	buf := make([]byte, 1)
+	n, _ := conn.Read(buf)
+	assert.Zero(t, n)
+}
+
+type bufferedTestConn struct {
+	net.Conn
+
+	buf bytes.Buffer
+}
+
+func (c *bufferedTestConn) Read(b []byte) (n int, err error) {
+	return c.buf.Read(b)
+}
+
+func (c *bufferedTestConn) Write(b []byte) (n int, err error) {
+	return c.buf.Write(b)
+}
+
+func newFakeServerConn(t *testing.T, input []byte) *fakeServerConn {
+	// we use a pipe just to closely resemble a real connection and simulate timeouts
+	clt, srv := net.Pipe()
+	t.Cleanup(func() {
+		clt.Close()
+		srv.Close()
+	})
+
+	return &fakeServerConn{
+		Conn: srv,
+		clt:  clt,
+		buf:  bytes.NewBuffer(input),
+	}
+}
+
+type fakeServerConn struct {
+	net.Conn
+	// reads beyond the buffered input may block until this end of the pipe is closed
+	clt net.Conn
+
+	buf     *bytes.Buffer
+	readErr error
+}
+
+func (c *fakeServerConn) Read(b []byte) (n int, err error) {
+	if c.readErr != nil {
+		return 0, c.readErr
+	}
+	return io.MultiReader(c.buf, c.Conn).Read(b)
+}
+
+func (c *fakeServerConn) Write(b []byte) (n int, err error) {
+	return c.buf.Write(b)
+}

--- a/lib/srv/db/mysql/protocol/packet_test.go
+++ b/lib/srv/db/mysql/protocol/packet_test.go
@@ -26,7 +26,11 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
+	mysqlpacket "github.com/go-mysql-org/go-mysql/packet"
+	"github.com/go-mysql-org/go-mysql/server"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -469,6 +473,58 @@ func TestParsePacket(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOKHasAffectedRows(t *testing.T) {
+	tests := []struct {
+		desc         string
+		affectedRows uint64
+		want         bool
+	}{
+		{
+			desc: "does not have affected rows",
+			want: false,
+		},
+		{
+			desc:         "has affected rows",
+			affectedRows: 42,
+			want:         true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			conn := &fakeConn{}
+			serverConn := &server.Conn{Conn: mysqlpacket.NewConn(conn)}
+			err := serverConn.WriteOK(&mysql.Result{AffectedRows: test.affectedRows})
+			require.NoError(t, err)
+			pkt, err := ParsePacket(conn)
+			require.NoError(t, err)
+			assert.Equal(t, &OK{
+				packet: packet{
+					bytes: []byte{
+						0x03, 0x00, 0x00, 0x00, // header
+						0x00, // type
+						byte(test.affectedRows),
+						0x00, // insert id
+					},
+				},
+			}, pkt)
+			assert.Equal(t, test.want, pkt.(*OK).HasAffectedRows())
+		})
+	}
+}
+
+type fakeConn struct {
+	net.Conn
+	buf bytes.Buffer
+}
+
+func (c *fakeConn) Read(b []byte) (n int, err error) {
+	return c.buf.Read(b)
+}
+
+func (c *fakeConn) Write(b []byte) (n int, err error) {
+	return c.buf.Write(b)
 }
 
 func isUnexpectedEOFError(err error) bool {

--- a/lib/srv/db/mysql/protocol/response.go
+++ b/lib/srv/db/mysql/protocol/response.go
@@ -28,6 +28,13 @@ import (
 // https://mariadb.com/kb/en/ok_packet/
 type OK struct {
 	packet
+
+	AffectedRows uint64
+}
+
+// HasAffectedRows returns true if the packet has non-zero affected rows.
+func (o *OK) HasAffectedRows() bool {
+	return o.packet.Bytes()[packetHeaderAndTypeSize] > 0
 }
 
 // Error represents the ERR packet.

--- a/lib/srv/db/mysql/protocol/version.go
+++ b/lib/srv/db/mysql/protocol/version.go
@@ -49,7 +49,7 @@ func FetchMySQLVersionInternal(ctx context.Context, dialer client.Dialer, databa
 		}
 	}
 
-	connBuf := newBufferedConn(ctx, conn)
+	connBuf := NewBufferedConn(ctx, conn)
 	pkgType, err := connBuf.Peek(5)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -99,25 +99,48 @@ func readHandshakeError(connBuf io.Reader) (string, error) {
 	return "", trace.ConnectionProblem(errors.New("failed to fetch MySQL version"), "%s", errPackage.Error())
 }
 
-// connReader is a net.Conn wrapper with additional Peek() method.
-type connReader struct {
+// IsHandshakeV10Packet peeks into the conn and checks for a handshake v10 packet.
+// The results of this function are only meaningful during the connection phase
+// of the MySQL protocol. It is the caller's responsibility to only use this
+// function during the connection phase.
+// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
+func IsHandshakeV10Packet(conn BufferedConn) (bool, error) {
+	pkgHeaderAndType, err := conn.Peek(packetHeaderAndTypeSize)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	const typeIdx = packetHeaderAndTypeSize - 1
+	return pkgHeaderAndType[typeIdx] == 10, nil
+}
+
+// BufferedConn is a net.Conn wrapper with additional Peek() method.
+type BufferedConn struct {
 	ctx    context.Context
 	reader *bufio.Reader
 	net.Conn
 }
 
-// newBufferedConn is a connReader constructor.
-func newBufferedConn(ctx context.Context, conn net.Conn) connReader {
-	return connReader{
+// NewBufferedConn wraps a [net.Conn] in a new [BufferedConn].
+func NewBufferedConn(ctx context.Context, conn net.Conn) BufferedConn {
+	return BufferedConn{
 		ctx:    ctx,
 		reader: bufio.NewReader(conn),
 		Conn:   conn,
 	}
 }
 
+// Discard discards n bytes from the reader.
+// It's basically a wrapper around (bufio.Reader).Discard()
+func (b BufferedConn) Discard(n int) (discarded int, err error) {
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return b.reader.Discard(n)
+}
+
 // Peek reads n bytes without advancing the reader.
 // It's basically a wrapper around (bufio.Reader).Peek()
-func (b connReader) Peek(n int) ([]byte, error) {
+func (b BufferedConn) Peek(n int) ([]byte, error) {
 	if err := b.ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -125,7 +148,7 @@ func (b connReader) Peek(n int) ([]byte, error) {
 }
 
 // Read returns data from underlying buffer.
-func (b connReader) Read(p []byte) (int, error) {
+func (b BufferedConn) Read(p []byte) (int, error) {
 	if err := b.ctx.Err(); err != nil {
 		return 0, err
 	}

--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -24,14 +24,13 @@ import (
 	"log/slog"
 	"net"
 	"runtime/debug"
-	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -82,11 +81,11 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	// has a chance to close the connection from its side.
 	defer func() {
 		if r := recover(); r != nil {
-			p.Log.WarnContext(ctx, "Recovered in MySQL proxy while handling connectionv.", "from", clientConn.RemoteAddr(), "problem", r, "stack", debug.Stack())
+			p.Log.WarnContext(ctx, "Recovered in MySQL proxy while handling connection.", "from", clientConn.RemoteAddr(), "problem", r, "stack", debug.Stack())
 			err = trace.BadParameter("failed to handle MySQL client connection")
 		}
 		if err != nil {
-			if writeErr := mysqlServer.WriteError(err); writeErr != nil {
+			if writeErr := mysqlServer.WriteError(trace.Unwrap(err)); writeErr != nil {
 				p.Log.DebugContext(ctx, "Failed to send error to MySQL client.", "original_err", err.Error(), "error", writeErr)
 			}
 		}
@@ -131,9 +130,23 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	// Before replying OK to the client which would make the client consider
 	// auth completed, wait for OK packet from db service indicating auth
 	// success.
-	err = p.waitForOK(mysqlServer, serviceConn)
+	err = waitForAgent(ctx, p.Log, getHandshakeMode(), serviceConn, func(c *client.Conn) error {
+		// forward (client & proxy) caps to get (client & proxy & agent) caps
+		// to the agent.
+		c.SetCapability(mysqlServer.Capability())
+		// forward attributes, notably: "_client_name" (user agent)
+		c.SetAttributes(mysqlServer.Attributes())
+		return nil
+	})
 	if err != nil {
+		p.Log.ErrorContext(ctx, "Failed to wait for agent connection notification",
+			"error", err,
+		)
 		return trace.Wrap(err)
+	}
+	// now tell the real client we are ready
+	if err := mysqlServer.WriteOK(nil); err != nil {
+		return trace.Wrap(err, "failed to write OK to real client")
 	}
 	// Auth has completed, the client enters command phase, start proxying
 	// all messages back-and-forth.
@@ -167,8 +180,10 @@ func getServerVersionFromCtx(ctx context.Context, configEngineVersion string) st
 // It's a no-op because authentication is done via mTLS.
 type credentialProvider struct{}
 
-func (p *credentialProvider) CheckUsername(_ string) (bool, error)         { return true, nil }
-func (p *credentialProvider) GetCredential(_ string) (string, bool, error) { return "", true, nil }
+func (p *credentialProvider) CheckUsername(_ string) (bool, error) { return true, nil }
+func (p *credentialProvider) GetCredential(_ string) (string, bool, error) {
+	return emptyPassword, true, nil
+}
 
 // makeServer creates a MySQL server from the accepted client connection that
 // provides access to various parts of the handshake.
@@ -245,27 +260,14 @@ func (p *Proxy) maybeReadProxyLine(ctx context.Context, conn *multiplexer.Conn) 
 	return nil
 }
 
-// waitForOK waits for OK_PACKET from the database service which indicates
-// that auth on the other side completed successfully.
-func (p *Proxy) waitForOK(server *server.Conn, serviceConn net.Conn) error {
-	err := serviceConn.SetReadDeadline(time.Now().Add(2 * defaults.DatabaseConnectTimeout))
-	if err != nil {
-		return trace.Wrap(err)
-	}
+func waitForOKPacket(serviceConn net.Conn) (*protocol.OK, error) {
 	packet, err := protocol.ParsePacket(serviceConn)
 	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = serviceConn.SetReadDeadline(time.Time{})
-	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	switch p := packet.(type) {
 	case *protocol.OK:
-		err = server.WriteOK(nil)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		return p, nil
 	case *protocol.Error:
 		// There may be a difference in capabilities between client <--> proxy
 		// than there is between proxy <--> agent, most notably,
@@ -273,14 +275,10 @@ func (p *Proxy) waitForOK(server *server.Conn, serviceConn net.Conn) error {
 		// So rather than forwarding packet bytes directly, convert the error
 		// packet into MyError and write with respect to caps between
 		// client <--> proxy.
-		err = server.WriteError(mysql.NewError(p.Code, p.Message))
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		return nil, trace.Wrap(mysql.NewError(p.Code, p.Message))
 	default:
-		return trace.BadParameter("expected OK or ERR packet, got %s", packet)
+		return nil, trace.BadParameter("expected OK or ERR packet, got %s", packet)
 	}
-	return nil
 }
 
 const (


### PR DESCRIPTION
Backports #57796 to branch/v18.
- #57796

Changelog: Added user_agent field to MySQL database session start audit events.