### PR TITLE
skip TestREPL

### DIFF
--- a/lib/client/db/mysql/repl/repl_test.go
+++ b/lib/client/db/mysql/repl/repl_test.go
@@ -60,11 +60,14 @@ func TestMain(m *testing.M) {
 	defer cancel()
 
 	// ignore errors, Ryuk or worst case VM termination in CI will deal with it
-	_ = testSrv.container.Terminate(ctx)
+	if testSrv != nil {
+		_ = testSrv.container.Terminate(ctx)
+	}
 	os.Exit(code)
 }
 
 func TestREPL(t *testing.T) {
+	t.Skip()
 	testSrv := newTestServer(t)
 	route := clientproto.RouteToDatabase{
 		ServiceName: "mysql-test-container",


### PR DESCRIPTION
This temporarily disables TestREPL because we're getting rate limited when pulling the test container image in CI causing test failures.
