### PR TITLE
Fix double dashes in markdown parsing

### DIFF
--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -186,8 +186,15 @@ function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
       const startI = i;
 
       while (i < lines.length && lines[i].trimStart().startsWith('- ')) {
+        const firstDashIndex = lines[i].indexOf('- ');
+
         listItems.push(
-          <li key={i}>{parseLine(activeParsers, lines[i].substring(2))}</li>
+          <li key={i}>
+            {parseLine(
+              activeParsers,
+              lines[i].substring(firstDashIndex + 2).trim()
+            )}
+          </li>
         );
 
         i += 1;


### PR DESCRIPTION
Previously, we were assuming the `-` was at the start of a line, so it would trim the text from index 2 (the dash + a space). This changes it to find the first dash space, and trim from there. This avoids double dashes when the `-` isn't at the start of a line.

Before
<img width="394" height="490" alt="image" src="https://github.com/user-attachments/assets/f4dce9d5-fdea-4266-9d74-4b58760420b0" />

After
<img width="315" height="601" alt="image" src="https://github.com/user-attachments/assets/c1f77af5-5824-43f3-a6af-b28d590b2046" />
