### PR TITLE
Add CreateAccessListNextKey and title sort to Access Lists cache

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -218,6 +218,10 @@ type Owner struct {
 	// Name is the username of the owner.
 	Name string `json:"name" yaml:"name"`
 
+	// Title is the title of an owner if it is of type MEMBERSHIP_KIND_LIST.
+	// This is only populated by the proxy when fetching an access list and its members for the web UI
+	Title string `json:"title" yaml:"title"`
+
 	// Description is the plaintext description of the owner and why they are an owner.
 	Description string `json:"description" yaml:"description"`
 

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"cmp"
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 
@@ -38,22 +37,9 @@ type accessListIndex string
 
 const (
 	accessListNameIndex          accessListIndex = "name"
+	accessListTitleIndex         accessListIndex = "title"
 	accessListAuditNextDateIndex accessListIndex = "auditNextDate"
 )
-
-func accessListNameIndexFn(al *accesslist.AccessList) string {
-	return al.GetMetadata().Name
-}
-
-func accessListAuditNextDateIndexFn(al *accesslist.AccessList) string {
-	if al.Spec.Audit.NextAuditDate.IsZero() {
-		// last lexical char make sure that if ACL don't have aduit date it will be at the end.
-		// Otherwise we will compare against `0001-01-01 00:00:00` which is the first element
-		// but means that the access list is not eligible for review.
-		return "z/" + al.GetName()
-	}
-	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + al.GetName()
-}
 
 func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (*collection[*accesslist.AccessList, accessListIndex], error) {
 	if upstream == nil {
@@ -66,9 +52,11 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 			(*accesslist.AccessList).Clone,
 			map[accessListIndex]func(*accesslist.AccessList) string{
 				// sorted by name
-				accessListNameIndex: accessListNameIndexFn,
+				accessListNameIndex: services.AccessListNameIndexKey,
+				// sorted by title, sanitized.
+				accessListTitleIndex: services.AccessListTitleIndexKey,
 				// sorted by upcoming audit date. lists with no audit dates sorted to the back
-				accessListAuditNextDateIndex: accessListAuditNextDateIndexFn,
+				accessListAuditNextDateIndex: services.AccessListAuditDateIndexKey,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
 			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListAccessLists))
@@ -118,7 +106,6 @@ func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAcc
 	defer span.End()
 
 	index := accessListNameIndex
-	keyFn := accessListNameIndexFn
 
 	var isDesc bool
 	sortBy := req.GetSortBy()
@@ -128,12 +115,12 @@ func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAcc
 		switch sortBy.Field {
 		case "name", "":
 			index = accessListNameIndex
-			keyFn = accessListNameIndexFn
 		case "auditNextDate":
 			index = accessListAuditNextDateIndex
-			keyFn = accessListAuditNextDateIndexFn
+		case "title":
+			index = accessListTitleIndex
 		default:
-			return nil, "", trace.BadParameter("unsupported sort %q but expected name or auditNextDate", sortBy.Field)
+			return nil, "", trace.BadParameter("unsupported sort %q but expected name, title or auditNextDate", sortBy.Field)
 		}
 	}
 	lister := genericLister[*accesslist.AccessList, accessListIndex]{
@@ -149,7 +136,10 @@ func (c *Cache) ListAccessListsV2(ctx context.Context, req *accesslistv1.ListAcc
 			return services.MatchAccessList(al, req.GetFilter())
 		},
 		nextToken: func(al *accesslist.AccessList) string {
-			return keyFn(al)
+			// ignore error because CreateAccessListNextKey only errors
+			// if the index is invalid, which we already check above
+			nextKey, _ := services.CreateAccessListNextKey(al, string(index))
+			return nextKey
 		},
 	}
 	out, next, err := lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -283,7 +283,8 @@ func TestListAccessListsV2(t *testing.T) {
 	t.Cleanup(p.Close)
 
 	ctx := context.Background()
-	clock := clockwork.NewFakeClock()
+	baseTime := time.Date(1984, 4, 4, 0, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(baseTime)
 
 	names := []string{"apple-list", "banana-access", "cherry-management", "apple-admin", "zebra-test"}
 
@@ -293,6 +294,7 @@ func TestListAccessListsV2(t *testing.T) {
 		// add arbitrary date so we can make sure its not just sorted by name
 		if name == "banana-access" {
 			auditDate = clock.Now().Add(100 * (time.Hour) * 24)
+			al.Spec.Title = "bananatitle"
 		}
 		al.Spec.Audit.NextAuditDate = auditDate
 
@@ -322,6 +324,16 @@ func TestListAccessListsV2(t *testing.T) {
 			name:          "sort by audit date",
 			sortBy:        &types.SortBy{Field: "auditNextDate", IsDesc: false},
 			expectedNames: []string{"apple-list", "cherry-management", "apple-admin", "zebra-test", "banana-access"},
+		},
+		{
+			name:          "sort by title",
+			sortBy:        &types.SortBy{Field: "title", IsDesc: false},
+			expectedNames: []string{"banana-access", "apple-admin", "apple-list", "cherry-management", "zebra-test"},
+		},
+		{
+			name:          "sort by title reverse",
+			sortBy:        &types.SortBy{Field: "title", IsDesc: true},
+			expectedNames: []string{"zebra-test", "cherry-management", "apple-list", "apple-admin", "banana-access"},
 		},
 		{
 			name:          "sort by audit date reverse",

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2280,7 +2280,7 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist
 			Name: name,
 		},
 		accesslist.Spec{
-			Title:       "title",
+			Title:       "Title" + name,
 			Description: "test access list",
 			Owners: []accesslist.Owner{
 				{

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -20,12 +20,14 @@ package services
 
 import (
 	"context"
+	"encoding/base32"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/charlievieth/strcase"
 	"github.com/gravitational/trace"
+	"golang.org/x/text/cases"
 
 	accesslistclient "github.com/gravitational/teleport/api/client/accesslist"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
@@ -276,6 +278,46 @@ func UnmarshalAccessListReview(data []byte, opts ...MarshalOption) (*accesslist.
 	return &review, nil
 }
 
+// CreateAccessListNextKey creates a pagination token based on the requested sort index name
+func CreateAccessListNextKey(al *accesslist.AccessList, indexName string) (string, error) {
+	switch indexName {
+	case "name":
+		return AccessListNameIndexKey(al), nil
+	case "auditNextDate":
+		return AccessListAuditDateIndexKey(al), nil
+	case "title":
+		return AccessListTitleIndexKey(al), nil
+	default:
+		return "", trace.BadParameter("unsupported sort %s but expected name, title or auditNextDate", indexName)
+	}
+}
+
+// AccessListNameIndexKey returns the resource name returned from GetName().
+func AccessListNameIndexKey(al *accesslist.AccessList) string {
+	return al.GetName()
+}
+
+// AccessListAuditDateIndexKey returns the DateOnly formatted next audit date
+// followed by the resource name for disambiguation.
+func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
+	if al.Spec.Audit.NextAuditDate.IsZero() {
+		// Use last lexical character to ensure that ACLs without an audit date
+		// appear at the end when sorted. Otherwise we would compare against
+		// `0001-01-01 00:00:00` which would sort first, but actually means
+		// the access list is not eligible for review.
+		return "z/" + al.GetName()
+	}
+	return al.Spec.Audit.NextAuditDate.Format(time.DateOnly) + "/" + al.GetName()
+}
+
+// AccessListTitleIndexKey returns the access list title base32hex encoded
+// followed by the resource name for disambiguation.
+func AccessListTitleIndexKey(al *accesslist.AccessList) string {
+	title := cases.Fold().String(al.Spec.Title)
+	title = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(title))
+	return title + "/" + al.GetName()
+}
+
 // MatchAccessList returns true if the access list matches the given filter criteria.
 // The function applies filters in sequence: owners, then roles, then search.
 // All provided filters must match for the access list to be included.
@@ -287,6 +329,9 @@ func UnmarshalAccessListReview(data []byte, opts ...MarshalOption) (*accesslist.
 //
 // All matching is case-insensitive and supports partial matches.
 func MatchAccessList(al *accesslist.AccessList, req *accesslistv1.AccessListsFilter) bool {
+	if req == nil {
+		return true
+	}
 	search := req.GetSearch()
 	owners := req.GetOwners()
 	roles := req.GetRoles()

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -177,12 +177,7 @@ func (a *AccessListService) ListAccessListsV2(ctx context.Context, req *accessli
 	// Currently, the backend only sorts on lexicographical keys and not
 	// based on fields within a resource
 	if req.SortBy != nil && (req.GetSortBy().Field != "name" || req.GetSortBy().IsDesc != false) {
-		return nil, "", trace.BadParameter("unsupported sort, only name:asc is supported, but got %q (desc = %t)", req.GetSortBy().Field, req.GetSortBy().IsDesc)
-	}
-
-	if req.GetFilter().Search == "" && len(req.GetFilter().Owners) == 0 && len(req.GetFilter().Roles) == 0 {
-		r, nextToken, err := a.service.ListResources(ctx, int(req.GetPageSize()), req.GetPageToken())
-		return r, nextToken, trace.Wrap(err)
+		return nil, "", trace.CompareFailed("unsupported sort, only name:asc is supported, but got %q (desc = %t)", req.GetSortBy().Field, req.GetSortBy().IsDesc)
 	}
 
 	return a.service.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), func(item *accesslist.AccessList) bool {


### PR DESCRIPTION
Adds and consumes `CreateAccessListNextKey` helper methods to ensure the auth server is able to generate a key that matches the currently requested `sort`, as backend.Key wont help us when sorting by something other than name. also added a title sort index to the access lists cache to enable the web UI to sort by the human readable title.