### PR TITLE
Tag Identity Governance pages: use case and cloud

### DIFF
--- a/docs/pages/identity-governance/access-lists/guide.mdx
+++ b/docs/pages/identity-governance/access-lists/guide.mdx
@@ -4,6 +4,7 @@ description: Learn how to use Access Lists to manage and audit long lived access
 tags:
  - get-started
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
@@ -4,6 +4,7 @@ description: Learn how to use nested Access Lists to manage complex permissions 
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 Nested Access Lists allow inclusion of an Access List as a member or owner of another Access List.

--- a/docs/pages/identity-governance/access-lists/terraform.mdx
+++ b/docs/pages/identity-governance/access-lists/terraform.mdx
@@ -4,6 +4,7 @@ description: Learn how to manage Access Lists and their members with Terraform.
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 You can manage Access List and their members using Terraform. This guide will help you:

--- a/docs/pages/identity-governance/access-monitoring.mdx
+++ b/docs/pages/identity-governance/access-monitoring.mdx
@@ -5,6 +5,7 @@ sidebar_position: 6
 tags:
  - how-to
  - identity-governance
+ - access-risks
 ---
 
 Access Monitoring allows users to understand and analyze the access patterns in a Teleport cluster.

--- a/docs/pages/identity-governance/access-request-plugins/access-plugin.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/access-plugin.mdx
@@ -4,6 +4,7 @@ description: Manage Access Requests using custom workflows with the Teleport API
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 With Teleport [Access Requests](../../identity-governance/access-requests/access-requests.mdx), you can

--- a/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
@@ -6,6 +6,7 @@ sidebar_position: 2
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
 ---
 
 Teleport Just-in-Time Access Requests allow users to receive temporary elevated

--- a/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's Datadog Incident Management plugin for pri
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 With Teleport's Datadog Incident Management integration, engineers can access the

--- a/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
@@ -5,6 +5,7 @@ sidebar_position: 11
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 With Teleport's Access Monitoring Rules, Access Request notifications can be

--- a/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's Opsgenie plugin for privilege elevation ap
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-request-plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/servicenow.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's ServiceNow plugin for privilege elevation 
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-discord.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's Discord plugin for privilege elevation app
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 import BotLogo from "/static/avatar_logo.png";

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-email.mdx
@@ -5,6 +5,7 @@ description: How to set up the Teleport email plugin to notify users when anothe
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 This guide will explain how to set up Teleport to send Just-in-Time Access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
@@ -5,6 +5,7 @@ description: How to set up the Teleport Jira plugin to notify users when another
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 This guide explains how to set up the Teleport Access Request plugin for Jira.

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's Mattermost plugin for privilege elevation 
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 import BotLogo from "/static/avatar_logo.png";

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's Microsoft Teams plugin for privilege eleva
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 This guide will explain how to set up Microsoft Teams to receive Access Request messages

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's PagerDuty plugin for privilege elevation a
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 With Teleport's PagerDuty integration, engineers can access the infrastructure

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -5,6 +5,7 @@ sidebar_label: Slack
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 import SlackVideoMp4 from "@version/docs/img/enterprise/plugins/slack/slack.mp4"

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 This guide explains the considerations you should make when configuring Teleport

--- a/docs/pages/identity-governance/access-requests/access-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/access-requests.mdx
@@ -6,6 +6,7 @@ sidebar_position: 1
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
 ---
 
 Just-in-time Access Requests allow Teleport users to request access to a

--- a/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
+++ b/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
@@ -4,6 +4,7 @@ description: Describes how to configure Access Automation Rules for Automatic Re
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 Teleport supports automatic reviews of Access Requests. This

--- a/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
@@ -4,6 +4,7 @@ description: Teleport Community Edition allows users to request access to roles 
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
 ---
 
 Just-in-time Access Requests are a feature of Teleport Enterprise.

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-requests/role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/role-requests.mdx
@@ -5,6 +5,7 @@ h1: Teleport Role Access Requests
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 Teleport's Just-in-time Access Requests allow users to request access to

--- a/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
@@ -4,6 +4,8 @@ description: Provides an overview of the Teleport AWS IAM Identity Center integr
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
+ - aws
 ---
 
 Teleport's integration with [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/)

