### PR TITLE
docs: update slack video to import

### DIFF
--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -7,6 +7,9 @@ labels:
  - identity-governance
 ---
 
+import SlackVideoMp4 from "@version/img/enterprise/plugins/slack/slack.mp4"
+import SlackVideoWebm from "@version/img/enterprise/plugins/slack/slack.webm"
+
 This guide will explain how to set up Slack to receive Access Request messages
 from Teleport. 
 
@@ -30,12 +33,12 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
 
 <video controls>
   <source
-    src="../../../img/enterprise/plugins/slack/slack.mp4"
+    src="{SlackVideoMp4}"
     type="video/mp4"
   />
 
   <source
-    src="../../../img/enterprise/plugins/slack/slack.webm"
+    src="{SlackVideoWebm}"
     type="video/webm"
   />
 

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -7,8 +7,8 @@ labels:
  - identity-governance
 ---
 
-import SlackVideoMp4 from "@version/img/enterprise/plugins/slack/slack.mp4"
-import SlackVideoWebm from "@version/img/enterprise/plugins/slack/slack.webm"
+import SlackVideoMp4 from "@version/docs/img/enterprise/plugins/slack/slack.mp4"
+import SlackVideoWebm from "@version/docs/img/enterprise/plugins/slack/slack.webm"
 
 This guide will explain how to set up Slack to receive Access Request messages
 from Teleport. 

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -31,7 +31,7 @@ best practices without compromising productivity.
 
 Here is an example of sending an Access Request via Teleport's Slack plugin:
 
-<video controls>
+<video controls width="75%" height="75%">
   <source
     src={SlackVideoMp4}
     type="video/mp4"

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -33,12 +33,12 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
 
 <video controls>
   <source
-    src="{SlackVideoMp4}"
+    src={SlackVideoMp4}
     type="video/mp4"
   />
 
   <source
-    src="{SlackVideoWebm}"
+    src={SlackVideoWebm}
     type="video/webm"
   />
 

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -31,7 +31,7 @@ best practices without compromising productivity.
 
 Here is an example of sending an Access Request via Teleport's Slack plugin:
 
-<video controls width="75%" height="75%">
+<video controls width="100%" height="100%">
   <source
     src={SlackVideoMp4}
     type="video/mp4"


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/58622

Slack videos are not accessible. 