### PR TITLE
Prevent TestIntegrations/LeafAgentlessConnection from flaking

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3867,6 +3867,9 @@ func testTrustedClusterAgentless(t *testing.T, suite *integrationTestSuite) {
 	// create agentless node in leaf cluster
 	node := CreateAgentlessNode(t, leaf.Process.GetAuthServer(), clusterAux, "leaf-agentless-node")
 
+	err = main.WaitForNodeCount(ctx, clusterAux, 1)
+	require.NoError(t, err)
+
 	// connect to leaf agentless node
 	creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
 		Process:        main.Process,


### PR DESCRIPTION
The test created a resource and immediately tried to connect to it, though due to resource propagation, the server did not yet exist in the inventory. This is resolved by first waiting for the server to be visible in the leaf cluster inventory before attempting a connection.

Fixes #58735.