### PR TITLE
[v17] Docs: Fix step numbers and "How it works" sections

### DIFF
--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -18,6 +18,8 @@ labels:
 
 </Tabs>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -31,6 +31,8 @@ that a user intends to access.
 
   ![Teleport Bastion](../../../img/server-access/getting-started-diagram.png)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/entra-id/getting-started.mdx
+++ b/docs/pages/identity-governance/entra-id/getting-started.mdx
@@ -12,6 +12,8 @@ This guide shows how to configure Entra ID integration in a guided configuration
 Teleport will generate a script that will configure your Entra ID tenant with the 
 properties required for the Teleport Entra ID integration.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - Your user must have privileged administrator permissions in the Microsoft Entra ID tenant.

--- a/docs/pages/identity-governance/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/entra-id/manual-installation.mdx
@@ -11,6 +11,8 @@ See [getting started with Entra ID integration](getting-started.mdx) for a guide
 
 The set up is based on the [OIDC IdP authentication method](entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - Teleport Identity Governance enabled for your Teleport cluster.

--- a/docs/pages/zero-trust-access/management/admin/labels.mdx
+++ b/docs/pages/zero-trust-access/management/admin/labels.mdx
@@ -16,6 +16,8 @@ the following:
 This guide demonstrates how to add labels to enrolled server resources.
 However, you can follow similar steps to add labels to other types of resources.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Static, dynamic, and resource-based labels
 
 The labels you assign to resources can be **static labels**, **dynamic labels**, or **resource-based labels**.


### PR DESCRIPTION
Backports #58690 and #58411

The Vale prose linter used to check docs pages for the following structural qualities in how-to guides:

- Correct step numbering.
- A "How it works" section providing an architectural overview, preventing newer users from getting lost and allowing users with knowledge of Teleport architecture to anticipate the steps within the guide.

Since the Vale linter used the `raw` scope, rather than a parsed Markdown AST, there was no way for a docs page to disable these linters in edge cases using comments. By making the structure `remark` linters, we can allow users to ignore them if they need to, while also taking advantage of unit testing for the linter code.

This change anticipates the new `remark` linters by adding "How it works" sections and fixing step numbering.

---------