### PR TITLE
[loadtest] Add batch create resource Helm chart

### DIFF
--- a/assets/loadtest/.gitignore
+++ b/assets/loadtest/.gitignore
@@ -18,3 +18,6 @@ k8s/secrets/**
 .secrets
 
 control-plane/vars.env
+
+# Rendered templates
+*.rendered.*

--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -145,3 +145,43 @@ deploy-soaktest:
 .PHONY: delete-soaktest
 delete-soaktest:
 	helm delete -n soaktest soaktest
+
+# In order to run a large number of `tctl create` commands in-cluster we make use of a tbot deployment.
+# See helm/fixtures/tbot.yaml for the token and permissions used, adjust as needed.
+.PHONY: create-tbot-resources
+create-tbot-resources:
+	STATIC_JWKS=$$(curl $$(kubectl get --raw /.well-known/openid-configuration | jq '.issuer + "/keys"' --raw-output)); \
+	sed "s/@@STATIC_JWKS@@/$${STATIC_JWKS}/g" helm/fixtures/tbot.yaml > tbot.rendered.yaml
+	kubectl --namespace teleport exec -i deploy/teleport-auth -- tctl create -f < tbot.rendered.yaml
+
+.PHONY: deploy-app-service
+deploy-app-service:
+	helm upgrade --install teleport-kube-agent ../../examples/chart/teleport-kube-agent \
+	--create-namespace \
+	--namespace teleport \
+	--set roles=app \
+	--set proxyAddr=${PROXY_SERVER} \
+	--set authToken=${TOKEN} \
+	--set "appResources[0].labels.*=*" \
+	--set teleportVersionOverride="${TELEPORT_VERSION}" \
+	--values ./helm/values/app-service-agent.yaml
+
+.PHONY: delete-app-service
+delete-app-service:
+	helm delete -n teleport teleport-kube-agent
+
+.PHONY: create-app-resources
+create-app-resources: COUNT ?= 100
+create-app-resources: PARALLELISM ?= 10
+create-app-resources:
+	helm upgrade --install resources \
+	-n resources --create-namespace \
+	./helm/resources \
+	--set proxy=${PROXY_SERVER} \
+	--set clusterName=${CLUSTER_NAME} \
+	--set resources.count=${COUNT} \
+	--set resources.parallelism=${PARALLELISM}
+
+.PHONY: delete-app-resources
+delete-app-resources:
+	helm delete -n resources resources

--- a/assets/loadtest/helm/fixtures/tbot.yaml
+++ b/assets/loadtest/helm/fixtures/tbot.yaml
@@ -1,0 +1,54 @@
+kind: role
+version: v8
+metadata:
+  name: k8s-editor
+spec:
+  allow:
+    kubernetes_labels:
+      '*': '*'
+    kubernetes_groups:
+    - editor
+    kubernetes_resources:
+    - kind: "*"
+      namespace: "*"
+      name: "*"
+      verbs: ["*"]
+      api_group: "*"
+
+---
+kind: role
+version: v8
+metadata:
+  name: appsmith
+spec:
+  allow:
+    app_labels:
+      "*": "*"
+    rules:
+      - resources: [app]
+        verbs: ['list', 'read', 'create', 'update', 'delete']
+---
+kind: bot
+version: v1
+metadata:
+  # name is a unique identifier for the Bot in the cluster.
+  name: k8s-tbot
+spec:
+  roles: [k8s-editor, appsmith]
+---
+kind: token
+version: v2
+metadata:
+  name: tbot-token
+spec:
+  roles: [Bot]
+  bot_name: k8s-tbot
+  join_method: kubernetes
+  kubernetes:
+    type: static_jwks
+    static_jwks:
+      jwks: |
+       @@STATIC_JWKS@@
+    allow:
+    - service_account: "resources:tbot"
+

--- a/assets/loadtest/helm/resources/Chart.yaml
+++ b/assets/loadtest/helm/resources/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: resources
+description: Deploys a batch job that creates a given number of resources.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "18.1.8"

--- a/assets/loadtest/helm/resources/README.md
+++ b/assets/loadtest/helm/resources/README.md
@@ -1,0 +1,58 @@
+# resources 
+
+This Helm chart can be used to programmatically spawn an arbitary number of resources in a Teleport cluster given a resource manifest.
+
+It assumes a pre-existing k8s Teleport cluster and correctly authenticated kubectl client.
+
+*note:* This is an experimental tool used for internal testing, do not use in production.
+
+## Testing dynamic applications
+
+All commands run from `assets/loadtest/`
+
+Create join token for the app service:
+```sh
+make create-token TYPE=node,app
+
+# Note the output and export it:
+export TOKEN=<token value>
+
+# Export proxy address:
+export PROXY_SERVER=example.teleport-test.com:443
+
+# Set the version
+export TELEPORT_VERSION="18.1.8"
+```
+
+Deploy application service agent:
+```sh
+make deploy-app-service
+```
+
+Prepare a tbot and the correct token:
+```sh
+make create-tbot-resources
+```
+
+Deploy tbot and create applications:
+```sh
+# This will spawn batch jobs using tbot credentials to run backend commands on the cluster.
+# By default each app job will spawn 10 applications for a total of 10*$COUNT items in the backend.
+make create-app-resources COUNT=1000 PARALLELISM=10
+```
+
+In the `teleport-kube-agent` logs you should see:
+```
+2025-09-02T08:57:10.170Z INFO [APP:SERVI] New resource matches, creating kind:app name:app6-7.example services/reconciler.go:175
+```
+And the app resources should show up in the web UI after logging in, or alternatively using `tctl`:
+```sh
+kubectl --namespace teleport exec -i deploy/teleport-auth -- tctl apps ls
+```
+
+To clean up:
+```sh
+make delete-app-resources delete-app-service
+```
+
+

--- a/assets/loadtest/helm/resources/resources/apps.yaml
+++ b/assets/loadtest/helm/resources/resources/apps.yaml
@@ -1,0 +1,239 @@
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app0-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app1-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app2-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app3-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app4-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app5-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app6-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app7-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app8-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3
+---
+kind: app
+metadata:
+  description: 'Dummy application'
+  labels:
+    application: SPACES
+    owner: test
+    read-only: ""
+    read-write: ""
+  name: app9-@@JOB_INDEX@@.example
+spec:
+  insecure_skip_verify: false
+  rewrite:
+    headers:
+      - name: X-TELEPORT-OWNER
+        value: test
+      - name: X-TELEPORT-READ-ONLY
+        value: ""
+      - name: X-TELEPORT-READ-WRITE
+        value: ""
+    jwt_claims: none
+  uri: https://localhost
+  use_any_proxy_public_addr: true
+version: v3

--- a/assets/loadtest/helm/resources/templates/config.yaml
+++ b/assets/loadtest/helm/resources/templates/config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  entrypoint.sh: |2
+    #!/bin/sh
+    set -euxo pipefail
+
+    cp ${RESOURCE_YAML} /tmp/rendered.yaml
+    sed -i "s/@@JOB_INDEX@@/$JOB_COMPLETION_INDEX/g" /tmp/rendered.yaml
+    cat /tmp/rendered.yaml
+
+    tctl \
+       --auth-server=${PROXY} \
+       -i /identity-output/identity \
+       create -f /tmp/rendered.yaml
+  resource.yaml: |
+    {{ .Files.Get .Values.resources.template | nindent 4 }}

--- a/assets/loadtest/helm/resources/templates/job.yaml
+++ b/assets/loadtest/helm/resources/templates/job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  completions: {{ .Values.resources.count }}
+  parallelism: {{ .Values.resources.parallelism }}
+  completionMode: Indexed
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - image: "{{ $.Values.image.repository }}:{{ default $.Chart.AppVersion $.Values.image.tag }}"
+          name: resources
+          command: [ "sh", "/etc/teleport-config/entrypoint.sh" ]
+          env:
+            - name: PROXY
+              value: {{ required "'proxy' value is required" .Values.proxy | quote }}
+            - name: RESOURCE_YAML
+              value:  "/etc/teleport-config/resource.yaml"
+            - name: JOB_COMPLETION_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+          volumeMounts:
+            - mountPath: /etc/teleport-config
+              name: config
+              readOnly: true
+            - name: identity-output
+              mountPath: /identity-output
+      volumes:
+        - configMap:
+            name: {{ .Release.Name }}
+            defaultMode: 0766
+          name: config
+        - name: identity-output
+          secret:
+            secretName: identity-output

--- a/assets/loadtest/helm/resources/templates/tbot.yaml
+++ b/assets/loadtest/helm/resources/templates/tbot.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tbot
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tbot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tbot
+    spec:
+      containers:
+        - name: tbot
+          image: public.ecr.aws/gravitational/tbot-distroless:{{ default $.Chart.AppVersion $.Values.image.tag }}
+          args:
+            - start
+            - -c
+            - /config/tbot.yaml
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+            - name: TELEPORT_ANONYMOUS_TELEMETRY
+              value: "0"
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+      serviceAccountName: tbot
+      volumes:
+        - name: config
+          configMap:
+            name: tbot-config
+        - name: join-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: join-sa-token
+                  expirationSeconds: 600
+                  audience: {{ .Values.clusterName }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tbot-config
+  namespace: {{ .Release.Namespace }}
+data:
+  tbot.yaml: |
+    version: v2
+    onboarding:
+      join_method: kubernetes
+      token: tbot-token
+    storage:
+      type: memory
+    proxy_server: {{ .Values.proxy }}
+    outputs:
+    - type: identity
+      destination:
+        type: kubernetes_secret
+        name: identity-output
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tbot
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secrets-admin
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tbot-secrets-admin
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: tbot
+roleRef:
+  kind: Role
+  name:  secrets-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/loadtest/helm/resources/values.yaml
+++ b/assets/loadtest/helm/resources/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: public.ecr.aws/gravitational/teleport-ent-distroless-debug
+  pullPolicy: IfNotPresent
+  tag: ""
+
+proxy: ""
+clusterName: ""
+
+resources:
+  template: "resources/apps.yaml"
+  # Total number of resouces to create
+  count: 10
+  # Number of batch jobs to run in parallel, scale this depending on cluster.
+  parallelism: 5
+

--- a/assets/loadtest/helm/values/app-service-agent.yaml
+++ b/assets/loadtest/helm/values/app-service-agent.yaml
@@ -1,0 +1,10 @@
+teleportConfig:
+  app_service:
+    enabled: true
+    debug_app: true
+    apps:
+    - name: "metrics"
+      uri: "http://127.0.0.1:3000/metrics"
+    resources:
+    - labels:
+        '*': '*'


### PR DESCRIPTION
This Helm chart is for internal testing purposes only and is subject to change.

It allows spawning of arbitary number of batch k8s jobs to run commands on the Teleport cluster such as creating resources.

For now only app kind resource is used but this could be extended in the future. It makes use of `tbot` to authenticate the batch jobs.

The resources are not deleted each time as currently the intent is to scale the number of resources in the backend while testing and tear down the cluster once done.