### PR TITLE
Access Lists: Update status.{member_of,owner_of} for all list owners/members on all updates

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1225,16 +1225,10 @@ type Cache interface {
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (users uint32, lists uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
-	// May return a DynamicAccessListError if the requested access list has an
-	// implicit member list and the underlying implementation does not have
-	// enough information to compute the dynamic member list.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all members of all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// GetAccessListMember returns the specified access list member resource.
-	// May return a DynamicAccessListError if the requested access list has an
-	// implicit member list and the underlying implementation does not have
-	// enough information to compute the dynamic member record.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
 
 	// ListAccessListReviews will list access list reviews for a particular access list.

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -279,9 +279,6 @@ func (c *Cache) CountAccessListMembers(ctx context.Context, accessListName strin
 }
 
 // ListAccessListMembers returns a paginated list of all access list members.
-// May return a DynamicAccessListError if the requested access list has an
-// implicit member list and the underlying implementation does not have
-// enough information to compute the dynamic member list.
 func (c *Cache) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccessListMembers")
 	defer span.End()
@@ -336,9 +333,6 @@ func (c *Cache) ListAllAccessListMembers(ctx context.Context, pageSize int, page
 }
 
 // GetAccessListMember returns the specified access list member resource.
-// May return a DynamicAccessListError if the requested access list has an
-// implicit member list and the underlying implementation does not have
-// enough information to compute the dynamic member record.
 func (c *Cache) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetAccessListMember")
 	defer span.End()

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -137,9 +137,6 @@ func (ImplicitAccessListError) Error() string {
 // AccessListMemberGetter defines an interface that can retrieve access list members.
 type AccessListMemberGetter interface {
 	// GetAccessListMember returns the specified access list member resource.
-	// May return a DynamicAccessListError if the requested access list has an
-	// implicit member list and the underlying implementation does not have
-	// enough information to compute the dynamic member record.
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
 	// GetAccessList returns the specified access list resource.
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
@@ -154,9 +151,6 @@ type AccessListMembersGetter interface {
 	// CountAccessListMembers will count all access list members.
 	CountAccessListMembers(ctx context.Context, accessListName string) (membersCount uint32, listCount uint32, err error)
 	// ListAccessListMembers returns a paginated list of all access list members.
-	// May return a DynamicAccessListError if the requested access list has an
-	// implicit member list and the underlying implementation does not have
-	// enough information to compute the dynamic member list.
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	// ListAllAccessListMembers returns a paginated list of all access list members for all access lists.
 	ListAllAccessListMembers(ctx context.Context, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -264,16 +264,6 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 	}
 
 	reconcileOwners := func() error {
-		// Create map to store owners for efficient lookup
-		originalOwnersMap := make(map[string]struct{})
-		if existingAccessList != nil {
-			for _, owner := range existingAccessList.Spec.Owners {
-				if owner.MembershipKind == accesslist.MembershipKindList {
-					originalOwnersMap[owner.Name] = struct{}{}
-				}
-			}
-		}
-
 		currentOwnersMap := make(map[string]struct{})
 		for _, owner := range accessList.Spec.Owners {
 			if owner.MembershipKind == accesslist.MembershipKindList {
@@ -283,18 +273,23 @@ func (a *AccessListService) runOpWithLock(ctx context.Context, accessList *acces
 
 		// update references for new owners
 		for ownerName := range currentOwnersMap {
-			if _, exists := originalOwnersMap[ownerName]; !exists {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), ownerName, true); err != nil {
-					return trace.Wrap(err)
-				}
+			if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), ownerName, true); err != nil {
+				return trace.Wrap(err)
 			}
 		}
 
 		// update references for old owners
-		for ownerName := range originalOwnersMap {
-			if _, exists := currentOwnersMap[ownerName]; !exists {
-				if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), ownerName, false); err != nil {
-					return trace.Wrap(err)
+		if existingAccessList != nil {
+			for _, owner := range existingAccessList.Spec.Owners {
+				if owner.MembershipKind != accesslist.MembershipKindList {
+					continue
+				}
+				// If this owner access list is not an owner anymore after the
+				// update/upsert, its status.owner_of has to be updated.
+				if _, exists := currentOwnersMap[owner.Name]; !exists {
+					if err := a.updateAccessListOwnerOf(ctx, accessList.GetName(), owner.Name, false); err != nil {
+						return trace.Wrap(err)
+					}
 				}
 			}
 		}
@@ -622,7 +617,17 @@ func (a *AccessListService) UpdateAccessListMember(ctx context.Context, member *
 			}
 
 			updated, err = a.memberService.WithPrefix(member.Spec.AccessList).ConditionalUpdateResource(ctx, member)
-			return trace.Wrap(err)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if member.Spec.MembershipKind == accesslist.MembershipKindList {
+				if err := a.updateAccessListMemberOf(ctx, member.Spec.AccessList, member.Spec.Name, true); err != nil {
+					return trace.Wrap(err)
+				}
+			}
+
+			return nil
 		})
 	})
 	return updated, trace.Wrap(err)
@@ -960,6 +965,17 @@ func (a *AccessListService) CreateAccessListReview(ctx context.Context, review *
 		accessList.Spec.Audit.NextAuditDate = nextAuditDate
 
 		for _, removedMember := range review.Spec.Changes.RemovedMembers {
+			_, err := a.memberService.WithPrefix(review.Spec.AccessList).GetResource(ctx, removedMember)
+			if err != nil && !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+			isAccessListMember := err == nil
+
+			if isAccessListMember {
+				if err := a.updateAccessListMemberOf(ctx, review.Spec.AccessList, removedMember, false); err != nil {
+					return trace.Wrap(err)
+				}
+			}
 			if err := a.memberService.WithPrefix(review.Spec.AccessList).DeleteResource(ctx, removedMember); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1236,6 +1236,50 @@ func TestAccessListReviewCRUD(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_CreateAccessListReview_NestedListMemberRemoval(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
+
+	a1, err := service.UpsertAccessList(ctx, newAccessList(t, "test_list_1", clock))
+	require.NoError(t, err)
+
+	memberList1, err := service.UpsertAccessList(ctx, newAccessList(t, "test_list_member_1", clock))
+	require.NoError(t, err)
+
+	assertMemberOf(t, ctx, service, memberList1.GetName(), nil)
+
+	// When nested access list member is added, expect it's status.member_of to be updated.
+
+	_, err = service.UpsertAccessListMember(ctx, newAccessListMember(t,
+		a1.GetName(),
+		memberList1.GetName(),
+		withMembershipKind(accesslist.MembershipKindList),
+	))
+	require.NoError(t, err)
+
+	assertMemberOf(t, ctx, service, memberList1.GetName(), []string{a1.GetName()})
+
+	// When nested access list member is removed via the review, expect it's status.member_of
+	// to be updated.
+
+	a1r1 := newAccessListReview(t, a1.GetName(), "al1-review1")
+	a1r1.Spec.Changes.RemovedMembers = []string{
+		memberList1.GetName(),
+	}
+	_, _, err = service.CreateAccessListReview(ctx, a1r1)
+	require.NoError(t, err)
+
+	assertMemberOf(t, ctx, service, memberList1.GetName(), nil)
+}
+
 func Test_CreateAccessListReview_FailForNonReviewable(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
@@ -1788,34 +1832,85 @@ func TestAccessListService_Status_OwnerOf(t *testing.T) {
 
 	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
-	ownersAccessList := createAccessList(t, service, "test-owners-acl-"+uuid.NewString(), clock)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), nil)
+	ownerAccessList1 := createAccessList(t, service, "test-owners-acl-"+uuid.NewString(), clock)
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), nil)
+	ownerAccessList2 := createAccessList(t, service, "test-owners-acl-"+uuid.NewString(), clock)
+	requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), nil)
 
 	accessList := createAccessList(t, service, "test-acl-"+uuid.NewString(), clock,
 		withOwners([]accesslist.Owner{
 			{
-				Name:           ownersAccessList.GetName(),
+				Name:           ownerAccessList1.GetName(),
 				MembershipKind: accesslist.MembershipKindList,
 			},
 		}),
 	)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), []string{accessList.GetName()})
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
 
