### PR TITLE
Add manual Access List Clone flow instead of json roundtrip

### DIFF
--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/utils/testutils/structfill"
 )
 
 func TestParseReviewFrequency(t *testing.T) {
@@ -392,4 +394,13 @@ func TestAccessList_setInitialReviewDate(t *testing.T) {
 			require.Equal(t, test.expected, accessList.Spec.Audit.NextAuditDate)
 		})
 	}
+}
+
+func TestAccessListClone(t *testing.T) {
+	item := &AccessList{}
+	err := structfill.Fill(item)
+	require.NoError(t, err)
+	cpy := item.Clone()
+	require.Empty(t, cmp.Diff(item, cpy))
+	require.NotSame(t, item, cpy)
 }

--- a/api/types/trait/trait.go
+++ b/api/types/trait/trait.go
@@ -16,5 +16,21 @@ limitations under the License.
 
 package trait
 
+import (
+	"slices"
+)
+
 // Traits is a mapping of traits to values.
 type Traits map[string][]string
+
+// Clone returns a deep copy of the traits map.
+func (t Traits) Clone() Traits {
+	if t == nil {
+		return nil
+	}
+	out := make(Traits, len(t))
+	for key, values := range t {
+		out[key] = slices.Clone(values)
+	}
+	return out
+}

--- a/api/utils/testutils/structfill/structfill.go
+++ b/api/utils/testutils/structfill/structfill.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package structfill
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+// Fill sets non-default values for all fields in the value pointed to by ptr.
+// It returns an error if it encounters a field it cannot set.
+// NOTE: Use only it tests.
+func Fill(ptr any) error {
+	if ptr == nil {
+		return trace.BadParameter("missing pointer")
+	}
+	root := reflect.ValueOf(ptr)
+	if root.Kind() != reflect.Ptr || root.IsNil() {
+		return trace.BadParameter("must pass a non-nil pointer")
+	}
+	return trace.Wrap(fill(root.Elem()))
+}
+
+func fill(v reflect.Value) error {
+	if !v.CanSet() {
+		return trace.BadParameter("cannot set value of type %v", v.Type())
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		v.SetBool(true)
+		return nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Type().PkgPath() == "time" && v.Type().Name() == "Duration" {
+			v.SetInt(int64(time.Second))
+		} else {
+			v.SetInt(1)
+		}
+		return nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		v.SetUint(1)
+		return nil
+
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(1.1)
+		return nil
+
+	case reflect.Complex64, reflect.Complex128:
+		v.SetComplex(complex(1, 1))
+		return nil
+
+	case reflect.String:
+		v.SetString("nonzero")
+		return nil
+
+	case reflect.Slice:
+		s := reflect.MakeSlice(v.Type(), 1, 1)
+		if err := fill(s.Index(0)); err != nil {
+			return trace.Wrap(err)
+		}
+		v.Set(s)
+		return nil
+
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := fill(v.Index(i)); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+
+	case reflect.Map:
+		kt, vt := v.Type().Key(), v.Type().Elem()
+		m := reflect.MakeMapWithSize(v.Type(), 1)
+
+		k := reflect.New(kt).Elem()
+		if err := fill(k); err != nil {
+			return trace.Wrap(err)
+		}
+
+		val := reflect.New(vt).Elem()
+		if err := fill(val); err != nil {
+			return trace.Wrap(err)
+		}
+
+		m.SetMapIndex(k, val)
+		v.Set(m)
+		return nil
+
+	case reflect.Ptr:
+		elem := reflect.New(v.Type().Elem())
+		if err := fill(elem.Elem()); err != nil {
+			return trace.Wrap(err)
+		}
+		v.Set(elem)
+		return nil
+
+	case reflect.Struct:
+		if v.Type().PkgPath() == "time" && v.Type().Name() == "Time" {
+			v.Set(reflect.ValueOf(time.Now()))
+			return nil
+		}
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			sf := t.Field(i)
+			f := v.Field(i)
+
+			if !f.CanSet() {
+				return trace.BadParameter(
+					"cannot set field %q of type %v (unexported or from another package)",
+					sf.Name, sf.Type,
+				)
+			}
+			if err := fill(f); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	default:
+		// For unsupported kinds (func, chan, unsafe pointers, interfaces)
+		return trace.BadParameter("unsupported kind %v", v.Kind())
+	}
+}

