### PR TITLE
[v18] Fill in missing "How it works" sections

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -12,7 +12,17 @@ runs in Kubernetes and can deploy applications to the same cluster or to other
 
 In this guide, you will configure the Machine ID agent, `tbot`, to manage Argo
 CD's cluster credentials, enabling it to securely deploy applications using
-Teleport Kubernetes Access.
+Teleport.
+
+## How it works
+
+Argo CD supports declaratively managing clusters using Kubernetes secrets (see
+the [Argo CD
+documentation](https://argo-cd.readthedocs.io/en/latest/operator-manual/declarative-setup/#clusters).
+The Argo CD application controller reads these secrets in order to retrieve
+cluster credentials. When configured to use the Argo CD output, `tbot` writes
+Teleport-signed Kubernetes cluster credentials into secrets that Argo CD can
+then use to access Teleport-protected Kubernetes clusters.
 
 ## Prerequisite
 


### PR DESCRIPTION
Backports #58690

* Fill in missing "How it works" sections

Add brief architectural overviews to make it clearer what a user is setting up when they the Machine ID Argo CD output guide.