### PR TITLE
docs: broken mwi links in tilegrid

### DIFF
--- a/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
+++ b/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
@@ -15,17 +15,17 @@ It integrates with Terraform, Pulumi, AWS, GCP, Azure, and also provides solutio
   tiles={[
     {
       icon: <Icon name="awsIdentity" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/aws-roles-anywhere",
+      to: "/docs/machine-workload-identity/workload-identity/aws-roles-anywhere",
       name: "AWS Roles Anywhere and Workload Identity",
     },
     {
       icon: <Icon name="googleCloud" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
+      to: "/docs/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
       name: "Google Cloud Workload Identity Federation",
     },
     {
       icon: <Icon name="azure" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/azure-federated-credentials",
+      to: "/docs/machine-workload-identity/workload-identity/azure-federated-credentials",
       name: "Azure Federated Credentials",
     },
     {

--- a/docs/pages/machine-workload-identity/iac-mwi.mdx
+++ b/docs/pages/machine-workload-identity/iac-mwi.mdx
@@ -16,17 +16,17 @@ AWS, GCP and Azure, as well as solutions for on-prem configuration.
   tiles={[
     {
       icon: <Icon name="awsIdentity" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/aws-roles-anywhere",
+      to: "/docs/machine-workload-identity/workload-identity/aws-roles-anywhere",
       name: "AWS Roles Anywhere and Workload Identity",
     },
     {
       icon: <Icon name="googleCloud" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
+      to: "/docs/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt",
       name: "Google Cloud Workload Identity Federation",
     },
     {
       icon: <Icon name="azure" size="xl" />,
-      to: "/machine-workload-identity/workload-identity/azure-federated-credentials",
+      to: "/docs/machine-workload-identity/workload-identity/azure-federated-credentials",
       name: "Azure Federated Credentials and Workload Identity",
     },
     {

--- a/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
+++ b/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
@@ -15,37 +15,37 @@ certificates at runtime. Teleport natively integrates with many CI/CD providers 
   tiles={[
     {
       icon: <Icon name="azureDevops" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/azure-devops",
+      to: "/docs/machine-workload-identity/machine-id/deployment/azure-devops",
       name: "Azure DevOps",
     },
     {
       icon: <Icon name="bitbucket" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/bitbucket",
+      to: "/docs/machine-workload-identity/machine-id/deployment/bitbucket",
       name: "BitBucket Pipelines",
     },
     {
       icon: <Icon name="circleci" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/circleci",
+      to: "/docs/machine-workload-identity/machine-id/deployment/circleci",
       name: "CircleCI",
     },
     {
       icon: <Icon name="gitlab" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/gitlab",
+      to: "/docs/machine-workload-identity/machine-id/deployment/gitlab",
       name: "GitLab CI",
     },
     {
       icon: <Icon name="githubActions" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/github-actions",
+      to: "/docs/machine-workload-identity/machine-id/deployment/github-actions",
       name: "GitHub Actions",
     },
     {
       icon: <Icon name="jenkins" size="xl" />,
-      to: "/machine-workload-identity/machine-id/deployment/jenkins",
+      to: "/docs/machine-workload-identity/machine-id/deployment/jenkins",
       name: "Jenkins",
     },
     {
       icon: <Icon name="spacelift" size="xl" />,
-      to: "/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
+      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
       name: "Spacelift",
     }
   ]}


### PR DESCRIPTION
From work in https://github.com/gravitational/teleport/pull/58333

Looks like even though these links in TileGrid rendered in the preview, once published they are broken because the 'docs' portion of the links is not present (Amplify doesn't need '/docs/' in the links path in previews), hence didn't trigger the broken links linter). 

e.g. from working preview link:
https://test-link-stuff.d1v2yqnl3ruxch.amplifyapp.com/machine-workload-identity/machine-id/deployment/bitbucket/

once published results in this broken link:
https://goteleport.com/machine-workload-identity/machine-id/deployment/bitbucket/

TileGrid links are on these pages:
https://goteleport.com/docs/machine-workload-identity/mwi-ci-cd/
https://goteleport.com/docs/machine-workload-identity/hybrid-multi-mwi/
https://goteleport.com/docs/machine-workload-identity/iac-mwi/
