### PR TITLE
[teleport-update] Expose install suffix, dir, and PATH as env vars

### DIFF
--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -50,15 +50,21 @@ Find out more at https://goteleport.com/docs/upgrading/agent-managed-updates`
 const (
 	// proxyServerEnvVar allows the proxy server address to be specified via env var.
 	proxyServerEnvVar = "TELEPORT_PROXY"
+	// installSuffixEnvVar specifies the Teleport install suffix.
+	installSuffixEnvVar = "TELEPORT_INSTALL_SUFFIX"
+	// installDirEnvVar specifies the Teleport install directory.
+	installDirEnvVar = "TELEPORT_INSTALL_DIR"
+	// pathEnvVar specifies the Teleport PATH for binary symlinks.
+	pathEnvVar = "TELEPORT_PATH"
 	// updateGroupEnvVar allows the update group to be specified via env var.
 	updateGroupEnvVar = "TELEPORT_UPDATE_GROUP"
 	// updateVersionEnvVar specifies the Teleport version.
 	updateVersionEnvVar = "TELEPORT_UPDATE_VERSION"
 	// updateFlagsEnvVar specifies Teleport version flags.
 	updateFlagsEnvVar = "TELEPORT_UPDATE_FLAGS"
+
 	// updateLockTimeout is the duration commands will wait for update to complete before failing.
 	updateLockTimeout = 10 * time.Minute
-
 	// notUpToDateExitCode is returned by `teleport-update status --is-up-to-date` if Teleport is not up-to-date.
 	notUpToDateExitCode = 3
 )
@@ -108,9 +114,9 @@ func Run(args []string) int {
 	app.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
 		Default(libutils.LogFormatText).EnumVar(&ccfg.LogFormat, libutils.LogFormatJSON, libutils.LogFormatText)
 	app.Flag("install-suffix", "Suffix for creating an agent installation outside of the default $PATH. Note: this changes the default data directory.").
-		Short('i').StringVar(&ccfg.InstallSuffix)
+		Short('i').Envar(installSuffixEnvVar).StringVar(&ccfg.InstallSuffix)
 	app.Flag("install-dir", "Directory containing Teleport installations.").
-		Hidden().StringVar(&ccfg.InstallDir)
+		Hidden().Envar(installDirEnvVar).StringVar(&ccfg.InstallDir)
 	app.Flag("insecure", "Insecure mode disables certificate verification. Do not use in production.").
 		BoolVar(&ccfg.Insecure)
 
@@ -136,7 +142,7 @@ func Run(args []string) int {
 	enableCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").
 		Hidden().BoolVar(&ccfg.SelfSetup)
 	enableCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
-		Hidden().StringVar(&ccfg.Path)
+		Hidden().Envar(pathEnvVar).StringVar(&ccfg.Path)
 	enableCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
 		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 
@@ -160,7 +166,7 @@ func Run(args []string) int {
 	pinCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").
 		Hidden().BoolVar(&ccfg.SelfSetup)
 	pinCmd.Flag("path", "Directory to link the active Teleport installation's binaries into.").
-		Hidden().StringVar(&ccfg.Path)
+		Hidden().Envar(pathEnvVar).StringVar(&ccfg.Path)
 	pinCmd.Flag("selinux-ssh", "Install an SELinux module to constrain Teleport SSH.").
 		Hidden().Envar(autoupdate.SetupSELinuxSSHEnvVar).IsSetByUser(&ccfg.SELinuxSSHChanged).BoolVar(&ccfg.SELinuxSSH)
 


### PR DESCRIPTION
This PR exposes `teleport-update`'s install suffix (e.g., used in `/etc/teleport_mysuffix.yaml`), install directory (default: `/opt/teleport`), and target path for linking binaries (default: `/usr/local/bin`) as env vars. This will make it easier for users invoking the Teleport install script (which invokes `teleport-update`) to set these values.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal: https://github.com/gravitational/cloud/issues/14225 (internal)