--- a/api/utils/testutils/structfill/structfill_test.go
+++ b/api/utils/testutils/structfill/structfill_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package structfill_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/testutils/structfill"
+)
+
+type InnerObject struct {
+	D  time.Duration
+	T  time.Time
+	DP *time.Duration
+	TP *time.Time
+}
+type Nested struct {
+	NI int
+}
+
+type object struct {
+	B    bool
+	I    int64
+	U    uint32
+	F    float64
+	C    complex128
+	S    string
+	A    [3]int
+	Sl   []InnerObject
+	SlP  []*InnerObject
+	M    map[string]*InnerObject
+	P    *int
+	Sub  InnerObject
+	SubP *InnerObject
+	SP   *string
+
+	*Nested
+}
+
+func TestRandFill(t *testing.T) {
+	var v object
+	err := structfill.Fill(&v)
+	require.NoError(t, err)
+
+	require.True(t, v.B)
+	require.NotZero(t, v.I)
+	require.NotZero(t, v.U)
+	require.NotZero(t, v.F)
+	require.NotZero(t, v.C)
+	require.NotEmpty(t, v.S)
+
+	require.Len(t, v.A, 3)
+	require.NotZero(t, v.A[0])
+	require.NotZero(t, v.A[1])
+	require.NotZero(t, v.A[2])
+
+	require.NotEmpty(t, v.Sl)
+	require.NotZero(t, v.Sl[0].D)
+	require.False(t, v.Sl[0].T.IsZero())
+	require.NotNil(t, v.Sl[0].DP)
+	require.NotZero(t, *v.Sl[0].DP)
+	require.NotNil(t, v.Sl[0].TP)
+	require.False(t, v.Sl[0].TP.IsZero())
+
+	require.NotEmpty(t, v.SlP)
+	require.NotNil(t, v.SlP[0])
+	require.NotZero(t, v.SlP[0].D)
+	require.False(t, v.SlP[0].T.IsZero())
+	require.NotNil(t, v.SlP[0].DP)
+	require.NotZero(t, *v.SlP[0].DP)
+	require.NotNil(t, v.SlP[0].TP)
+	require.False(t, v.SlP[0].TP.IsZero())
+
+	require.NotEmpty(t, v.M)
+	for k, val := range v.M {
+		require.NotEmpty(t, k)
+		require.NotNil(t, val)
+		require.NotZero(t, val.D)
+		require.False(t, val.T.IsZero())
+		require.NotNil(t, val.DP)
+		require.NotZero(t, *val.DP)
+		require.NotNil(t, val.TP)
+		require.False(t, val.TP.IsZero())
+	}
+
+	require.NotNil(t, v.P)
+	require.NotZero(t, *v.P)
+
+	require.NotZero(t, v.Sub.D)
+	require.False(t, v.Sub.T.IsZero())
+	require.NotNil(t, v.Sub.DP)
+	require.NotZero(t, *v.Sub.DP)
+	require.NotNil(t, v.Sub.TP)
+	require.False(t, v.Sub.TP.IsZero())
+
+	require.NotNil(t, v.SubP)
+	require.NotZero(t, v.SubP.D)
+	require.False(t, v.SubP.T.IsZero())
+	require.NotNil(t, v.SubP.DP)
+	require.NotZero(t, *v.SubP.DP)
+	require.NotNil(t, v.SubP.TP)
+	require.False(t, v.SubP.TP.IsZero())
+
+	require.NotNil(t, v.SP)
+	require.NotEmpty(t, *v.SP)
+
+	require.NotNil(t, v.Nested)
+	require.NotEmpty(t, v.Nested.NI)
+}


### PR DESCRIPTION
### What

Add access list clone method: 

Before: 

```
BenchmarkAccessListClone
BenchmarkAccessListClone/count=100
BenchmarkAccessListClone/count=100-14         	    1298	    797231 ns/op	  331981 B/op	    4402 allocs/op
BenchmarkAccessListClone/count=1000
BenchmarkAccessListClone/count=1000-14        	     147	   8129994 ns/op	 3321163 B/op	   44030 allocs/op
BenchmarkAccessListClone/count=10000
BenchmarkAccessListClone/count=10000-14       	      14	  82122917 ns/op	33157790 B/op	  440135 allocs/op
BenchmarkAccessListClone/count=100000
BenchmarkAccessListClone/count=100000-14      	       2	 792551083 ns/op	331255472 B/op	 4400209 allocs/op
PASS
```

After:
```
BenchmarkAccessListClone
BenchmarkAccessListClone/count=100
BenchmarkAccessListClone/count=100-14         	   64868	     18246 ns/op	   65600 B/op	     300 allocs/op
BenchmarkAccessListClone/count=1000
BenchmarkAccessListClone/count=1000-14        	    6130	    195624 ns/op	  656005 B/op	    3000 allocs/op
BenchmarkAccessListClone/count=10000
BenchmarkAccessListClone/count=10000-14       	     891	   1335078 ns/op	 6560006 B/op	   30000 allocs/op
BenchmarkAccessListClone/count=100000
BenchmarkAccessListClone/count=100000-14      	     104	  11364657 ns/op	65600056 B/op	  300000 allocs/op
PASS
```