### PR TITLE
MWI: Fix panic in SSH multiplexer

### DIFF
--- a/lib/tbot/services/ssh/multiplexer.go
+++ b/lib/tbot/services/ssh/multiplexer.go
@@ -271,7 +271,7 @@ func (s *MultiplexerService) setup(ctx context.Context) (
 			select {
 			case <-s.botIdentityReadyCh:
 			case <-ctx.Done():
-				return nil, nil, "", nil, nil
+				return nil, nil, "", nil, ctx.Err()
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a panic that would occur when:

1. Using the `ssh-multiplexer` service
2. Renewing the bot's identity fails on-startup
3. You kill `tbot` before it has a chance to successfully renew its identity

changelog: Fix panic in `tbot`'s `ssh-multiplexer` service
