### PR TITLE
Add the session recording playback stream

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
@@ -1,0 +1,39 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { BaseEvent } from '../stream/types';
+
+export abstract class Player<
+  TEvent extends BaseEvent<TEventType>,
+  TEventType extends number = number,
+> {
+  abstract init(element: HTMLElement): void;
+  abstract destroy(): void;
+
+  abstract apply(event: TEvent): void;
+  abstract handle(event: TEvent): boolean;
+  abstract clear(): void;
+
+  fit(): void {}
+
+  onPlay(): void {}
+  onPause(): void {}
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  onSeek(time: number): void {}
+  onStop(): void {}
+}

--- a/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
@@ -25,12 +25,37 @@ export abstract class Player<
   abstract init(element: HTMLElement): void;
   abstract destroy(): void;
 
-  abstract apply(event: TEvent): void;
-  abstract handle(event: TEvent): boolean;
+  /**
+   * clear is called to clear the current state of the player. This is called when seeking to a time before the
+   * current time, to reset the state of the player before receiving the state of the screen.
+   */
   abstract clear(): void;
 
+  /**
+   * applyEvent is called to apply a single event to the player, at the correct moment in time.
+   * This is typically used for events that change the state of the player, such as print or resize.
+   *
+   * @param event The event to apply.
+   *
+   * @returns void
+   */
+  abstract applyEvent(event: TEvent): void;
+
+  /**
+   * handleEvent is called to handle an event that needs to be handled as soon as it is received from
+   * the stream, regardless of the current playback time. Typically this would be for receiving the
+   * full state of the screen.
+   *
+   * @param event The event to handle.
+   *
+   * @returns true if the event was handled (and therefore should not be added to the stream buffer), false otherwise.
+   */
+  abstract handleHandle(event: TEvent): boolean;
+
+  // fit is called to resize the player to fit its container. This is typically player specific.
   fit(): void {}
 
+  // Event hooks for subclasses to optionally implement.
   onPlay(): void {}
   onPause(): void {}
   // eslint-disable-next-line unused-imports/no-unused-vars

--- a/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/player/Player.ts
@@ -50,7 +50,7 @@ export abstract class Player<
    *
    * @returns true if the event was handled (and therefore should not be added to the stream buffer), false otherwise.
    */
-  abstract handleHandle(event: TEvent): boolean;
+  abstract handleEvent(event: TEvent): boolean;
 
   // fit is called to resize the player to fit its container. This is typically player specific.
   fit(): void {}

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
@@ -114,7 +114,7 @@ describe('play', () => {
 
     stream.play();
 
-    expect(player.playState.onPlay).toBe(true);
+    expect(player.onPlay).toHaveBeenCalled();
   });
 });
 
