### PR TITLE
[v16]docs: Adding New Searchbar Header to Docs Homepage

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,13 +1,32 @@
 ---
 h1: Introduction to Teleport
-title: "Introduction to the Teleport Access Platform: Zero Trust Security for Your Infrastructure"
+title: "The Teleport Infrastructure Identity Platform"
 description: Read an overview of the Teleport Access Platform. Learn how to implement Zero Trust Security across all your infrastructure for enhanced protection and streamlined access control.
 tocDepth: 3
-hide_table_of_contents: true
+template: "landing-page"
 labels:
  - get-started
  - platform-wide
 ---
+
+import DocsHeader, { DocsHeaderProps } from "@site/src/components/Pages/Homepage/DocsHeader";
+
+<DocsHeader
+  quickActions={[
+    { 
+      label: "Enroll Kubernetes cluster", 
+      href: "./enroll-resources/kubernetes-access/getting-started/" 
+    },
+    { 
+      label: "Set up SSO with GitHub", 
+      href: "./zero-trust-access/sso/github-sso/" 
+    },
+    { 
+      label: "Set up Slack Access Request Plugin", 
+      href: "./identity-governance/access-request-plugins/ssh-approval-slack/" 
+    }
+  ]}
+/>
 
 Teleport is the easiest and most secure way to access and protect all your
 infrastructure.


### PR DESCRIPTION
backports #57754

This PR is to add the new Searchbar header to the Docs homepage. The component was merged in the docs-website repo. We are adding the component with the three quicklinks as props directly on the docs homepage.