### PR TITLE
AWS Roles Anywhere: prevent invalid RoleSessionName in create session

### DIFF
--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -192,3 +192,32 @@ func TestEncodeCredentialProcessFormat(t *testing.T) {
 	expected := `{"Version":1,"AccessKeyId":"mock-access-key-id","SecretAccessKey":"mock-secret-access-key","SessionToken":"mock-session-token","Expiration":"2030-06-24T00:00:00Z"}`
 	require.JSONEq(t, expected, encoded)
 }
+
+func TestRoleSessionNameFromSubjec(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		subject  string
+		expected string
+	}{
+		{
+			name:     "valid subject",
+			subject:  "my-service-name",
+			expected: "my-service-name",
+		},
+		{
+			name:     "using email",
+			subject:  "user@example.com",
+			expected: "user@example.com",
+		},
+		{
+			name:     "using email with plus sign",
+			subject:  "user+tag@example.com",
+			expected: "user_tag@example.com",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := roleSessionNameFromSubject(t.Context(), tt.subject)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -193,7 +193,7 @@ func TestEncodeCredentialProcessFormat(t *testing.T) {
 	require.JSONEq(t, expected, encoded)
 }
 
-func TestRoleSessionNameFromSubjec(t *testing.T) {
+func TestRoleSessionNameFromSubject(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		subject  string


### PR DESCRIPTION
Example of how role will look like in AWS web console:
Teleport User: `marco.dinis+andre@goteleport.com`
<img width="296" height="80" alt="image" src="https://github.com/user-attachments/assets/f3d000c8-040c-4129-baf1-e2efaed4368b" />
