### PR TITLE
[v18] MWI: Fix panic in SSH multiplexer

### DIFF
--- a/lib/tbot/services/ssh/multiplexer.go
+++ b/lib/tbot/services/ssh/multiplexer.go
@@ -271,7 +271,7 @@ func (s *MultiplexerService) setup(ctx context.Context) (
 			select {
 			case <-s.botIdentityReadyCh:
 			case <-ctx.Done():
-				return nil, nil, "", nil, nil
+				return nil, nil, "", nil, ctx.Err()
 			}
 		}
 	}


### PR DESCRIPTION
Backport #58565 to branch/v18

changelog: Fix panic in `tbot`'s `ssh-multiplexer` service
