### PR TITLE
Update pnpm to 10.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "engines": {
     "node": "^22"
   }


### PR DESCRIPTION
This PR updates the package manager for JS deps.

The changelog for 10.15.0 mentions this:

> Semi-breaking. When automatically installing missing peer dependencies, prefer versions that are already present in the direct dependencies of the root workspace package

However, we turned off automatically installing missing peer deps, so this won't affect us.