### PR TITLE
docs: update link to entra id

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -293,8 +293,7 @@ If you plan to skip this step, make sure to remove the `module "saml"` or
    - [Google
      Workspace](../../sso/google-workspace.mdx#step-14-configure-google-workspace)
    - [OneLogin](../../sso/one-login.mdx#step-13-create-teleport-application-in-onelogin)
-   - [Azure
-     AD](../../sso/entra-id.mdx#step-13-configure-microsoft-entra-id)
+   - [Entra ID](../../sso/entra-id.mdx#step-13-configure-microsoft-entra-id)
    - [Okta](../../sso/okta.mdx#step-24-configure-okta)
 
 1. Configure the redirect URL (for OIDC) or assertion consumer service (for SAML):


### PR DESCRIPTION
Update to Entra ID from Azure AD. Was missed in earlier update due to Azure AD not being on the same line in searches.