### PR TITLE
Change Session Summary section title

### DIFF
--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -19,7 +19,7 @@ Teleport doesn't currently support any spend controls; controlling the LLM
 token budget is your responsibility.
 </Admonition>
 
-## How session recording summarization works
+## How it works
 
 Teleport can automatically summarize any recorded interactive SSH or Kubernetes
 session, as well as any recorded database session.


### PR DESCRIPTION
Use "How it works" so we can standardize this section title across how-to guides and automatically ensure that new how-to guides include an architectural overview.