### PR TITLE
Use ListAccessList RPC in (Client) ListAccessLists

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -64,9 +64,11 @@ func (c *Client) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, 
 // Deprecated: Use [Client.ListAccessListsV2] instead.
 // TODO (avatus): DELETE IN 21.0.0
 func (c *Client) ListAccessLists(ctx context.Context, pageSize int, nextToken string) ([]*accesslist.AccessList, string, error) {
-	resp, err := c.grpcClient.ListAccessListsV2(ctx, &accesslistv1.ListAccessListsV2Request{
+	//nolint:staticcheck // SA1019. ListAccessLists is deprecated but will
+	// continue be supported for backward compatibility.
+	resp, err := c.grpcClient.ListAccessLists(ctx, &accesslistv1.ListAccessListsRequest{
 		PageSize:  int32(pageSize),
-		PageToken: nextToken,
+		NextToken: nextToken,
 	})
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -81,7 +83,7 @@ func (c *Client) ListAccessLists(ctx context.Context, pageSize int, nextToken st
 		}
 	}
 
-	return accessLists, resp.GetNextPageToken(), nil
+	return accessLists, resp.GetNextToken(), nil
 }
 
 // ListAccessListsV2 returns a filtered and sorted paginated list of access lists.


### PR DESCRIPTION
The client implementation used ListAccessListV2 to avoid calling a deprecated RPC, however, that causes compatibility issues since it does not allow retrieving AccessLists from older versions of Teleport which don't implement the V2 RPC variant.