### PR TITLE
Optimize UserMeetsRequirements

### DIFF
--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -399,6 +399,11 @@ func IsAccessListMember(
 
 // UserMeetsRequirements is a helper which will return whether the User meets the AccessList Ownership/MembershipRequires.
 func UserMeetsRequirements(identity types.User, requires accesslist.Requires) bool {
+	if requires.IsEmpty() {
+		// No requirements to meet return early to avoid unnecessary work
+		return true
+	}
+
 	// Assemble the user's roles for easy look up.
 	userRolesMap := map[string]struct{}{}
 	for _, role := range identity.GetRoles() {


### PR DESCRIPTION
### What


For the common 98% cases where access list requirements are empty, UserMeetsRequirements does unnecessary work iterating over traits and roles. This PR adds a fast path that immediately returns success when requirements are empty, reducing CPU and allocations - especially noticeable for users with many traits/roles (e.g., ~20 traits and ~20 roles showd in the `BenchmarkUserMeetsRequirements`) and access list without any requirements **98% cases**)

This is a small, easy win extracted from https://github.com/gravitational/teleport/pull/58568/files#diff-798e20f03c96df0d747c22571075a13a42ec35e72e7321001a4dc2e5db9d1295R177 to speed up shipping fixes improvement, while more complex/refactoring PRs are getting delayed in review process. 



Before 

```
Before:

BenchmarkUserMeetsRequirements
BenchmarkUserMeetsRequirements/count=100
BenchmarkUserMeetsRequirements/count=100-14         	     808	   1445203 ns/op	 2926429 B/op	   11800 allocs/op
BenchmarkUserMeetsRequirements/count=1000
BenchmarkUserMeetsRequirements/count=1000-14        	      81	  13760988 ns/op	29264040 B/op	  118000 allocs/op
BenchmarkUserMeetsRequirements/count=10000
BenchmarkUserMeetsRequirements/count=10000-14       	       8	 128641177 ns/op	292640048 B/op	 1180000 allocs/op
BenchmarkUserMeetsRequirements/count=100000
BenchmarkUserMeetsRequirements/count=100000-14      	       1	1288153209 ns/op	2926400000 B/op	11800000 allocs/op
PASS

```

After:
```
BenchmarkUserMeetsRequirements
BenchmarkUserMeetsRequirements/count=100
BenchmarkUserMeetsRequirements/count=100-14         	 7322629	       161.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkUserMeetsRequirements/count=1000
BenchmarkUserMeetsRequirements/count=1000-14        	  724706	      1632 ns/op	       0 B/op	       0 allocs/op
BenchmarkUserMeetsRequirements/count=10000
BenchmarkUserMeetsRequirements/count=10000-14       	   70753	     16573 ns/op	       0 B/op	       0 allocs/op
BenchmarkUserMeetsRequirements/count=100000
BenchmarkUserMeetsRequirements/count=100000-14      	    7092	    163487 ns/op	       0 B/op	       0 allocs/op
PASS

```