### PR TITLE
[v18] chore: Bump Go to 1.24.7 ⬆️

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.23.12
+go 1.24.7
 
 require (
 	github.com/charlievieth/strcase v0.0.5

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.24.7
+go 1.23.12
 
 require (
 	github.com/charlievieth/strcase v0.0.5

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -87,7 +87,7 @@ func TestValidateInferenceModel(t *testing.T) {
 		t.Run(tc.msg, func(t *testing.T) {
 			m := proto.CloneOf(valid)
 			tc.fn(m)
-			assert.ErrorIs(t, ValidateInferenceModel(m), trace.BadParameter(tc.msg))
+			assert.ErrorIs(t, ValidateInferenceModel(m), &trace.BadParameterError{Message: tc.msg})
 		})
 	}
 }
@@ -141,7 +141,7 @@ func TestValidateInferenceSecret(t *testing.T) {
 		t.Run(tc.msg, func(t *testing.T) {
 			s := proto.CloneOf(valid)
 			tc.fn(s)
-			assert.ErrorIs(t, ValidateInferenceSecret(s), trace.BadParameter(tc.msg))
+			assert.ErrorIs(t, ValidateInferenceSecret(s), &trace.BadParameterError{Message: tc.msg})
 		})
 	}
 }

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -1,8 +1,6 @@
 module github.com/teleport/assets/backport
 
-go 1.23.7
-
-toolchain go1.24.1
+go 1.24.7
 
 require (
 	github.com/google/go-github/v41 v41.0.0

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.6
+FROM docker.io/golang:1.24.7
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.24.6
+go 1.24.7
 
 require (
 	buf.build/go/bufplugin v0.9.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.24.6
+GOLANG_VERSION ?= go1.24.7
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/examples/access-plugin-minimal/go.mod
+++ b/examples/access-plugin-minimal/go.mod
@@ -1,6 +1,6 @@
 module teleport-sheets
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/desktop-registration/go.mod
+++ b/examples/desktop-registration/go.mod
@@ -1,6 +1,6 @@
 module teleport-desktop-registration
 
-go 1.24.6
+go 1.24.7
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,6 @@
 module go-client
 
-go 1.24.6
+go 1.24.7
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/service-discovery-api-client/go.mod
+++ b/examples/service-discovery-api-client/go.mod
@@ -1,6 +1,6 @@
 module register-app-service
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.24.6
+go 1.24.7
 
 require (
 	cloud.google.com/go/alloydb v1.16.1

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/alecthomas/kong v1.10.0

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform-mwi
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.24.6
+go 1.24.7
 
 // TF provider dependencies
 require (


### PR DESCRIPTION
Backport #58806 to branch/v18

changelog: Updated Go to 1.24.7.
