### PR TITLE
Change a heading in the session summaries guide

### DIFF
--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -19,7 +19,7 @@ Teleport doesn't currently support any spend controls; controlling the LLM
 token budget is your responsibility.
 </Admonition>
 
-## How session recording summarization works
+## How it works
 
 Teleport can automatically summarize any recorded interactive SSH or Kubernetes
 session, as well as any recorded database session.


### PR DESCRIPTION
This reflects the change made during the review of the v18 backport of this document.