### PR TITLE
Align AccessListMember.Clone method

### DIFF
--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -125,9 +125,23 @@ func (a *AccessListMember) MatchSearch(values []string) bool {
 
 // Clone returns a copy of the member.
 func (a *AccessListMember) Clone() *AccessListMember {
-	var copy *AccessListMember
-	utils.StrictObjectToStruct(a, &copy)
-	return copy
+	if a == nil {
+		return nil
+	}
+	return &AccessListMember{
+		ResourceHeader: *a.ResourceHeader.Clone(),
+		Spec: AccessListMemberSpec{
+			AccessList:       a.Spec.AccessList,
+			Name:             a.Spec.Name,
+			Title:            a.Spec.Title,
+			Joined:           a.Spec.Joined,
+			Expires:          a.Spec.Expires,
+			Reason:           a.Spec.Reason,
+			AddedBy:          a.Spec.AddedBy,
+			IneligibleStatus: a.Spec.IneligibleStatus,
+			MembershipKind:   a.Spec.MembershipKind,
+		},
+	}
 }
 
 // IsExpired checks if the access list member is expired based on the current time.

--- a/api/types/accesslist/member_test.go
+++ b/api/types/accesslist/member_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils/testutils/structfill"
 )
 
 func TestAccessListMemberDefaults(t *testing.T) {
@@ -58,4 +60,13 @@ func TestAccessListMemberDefaults(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, MembershipKindUser, uut.Spec.MembershipKind)
 	})
+}
+
+func TestAccessListMemberClone(t *testing.T) {
+	item := &AccessListMember{}
+	err := structfill.Fill(item)
+	require.NoError(t, err)
+	cpy := item.Clone()
+	require.Empty(t, cmp.Diff(item, cpy))
+	require.NotSame(t, item, cpy)
 }


### PR DESCRIPTION
### What

Access list members count can be > 10M. The json clone doesn't scale for this case. 

### Before: 

```
cpu: Apple M3 Max
BenchmarkAccessListClone
BenchmarkAccessListClone/count=100
BenchmarkAccessListClone/count=100-14         	   20560	     57787 ns/op	  243458 B/op	     600 allocs/op
BenchmarkAccessListClone/count=1000
BenchmarkAccessListClone/count=1000-14        	    2056	    584011 ns/op	 2434603 B/op	    6007 allocs/op
BenchmarkAccessListClone/count=10000
BenchmarkAccessListClone/count=10000-14       	     198	   6000901 ns/op	24346672 B/op	   60080 allocs/op
BenchmarkAccessListClone/count=100000
BenchmarkAccessListClone/count=100000-14      	      18	  60888808 ns/op	243399482 B/op	  600710 allocs/op
PASS

```


### After: 

```
BenchmarkAccessListClone
BenchmarkAccessListClone/count=100
BenchmarkAccessListClone/count=100-14         	 7814946	       136.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkAccessListClone/count=1000
BenchmarkAccessListClone/count=1000-14        	  886110	      1393 ns/op	       0 B/op	       0 allocs/op
BenchmarkAccessListClone/count=10000
BenchmarkAccessListClone/count=10000-14       	   78871	     13630 ns/op	       0 B/op	       0 allocs/op
BenchmarkAccessListClone/count=100000
BenchmarkAccessListClone/count=100000-14      	    8863	    133654 ns/op	       0 B/op	       0 allocs/op
PASS

```
