### PR TITLE
Fix logs not being emitted in verbose mode in `lib/tbot`

### DIFF
--- a/lib/tbot/internal/carotation/service_test.go
+++ b/lib/tbot/internal/carotation/service_test.go
@@ -20,6 +20,7 @@ package carotation
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 func Test_filterCAEvent(t *testing.T) {
 	clusterName := "example.com"

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -40,6 +40,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
+
 type fakeHeartbeatSubmitter struct {
 	ch chan *machineidv1pb.SubmitHeartbeatRequest
 }

--- a/lib/tbot/internal/loop_test.go
+++ b/lib/tbot/internal/loop_test.go
@@ -21,6 +21,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -31,6 +32,11 @@ import (
 
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 func Test_RunOnInterval(t *testing.T) {
 	t.Parallel()

--- a/lib/tbot/internal/sds/handler_test.go
+++ b/lib/tbot/internal/sds/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -40,6 +41,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type mockTrustBundleCache struct {
 	currentBundle *workloadidentity.BundleSet

--- a/lib/tbot/services/application/helpers_test.go
+++ b/lib/tbot/services/application/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -39,9 +40,15 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/awsra/helpers_test.go
+++ b/lib/tbot/services/awsra/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -42,9 +43,15 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/database/helpers_test.go
+++ b/lib/tbot/services/database/helpers_test.go
@@ -20,6 +20,7 @@ package database
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,8 +28,14 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/identity/helpers_test.go
+++ b/lib/tbot/services/identity/helpers_test.go
@@ -20,14 +20,21 @@ package identity
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/k8s/helpers_test.go
+++ b/lib/tbot/services/k8s/helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"log/slog"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -38,9 +39,15 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/ssh/helpers_test.go
+++ b/lib/tbot/services/ssh/helpers_test.go
@@ -20,14 +20,21 @@ package ssh
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/services/workloadidentity/helpers_test.go
+++ b/lib/tbot/services/workloadidentity/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -42,9 +43,15 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 type testYAMLCase[T any] struct {
 	name string

--- a/lib/tbot/workloadidentity/trust_bundle_cache_test.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509/pkix"
+	"os"
 	"testing"
 	"time"
 
@@ -42,6 +43,11 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
 
 func TestBundleSet_Clone(t *testing.T) {
 	t.Parallel()

--- a/lib/tbot/workloadidentity/workloadattest/workloadattest_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/workloadattest_test.go
@@ -1,0 +1,30 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package workloadattest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
It looks like the intersection of https://github.com/gravitational/teleport/pull/56741 and the `lib/tbot` refactor meant that the newly introduced log initialisation is missing from our packages, which results in no logs being emitted when slog is used, regardless of if verbose mode has been specified.