### PR TITLE
Round timeline's time value so it doesn't pass a float

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/RecordingTimeline.tsx
@@ -281,7 +281,7 @@ export function RecordingTimeline({
         event.clientX - canvasRef.current.getBoundingClientRect().left
       );
 
-      onTimeChange(time);
+      onTimeChange(Math.round(time)); // round to avoid sending a float for the current time
     },
     [onTimeChange]
   );


### PR DESCRIPTION
The players encode the time as an integer so the timeline shouldn't be passing back floats

(I didn't update the `getTimeAtX` method because for we need the precision when grabbing the user's mouse time position when they zoom)