### PR TITLE
[v18] Cache fix panic due to missing clone call

### DIFF
--- a/lib/cache/app.go
+++ b/lib/cache/app.go
@@ -83,7 +83,7 @@ func (c *Cache) Apps(ctx context.Context, start, end string) iter.Seq2[types.App
 
 		if rg.ReadCache() {
 			for a := range rg.store.resources(appNameIndex, start, end) {
-				if !yield(a, nil) {
+				if !yield(a.Copy(), nil) {
 					return
 				}
 			}

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -153,7 +153,7 @@ func (c *Cache) RangeDatabases(ctx context.Context, start, end string) iter.Seq2
 
 		if rg.ReadCache() {
 			for database := range rg.store.resources(databaseNameIndex, start, end) {
-				if !yield(database, nil) {
+				if !yield(database.Copy(), nil) {
 					return
 				}
 			}

--- a/lib/cache/identitycenter.go
+++ b/lib/cache/identitycenter.go
@@ -240,7 +240,7 @@ func (c *Cache) GetIdentityCenterAccountAssignment(ctx context.Context, id strin
 		return nil, trace.Wrap(err)
 	}
 
-	return assignment, nil
+	return proto.CloneOf(assignment), nil
 }
 
 // ListAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
@@ -292,7 +292,7 @@ func (c *Cache) ListIdentityCenterAccountAssignments(ctx context.Context, pageSi
 			return assignments, assignment.GetMetadata().Name, nil
 		}
 
-		assignments = append(assignments, assignment)
+		assignments = append(assignments, proto.CloneOf(assignment))
 	}
 	return assignments, "", nil
 }

--- a/lib/cache/user_login_state.go
+++ b/lib/cache/user_login_state.go
@@ -33,7 +33,7 @@ const userLoginStateNameIndex userLoginStateIndex = "name"
 
 func newUserLoginStateCollection(upstream services.UserLoginStates, w types.WatchKind) (*collection[*userloginstate.UserLoginState, userLoginStateIndex], error) {
 	if upstream == nil {
-		return nil, trace.BadParameter("missing parameter UserTasks")
+		return nil, trace.BadParameter("missing parameter UserLoginStates")
 	}
 
 	return &collection[*userloginstate.UserLoginState, userLoginStateIndex]{


### PR DESCRIPTION
Backport #58577 to branch/v18

changelog: Fix internal cache issue that could cause crashes in AWS IC, Database, and App access flows.