-	ownersAccessList, _, err = service.UpsertAccessListWithMembers(ctx, ownersAccessList, nil)
+	ownerAccessList1, _, err = service.UpsertAccessListWithMembers(ctx, ownerAccessList1, nil)
 	require.NoError(t, err)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), []string{accessList.GetName()})
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
 
-	ownersAccessList, err = service.UpsertAccessList(ctx, ownersAccessList)
+	ownerAccessList1, err = service.UpsertAccessList(ctx, ownerAccessList1)
 	require.NoError(t, err)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), []string{accessList.GetName()})
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
 
-	ownersAccessList, err = service.UpdateAccessList(ctx, ownersAccessList)
+	ownerAccessList1, err = service.UpdateAccessList(ctx, ownerAccessList1)
 	require.NoError(t, err)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), []string{accessList.GetName()})
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
+
+	t.Run("origin access list updates and upserts fix status.owner_of of existing list owners", func(t *testing.T) {
+		requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
+
+		err = service.updateAccessListOwnerOf(ctx, accessList.GetName(), ownerAccessList1.GetName(), false /* new - this will delete */)
+		require.NoError(t, err)
+		requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{})
+
+		accessList, err = service.UpsertAccessList(ctx, accessList)
+		require.NoError(t, err)
+		requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
+
+		err = service.updateAccessListOwnerOf(ctx, accessList.GetName(), ownerAccessList1.GetName(), false /* new - this will delete */)
+		require.NoError(t, err)
+		requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{})
+
+		accessList, err = service.UpdateAccessList(ctx, accessList)
+		require.NoError(t, err)
+		requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), []string{accessList.GetName()})
+	})
+
+	t.Run("when list owner is deleted during update or upsert former owners list status.owner_of is updated", func(t *testing.T) {
+		requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), nil)
+
+		owner2 := accesslist.Owner{
+			Name:           ownerAccessList2.GetName(),
+			MembershipKind: accesslist.MembershipKindList,
+		}
+
+		accessList.Spec.Owners = append(accessList.Spec.Owners, owner2)
+		accessList, err = service.UpsertAccessList(ctx, accessList)
+		requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), []string{accessList.GetName()})
+
+		accessList.Spec.Owners = slices.DeleteFunc(accessList.Spec.Owners, func(o accesslist.Owner) bool {
+			return o.Name == owner2.Name
+		})
+		accessList, err = service.UpsertAccessList(ctx, accessList)
+		requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), nil)
+
+		accessList.Spec.Owners = append(accessList.Spec.Owners, owner2)
+		accessList, err = service.UpdateAccessList(ctx, accessList)
+		requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), []string{accessList.GetName()})
+
+		accessList.Spec.Owners = slices.DeleteFunc(accessList.Spec.Owners, func(o accesslist.Owner) bool {
+			return o.Name == owner2.Name
+		})
+		accessList, err = service.UpdateAccessList(ctx, accessList)
+		requireStatusOwnerOf(t, service, ownerAccessList2.GetName(), nil)
+	})
 
 	err = service.DeleteAccessList(ctx, accessList.GetName())
 	require.NoError(t, err)
