### PR TITLE
Remove OSS link in prerequisite partial

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,8 +1,7 @@
 {{ edition="Teleport" clients="`tctl` and `tsh` clients" }}
 
-- A running {{ edition }} cluster. If you want to get started with Teleport,
-  [sign up](https://goteleport.com/signup) for a free trial or [set up a demo
-  environment](../linux-demo.mdx).
+- A running {{ edition }} cluster. If you do not have one, read [Getting
+  Started](../get-started.mdx).
 
 - The {{ clients }}.
 


### PR DESCRIPTION
Closes #58342

The `edition-prereqs-tabs.mdx` partial, which we use to standardize the Prerequisites section for most how-to guides in the docs, includes a link for how to get started with the Linux demo guide. However, for guides that pertain only to Teleport Enterprise, the Linux demo guide is inappropriate.

This change removes the Linux demo guide link from `edition-prereqs-tabs.mdx` and links to the main Getting Started guide instead. That guide takes care of describing the context for the Linux demo guide and other beginner-level documentation. By referring the reader to the general Getting Started guide, we can make sure the reader finds the right information for setting up a Teleport cluster.