### PR TITLE
[v16] Ignore missing "How it works" sections

### DIFF
--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/azure.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/azure.mdx
@@ -17,6 +17,8 @@ behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
 For other methods of joining a Teleport process to a cluster, see [Joining
 Teleport Services to a Cluster](join-services-to-your-cluster.mdx).
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/gcp.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/gcp.mdx
@@ -16,6 +16,8 @@ The VM must have a
 assigned to it (the default service account is fine). No IAM roles are required
 on the Teleport process joining the cluster.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
@@ -27,6 +27,8 @@ The Kubernetes join method is available in self-hosted versions of Teleport.
 It supports joining any Teleport service running in the same Kubernetes cluster
 as the Auth Service.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - A running Teleport cluster in Kubernetes. For details on how to set this up,

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -25,6 +25,8 @@ AWS Management Console or executes a command with an AWS client application, the
 Teleport Application Service checks the user's RBAC permissions and, if they are
 authorized, forwards the user's requests to AWS. 
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -23,6 +23,8 @@ The Teleport Application Service connects to the Teleport Proxy Service over a
 reverse tunnel, so you can run the Application Service in a private network and
 prevent unauthorized access to your organization's Google Cloud service accounts.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -14,6 +14,8 @@ configured labels.
 
 (!docs/pages/includes/discovery/same-host-tip.mdx serviceName="Kubernetes" resourceDesc="cluster" !)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -15,6 +15,8 @@ each creation.
 In this guide, we will show you how to get started with Teleport Kubernetes
 Discovery for GKE.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Overview
 
 (!docs/pages/includes/discovery/step-description.mdx serviceName="Kubernetes" resourceDesc="cluster" resourceKind="kube_cluster" !)

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -11,6 +11,8 @@ discover and enroll virtual machines matching configured labels. It will then
 execute a script on these discovered instances that will install Teleport,
 start it and join the cluster.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -15,6 +15,8 @@ In this scenario, Teleport Discovery Service uses an IAM invite token with a
 long time-to-live (TTL), so that new instances can be discovered and added to
 the Teleport cluster for the lifetime of the token.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -11,6 +11,8 @@ discover and enroll GCP Compute Engine instances matching configured labels. It 
 execute a script on these discovered instances that will install Teleport,
 start it and join the cluster.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -18,6 +18,8 @@ labels:
 
 </Tabs>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -21,6 +21,8 @@ desktop. You can disable Directory Sharing for specific users via their Teleport
 roles, and use session recording to audit activity in the shared directory
 after the session ends.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -21,6 +21,8 @@ Teleport Kubernetes Service running on the Kubernetes cluster:
 For information about other ways to enroll and discover Kubernetes clusters, see
 [Registering Kubernetes Clusters with Teleport](register-clusters/register-clusters.mdx).
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - Access to a running Teleport cluster, `tctl` admin tool, and `tsh` client tool, 

--- a/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
@@ -19,6 +19,8 @@ In this guide, we will use a local Kubernetes cluster to show you how to
 configure Teleport's role-based access control (RBAC) system to manage access to
 Kubernetes clusers, groups, users, and resources.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -18,6 +18,8 @@ In this guide, we will show you how to set up dynamic Kubernetes cluster
 registration, then create, list, update, and delete Kubernetes clusters via
 `tctl`.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -20,6 +20,8 @@ to automatically join the cluster on subsequent restarts.
 Support for joining a cluster with the Proxy Service behind a layer 7 load
 balancer or reverse proxy is available in Teleport 13.0+.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -17,6 +17,8 @@ authenticate to the API server of your chosen Kubernetes cluster.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -31,6 +31,8 @@ that a user intends to access.
 
 ![Teleport Bastion](../../../img/server-access/getting-started-diagram.svg)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -45,6 +45,8 @@ In this setup, the Teleport SSH Service performs RBAC checks as well as audits a
 
 </Admonition>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - OpenSSH version 6.9 or above on your local machine. View your OpenSSH version

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -43,6 +43,8 @@ In this setup, the Teleport SSH Service performs RBAC checks as well as audits a
 
 </Admonition>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - OpenSSH version 6.9 or above on your local machine. View your OpenSSH version

