### PR TITLE
[v17] MWI: Allow configuration of default namespace for `kubernetes/v2` service (#58393)

### DIFF
--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -216,14 +216,14 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 	}
 	defer impersonatedClient.Close()
 
-	clusters, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
+	matches, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var clusterNames []string
-	for _, c := range clusters {
-		clusterNames = append(clusterNames, c.GetName())
+	for _, m := range matches {
+		clusterNames = append(clusterNames, m.cluster.GetName())
 	}
 	clusterNames = utils.Deduplicate(clusterNames)
 

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -166,14 +166,27 @@ func (s *OutputV2Service) generate(ctx context.Context) error {
 	}
 	defer impersonatedClient.Close()
 
-	clusters, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
+	matches, err := fetchAllMatchingKubeClusters(ctx, impersonatedClient, s.cfg.Selectors)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	var clusterNames []string
-	for _, c := range clusters {
-		clusterNames = append(clusterNames, c.GetName())
+	for _, m := range matches {
+		clusterNames = append(clusterNames, m.cluster.GetName())
+	}
+	defaultNamespaces := map[string]string{}
+	for _, m := range matches {
+		if m.selector.DefaultNamespace != "" {
+			if _, ok := defaultNamespaces[m.cluster.GetName()]; ok {
+				s.log.WarnContext(
+					ctx,
+					"Multiple selectors match the same cluster with different default namespaces configured, last definition will take priority",
+					"cluster", m.cluster.GetName(),
+				)
+			}
+			defaultNamespaces[m.cluster.GetName()] = m.selector.DefaultNamespace
+		}
 	}
 
 	clusterNames = utils.Deduplicate(clusterNames)
@@ -211,6 +224,7 @@ func (s *OutputV2Service) generate(ctx context.Context) error {
 		credentials:            keyRing,
 		teleportClusterName:    proxyPong.ClusterName,
 		kubernetesClusterNames: clusterNames,
+		defaultNamespaces:      defaultNamespaces,
 	}
 
 	return trace.Wrap(s.render(ctx, status, id.Get(), hostCAs))
@@ -224,6 +238,9 @@ type kubernetesStatusV2 struct {
 	tlsServerName          string
 	credentials            *libclient.KeyRing
 	kubernetesClusterNames []string
+	// defaultNamespace is map of the cluster name to the default namespace
+	// which should be used for that cluster.
+	defaultNamespaces map[string]string
 }
 
 // queryKubeClustersByLabels fetches a list of Kubernetes clusters matching the
@@ -249,13 +266,18 @@ func queryKubeClustersByLabels(ctx context.Context, clt apiclient.GetResourcesCl
 	return clusters, nil
 }
 
+type selectorMatch struct {
+	selector *KubernetesSelector
+	cluster  types.KubeCluster
+}
+
 // fetchAllMatchingKubeClusters returns a list of all clusters matching the
 // given selectors.
-func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResourcesClient, selectors []*KubernetesSelector) ([]types.KubeCluster, error) {
+func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResourcesClient, selectors []*KubernetesSelector) ([]selectorMatch, error) {
 	ctx, span := tracer.Start(ctx, "findAllMatchingKubeClusters")
 	defer span.End()
 
-	clusters := []types.KubeCluster{}
+	matches := []selectorMatch{}
 	for _, selector := range selectors {
 		if selector.Name != "" {
 			cluster, err := getKubeCluster(ctx, clt, selector.Name)
@@ -264,7 +286,10 @@ func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResource
 				return nil, trace.Wrap(err, "unable to fetch cluster %q by name", selector.Name)
 			}
 
-			clusters = append(clusters, cluster)
+			matches = append(matches, selectorMatch{
+				selector: selector,
+				cluster:  cluster,
+			})
 			continue
 		}
 
@@ -278,11 +303,15 @@ func fetchAllMatchingKubeClusters(ctx context.Context, clt apiclient.GetResource
 			// clusters are returned.)
 			return nil, trace.Wrap(err, "unable to fetch clusters with labels %v", selector.Labels)
 		}
-
-		clusters = append(clusters, labeledClusters...)
+		for _, cluster := range labeledClusters {
+			matches = append(matches, selectorMatch{
+				selector: selector,
+				cluster:  cluster,
+			})
+		}
 	}
 
-	return clusters, nil
+	return matches, nil
 }
 
 func (s *OutputV2Service) render(
@@ -431,6 +460,9 @@ func generateKubeConfigV2WithPlugin(ks *kubernetesStatusV2, destPath string, exe
 			Cluster:  contextName,
 			AuthInfo: ks.teleportClusterName,
 		}
+		if ns, ok := ks.defaultNamespaces[cluster]; ok {
+			config.Contexts[contextName].Namespace = ns
+		}
 
 		// Always set the current context to the first-matched cluster. This
 		// won't be perfectly consistent if the first selector uses labels, so
@@ -477,6 +509,9 @@ func generateKubeConfigV2WithoutPlugin(ks *kubernetesStatusV2) (*clientcmdapi.Co
 		config.Contexts[contextName] = &clientcmdapi.Context{
 			Cluster:  contextName,
 			AuthInfo: ks.teleportClusterName,
+		}
+		if ns, ok := ks.defaultNamespaces[cluster]; ok {
+			config.Contexts[contextName].Namespace = ns
 		}
 
 		if i == 0 {

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -140,6 +140,10 @@ type KubernetesSelector struct {
 	Name string `yaml:"name,omitempty"`
 
 	Labels map[string]string `yaml:"labels,omitempty"`
+
+	// DefaultNamespace specifies the default namespace that should be set in
+	// the resulting kubeconfig context for clusters yielded by this selector.
+	DefaultNamespace string `yaml:"default_namespace,omitempty"`
 }
 
 // String returns a human-readable representation of the selector for logs.

--- a/lib/tbot/services/k8s/output_v2_config_test.go
+++ b/lib/tbot/services/k8s/output_v2_config_test.go
@@ -49,6 +49,7 @@ func TestKubernetesV2Output_YAML(t *testing.T) {
 						Labels: map[string]string{
 							"foo": "bar",
 						},
+						DefaultNamespace: "foo-namespace",
 					},
 				},
 				CredentialLifetime: bot.CredentialLifetime{

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/absolute_path/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/absolute_path/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/exec_plugin_disabled/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/exec_plugin_disabled/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/relative_path/kubeconfig.yaml.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2OutputService_render/relative_path/kubeconfig.yaml.golden
@@ -18,6 +18,7 @@ clusters:
 contexts:
 - context:
     cluster: tele.blackmesa.gov-a
+    namespace: namespace-a
     user: tele.blackmesa.gov
   name: tele.blackmesa.gov-a
 - context:

--- a/lib/tbot/services/k8s/testdata/TestKubernetesV2Output_YAML/full.golden
+++ b/lib/tbot/services/k8s/testdata/TestKubernetesV2Output_YAML/full.golden
@@ -6,5 +6,6 @@ selectors:
   - name: foo
   - labels:
       foo: bar
+    default_namespace: foo-namespace
 credential_ttl: 1m0s
 renewal_interval: 30s


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/58393

changelog: Added support for `tbot` configuration of a default namespace for kubeconfig files generated by the kubernetes/v2 service.