### PR TITLE
Allow `tsh scp` to copy between two hosts

### DIFF
--- a/lib/sshutils/sftp/http.go
+++ b/lib/sshutils/sftp/http.go
@@ -175,6 +175,13 @@ func (h *httpFS) RealPath(path string) (string, error) {
 	return path, nil
 }
 
+func (h *httpFS) Close() error {
+	if h.reader != nil {
+		return trace.Wrap(h.reader.Close())
+	}
+	return nil
+}
+
 type nopWriteCloser struct {
 	io.Writer
 }

--- a/lib/sshutils/sftp/local.go
+++ b/lib/sshutils/sftp/local.go
@@ -150,3 +150,7 @@ func (l localFS) RealPath(path string) (string, error) {
 	}
 	return filepath.EvalSymlinks(path)
 }
+
+func (l localFS) Close() error {
+	return nil
+}

--- a/lib/sshutils/sftp/parse_test.go
+++ b/lib/sshutils/sftp/parse_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/utils"
@@ -31,16 +32,16 @@ import (
 var parseTestCases = []struct {
 	name     string
 	in       string
-	dest     Destination
+	dest     Target
 	errCheck require.ErrorAssertionFunc
 }{
 	{
 		name: "full spec of the remote destination",
 		in:   "root@remote.host:/etc/nginx.conf",
-		dest: Destination{
+		dest: Target{
 			Login: "root",
-			Host: &utils.NetAddr{
-				Addr:        "remote.host",
+			Addr: &utils.NetAddr{
+				Addr:        "remote.host:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/etc/nginx.conf",
@@ -49,9 +50,9 @@ var parseTestCases = []struct {
 	{
 		name: "spec with just the remote host",
 		in:   "remote.host:/etc/nginx.co:nf",
-		dest: Destination{
-			Host: &utils.NetAddr{
-				Addr:        "remote.host",
+		dest: Target{
+			Addr: &utils.NetAddr{
+				Addr:        "remote.host:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/etc/nginx.co:nf",
@@ -60,9 +61,9 @@ var parseTestCases = []struct {
 	{
 		name: "ipv6 remote destination address",
 		in:   "[::1]:/etc/nginx.co:nf",
-		dest: Destination{
-			Host: &utils.NetAddr{
-				Addr:        "[::1]",
+		dest: Target{
+			Addr: &utils.NetAddr{
+				Addr:        "[::1]:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/etc/nginx.co:nf",
@@ -71,10 +72,10 @@ var parseTestCases = []struct {
 	{
 		name: "full spec of the remote destination using ipv4 address",
 		in:   "root@123.123.123.123:/var/www/html/",
-		dest: Destination{
+		dest: Target{
 			Login: "root",
-			Host: &utils.NetAddr{
-				Addr:        "123.123.123.123",
+			Addr: &utils.NetAddr{
+				Addr:        "123.123.123.123:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/var/www/html/",
@@ -83,10 +84,10 @@ var parseTestCases = []struct {
 	{
 		name: "target location using wildcard",
 		in:   "myusername@myremotehost.com:/home/hope/*",
-		dest: Destination{
+		dest: Target{
 			Login: "myusername",
-			Host: &utils.NetAddr{
-				Addr:        "myremotehost.com",
+			Addr: &utils.NetAddr{
+				Addr:        "myremotehost.com:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/home/hope/*",
@@ -95,10 +96,10 @@ var parseTestCases = []struct {
 	{
 		name: "complex login",
 		in:   "complex@example.com@remote.com:/anything.txt",
-		dest: Destination{
+		dest: Target{
 			Login: "complex@example.com",
-			Host: &utils.NetAddr{
-				Addr:        "remote.com",
+			Addr: &utils.NetAddr{
+				Addr:        "remote.com:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/anything.txt",
@@ -107,10 +108,10 @@ var parseTestCases = []struct {
 	{
 		name: "implicit user's home directory",
 		in:   "root@remote.host:",
-		dest: Destination{
+		dest: Target{
 			Login: "root",
-			Host: &utils.NetAddr{
-				Addr:        "remote.host",
+			Addr: &utils.NetAddr{
+				Addr:        "remote.host:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: ".",
@@ -119,9 +120,9 @@ var parseTestCases = []struct {
 	{
 		name: "no login and '@' in path",
 		in:   "remote.host:/some@file",
-		dest: Destination{
-			Host: &utils.NetAddr{
-				Addr:        "remote.host",
+		dest: Target{
+			Addr: &utils.NetAddr{
+				Addr:        "remote.host:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/some@file",
@@ -130,9 +131,9 @@ var parseTestCases = []struct {
 	{
 		name: "no login, '@' and ':' in path",
 		in:   "remote.host:/some@remote:file",
-		dest: Destination{
-			Host: &utils.NetAddr{
-				Addr:        "remote.host",
+		dest: Target{
+			Addr: &utils.NetAddr{
+				Addr:        "remote.host:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/some@remote:file",
@@ -141,10 +142,10 @@ var parseTestCases = []struct {
 	{
 		name: "complex login, IPv6 addr and ':' in path",
 		in:   "complex@user@[::1]:/remote:file",
-		dest: Destination{
+		dest: Target{
 			Login: "complex@user",
-			Host: &utils.NetAddr{
-				Addr:        "[::1]",
+			Addr: &utils.NetAddr{
+				Addr:        "[::1]:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/remote:file",
@@ -153,10 +154,10 @@ var parseTestCases = []struct {
 	{
 		name: "filename with timestamp",
 		in:   "user@server.com:/tmp/user-2022-03-10T09:49:23-98cd2a03/file.txt",
-		dest: Destination{
+		dest: Target{
 			Login: "user",
-			Host: &utils.NetAddr{
-				Addr:        "server.com",
+			Addr: &utils.NetAddr{
+				Addr:        "server.com:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "/tmp/user-2022-03-10T09:49:23-98cd2a03/file.txt",
@@ -165,10 +166,10 @@ var parseTestCases = []struct {
 	{
 		name: "filename with '@' suffix",
 		in:   "user@server:file@",
-		dest: Destination{
+		dest: Target{
 			Login: "user",
-			Host: &utils.NetAddr{
-				Addr:        "server",
+			Addr: &utils.NetAddr{
+				Addr:        "server:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "file@",
@@ -177,10 +178,10 @@ var parseTestCases = []struct {
 	{
 		name: "filename with IPv6 address",
 		in:   "user@server:file[::1]name",
-		dest: Destination{
+		dest: Target{
 			Login: "user",
-			Host: &utils.NetAddr{
-				Addr:        "server",
+			Addr: &utils.NetAddr{
+				Addr:        "server:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "file[::1]name",
@@ -189,10 +190,10 @@ var parseTestCases = []struct {
 	{
 		name: "IPv6 address and filename with IPv6 address",
 		in:   "user@[::1]:file[::1]name",
-		dest: Destination{
+		dest: Target{
 			Login: "user",
-			Host: &utils.NetAddr{
-				Addr:        "[::1]",
+			Addr: &utils.NetAddr{
+				Addr:        "[::1]:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "file[::1]name",
@@ -201,27 +202,34 @@ var parseTestCases = []struct {
 	{
 		name: "IPv6 address and filename with IPv6 address and '@'s",
 		in:   "user@[::1]:file@[::1]@name",
-		dest: Destination{
+		dest: Target{
 			Login: "user",
-			Host: &utils.NetAddr{
-				Addr:        "[::1]",
+			Addr: &utils.NetAddr{
+				Addr:        "[::1]:8080",
 				AddrNetwork: "tcp",
 			},
 			Path: "file@[::1]@name",
 		},
 	},
 	{
+		name: "path only",
+		in:   "path/to/somewhere",
+		dest: Target{
+			Path: "path/to/somewhere",
+		},
+	},
+	{
 		name: "missing path",
 		in:   "user@server",
 		errCheck: func(t require.TestingT, err error, i ...any) {
-			require.EqualError(t, err, fmt.Sprintf("%q is missing a path, use form [user@]host:[path]", i[0]))
+			require.EqualError(t, err, fmt.Sprintf("%q is missing a path, use form [[user@]host:]path", i[0]))
 		},
 	},
 	{
 		name: "missing host",
 		in:   "user@:/foo",
 		errCheck: func(t require.TestingT, err error, i ...any) {
-			require.EqualError(t, err, fmt.Sprintf("%q is missing a host, use form [user@]host:[path]", i[0]))
+			require.EqualError(t, err, fmt.Sprintf("%q is missing a host, use form [[user@]host:]path", i[0]))
 		},
 	},
 	{
@@ -242,20 +250,20 @@ var parseTestCases = []struct {
 		name: "missing path with IPv6 addr",
 		in:   "[user]@[::1]",
 		errCheck: func(t require.TestingT, err error, i ...any) {
-			require.EqualError(t, err, fmt.Sprintf("%q is missing a path, use form [user@]host:[path]", i[0]))
+			require.EqualError(t, err, fmt.Sprintf("%q is missing a path, use form [[user@]host:]path", i[0]))
 		},
 	},
 }
 
-func TestParseDestination(t *testing.T) {
+func TestParseTarget(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range parseTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := ParseDestination(tt.in)
+			resp, err := ParseTarget(tt.in, 8080)
 			if tt.errCheck == nil {
 				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(resp, &tt.dest))
+				require.Empty(t, cmp.Diff(resp, tt.dest))
 			} else {
 				tt.errCheck(t, err, tt.in)
 			}
@@ -263,14 +271,64 @@ func TestParseDestination(t *testing.T) {
 	}
 }
 
-func FuzzParseDestination(f *testing.F) {
+func FuzzParseTarget(f *testing.F) {
 	for _, tt := range parseTestCases {
 		f.Add(tt.in)
 	}
 
 	f.Fuzz(func(t *testing.T, input string) {
-		_, _ = ParseDestination(input)
+		_, _ = ParseTarget(input, 8080)
 	})
+}
+
+func TestParseSources(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		inputSources    []string
+		assert          assert.ErrorAssertionFunc
+		expectedSources Sources
+	}{
+		{
+			name:         "ok one source",
+			inputSources: []string{"alice@foo:/path/to/thing"},
+			assert:       assert.NoError,
+			expectedSources: Sources{
+				Login: "alice",
+				Addr:  utils.MustParseAddr("foo:8080"),
+				Paths: []string{"/path/to/thing"},
+			},
+		},
+		{
+			name:         "ok multiple sources",
+			inputSources: []string{"alice@foo:/path/one", "alice@foo:/path/two"},
+			assert:       assert.NoError,
+			expectedSources: Sources{
+				Login: "alice",
+				Addr:  utils.MustParseAddr("foo:8080"),
+				Paths: []string{"/path/one", "/path/two"},
+			},
+		},
+		{
+			name:   "no sources",
+			assert: assert.Error,
+		},
+		{
+			name:         "sources from different hosts",
+			inputSources: []string{"alice@foo:/path", "/local/path"},
+			assert:       assert.Error,
+		},
+		{
+			name:         "sources with different logins",
+			inputSources: []string{"alice@foo:/path/one", "bob@foo:/path/two"},
+			assert:       assert.Error,
+		},
+	}
+	for _, tc := range tests {
+		sources, err := ParseSources(tc.inputSources, 8080)
+		tc.assert(t, err)
+		assert.Equal(t, tc.expectedSources, sources)
+	}
 }
 
 func TestIsRemotePath(t *testing.T) {

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -20,7 +20,6 @@
 package sftp
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -31,7 +30,6 @@ import (
 	"os"
 	"path" // SFTP requires UNIX-style path separators
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +39,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 
 	"github.com/gravitational/teleport"
-	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 )
@@ -78,32 +76,69 @@ const (
 	MethodReadlink = "Readlink"
 )
 
-// Options control aspects of a file transfer
-type Options struct {
-	// Recursive indicates recursive file transfer
+// FileTransferRequest holds the settings for an SFTP file transfer.
+type FileTransferRequest struct {
+	// Sources is the source paths, local or remtoe.
+	Sources Sources
+	// Destination is the destination path, local or remote.
+	Destination Target
+	// DialHost opens an SSH client to the given address.
+	DialHost func(ctx context.Context, login, addr string) (*ssh.Client, error)
+	// Recursive indicates recursive file transfer.
 	Recursive bool
 	// PreserveAttrs preserves access and modification times
-	// from the original file
+	// from the original file.
 	PreserveAttrs bool
-	// Quiet indicates whether progress should be displayed.
-	Quiet bool
 	// ProgressWriter is used to write the progress output.
 	ProgressWriter io.Writer
-}
-
-// Config describes the settings of a file transfer
-type Config struct {
-	srcPaths []string
-	dstPath  string
-	srcFS    FileSystem
-	dstFS    FileSystem
-	opts     Options
-
 	// ProgressStream is a callback to return a read/writer for printing the progress
 	// (used only on the client)
 	ProgressStream func(fileInfo os.FileInfo) io.ReadWriter
 	// Log optionally specifies the logger
 	Log *slog.Logger
+	// HTTPReader is a reader for downloads from an HTTP server.
+	HTTPReader io.ReadCloser
+	// HTTPWriter is a writer for uploads to an HTTP server.
+	HTTPWriter http.ResponseWriter
+	// Size is the size of the file for HTTP transfers.
+	Size int64
+	// ModeratedSessionID is the optional ID of a moderated session.
+	ModeratedSessionID string
+
+	srcFS FileSystem
+	dstFS FileSystem
+}
+
+func (req *FileTransferRequest) checkAndSetDefaults() error {
+	if len(req.Sources.Paths) == 0 {
+		return trace.BadParameter("missing sources")
+	}
+	if req.Sources.Addr != nil && req.Sources.Login == "" {
+		return trace.BadParameter("missing login for source host")
+	}
+	if req.Destination.Addr != nil && req.Destination.Login == "" {
+		return trace.BadParameter("missing login for destination host")
+	}
+	if (req.Sources.Addr != nil || req.Destination.Addr != nil) && req.DialHost == nil {
+		return trace.BadParameter("request has a remote target but DialHost is not set")
+	}
+
+	if req.Log == nil {
+		req.Log = slog.Default()
+	}
+	req.Log = req.Log.With(
+		teleport.ComponentKey, "SFTP",
+		"src_paths", req.Sources.Paths,
+		"dst_path", req.Destination,
+		"recursive", req.Recursive,
+		"preserve_attrs", req.PreserveAttrs,
+	)
+	if req.ProgressWriter != nil && req.ProgressStream == nil {
+		req.ProgressStream = func(fileInfo os.FileInfo) io.ReadWriter {
+			return NewProgressBar(fileInfo.Size(), fileInfo.Name(), req.ProgressWriter)
+		}
+	}
+	return nil
 }
 
 // File is the file interface required for [FileSystem].
@@ -121,6 +156,7 @@ type File interface {
 // Note: errors returned by a FileSystem should not be `trace.Wrap()`ed so the
 // sftp package can parse os errors.
 type FileSystem interface {
+	io.Closer
 	// Type returns whether the filesystem is "local" or "remote".
 	Type() string
 	// Glob returns matching files of a glob pattern.
@@ -166,65 +202,27 @@ type FileSystem interface {
 	RealPath(path string) (string, error)
 }
 
-// CreateUploadConfig returns a Config ready to upload files over SFTP.
-func CreateUploadConfig(src []string, dst string, opts Options) (*Config, error) {
-	if slices.Contains(src, "") {
-		return nil, trace.BadParameter("source path is empty")
-	}
-	if dst == "" {
-		return nil, trace.BadParameter("destination path is empty")
-	}
-
-	c := &Config{
-		srcPaths: src,
-		dstPath:  dst,
-		srcFS:    &localFS{},
-		dstFS:    &RemoteFS{},
-		opts:     opts,
-	}
-	c.setDefaults()
-
-	return c, nil
-}
-
-// CreateDownloadConfig returns a Config ready to download files over SFTP.
-func CreateDownloadConfig(src, dst string, opts Options) (*Config, error) {
-	if src == "" {
-		return nil, trace.BadParameter("source path is empty")
-	}
-	if dst == "" {
-		return nil, trace.BadParameter("destination path is empty")
-	}
-
-	c := &Config{
-		srcPaths: []string{src},
-		dstPath:  dst,
-		srcFS:    &RemoteFS{},
-		dstFS:    &localFS{},
-		opts:     opts,
-	}
-	c.setDefaults()
-
-	return c, nil
-}
-
 // HTTPTransferRequest describes file transfer request over HTTP.
 type HTTPTransferRequest struct {
 	// Src is the source file name
-	Src string
+	Src Target
 	// Dst is the destination file name
-	Dst string
+	Dst Target
 	// HTTPRequest is where the source file will be read from for
 	// file upload transfers
 	HTTPRequest *http.Request
 	// HTTPResponse is where the destination file will be written to for
 	// file download transfers
 	HTTPResponse http.ResponseWriter
+	// DialHost opens an SSH client to the given address.
+	DialHost func(ctx context.Context, login, addr string) (*ssh.Client, error)
+	// ModeratedSessionID is the optional ID of a moderated session.
+	ModeratedSessionID string
 }
 
-// CreateHTTPUploadConfig returns a Config ready to upload a file from
+// CreateHTTPUploadRequest returns a FileTransferRequest ready to upload a file from
 // a HTTP request over SFTP.
-func CreateHTTPUploadConfig(req HTTPTransferRequest) (*Config, error) {
+func CreateHTTPUploadRequest(req HTTPTransferRequest) (*FileTransferRequest, error) {
 	if err := req.checkDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -237,25 +235,23 @@ func CreateHTTPUploadConfig(req HTTPTransferRequest) (*Config, error) {
 	if err != nil {
 		return nil, trace.Errorf("failed to parse Content-Length header: %w", err)
 	}
-
-	c := &Config{
-		srcPaths: []string{req.Src},
-		dstPath:  req.Dst,
-		srcFS: &httpFS{
-			reader:   req.HTTPRequest.Body,
-			fileName: req.Src,
-			fileSize: fileSize,
+	return &FileTransferRequest{
+		Sources: Sources{
+			Login: req.Src.Login,
+			Addr:  req.Src.Addr,
+			Paths: []string{req.Src.Path},
 		},
-		dstFS: &RemoteFS{},
-	}
-	c.setDefaults()
-
-	return c, nil
+		Destination:        req.Dst,
+		DialHost:           req.DialHost,
+		HTTPReader:         req.HTTPRequest.Body,
+		Size:               fileSize,
+		ModeratedSessionID: req.ModeratedSessionID,
+	}, nil
 }
 
-// CreateHTTPDownloadConfig returns a Config ready to download a file
+// CreateHTTPDownloadRequest returns a FileTransferRequest ready to download a file
 // from over SFTP and write it to a HTTP response.
-func CreateHTTPDownloadConfig(req HTTPTransferRequest) (*Config, error) {
+func CreateHTTPDownloadRequest(req HTTPTransferRequest) (*FileTransferRequest, error) {
 	if err := req.checkDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -263,159 +259,96 @@ func CreateHTTPDownloadConfig(req HTTPTransferRequest) (*Config, error) {
 		return nil, trace.BadParameter("HTTP response is empty")
 	}
 
-	c := &Config{
-		srcPaths: []string{req.Src},
-		dstPath:  req.Dst,
-		srcFS:    &RemoteFS{},
-		dstFS: &httpFS{
-			writer:   req.HTTPResponse,
-			fileName: req.Dst,
+	return &FileTransferRequest{
+		Sources: Sources{
+			Login: req.Src.Login,
+			Addr:  req.Src.Addr,
+			Paths: []string{req.Src.Path},
 		},
-	}
-	c.setDefaults()
-
-	return c, nil
+		Destination:        req.Dst,
+		DialHost:           req.DialHost,
+		HTTPWriter:         req.HTTPResponse,
+		ModeratedSessionID: req.ModeratedSessionID,
+	}, nil
 }
 
 func (h HTTPTransferRequest) checkDefaults() error {
-	if h.Src == "" {
+	if h.Src.Path == "" {
 		return trace.BadParameter("source path is empty")
 	}
-	if h.Dst == "" {
+	if h.Dst.Path == "" {
 		return trace.BadParameter("destination path is empty")
 	}
 	return nil
 }
 
-// setDefaults sets default values
-func (c *Config) setDefaults() {
-	logger := c.Log
-	if logger == nil {
-		logger = slog.Default()
-	}
-	c.Log = logger.With(
-		teleport.ComponentKey, "SFTP",
-		"src_paths", c.srcPaths,
-		"dst_path", c.dstPath,
-		"recursive", c.opts.Recursive,
-		"preserve_attrs", c.opts.PreserveAttrs,
-	)
-
-	if !c.opts.Quiet {
-		c.ProgressStream = func(fileInfo os.FileInfo) io.ReadWriter {
-			return NewProgressBar(fileInfo.Size(), fileInfo.Name(), cmp.Or(c.opts.ProgressWriter, io.Writer(os.Stdout)))
-		}
-	}
-}
-
 // TransferFiles transfers files from the configured source paths to the
 // configured destination path over SFTP or HTTP depending on the Config.
-// moderatedSessionID must be provided for filetransfers in a moderated session.
-func (c *Config) TransferFiles(ctx context.Context, sshClient *tracessh.Client, moderatedSessionID string) error {
-	s, err := sshClient.NewSessionWithParams(ctx, &tracessh.SessionParams{
-		// File transfers in a moderated session require this variable
-		// to check for approval on the ssh server
-		ModeratedSessionID: moderatedSessionID,
-	})
-	if err != nil {
+func TransferFiles(ctx context.Context, req *FileTransferRequest) error {
+	if err := req.checkAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-	defer s.Close()
-
-	// TODO(Joerger): DELETE IN v20.0.0 - moderated session ID is provided
-	// in the session channel params above instead of indirectly through env vars.
-	if moderatedSessionID != "" {
-		s.Setenv(ctx, EnvModeratedSessionID, moderatedSessionID)
-	}
-
-	pe, err := s.StderrPipe()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := s.RequestSubsystem(ctx, teleport.SFTPSubsystem); err != nil {
-		// If the subsystem request failed and a generic error is
-		// returned, return the session's stderr as the error if it's
-		// non-empty, as the session's stderr may have a more useful
-		// error message. String comparison is only used here because
-		// the error is not exported.
-		if strings.Contains(err.Error(), "ssh: subsystem request failed") {
-			var sb strings.Builder
-			if n, _ := io.Copy(&sb, pe); n > 0 {
-				return trace.Wrap(errors.New(sb.String()))
-			}
+	// Set up file systems.
+	switch {
+	case req.srcFS != nil:
+	case req.HTTPReader != nil:
+		if len(req.Sources.Paths) > 1 {
+			return trace.BadParameter("only one source allowed for http filesystems")
 		}
-		return trace.Wrap(err)
-	}
-	pw, err := s.StdinPipe()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	pr, err := s.StdoutPipe()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	sftpClient, err := sftp.NewClientPipe(pr, pw,
-		// Use concurrent stream to speed up transfer on slow networks as described in
-		// https://github.com/gravitational/teleport/issues/20579
-		sftp.UseConcurrentReads(true),
-		sftp.UseConcurrentWrites(true),
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := c.initFS(sftpClient); err != nil {
-		return trace.Wrap(err)
-	}
-
-	transferErr := c.transfer(ctx)
-	closeErr := sftpClient.Close()
-	if transferErr != nil {
-		return trace.Wrap(transferErr)
-	}
-
-	return trace.Wrap(closeErr)
-}
-
-// initFS ensures the source and destination filesystems are ready to transfer
-func (c *Config) initFS(client *sftp.Client) error {
-	var haveRemoteFS bool
-	srcFS, srcOK := c.srcFS.(*RemoteFS)
-	if srcOK {
-		srcFS.Client = client
-		haveRemoteFS = true
-	}
-	dstFS, dstOK := c.dstFS.(*RemoteFS)
-	if dstOK {
-		dstFS.Client = client
-		haveRemoteFS = true
-	}
-	// this will only happen in tests
-	if !haveRemoteFS {
-		return nil
-	}
-
-	return trace.Wrap(c.expandPaths(srcOK, dstOK))
-}
-
-func (c *Config) expandPaths(srcIsRemote, dstIsRemote bool) (err error) {
-	if srcIsRemote {
-		for i, srcPath := range c.srcPaths {
-			c.srcPaths[i], err = expandPath(srcPath)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		req.srcFS = &httpFS{
+			reader:   req.HTTPReader,
+			fileName: req.Sources.Paths[0],
+			fileSize: req.Size,
 		}
-	}
-
-	if dstIsRemote {
-		c.dstPath, err = expandPath(c.dstPath)
+	case req.Sources.Addr != nil:
+		sshClient, err := req.DialHost(ctx, req.Sources.Login, req.Sources.Addr.String())
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		req.srcFS, err = OpenRemoteFilesystem(ctx, sshClient, req.ModeratedSessionID)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for i, srcPath := range req.Sources.Paths {
+			expandedPath, err := expandPath(srcPath)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			req.Sources.Paths[i] = expandedPath
+		}
+	default:
+		req.srcFS = localFS{}
 	}
+	defer req.srcFS.Close()
 
-	return nil
+	switch {
+	case req.dstFS != nil:
+	case req.HTTPWriter != nil:
+		req.dstFS = &httpFS{
+			writer:   req.HTTPWriter,
+			fileName: req.Destination.Path,
+			fileSize: req.Size,
+		}
+	case req.Destination.Addr != nil:
+		sshClient, err := req.DialHost(ctx, req.Destination.Login, req.Destination.Addr.String())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.dstFS, err = OpenRemoteFilesystem(ctx, sshClient, req.ModeratedSessionID)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		expandedPath, err := expandPath(req.Destination.Path)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.Destination.Path = expandedPath
+	default:
+		req.dstFS = localFS{}
+	}
+	defer req.dstFS.Close()
+
+	return trace.Wrap(transfer(ctx, req))
 }
 
 // PathExpansionError is an [error] indicating that
@@ -472,17 +405,17 @@ func homeDirPrefixLen(path string) (int, bool) {
 }
 
 // transfer performs file transfers
-func (c *Config) transfer(ctx context.Context) error {
+func transfer(ctx context.Context, req *FileTransferRequest) error {
 	// get info of source files and ensure appropriate options were passed
-	matchedPaths := make([]string, 0, len(c.srcPaths))
-	fileInfos := make([]os.FileInfo, 0, len(c.srcPaths))
-	for _, srcPath := range c.srcPaths {
+	matchedPaths := make([]string, 0, len(req.Sources.Paths))
+	fileInfos := make([]os.FileInfo, 0, len(req.Sources.Paths))
+	for _, srcPath := range req.Sources.Paths {
 		// This source path may or may not contain a glob pattern, but
 		// try and glob just in case. It is also possible the user
 		// specified a file path containing glob pattern characters but
 		// means the literal path without globbing, in which case we'll
 		// use the raw source path as the sole match below.
-		matches, err := c.srcFS.Glob(srcPath)
+		matches, err := req.srcFS.Glob(srcPath)
 		if err != nil {
 			return trace.Wrap(err, "error matching glob pattern %q", srcPath)
 		}
@@ -498,11 +431,11 @@ func (c *Config) transfer(ctx context.Context) error {
 		matchedPaths = append(matchedPaths, matches...)
 
 		for _, match := range matches {
-			fi, err := c.srcFS.Stat(match)
+			fi, err := req.srcFS.Stat(match)
 			if err != nil {
-				return trace.Wrap(err, "could not access %s path %q", c.srcFS.Type(), match)
+				return trace.Wrap(err, "could not access %s path %q", req.srcFS.Type(), match)
 			}
-			if fi.IsDir() && !c.opts.Recursive {
+			if fi.IsDir() && !req.Recursive {
 				// Note: Using an error constructor included in lib/client.IsErrorResolvableWithRelogin,
 				// e.g. BadParameter, will lead to relogin attempt and a completely obscure error message.
 				return trace.Wrap(&NonRecursiveDirectoryTransferError{Path: match})
@@ -513,35 +446,35 @@ func (c *Config) transfer(ctx context.Context) error {
 
 	// validate destination path and create it if necessary
 	var dstIsDir bool
-	c.dstPath = path.Clean(c.dstPath)
-	dstInfo, err := c.dstFS.Stat(c.dstPath)
+	req.Destination.Path = path.Clean(req.Destination.Path)
+	dstInfo, err := req.dstFS.Stat(req.Destination.Path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return trace.NotFound("error accessing %s path %q: %v", c.dstFS.Type(), c.dstPath, err)
+			return trace.NotFound("error accessing %s path %q: %v", req.dstFS.Type(), req.Destination.Path, err)
 		}
 		// if there are multiple source paths and the destination path
 		// doesn't exist, create it as a directory
 		if len(matchedPaths) > 1 {
-			if err := c.dstFS.Mkdir(c.dstPath); err != nil {
-				return trace.Errorf("error creating %s directory %q: %w", c.dstFS.Type(), c.dstPath, err)
+			if err := req.dstFS.Mkdir(req.Destination.Path); err != nil {
+				return trace.Errorf("error creating %s directory %q: %w", req.dstFS.Type(), req.Destination.Path, err)
 			}
-			if err := c.dstFS.Chmod(c.dstPath, defaults.DirectoryPermissions); err != nil {
-				return trace.Errorf("error setting permissions of %s directory %q: %w", c.dstFS.Type(), c.dstPath, err)
+			if err := req.dstFS.Chmod(req.Destination.Path, defaults.DirectoryPermissions); err != nil {
+				return trace.Errorf("error setting permissions of %s directory %q: %w", req.dstFS.Type(), req.Destination.Path, err)
 			}
 			dstIsDir = true
 		}
 	} else if len(matchedPaths) > 1 && !dstInfo.IsDir() {
 		// if there are multiple source paths, ensure the destination path
 		// is a directory
-		if len(matchedPaths) != len(c.srcPaths) {
+		if len(matchedPaths) != len(req.Sources.Paths) {
 			return trace.BadParameter("%s file %q is not a directory, but multiple source files were matched by a glob pattern",
-				c.dstFS.Type(),
-				c.dstPath,
+				req.dstFS.Type(),
+				req.Destination.Path,
 			)
 		} else {
 			return trace.BadParameter("%s file %q is not a directory, but multiple source files were specified",
-				c.dstFS.Type(),
-				c.dstPath,
+				req.dstFS.Type(),
+				req.Destination.Path,
 			)
 		}
 	} else if dstInfo.IsDir() {
@@ -549,17 +482,17 @@ func (c *Config) transfer(ctx context.Context) error {
 	}
 
 	for i, fi := range fileInfos {
-		dstPath := c.dstPath
+		dstPath := req.Destination.Path
 		if dstIsDir || fi.IsDir() {
 			dstPath = path.Join(dstPath, fi.Name())
 		}
 
 		if fi.IsDir() {
-			if err := c.transferDir(ctx, dstPath, matchedPaths[i], fi, nil); err != nil {
+			if err := transferDir(ctx, req, dstPath, matchedPaths[i], fi, nil); err != nil {
 				return trace.Wrap(err)
 			}
 		} else {
-			if err := c.transferFile(ctx, dstPath, matchedPaths[i], fi); err != nil {
+			if err := transferFile(ctx, req, dstPath, matchedPaths[i], fi); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -569,32 +502,37 @@ func (c *Config) transfer(ctx context.Context) error {
 }
 
 // transferDir transfers a directory
-func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo, visited map[string]struct{}) error {
+func transferDir(ctx context.Context, req *FileTransferRequest, dstPath, srcPath string, srcFileInfo os.FileInfo, visited map[string]struct{}) error {
 	if visited == nil {
 		visited = make(map[string]struct{})
 	}
-	realSrcPath, err := c.srcFS.RealPath(srcPath)
+	realSrcPath, err := req.srcFS.RealPath(srcPath)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if _, ok := visited[realSrcPath]; ok {
-		c.Log.DebugContext(ctx, "symlink loop detected, directory will be skipped", "link", srcPath, "target", realSrcPath)
+		req.Log.DebugContext(ctx, "symlink loop detected, directory will be skipped", "link", srcPath, "target", realSrcPath)
 		return nil
 	}
 	visited[realSrcPath] = struct{}{}
-	c.Log.DebugContext(ctx, "transferring contents of directory", "source_fs", c.srcFS.Type(), "source_path", srcPath, "dest_fs", c.dstFS.Type(), "dest_path", dstPath)
+	req.Log.DebugContext(ctx, "transferring contents of directory",
+		"source_fs", req.srcFS.Type(),
+		"source_path", srcPath,
+		"dest_fs", req.dstFS.Type(),
+		"dest_path", dstPath,
+	)
 
-	err = c.dstFS.Mkdir(dstPath)
+	err = req.dstFS.Mkdir(dstPath)
 	if err != nil && !errors.Is(err, os.ErrExist) {
-		return trace.Errorf("error creating %s directory %q: %w", c.dstFS.Type(), dstPath, err)
+		return trace.Errorf("error creating %s directory %q: %w", req.dstFS.Type(), dstPath, err)
 	}
-	if err := c.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
-		return trace.Errorf("error setting permissions of %s directory %q: %w", c.dstFS.Type(), dstPath, err)
+	if err := req.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
+		return trace.Errorf("error setting permissions of %s directory %q: %w", req.dstFS.Type(), dstPath, err)
 	}
 
-	infos, err := c.srcFS.ReadDir(srcPath)
+	infos, err := req.srcFS.ReadDir(srcPath)
 	if err != nil {
-		return trace.Errorf("error reading %s directory %q: %w", c.srcFS.Type(), srcPath, err)
+		return trace.Errorf("error reading %s directory %q: %w", req.srcFS.Type(), srcPath, err)
 	}
 
 	for _, info := range infos {
@@ -602,11 +540,11 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 		lSubPath := path.Join(srcPath, info.Name())
 
 		if info.IsDir() {
-			if err := c.transferDir(ctx, dstSubPath, lSubPath, info, visited); err != nil {
+			if err := transferDir(ctx, req, dstSubPath, lSubPath, info, visited); err != nil {
 				return trace.Wrap(err)
 			}
 		} else {
-			if err := c.transferFile(ctx, dstSubPath, lSubPath, info); err != nil {
+			if err := transferFile(ctx, req, dstSubPath, lSubPath, info); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -614,10 +552,10 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 
 	// set modification and access times last so creating sub dirs/files
 	// doesn't update the times
-	if c.opts.PreserveAttrs {
-		err := c.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
+	if req.PreserveAttrs {
+		err := req.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
 		if err != nil {
-			return trace.Errorf("error changing times of %s directory %q: %w", c.dstFS.Type(), dstPath, err)
+			return trace.Errorf("error changing times of %s directory %q: %w", req.dstFS.Type(), dstPath, err)
 		}
 	}
 
@@ -625,28 +563,33 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 }
 
 // transferFile transfers a file
-func (c *Config) transferFile(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo) error {
-	c.Log.DebugContext(ctx, "transferring file", "source_fs", c.srcFS.Type(), "source_file", srcPath, "dest_fs", c.dstFS.Type(), "dest_file", dstPath)
+func transferFile(ctx context.Context, req *FileTransferRequest, dstPath, srcPath string, srcFileInfo os.FileInfo) error {
+	req.Log.DebugContext(ctx, "transferring file",
+		"source_fs", req.srcFS.Type(),
+		"source_file", srcPath,
+		"dest_fs", req.dstFS.Type(),
+		"dest_file", dstPath,
+	)
 
-	srcFile, err := c.srcFS.Open(srcPath)
+	srcFile, err := req.srcFS.Open(srcPath)
 	if err != nil {
-		return trace.Errorf("error opening %s file %q: %w", c.srcFS.Type(), srcPath, err)
+		return trace.Errorf("error opening %s file %q: %w", req.srcFS.Type(), srcPath, err)
 	}
 	defer srcFile.Close()
 
-	dstFile, err := c.dstFS.Create(dstPath, srcFileInfo.Size())
+	dstFile, err := req.dstFS.Create(dstPath, srcFileInfo.Size())
 	if err != nil {
-		return trace.Errorf("error creating %s file %q: %w", c.dstFS.Type(), dstPath, err)
+		return trace.Errorf("error creating %s file %q: %w", req.dstFS.Type(), dstPath, err)
 	}
 	defer dstFile.Close()
 
-	if err := c.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
-		return trace.Errorf("error setting permissions of %s file %q: %w", c.dstFS.Type(), dstPath, err)
+	if err := req.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
+		return trace.Errorf("error setting permissions of %s file %q: %w", req.dstFS.Type(), dstPath, err)
 	}
 
 	var progressBar io.ReadWriter
-	if c.ProgressStream != nil {
-		progressBar = c.ProgressStream(srcFileInfo)
+	if req.ProgressStream != nil {
+		progressBar = req.ProgressStream(srcFileInfo)
 	}
 
 	reader, writer := prepareStreams(ctx, srcFile, dstFile, progressBar)
@@ -657,28 +600,28 @@ func (c *Config) transferFile(ctx context.Context, dstPath, srcPath string, srcF
 	n, err := io.Copy(writer, reader)
 	if err != nil {
 		return trace.Errorf("error copying %s file %q to %s file %q: %w",
-			c.srcFS.Type(),
+			req.srcFS.Type(),
 			srcPath,
-			c.dstFS.Type(),
+			req.dstFS.Type(),
 			dstPath,
 			err,
 		)
 	}
 	if n != srcFileInfo.Size() {
 		return trace.Errorf("error copying %s file %q to %s file %q: short write: wrote %d bytes, expected to write %d bytes",
-			c.srcFS.Type(),
+			req.srcFS.Type(),
 			srcPath,
-			c.dstFS.Type(),
+			req.dstFS.Type(),
 			dstPath,
 			n,
 			srcFileInfo.Size(),
 		)
 	}
 
-	if c.opts.PreserveAttrs {
-		err := c.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
+	if req.PreserveAttrs {
+		err := req.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
 		if err != nil {
-			return trace.Errorf("error changing times of %s file %q: %w", c.dstFS.Type(), dstPath, err)
+			return trace.Errorf("error changing times of %s file %q: %w", req.dstFS.Type(), dstPath, err)
 		}
 	}
 

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -53,25 +53,25 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestUpload(t *testing.T) {
+func TestTransferFiles(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name            string
-		srcPaths        []string
+		req             *FileTransferRequest
 		globbedSrcPaths []string
-		dstPath         string
-		opts            Options
 		files           []string
 		errCheck        require.ErrorAssertionFunc
 	}{
 		{
 			name: "one file",
-			srcPaths: []string{
-				"file",
-			},
-			dstPath: "copied-file",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"file"},
+				},
+				Destination: Target{
+					Path: "copied-file",
+				},
 				PreserveAttrs: true,
 			},
 			files: []string{
@@ -80,11 +80,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "one file to dir",
-			srcPaths: []string{
-				"file",
-			},
-			dstPath: "dst/",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"file"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 				PreserveAttrs: true,
 			},
 			files: []string{
@@ -94,11 +96,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "one dir",
-			srcPaths: []string{
-				"src/",
-			},
-			dstPath: "dir/",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"src/"},
+				},
+				Destination: Target{
+					Path: "dir/",
+				},
 				PreserveAttrs: true,
 				Recursive:     true,
 			},
@@ -108,12 +112,16 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "two files dst doesn't exist",
-			srcPaths: []string{
-				"src/file1",
-				"src/file2",
-			},
-			dstPath: "dst/",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"src/file1",
+						"src/file2",
+					},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 				PreserveAttrs: true,
 			},
 			files: []string{
@@ -123,12 +131,16 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "two files dst does exist",
-			srcPaths: []string{
-				"src/file1",
-				"src/file2",
-			},
-			dstPath: "dst/",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"src/file1",
+						"src/file2",
+					},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 				PreserveAttrs: true,
 			},
 			files: []string{
@@ -139,11 +151,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "nested dirs",
-			srcPaths: []string{
-				"s",
-			},
-			dstPath: "dst/",
-			opts: Options{
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"s"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 				PreserveAttrs: true,
 				Recursive:     true,
 			},
@@ -159,8 +173,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "globbed files dst doesn't exist",
-			srcPaths: []string{
-				"glob*",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"glob*"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 			},
 			globbedSrcPaths: []string{
 				"globS",
@@ -168,7 +187,6 @@ func TestUpload(t *testing.T) {
 				"globT",
 				"globB",
 			},
-			dstPath: "dst/",
 			files: []string{
 				"globS",
 				"globA",
@@ -178,8 +196,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "globbed files dst does exist",
-			srcPaths: []string{
-				"glob*",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"glob*"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 			},
 			globbedSrcPaths: []string{
 				"globS",
@@ -187,7 +210,6 @@ func TestUpload(t *testing.T) {
 				"globT",
 				"globB",
 			},
-			dstPath: "dst/",
 			files: []string{
 				"globS",
 				"globA",
@@ -198,9 +220,16 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "multiple glob patterns",
-			srcPaths: []string{
-				"glob*",
-				"*stuff",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"glob*",
+						"*stuff",
+					},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 			},
 			globbedSrcPaths: []string{
 				"globS",
@@ -210,7 +239,6 @@ func TestUpload(t *testing.T) {
 				"mystuff",
 				"yourstuff",
 			},
-			dstPath: "dst/",
 			files: []string{
 				"globS",
 				"globA",
@@ -223,10 +251,17 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "multiple glob patterns with normal path",
-			srcPaths: []string{
-				"glob*",
-				"file",
-				"*stuff",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"glob*",
+						"file",
+						"*stuff",
+					},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 			},
 			globbedSrcPaths: []string{
 				"globS",
@@ -237,7 +272,6 @@ func TestUpload(t *testing.T) {
 				"mystuff",
 				"yourstuff",
 			},
-			dstPath: "dst/",
 			files: []string{
 				"globS",
 				"globA",
@@ -250,10 +284,51 @@ func TestUpload(t *testing.T) {
 			},
 		},
 		{
+			name: "recursive glob pattern",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"glob*"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
+				Recursive:     true,
+				PreserveAttrs: true,
+			},
+			globbedSrcPaths: []string{
+				"globS",
+				"globA",
+				"globT",
+				"globB",
+				"globfile",
+			},
+			files: []string{
+				"globS/",
+				"globS/file",
+				"globA/",
+				"globA/file",
+				"globT/",
+				"globT/file",
+				"globB/",
+				"globB/file",
+				"globfile",
+				"dst/",
+			},
+		},
+		{
 			name: "recursive glob pattern with normal path",
-			srcPaths: []string{
-				"glob*",
-				"file",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"glob*",
+						"file",
+					},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
+				PreserveAttrs: true,
+				Recursive:     true,
 			},
 			globbedSrcPaths: []string{
 				"globS",
@@ -262,11 +337,6 @@ func TestUpload(t *testing.T) {
 				"globB",
 				"globfile",
 				"file",
-			},
-			dstPath: "dst/",
-			opts: Options{
-				Recursive:     true,
-				PreserveAttrs: true,
 			},
 			files: []string{
 				"globS/",
@@ -284,12 +354,18 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "multiple src dst not dir",
-			srcPaths: []string{
-				"uno",
-				"dos",
-				"tres",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{
+						"uno",
+						"dos",
+						"tres",
+					},
+				},
+				Destination: Target{
+					Path: "dst_file",
+				},
 			},
-			dstPath: "dst_file",
 			files: []string{
 				"uno",
 				"dos",
@@ -302,10 +378,14 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "multiple matches from src dst not dir",
-			srcPaths: []string{
-				"glob*",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"glob*"},
+				},
+				Destination: Target{
+					Path: "dst_file",
+				},
 			},
-			dstPath: "dst_file",
 			files: []string{
 				"glob1",
 				"glob2",
@@ -318,10 +398,14 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "src dir with recursive not passed",
-			srcPaths: []string{
-				"src/",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"src/"},
+				},
+				Destination: Target{
+					Path: "dst/",
+				},
 			},
-			dstPath: "dst/",
 			files: []string{
 				"src/",
 			},
@@ -332,8 +416,13 @@ func TestUpload(t *testing.T) {
 		},
 		{
 			name: "non-existent src file",
-			srcPaths: []string{
-				"idontexist",
+			req: &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{"idontexist"},
+				},
+				Destination: Target{
+					Path: "whocares",
+				},
 			},
 			errCheck: func(t require.TestingT, err error, i ...any) {
 				require.ErrorIs(t, err, os.ErrNotExist)
@@ -353,208 +442,23 @@ func TestUpload(t *testing.T) {
 					createFile(t, filepath.Join(tempDir, file))
 				}
 			}
-			for i := range tt.srcPaths {
-				tt.srcPaths[i] = filepath.Join(tempDir, tt.srcPaths[i])
+			for i, src := range tt.req.Sources.Paths {
+				tt.req.Sources.Paths[i] = filepath.Join(tempDir, src)
 			}
 			for i := range tt.globbedSrcPaths {
 				tt.globbedSrcPaths[i] = filepath.Join(tempDir, tt.globbedSrcPaths[i])
 			}
-			tt.dstPath = filepath.Join(tempDir, tt.dstPath)
-
-			cfg, err := CreateUploadConfig(tt.srcPaths, tt.dstPath, tt.opts)
-			require.NoError(t, err)
-			// use all local filesystems to avoid SSH overhead
-			cfg.dstFS = &localFS{}
-			err = cfg.initFS(nil)
-			require.NoError(t, err)
+			tt.req.Destination.Path = filepath.Join(tempDir, tt.req.Destination.Path)
 
 			ctx := context.Background()
-			err = cfg.transfer(ctx)
+			err := TransferFiles(ctx, tt.req)
 			if tt.errCheck == nil {
 				require.NoError(t, err)
-				srcPaths := tt.srcPaths
+				srcPaths := tt.req.Sources.Paths
 				if len(tt.globbedSrcPaths) != 0 {
 					srcPaths = tt.globbedSrcPaths
 				}
-				checkTransfer(t, tt.opts.PreserveAttrs, tt.dstPath, srcPaths...)
-			} else {
-				tt.errCheck(t, err, tempDir)
-			}
-		})
-	}
-}
-
-func TestDownload(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name            string
-		srcPath         string
-		globbedSrcPaths []string
-		dstPath         string
-		opts            Options
-		files           []string
-		errCheck        require.ErrorAssertionFunc
-	}{
-		{
-			name:    "one file",
-			srcPath: "file",
-			dstPath: "copied-file",
-			opts: Options{
-				PreserveAttrs: true,
-			},
-			files: []string{
-				"file",
-			},
-		},
-		{
-			name:    "one dir",
-			srcPath: "src/",
-			dstPath: "dst/",
-			opts: Options{
-				PreserveAttrs: true,
-				Recursive:     true,
-			},
-			files: []string{
-				"src/",
-				"dst/",
-			},
-		},
-		{
-			name:    "nested dirs",
-			srcPath: "s",
-			dstPath: "dst/",
-			opts: Options{
-				PreserveAttrs: true,
-				Recursive:     true,
-			},
-			files: []string{
-				"s/",
-				"s/file",
-				"s/r/",
-				"s/r/file",
-				"s/r/c/",
-				"s/r/c/file",
-				"dst/",
-			},
-		},
-		{
-			name:    "globbed files dst doesn't exist",
-			srcPath: "glob*",
-			globbedSrcPaths: []string{
-				"globS",
-				"globA",
-				"globT",
-				"globB",
-			},
-			dstPath: "dst/",
-			files: []string{
-				"globS",
-				"globA",
-				"globT",
-				"globB",
-			},
-		},
-		{
-			name:    "globbed files dst does exist",
-			srcPath: "glob*",
-			globbedSrcPaths: []string{
-				"globS",
-				"globA",
-				"globT",
-				"globB",
-			},
-			dstPath: "dst/",
-			files: []string{
-				"globS",
-				"globA",
-				"globT",
-				"globB",
-				"dst/",
-			},
-		},
-		{
-			name:    "recursive glob pattern",
-			srcPath: "glob*",
-			globbedSrcPaths: []string{
-				"globS",
-				"globA",
-				"globT",
-				"globB",
-				"globfile",
-			},
-			dstPath: "dst/",
-			opts: Options{
-				Recursive:     true,
-				PreserveAttrs: true,
-			},
-			files: []string{
-				"globS/",
-				"globS/file",
-				"globA/",
-				"globA/file",
-				"globT/",
-				"globT/file",
-				"globB/",
-				"globB/file",
-				"globfile",
-				"dst/",
-			},
-		},
-		{
-			name:    "src dir with recursive not passed",
-			srcPath: "src/",
-			dstPath: "dst/",
-			files: []string{
-				"src/",
-			},
-			errCheck: func(t require.TestingT, err error, i ...any) {
-				require.EqualError(t, err, fmt.Sprintf(`"%s/src" is a directory, but the recursive option was not passed`, i[0]))
-			},
-		},
-		{
-			name:    "non-existent src file",
-			srcPath: "idontexist",
-			errCheck: func(t require.TestingT, err error, i ...any) {
-				require.ErrorIs(t, err, os.ErrNotExist)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// create necessary files
-			tempDir := t.TempDir()
-			for _, file := range tt.files {
-				// if path ends in slash, create dir
-				if strings.HasSuffix(file, string(filepath.Separator)) {
-					createDir(t, filepath.Join(tempDir, file))
-				} else {
-					createFile(t, filepath.Join(tempDir, file))
-				}
-			}
-			tt.srcPath = filepath.Join(tempDir, tt.srcPath)
-			for i := range tt.globbedSrcPaths {
-				tt.globbedSrcPaths[i] = filepath.Join(tempDir, tt.globbedSrcPaths[i])
-			}
-			tt.dstPath = filepath.Join(tempDir, tt.dstPath)
-
-			cfg, err := CreateDownloadConfig(tt.srcPath, tt.dstPath, tt.opts)
-			require.NoError(t, err)
-			// use all local filesystems to avoid SSH overhead
-			cfg.srcFS = &localFS{}
-			err = cfg.initFS(nil)
-			require.NoError(t, err)
-
-			ctx := context.Background()
-			err = cfg.transfer(ctx)
-			if tt.errCheck == nil {
-				require.NoError(t, err)
-				srcPaths := []string{tt.srcPath}
-				if len(tt.globbedSrcPaths) != 0 {
-					srcPaths = tt.globbedSrcPaths
-				}
-				checkTransfer(t, tt.opts.PreserveAttrs, tt.dstPath, srcPaths...)
+				checkTransfer(t, tt.req.PreserveAttrs, tt.req.Destination.Path, srcPaths...)
 			} else {
 				tt.errCheck(t, err, tempDir)
 			}
@@ -619,15 +523,16 @@ func TestCopyingSymlinkedFile(t *testing.T) {
 	require.NoError(t, err)
 
 	dstPath := filepath.Join(tempDir, "dst")
-	cfg, err := CreateDownloadConfig(linkPath, dstPath, Options{})
-	require.NoError(t, err)
-	// use all local filesystems to avoid SSH overhead
-	cfg.srcFS = &localFS{}
-	err = cfg.initFS(nil)
-	require.NoError(t, err)
+	req := &FileTransferRequest{
+		Sources: Sources{
+			Paths: []string{linkPath},
+		},
+		Destination: Target{
+			Path: dstPath,
+		},
+	}
 
-	ctx := context.Background()
-	err = cfg.transfer(ctx)
+	err = TransferFiles(t.Context(), req)
 	require.NoError(t, err)
 
 	checkTransfer(t, false, dstPath, linkPath)
@@ -639,7 +544,7 @@ type mockFS struct {
 }
 
 func (m *mockFS) Open(path string) (File, error) {
-	realPath, err := filepath.EvalSymlinks(path)
+	realPath, err := m.localFS.RealPath(path)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -681,22 +586,27 @@ func TestRecursiveSymlinks(t *testing.T) {
 			dstDir := filepath.Join(root, "dst")
 			t.Cleanup(func() { os.RemoveAll(dstDir) })
 
-			cfg, err := CreateDownloadConfig(tc.srcDir, dstDir, Options{Recursive: true})
-			require.NoError(t, err)
-			// use all local filesystems to avoid SSH overhead
 			srcFS := &mockFS{fileAccesses: make(map[string]int)}
-			cfg.srcFS = srcFS
-			require.NoError(t, cfg.initFS(nil))
-			require.NoError(t, cfg.transfer(t.Context()))
+			req := &FileTransferRequest{
+				Sources: Sources{
+					Paths: []string{tc.srcDir},
+				},
+				Destination: Target{
+					Path: dstDir,
+				},
+				Recursive: true,
+				srcFS:     srcFS,
+			}
+			require.NoError(t, TransferFiles(t.Context(), req))
 
 			// Check results. Don't use checkTransfer() as the directories will not have
 			// matching sizes (the symlinks that aren't copied over).
 			for _, file := range []string{fileA, fileB, fileC} {
-				srcFile, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(tc.srcDir), file))
+				srcFile, err := srcFS.RealPath(filepath.Join(filepath.Dir(tc.srcDir), file))
 				require.NoError(t, err)
 				srcInfo, err := os.Stat(srcFile)
 				require.NoError(t, err)
-				dstFile, err := filepath.EvalSymlinks(filepath.Join(dstDir, file))
+				dstFile, err := srcFS.RealPath(filepath.Join(dstDir, file))
 				require.NoError(t, err)
 				dstInfo, err := os.Stat(dstFile)
 				require.NoError(t, err)
@@ -730,17 +640,21 @@ func TestHTTPUpload(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Length", strconv.FormatInt(fi.Size(), 10))
 
-	cfg, err := CreateHTTPUploadConfig(
+	transferReq, err := CreateHTTPUploadRequest(
 		HTTPTransferRequest{
-			Src:         "source",
-			Dst:         dst,
+			Src: Target{
+				Path: "source",
+			},
+			Dst: Target{
+				Path: dst,
+			},
 			HTTPRequest: req,
 		},
 	)
 	require.NoError(t, err)
-	cfg.dstFS = &localFS{}
+	transferReq.dstFS = &localFS{}
 
-	err = cfg.transfer(req.Context())
+	err = TransferFiles(t.Context(), transferReq)
 	require.NoError(t, err)
 
 	srcContents, err := os.ReadFile(src)
@@ -767,17 +681,20 @@ func TestHTTPDownload(t *testing.T) {
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	cfg, err := CreateHTTPDownloadConfig(
+	transferReq, err := CreateHTTPDownloadRequest(
 		HTTPTransferRequest{
-			Src:          src,
-			Dst:          "/home/robots.txt",
+			Src: Target{
+				Path: src,
+			},
+			Dst: Target{
+				Path: "/home/robots.txt",
+			},
 			HTTPResponse: w,
 		},
 	)
 	require.NoError(t, err)
-	cfg.srcFS = &localFS{}
 
-	err = cfg.transfer(context.Background())
+	err = TransferFiles(t.Context(), transferReq)
 	require.NoError(t, err)
 
 	data, err := io.ReadAll(w.Body)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -19,6 +19,7 @@
 package web
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/agentless"
@@ -126,25 +128,6 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		return nil, trace.AccessDenied("MFA required for file transfer")
 	}
 
-	var cfg *sftp.Config
-	isUpload := r.Method == http.MethodPost
-	if isUpload {
-		cfg, err = sftp.CreateHTTPUploadConfig(sftp.HTTPTransferRequest{
-			Src:         req.filename,
-			Dst:         req.remoteLocation,
-			HTTPRequest: r,
-		})
-	} else {
-		cfg, err = sftp.CreateHTTPDownloadConfig(sftp.HTTPTransferRequest{
-			Src:          req.remoteLocation,
-			Dst:          req.filename,
-			HTTPResponse: w,
-		})
-	}
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	tc, err := ft.createClient(req, r, h.cfg.PROXYSigner)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -239,7 +222,42 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	defer nodeClient.Close()
 
-	if err := nodeClient.TransferFiles(ctx, cfg, moderatedSessionID); err != nil {
+	webTarget := sftp.Target{
+		Path: req.filename,
+	}
+	remoteTarget := sftp.Target{
+		Login: req.login,
+		Addr: &utils.NetAddr{
+			Addr: req.serverID + ":0",
+		},
+		Path: req.remoteLocation,
+	}
+	dialHost := func(_ context.Context, _, _ string) (*tracessh.Client, error) {
+		return nodeClient.Client, nil
+	}
+	var sftpReq *sftp.FileTransferRequest
+	if r.Method == http.MethodPost {
+		sftpReq, err = sftp.CreateHTTPUploadRequest(sftp.HTTPTransferRequest{
+			Src:                webTarget,
+			Dst:                remoteTarget,
+			HTTPRequest:        r,
+			DialHost:           dialHost,
+			ModeratedSessionID: moderatedSessionID,
+		})
+	} else {
+		sftpReq, err = sftp.CreateHTTPDownloadRequest(sftp.HTTPTransferRequest{
+			Src:                remoteTarget,
+			Dst:                webTarget,
+			HTTPResponse:       w,
+			DialHost:           dialHost,
+			ModeratedSessionID: moderatedSessionID,
+		})
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := sftp.TransferFiles(ctx, sftpReq); err != nil {
 		if errors.As(err, new(*sftp.NonRecursiveDirectoryTransferError)) {
 			return nil, trace.Errorf("transferring directories through the Web UI is not supported at the moment, please use tsh scp -r")
 		}


### PR DESCRIPTION
This change updates `tsh scp` to be able to copy between two remote hosts.

```code
$ tsh scp alice@foo:/path/to/foo.txt bob@bar:/path/to/bar.txt
```

Resolves #7915.

Changelog: Added tsh scp copying between two hosts