### PR TITLE
[v18] Fix TestParallelUpdate test on heavily loaded CI

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -104,17 +104,16 @@ func TestParallelUpdate(t *testing.T) {
 	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
-	// By setting the limit request next test http serving file going blocked until unlock is sent.
-	lock := make(chan struct{})
-	limitedWriter.SetLimitRequest(limitRequest{
-		limit: 1024,
-		lock:  lock,
-	})
+	tCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	t.Cleanup(cancel)
 
+	// Spawn three parallel processes with an environment variable to request a version update.
+	// Only one process should initiate the update, while the other two must be locked and wait
+	// until the first process finishes downloading and unpacking the update.
 	outputs := make([]bytes.Buffer, 3)
 	errChan := make(chan error, 3)
 	for i := range outputs {
-		cmd := exec.Command(tshPath, "version")
+		cmd := exec.CommandContext(tCtx, tshPath, "version")
 		cmd.Stdout = &outputs[i]
 		cmd.Stderr = &outputs[i]
 		cmd.Env = append(
@@ -129,33 +128,20 @@ func TestParallelUpdate(t *testing.T) {
 		}(cmd)
 	}
 
-	select {
-	case err := <-errChan:
-		require.Fail(t, "we shouldn't receive any error", err)
-	case <-time.After(5 * time.Second):
-		require.Fail(t, "failed to wait till the download is started")
-	case <-lock:
-		// Wait for a short period to allow other processes to launch and attempt to acquire the lock.
-		time.Sleep(100 * time.Millisecond)
-		lock <- struct{}{}
-	}
-
 	// Wait till process finished with exit code 0, but we still should get progress
 	// bar in output content.
 	for range cap(outputs) {
-		select {
-		case <-time.After(5 * time.Second):
-			require.Fail(t, "failed to wait till the process is finished")
-		case err := <-errChan:
-			require.NoError(t, err)
-		}
+		require.NoError(t, <-errChan)
 	}
 
+	// Verify the output of all spawned processes to ensure that only one process
+	// indicates the client tools were updating. As a result, all outputs must show
+	// the updated version: the first process performs the update and re-executes,
+	// while the other two wait until the first process finishes before re-executing
+	// to the desired version.
 	var progressCount int
 	for i := range cap(outputs) {
-		matches := pattern.FindStringSubmatch(outputs[i].String())
-		require.Len(t, matches, 2)
-		assert.Equal(t, testVersions[1], matches[1])
+		matchVersion(t, outputs[i].String(), testVersions[1])
 		if strings.Contains(outputs[i].String(), "Update progress:") {
 			progressCount++
 		}
@@ -206,7 +192,7 @@ func TestUpdateInterruptSignal(t *testing.T) {
 	select {
 	case err := <-errChan:
 		require.Fail(t, "we shouldn't receive any error", err)
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		require.Fail(t, "failed to wait till the download is started")
 	case <-lock:
 		time.Sleep(100 * time.Millisecond)
@@ -217,7 +203,7 @@ func TestUpdateInterruptSignal(t *testing.T) {
 	// Wait till process finished with exit code 0, but we still should get progress
 	// bar in output content.
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		require.Fail(t, "failed to wait till the process interrupted")
 	case err := <-errChan:
 		require.NoError(t, err)


### PR DESCRIPTION
Backport #58290 to branch/v18