### PR TITLE
[loadtest] switch etcd Helm to legacy images

### DIFF
--- a/assets/loadtest/etcd/Makefile
+++ b/assets/loadtest/etcd/Makefile
@@ -1,13 +1,15 @@
+# Note as of 2025-08-28 this chart is no longer supported https://github.com/bitnami/containers/issues/83267
 # deploys etcd into the cluster
 .PHONY: deploy
 deploy:
-	helm install etcd -n etcd --create-namespace oci://registry-1.docker.io/bitnamicharts/etcd \
+	helm --version 12.0.18 install etcd -n etcd --create-namespace oci://registry-1.docker.io/bitnamicharts/etcd \
 		--set replicaCount=3 \
 		--set metrics.enabled=true \
 		--set metrics.podMonitor.enabled=true \
 		--set auth.rbac.create=false \
 		--set auth.rbac.allowNoneAuthentication=true \
-		--set auth.token.enabled=false
+		--set auth.token.enabled=false \
+		--values etcd-values.yaml
 
 # deletes etcd from the cluster
 .PHONY: delete

--- a/assets/loadtest/etcd/etcd-values.yaml
+++ b/assets/loadtest/etcd/etcd-values.yaml
@@ -1,0 +1,10 @@
+persistence:
+  enabled: true
+  storageClass: "gp2"
+  accessModes:
+    - ReadWriteOnce
+  size: 32Gi
+
+# Switch to legacy images
+image:
+  repository: bitnamilegacy/etcd


### PR DESCRIPTION
The images used by the bitnami helm chart have been migrated to the legacy registry. To unblock testing switch to the legacy. Pin the chart version to prevent future breaks. 

This commit also adds the required PVs to be created during deployment.

Related: https://github.com/bitnami/containers/issues/83267