--- a/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
@@ -4,6 +4,8 @@ description: Explains how to set up and use Teleport AWS IAM Identity Center int
 tags:
  - how-to
  - identity-governance
+ - privileged-access
+ - aws
 ---
 
 Teleport's integration with [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/)

--- a/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -5,6 +5,8 @@ tocDepth: 3
 tags:
  - how-to
  - identity-governance
+ - privileged-access
+ - aws
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
@@ -4,6 +4,8 @@ description: Provides an overview of the Teleport AWS IAM Identity Center integr
 tags:
  - how-to
  - identity-governance
+ - privileged-access
+ - aws
 ---
 
 This guide will show you how to configure the `aws` command-line tool to use

--- a/docs/pages/identity-governance/device-trust/device-management.mdx
+++ b/docs/pages/identity-governance/device-trust/device-management.mdx
@@ -4,6 +4,7 @@ description: Learn how to manage Trusted Devices
 tags:
  - conceptual
  - identity-governance
+ - resiliency
 ---
 
 This guide provides instructions for performing Device Trust management

--- a/docs/pages/identity-governance/device-trust/device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/device-trust.mdx
@@ -7,6 +7,7 @@ sidebar_position: 5
 tags:
  - conceptual
  - identity-governance
+ - resiliency
 ---
 
 (!docs/pages/includes/device-trust/support-notice.mdx!)

--- a/docs/pages/identity-governance/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/enforcing-device-trust.mdx
@@ -5,6 +5,7 @@ videoBanner: gBQyj_X1LVw
 tags:
  - conceptual
  - identity-governance
+ - resiliency
 ---
 
 <Admonition type="note" title="Supported Resources">

--- a/docs/pages/identity-governance/device-trust/guide.mdx
+++ b/docs/pages/identity-governance/device-trust/guide.mdx
@@ -5,6 +5,7 @@ videoBanner: gBQyj_X1LVw
 tags:
  - get-started
  - identity-governance
+ - resiliency
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/device-trust/intune-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/intune-integration.mdx
@@ -4,6 +4,8 @@ description: Sync your Microsoft Intune inventory into Teleport
 tags:
  - how-to
  - identity-governance
+ - azure
+ - resiliency
 ---
 
 The Device Trust Microsoft Intune integration lets you automatically sync your managed devices from

--- a/docs/pages/identity-governance/device-trust/jamf-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/jamf-integration.mdx
@@ -4,6 +4,7 @@ description: Sync your Jamf Pro inventory into Teleport
 tags:
  - how-to
  - identity-governance
+ - resiliency
 ---
 
 The Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer

--- a/docs/pages/identity-governance/entra-id/configure-access.mdx
+++ b/docs/pages/identity-governance/entra-id/configure-access.mdx
@@ -4,7 +4,8 @@ description: Learn how to map Entra ID groups to Teleport roles with Nested Acce
 sidebar_position: 4
 tags:
  - identity-governance
- - rbac
+ - azure
+ - privileged-access
 ---
 
 This guide shows how to setup access for Entra ID imported users based on their Entra

--- a/docs/pages/identity-governance/entra-id/entra-id.mdx
+++ b/docs/pages/identity-governance/entra-id/entra-id.mdx
@@ -3,6 +3,8 @@ title: Entra ID Integration
 description: Describes how Entra ID integration works in Teleport.
 tags:
  - identity-governance
+ - azure
+ - privileged-access
 ---
 
 The Entra ID integration enables the following features in Teleport:

--- a/docs/pages/identity-governance/entra-id/faq.mdx
+++ b/docs/pages/identity-governance/entra-id/faq.mdx
@@ -4,6 +4,8 @@ description: Frequently asked questions on the Teleport Entra ID integration.
 sidebar_position: 5
 tags:
  - identity-governance
+ - azure
+ - privileged-access
 ---
 
 This page provides answers to frequently asked questions about Teleport Entra ID integration. 

--- a/docs/pages/identity-governance/entra-id/getting-started.mdx
+++ b/docs/pages/identity-governance/entra-id/getting-started.mdx
@@ -4,6 +4,8 @@ description: Describes how to set up the Teleport Entra ID integration in Telepo
 tags:
  - how-to
  - identity-governance
+ - azure
+ - privileged-access
 ---
 
 

