### PR TITLE
Add Kube annotation for discovered app description

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -922,6 +922,8 @@ const (
 	DiscoveryAppIgnore = TeleportNamespace + "/ignore"
 	// DiscoveryPublicAddr specifies the public address for a discovered app created from a Kubernetes service.
 	DiscoveryPublicAddr = TeleportNamespace + "/public-addr"
+	// DiscoveryDescription specifies the description for a discovered app created from a Kubernetes service.
+	DiscoveryDescription = TeleportNamespace + "/description"
 
 	// ReqAnnotationApproveSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationApproveSchedulesLabel = "/schedules"

--- a/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
@@ -105,6 +105,10 @@ Controls resulting app name. If present it will override default app name patter
 as a suffix to the annotation value, as `$APP_NAME-$PORT1_NAME`, `$APP_NAME-$PORT2_NAME` etc, where `$APP_NAME` is the name
 set by the annotation.
 
+### `teleport.dev/description`
+
+Overrides the default description of the discovered app.
+
 ### `teleport.dev/insecure-skip-verify`
 
 Controls whether TLS certificate verification should be skipped for this app.

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -19,6 +19,7 @@
 package services
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
@@ -190,9 +191,12 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 	}
 
 	app, err := types.NewAppV3(types.Metadata{
-		Name:        appName,
-		Description: fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName),
-		Labels:      labels,
+		Name: appName,
+		Description: cmp.Or(
+			getDescription(service.GetAnnotations()),
+			fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName),
+		),
+		Labels: labels,
 	}, types.AppSpecV3{
 		URI:                appURI,
 		Rewrite:            rewriteConfig,
@@ -240,6 +244,10 @@ func getAppRewriteConfig(annotations map[string]string) (*types.Rewrite, error) 
 	}
 
 	return &rw, nil
+}
+
+func getDescription(annotations map[string]string) string {
+	return annotations[types.DiscoveryDescription]
 }
 
 func getPublicAddr(annotations map[string]string) string {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1024,7 +1024,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 	mockKubeServices := []*corev1.Service{
 		newMockKubeService("service1", "ns1", "",
 			map[string]string{"test-label": "testval"},
-			map[string]string{types.DiscoveryPublicAddr: "custom.example.com", types.DiscoveryPathLabel: "foo/bar baz"},
+			map[string]string{
+				types.DiscoveryPublicAddr:  "custom.example.com",
+				types.DiscoveryPathLabel:   "foo/bar baz",
+				types.DiscoveryDescription: "example description",
+			},
 			[]corev1.ServicePort{{Port: 42, Name: "http", Protocol: corev1.ProtocolTCP}}),
 		newMockKubeService("service2", "ns2", "",
 			map[string]string{
@@ -1867,6 +1871,11 @@ func mustConvertKubeServiceToApp(t *testing.T, discoveryGroup, protocol string, 
 	app, err := services.NewApplicationFromKubeService(*kubeService, discoveryGroup, protocol, port)
 	require.NoError(t, err)
 	require.Equal(t, kubeService.Annotations[types.DiscoveryPublicAddr], app.GetPublicAddr())
+
+	if desc, ok := kubeService.Annotations[types.DiscoveryDescription]; ok {
+		require.Equal(t, desc, app.GetMetadata().Description)
+	}
+
 	if p, ok := kubeService.Annotations[types.DiscoveryPathLabel]; ok {
 		components := strings.Split(p, "/")
 		for i := range components {


### PR DESCRIPTION
Closes #58516

Changelog: Allow controlling the description of auto-discovered Kubernetes apps with an annotation.