### PR TITLE
Component updates to support paginated AccessLists

### DIFF
--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -47,6 +47,12 @@ type AccessListMemberSpec struct {
 	// Name is the name of the member of the access list.
 	Name string `json:"name" yaml:"name"`
 
+	// TODO (avatus): eventually populate this in the backend/cache.
+
+	// Title is the title of an AccessListMember if it is of type MEMBERSHIP_KIND_LIST.
+	// This is only populated by the proxy when fetching an access list and its members for the web UI
+	Title string `json:"title" yaml:"title"`
+
 	// Joined is when the user joined the access list.
 	Joined time.Time `json:"joined" yaml:"joined"`
 

--- a/web/packages/design/src/DataTable/Table.tsx
+++ b/web/packages/design/src/DataTable/Table.tsx
@@ -151,6 +151,15 @@ export default function Table<T>(props: TableProps<T>) {
       return <tbody>{rows}</tbody>;
     }
 
+    // if we provide infiniteScrollProps, we want to not render anything if
+    // the fetch status is loading. this is so that the existing items dont dissapear
+    // during the fetch, but also, we dont want the empty text to show while fetching
+    // and lastly, the infinite scroll page will usually provide its own loading
+    // indicator at the bottom of the component
+    if (props.infiniteScrollProps?.fetchStatus === 'loading') {
+      return <tbody></tbody>;
+    }
+
     return (
       <EmptyIndicator
         emptyText={emptyText}

--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -25,6 +25,9 @@ import { Pagination } from './useTable';
 export type TableProps<T> = {
   data: T[];
   columns: TableColumn<T>[];
+  infiniteScrollProps?: {
+    fetchStatus: FetchStatus;
+  };
   emptyText: string;
   /**
    * Optional button that is rendered below emptyText if there's no data, during processing or on

--- a/web/packages/shared/components/Controls/MultiselectMenu.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.tsx
@@ -210,7 +210,19 @@ export const MultiselectMenu = <T extends readonly Option<any>[]>({
               <MenuItem
                 disabled={opt.disabled}
                 px={2}
-                onClick={() => (!opt.disabled ? handleSelect(opt.value) : null)}
+                onClick={e => {
+                  const target = e.target as HTMLElement;
+                  // Check if the click originated from the checkbox
+                  if (
+                    (target as HTMLInputElement).type === 'checkbox' ||
+                    target.closest('input[type="checkbox"]')
+                  ) {
+                    return; // Don't handle if click came from checkbox
+                  }
+                  if (!opt.disabled) {
+                    handleSelect(opt.value);
+                  }
+                }}
               >
                 {$checkbox}
               </MenuItem>

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -38,6 +38,10 @@ export default function generateResourcePath(
       processedParams[param] = (params[param] ?? []).join('&status=');
     } else if (param === 'regions') {
       processedParams[param] = (params[param] ?? []).join('&regions=');
+    } else if (param === 'owners') {
+      processedParams[param] = (params[param] ?? []).join('&owners=');
+    } else if (param === 'roles') {
+      processedParams[param] = (params[param] ?? []).join('&roles=');
     } else
       processedParams[param] = params[param]
         ? encodeURIComponent(params[param])
@@ -71,6 +75,8 @@ export default function generateResourcePath(
     .replace(':sort?', processedParams.sort || '')
     .replace(':startKey?', params.startKey || '')
     .replace(':regions?', processedParams.regions || '')
+    .replace(':owners?', processedParams.owners || '')
+    .replace(':roles?', processedParams.roles || '')
     .replace(
       ':includedResourceMode?',
       processedParams.includedResourceMode || ''


### PR DESCRIPTION
requires: https://github.com/gravitational/teleport/pull/58323
part of: https://github.com/gravitational/teleport/issues/57985

Most of the work for paginated access lists will be in an `e` PR, but this PR has a couple small changes I've bundled together.

1. add Title to AccessListMemberSpec AccessListMember's only have the ID of the resource it's referencing. For users, this is ok because the ID is the username. however, for access lists, its just the UUID of the access list, which looks really bad in a Members data table. This isn't much of a problem when every access list is fetched because we would just search through every access list for the right UUID and get the title from there, all client side. Now we need to populate it when we fetch members for a single access list.

2. Add some infiniteScrollProps to our data table. Access List "list view" was a data table with client side pagination. normally when the Attempt for a data table is fetching, the entire table dissapears into a Spinner. We want the table and its items to persist when fetching "the next page" with infinite scrolling so these props help make that easier

3. In our multiselect menu, i found a bug that would "double click" if the user selected the checkbox rather than clicking the text. this is because the event was bubbling up to the container MenuItem as well. I ended up _not_ using the checkboxes in the `e` PR because we removed the filters from the page, but we will be reworking those filters in the future so i might as well squeeze this change in now (this fixes the bug for all other instances of this component in the web UI anyway, why not)

4. updated generateResource path to take the two new parameters that we can filter access lists by, owners and roles.