@@ -152,7 +152,7 @@ describe('pause', () => {
     stream.play();
     stream.pause();
 
-    expect(player.playState.onPause).toBe(true);
+    expect(player.onPause).toHaveBeenCalled();
   });
 
   it('should not do anything if already paused', () => {
@@ -202,7 +202,7 @@ describe('seek', () => {
 
     stream.seek(750);
 
-    expect(player.playState.onSeek).toBe(true);
+    expect(player.onSeek).toHaveBeenCalledWith(750);
   });
 
   it('should clear player when seeking backwards', () => {
@@ -366,12 +366,6 @@ class MockPlayer extends Player<MockEvent> {
   cleared = false;
   destroyed = false;
   handleCalled = false;
-  playState = {
-    onPlay: false,
-    onPause: false,
-    onSeek: false,
-    onStop: false,
-  };
 
   init(): void {}
 
@@ -394,21 +388,10 @@ class MockPlayer extends Player<MockEvent> {
     this.events = [];
   }
 
-  onPlay(): void {
-    this.playState.onPlay = true;
-  }
-
-  onPause(): void {
-    this.playState.onPause = true;
-  }
-
-  onSeek(): void {
-    this.playState.onSeek = true;
-  }
-
-  onStop(): void {
-    this.playState.onStop = true;
-  }
+  onPlay = jest.fn();
+  onPause = jest.fn();
+  onSeek = jest.fn();
+  onStop = jest.fn();
 }
 
 interface WebSocketEventMap {

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
@@ -18,7 +18,6 @@
 
 import { EventEmitter } from 'events';
 
-import { Player } from 'teleport/SessionRecordings/view/SshRecordingPlayer/Player';
 import {
   PlayerState,
   SessionStream,
@@ -27,6 +26,8 @@ import {
   ResponseType,
   type BaseEvent,
 } from 'teleport/SessionRecordings/view/stream/types';
+
+import { Player } from '../player/Player';
 
 function setup() {
   const ws = new MockWebSocket();
@@ -378,11 +379,11 @@ class MockPlayer extends Player<MockEvent> {
     this.destroyed = true;
   }
 
-  apply(event: MockEvent): void {
+  applyEvent(event: MockEvent): void {
     this.events.push(event);
   }
 
-  handle(event: MockEvent): boolean {
+  handleEvent(event: MockEvent): boolean {
     this.handleCalled = true;
 
     return event.type === MockEventType.End;

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EventEmitter } from 'events';
+
+import { Player } from 'teleport/SessionRecordings/view/SshRecordingPlayer/Player';
+import {
+  PlayerState,
+  SessionStream,
+} from 'teleport/SessionRecordings/view/stream/SessionStream';
+import {
+  ResponseType,
+  type BaseEvent,
+} from 'teleport/SessionRecordings/view/stream/types';
+
+function setup() {
+  const ws = new MockWebSocket();
+  const player = new MockPlayer();
+  const stream = new SessionStream(
+    ws,
+    player,
+    decodeMockEvent,
+    MockEventType.End,
+    25000
+  );
+
+  return { stream, player, ws };
+}
+
+describe('play', () => {
+  it('should not transition to playing whilst loading', () => {
+    const { stream } = setup();
+
+    const stateListener = jest.fn();
+    stream.on('state', stateListener);
+
+    stream.play();
+
+    expect(stateListener).not.toHaveBeenCalled();
+  });
+
+  it('should transition from loading to paused once the initial events are loaded', async () => {
+    const { stream, ws } = setup();
+
+    const statePromise = new Promise<PlayerState>(resolve => {
+      stream.once('state', resolve);
+    });
+
+    stream.loadInitial();
+
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    expect(await statePromise).toBe(PlayerState.Paused);
+  });
+
+  it('should resume to playing state after initial load if wasPlayingBeforeSeek', async () => {
+    const { stream, ws } = setup();
+
+    const pausedPromise = new Promise<PlayerState>(resolve => {
+      stream.once('state', resolve);
+    });
+
+    stream.loadInitial();
+
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 20000));
+
+    expect(await pausedPromise).toBe(PlayerState.Paused);
+
+    const playPromise = new Promise<PlayerState>(resolve => {
+      stream.once('state', resolve);
+    });
+
+    stream.play();
+    stream.seek(22000);
+
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 22500)], 2)
+    );
+
+    expect(await playPromise).toBe(PlayerState.Playing);
+  });
+
+  it('should call player.onPlay when transitioning to playing', () => {
+    const { stream, player, ws } = setup();
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.play();
+
+    expect(player.playState.onPlay).toBe(true);
+  });
+});
+
+describe('pause', () => {
+  it('should transition from playing to paused', () => {
+    const { stream, ws } = setup();
+
+    const stateListener = jest.fn();
+    stream.on('state', stateListener);
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.play();
+
+    expect(stateListener).toHaveBeenCalledWith(PlayerState.Playing);
+
+    stream.pause();
+
+    expect(stateListener).toHaveBeenCalledWith(PlayerState.Paused);
+  });
+
+  it('should call player.onPause when pausing', () => {
+    const { stream, player, ws } = setup();
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.play();
+    stream.pause();
+
+    expect(player.playState.onPause).toBe(true);
+  });
+
+  it('should not do anything if already paused', () => {
+    const { stream, ws } = setup();
+
+    const stateListener = jest.fn();
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.on('state', stateListener);
+    stream.pause();
+
+    expect(stateListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('seek', () => {
+  it('should emit time event when seeking', () => {
+    const { stream, ws } = setup();
+
+    const timeListener = jest.fn();
+    stream.on('time', timeListener);
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.seek(750);
+
+    expect(timeListener).toHaveBeenCalledWith(750);
+  });
+
+  it('should call player.onSeek when seeking', () => {
+    const { stream, player, ws } = setup();
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.seek(750);
+
+    expect(player.playState.onSeek).toBe(true);
+  });
+
+  it('should clear player when seeking backwards', () => {
+    const { stream, ws, player } = setup();
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([
+        createMockEvent(MockEventType.Print, 500),
+        createMockEvent(MockEventType.Print, 1000),
+      ])
+    );
+    ws.receiveMessage(createStopEvent(0, 2000));
+
+    stream.seek(1500);
+    player.cleared = false;
+    stream.seek(250);
+
+    expect(player.cleared).toBe(true);
+  });
+});
+
+describe('event handling', () => {
+  it('should ignore messages with wrong requestId', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { stream, ws, player } = setup();
+
+    stream.loadInitial();
+
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 100)], 999)
+    );
+
+    expect(player.events).toHaveLength(0);
+  });
+
+  it('should stop when an end event is encountered', () => {
+    const { stream, ws } = setup();
+
+    const stateListener = jest.fn();
+
+    stream.loadInitial();
+
+    ws.receiveMessage(
+      createBatchEvent([
+        createMockEvent(MockEventType.Print, 100),
+        createMockEvent(MockEventType.Print, 200),
+        createMockEvent(MockEventType.End, 300),
+      ])
+    );
+
+    jest.spyOn(performance, 'now').mockReturnValueOnce(0);
+    jest.spyOn(performance, 'now').mockReturnValueOnce(400);
+
+    stream.on('state', stateListener);
+    stream.play();
+
+    expect(stateListener).toHaveBeenCalledWith(PlayerState.Stopped);
+  });
+});
+
+describe('time events', () => {
+  it('should emit time events during playback', () => {
+    const { stream, ws } = setup();
+
+    const timeListener = jest.fn();
+    stream.on('time', timeListener);
+
+    stream.loadInitial();
+    ws.receiveMessage(
+      createBatchEvent([createMockEvent(MockEventType.Print, 500)])
+    );
+    ws.receiveMessage(createStopEvent(0, 1000));
+
+    stream.play();
+
+    expect(timeListener).toHaveBeenCalled();
+  });
+});
+
+function createStopEvent(startTime: number, endTime: number, requestId = 1) {
+  const buffer = new ArrayBuffer(33);
+  const view = new DataView(buffer);
+  view.setUint8(0, ResponseType.Stop);
+  view.setBigInt64(1, BigInt(0));
+  view.setUint32(9, 0);
+  view.setUint32(13, requestId);
+  view.setBigInt64(17, BigInt(startTime));
+  view.setBigInt64(25, BigInt(endTime));
+  return buffer;
+}
+
+function createBatchEvent(events: ArrayBuffer[], requestId = 1) {
+  const totalLength = events.reduce((sum, event) => sum + event.byteLength, 0);
+  const buffer = new ArrayBuffer(17 + totalLength);
+  const view = new DataView(buffer);
+
+  view.setUint8(0, ResponseType.Batch);
+  view.setUint32(1, events.length);
+  view.setUint32(5, requestId);
+  view.setUint32(9, totalLength);
+
+  let offset = 17;
+  for (const event of events) {
+    new Uint8Array(buffer, offset, event.byteLength).set(new Uint8Array(event));
+    offset += event.byteLength;
+  }
+
+  return buffer;
+}
+
+function createMockEvent(
+  type: MockEventType,
+  timestamp: number,
+  requestId = 1
+): ArrayBuffer {
+  const buffer = new ArrayBuffer(17);
+  const view = new DataView(buffer);
+  view.setUint8(0, type);
+  view.setBigInt64(1, BigInt(timestamp));
+  view.setUint32(9, 0);
+  view.setUint32(13, requestId);
+  return buffer;
+}
+
+function decodeMockEvent(buffer: ArrayBuffer): MockEvent {
+  const view = new DataView(buffer);
+  const type = view.getUint8(0) as MockEventType;
+  const timestamp = Number(view.getBigInt64(1));
+  const requestId = view.getUint32(13);
+
+  return {
+    type,
+    timestamp,
+    requestId,
+  } as MockEvent;
+}
+
+enum MockEventType {
+  Print,
+  Resize,
+  End,
+}
+
+interface MockEventPrint extends BaseEvent<MockEventType.Print> {
+  content: string;
+}
+
+interface MockEventResize extends BaseEvent<MockEventType.Resize> {
+  cols: number;
+  rows: number;
+}
+
+interface MockEventEnd extends BaseEvent<MockEventType.End> {}
+
+type MockEvent = MockEventPrint | MockEventResize | MockEventEnd;
+
+class MockPlayer extends Player<MockEvent> {
+  events: MockEvent[] = [];
+  cleared = false;
+  destroyed = false;
+  handleCalled = false;
+  playState = {
+    onPlay: false,
+    onPause: false,
+    onSeek: false,
+    onStop: false,
+  };
+
+  init(): void {}
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+
+  apply(event: MockEvent): void {
+    this.events.push(event);
+  }
+
+  handle(event: MockEvent): boolean {
+    this.handleCalled = true;
+
+    return event.type === MockEventType.End;
+  }
+
+  clear(): void {
+    this.cleared = true;
+    this.events = [];
+  }
+
+  onPlay(): void {
+    this.playState.onPlay = true;
+  }
+
+  onPause(): void {
+    this.playState.onPause = true;
+  }
+
+  onSeek(): void {
+    this.playState.onSeek = true;
+  }
+
+  onStop(): void {
+    this.playState.onStop = true;
+  }
+}
+
+interface WebSocketEventMap {
+  close: [CloseEvent];
+  error: [Event];
+  message: [MessageEvent];
+  open: [Event];
+}
+
+class MockWebSocket
+  extends EventEmitter<WebSocketEventMap>
+  implements WebSocket
+{
+  sentMessages: ArrayBuffer[] = [];
+  closed = false;
+  binaryType = 'arraybuffer' as const;
+  bufferedAmount = 0;
+  extensions = '';
+  protocol = '';
+  readyState = WebSocket.OPEN;
+  url = 'ws://localhost';
+
+  send(data: ArrayBuffer): void {
+    this.sentMessages.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  // Helper to simulate receiving a message
+  receiveMessage(data: ArrayBuffer): void {
+    const event = new MessageEvent('message', { data });
+    if (this.onmessage) {
+      this.onmessage(event);
+    }
+  }
+
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  dispatchEvent(event: Event): boolean {
+    return this.emit(event.type as keyof WebSocketEventMap, event as any);
+  }
+
+  readonly CLOSED: 3;
+  readonly CLOSING: 2;
+  readonly CONNECTING: 0;
+  readonly OPEN: 1;
+
+  addEventListener<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    this.on(type as keyof WebSocketEventMap, listener as any);
+  }
+
+  removeEventListener<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any,
+    options?: boolean | EventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    options?: boolean | EventListenerOptions
+  ): void {
+    this.off(type as keyof WebSocketEventMap, listener as any);
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -1,0 +1,459 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EventEmitter } from 'events';
+
+import { parseArrayBuffer } from 'teleport/SessionRecordings/view/stream/decoding';
+import {
+  isBatchEvent,
+  isErrorEvent,
+  isStartEvent,
+  isStopEvent,
+  type BaseEvent,
+} from 'teleport/SessionRecordings/view/stream/types';
+
+import { type Player } from '../SshRecordingPlayer/Player';
+import { encodeFetchRequest } from './encoding';
+
+export enum PlayerState {
+  Loading,
+  Paused,
+  Playing,
+  Stopped,
+}
+
+interface SessionStreamEvents {
+  state: [PlayerState];
+  time: [number];
+}
+
+interface Range {
+  end: number;
+  start: number;
+}
+
+const LOAD_THRESHOLD_MS = 5 * 1000; // 5 seconds
+const LOAD_CHUNK_MS = 20 * 1000; // 20 seconds
+
+/**
+ * SessionStream manages the loading and buffering of events from a WebSocket connection.
+ *
+ * It handles play, pause, and seek operations, ensuring that events are loaded and played back
+ * in a smooth manner. The class uses an internal buffer to store events and manages the state of playback.
+ *
+ * It passes the events to a Player instance for rendering, so it can be used with different types of
+ * session recordings.
+ */
+export class SessionStream<
+  TEvent extends BaseEvent<TEventType>,
+  TEventType extends number = number,
+  TEndEventType extends TEventType = TEventType,
+> extends EventEmitter<SessionStreamEvents> {
+  private buffer: TEvent[] = [];
+  private currentBufferIndex = 0;
+  private maxBufferSize = 2000;
+
+  private loadedRange: Range = {
+    end: 0,
+    start: 0,
+  };
+  private loadingRange: Range | null = null;
+
+  private animationFrameId: number | null = null;
+  private currentTime = 0;
+  private pausedTime = 0;
+  private startTime = 0;
+
+  private atEnd = false;
+  // we track loading separately from the loading state as we can still play and load at the same time
+  private loading = true;
+  private requestId = 0;
+  private state: PlayerState = PlayerState.Loading;
+  private wasPlayingBeforeSeek = false;
+
+  constructor(
+    private ws: WebSocket,
+    private player: Player<TEvent>,
+    private decodeEvent: (data: ArrayBuffer) => TEvent,
+    private endEventType: TEndEventType,
+    private duration: number
+  ) {
+    super();
+
+    ws.onmessage = this.handleMessage.bind(this);
+  }
+
+  destroy() {
+    this.removeAllListeners();
+    this.ws.close();
+
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+
+    this.player.destroy();
+  }
+
+  loadInitial() {
+    this.load(0, LOAD_CHUNK_MS, false);
+  }
+
+  play() {
+    if (this.loading || this.state === PlayerState.Playing) {
+      return;
+    }
+
+    this.setState(PlayerState.Playing);
+
+    if (this.pausedTime > 0) {
+      this.startTime = performance.now() - this.pausedTime;
+      this.pausedTime = 0;
+    } else if (!this.startTime) {
+      this.startTime = performance.now();
+      this.currentBufferIndex = 0;
+    }
+
+    this.playEvents();
+    this.player.onPlay();
+  }
+
+  seek(time: number) {
+    if (time > this.duration) {
+      return;
+    }
+
+    this.wasPlayingBeforeSeek = this.state === PlayerState.Playing;
+
+    this.emit('time', time);
+    this.player.onSeek(time);
+
+    if (this.state === PlayerState.Stopped) {
+      this.setState(PlayerState.Paused);
+    }
+
+    const isTimeLoaded =
+      time >= this.loadedRange.start && time <= this.loadedRange.end;
+
+    if (!isTimeLoaded) {
+      // we do not have the requested time loaded in the buffer, so clear the buffer
+      // and request the state of the screen at the requested time, and continue playback
+      // from there
+      this.clearBuffer();
+
+      if (this.animationFrameId !== null) {
+        cancelAnimationFrame(this.animationFrameId);
+        this.animationFrameId = null;
+      }
+
+      this.startTime = performance.now() - time;
+      this.currentTime = time;
+
+      if (
+        this.state === PlayerState.Paused ||
+        this.state === PlayerState.Stopped
+      ) {
+        this.pausedTime = time;
+      }
+
+      this.setState(PlayerState.Loading);
+
+      this.load(time, time + LOAD_CHUNK_MS, true);
+
+      return;
+    }
+
+    if (time < this.currentTime) {
+      // we are seeking backwards, so we cannot just apply the events from the current buffer index
+      // we need to reset the player state and re-apply all events from the start of the buffer
+      this.currentTime = 0;
+      this.currentBufferIndex = 0;
+
+      this.player.clear();
+    }
+
+    this.startTime = performance.now() - time;
+
+    // play all events up until the requested time
+    this.playEventsUpUntil(time);
+
+    if (
+      this.state === PlayerState.Paused ||
+      this.state === PlayerState.Stopped
+    ) {
+      // if we are paused or stopped, we need to update the paused time to the requested time
+      this.pausedTime = time;
+    }
+  }
+
+  pause() {
+    if (this.state === PlayerState.Paused) {
+      return;
+    }
+
+    this.setState(PlayerState.Paused);
+
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+
+    this.pausedTime = performance.now() - this.startTime;
+    this.currentTime = this.pausedTime;
+    this.wasPlayingBeforeSeek = false;
+
+    this.player.onPause();
+  }
+
+  private playEvents = () => {
+    if (this.state !== PlayerState.Playing) {
+      return;
+    }
+
+    const currentTime = performance.now() - this.startTime;
+
+    this.currentTime = currentTime;
+
+    this.emit('time', currentTime);
+
+    while (
+      this.currentBufferIndex < this.buffer.length &&
+      this.buffer[this.currentBufferIndex].timestamp <= currentTime
+    ) {
+      const event = this.buffer[this.currentBufferIndex];
+
+      this.currentBufferIndex++;
+
+      if (event.type === this.endEventType) {
+        this.setState(PlayerState.Stopped);
+        this.player.onStop();
+
+        return;
+      }
+
+      this.player.apply(event);
+    }
+
+    this.checkBufferStatus(currentTime);
+
+    this.animationFrameId = requestAnimationFrame(this.playEvents);
+  };
+
+  private playEventsUpUntil(time: number) {
+    while (
+      this.currentBufferIndex < this.buffer.length &&
+      this.buffer[this.currentBufferIndex].timestamp <= time
+    ) {
+      const event = this.buffer[this.currentBufferIndex];
+
+      this.currentBufferIndex++;
+
+      this.player.apply(event);
+    }
+
+    this.currentTime = time;
+
+    this.checkBufferStatus(time);
+  }
+
+  private checkBufferStatus(currentTime: number) {
+    if (this.loadingRange) {
+      return;
+    }
+
+    const isWithinLoadedRange =
+      currentTime >= this.loadedRange.start &&
+      currentTime + LOAD_THRESHOLD_MS <= this.loadedRange.end;
+
+    if (isWithinLoadedRange) {
+      return;
+    }
+
+    const lastEventTime =
+      this.buffer.length > 0
+        ? this.buffer[this.buffer.length - 1].timestamp
+        : currentTime;
+
+    const remainingBufferTime = lastEventTime - currentTime;
+
+    if (
+      !this.atEnd &&
+      !this.loading &&
+      remainingBufferTime < LOAD_THRESHOLD_MS
+    ) {
+      const newStartTime = this.loadedRange.end;
+      const newEndTime = newStartTime + LOAD_CHUNK_MS;
+
+      this.load(newStartTime, newEndTime);
+    }
+  }
+
+  private setState(state: PlayerState) {
+    this.state = state;
+    this.emit('state', state);
+  }
+
+  private handleMessage(event: MessageEvent) {
+    if (!(event.data instanceof ArrayBuffer)) {
+      return;
+    }
+
+    const parsed = parseArrayBuffer(event.data, this.decodeEvent);
+
+    if (parsed.requestId !== this.requestId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Ignoring event with requestId ${parsed.requestId}, current requestId is ${this.requestId}`
+      );
+
+      return;
+    }
+
+    if (isBatchEvent(parsed)) {
+      // mark loading as false as soon as we get any batch event so we can start playing again
+      this.loading = false;
+
+      if (this.state === PlayerState.Loading) {
+        if (this.wasPlayingBeforeSeek) {
+          this.play();
+        } else {
+          this.setState(PlayerState.Paused);
+        }
+      }
+
+      this.pushBatchToBuffer(parsed.events);
+
+      const hasEnd =
+        parsed.events[parsed.events.length - 1].type === this.endEventType;
+
+      if (hasEnd) {
+        this.end();
+      }
+
+      return;
+    }
+
+    if (isStartEvent(parsed)) {
+      return;
+    }
+
+    if (isStopEvent(parsed)) {
+      this.loading = false;
+      this.loadingRange = null;
+
+      this.updateLoadedTimes(parsed.startTime, parsed.endTime);
+
+      return;
+    }
+
+    if (isErrorEvent(parsed)) {
+      return;
+    }
+
+    if (this.player.handle(parsed)) {
+      return;
+    }
+
+    this.pushToBuffer(parsed);
+  }
+
+  private end() {
+    this.atEnd = true;
+  }
+
+  private load(
+    startTime: number,
+    endTime: number,
+    requestCurrentScreen = false
+  ) {
+    if (this.atEnd) {
+      return;
+    }
+
+    const isAlreadyLoading =
+      this.loadingRange &&
+      this.loadingRange.start <= startTime &&
+      this.loadingRange.end >= endTime;
+
+    if (isAlreadyLoading) {
+      return;
+    }
+
+    this.requestId += 1;
+
+    this.loading = true;
+
+    this.loadingRange = { end: endTime, start: startTime };
+
+    this.ws.send(
+      encodeFetchRequest({
+        endTime,
+        requestCurrentScreen,
+        requestId: this.requestId,
+        startTime,
+      })
+    );
+  }
+
+  private pushBatchToBuffer(events: TEvent[]) {
+    this.buffer = this.buffer.concat(events);
+    this.trimBuffer();
+  }
+
+  private pushToBuffer(event: TEvent) {
+    this.buffer.push(event);
+    this.trimBuffer();
+  }
+
+  private trimBuffer() {
+    if (this.buffer.length - this.currentBufferIndex > this.maxBufferSize) {
+      this.buffer = this.buffer.slice(this.currentBufferIndex);
+      this.currentBufferIndex = 0;
+      this.updateLoadedTimes(
+        this.buffer[0]?.timestamp ?? 0,
+        this.buffer[this.buffer.length - 1]?.timestamp ?? 0
+      );
+    }
+  }
+
+  private clearBuffer() {
+    this.buffer = [];
+    this.currentBufferIndex = 0;
+    this.startTime = 0;
+    this.pausedTime = 0;
+    this.loadedRange = {
+      end: 0,
+      start: 0,
+    };
+    this.atEnd = false;
+    this.loadingRange = null;
+  }
+
+  private updateLoadedTimes(start: number, end: number) {
+    if (this.loadedRange.start === 0 && this.loadedRange.end === 0) {
+      this.loadedRange = { start, end };
+
+      return;
+    }
+
+    this.loadedRange = {
+      start: Math.min(this.loadedRange.start, start),
+      end: Math.max(this.loadedRange.end, end),
+    };
+  }
+}

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -27,7 +27,7 @@ import {
   type BaseEvent,
 } from 'teleport/SessionRecordings/view/stream/types';
 
-import { type Player } from '../SshRecordingPlayer/Player';
+import { type Player } from '../player/Player';
 import { encodeFetchRequest } from './encoding';
 
 export enum PlayerState {
@@ -246,7 +246,7 @@ export class SessionStream<
         return;
       }
 
-      this.player.apply(event);
+      this.player.applyEvent(event);
     }
 
     this.checkBufferStatus(currentTime);
@@ -263,7 +263,7 @@ export class SessionStream<
 
       this.currentBufferIndex++;
 
-      this.player.apply(event);
+      this.player.applyEvent(event);
     }
 
     this.currentTime = time;
@@ -365,7 +365,8 @@ export class SessionStream<
       return;
     }
 
-    if (this.player.handle(parsed)) {
+    // if handleEvent returns true, it means the event has been handled and does not need to be added to the buffer
+    if (this.player.handleEvent(parsed)) {
       return;
     }
 

--- a/web/packages/teleport/src/SessionRecordings/view/stream/decoding.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/decoding.ts
@@ -1,0 +1,131 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  ResponseType,
+  type BaseEvent,
+  type BatchEvent,
+  type StreamEvent,
+} from './types';
+
+const responseHeaderSize = 17;
+
+export function parseArrayBuffer<
+  T extends BaseEvent<TType>,
+  TType extends number = number,
+>(
+  buffer: ArrayBuffer,
+  decodeEvent: (buffer: ArrayBuffer) => T
+): StreamEvent<T> | T {
+  if (buffer.byteLength < responseHeaderSize) {
+    throw new Error('Event too short');
+  }
+
+  const view = new DataView(buffer);
+  const responseType = view.getUint8(0) as ResponseType;
+  const timestamp = Number(view.getBigInt64(1));
+  const dataLength = view.getUint32(9);
+
+  if (buffer.byteLength < responseHeaderSize + dataLength) {
+    throw new Error('Incomplete event data');
+  }
+
+  const data = new Uint8Array(buffer, responseHeaderSize, dataLength);
+
+  const requestId = view.getUint32(13);
+
+  switch (responseType) {
+    case ResponseType.Batch:
+      return parseBatchEvent(buffer, decodeEvent);
+
+    case ResponseType.Error:
+      return {
+        error: new TextDecoder().decode(data),
+
+        requestId,
+        timestamp,
+        type: responseType,
+      };
+
+    case ResponseType.Start:
+      return { requestId, timestamp, type: responseType };
+
+    case ResponseType.Stop:
+      const startTime = Number(view.getBigInt64(responseHeaderSize));
+      const endTime = Number(view.getBigInt64(25));
+
+      return {
+        endTime,
+        requestId,
+        startTime,
+        timestamp,
+        type: responseType,
+      };
+
+    default:
+      return decodeEvent(buffer);
+  }
+}
+
+function parseBatchEvent<T>(
+  buffer: ArrayBuffer,
+  decodeEvent: (buffer: ArrayBuffer) => T
+): BatchEvent<T> {
+  if (buffer.byteLength < responseHeaderSize) {
+    throw new Error('Batch event header too short');
+  }
+
+  const headerView = new DataView(buffer);
+  const batchCount = headerView.getUint32(1);
+  const requestId = headerView.getUint32(5);
+
+  const events: T[] = [];
+
+  let offset = responseHeaderSize;
+
+  for (let i = 0; i < batchCount; i++) {
+    if (offset + responseHeaderSize > buffer.byteLength) {
+      throw new Error(`Incomplete batch event at index ${i}`);
+    }
+
+    const eventView = new DataView(buffer, offset);
+    const dataLength = eventView.getUint32(9);
+
+    if (offset + responseHeaderSize + dataLength > buffer.byteLength) {
+      throw new Error(`Incomplete event data at index ${i}`);
+    }
+
+    const eventBuffer = new ArrayBuffer(responseHeaderSize + dataLength);
+    const eventBytes = new Uint8Array(eventBuffer);
+    eventBytes.set(
+      new Uint8Array(buffer, offset, responseHeaderSize + dataLength)
+    );
+
+    const parsedEvent = decodeEvent(eventBuffer);
+    events.push(parsedEvent);
+
+    offset += responseHeaderSize + dataLength;
+  }
+
+  return {
+    events,
+    requestId,
+    timestamp: 0,
+    type: ResponseType.Batch,
+  };
+}

--- a/web/packages/teleport/src/SessionRecordings/view/stream/encoding.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/encoding.ts
@@ -1,0 +1,37 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RequestType, type FetchRequest } from './types';
+
+const requestHeaderSize = 21;
+
+export function encodeFetchRequest(request: FetchRequest): ArrayBuffer {
+  const buffer = new ArrayBuffer(22);
+  const view = new DataView(buffer);
+
+  view.setUint8(0, RequestType.Fetch);
+  view.setBigInt64(1, BigInt(Math.floor(request.startTime)));
+  view.setBigInt64(9, BigInt(Math.floor(request.endTime)));
+  view.setUint32(17, request.requestId);
+
+  if (request.requestCurrentScreen !== undefined) {
+    view.setUint8(requestHeaderSize, request.requestCurrentScreen ? 1 : 0);
+  }
+
+  return buffer;
+}

--- a/web/packages/teleport/src/SessionRecordings/view/stream/types.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/types.ts
@@ -29,6 +29,9 @@ export enum ResponseType {
 
 export interface FetchRequest {
   endTime: number;
+  // requestCurrentScreen is used to request the stream to send the full state of the recording at the requested start time.
+  // This is so the correct state of the recording can be rendered without having to return all the events up until
+  // the requested start time.
   requestCurrentScreen?: boolean;
   requestId: number;
   startTime: number;

--- a/web/packages/teleport/src/SessionRecordings/view/stream/types.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export enum RequestType {
+  Fetch = 1,
+}
+
+export enum ResponseType {
+  Start = 1,
+  Stop = 2,
+  Error = 3,
+  Batch = 9,
+}
+
+export interface FetchRequest {
+  endTime: number;
+  requestCurrentScreen?: boolean;
+  requestId: number;
+  startTime: number;
+}
+
+export interface BaseEvent<TType extends number = number> {
+  requestId: number;
+  timestamp: number;
+  type: TType;
+}
+
+export interface BatchEvent<T> extends BaseEvent<ResponseType.Batch> {
+  events: T[];
+}
+
+export interface ErrorEvent extends BaseEvent<ResponseType.Error> {
+  error: string;
+}
+
+export interface StartEvent extends BaseEvent<ResponseType.Start> {}
+
+export interface StopEvent extends BaseEvent<ResponseType.Stop> {
+  endTime: number;
+  startTime: number;
+}
+
+export type StreamEvent<T> =
+  | StartEvent
+  | StopEvent
+  | ErrorEvent
+  | BatchEvent<T>;
+
+export function isBatchEvent<
+  TEvent extends BaseEvent<TType>,
+  TType extends number = number,
+>(event: TEvent | StreamEvent<TEvent>): event is BatchEvent<TEvent> {
+  return event.type === ResponseType.Batch;
+}
+
+export function isErrorEvent<
+  TEvent extends BaseEvent<TType>,
+  TType extends number = number,
+>(event: TEvent | StreamEvent<TEvent>): event is ErrorEvent {
+  return event.type === ResponseType.Error;
+}
+
+export function isStartEvent<
+  TEvent extends BaseEvent<TType>,
+  TType extends number = number,
+>(event: TEvent | StreamEvent<TEvent>): event is StartEvent {
+  return event.type === ResponseType.Start;
+}
+
+export function isStopEvent<
+  TEvent extends BaseEvent<TType>,
+  TType extends number = number,
+>(event: TEvent | StreamEvent<TEvent>): event is StopEvent {
+  return event.type === ResponseType.Stop;
+}


### PR DESCRIPTION
This adds the session stream handler for the new playback API in https://github.com/gravitational/teleport/pull/58116

This is a generic streamer that takes a `Player` instance (in a follow-up PR) to play the events received. This way, it should work with both tty events and desktop events

This is the first PR for the new player

<img width="1889" height="1629" alt="image" src="https://github.com/user-attachments/assets/5a854421-7650-428f-b855-9f9c5495ca5c" />
