### PR TITLE
Periodically publish CRL

### DIFF
--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -119,6 +119,10 @@ windows_desktop_service:
   # (optional) interval at which to run desktop discovery
   discovery_interval: 10m
 
+  # (optional) interval at which to publish CRLs
+  # Defaults to 5m if unspecified
+  publish_crl_interval: 10m
+
   # (optional) configure a set of label selectors for dynamic registration.
   # If specified, this service will monitor the cluster for dynamic_windows_desktop
   # and automatically proxy connections for desktops with matching labels.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2198,6 +2198,11 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return trace.BadParameter("desktop discovery interval must not be negative (%v)", fc.WindowsDesktop.DiscoveryInterval.String())
 	}
 
+	cfg.WindowsDesktop.PublishCRLInterval = fc.WindowsDesktop.PublishCRLInterval
+	if cfg.WindowsDesktop.PublishCRLInterval < 0 {
+		return trace.BadParameter("publish CRL interval must not be negative (%v)", fc.WindowsDesktop.PublishCRLInterval.String())
+	}
+
 	var err error
 	cfg.WindowsDesktop.PublicAddrs, err = utils.AddrsFromStrings(fc.WindowsDesktop.PublicAddr, defaults.WindowsDesktopListenPort)
 	if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2571,6 +2571,8 @@ type WindowsDesktopService struct {
 	DiscoveryConfigs []LDAPDiscoveryConfig `yaml:"discovery_configs,omitempty"`
 	// DiscoveryInterval controls how frequently the discovery process runs.
 	DiscoveryInterval time.Duration `yaml:"discovery_interval"`
+	// PublishCRLInterval determines how frequently CRLs should be published.
+	PublishCRLInterval time.Duration `yaml:"publish_crl_interval"`
 	// ADHosts is a list of static, AD-connected Windows hosts. This gives users
 	// a way to specify AD-connected hosts that won't be found by the filters
 	// specified in `discovery` (or if `discovery` is omitted).

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -234,6 +234,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		PKIDomain:            cfg.WindowsDesktop.PKIDomain,
 		Discovery:            cfg.WindowsDesktop.Discovery,
 		DiscoveryInterval:    cfg.WindowsDesktop.DiscoveryInterval,
+		PublishCRLInterval:   cfg.WindowsDesktop.PublishCRLInterval,
 		Hostname:             cfg.Hostname,
 		ConnectedProxyGetter: proxyGetter,
 		ResourceMatchers:     cfg.WindowsDesktop.ResourceMatchers,

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -61,6 +61,9 @@ type WindowsDesktopConfig struct {
 	Discovery         []LDAPDiscoveryConfig
 	DiscoveryInterval time.Duration
 
+	// PublishCRLInterval determines how often CRLs should be published.
+	PublishCRLInterval time.Duration
+
 	// StaticHosts is an optional list of static Windows hosts to expose through this
 	// service.
 	StaticHosts []WindowsHost

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -391,15 +391,16 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 			ldap.DialWithTLSConfig(ldapTLSConfig),
 		)
 
-		if err != nil {
-			// If the connection fails, try the next server
-			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
-			continue
+		if err == nil {
+			c.Logger.DebugContext(ctx, "Connected to LDAP server", "server", server)
+			conn.SetTimeout(ldapRequestTimeout)
+			return conn, nil
 		}
 
-		c.Logger.DebugContext(ctx, "Connected to LDAP server", "server", server)
-		conn.SetTimeout(ldapRequestTimeout)
-		return conn, nil
+		if c.LocateServer.Enabled {
+			// If the connection fails and we're using LocateServer, log that a server failed.
+			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
+		}
 	}
 
 	return nil, trace.NotFound("no LDAP servers responded successfully for domain %q", c.Domain)


### PR DESCRIPTION
We want to periodically publish our empty CRLs to ensure they're present and in the correct location. These CRLs are necessary for users to log in to their Windows desktops.