### PR TITLE
Fix Encrypted Session Recording guides

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
@@ -7,14 +7,25 @@ labels:
   - data-protection
 ---
 
-## Prerequisites
+This guide explains how to rotate encryption keys for session recordings using
+the automatic method. In this approach, the Teleport Auth Service manages the
+selection and labeling of encryption keys for you.
 
-- (!docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx!)
+For instructions on manually rotating encryption keys for session recordings,
+see [Rotating Manual Session Recording Encryption
+Keys](rotating-manual-keys.mdx).
+
+## How it works
 
 Session recording encryption keys are rotated using `tctl`. Rotation is a
 two-phase process that requires initiating a rotation and then completing that
 rotation. It is also possible to roll back an in-progress rotation in the event
 that the previous key state needs to be restored.
+
+## Prerequisites
+
+This guide assumes that you have followed the setup instructions in [Encrypted
+Session Recordings](encrypted-session-recordings.mdx).
 
 ## Step 1/3. Initiate a rotation
 

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -7,9 +7,24 @@ labels:
   - data-protection
 ---
 
+This guide explains how to rotate encryption keys for session recordings.
+
+For instructions on using the automatic approach, see [Rotating Session
+Recording Encryption Keys](rotating-keys.mdx).
+
+## How it works
+
+In the manual approach to session recording key management, a user provides the
+Auth Service with the types and labels of keys used to encrypt Teleport session
+recordings. In this way, the user has control over the keys the Auth Service
+uses to encrypt session recordings, as well as rotated keys that the Auth
+Service no longer uses for encryption, but that are available for decrypting
+stored session recordings.
+
 ## Prerequisites
 
-- (!docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx!)
+This guide assumes that you have followed the setup instructions in [Encrypted
+Session Recordings](encrypted-session-recordings.mdx).
 
 Although Manual Key Management leaves key rotation entirely up to the
 administrator, the `manual_key_management` configuration can be leveraged to help facilitate rotations.


### PR DESCRIPTION
Two of these guides include the entire getting started guide as a prerequisite. Instead, refer to the guide using a link instead to clean up the structure of the guide. Also add "How it works" sections and introductory paragraphs.