### PR TITLE
fix: fix predicate `set` function

### DIFF
--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -167,14 +167,14 @@ func newDefaultWhereParserDef(ctx RuleContext) predicate.Def {
 			"contains":     predicate.Contains,
 			"contains_all": predicateContainsAll,
 			"contains_any": predicateContainsAny,
-			"set": func(a ...any) types.WhereExpr {
+			"set": func(a ...any) []string {
 				aVal := make([]string, 0, len(a))
 				for _, v := range a {
 					if str, ok := v.(string); ok {
 						aVal = append(aVal, str)
 					}
 				}
-				return types.WhereExpr{Literal: aVal}
+				return aVal
 			},
 			"all_end_with": predicateAllEndWith,
 			"all_equal":    predicateAllEqual,

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -438,6 +438,7 @@ func TestParserHostCertContext(t *testing.T) {
 				`all_equal(host_cert.principals, "foo.example.com")`,
 				`is_subset(host_cert.principals, "a", "b", "foo.example.com")`,
 				`all_end_with(host_cert.principals, ".example.com")`,
+				`contains_any(set("a", "b", "foo.example.com"), host_cert.principals)`,
 			},
 			negative: []string{
 				`all_equal(host_cert.principals, "foo")`,


### PR DESCRIPTION
`set` function should have returned the underlying type, not the type.WhereExpr value.