--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -26,6 +26,8 @@ This guide explains how to register a local server with a Teleport Enterprise
 Teleport Web UI in a browser or using the terminal. You can also record your
 sessions, so you can review them later.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - A Teleport Enterprise (Cloud) account. You can sign up for a free trial at the

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
@@ -24,6 +24,8 @@ webhook run by the plugin, which modifies the Access Request in Teleport.
 
 </details>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
@@ -24,6 +24,8 @@ compromising productivity.
 
 </details>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
@@ -15,6 +15,8 @@ compromising productivity.
 
 ![The Microsoft Teams Access Request plugin](../../../img/enterprise/plugins/msteams.png)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -29,6 +29,8 @@ PagerDuty.
 
 ![PagerDuty plugin architecture](../../../img/enterprise/plugins/pagerduty/diagram.png)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -38,6 +38,8 @@ Here is an example of sending an Access Request via Teleport's Slack plugin:
   Your browser does not support the video tag.
 </video>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/identity-governance/device-trust/jamf-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/jamf-integration.mdx
@@ -27,6 +27,8 @@ and behavior.
 
 </details>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
@@ -24,6 +24,8 @@ for the cluster and the Kubernetes service account that will be used by the
 `tbot` pod. See the [Kubernetes platform guide](kubernetes.mdx) for further
 guidance on deploying Machine ID as a workload on Kubernetes.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
@@ -21,6 +21,8 @@ The `azure` join method instructs the bot to use this attested data document and
 JWT to prove its identity to the Teleport Auth Server. This allows joining to
 occur without the use of a long-lived secret.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
@@ -25,6 +25,8 @@ for the cluster and the Kubernetes service account that will be used by the
 `tbot` pod. See the [Kubernetes platform guide](kubernetes.mdx) for further
 guidance on deploying Machine ID as a workload on Kubernetes.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
@@ -47,6 +47,8 @@ a single join token. These services are:
 
 </details>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
@@ -18,6 +18,8 @@ it is the only join method that relies on a shared secret. In order to mitigate
 the risks associated with this, the `token` join method is single use and it
 is not possible to use the same token multiple times.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
@@ -15,6 +15,8 @@ In this guide, you'll configure the RBAC necessary to allow a Bot to issue
 SPIFFE SVIDs and then configure `tbot` to expose a SPIFFE Workload API endpoint.
 You can then connect your workloads to this endpoint to receive SPIFFE SVIDs.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/access-controls/getting-started.mdx
+++ b/docs/pages/zero-trust-access/access-controls/getting-started.mdx
@@ -13,6 +13,8 @@ desktops, and web apps.
 We will start with local users and preset roles, assign roles to SSO users, and
 wrap up with creating your own role.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/hardware-key-support.mdx
@@ -65,6 +65,8 @@ like `tctl edit`. With touch required, hardware key support provides better secu
   and fall back to MFA prompts when user presence or verification is needed, like for per-session MFA.
 </Admonition>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -39,6 +39,8 @@ connect it to your production Teleport cluster.**  Use a demo cluster instead.
 
 </Admonition>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
