### PR TITLE
Include fdpass-teleport in install script

### DIFF
--- a/build.assets/install
+++ b/build.assets/install
@@ -14,7 +14,7 @@ VARDIR=/var/lib/teleport
 echo "Starting Teleport installation..."
 cd $(dirname $0)
 mkdir -p $VARDIR $BINDIR
-cp -f teleport tctl tsh tbot teleport-update $BINDIR/ || exit 1
+cp -f teleport tctl tsh tbot fdpass-teleport teleport-update $BINDIR/ || exit 1
 
 #
 # What operating system is the user running?


### PR DESCRIPTION
The `fdpass-teleport` binary is not included in the install script provided in tar downloads. This is installed in apt installs and other install scripts.

changelog: Include fdpass-teleport binary in install script for Teleport tar downloads