### PR TITLE
[v18] Periodically publish CRL

### DIFF
--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -119,6 +119,10 @@ windows_desktop_service:
   # (optional) interval at which to run desktop discovery
   discovery_interval: 10m
 
+  # (optional) interval at which to publish CRLs
+  # Defaults to 5m if unspecified
+  publish_crl_interval: 10m
+
   # (optional) configure a set of label selectors for dynamic registration.
   # If specified, this service will monitor the cluster for dynamic_windows_desktop
   # and automatically proxy connections for desktops with matching labels.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2172,6 +2172,11 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		return trace.BadParameter("desktop discovery interval must not be negative (%v)", fc.WindowsDesktop.DiscoveryInterval.String())
 	}
 
+	cfg.WindowsDesktop.PublishCRLInterval = fc.WindowsDesktop.PublishCRLInterval
+	if cfg.WindowsDesktop.PublishCRLInterval < 0 {
+		return trace.BadParameter("publish CRL interval must not be negative (%v)", fc.WindowsDesktop.PublishCRLInterval.String())
+	}
+
 	var err error
 	cfg.WindowsDesktop.PublicAddrs, err = utils.AddrsFromStrings(fc.WindowsDesktop.PublicAddr, defaults.WindowsDesktopListenPort)
 	if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2560,6 +2560,8 @@ type WindowsDesktopService struct {
 	DiscoveryConfigs []LDAPDiscoveryConfig `yaml:"discovery_configs,omitempty"`
 	// DiscoveryInterval controls how frequently the discovery process runs.
 	DiscoveryInterval time.Duration `yaml:"discovery_interval"`
+	// PublishCRLInterval determines how frequently CRLs should be published.
+	PublishCRLInterval time.Duration `yaml:"publish_crl_interval"`
 	// ADHosts is a list of static, AD-connected Windows hosts. This gives users
 	// a way to specify AD-connected hosts that won't be found by the filters
 	// specified in `discovery` (or if `discovery` is omitted).

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -234,6 +234,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		PKIDomain:            cfg.WindowsDesktop.PKIDomain,
 		Discovery:            cfg.WindowsDesktop.Discovery,
 		DiscoveryInterval:    cfg.WindowsDesktop.DiscoveryInterval,
+		PublishCRLInterval:   cfg.WindowsDesktop.PublishCRLInterval,
 		Hostname:             cfg.Hostname,
 		ConnectedProxyGetter: proxyGetter,
 		ResourceMatchers:     cfg.WindowsDesktop.ResourceMatchers,

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -61,6 +61,9 @@ type WindowsDesktopConfig struct {
 	Discovery         []LDAPDiscoveryConfig
 	DiscoveryInterval time.Duration
 
+	// PublishCRLInterval determines how often CRLs should be published.
+	PublishCRLInterval time.Duration
+
 	// StaticHosts is an optional list of static Windows hosts to expose through this
 	// service.
 	StaticHosts []WindowsHost

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
@@ -184,6 +185,8 @@ type WindowsServiceConfig struct {
 	Discovery []servicecfg.LDAPDiscoveryConfig
 	// DiscoveryInterval configures how frequently the discovery process runs.
 	DiscoveryInterval time.Duration
+	// PublishCRLInterval configures how frequently to publish CRLs.
+	PublishCRLInterval time.Duration
 	// Hostname of the Windows desktop service
 	Hostname string
 	// ConnectedProxyGetter gets the proxies teleport is connected to.
@@ -228,6 +231,7 @@ func (cfg *WindowsServiceConfig) checkAndSetDiscoveryDefaults() error {
 	}
 
 	cfg.DiscoveryInterval = cmp.Or(cfg.DiscoveryInterval, 5*time.Minute)
+	cfg.PublishCRLInterval = cmp.Or(cfg.PublishCRLInterval, 5*time.Minute)
 
 	return nil
 }
@@ -377,9 +381,7 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if err := s.ca.Update(s.closeCtx, tc); err != nil {
-			return nil, trace.Wrap(err)
-		}
+		go s.runCRLUpdateLoop(tc)
 	}
 
 	ok := false
@@ -1301,4 +1303,25 @@ func (m *monitorErrorSender) WriteString(s string) (n int, err error) {
 	}
 
 	return len(s), nil
+}
+
+// runCRLUpdateLoop publishes the Certificate Revocation List to the given
+// LDAP server. It continues to do so every 5 minutes (by default) to make sure it is present
+// and in the correct location.
+func (s *WindowsService) runCRLUpdateLoop(tlsConfig *tls.Config) {
+	t := s.cfg.Clock.NewTicker(retryutils.SeventhJitter(s.cfg.PublishCRLInterval))
+	defer t.Stop()
+
+	for {
+		if err := s.ca.Update(s.closeCtx, tlsConfig); err != nil && !errors.Is(err, context.Canceled) {
+			s.cfg.Logger.ErrorContext(s.closeCtx, "failed to publish CRL", "error", err)
+		}
+
+		select {
+		case <-s.closeCtx.Done():
+			return
+		case <-t.Chan():
+			continue
+		}
+	}
 }

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -391,15 +391,16 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 			ldap.DialWithTLSConfig(ldapTLSConfig),
 		)
 
-		if err != nil {
-			// If the connection fails, try the next server
-			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
-			continue
+		if err == nil {
+			c.Logger.DebugContext(ctx, "Connected to LDAP server", "server", server)
+			conn.SetTimeout(ldapRequestTimeout)
+			return conn, nil
 		}
 
-		c.Logger.DebugContext(ctx, "Connected to LDAP server", "server", server)
-		conn.SetTimeout(ldapRequestTimeout)
-		return conn, nil
+		if c.LocateServer.Enabled {
+			// If the connection fails and we're using LocateServer, log that a server failed.
+			c.Logger.DebugContext(ctx, "Error connecting to LDAP server, trying next available server", "server", server, "error", err)
+		}
 	}
 
 	return nil, trace.NotFound("no LDAP servers responded successfully for domain %q", c.Domain)


### PR DESCRIPTION
We want to periodically publish our empty CRLs to ensure they're present and in the correct location. These CRLs are necessary for users to log in to their Windows desktops.

Backport #58558 to v18