### PR TITLE
Web UI: Add Entrypoints for AWS Roles Anywhere

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/Tile.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/Tile.tsx
@@ -17,9 +17,10 @@
  */
 
 import { useState, type ComponentPropsWithoutRef } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Box, Flex, Link, Text } from 'design';
+import { Box, Link as ExternalLink, Flex, Text } from 'design';
 import { NewTab } from 'design/Icon';
 import { Theme } from 'design/theme';
 import { PinningSupport } from 'shared/components/UnifiedResources';
@@ -71,7 +72,9 @@ export function Tile({
     onSelectResource(resourceSpec);
   };
 
-  let resourceCardProps: ComponentPropsWithoutRef<'button' | typeof Link>;
+  let resourceCardProps: ComponentPropsWithoutRef<
+    'button' | typeof ExternalLink | typeof Link
+  >;
 
   if (resourceSpec.kind === ResourceKind.Application && resourceSpec.isDialog) {
     resourceCardProps = {
@@ -81,11 +84,19 @@ export function Tile({
     };
   } else if (resourceSpec.unguidedLink) {
     resourceCardProps = {
-      as: Link,
+      as: ExternalLink,
       href: resourceSpec.hasAccess ? resourceSpec.unguidedLink : null,
       target: '_blank',
       style: { textDecoration: 'none' },
       role: 'link',
+    };
+  } else if (resourceSpec.guidedLink) {
+    resourceCardProps = {
+      as: Link,
+      to: {
+        pathname: resourceSpec.hasAccess ? resourceSpec.guidedLink : null,
+      },
+      style: { textDecoration: 'none' },
     };
   } else {
     resourceCardProps = {

--- a/web/packages/teleport/src/Discover/SelectResource/Tile.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/Tile.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useState, type ComponentPropsWithoutRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Box, Link as ExternalLink, Flex, Text } from 'design';
@@ -73,7 +73,7 @@ export function Tile({
   };
 
   let resourceCardProps: ComponentPropsWithoutRef<
-    'button' | typeof ExternalLink | typeof Link
+    'button' | typeof ExternalLink | typeof InternalLink
   >;
 
   if (resourceSpec.kind === ResourceKind.Application && resourceSpec.isDialog) {
@@ -92,7 +92,7 @@ export function Tile({
     };
   } else if (resourceSpec.guidedLink) {
     resourceCardProps = {
-      as: Link,
+      as: InternalLink,
       to: {
         pathname: resourceSpec.hasAccess ? resourceSpec.guidedLink : null,
       },

--- a/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
@@ -19,6 +19,8 @@
 import { Platform } from 'design/platform';
 import { assertUnreachable } from 'shared/utils/assertUnreachable';
 
+import cfg from 'teleport/config';
+import { IntegrationKind } from 'teleport/services/integrations';
 import {
   DiscoverDiscoveryConfigMethod,
   DiscoverEventResource,
@@ -158,12 +160,21 @@ export const APPLICATIONS: SelectResourceSpec[] = [
   },
   {
     id: DiscoverGuideId.ApplicationAwsCliConsole,
-    name: 'AWS CLI/Console Access',
+    name: 'AWS CLI/Console Access via AWS OIDC IdP',
     kind: ResourceKind.Application,
     keywords: [...awsKeywords, 'application', 'cli', 'console access'],
     icon: 'aws',
     event: DiscoverEventResource.ApplicationAwsConsole,
     appMeta: { awsConsole: true },
+  },
+  {
+    id: DiscoverGuideId.ApplicationAwsRolesAnywhere,
+    name: 'AWS CLI/Console Access via AWS Roles Anywhere',
+    kind: ResourceKind.Application,
+    keywords: [...awsKeywords, 'application', 'cli', 'console access'],
+    icon: 'aws',
+    event: DiscoverEventResource.ApplicationAwsConsole,
+    guidedLink: cfg.getIntegrationEnrollRoute(IntegrationKind.AwsRa),
   },
 ];
 
@@ -286,7 +297,10 @@ export function getResourcePretitle(r: SelectResourceSpec) {
     case ResourceKind.ConnectMyComputer:
       return 'SSH';
     case ResourceKind.Application:
-      if (r.id === DiscoverGuideId.ApplicationAwsCliConsole) {
+      if (
+        r.id === DiscoverGuideId.ApplicationAwsCliConsole ||
+        r.id === DiscoverGuideId.ApplicationAwsRolesAnywhere
+      ) {
         return 'Amazon Web Services (AWS)';
       }
       if (r.id === DiscoverGuideId.ApplicationWebHttpProxy) {

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -98,7 +98,7 @@ export interface ResourceSpec {
    */
   unguidedLink?: string;
   /**
-   * guidedLink is the link out to a guided flow outside of Discover flow.
+   * guidedLink is an internal link to a guided flow outside of Discover flow.
    */
   guidedLink?: string;
   /**

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -98,6 +98,10 @@ export interface ResourceSpec {
    */
   unguidedLink?: string;
   /**
+   * guidedLink is the link out to a guided flow outside of Discover flow.
+   */
+  guidedLink?: string;
+  /**
    * isDialog indicates whether the flow for this resource is a popover dialog as opposed to a
    * Discover flow. This is the case for the 'Application' resource.
    */

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -298,7 +298,7 @@ export function DiscoverProvider({
     // We still want to emit an event if user clicked on an
     // unguided link to gather data on which unguided resource
     // is most popular.
-    if (resource.unguidedLink || resource.isDialog) {
+    if (resource.unguidedLink || resource.guidedLink || resource.isDialog) {
       emitEvent(
         { stepStatus: DiscoverEventStatus.Success },
         {

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.test.tsx
@@ -33,8 +33,8 @@ test('render', async () => {
 
   expect(screen.getByText(/AWS OIDC Identity Provider/i)).toBeInTheDocument();
   expect(screen.queryByText(/no permission/i)).not.toBeInTheDocument();
-  expect(screen.getAllByTestId('res-icon-aws')).toHaveLength(2);
-  expect(screen.getAllByRole('link')).toHaveLength(2);
+  expect(screen.getAllByTestId('res-icon-aws')).toHaveLength(3);
+  expect(screen.getAllByRole('link')).toHaveLength(3);
 
   const tile = screen.getByTestId('tile-aws-oidc');
   expect(tile).toBeEnabled();
@@ -65,7 +65,7 @@ test('render disabled', async () => {
   expect(tile).toHaveAttribute('disabled');
 
   // Disabled states have badges on them. Test it renders on hover.
-  const badge = screen.getByText(/lacking permission/i);
+  const badge = tile.querySelector('[data-testid="tooltip"]');
   await userEvent.hover(badge);
   expect(
     screen.getByText(/request additional permissions/i)

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/integrations.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/integrations.ts
@@ -48,6 +48,12 @@ const integrations: IntegrationTileSpec[] = [
     icon: 'aws',
     name: 'AWS OIDC Identity Provider',
   },
+  {
+    type: 'integration',
+    kind: IntegrationKind.AwsRa,
+    icon: 'aws',
+    name: 'AWS IAM Roles Anywhere',
+  },
 ];
 
 export function installableIntegrations() {

--- a/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
+++ b/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
@@ -39,6 +39,7 @@ export enum DiscoverGuideId {
   // Applications:
   ApplicationWebHttpProxy = 'application-web-http-proxy',
   ApplicationAwsCliConsole = 'application-aws-cli-console',
+  ApplicationAwsRolesAnywhere = 'application-aws-iam-roles-anywhere',
   ApplicationSamlGeneric = 'application-saml-generic',
   ApplicationSamlGrafana = 'application-saml-grafana',
   ApplicationSamlWorkforceIdentityFederation = 'application-saml-workforce-identity-federation',

--- a/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
+++ b/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
@@ -38,7 +38,7 @@ export enum DiscoverGuideId {
 
   // Applications:
   ApplicationWebHttpProxy = 'application-web-http-proxy',
-  ApplicationAwsCliConsole = 'application-aws-cli-console',
+  ApplicationAwsCliConsole = 'application-aws-cli-console', // AWS OIDC IdP
   ApplicationAwsRolesAnywhere = 'application-aws-iam-roles-anywhere',
   ApplicationSamlGeneric = 'application-saml-generic',
   ApplicationSamlGrafana = 'application-saml-grafana',


### PR DESCRIPTION
## Description

Issue: https://github.com/gravitational/teleport/issues/58249

Adds entrypoints for the AWS Roles anywhere flow in the `Resources > New` and `Integrations > Enroll` pages

Clicking on a RA tile will direct you to `/web/integrations/new/aws-ra` to enter the flow

### Screenshots

<img width="600" alt="Screenshot 2025-09-02 at 3 12 52 PM" src="https://github.com/user-attachments/assets/c3286447-68be-4527-abe5-e1d6de6127da" />

_New Resource Entrypoint_



<img width="600"  alt="Screenshot 2025-09-02 at 3 13 30 PM" src="https://github.com/user-attachments/assets/cf81b462-5fd7-46b0-8845-9856de44b764" />

_Enroll Integration Entrypoint_
