### PR TITLE
Add metrics for `healthcheck` package

### DIFF
--- a/api/types/target_health.go
+++ b/api/types/target_health.go
@@ -46,6 +46,8 @@ const (
 
 // Canonical converts a status into its canonical form.
 // An empty or unknown status is converted to [TargetHealthStatusUnknown].
+//
+// Returns only a healthy, unhealthy, or unknown status.
 func (s TargetHealthStatus) Canonical() TargetHealthStatus {
 	switch s {
 	case TargetHealthStatusHealthy, TargetHealthStatusUnhealthy:

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -221,6 +221,14 @@ The following table identifies all metrics available for incoming connections.
 | `teleport_cache_stale_events` | counter | Teleport | Number of stale events received by a Teleport service cache. A high percentage of stale events can indicate a degraded backend. |
 | `tx` | counter | Teleport | Number of bytes transmitted during an SSH connection. |
 
+## Teleport Health Checks
+
+| Name                                         | Type  | Component             | Description                                     |
+|----------------------------------------------|-------|-----------------------|-------------------------------------------------|
+| `teleport_resources_health_status_healthy`   | gauge | Teleport Health Check | Number of healthy resources.                    |
+| `teleport_resources_health_status_unhealthy` | gauge | Teleport Health Check | Number of unhealthy resources.                  |
+| `teleport_resources_health_status_unknown`   | gauge | Teleport Health Check | Number of resources in an unknown health state. |
+
 ## Go runtime metrics
 
 These metrics are surfaced by the Go runtime and are not specific to Teleport.

--- a/lib/healthcheck/manager_test.go
+++ b/lib/healthcheck/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
@@ -134,7 +135,7 @@ func TestManager(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	eventsCh := make(chan testEvent, 1024)
 	mgr, err := NewManager(ctx, ManagerConfig{
-		Component:               "test",
+		Component:               teleport.ComponentDatabase,
 		Events:                  local.NewEventsService(bk),
 		HealthCheckConfigReader: healthConfigSvc,
 		Clock:                   clock,

--- a/metrics.go
+++ b/metrics.go
@@ -277,6 +277,24 @@ const (
 	// MetricTeleportServices tracks which services are currently running in the current Teleport Process.
 	MetricTeleportServices = "services"
 
+	// MetricResourcesHealthStatus tracks resource health status.
+	MetricResourcesHealthStatus = "resources_health_status"
+
+	// MetricHealthy represents a resource in an healthy state.
+	MetricHealthy = "healthy"
+
+	// MetricUnhealthy represents a resource in an unhealthy state.
+	MetricUnhealthy = "unhealthy"
+
+	// MetricUnknown represents a resource in an unknown health state.
+	MetricUnknown = "unknown"
+
+	// MetricResourceDB is a database resource metric.
+	MetricResourceDB = "db"
+
+	// MetricResourceKubernetes is a Kubernetes cluster resource metric.
+	MetricResourceKubernetes = "kubernetes"
+
 	// TagRange is a tag specifying backend requests
 	TagRange = "range"
 


### PR DESCRIPTION
Add metrics for `healthcheck` package

Health check metrics are incremented and decremented in `worker.go` during state changes, and decremented on closing. Each metric is labeled with a resource type such as `db` or `kubernetes`.

- Add gauge metric `teleport_resources_health_status_healthy`
- Add gauge metric `teleport_resources_health_status_unhealthy`
- Add gauge metric `teleport_resources_health_status_unknown`

Relates to:
- #58413

---
changelog: Improved observability by adding health check metrics for healthy, unhealthy, and unknown states. Database health checks can now be monitored with these metrics.