### PR TITLE
Access list hierarchy refactor

### DIFF
--- a/lib/accesslists/errors.go
+++ b/lib/accesslists/errors.go
@@ -24,6 +24,11 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// IsUserLocked checks if the error was a result of the Access List member user having a lock.
+func IsUserLocked(err error) bool {
+	return errors.As(err, &userLockedError{})
+}
+
 // userLockedError is used to check specific condition of user being locked with [IsUserLocked]. It
 // is also being matched by [trace.IsAccessDenied] while allowing creating a dynamic error message
 // containing the username.
@@ -36,8 +41,3 @@ func newUserLockedError(user string) userLockedError {
 
 func (e userLockedError) Unwrap() error { return e.err }
 func (e userLockedError) Error() string { return e.err.Error() }
-
-// IsUserLocked checks if the error was a result of the Access List member user having a lock.
-func IsUserLocked(err error) bool {
-	return errors.As(err, &userLockedError{})
-}

--- a/lib/accesslists/errors.go
+++ b/lib/accesslists/errors.go
@@ -1,0 +1,43 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslists
+
+import (
+	"errors"
+
+	"github.com/gravitational/trace"
+)
+
+// userLockedError is used to check specific condition of user being locked with [IsUserLocked]. It
+// is also being matched by [trace.IsAccessDenied] while allowing creating a dynamic error message
+// containing the username.
+type userLockedError struct{ err error }
+
+// newUserLockedError returns a new userLockedError.
+func newUserLockedError(user string) userLockedError {
+	return userLockedError{trace.AccessDenied("User %q is currently locked", user)}
+}
+
+func (e userLockedError) Unwrap() error { return e.err }
+func (e userLockedError) Error() string { return e.err.Error() }
+
+// IsUserLocked checks if the error was a result of the Access List member user having a lock.
+func IsUserLocked(err error) bool {
+	return errors.As(err, &userLockedError{})
+}

--- a/lib/accesslists/hierarchy_legacy.go
+++ b/lib/accesslists/hierarchy_legacy.go
@@ -1,0 +1,120 @@
+package accesslists
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// GetMembersFor returns a flattened list of Members for an Access List, including inherited Members.
+//
+// Returned Members are not validated for expiration or other requirements – use IsAccessListMember
+// to validate a Member's membership status.
+// DEPRECATED: use Hierarchy.GetMembersFor instead.
+func GetMembersFor(ctx context.Context, accessListName string, g AccessListAndMembersGetter) ([]*accesslist.AccessListMember, error) {
+	h, err := NewHierarchy(HierarchyConfig{
+		AccessListsService: g,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	members, err := h.GetMembersFor(ctx, accessListName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return members, nil
+}
+
+// GetOwnersFor returns a flattened list of Owners for an Access List, including inherited Owners.
+//
+// Returned Owners are not validated for expiration or other requirements – use IsAccessListOwner
+// to validate an Owner's ownership status.
+// DEPRECATED: use Hierarchy.GetOwnersFor instead.
+func GetOwnersFor(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter) ([]*accesslist.Owner, error) {
+	h, err := NewHierarchy(HierarchyConfig{
+		AccessListsService: g,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	owners, err := h.GetOwnersFor(ctx, accessList)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return owners, nil
+}
+
+// IsAccessListOwner checks if the given user is the Access List owner. It returns an error matched
+// by [IsUserLocked] if the user is locked.
+// DEPRECATED: use Hierarchy.IsAccessListOwner instead.
+func IsAccessListOwner(
+	ctx context.Context,
+	user types.User,
+	accessList *accesslist.AccessList,
+	g AccessListAndMembersGetter,
+	lockGetter services.LockGetter,
+	clock clockwork.Clock,
+) (accesslistv1.AccessListUserAssignmentType, error) {
+	h, err := NewHierarchy(HierarchyConfig{
+		AccessListsService: g,
+		LockService:        lockGetter,
+		Clock:              clock,
+	})
+	if err != nil {
+		return assUnspecified, trace.Wrap(err)
+	}
+	r, err := h.IsAccessListOwner(ctx, user, accessList)
+	if err != nil {
+		return assUnspecified, trace.Wrap(err)
+	}
+	return r, nil
+}
+
+// IsAccessListMember checks if the given user is the Access List member. It returns an error
+// matched by [IsUserLocked] if the user is locked.
+// DEPRECATED: use Hierarchy.IsAccessListMember instead.
+func IsAccessListMember(
+	ctx context.Context,
+	user types.User,
+	accessList *accesslist.AccessList,
+	g AccessListAndMembersGetter,
+	lockGetter services.LockGetter,
+	clock clockwork.Clock,
+) (accesslistv1.AccessListUserAssignmentType, error) {
+	h, err := NewHierarchy(HierarchyConfig{
+		AccessListsService: g,
+		LockService:        lockGetter,
+		Clock:              clock,
+	})
+	if err != nil {
+		return assUnspecified, trace.Wrap(err)
+	}
+	r, err := h.IsAccessListMember(ctx, user, accessList)
+	if err != nil {
+		return assUnspecified, trace.Wrap(err)
+	}
+	return r, nil
+}
+
+// GetAncestorsFor calculates and returns the set of Ancestor ACLs depending on
+// the supplied relationship criteria. Order of the ancestor list is undefined.
+// DEPRECATED: use Hierarchy.GetAncestorsFor instead.
+func GetAncestorsFor(ctx context.Context, accessList *accesslist.AccessList, kind RelationshipKind, g AccessListAndMembersGetter) ([]*accesslist.AccessList, error) {
+	h, err := NewHierarchy(HierarchyConfig{
+		AccessListsService: g,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ancestors, err := h.GetAncestorsFor(ctx, accessList, kind)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return ancestors, nil
+}

--- a/lib/accesslists/hierarchy_legacy.go
+++ b/lib/accesslists/hierarchy_legacy.go
@@ -67,11 +67,11 @@ func IsAccessListOwner(
 		Clock:              clock,
 	})
 	if err != nil {
-		return assUnspecified, trace.Wrap(err)
+		return userAssignUnspecified, trace.Wrap(err)
 	}
 	r, err := h.IsAccessListOwner(ctx, user, accessList)
 	if err != nil {
-		return assUnspecified, trace.Wrap(err)
+		return userAssignUnspecified, trace.Wrap(err)
 	}
 	return r, nil
 }
@@ -93,11 +93,11 @@ func IsAccessListMember(
 		Clock:              clock,
 	})
 	if err != nil {
-		return assUnspecified, trace.Wrap(err)
+		return userAssignUnspecified, trace.Wrap(err)
 	}
 	r, err := h.IsAccessListMember(ctx, user, accessList)
 	if err != nil {
-		return assUnspecified, trace.Wrap(err)
+		return userAssignUnspecified, trace.Wrap(err)
 	}
 	return r, nil
 }

--- a/lib/accesslists/hierarchy_legacy.go
+++ b/lib/accesslists/hierarchy_legacy.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package accesslists
 
 import (

--- a/lib/accesslists/requirment.go
+++ b/lib/accesslists/requirment.go
@@ -1,0 +1,201 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accesslists
+
+import (
+	"context"
+	"slices"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/trait"
+)
+
+// UserMeetsRequirements is a helper which will return whether the User meets the AccessList Ownership/MembershipRequires.
+func UserMeetsRequirements(identity types.User, requires accesslist.Requires) bool {
+	return newRequirementsEvaluator(identity).meets(requires)
+}
+
+// GetInheritedMembershipRequires returns the combined Requires for an Access List's members,
+// inherited from any ancestor lists, and the Access List's own MembershipRequires.
+func GetInheritedMembershipRequires(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter) (*accesslist.Requires, error) {
+	ownRequires := accessList.GetMembershipRequires()
+	ancestors, err := GetAncestorsFor(ctx, accessList, RelationshipKindMember, g)
+	if err != nil {
+		return &ownRequires, trace.Wrap(err)
+	}
+
+	roles := ownRequires.Roles
+	traits := ownRequires.Traits
+
+	for _, ancestor := range ancestors {
+		requires := ancestor.GetMembershipRequires()
+		roles = append(roles, requires.Roles...)
+		for traitKey, traitValues := range requires.Traits {
+			if _, exists := traits[traitKey]; !exists {
+				traits[traitKey] = []string{}
+			}
+			traits[traitKey] = append(traits[traitKey], traitValues...)
+		}
+	}
+
+	slices.Sort(roles)
+	roles = slices.Compact(roles)
+
+	for k, v := range traits {
+		slices.Sort(v)
+		traits[k] = slices.Compact(v)
+	}
+
+	return &accesslist.Requires{
+		Roles:  roles,
+		Traits: traits,
+	}, nil
+}
+
+// GetInheritedGrants returns the combined Grants for an Access List's members, inherited from any ancestor lists.
+func GetInheritedGrants(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter) (*accesslist.Grants, error) {
+	grants := accesslist.Grants{
+		Traits: trait.Traits{},
+	}
+
+	collectedRoles := make(map[string]struct{})
+	collectedTraits := make(map[string]map[string]struct{})
+
+	addGrants := func(grantRoles []string, grantTraits trait.Traits) {
+		for _, role := range grantRoles {
+			if _, exists := collectedRoles[role]; !exists {
+				grants.Roles = append(grants.Roles, role)
+				collectedRoles[role] = struct{}{}
+			}
+		}
+		for traitKey, traitValues := range grantTraits {
+			if _, exists := collectedTraits[traitKey]; !exists {
+				collectedTraits[traitKey] = make(map[string]struct{})
+			}
+			for _, traitValue := range traitValues {
+				if _, exists := collectedTraits[traitKey][traitValue]; !exists {
+					grants.Traits[traitKey] = append(grants.Traits[traitKey], traitValue)
+					collectedTraits[traitKey][traitValue] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Get ancestors via member relationship
+	ancestorLists, err := GetAncestorsFor(ctx, accessList, RelationshipKindMember, g)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, ancestor := range ancestorLists {
+		memberGrants := ancestor.GetGrants()
+		addGrants(memberGrants.Roles, memberGrants.Traits)
+	}
+
+	// Get ancestors via owner relationship
+	ancestorOwnerLists, err := GetAncestorsFor(ctx, accessList, RelationshipKindOwner, g)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, ancestorOwner := range ancestorOwnerLists {
+		ownerGrants := ancestorOwner.GetOwnerGrants()
+		addGrants(ownerGrants.Roles, ownerGrants.Traits)
+	}
+
+	slices.Sort(grants.Roles)
+	grants.Roles = slices.Compact(grants.Roles)
+
+	for k, v := range grants.Traits {
+		slices.Sort(v)
+		grants.Traits[k] = slices.Compact(v)
+	}
+
+	return &grants, nil
+}
+
+// requirementsEvaluator caches role/trait lookups for a single user to avoid rebuilding sets.
+type requirementsEvaluator struct {
+	rolesSet map[string]struct{}
+	traits   map[string]map[string]struct{}
+	user     types.User
+}
+
+func newRequirementsEvaluator(u types.User) *requirementsEvaluator {
+	return &requirementsEvaluator{
+		user: u,
+	}
+}
+
+func (e requirementsEvaluator) createLazyRoleLookupMap() {
+	if e.rolesSet != nil {
+		return
+	}
+	// Assemble the user's roles for easy look up.
+	e.rolesSet = make(map[string]struct{}, len(e.user.GetRoles()))
+	for _, r := range e.user.GetRoles() {
+		e.rolesSet[r] = struct{}{}
+	}
+}
+
+func (e requirementsEvaluator) createLazyTraitsLookupMap() {
+	if e.traits != nil {
+		return
+	}
+	// Assemble traits for easy lookup.
+	e.traits = map[string]map[string]struct{}{}
+	for k, values := range e.user.GetTraits() {
+		if _, ok := e.traits[k]; !ok {
+			e.traits[k] = map[string]struct{}{}
+		}
+		for _, v := range values {
+			e.traits[k][v] = struct{}{}
+		}
+	}
+}
+
+func (e requirementsEvaluator) meets(requires accesslist.Requires) bool {
+	if len(requires.Roles) > 0 {
+		e.createLazyRoleLookupMap()
+	}
+	// Check that the user meets the role requirements.
+	for _, role := range requires.Roles {
+		if _, ok := e.rolesSet[role]; !ok {
+			return false
+		}
+	}
+	if len(requires.Traits) > 0 {
+		e.createLazyTraitsLookupMap()
+	}
+	// Check that user meets trait requirements.
+	for k, values := range requires.Traits {
+		if _, ok := e.traits[k]; !ok {
+			return false
+		}
+
+		for _, v := range values {
+			if _, ok := e.traits[k][v]; !ok {
+				return false
+			}
+		}
+	}
+	// The user meets all requirements.
+	return true
+}


### PR DESCRIPTION
### What

No logic changes introduced, this is purely a refactor

 * move logic into seperate file to clear the hierarchy.go 
 * User Hierarchy struct methods instead of free functions. Free futnion was marked as Depricated. 
 * introduced `requirementsEvaluator` to create abstraction for requirement check. 