--- a/docs/pages/identity-governance/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/entra-id/manual-installation.mdx
@@ -4,6 +4,8 @@ description: Describes how to manually set up Entra ID for the Teleport Entra ID
 tags:
  - how-to
  - identity-governance
+ - azure
+ - privileged-access
 ---
 
 This guide shows manual Entra ID configuration steps to set up Teleport Entra ID integration.

--- a/docs/pages/identity-governance/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/entra-id/terraform.mdx
@@ -5,7 +5,8 @@ sidebar_position: 3
 tags:
  - how-to
  - identity-governance
- - terraform
+ - azure
+ - privileged-access
 ---
 
 This guide shows you how to integrate Teleport with Microsoft Entra ID using Terraform and `tctl`.

--- a/docs/pages/identity-governance/idps/idps.mdx
+++ b/docs/pages/identity-governance/idps/idps.mdx
@@ -3,6 +3,7 @@ title: Configure Teleport as an identity provider
 description: How to set up Teleport's identity provider functionality
 tags:
  - identity-governance
+ - infrastructure-identity
 ---
 
 Users can authenticate to both internal and external applications

--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -5,6 +5,7 @@ h1: SAML Attribute Mapping
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
 ---
 
 Attribute mapping configures Teleport SAML Identity Provider to assert custom user attributes in SAML response.

--- a/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
@@ -5,6 +5,8 @@ h1: GCP Workforce Identity Federation with Teleport SAML IdP
 tags:
  - how-to
  - identity-governance
+ - google-cloud
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/idps/saml-grafana.mdx
+++ b/docs/pages/identity-governance/idps/saml-grafana.mdx
@@ -4,6 +4,7 @@ description: Configure Grafana to use identities provided by Teleport.
 tags:
  - how-to
  - identity-governance
+ - infrastructure-identity
 ---
 
 Grafana is an open source observability platform. Their enterprise version supports

--- a/docs/pages/identity-governance/idps/saml-guide.mdx
+++ b/docs/pages/identity-governance/idps/saml-guide.mdx
@@ -5,6 +5,7 @@ h1: Teleport as a SAML identity provider
 tags:
  - how-to
  - identity-governance
+ - infrastructure-identity
 ---
 
 This guide details an example on how to use Teleport as a SAML identity provider

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -4,6 +4,8 @@ description: Access Azure Portal and CLI by authenticating with Teleport SAML Id
 tags:
  - how-to
  - identity-governance
+ - azure
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -4,6 +4,7 @@ description: How to lock compromised users or agents
 tags:
  - how-to
  - identity-governance
+ - resiliency
 ---
 
 System administrators can disable a compromised user or Teleport Agent—or

--- a/docs/pages/identity-governance/okta/app-and-group-sync.mdx
+++ b/docs/pages/identity-governance/okta/app-and-group-sync.mdx
@@ -4,6 +4,7 @@ description: Explains how to enable the Okta app and group sync integration, whi
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 Okta has its own permissions system that doesn't directly map into Teleport. This

--- a/docs/pages/identity-governance/okta/guided-sso.mdx
+++ b/docs/pages/identity-governance/okta/guided-sso.mdx
@@ -4,6 +4,7 @@ description: Explains how to enroll Okta in your Teleport cluster as an identity
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/okta/okta.mdx
+++ b/docs/pages/identity-governance/okta/okta.mdx
@@ -5,6 +5,7 @@ sidebar_position: 4
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 The Teleport Okta integration can import and grant access to resources from an

--- a/docs/pages/identity-governance/okta/scim-integration.mdx
+++ b/docs/pages/identity-governance/okta/scim-integration.mdx
@@ -4,6 +4,7 @@ description: Explains how to use the guided integration enrollment flow to enabl
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 The SCIM (System for Cross-domain Identity Management) integration enables automated user management,

--- a/docs/pages/identity-governance/okta/user-sync.mdx
+++ b/docs/pages/identity-governance/okta/user-sync.mdx
@@ -4,6 +4,7 @@ description: Explains how to set up Okta user sync with the guided integration f
 tags:
  - how-to
  - identity-governance
+ - privileged-access
 ---
 
 {/* lint disable page-structure remark-lint */}


### PR DESCRIPTION
Tag pages in the Identity Governance section of the docs with the appropriate use case and cloud provider tags. Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.