### PR TITLE
Database Web UI REPL handles window resizing

### DIFF
--- a/lib/client/db/mysql/repl/repl.go
+++ b/lib/client/db/mysql/repl/repl.go
@@ -40,10 +40,11 @@ import (
 
 // REPL implements [dbrepl.REPLInstance] for MySQL.
 type REPL struct {
+	*term.Terminal
+
 	client     io.ReadWriteCloser
 	serverConn net.Conn
 	route      clientproto.RouteToDatabase
-	term       *term.Terminal
 	parser     *parser
 	myConn     mysqlConn
 
@@ -72,10 +73,10 @@ func New(_ context.Context, cfg *dbrepl.NewREPLConfig) (dbrepl.REPLInstance, err
 		return nil, trace.Wrap(err)
 	}
 	return &REPL{
+		Terminal:   term.NewTerminal(cfg.Client, ""),
 		client:     cfg.Client,
 		serverConn: cfg.ServerConn,
 		route:      cfg.Route,
-		term:       term.NewTerminal(cfg.Client, ""),
 		parser:     parser,
 	}, nil
 }
@@ -150,7 +151,7 @@ func withClientCapabilities(caps ...uint32) client.Option {
 
 func (r *REPL) presentBanner() error {
 	_, err := fmt.Fprintf(
-		r.term,
+		r.Terminal,
 		`Teleport MySQL interactive shell (v%s)
 Connected to instance %q as user %q.
 Type 'help' or '\h' for help.
@@ -163,8 +164,8 @@ Type 'help' or '\h' for help.
 }
 
 func (r *REPL) readLine() (string, error) {
-	r.term.SetPrompt(r.getPrompt())
-	return r.term.ReadLine()
+	r.Terminal.SetPrompt(r.getPrompt())
+	return r.Terminal.ReadLine()
 }
 
 func (r *REPL) getPrompt() string {
@@ -205,7 +206,7 @@ func (r *REPL) print(reply string) error {
 	if reply == "" {
 		return nil
 	}
-	_, err := r.term.Write([]byte(lineBreak + reply + lineBreak + lineBreak))
+	_, err := r.Terminal.Write([]byte(lineBreak + reply + lineBreak + lineBreak))
 	return trace.Wrap(err)
 }
 

--- a/lib/client/db/repl/repl.go
+++ b/lib/client/db/repl/repl.go
@@ -44,6 +44,8 @@ type REPLNewFunc func(context.Context, *NewREPLConfig) (REPLInstance, error)
 type REPLInstance interface {
 	// Run executes the REPL. This is a blocking operation.
 	Run(context.Context) error
+	// SetSize sets the REPL terminal window dimensions.
+	SetSize(width, height int) error
 }
 
 // REPLRegistry is an interface for initializing REPL instances and checking

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -21,6 +21,7 @@
 package session
 
 import (
+	"cmp"
 	"fmt"
 	"strconv"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/moby/term"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -232,6 +234,17 @@ func (p *TerminalParams) Winsize() *term.Winsize {
 		Width:  uint16(p.W),
 		Height: uint16(p.H),
 	}
+}
+
+// CheckAndSetDefaults checks and sets default terminal params.
+func (p *TerminalParams) CheckAndSetDefaults() error {
+	p.W = cmp.Or(p.W, teleport.DefaultTerminalWidth)
+	p.H = cmp.Or(p.H, teleport.DefaultTerminalHeight)
+	if p.W < 0 || p.H < 0 ||
+		p.W >= 4096 || p.H >= 4096 {
+		return trace.BadParameter("term: bad dimensions(%dx%d)", p.W, p.H)
+	}
+	return nil
 }
 
 // MaxSessionSliceLength is the maximum number of sessions per time window

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3822,7 +3822,7 @@ func (f SessionControllerFunc) AcquireSessionContext(ctx context.Context, sctx *
 func (h *Handler) siteNodeConnect(
 	w http.ResponseWriter,
 	r *http.Request,
-	p httprouter.Params,
+	_ httprouter.Params,
 	sessionCtx *SessionContext,
 	cluster reversetunnelclient.Cluster,
 	ws *websocket.Conn,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1774,7 +1774,7 @@ func TestNewTerminalHandler(t *testing.T) {
 			},
 		},
 		{
-			expectedErr: "term: bad dimensions(-1x0)",
+			expectedErr: "term: bad dimensions(-1x25)",
 			cfg: TerminalHandlerConfig{
 				SessionData: session.Session{
 					ID:       session.NewID(),
@@ -1784,6 +1784,20 @@ func TestNewTerminalHandler(t *testing.T) {
 				Term: session.TerminalParams{
 					W: -1,
 					H: 0,
+				},
+			},
+		},
+		{
+			expectedErr: "term: bad dimensions(80x-1)",
+			cfg: TerminalHandlerConfig{
+				SessionData: session.Session{
+					ID:       session.NewID(),
+					Login:    "root",
+					ServerID: uuid.New().String(),
+				},
+				Term: session.TerminalParams{
+					W: 0,
+					H: -1,
 				},
 			},
 		},

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -227,9 +227,8 @@ func (t *TerminalHandlerConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("server: missing server")
 	}
 
-	if t.Term.W <= 0 || t.Term.H <= 0 ||
-		t.Term.W >= 4096 || t.Term.H >= 4096 {
-		return trace.BadParameter("term: bad dimensions(%dx%d)", t.Term.W, t.Term.H)
+	if err := t.Term.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if t.UserAuthClient == nil {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -305,7 +305,8 @@ const cfg = {
       'wss://:fqdn/v1/webapi/sites/:clusterId/connect/ws?params=:params&traceparent=:traceparent',
     ttyKubeExecWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/kube/exec/ws?params=:params&traceparent=:traceparent',
-    ttyDbWsAddr: 'wss://:fqdn/v1/webapi/sites/:clusterId/db/exec/ws',
+    ttyDbWsAddr:
+      'wss://:fqdn/v1/webapi/sites/:clusterId/db/exec/ws?params=:params',
     ttyPlaybackWsAddr:
       'wss://:fqdn/v1/webapi/sites/:clusterId/ttyplayback/:sid?access_token=:token', // TODO(zmb3): get token out of URL
     activeAndPendingSessionsPath: '/v1/webapi/sites/:clusterId/sessions',


### PR DESCRIPTION
Changelog: Added support for browser window resizing to the Teleport Web UI database client terminal.

In this recorded example I show that the terminal wraps the text properly according to the current window size:

https://github.com/user-attachments/assets/603230e8-85b1-44ce-8a62-e2d7710f3377

