### PR TITLE
Fix excessive logging in proxy for DB connections

### DIFF
--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/db"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 func (process *TeleportProcess) shouldInitDatabases() bool {
@@ -227,7 +228,9 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	})
 
 	process.BroadcastEvent(Event{Name: DatabasesReady, Payload: nil})
-	logger.InfoContext(process.ExitContext(), "Database service has successfully started.", "database", databases)
+	logger.InfoContext(process.ExitContext(), "Database service has successfully started",
+		"databases", logutils.StringerSliceAttr(databases),
+	)
 
 	// Block and wait while the server and agent pool are running.
 	if err := dbService.Wait(); err != nil {

--- a/lib/srv/db/common/connect/connect.go
+++ b/lib/srv/db/common/connect/connect.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // DatabaseServersGetter is an interface for retrieving information about
@@ -68,8 +69,6 @@ func GetDatabaseServers(ctx context.Context, params GetDatabaseServersParams) ([
 		return nil, trace.Wrap(err)
 	}
 
-	params.Logger.DebugContext(ctx, "Available database servers.", "cluster", params.ClusterName, "servers", servers)
-
 	// Find out which database servers proxy the database a user is
 	// connecting to using routing information from identity.
 	var result []types.DatabaseServer
@@ -78,6 +77,11 @@ func GetDatabaseServers(ctx context.Context, params GetDatabaseServersParams) ([
 			result = append(result, server)
 		}
 	}
+
+	params.Logger.DebugContext(ctx, "Available database servers",
+		"cluster", params.ClusterName,
+		"servers", logutils.StringerSliceAttr(result),
+	)
 
 	if len(result) != 0 {
 		return result, nil

--- a/lib/utils/log/slog.go
+++ b/lib/utils/log/slog.go
@@ -175,6 +175,29 @@ func (s stringerAttr) LogValue() slog.Value {
 	return slog.StringValue(s.Stringer.String())
 }
 
+type stringerSliceAttr[T fmt.Stringer] struct {
+	stringers []T
+}
+
+func (s stringerSliceAttr[T]) LogValue() slog.Value {
+	return slog.StringValue(fmt.Sprint(s.stringers))
+}
+
+// StringerSliceAttr creates a [slog.LogValuer] that will defer formatting a
+// slice of [fmt.Stringer] as a string. All slog attributes are always evaluated,
+// even if the log event is discarded due to the configured log level.
+// A text [slog.Handler] will try to defer evaluation if the attribute is a
+// [fmt.Stringer], however, the JSON [slog.Handler] only defers to [json.Marshaler].
+// This means that to defer evaluation and creation of the string representation,
+// the object must implement [fmt.Stringer] and [json.Marshaler], otherwise additional
+// and unwanted values may be emitted if the logger is configured to use JSON
+// instead of text. This wrapping mechanism allows a slice of a type that
+// implements [fmt.Stringer], to be guaranteed to be lazily constructed and
+// always output the same content regardless of the output format.
+func StringerSliceAttr[T fmt.Stringer](ss []T) slog.LogValuer {
+	return stringerSliceAttr[T]{stringers: ss}
+}
+
 type typeAttr struct {
 	val any
 }


### PR DESCRIPTION
Without this change, the proxy logs every database server in the cluster with full JSON spec when using JSON format.
As a result, a customer on a debugging call enabled DEBUG level logs and this log line printed tens of megabytes of data, which made it impossible to share or interpret the logs effectively.

With this change, the proxy only logs the database servers that match the requested database name, and each db server is formatted as a string instead of marshaling the full spec to JSON.