@@ -28,6 +28,8 @@ private keys, a CA rotation must be performed.
 Read on to [migrating an existing cluster](#migrating-an-existing-cluster) to
 learn more.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 The features documented on this page are available in Teleport `15.0.0` and

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -22,6 +22,8 @@ cluster to Teleport.
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - A registered domain name. This is required for Teleport to set up TLS via

--- a/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
@@ -16,6 +16,8 @@ to send your Teleport audit events to the Elastic Stack. In this setup, the
 Event Handler plugin forwards audit events from Teleport to Logstash, which
 stores them in Elasticsearch for visualization and alerting in Kibana. 
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
@@ -23,6 +23,8 @@ You can follow the instructions below for a local proof-of-concept demo, or use 
 of the additional installation instructions to configure the Teleport Event Handler
 to integrate with your infrastructure.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -17,6 +17,8 @@ Event Handler plugin forwards audit logs from Teleport to Splunk's Universal
 Forwarder, which stores them in Splunk Cloud Platform or Splunk Enterprise for
 visualization and alerting.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
@@ -23,6 +23,8 @@ While following this guide, you will create a Teleport user and role with no
 privileges in order to show you how to use Spacelift to create dynamic
 resources. 
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/management/admin/labels.mdx
+++ b/docs/pages/zero-trust-access/management/admin/labels.mdx
@@ -16,6 +16,8 @@ the following:
 This guide demonstrates how to add labels to enrolled server resources.
 However, you can follow similar steps to add labels to other types of resources.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Static, dynamic, and resource-based labels
 
 The labels you assign to resources can be **static labels**, **dynamic labels**, or **resource-based labels**.

--- a/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
@@ -33,6 +33,8 @@ instance running on the root cluster.
    firewall to ensure leaf Proxy services are only allowed to connect to the appropriate resources.  
 </Admonition>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Who uses trusted clusters?
 
 Most organizations don't need to configure trusted clusters. In most cases, you can add 

--- a/docs/pages/zero-trust-access/management/guides/ssh-key-extensions.mdx
+++ b/docs/pages/zero-trust-access/management/guides/ssh-key-extensions.mdx
@@ -5,6 +5,8 @@ description:  How to use Teleport's short-lived SSH certificates with the GitHub
 
 Teleport supports exporting user SSH certificates with configurable key extensions. This allows the Teleport CA to be used in conjunction with GitHub's support for SSH Certificate Authorities. This way, users can access their organizations' repositories with short-lived, signed SSH certificates.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/zero-trust-access/management/operations/proxy-peering.mdx
+++ b/docs/pages/zero-trust-access/management/operations/proxy-peering.mdx
@@ -12,6 +12,8 @@ your Proxy Service instances horizontally by reducing the
 number of connections created between Teleport Proxy instances
 and Teleport services like the Database Service and Application Service.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 An existing self-hosted Teleport Enterprise cluster that is **not** using [Trusted Clusters](../../../zero-trust-access/management/admin/trustedclusters.mdx). See the documentation on [self-hosting Teleport](../../../zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx) to get started.

--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -16,6 +16,8 @@ allows Teleport administrators to define policies like:
 - Only members of "DBA" group can SSH into machines running PostgreSQL.
 - Developers must never SSH into production servers.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - ADFS installation with Admin access and users assigned to at least two groups.

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -17,6 +17,8 @@ administrators to define policies like:
 The following steps configure an example SAML authentication connector matching
 Entra ID groups with security roles. You can choose to configure other options.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 Before you get started, you’ll need:

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -16,6 +16,8 @@ like:
 - Only members of "ProductionKubernetes" can access production Kubernetes clusters
 - Developers must never SSH into production servers.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - At least two groups in GitLab with users assigned. In our examples below,

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -15,6 +15,8 @@ access control (RBAC), you can define policies like the following:
 - Only members of the "DBA" Google group can connect to PostgreSQL databases.
 - Developers must never use SSH to access production servers.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 Before you get started, verify the following:

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -38,6 +38,8 @@ guide you through configuring the Okta integration.
 
 </details>
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - An Okta account with admin access. Your account must include users and at

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -19,6 +19,8 @@ to define policies like:
 - Developers must never SSH into production servers.
 - ... and many others.
 
+{/* lint ignore page-structure remark-lint */}
+
 ## Prerequisites
 
 - A OneLogin account with admin access, and users assigned to at least two groups.


### PR DESCRIPTION
The Vale prose linter used to check docs pages for the following structural qualities in how-to guides:

- Correct step numbering.
- A "How it works" section providing an architectural overview, preventing newer users from getting lost and allowing users with knowledge of Teleport architecture to anticipate the steps within the guide.

Since the Vale linter used the `raw` scope, rather than a parsed Markdown AST, there was no way for a docs page to disable these linters in edge cases using comments. By making the structure `remark` linters, we can allow users to ignore them if they need to, while also taking advantage of unit testing for the linter code.

This change anticipates the new `remark` linters by ignoring missing "How it works" sections in v16.