### PR TITLE
Marshal iterator into event instead of map[string]any

### DIFF
--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -825,5 +824,91 @@ func TestStartKeyBackCompat(t *testing.T) {
 	newCP, err := getCheckpointFromStartKey(newStartKey)
 	require.NoError(t, err)
 
-	require.Empty(t, cmp.Diff(oldCP, newCP))
+	// we must check the iterator field equality separately because it's a string
+	// containing a JSON-encoded event and field ordering might not be consistent.
+	require.Equal(t, oldCP.EventKey, newCP.EventKey)
+	require.Equal(t, oldCP.Date, newCP.Date)
+
+	var oldIterator, newIterator event
+	require.NoError(t, json.Unmarshal([]byte(oldCP.Iterator), &oldIterator))
+	require.NoError(t, json.Unmarshal([]byte(newCP.Iterator), &newIterator))
+	require.Equal(t, oldIterator, newIterator)
+}
+
+// TestCursorIteratorPrecision exists because cursors are sensitive to data-loss
+// and we had a bug where we would unmarshall a cursor into `map[string]any`,
+// causing all int64 to do a round-trip through float64 and losing precision.
+// The precision loss would cause the cursor hash to be in te past.
+// If the cursor shifts by more events than the page size, this creates a
+// livelock and the query cannot proceed.
+// This test creates events with very close EventIndex (1 nanosecond diff),
+// reads the events 1 by one, and makes sure the reader is not stuck reading the
+// same event over and over.
+func TestCursorIteratorPrecision(t *testing.T) {
+	tt := setupDynamoContext(t)
+	clock, ok := tt.log.Clock.(*clockwork.FakeClock)
+	require.True(t, ok, "this test requires a FakeClock")
+	baseTime := clock.Now().UTC()
+
+	// Test Setup: creating fixtures really close in the dynamo index.
+
+	// For this test to work, we need the same session ID for all events
+	sessionId := uuid.NewString()
+	numEvents := 5
+	testEvents := make(map[string]struct{}, numEvents)
+
+	for range numEvents {
+		id := uuid.NewString()
+		// For the first event, EventIndex will be zero, for the next ones it
+		// will be the unix nanosecond timestamp.
+		clock.Advance(time.Nanosecond)
+		err := tt.log.EmitAuditEvent(context.Background(), &apievents.Exec{
+			UserMetadata: apievents.UserMetadata{User: "test-user"},
+			Metadata: apievents.Metadata{
+				ID:   id,
+				Type: events.UserLoginEvent,
+				Time: clock.Now().UTC(),
+			},
+			SessionMetadata: apievents.SessionMetadata{
+				SessionID: sessionId,
+			},
+		})
+		testEvents[id] = struct{}{}
+		require.NoError(t, err)
+	}
+
+	// Test execution: do paginated queries to read all the fixtures.
+	eventsSeen := make(map[string]apievents.AuditEvent, numEvents)
+	toTime := baseTime.Add(time.Hour)
+	var arr []apievents.AuditEvent
+	var err error
+	var checkpoint string
+
+	for range testEvents {
+		arr, checkpoint, err = tt.log.SearchEvents(t.Context(), events.SearchEventsRequest{
+			From:     baseTime,
+			To:       toTime,
+			Limit:    1,
+			Order:    types.EventOrderAscending,
+			StartKey: checkpoint,
+		})
+		require.NoError(t, err)
+		require.Len(t, arr, 1)
+
+		id := arr[0].GetID()
+		var c checkpointKey
+		require.NoError(t, json.Unmarshal([]byte(checkpoint), &c), "event %s", id)
+		require.NotEmpty(t, c.Iterator, "event %s", id)
+
+		var e EventKey
+		require.NoError(t, json.Unmarshal([]byte(c.Iterator), &e), "event %s", id)
+		eventsSeen[id] = arr[0]
+	}
+
+	// Test validation: make sure that all fixtures were read (as opposed to
+	// some event being returned several times because of a cursor issue).
+	for id := range testEvents {
+		require.Contains(t, eventsSeen, id, "eventsSeen should contain %q", id)
+	}
+
 }


### PR DESCRIPTION
Tentative fix of https://github.com/gravitational/teleport/issues/58365

This PR fixes a data loss bug causing the DynamoDB cursor EventIndex field to be sightly changed due to conversion issues. As this field is used to index events, this could lead to paginated queries not returning the right events, either returning events from before or after the requested page. In the worst case, this could cause a livelock as the query continuously processes the same events.

The data loss issue is caused by improper JSON unmarshalling of large integers. This happened because of this reasons:
- JSON is fundamentally flawed as it offers a single number type "binary64"  for all numbers, whether they are integers or float. Go's encoding/json library uses field types to detect if the number should be stored in an int64 or a float64.
- [The AWS SDK v2 migration PR](https://github.com/gravitational/teleport/pull/44363) changed the cursor JSON unmarshalling logic and unmarshalled the cursor into `map[string]any`. This caused every integer field of `event` to round-trip through float64 instead of int64.
- [The Emit event fallback PR](https://github.com/gravitational/teleport/pull/40854) changed the EventIndex value from a small incremental integer to a large unix nanosecond timestamp in case of conflict. The large value was no longer safe for storage in a float64.

The combination of those 3 factors caused the cursor EventIndex to get corrupted and unexpectedly offset the event search queries. When presented with a non-existing document, DynamoDB still hashes it and starts the query from its supposed location in the index. This is why this issue has not been detected for so long. Its consequences were:
- duplicated events returned on 2 consecutive pages (this case was handled properly by the event forwarder as it keeps track of the last processed event)
- livelock if the number of duplicated events exceeds the page size
- missing events if the index offset was in the future

Changelog: Fixed a DynamoDB bug potentially causing event queries to return a different range of events. In the worst case scenario, this bug would block the event-handler.