### PR TITLE
Fix `TestGetTargetHealth` deadlock

### DIFF
--- a/lib/healthcheck/worker_experimental_test.go
+++ b/lib/healthcheck/worker_experimental_test.go
@@ -70,8 +70,10 @@ func TestGetTargetHealth(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(t.Context())
 			synctest.Run(func() {
+				// TODO(gavin): use t.Context() once we bump to go1.25 which adds synctest.Test(t, func(t *testing.T) { ... })
+				// See https://github.com/golang/go/issues/74837#issuecomment-3177146173 for more info
+				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				worker, err := newWorker(ctx, workerConfig{
 					HealthCheckCfg: test.healthCheckConfig,


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/58386
- https://github.com/gravitational/teleport/issues/58386

I was not able to reproduce the failure locally, however I believe the issue is related to issues with passing in a context from outside the synctest bubble: https://github.com/golang/go/issues/74837#issuecomment-3177146173

If test failures persist, we'll have to wait until we bump to go 1.25 to see where our goroutines are getting stuck in the synctest "bubble".