### PR TITLE
Fill in missing "How it works" sections

### DIFF
--- a/docs/pages/identity-governance/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/entra-id/terraform.mdx
@@ -20,8 +20,8 @@ For other supported configuration methods, see the following guides:
 
 If you are new to the Teleport Entra ID integration, start by reading [how the
 integration works](entra-id.mdx). The `entra-id-integration` Terraform module
-sets up the integration by deploying a Microsoft Entra ID SAML application and
-configuring it as a service principal for your Teleport cluster in order to
+sets up the integration by deploying a Microsoft Entra ID enterprise application and
+configuring it as a SAML identity provider for your Teleport cluster in order to
 enable authentication to Teleport via Microsoft Entra ID. 
 
 The module also assigns permissions to the Teleport Auth Service to fetch user

--- a/docs/pages/identity-governance/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/entra-id/terraform.mdx
@@ -16,7 +16,19 @@ For other supported configuration methods, see the following guides:
 - [Getting Started with the Entra ID Integration](getting-started.mdx)
 - [Configure the Entra ID Integration using Azure Portal](manual-installation.mdx)
 
-If you are new to the Teleport Entra ID integration, start by reading [how the integration works](entra-id.mdx). 
+## How it works
+
+If you are new to the Teleport Entra ID integration, start by reading [how the
+integration works](entra-id.mdx). The `entra-id-integration` Terraform module
+sets up the integration by deploying a Microsoft Entra ID SAML application and
+configuring it as a service principal for your Teleport cluster in order to
+enable authentication to Teleport via Microsoft Entra ID. 
+
+The module also assigns permissions to the Teleport Auth Service to fetch user
+and group data from Microsoft Entra ID in order to synchronize it with Teleport
+RBAC resources. Depending on your configuration, the Terraform module either
+does this by using system credentials (Microsoft Graph API permission IDs) or
+using Teleport as an OIDC IdP.
 
 ## Prerequisites
 

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -12,7 +12,17 @@ runs in Kubernetes and can deploy applications to the same cluster or to other
 
 In this guide, you will configure the Machine ID agent, `tbot`, to manage Argo
 CD's cluster credentials, enabling it to securely deploy applications using
-Teleport Kubernetes Access.
+Teleport.
+
+## How it works
+
+Argo CD supports declaratively managing clusters using Kubernetes secrets (see
+the [Argo CD
+documentation](https://argo-cd.readthedocs.io/en/latest/operator-manual/declarative-setup/#clusters).
+The Argo CD application controller reads these secrets in order to retrieve
+cluster credentials. When configured to use the Argo CD output, `tbot` writes
+Teleport-signed Kubernetes cluster credentials into secrets that Argo CD can
+then use to access Teleport-protected Kubernetes clusters.
 
 ## Prerequisite
 


### PR DESCRIPTION
Add brief architectural overviews to make it clearer what a user is setting up when they follow two how-to guides:

- The Machine ID Argo CD output guide
- The Terraform guide for the Microsoft Entra ID integration