### PR TITLE
Prevent race in TestFeaturesWatcher

### DIFF
--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,16 +41,22 @@ import (
 // that returns the internal features
 type mockedFeatureGetter struct {
 	authclient.ClientI
+
+	mu       sync.Mutex
 	features proto.Features
 }
 
 func (m *mockedFeatureGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return proto.PingResponse{
 		ServerFeatures: utils.CloneProtoMsg(&m.features),
 	}, nil
 }
 
 func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.features = f
 }
 


### PR DESCRIPTION
Protects the features field with a mutex to prevent races during test execution.

Fixes #58820.