-	requireStatusOwnerOf(t, service, ownersAccessList.GetName(), nil)
+	requireStatusOwnerOf(t, service, ownerAccessList1.GetName(), nil)
 }
 
 func TestAccessListService_Status_MemberOf(t *testing.T) {
@@ -1927,6 +2022,36 @@ func TestAccessListService_Status_MemberOf(t *testing.T) {
 		require.NoError(t, err)
 		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
 	})
+
+	t.Run("member updates and upserts fix status.member_of of existing members", func(t *testing.T) {
+		accessList := createAccessList(t, service, "test-acl-"+uuid.NewString(), clock)
+		nestedAccessList := createAccessList(t, service, "test-nested-acl-"+uuid.NewString(), clock)
+
+		member, err := service.UpsertAccessListMember(ctx, newAccessListMember(t,
+			accessList.GetName(),
+			nestedAccessList.GetName(),
+			withMembershipKind(accesslist.MembershipKindList),
+		))
+		require.NoError(t, err)
+
+		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
+
+		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		require.NoError(t, err)
+		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
+
+		updatedMember, err := service.UpdateAccessListMember(ctx, member)
+		require.NoError(t, err)
+		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
+
+		err = service.updateAccessListMemberOf(ctx, accessList.GetName(), nestedAccessList.GetName(), false /* new - this will delete */)
+		require.NoError(t, err)
+		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{})
+
+		_, err = service.UpsertAccessListMember(ctx, updatedMember)
+		require.NoError(t, err)
+		requireStatusMemberOf(t, service, nestedAccessList.GetName(), []string{accessList.GetName()})
+	})
 }
 
 func requireStatusOwnerOf(t *testing.T, service *AccessListService, accessListName string, ownerOf []string) {
@@ -1965,4 +2090,11 @@ func newAccessListService(t *testing.T, mem *memory.Memory, clock clockwork.Cloc
 	require.NoError(t, err)
 
 	return service
+}
+
+func assertMemberOf(t *testing.T, ctx context.Context, svc *AccessListService, name string, expected []string) {
+	t.Helper()
+	item, err := svc.GetAccessList(ctx, name)
+	require.NoError(t, err)
+	require.ElementsMatch(t, expected, item.Status.MemberOf)
 }


### PR DESCRIPTION
This is needed for `accesslist.statusReconciler` in `e`. PR https://github.com/gravitational/teleport.e/pull/7180

That included `CreateAccessListReview` (https://github.com/gravitational/teleport/pull/58677#issuecomment-3265854009)

Backports:

- [x] https://github.com/gravitational/teleport/pull/59018
- [ ] https://github.com/gravitational/teleport/pull/59019