### PR TITLE
[v18] scopes backports

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -93,6 +93,7 @@ import (
 	recordingmetadatav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1"
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	secreportsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
@@ -837,6 +838,12 @@ func (c *Client) UpsertDeviceResource(ctx context.Context, res *types.DeviceV1) 
 		return nil, trace.Wrap(err)
 	}
 	return types.DeviceToResource(upserted), nil
+}
+
+// ScopedAccessServiceClient returns an unadorned Scoped Access Service client, using the underlying
+// Auth gRPC connection.
+func (c *Client) ScopedAccessServiceClient() scopedaccessv1.ScopedAccessServiceClient {
+	return scopedaccessv1.NewScopedAccessServiceClient(c.conn)
 }
 
 // LoginRuleClient returns an unadorned Login Rule client, using the underlying

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -30,7 +30,7 @@ import (
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -129,11 +129,11 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 		out.Resource = &proto.Event_AutoUpdateAgentReport{
 			AutoUpdateAgentReport: r.UnwrapT(),
 		}
-	case types.Resource153UnwrapperT[*accessv1.ScopedRole]:
+	case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]:
 		out.Resource = &proto.Event_ScopedRole{
 			ScopedRole: r.UnwrapT(),
 		}
-	case types.Resource153UnwrapperT[*accessv1.ScopedRoleAssignment]:
+	case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]:
 		out.Resource = &proto.Event_ScopedRoleAssignment{
 			ScopedRoleAssignment: r.UnwrapT(),
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -124,6 +124,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/release"
 	"github.com/gravitational/teleport/lib/resourceusage"
+	scopedaccesscache "github.com/gravitational/teleport/lib/scopes/cache/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -533,6 +534,9 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			return nil, trace.Wrap(err, "creating VnetConfigService")
 		}
 	}
+	if cfg.ScopedAccess == nil {
+		cfg.ScopedAccess = local.NewScopedAccessService(cfg.Backend)
+	}
 
 	if cfg.Logger == nil {
 		cfg.Logger = slog.With(teleport.ComponentKey, teleport.ComponentAuth)
@@ -559,6 +563,14 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	scopedAccessCache, err := scopedaccesscache.NewCache(scopedaccesscache.CacheConfig{
+		Events: cfg.Events,
+		Reader: cfg.ScopedAccess,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	services := &Services{
@@ -635,6 +647,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Unstable:                  local.NewUnstableService(cfg.Backend, cfg.AssertionReplayService),
 		Services:                  services,
 		Cache:                     services,
+		scopedAccessBackend:       cfg.ScopedAccess,
+		scopedAccessCache:         scopedAccessCache,
 		keyStore:                  cfg.KeyStore,
 		traceClient:               cfg.TraceClient,
 		fips:                      cfg.FIPS,
@@ -1099,6 +1113,13 @@ type Server struct {
 	// and Services will call the one from Cache. To bypass the cache, call the
 	// method on Services instead.
 	authclient.Cache
+
+	// scopedAccessCache is a specialized cache that provides read methods for select
+	// scoped access control resources.
+	scopedAccessCache *scopedaccesscache.Cache
+
+	// scopedAccessBackend is the backend service for scoped access control resources.
+	scopedAccessBackend services.ScopedAccess
 
 	// ReadOnlyCache is a specialized cache that provides read-only shared references
 	// in certain performance-critical paths where deserialization/cloning may be too

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -53,7 +53,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/metadata"
@@ -82,7 +82,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/okta/oktatest"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/session"
@@ -9937,10 +9937,10 @@ func TestScopedRoleEvents(t *testing.T) {
 	watcher, err := client.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{
 			{
-				Kind: scopedrole.KindScopedRole,
+				Kind: scopedaccess.KindScopedRole,
 			},
 			{
-				Kind: scopedrole.KindScopedRoleAssignment,
+				Kind: scopedaccess.KindScopedRoleAssignment,
 			},
 		},
 	})
@@ -9969,19 +9969,19 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpInit, event.Type)
 
 	// Create a ScopedRole and verify create event is well-formed.
-	role := &accessv1.ScopedRole{
-		Kind: scopedrole.KindScopedRole,
+	role := &scopedaccessv1.ScopedRole{
+		Kind: scopedaccess.KindScopedRole,
 		Metadata: &headerv1.Metadata{
 			Name: "test-role",
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleSpec{
+		Spec: &scopedaccessv1.ScopedRoleSpec{
 			AssignableScopes: []string{"/foo", "/bar"},
 		},
 		Version: types.V1,
 	}
 
-	crsp, err := service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+	crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: role,
 	})
 	require.NoError(t, err)
@@ -9989,11 +9989,11 @@ func TestScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpPut, event.Type)
 
-	resource := (event.Resource).(types.Resource153UnwrapperT[*accessv1.ScopedRole]).UnwrapT()
+	resource := (event.Resource).(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT()
 	require.Empty(t, cmp.Diff(crsp.Role, resource, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// delete the role and verify delete event is well-formed.
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name: role.Metadata.Name,
 	})
 	require.NoError(t, err)
@@ -10002,29 +10002,29 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpDelete, event.Type)
 
 	require.Empty(t, cmp.Diff(&types.ResourceHeader{
-		Kind: scopedrole.KindScopedRole,
+		Kind: scopedaccess.KindScopedRole,
 		Metadata: types.Metadata{
 			Name: role.Metadata.Name,
 		},
 	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
 
 	// recreate scoped role so that we can use it for testing assignment events
-	crsp, err = service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+	crsp, err = service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: role,
 	})
 	require.NoError(t, err)
 
 	_ = getNextEvent() // drain the role create event
 
-	assignment := &accessv1.ScopedRoleAssignment{
-		Kind: scopedrole.KindScopedRoleAssignment,
+	assignment := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: &headerv1.Metadata{
 			Name: uuid.New().String(),
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleAssignmentSpec{
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: "alice",
-			Assignments: []*accessv1.Assignment{
+			Assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  role.Metadata.Name,
 					Scope: "/foo",
@@ -10034,7 +10034,7 @@ func TestScopedRoleEvents(t *testing.T) {
 		Version: types.V1,
 	}
 
-	acrsp, err := service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	acrsp, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment,
 		RoleRevisions: map[string]string{
 			role.Metadata.Name: crsp.Role.Metadata.Revision,
@@ -10044,11 +10044,11 @@ func TestScopedRoleEvents(t *testing.T) {
 
 	event = getNextEvent()
 	require.Equal(t, types.OpPut, event.Type)
-	assignmentResource := (event.Resource).(types.Resource153UnwrapperT[*accessv1.ScopedRoleAssignment]).UnwrapT()
+	assignmentResource := (event.Resource).(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]).UnwrapT()
 	require.Empty(t, cmp.Diff(acrsp.Assignment, assignmentResource, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// delete the assignment and verify delete event is well-formed.
-	_, err = service.DeleteScopedRoleAssignment(ctx, &accessv1.DeleteScopedRoleAssignmentRequest{
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name: assignment.Metadata.Name,
 	})
 	require.NoError(t, err)
@@ -10057,7 +10057,7 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpDelete, event.Type)
 
 	require.Empty(t, cmp.Diff(&types.ResourceHeader{
-		Kind: scopedrole.KindScopedRoleAssignment,
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: types.Metadata{
 			Name: assignment.Metadata.Name,
 		},

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -69,6 +69,8 @@ import (
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	recordingencryptionv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
 	recordingmetadatav1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingmetadata/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	secreportsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
@@ -108,6 +110,8 @@ import (
 	"github.com/gravitational/teleport/lib/auth/presence/presencev1"
 	"github.com/gravitational/teleport/lib/auth/recordingencryption/recordingencryptionv1"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata/recordingmetadatav1"
+	scopedaccess "github.com/gravitational/teleport/lib/auth/scopes/access"
+	scopedjoining "github.com/gravitational/teleport/lib/auth/scopes/joining"
 	"github.com/gravitational/teleport/lib/auth/secreports/secreportsv1"
 	"github.com/gravitational/teleport/lib/auth/stableunixusers"
 	"github.com/gravitational/teleport/lib/auth/summarizer/summarizerv1"
@@ -5652,6 +5656,22 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		server,
 		stableUNIXUsersServiceServer,
 	)
+
+	scopedAccessControl, err := scopedaccess.New(scopedaccess.Config{
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating scoped access control service")
+	}
+	scopedaccessv1.RegisterScopedAccessServiceServer(server, scopedAccessControl)
+
+	scopedJoining, err := scopedjoining.New(scopedjoining.Config{
+		Authorizer: cfg.Authorizer,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "creating scoped provisioning service")
+	}
+	scopedjoiningv1.RegisterScopedJoiningServiceServer(server, scopedJoining)
 
 	authServer := &GRPCServer{
 		APIConfig: cfg.APIConfig,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5659,6 +5659,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 
 	scopedAccessControl, err := scopedaccess.New(scopedaccess.Config{
 		Authorizer: cfg.Authorizer,
+		Reader:     cfg.AuthServer.scopedAccessCache,
+		Writer:     cfg.AuthServer.scopedAccessBackend,
+		Logger:     logger,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating scoped access control service")

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -402,6 +402,17 @@ type InitConfig struct {
 	// It allows for late initialization of the summarizer in the enterprise
 	// plugin. The summarizer itself summarizes session recordings.
 	SessionSummarizerProvider *summarizer.SessionSummarizerProvider
+
+	// RunWhileLockedRetryInterval defines the interval at which the auth server retries
+	// a locking operation for backend objects.
+	// This setting is particularly useful in test environments,
+	// as it can help accelerate operations such as updating the access list,
+	// especially when the list is also being modified concurrently by the background
+	// eligibility handler.
+	RunWhileLockedRetryInterval time.Duration
+
+	// ScopedAccess is a service that manages scoped access resources.
+	ScopedAccess services.ScopedAccess
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -1,0 +1,194 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesscontrol
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+// Config contains the parameters for [New].
+type Config struct {
+	Authorizer authz.Authorizer
+	Logger     *slog.Logger
+}
+
+// Server is the [scopedaccessv1.UnimplementedScopedAccessServiceServer] returned by [New].
+type Server struct {
+	scopedaccessv1.UnimplementedScopedAccessServiceServer
+
+	authorizer authz.Authorizer
+	logger     *slog.Logger
+}
+
+// New returns the auth server implementation for the scoped access control
+// service, including the gRPC interface, authz enforcement, and business logic.
+func New(c Config) (*Server, error) {
+	if c.Authorizer == nil {
+		return nil, trace.BadParameter("missing Authorizer")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+	}
+
+	return &Server{
+		authorizer: c.Authorizer,
+		logger:     c.Logger,
+	}, nil
+}
+
+// CreateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRole(ctx, req)
+}
+
+// CreateScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRoleAssignment(ctx, req)
+}
+
+// DeleteScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRole(ctx, req)
+}
+
+// DeleteScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped role assignment", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped role assignment", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRoleAssignment(ctx, req)
+}
+
+// GetScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRole(ctx, req)
+}
+
+// GetScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRoleAssignment(ctx, req)
+}
+
+// ListScopedRoleAssignments implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped role assignments", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped role assignments", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoleAssignments(ctx, req)
+}
+
+// ListScopedRoles implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoles(ctx, req)
+}
+
+// UpdateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
+func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission update scoped roles", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission update scoped roles", authzContext.User.GetName())
+	}
+
+	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).UpdateScopedRole(ctx, req)
+}

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -20,175 +20,250 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Config contains the parameters for [New].
 type Config struct {
 	Authorizer authz.Authorizer
+	Reader     services.ScopedAccessReader
+	Writer     services.ScopedAccessWriter
 	Logger     *slog.Logger
+}
+
+// CheckAndSetDefaults checks the config for missing parameters and sets default values.
+func (c *Config) CheckAndSetDefaults() error {
+	if c.Authorizer == nil {
+		return trace.BadParameter("missing Authorizer in scoped access grpc service config")
+	}
+
+	if c.Reader == nil {
+		return trace.BadParameter("missing Reader in scoped access grpc service config")
+	}
+
+	if c.Writer == nil {
+		return trace.BadParameter("missing Writer in scoped access grpc service config")
+	}
+
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+	}
+
+	return nil
 }
 
 // Server is the [scopedaccessv1.UnimplementedScopedAccessServiceServer] returned by [New].
 type Server struct {
 	scopedaccessv1.UnimplementedScopedAccessServiceServer
-
-	authorizer authz.Authorizer
-	logger     *slog.Logger
+	cfg Config
 }
 
 // New returns the auth server implementation for the scoped access control
 // service, including the gRPC interface, authz enforcement, and business logic.
-func New(c Config) (*Server, error) {
-	if c.Authorizer == nil {
-		return nil, trace.BadParameter("missing Authorizer")
-	}
-	if c.Logger == nil {
-		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+func New(cfg Config) (*Server, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &Server{
-		authorizer: c.Authorizer,
-		logger:     c.Logger,
+		cfg: cfg,
 	}, nil
 }
 
 // CreateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	if err := scopes.AssertFeatureEnabled(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to create scoped roles", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to create scoped roles", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRole(ctx, req)
+	return s.cfg.Writer.CreateScopedRole(ctx, req)
 }
 
 // CreateScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	if err := scopes.AssertFeatureEnabled(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to create scoped role assignments", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to create scoped role assignments", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).CreateScopedRoleAssignment(ctx, req)
+	if req.GetAssignment() == nil {
+		return nil, trace.BadParameter("missing assignment in request")
+	}
+
+	if assignment := req.GetAssignment(); assignment.GetMetadata() == nil {
+		assignment.Metadata = &headerv1.Metadata{}
+	}
+
+	if req.GetAssignment().GetMetadata().GetName() == "" {
+		req.GetAssignment().GetMetadata().Name = uuid.New().String()
+	}
+
+	if err := scopedaccess.StrongValidateAssignment(req.GetAssignment()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.GetRoleRevisions() == nil {
+		req.RoleRevisions = make(map[string]string)
+	}
+
+	for _, subAssignment := range req.GetAssignment().GetSpec().GetAssignments() {
+		rsp, err := s.cfg.Reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+			Name: subAssignment.GetRole(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if revision, ok := req.GetRoleRevisions()[subAssignment.GetRole()]; ok {
+			if revision != rsp.GetRole().GetMetadata().GetRevision() {
+				return nil, trace.CompareFailed("role %q revision %q does not match expected revision %q",
+					subAssignment.GetRole(), rsp.GetRole().GetMetadata().GetRevision(), revision)
+			}
+		} else {
+			// If the revision is not specified, use the current revision of the role.
+			req.RoleRevisions[subAssignment.GetRole()] = rsp.GetRole().GetMetadata().GetRevision()
+		}
+
+		// TODO(fspmarshall): implement validation of role assignment access-controls at this step.
+	}
+
+	return s.cfg.Writer.CreateScopedRoleAssignment(ctx, req)
 }
 
 // DeleteScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped roles", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete a scoped roles", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped roles", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRole(ctx, req)
+	return s.cfg.Writer.DeleteScopedRole(ctx, req)
 }
 
 // DeleteScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to delete a scoped role assignment", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete a scoped role assignment", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped role assignment", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).DeleteScopedRoleAssignment(ctx, req)
+	return s.cfg.Writer.DeleteScopedRoleAssignment(ctx, req)
 }
 
 // GetScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to get scoped roles", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to get scoped roles", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to get scoped roles", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRole(ctx, req)
+	return s.cfg.Reader.GetScopedRole(ctx, req)
 }
 
 // GetScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to get scoped role assignments", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to get scoped role assignments", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to get scoped role assignments", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).GetScopedRoleAssignment(ctx, req)
+	return s.cfg.Reader.GetScopedRoleAssignment(ctx, req)
 }
 
 // ListScopedRoleAssignments implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to list scoped role assignments", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to list scoped role assignments", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to list scoped role assignments", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoleAssignments(ctx, req)
+	return s.cfg.Reader.ListScopedRoleAssignments(ctx, req)
 }
 
 // ListScopedRoles implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to list scoped roles", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to list scoped roles", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission to list scoped roles", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).ListScopedRoles(ctx, req)
+	return s.cfg.Reader.ListScopedRoles(ctx, req)
 }
 
 // UpdateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	if err := scopes.AssertFeatureEnabled(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission update scoped roles", "user", authzContext.User.GetName())
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission update scoped roles", "user", authzContext.User.GetName())
 		return nil, trace.AccessDenied("user %q does not have permission update scoped roles", authzContext.User.GetName())
 	}
 
-	return (scopedaccessv1.UnimplementedScopedAccessServiceServer{}).UpdateScopedRole(ctx, req)
+	return s.cfg.Writer.UpdateScopedRole(ctx, req)
 }

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -1,0 +1,134 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provisioning
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+)
+
+// Config contains the parameters for [New].
+type Config struct {
+	Authorizer authz.Authorizer
+	Logger     *slog.Logger
+}
+
+// Server is the [scopedjoiningv1.ScopedJoiningServiceServer] returned by [New].
+type Server struct {
+	scopedjoiningv1.UnsafeScopedJoiningServiceServer
+
+	authorizer authz.Authorizer
+	logger     *slog.Logger
+}
+
+// New returns the auth server implementation for the scoped provisioning
+// service, including the gRPC interface, authz enforcement, and business logic.
+func New(c Config) (*Server, error) {
+	if c.Authorizer == nil {
+		return nil, trace.BadParameter("missing Authorizer")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, "scopes")
+	}
+
+	return &Server{
+		authorizer: c.Authorizer,
+		logger:     c.Logger,
+	}, nil
+}
+
+// CreateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.CreateScopedTokenRequest) (*scopedjoiningv1.CreateScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to create scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).CreateScopedToken(ctx, req)
+}
+
+// DeleteScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.DeleteScopedTokenRequest) (*scopedjoiningv1.DeleteScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to delete scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to delete scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).DeleteScopedToken(ctx, req)
+}
+
+// GetScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) GetScopedToken(ctx context.Context, req *scopedjoiningv1.GetScopedTokenRequest) (*scopedjoiningv1.GetScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to get scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to get scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).GetScopedToken(ctx, req)
+}
+
+// ListScopedTokens implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.ListScopedTokensRequest) (*scopedjoiningv1.ListScopedTokensResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to list scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to list scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).ListScopedTokens(ctx, req)
+}
+
+// UpdateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
+func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.UpdateScopedTokenRequest) (*scopedjoiningv1.UpdateScopedTokenResponse, error) {
+	authzContext, err := s.authorizer.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
+		s.logger.WarnContext(ctx, "user does not have permission to update scoped tokens", "user", authzContext.User.GetName())
+		return nil, trace.AccessDenied("user %q does not have permission to update scoped tokens", authzContext.User.GetName())
+	}
+
+	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).UpdateScopedToken(ctx, req)
+}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -48,7 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/observability/tracing"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
@@ -147,8 +147,8 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindToken},
 		{Kind: types.KindUser},
 		{Kind: types.KindRole},
-		{Kind: scopedrole.KindScopedRole},
-		{Kind: scopedrole.KindScopedRoleAssignment},
+		{Kind: scopedaccess.KindScopedRole},
+		{Kind: scopedaccess.KindScopedRoleAssignment},
 		{Kind: types.KindNode},
 		{Kind: types.KindProxy},
 		{Kind: types.KindAuthServer},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -56,7 +56,7 @@ import (
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -84,7 +84,7 @@ import (
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
@@ -1928,8 +1928,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindRecordingEncryption:               types.Resource153ToLegacy(newRecordingEncryption()),
 		types.KindHealthCheckConfig:                 types.Resource153ToLegacy(newHealthCheckConfig(t, "some-name")),
 		types.KindBotInstance:                       types.ProtoResource153ToLegacy(new(machineidv1.BotInstance)),
-		scopedrole.KindScopedRole:                   types.Resource153ToLegacy(&accessv1.ScopedRole{}),
-		scopedrole.KindScopedRoleAssignment:         types.Resource153ToLegacy(&accessv1.ScopedRoleAssignment{}),
+		scopedaccess.KindScopedRole:                 types.Resource153ToLegacy(&scopedaccessv1.ScopedRole{}),
+		scopedaccess.KindScopedRoleAssignment:       types.Resource153ToLegacy(&scopedaccessv1.ScopedRoleAssignment{}),
 	}
 
 	for name, cfg := range cases {
@@ -1993,10 +1993,10 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*machineidv1.BotInstance]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*machineidv1.BotInstance]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
-				case types.Resource153UnwrapperT[*accessv1.ScopedRole]:
-					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*accessv1.ScopedRole]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
-				case types.Resource153UnwrapperT[*accessv1.ScopedRoleAssignment]:
-					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*accessv1.ScopedRoleAssignment]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				default:
 					require.Empty(t, cmp.Diff(resource, event.Resource))
 				}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/api/types/userloginstate"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // collectionHandler is used by the [Cache] to seed the initial
@@ -148,7 +148,7 @@ type collections struct {
 // resources events can be processed by downstream watchers.
 func isKnownUncollectedKind(kind string) bool {
 	switch kind {
-	case types.KindAccessRequest, types.KindHeadlessAuthentication, scopedrole.KindScopedRole, scopedrole.KindScopedRoleAssignment:
+	case types.KindAccessRequest, types.KindHeadlessAuthentication, scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment:
 		return true
 	default:
 		return false

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package roles
+package access
 
 import (
 	"iter"
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
 )
@@ -47,7 +47,7 @@ const (
 )
 
 // RoleIsAssignableAtScope checks if the given role is assignable at the given scope.
-func RoleIsAssignableAtScope(role *accessv1.ScopedRole, scope string) bool {
+func RoleIsAssignableAtScope(role *scopedaccessv1.ScopedRole, scope string) bool {
 	for assignableScope := range WeakValidatedAssignableScopes(role) {
 		if scopes.Glob(assignableScope).Matches(scope) {
 			return true
@@ -58,7 +58,7 @@ func RoleIsAssignableAtScope(role *accessv1.ScopedRole, scope string) bool {
 }
 
 // WeakValidatedAssignableScopes is a helper for iterating all well formed assignable scopes for a given role.
-func WeakValidatedAssignableScopes(role *accessv1.ScopedRole) iter.Seq[string] {
+func WeakValidatedAssignableScopes(role *scopedaccessv1.ScopedRole) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		for _, assignableScope := range role.GetSpec().GetAssignableScopes() {
 			if err := scopes.WeakValidateGlob(assignableScope); err != nil {
@@ -81,7 +81,7 @@ func WeakValidatedAssignableScopes(role *accessv1.ScopedRole) iter.Seq[string] {
 // WeakValidateRole valides a role to ensure it is free of obvious issues that would render it unusable and/or
 // induce serious unintended behavior. Prefer using this function for validating roles loaded from "internal" sources
 // (e.g. backend/control-plane), and [StrongValidateRole] for validating roles loaded from "external" sources (e.g. user input).
-func WeakValidateRole(role *accessv1.ScopedRole) error {
+func WeakValidateRole(role *scopedaccessv1.ScopedRole) error {
 	if err := commonValidateRole(role); err != nil {
 		return trace.Wrap(err)
 	}
@@ -101,7 +101,7 @@ func WeakValidateRole(role *accessv1.ScopedRole) error {
 // StrongValidateRole performs robust validation of a role to ensure it complies with all expected constraints. Prefer
 // using this function for validating roles loaded from "external" sources (e.g. user input), and [WeakValidateRole] for
 // validating roles loaded from "internal" sources (e.g. backend/control-plane).
-func StrongValidateRole(role *accessv1.ScopedRole) error {
+func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 	if err := commonValidateRole(role); err != nil {
 		return trace.Wrap(err)
 	}
@@ -143,7 +143,7 @@ func validateRoleName(name string) error {
 }
 
 // commonValidateRole performs the subset of role validation common to both weak and strong validation.
-func commonValidateRole(role *accessv1.ScopedRole) error {
+func commonValidateRole(role *scopedaccessv1.ScopedRole) error {
 	if role.GetMetadata().GetName() == "" {
 		return trace.BadParameter("scoped role is missing metadata.name")
 	}
@@ -181,8 +181,8 @@ func commonValidateRole(role *accessv1.ScopedRole) error {
 // by this iterator is sub-assignments that are so obviously misconfigured that we can't reason about them at all. Sub-assignments
 // returned by this iterator may still be broken because they assign a nonexistent role, or to a scope that the target role is not
 // assignable to.
-func WeakValidatedSubAssignments(assignment *accessv1.ScopedRoleAssignment) iter.Seq[*accessv1.Assignment] {
-	return func(yield func(*accessv1.Assignment) bool) {
+func WeakValidatedSubAssignments(assignment *scopedaccessv1.ScopedRoleAssignment) iter.Seq[*scopedaccessv1.Assignment] {
+	return func(yield func(*scopedaccessv1.Assignment) bool) {
 		for _, subAssignment := range assignment.GetSpec().GetAssignments() {
 			if subAssignment.GetRole() == "" {
 				// ignore sub-assignments with missing role
@@ -209,7 +209,7 @@ func WeakValidatedSubAssignments(assignment *accessv1.ScopedRoleAssignment) iter
 // WeakValidateAssignment validates an assignment to ensure it is free of obvious issues that would render it unusable and/or
 // induce serious unintended behavior. Prefer using this function for validating assignments loaded from "internal" sources
 // (e.g. backend/control-plane), and [StrongValidateAssignment] for validating assignments loaded from "external" sources (e.g. user input).
-func WeakValidateAssignment(assignment *accessv1.ScopedRoleAssignment) error {
+func WeakValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) error {
 	if err := commonValidateAssignment(assignment); err != nil {
 		return trace.Wrap(err)
 	}
@@ -228,7 +228,7 @@ func WeakValidateAssignment(assignment *accessv1.ScopedRoleAssignment) error {
 // StrongValidateAssignment performs robust validation of an assignment to ensure it complies with all expected constraints. Prefer
 // using this function for validating assignments loaded from "external" sources (e.g. user input), and [WeakValidateAssignment] for
 // validating assignments loaded from "internal" sources (e.g. backend/control-plane).
-func StrongValidateAssignment(assignment *accessv1.ScopedRoleAssignment) error {
+func StrongValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) error {
 	if err := commonValidateAssignment(assignment); err != nil {
 		return trace.Wrap(err)
 	}
@@ -270,7 +270,7 @@ func StrongValidateAssignment(assignment *accessv1.ScopedRoleAssignment) error {
 	return nil
 }
 
-func commonValidateAssignment(assignment *accessv1.ScopedRoleAssignment) error {
+func commonValidateAssignment(assignment *scopedaccessv1.ScopedRoleAssignment) error {
 	if assignment.GetMetadata().GetName() == "" {
 		return trace.BadParameter("scoped role assignment is missing metadata.name")
 	}

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package roles
+package access
 
 import (
 	"slices"
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -34,19 +34,19 @@ func TestValidateRole(t *testing.T) {
 
 	tts := []struct {
 		name     string
-		role     *accessv1.ScopedRole
+		role     *scopedaccessv1.ScopedRole
 		strongOk bool
 		weakOk   bool
 	}{
 		{
 			name: "basic",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -56,14 +56,14 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "unknown sub_kind",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind:    KindScopedRole,
 				SubKind: "unknown",
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -73,11 +73,11 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "missing name",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind:     KindScopedRole,
 				Metadata: &headerv1.Metadata{},
 				Scope:    "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -87,12 +87,12 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "missing kind",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -102,12 +102,12 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "missing scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -117,13 +117,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "missing version",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 			},
@@ -132,13 +132,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "malformed name",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "foo/bar",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -148,13 +148,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "malformed kind",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: "role",
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -164,13 +164,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "slightly malformed scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "foo/bar",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo/bar"},
 				},
 				Version: types.V1,
@@ -180,13 +180,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "siginifcantly malformed scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "foo@bar",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo/bar"},
 				},
 				Version: types.V1,
@@ -196,13 +196,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "missing assignable scopes",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope:   "/",
-				Spec:    &accessv1.ScopedRoleSpec{},
+				Spec:    &scopedaccessv1.ScopedRoleSpec{},
 				Version: types.V1,
 			},
 			strongOk: false,
@@ -210,13 +210,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "slightly malformed assignable scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"foo/bar"},
 				},
 				Version: types.V1,
@@ -226,13 +226,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "siginifcantly malformed assignable scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"foo@bar"},
 				},
 				Version: types.V1,
@@ -242,13 +242,13 @@ func TestValidateRole(t *testing.T) {
 		},
 		{
 			name: "impermissable assignable scope",
-			role: &accessv1.ScopedRole{
+			role: &scopedaccessv1.ScopedRole{
 				Kind: KindScopedRole,
 				Metadata: &headerv1.Metadata{
 					Name: "test",
 				},
 				Scope: "/foo/bar",
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: []string{"/foo"},
 				},
 				Version: types.V1,
@@ -282,21 +282,21 @@ func TestValidateAsssignment(t *testing.T) {
 
 	tts := []struct {
 		name       string
-		assignment *accessv1.ScopedRoleAssignment
+		assignment *scopedaccessv1.ScopedRoleAssignment
 		strongOk   bool
 		weakOk     bool
 	}{
 		{
 			name: "basic",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -310,16 +310,16 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "unknown sub_kind",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:    KindScopedRoleAssignment,
 				SubKind: "unknown",
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -333,13 +333,13 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "missing name",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind:     KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{},
 				Scope:    "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -353,14 +353,14 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "missing kind",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -374,14 +374,14 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "missing scope",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -395,15 +395,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "missing version",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -416,15 +416,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "malformed name",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: "not-a-uuid",
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -438,15 +438,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "malformed kind",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: "not_scoped_role_assignment",
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -460,15 +460,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "slightly malformed scope",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "foo",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -482,15 +482,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "significantly malformed scope",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "foo@bar",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -504,15 +504,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "impermissable assigned scope",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/foo/bar",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -526,15 +526,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "malformed assigned scope",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "foo",
@@ -548,15 +548,15 @@ func TestValidateAsssignment(t *testing.T) {
 		},
 		{
 			name: "basic",
-			assignment: &accessv1.ScopedRoleAssignment{
+			assignment: &scopedaccessv1.ScopedRoleAssignment{
 				Kind: KindScopedRoleAssignment,
 				Metadata: &headerv1.Metadata{
 					Name: uuid.New().String(),
 				},
 				Scope: "/",
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					User: "alice",
-					Assignments: []*accessv1.Assignment{
+					Assignments: []*scopedaccessv1.Assignment{
 						{
 							Role:  "test",
 							Scope: "/foo",
@@ -632,9 +632,9 @@ func TestWeakValidatedAssignableScopes(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			result := slices.Collect(WeakValidatedAssignableScopes(&accessv1.ScopedRole{
+			result := slices.Collect(WeakValidatedAssignableScopes(&scopedaccessv1.ScopedRole{
 				Scope: tt.scope,
-				Spec: &accessv1.ScopedRoleSpec{
+				Spec: &scopedaccessv1.ScopedRoleSpec{
 					AssignableScopes: tt.assignableScopes,
 				},
 			}))
@@ -649,13 +649,13 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 	tts := []struct {
 		name        string
 		scope       string
-		assignments []*accessv1.Assignment
-		expect      []*accessv1.Assignment
+		assignments []*scopedaccessv1.Assignment
+		expect      []*scopedaccessv1.Assignment
 	}{
 		{
 			name:  "basic",
 			scope: "/foo",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -665,7 +665,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -679,7 +679,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 		{
 			name:  "mildly malformed scope",
 			scope: "/foo",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "foo/bar",
@@ -689,7 +689,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "foo/bar",
@@ -703,7 +703,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 		{
 			name:  "significantly malformed scope",
 			scope: "/foo",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "foo@bar",
@@ -713,7 +713,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/baz",
@@ -723,7 +723,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 		{
 			name:  "impermissible scope",
 			scope: "/foo/bar",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -733,7 +733,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -743,7 +743,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 		{
 			name:  "missing scope",
 			scope: "/foo",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "",
@@ -753,7 +753,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/baz",
@@ -763,7 +763,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 		{
 			name:  "missing role",
 			scope: "/foo",
-			assignments: []*accessv1.Assignment{
+			assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -773,7 +773,7 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 					Scope: "/foo/baz",
 				},
 			},
-			expect: []*accessv1.Assignment{
+			expect: []*scopedaccessv1.Assignment{
 				{
 					Role:  "test",
 					Scope: "/foo/bar",
@@ -784,9 +784,9 @@ func TestWeakValidatedSubAssignments(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			result := slices.Collect(WeakValidatedSubAssignments(&accessv1.ScopedRoleAssignment{
+			result := slices.Collect(WeakValidatedSubAssignments(&scopedaccessv1.ScopedRoleAssignment{
 				Scope: tt.scope,
-				Spec: &accessv1.ScopedRoleAssignmentSpec{
+				Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 					Assignments: tt.assignments,
 				},
 			}))

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -1,0 +1,367 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package access
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
+	"github.com/gravitational/teleport/lib/scopes/cache/roles"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// CacheConfig configures the scoped access cache.
+type CacheConfig struct {
+	Events            types.Events
+	Reader            services.ScopedAccessReader
+	MaxRetryPeriod    time.Duration
+	TTLCacheRetention time.Duration
+}
+
+// CheckAndSetDefaults verifies required fields and sets default values as appropriate.
+func (c *CacheConfig) CheckAndSetDefaults() error {
+	if c.Events == nil {
+		return trace.BadParameter("missing required parameter Events in scoped access cache config")
+	}
+
+	if c.Reader == nil {
+		return trace.BadParameter("missing required parameter Reader in scoped access cache config")
+	}
+
+	if c.MaxRetryPeriod <= 0 {
+		c.MaxRetryPeriod = defaults.MaxLongWatcherBackoff
+	}
+
+	if c.TTLCacheRetention <= 0 {
+		c.TTLCacheRetention = time.Second * 3
+	}
+
+	return nil
+}
+
+// state holds the cache state elements.
+type state struct {
+	roles       *roles.RoleCache
+	assignments *assignments.AssignmentCache
+}
+
+// Cache is an in-memory cache for scoped access resources. It provides similar features to the primary
+// teleport cache, but is specifically tailored to support scope-based queries that are difficult to implement
+// with the primary cache.
+type Cache struct {
+	cfg      CacheConfig
+	rw       sync.RWMutex
+	state    state
+	ok       bool
+	closed   bool
+	cancel   context.CancelFunc
+	ttlCache *utils.FnCache
+	done     chan struct{}
+}
+
+// NewCache attempts to configure and start a new scoped access cache. The cache is immediately readable if returned,
+// but performance may be suboptimal until watcher init has completed.
+func NewCache(cfg CacheConfig) (*Cache, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		First:  retryutils.FullJitter(cfg.MaxRetryPeriod / 16),
+		Driver: retryutils.NewExponentialDriver(cfg.MaxRetryPeriod / 16),
+		Max:    cfg.MaxRetryPeriod,
+		Jitter: retryutils.HalfJitter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	closeContext, cancel := context.WithCancel(context.Background())
+
+	ttlCache, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL:     cfg.TTLCacheRetention,
+		Context: closeContext,
+	})
+	if err != nil {
+		cancel()
+		return nil, trace.Wrap(err)
+	}
+
+	cache := &Cache{
+		cfg:      cfg,
+		ttlCache: ttlCache,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+	}
+
+	go cache.update(closeContext, retry)
+
+	return cache, nil
+}
+
+// GetScopedRole retrieves a scoped role by name.
+func (c *Cache) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.roles.GetScopedRole(ctx, req)
+}
+
+// ListScopedRoles returns a paginated list of scoped roles.
+func (c *Cache) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.roles.ListScopedRoles(ctx, req)
+}
+
+// GetScopedRoleAssignment retrieves a scoped role assignment by name.
+func (c *Cache) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.assignments.GetScopedRoleAssignment(ctx, req)
+}
+
+// ListScopedRoleAssignments returns a paginated list of scoped role assignments.
+func (c *Cache) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.assignments.ListScopedRoleAssignments(ctx, req)
+}
+
+// Close stops cache background operations and causes future reads to fail. It is safe to call multiple times.
+func (c *Cache) Close() error {
+	c.cancel()
+
+	// wait for done signal so that all reads with a "happens after" relation to close
+	// fail consistently.
+	<-c.done
+	return nil
+}
+
+// update is the main background loop that handles cache setup, update, and retry.
+func (c *Cache) update(ctx context.Context, retry retryutils.Retry) {
+	defer func() {
+		slog.InfoContext(ctx, "scoped access cache closing")
+		c.rw.Lock()
+		c.closed = true
+		c.rw.Unlock()
+		close(c.done)
+	}()
+
+	for {
+		err := c.fetchAndWatch(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+
+		slog.WarnContext(ctx, "scoped access cache failed", "error", err)
+
+		waitStart := time.Now()
+		select {
+		case <-retry.After():
+			slog.InfoContext(ctx, "attempting re-init of scoped access cache after delay", "delay", time.Since(waitStart))
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// fetchAndWatch attempts to establish a watcher with the upstream events service, populate the cache
+// state, and process changes as they come in.
+func (c *Cache) fetchAndWatch(ctx context.Context) error {
+	watcher, err := c.cfg.Events.NewWatcher(ctx, types.Watch{
+		Name: "scoped-access-cache",
+		Kinds: []types.WatchKind{
+			{
+				Kind: scopedaccess.KindScopedRole,
+			},
+			{
+				Kind: scopedaccess.KindScopedRoleAssignment,
+			},
+		},
+	})
+	if err != nil {
+		return trace.Errorf("failed to create watcher: %w", err)
+	}
+
+	defer watcher.Close()
+
+	select {
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.BadParameter("expected init event, got %v instead", event.Type)
+		}
+	case <-watcher.Done():
+		return trace.Errorf("watcher failed while waiting for init event: %w", watcher.Error())
+	case <-time.After(retryutils.SeventhJitter(time.Minute)):
+		return trace.Errorf("timed out waiting for init event from watcher")
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	}
+
+	fetchStart := time.Now()
+	state, err := c.fetch(ctx)
+	if err != nil {
+		return trace.Errorf("failed to fetch initial state: %w", err)
+	}
+
+	slog.InfoContext(ctx, "scoped access cache fetched initial state", "elapsed", time.Since(fetchStart))
+
+	c.rw.Lock()
+	c.state = state
+	c.ok = true
+	c.rw.Unlock()
+
+	slog.InfoContext(ctx, "scoped access cache successfully initialized")
+
+	// start processing and applying changes
+	for {
+		select {
+		case event := <-watcher.Events():
+			if err := processEvent(ctx, state, event); err != nil {
+				return trace.Errorf("failed to process event: %w", err)
+			}
+		case <-watcher.Done():
+			return trace.Errorf("watcher failed: %w", watcher.Error())
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+	}
+}
+
+// processEvent attempts to update the provided cache state with the given event.
+func processEvent(ctx context.Context, state state, event types.Event) error {
+	switch event.Type {
+	case types.OpPut:
+		switch item := event.Resource.(type) {
+		case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]:
+			if err := state.roles.Put(item.UnwrapT()); err != nil {
+				return trace.Errorf("failed to put scoped role %q: %w", item.UnwrapT().GetMetadata().GetName(), err)
+			}
+		case types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]:
+			if err := state.assignments.Put(item.UnwrapT()); err != nil {
+				return trace.Errorf("failed to put scoped role assignment %q: %w", item.UnwrapT().GetMetadata().GetName(), err)
+			}
+		default:
+			return trace.BadParameter("unexpected resource type %T in put event", event.Resource)
+		}
+	case types.OpDelete:
+		switch event.Resource.GetKind() {
+		case scopedaccess.KindScopedRole:
+			state.roles.Delete(event.Resource.GetName())
+		case scopedaccess.KindScopedRoleAssignment:
+			state.assignments.Delete(event.Resource.GetName())
+		default:
+			return trace.BadParameter("unexpected resource kind %q in event delete event", event.Resource.GetKind())
+		}
+	default:
+		slog.WarnContext(ctx, "scoped access cache skipping unexpected event type", "event_type", event.Type)
+		return nil
+	}
+	return nil
+}
+
+// read gets a read-ready cache state suitable for use in serving reads. the underlying state may
+// be the actual primary cache state, or a ttl-cached image if the primary is unavailable.
+func (c *Cache) read(ctx context.Context) (state, error) {
+	c.rw.RLock()
+	primary, ok, closed := c.state, c.ok, c.closed
+	c.rw.RUnlock()
+
+	if closed {
+		// theoretically there's nothing wrong with reading *immediately* after close since cache reads are async/trailing
+		// anyhow, but allowing reads of a closed cache might mask more serious bugs so its better to fail fast.
+		return state{}, trace.Errorf("scoped access cache is closed")
+	}
+
+	if ok {
+		// the primary cache is available, return it immediately.
+		return primary, nil
+	}
+
+	// the cache is not ready, load a frozen readonly copy via ttl cache
+	temp, err := utils.FnCacheGet(ctx, c.ttlCache, "access-cache", func(ctx context.Context) (state, error) {
+		return c.fetch(ctx)
+	})
+
+	// primary may have been concurrently loaded. prefer using it if so.
+	c.rw.RLock()
+	primary, ok = c.state, c.ok
+	c.rw.RUnlock()
+
+	if ok {
+		return primary, nil
+	}
+
+	return temp, trace.Wrap(err)
+}
+
+// fetch loads all currently available roles and assignments from the upstream and builds a cache state.
+func (c *Cache) fetch(ctx context.Context) (state, error) {
+	roleCache := roles.NewRoleCache()
+
+	for role, err := range StreamRoles(ctx, c.cfg.Reader) {
+		if err != nil {
+			return state{}, trace.Wrap(err)
+		}
+
+		if err := roleCache.Put(role); err != nil {
+			return state{}, trace.Wrap(err)
+		}
+	}
+
+	assignmentCache := assignments.NewAssignmentCache()
+
+	for assignment, err := range StreamAssignments(ctx, c.cfg.Reader) {
+		if err != nil {
+			return state{}, trace.Wrap(err)
+		}
+
+		if err := assignmentCache.Put(assignment); err != nil {
+			return state{}, trace.Wrap(err)
+		}
+	}
+
+	return state{
+		roles:       roleCache,
+		assignments: assignmentCache,
+	}, nil
+}

--- a/lib/scopes/cache/access/access_test.go
+++ b/lib/scopes/cache/access/access_test.go
@@ -1,0 +1,497 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package access
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+// TestScopedAccessCacheReplication verifies basic replication behavior of the scoped access cache.
+func TestScopedAccessCacheReplication(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	defer backend.Close()
+
+	service := local.NewScopedAccessService(backend)
+
+	events := local.NewEventsService(backend)
+
+	// populate roles prior to starting the cache so that we can cover
+	// loading of initial state.
+	var expectedRoleNames []string
+	expectedRoleRevisions := make(map[string]string)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("role-%d", i)
+		crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: newScopedRole(name),
+		})
+		require.NoError(t, err)
+
+		expectedRoleNames = append(expectedRoleNames, name)
+		expectedRoleRevisions[name] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	// populate assignments prior to starting the cache so that we can cover
+	// loading of initial state.
+	var expectedAssignmentNames []string
+	for i := 0; i < 10; i++ {
+		assignment := newScopedRoleAssignment(expectedRoleNames[i])
+		_, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: assignment,
+			RoleRevisions: map[string]string{
+				expectedRoleNames[i]: expectedRoleRevisions[expectedRoleNames[i]],
+			},
+		})
+		require.NoError(t, err)
+
+		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	// start the cache with the service and events.
+	cache, err := NewCache(CacheConfig{
+		Events:            events,
+		Reader:            service,
+		TTLCacheRetention: time.Hour, // ensures state-changes are from watcher events rather than ttl cache reloads
+	})
+	require.NoError(t, err)
+
+	defer cache.Close()
+
+	// verify that initial role states are immediately available
+	var gotRoleNames []string
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedRoleNames, gotRoleNames)
+
+	// verify that initial assignment states are immediately available
+	var gotAssignmentNames []string
+	for assignment, err := range StreamAssignments(ctx, cache) {
+		require.NoError(t, err)
+
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedAssignmentNames, gotAssignmentNames)
+
+	// perform additional role writes to cover event replication
+	for i := 10; i < 20; i++ {
+		name := fmt.Sprintf("role-%d", i)
+		crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: newScopedRole(name),
+		})
+		require.NoError(t, err)
+
+		expectedRoleNames = append(expectedRoleNames, name)
+		expectedRoleRevisions[name] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	// perform additional assignment writes to cover event replication
+	for i := 10; i < 20; i++ {
+		assignment := newScopedRoleAssignment(expectedRoleNames[i])
+		_, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: assignment,
+			RoleRevisions: map[string]string{
+				expectedRoleNames[i]: expectedRoleRevisions[expectedRoleNames[i]],
+			},
+		})
+		require.NoError(t, err)
+
+		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	// wait for the cache to replicate the new roles
+	waitForRoleCondition(t, cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		t.Helper()
+		return len(roles) >= len(expectedRoleNames)
+	})
+
+	gotRoleNames = nil
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+	require.ElementsMatch(t, expectedRoleNames, gotRoleNames)
+
+	// wait for the cache to replicate the new assignments
+	waitForAssignmentCondition(t, cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		t.Helper()
+		return len(assignments) >= len(expectedAssignmentNames)
+	})
+
+	gotAssignmentNames = nil
+	for assignment, err := range StreamAssignments(ctx, cache) {
+		require.NoError(t, err)
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+	require.ElementsMatch(t, expectedAssignmentNames, gotAssignmentNames)
+
+	// test that cache can handle updates to existing roles (NOTE: no corellary for assignments)
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+
+		role.Metadata.Labels = map[string]string{"updated": "true"}
+
+		crsp, err := service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+
+		expectedRoleRevisions[role.GetMetadata().GetName()] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	waitForRoleCondition(t, cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		t.Helper()
+		for _, role := range roles {
+			if role.GetMetadata().GetLabels()["updated"] != "true" {
+				return false
+			}
+		}
+		return true
+	})
+
+	// test that cache can handle partial deletes for assignments
+	for _, name := range expectedAssignmentNames[0:10] {
+		_, err := service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+	}
+
+	waitForAssignmentCondition(t, cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		t.Helper()
+		return len(assignments) <= len(expectedAssignmentNames)-10
+	})
+
+	gotAssignmentNames = nil
+	for assignment, err := range StreamAssignments(ctx, cache) {
+		require.NoError(t, err)
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedAssignmentNames[10:], gotAssignmentNames)
+
+	// test that cache can handle delete of all assignments
+	for _, name := range expectedAssignmentNames[10:] {
+		_, err := service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+	}
+
+	waitForAssignmentCondition(t, cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		t.Helper()
+		return len(assignments) == 0
+	})
+
+	// test that cache can handle partial deletes for roles
+	for _, name := range expectedRoleNames[0:10] {
+		_, err := service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+	}
+
+	waitForRoleCondition(t, cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		t.Helper()
+		return len(roles) <= len(expectedRoleNames)-10
+	})
+
+	gotRoleNames = nil
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+	require.ElementsMatch(t, expectedRoleNames[10:], gotRoleNames)
+
+	// test that cache can handle delete of all roles
+	for _, name := range expectedRoleNames[10:] {
+		_, err := service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+	}
+
+	waitForRoleCondition(t, cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		t.Helper()
+		return len(roles) == 0
+	})
+}
+
+// TestScopedAccessCacheFallback verified the fallback behavior of the scoped access cache
+// when the upstream event system is unavailable.
+func TestScopedAccessCacheFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	defer backend.Close()
+
+	service := local.NewScopedAccessService(backend)
+
+	events := &neverEvents{} // use a fake events service that never initializes watchers
+
+	// populate roles prior to starting the cache so that we can cover
+	// loading of initial state.
+	var expectedRoleNames []string
+	expectedRoleRevisions := make(map[string]string)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("role-%d", i)
+		crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: newScopedRole(name),
+		})
+		require.NoError(t, err)
+
+		expectedRoleNames = append(expectedRoleNames, name)
+		expectedRoleRevisions[name] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	// populate assignments prior to starting the cache so that we can cover
+	// loading of initial state.
+	var expectedAssignmentNames []string
+	for i := 0; i < 10; i++ {
+		assignment := newScopedRoleAssignment(expectedRoleNames[i])
+		_, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: assignment,
+			RoleRevisions: map[string]string{
+				expectedRoleNames[i]: expectedRoleRevisions[expectedRoleNames[i]],
+			},
+		})
+		require.NoError(t, err)
+
+		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	// start the cache with the service and never-events.
+	cache, err := NewCache(CacheConfig{
+		Events:            events,
+		Reader:            service,
+		TTLCacheRetention: time.Millisecond * 10, // ensure we don't spend more than 1 cycle waiting
+	})
+	require.NoError(t, err)
+
+	defer cache.Close()
+
+	// verify that initial role states are immediately available
+	var gotRoleNames []string
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedRoleNames, gotRoleNames)
+
+	// verify that initial assignment states are immediately available
+	var gotAssignmentNames []string
+	for assignment, err := range StreamAssignments(ctx, cache) {
+		require.NoError(t, err)
+
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedAssignmentNames, gotAssignmentNames)
+
+	// perform additional role writes to cover subsequent ttl-cache image loads
+	for i := 10; i < 20; i++ {
+		name := fmt.Sprintf("role-%d", i)
+		crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: newScopedRole(name),
+		})
+		require.NoError(t, err)
+
+		expectedRoleNames = append(expectedRoleNames, name)
+		expectedRoleRevisions[name] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	// perform additional assignment writes to cover ttl-cache image loads
+	for i := 10; i < 20; i++ {
+		assignment := newScopedRoleAssignment(expectedRoleNames[i])
+		_, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment: assignment,
+			RoleRevisions: map[string]string{
+				expectedRoleNames[i]: expectedRoleRevisions[expectedRoleNames[i]],
+			},
+		})
+		require.NoError(t, err)
+
+		expectedAssignmentNames = append(expectedAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	// wait for the new roles to become visible
+	waitForRoleCondition(t, cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		t.Helper()
+		return len(roles) >= len(expectedRoleNames)
+	})
+
+	gotRoleNames = nil
+	for role, err := range StreamRoles(ctx, cache) {
+		require.NoError(t, err)
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+	require.ElementsMatch(t, expectedRoleNames, gotRoleNames)
+
+	// wait for the new assignments to become visible
+	waitForAssignmentCondition(t, cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		t.Helper()
+		return len(assignments) >= len(expectedAssignmentNames)
+	})
+
+	gotAssignmentNames = nil
+	for assignment, err := range StreamAssignments(ctx, cache) {
+		require.NoError(t, err)
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+	require.ElementsMatch(t, expectedAssignmentNames, gotAssignmentNames)
+}
+
+func newScopedRole(name string) *scopedaccessv1.ScopedRole {
+	return &scopedaccessv1.ScopedRole{
+		Kind: scopedaccess.KindScopedRole,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleSpec{
+			AssignableScopes: []string{"/foo"},
+		},
+		Version: types.V1,
+	}
+}
+
+func newScopedRoleAssignment(roleName string) *scopedaccessv1.ScopedRoleAssignment {
+	return &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
+		Metadata: &headerv1.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			User: "alice",
+			Assignments: []*scopedaccessv1.Assignment{
+				{
+					Role:  roleName,
+					Scope: "/foo",
+				},
+			},
+		},
+		Version: types.V1,
+	}
+}
+
+func waitForRoleCondition(t *testing.T, reader services.ScopedRoleReader, condition func([]*scopedaccessv1.ScopedRole) bool) {
+	t.Helper()
+	timeout := time.After(30 * time.Second)
+	for {
+		var roles []*scopedaccessv1.ScopedRole
+		for role, err := range StreamRoles(t.Context(), reader) {
+			require.NoError(t, err)
+			roles = append(roles, role)
+		}
+
+		if condition(roles) {
+			return
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 120):
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for role condition")
+		}
+	}
+}
+
+func waitForAssignmentCondition(t *testing.T, reader services.ScopedRoleAssignmentReader, condition func([]*scopedaccessv1.ScopedRoleAssignment) bool) {
+	t.Helper()
+	timeout := time.After(30 * time.Second)
+	for {
+		var assignments []*scopedaccessv1.ScopedRoleAssignment
+		for assignment, err := range StreamAssignments(t.Context(), reader) {
+			require.NoError(t, err)
+			assignments = append(assignments, assignment)
+		}
+
+		if condition(assignments) {
+			return
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 200):
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for assignment condition")
+		}
+	}
+}
+
+// neverEvents is a fake event service whose watchers never initialize.
+type neverEvents struct{}
+
+func (e *neverEvents) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	return &neverWatcher{}, nil
+}
+
+// neverWatcher is a fake watcher that never initializes.
+type neverWatcher struct{}
+
+func (w *neverWatcher) Events() <-chan types.Event {
+	return nil
+}
+
+func (w *neverWatcher) Done() <-chan struct{} {
+	return nil
+}
+
+func (w *neverWatcher) Close() error {
+	return nil
+}
+
+func (w *neverWatcher) Error() error {
+	return nil
+}

--- a/lib/scopes/cache/access/helpers.go
+++ b/lib/scopes/cache/access/helpers.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package access
+
+import (
+	"context"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// StreamRoles is a helper function that streams scoped roles from the provided reader.
+func StreamRoles(ctx context.Context, reader services.ScopedRoleReader) stream.Stream[*scopedaccessv1.ScopedRole] {
+	return func(yield func(*scopedaccessv1.ScopedRole, error) bool) {
+		var cursor string
+		for {
+			rsp, err := reader.ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{
+				PageToken: cursor,
+			})
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, role := range rsp.GetRoles() {
+				if !yield(role, nil) {
+					return
+				}
+			}
+
+			cursor = rsp.GetNextPageToken()
+
+			if cursor == "" {
+				break
+			}
+		}
+	}
+}
+
+// StreamAssignments is a helper function that streams scoped role assignments from the provided reader.
+func StreamAssignments(ctx context.Context, reader services.ScopedRoleAssignmentReader) stream.Stream[*scopedaccessv1.ScopedRoleAssignment] {
+	return func(yield func(*scopedaccessv1.ScopedRoleAssignment, error) bool) {
+		var cursor string
+		for {
+			rsp, err := reader.ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{
+				PageToken: cursor,
+			})
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			for _, assignment := range rsp.GetAssignments() {
+				if !yield(assignment, nil) {
+					return
+				}
+			}
+
+			cursor = rsp.GetNextPageToken()
+
+			if cursor == "" {
+				break
+			}
+		}
+	}
+}

--- a/lib/scopes/cache/access/helpers_test.go
+++ b/lib/scopes/cache/access/helpers_test.go
@@ -1,0 +1,123 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package access
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/cache/assignments"
+	"github.com/gravitational/teleport/lib/scopes/cache/roles"
+)
+
+func TestStreamRoles(t *testing.T) {
+	const roleCount = 503
+
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	upstream := roles.NewRoleCache()
+
+	expectedRoleNames := make([]string, 0, roleCount)
+
+	for i := range roleCount {
+		name := fmt.Sprintf("role-%d", i)
+		err := upstream.Put(&scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: name,
+			},
+			Scope: "/foo",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/foo"},
+			},
+			Version: types.V1,
+		})
+		require.NoError(t, err)
+		expectedRoleNames = append(expectedRoleNames, name)
+	}
+
+	gotRoleNames := make([]string, 0, roleCount)
+
+	for role, err := range StreamRoles(ctx, upstream) {
+		require.NoError(t, err)
+		require.NotNil(t, role)
+
+		gotRoleNames = append(gotRoleNames, role.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedRoleNames, gotRoleNames)
+}
+
+func TestStreamAssignments(t *testing.T) {
+	const assignmentCount = 503
+
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	upstream := assignments.NewAssignmentCache()
+
+	expectedAssignmentNames := make([]string, 0, assignmentCount)
+
+	for range assignmentCount {
+		name := uuid.New().String()
+		err := upstream.Put(&scopedaccessv1.ScopedRoleAssignment{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerv1.Metadata{
+				Name: name,
+			},
+			Scope: "/",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "some-role",
+						Scope: "/foo",
+					},
+				},
+			},
+			Version: types.V1,
+		})
+		require.NoError(t, err)
+		expectedAssignmentNames = append(expectedAssignmentNames, name)
+	}
+
+	gotAssignmentNames := make([]string, 0, assignmentCount)
+
+	for assignment, err := range StreamAssignments(ctx, upstream) {
+		require.NoError(t, err)
+		require.NotNil(t, assignment)
+
+		gotAssignmentNames = append(gotAssignmentNames, assignment.GetMetadata().GetName())
+	}
+
+	require.ElementsMatch(t, expectedAssignmentNames, gotAssignmentNames)
+}

--- a/lib/scopes/cache/assignments/assignment_cache.go
+++ b/lib/scopes/cache/assignments/assignment_cache.go
@@ -25,11 +25,11 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/cache"
-	sr "github.com/gravitational/teleport/lib/scopes/roles"
 )
 
 const (
@@ -39,26 +39,42 @@ const (
 
 // AssignmentCache is a cache for scoped role assignments.
 type AssignmentCache struct {
-	cache *cache.Cache[*accessv1.ScopedRoleAssignment, string]
+	cache *cache.Cache[*scopedaccessv1.ScopedRoleAssignment, string]
 }
 
 // NewAssignmentCache creates a new assignment cache instance.
 func NewAssignmentCache() *AssignmentCache {
 	return &AssignmentCache{
-		cache: cache.Must(cache.Config[*accessv1.ScopedRoleAssignment, string]{
-			Scope: func(assignment *accessv1.ScopedRoleAssignment) string {
+		cache: cache.Must(cache.Config[*scopedaccessv1.ScopedRoleAssignment, string]{
+			Scope: func(assignment *scopedaccessv1.ScopedRoleAssignment) string {
 				return assignment.GetScope()
 			},
-			Key: func(assignment *accessv1.ScopedRoleAssignment) string {
+			Key: func(assignment *scopedaccessv1.ScopedRoleAssignment) string {
 				return assignment.GetMetadata().GetName()
 			},
-			Clone: proto.CloneOf[*accessv1.ScopedRoleAssignment],
+			Clone: proto.CloneOf[*scopedaccessv1.ScopedRoleAssignment],
 		}),
 	}
 }
 
+// GetScopedRoleAssignment gets an assignment by name.
+func (c *AssignmentCache) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("missing scoped role assignment name in get request")
+	}
+
+	assignment, ok := c.cache.Get(req.GetName())
+	if !ok {
+		return nil, trace.NotFound("scoped role assignment %q not found", req.GetName())
+	}
+
+	return &scopedaccessv1.GetScopedRoleAssignmentResponse{
+		Assignment: assignment,
+	}, nil
+}
+
 // ListScopedRoleAssignments returns a paginated list of scoped role assignments.
-func (c *AssignmentCache) ListScopedRoleAssignments(ctx context.Context, req *accessv1.ListScopedRoleAssignmentsRequest) (*accessv1.ListScopedRoleAssignmentsResponse, error) {
+func (c *AssignmentCache) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
 	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
@@ -71,13 +87,13 @@ func (c *AssignmentCache) ListScopedRoleAssignments(ctx context.Context, req *ac
 		return nil, trace.BadParameter("cannot filter by both resource scope and assigned scope simultaneously")
 	}
 
-	filter := func(assignment *accessv1.ScopedRoleAssignment) bool {
+	filter := func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
 		if req.GetUser() != "" && assignment.GetSpec().GetUser() != req.GetUser() {
 			return false
 		}
 
 		if req.GetRole() != "" {
-			if !slices.ContainsFunc(assignment.GetSpec().Assignments, func(a *accessv1.Assignment) bool { return a.GetRole() == req.GetRole() }) {
+			if !slices.ContainsFunc(assignment.GetSpec().Assignments, func(a *scopedaccessv1.Assignment) bool { return a.GetRole() == req.GetRole() }) {
 				// if the assignment does not have the requested role, skip it
 				return false
 			}
@@ -120,7 +136,7 @@ func (c *AssignmentCache) ListScopedRoleAssignments(ctx context.Context, req *ac
 		return nil, trace.NotImplemented("assigned scope filtering for scoped role assignments is not yet supported")
 	}
 
-	var out []*accessv1.ScopedRoleAssignment
+	var out []*scopedaccessv1.ScopedRoleAssignment
 	var nextCursor cache.Cursor[string]
 Outer:
 	for scope := range getter(scope, c.cache.WithFilter(filter), c.cache.WithCursor(cursor)) {
@@ -144,15 +160,15 @@ Outer:
 		}
 	}
 
-	return &accessv1.ListScopedRoleAssignmentsResponse{
+	return &scopedaccessv1.ListScopedRoleAssignmentsResponse{
 		Assignments:   out,
 		NextPageToken: nextPageToken,
 	}, nil
 }
 
 // Put adds a new assignment to the cache. It will overwrite any existing assignment with the same name.
-func (c *AssignmentCache) Put(assignment *accessv1.ScopedRoleAssignment) error {
-	if err := sr.WeakValidateAssignment(assignment); err != nil {
+func (c *AssignmentCache) Put(assignment *scopedaccessv1.ScopedRoleAssignment) error {
+	if err := scopedaccess.WeakValidateAssignment(assignment); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/scopes/cache/assignments/assignment_cache_test.go
+++ b/lib/scopes/cache/assignments/assignment_cache_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	headerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopespb "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
-	sr "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // TestListScopedRoleAssignmentsScenarios tests particular more tricky ListScopedRoleAssignments scenarios, such
@@ -36,16 +36,16 @@ import (
 func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 	t.Parallel()
 
-	assignments := []*accessv1.ScopedRoleAssignment{
+	assignments := []*scopedaccessv1.ScopedRoleAssignment{
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "alice-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-01",
 						Scope: "/aa",
@@ -59,14 +59,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "alice-02",
 			},
 			Scope: "/aa",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-03",
 						Scope: "/aa",
@@ -80,14 +80,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "bob-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "bob",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-01",
 						Scope: "/aa",
@@ -101,14 +101,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "bob-02",
 			},
 			Scope: "/aa",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "bob",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-03",
 						Scope: "/aa",
@@ -122,14 +122,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "alice-03",
 			},
 			Scope: "/aa/bb",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-05",
 						Scope: "/aa/bb",
@@ -143,14 +143,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "bob-03",
 			},
 			Scope: "/aa/bb",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-05",
 						Scope: "/aa/bb",
@@ -164,14 +164,14 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "carol-01",
 			},
 			Scope: "/bb",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "carol",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-07",
 						Scope: "/bb",
@@ -188,11 +188,23 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 
 	cache := NewAssignmentCache()
 	for _, assignment := range assignments {
+		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name: assignment.GetMetadata().GetName(),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
 		cache.Put(assignment)
+
+		rsp, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name: assignment.GetMetadata().GetName(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.GetAssignment())
 	}
 
 	// verify expected behavior for standard cursors in resources subject to scope mode
-	rsp, err := cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err := cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 			Scope: "/aa",
@@ -204,7 +216,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 	require.Equal(t, []string{"bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
 
 	// try to inject a malicious root out-of-band cursor in resources subject to scope mode (no effect)
-	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 			Scope: "/aa",
@@ -216,7 +228,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 	require.Equal(t, []string{"alice-02", "bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
 
 	// try to inject a malicious orthogonal out-of-band cursor in resources subject to scope mode (no effect)
-	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 			Scope: "/aa",
@@ -228,7 +240,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 	require.Equal(t, []string{"alice-02", "bob-02", "alice-03", "bob-03"}, collectAssignmentNames(rsp.Assignments))
 
 	// verify expected behavior for standard cursors in policies applicable to scope mode
-	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 			Scope: "/aa",
@@ -241,7 +253,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 
 	// try to inject a malicious child out-of-band cursor in policies applicable to scope mode (effect is
 	// to ignore all items in valid query path).
-	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 			Scope: "/aa",
@@ -254,7 +266,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 
 	// try to inject a malicious orthogonal out-of-band cursor in policies applicable to scope mode (effect is to
 	// ignore root, but process leaf normally).
-	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	rsp, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 			Scope: "/aa",
@@ -266,7 +278,7 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 	require.Equal(t, []string{"alice-02", "bob-02"}, collectAssignmentNames(rsp.Assignments))
 
 	// verify rejection of unknown cursor version
-	_, err = cache.ListScopedRoleAssignments(t.Context(), &accessv1.ListScopedRoleAssignmentsRequest{
+	_, err = cache.ListScopedRoleAssignments(t.Context(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 		ResourceScope: &scopespb.Filter{
 			Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 			Scope: "/aa",
@@ -281,16 +293,16 @@ func TestListScopedRoleASsignmentsScenarios(t *testing.T) {
 func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 	t.Parallel()
 
-	assignments := []*accessv1.ScopedRoleAssignment{
+	assignments := []*scopedaccessv1.ScopedRoleAssignment{
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "alice-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-01",
 						Scope: "/aa",
@@ -304,14 +316,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "alice-02",
 			},
 			Scope: "/aa",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "alice",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-03",
 						Scope: "/aa",
@@ -325,14 +337,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "bob-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "bob",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-01",
 						Scope: "/aa",
@@ -346,14 +358,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "bob-02",
 			},
 			Scope: "/aa",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "bob",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-03",
 						Scope: "/aa",
@@ -367,14 +379,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 			Version: types.V1,
 		},
 		{
-			Kind: sr.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: &headerpb.Metadata{
 				Name: "carol-01",
 			},
 			Scope: "/bb",
-			Spec: &accessv1.ScopedRoleAssignmentSpec{
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 				User: "carol",
-				Assignments: []*accessv1.Assignment{
+				Assignments: []*scopedaccessv1.Assignment{
 					{
 						Role:  "role-05",
 						Scope: "/bb",
@@ -391,12 +403,12 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 
 	tts := []struct {
 		name   string
-		req    *accessv1.ListScopedRoleAssignmentsRequest
+		req    *scopedaccessv1.ListScopedRoleAssignmentsRequest
 		expect [][]string
 	}{
 		{
 			name: "all single page explicit excess",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				PageSize: int32(len(assignments) + 1),
 			},
 			expect: [][]string{
@@ -411,7 +423,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "all single page implicit excess",
-			req:  &accessv1.ListScopedRoleAssignmentsRequest{},
+			req:  &scopedaccessv1.ListScopedRoleAssignmentsRequest{},
 			expect: [][]string{
 				{
 					"alice-01",
@@ -424,7 +436,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "all single page exact",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				PageSize: int32(len(assignments)),
 			},
 			expect: [][]string{
@@ -439,7 +451,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "all multi page",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				PageSize: 2,
 			},
 			expect: [][]string{
@@ -458,7 +470,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "user single page",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				User: "alice",
 			},
 			expect: [][]string{
@@ -470,7 +482,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "user multi page",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				PageSize: 1,
 				User:     "alice",
 			},
@@ -481,14 +493,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "user nonexistent",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				User: "dave",
 			},
 			expect: nil,
 		},
 		{
 			name: "role single page",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				Role: "role-01",
 			},
 			expect: [][]string{
@@ -500,7 +512,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "role multi page",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				PageSize: 1,
 				Role:     "role-01",
 			},
@@ -511,14 +523,14 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "role nonexistent",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				Role: "role-99",
 			},
 			expect: nil,
 		},
 		{
 			name: "resource scope root",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				ResourceScope: &scopespb.Filter{
 					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/",
@@ -536,7 +548,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "resource scope non-root",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				ResourceScope: &scopespb.Filter{
 					Mode:  scopespb.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/aa",
@@ -551,7 +563,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "policy scope root",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				ResourceScope: &scopespb.Filter{
 					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 					Scope: "/",
@@ -566,7 +578,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 		},
 		{
 			name: "policy scope non-root",
-			req: &accessv1.ListScopedRoleAssignmentsRequest{
+			req: &scopedaccessv1.ListScopedRoleAssignmentsRequest{
 				ResourceScope: &scopespb.Filter{
 					Mode:  scopespb.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 					Scope: "/aa",
@@ -585,7 +597,19 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 
 	cache := NewAssignmentCache()
 	for _, assignment := range assignments {
+		_, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name: assignment.GetMetadata().GetName(),
+		})
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
+
 		cache.Put(assignment)
+
+		rsp, err := cache.GetScopedRoleAssignment(t.Context(), &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name: assignment.GetMetadata().GetName(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.GetAssignment())
 	}
 
 	for _, tt := range tts {
@@ -613,7 +637,7 @@ func TestListScopedRoleAssignmentsBasics(t *testing.T) {
 	}
 }
 
-func collectAssignmentNames(assignments []*accessv1.ScopedRoleAssignment) []string {
+func collectAssignmentNames(assignments []*scopedaccessv1.ScopedRoleAssignment) []string {
 	var names []string
 	for _, assignment := range assignments {
 		names = append(names, assignment.Metadata.Name)

--- a/lib/scopes/cache/cache.go
+++ b/lib/scopes/cache/cache.go
@@ -148,6 +148,19 @@ func (c *Cache[T, K]) WithFilter(filter func(T) bool) Option[T, K] {
 	}
 }
 
+// Get retrieves the value associated with the given primary key.
+func (c *Cache[T, K]) Get(key K) (T, bool) {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
+
+	value, ok := c.items[key]
+	if !ok {
+		return *new(T), false
+	}
+
+	return c.cfg.Clone(value), true
+}
+
 // PoliciesApplicableToResourceScope iterates over the cached items using policy-application rules (i.e.
 // a descending iteration from root, through the leaf of the specified scope).
 func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string, opts ...Option[T, K]) iter.Seq[ScopedItems[T]] {

--- a/lib/scopes/cache/cache_test.go
+++ b/lib/scopes/cache/cache_test.go
@@ -209,7 +209,16 @@ func TestCacheFiltering(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range items {
+				_, ok := cache.Get(item.Key())
+				require.False(t, ok, "item %+v should not be in cache before Put", item)
+
 				cache.Put(item)
+
+				got, ok := cache.Get(item.Key())
+				require.True(t, ok, "item %+v should be in cache after Put", item)
+				require.Equal(t, item, got, "item %+v should match after Put", item)
+				require.Equal(t, 1, cloned)
+				cloned = 0 // reset cloned counter after each Put
 			}
 
 			var policiesApplicableTo []item[int]
@@ -264,7 +273,14 @@ func TestCacheConcurrency(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, item := range items {
+		_, ok := cache.Get(item.Key())
+		require.False(t, ok, "item %+v should not be in cache before Put", item)
+
 		cache.Put(item)
+
+		got, ok := cache.Get(item.Key())
+		require.True(t, ok, "item %+v should be in cache after Put", item)
+		require.Equal(t, item, got, "item %+v should match after Put", item)
 	}
 
 	// lockstepC is used to force the background queries to progress in lockstep
@@ -628,7 +644,14 @@ func TestCursorScenarios(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range tt.items {
+				_, ok := cache.Get(item.Key())
+				require.False(t, ok, "item %+v should not be in cache before Put", item)
+
 				cache.Put(item)
+
+				got, ok := cache.Get(item.Key())
+				require.True(t, ok, "item %+v should be in cache after Put", item)
+				require.Equal(t, item, got, "item %+v should match after Put", item)
 			}
 
 			// verify policies-applicable-to-resource iteration
@@ -797,7 +820,14 @@ func TestCursorPagination(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, item := range tt.items {
+				_, ok := cache.Get(item.Key())
+				require.False(t, ok, "item %+v should not be in cache before Put", item)
+
 				cache.Put(item)
+
+				got, ok := cache.Get(item.Key())
+				require.True(t, ok, "item %+v should be in cache after Put", item)
+				require.Equal(t, item, got, "item %+v should match after Put", item)
 			}
 
 			// verify policies-applicable-to-resource iteration

--- a/lib/scopes/feature.go
+++ b/lib/scopes/feature.go
@@ -1,0 +1,48 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"os"
+
+	"github.com/gravitational/trace"
+
+	apiutils "github.com/gravitational/teleport/api/utils"
+)
+
+const (
+	// featureVarName is the name of the unstable scopes feature flag.
+	featureVarName = "TELEPORT_UNSTABLE_SCOPES"
+)
+
+// FeatureEnabled checks if the scopes feature is enabled.
+func FeatureEnabled() bool {
+	enabled, err := apiutils.ParseBool(os.Getenv(featureVarName))
+	return enabled && err == nil
+}
+
+// AssertFeatureEnabled checks if the scopes feature is enabled, and returns a helpful
+// error message if it is not.
+func AssertFeatureEnabled() error {
+	if !FeatureEnabled() {
+		return trace.Errorf("scoping features are not enabled, set " + featureVarName + "=yes to enable scoping features (caution: not ready for production use)")
+	}
+
+	return nil
+}

--- a/lib/scopes/feature_test.go
+++ b/lib/scopes/feature_test.go
@@ -1,0 +1,33 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFeatureEnabled verifies the expected behavior of the scope feature flag.
+func TestFeatureEnabled(t *testing.T) {
+	require.Error(t, AssertFeatureEnabled())
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+	require.NoError(t, AssertFeatureEnabled())
+
+}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -109,9 +109,9 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newNamespaceParser(kind.Name)
 		case types.KindRole:
 			parser = newRoleParser()
-		case scopedrole.KindScopedRole:
+		case scopedaccess.KindScopedRole:
 			parser = newScopedRoleParser()
-		case scopedrole.KindScopedRoleAssignment:
+		case scopedaccess.KindScopedRoleAssignment:
 			parser = newScopedRoleAssignmentParser()
 		case types.KindUser:
 			parser = newUserParser()
@@ -1023,7 +1023,7 @@ func (p *scopedRoleParser) parse(event backend.Event) (types.Resource, error) {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
 		return &types.ResourceHeader{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: types.Metadata{
 				Name: name,
 			},
@@ -1057,7 +1057,7 @@ func (p *scopedRoleAssignmentParser) parse(event backend.Event) (types.Resource,
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
 		}
 		return &types.ResourceHeader{
-			Kind: scopedrole.KindScopedRoleAssignment,
+			Kind: scopedaccess.KindScopedRoleAssignment,
 			Metadata: types.Metadata{
 				Name: name,
 			},

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -28,12 +28,12 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/gravitational/teleport"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -76,7 +76,7 @@ func NewScopedAccessService(bk backend.Backend) *ScopedAccessService {
 	}
 }
 
-func (s *ScopedAccessService) GetScopedRole(ctx context.Context, req *accessv1.GetScopedRoleRequest) (*accessv1.GetScopedRoleResponse, error) {
+func (s *ScopedAccessService) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
 	if req.GetName() == "" {
 		return nil, trace.BadParameter("missing scoped role name in get request")
 	}
@@ -94,19 +94,52 @@ func (s *ScopedAccessService) GetScopedRole(ctx context.Context, req *accessv1.G
 		return nil, trace.Wrap(err)
 	}
 
-	if err := scopedrole.WeakValidateRole(role); err != nil {
+	if err := scopedaccess.WeakValidateRole(role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.GetScopedRoleResponse{
+	return &scopedaccessv1.GetScopedRoleResponse{
 		Role: role,
+	}, nil
+}
+
+// ListScopedRoles returns a paginated list of scoped roles.
+// NOTE: this method is only used by local auth caches, and doesn't implement sorting, filtering, or pagination.
+func (s *ScopedAccessService) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	if req.GetPageSize() != 0 {
+		return nil, trace.NotImplemented("page size limits are not implemented for direct backend scoped role reads")
+	}
+
+	if req.GetResourceScope() != nil {
+		return nil, trace.NotImplemented("filtering by resource scope is not implemented for direct backend scoped role reads")
+	}
+
+	if req.GetAssignableScope() != nil {
+		return nil, trace.NotImplemented("filtering by assignable scope is not implemented for direct backend scoped role reads")
+	}
+
+	if req.GetPageToken() != "" {
+		return nil, trace.NotImplemented("pagination is not implemented for direct backend scoped role reads")
+	}
+
+	var out []*scopedaccessv1.ScopedRole
+	for role, err := range s.StreamScopedRoles(ctx) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		out = append(out, role)
+	}
+
+	return &scopedaccessv1.ListScopedRolesResponse{
+		Roles: out,
 	}, nil
 }
 
 // StreamScopedRoles returns a stream of all scoped roles in the backend. Malformed roles are skipped. Returned roles
 // have had weak validation applied.
-func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stream[*accessv1.ScopedRole] {
-	return func(yield func(*accessv1.ScopedRole, error) bool) {
+func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stream[*scopedaccessv1.ScopedRole] {
+	return func(yield func(*scopedaccessv1.ScopedRole, error) bool) {
 		startKey := scopedRoleKey("")
 		params := backend.ItemsParams{
 			StartKey: startKey,
@@ -127,7 +160,7 @@ func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stre
 				continue
 			}
 
-			if err := scopedrole.WeakValidateRole(role); err != nil {
+			if err := scopedaccess.WeakValidateRole(role); err != nil {
 				// per-role errors are logged and skipped
 				s.logger.WarnContext(ctx, "skipping scoped role due to validation error", "error", err, "key", logutils.StringerAttr(item.Key))
 				continue
@@ -140,13 +173,13 @@ func (s *ScopedAccessService) StreamScopedRoles(ctx context.Context) stream.Stre
 	}
 }
 
-func (s *ScopedAccessService) CreateScopedRole(ctx context.Context, req *accessv1.CreateScopedRoleRequest) (*accessv1.CreateScopedRoleResponse, error) {
+func (s *ScopedAccessService) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
 	role := req.GetRole()
 	if role == nil {
 		return nil, trace.BadParameter("missing scoped role in create request")
 	}
 
-	if err := scopedrole.StrongValidateRole(role); err != nil {
+	if err := scopedaccess.StrongValidateRole(role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -212,22 +245,22 @@ func (s *ScopedAccessService) CreateScopedRole(ctx context.Context, req *accessv
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.CreateScopedRoleResponse{
+	return &scopedaccessv1.CreateScopedRoleResponse{
 		Role: scopedRoleWithRevision(role, revision),
 	}, nil
 }
 
-func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *accessv1.UpdateScopedRoleRequest) (*accessv1.UpdateScopedRoleResponse, error) {
+func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
 	role := req.GetRole()
 	if role == nil {
 		return nil, trace.BadParameter("missing scoped role in update request")
 	}
 
-	if err := scopedrole.StrongValidateRole(role); err != nil {
+	if err := scopedaccess.StrongValidateRole(role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	extant, err := s.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+	extant, err := s.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: role.GetMetadata().GetName(),
 	})
 	if err != nil {
@@ -269,7 +302,7 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *accessv
 					continue
 				}
 
-				if !scopedrole.RoleIsAssignableAtScope(extant.GetRole(), subAssignment.GetScope()) {
+				if !scopedaccess.RoleIsAssignableAtScope(extant.GetRole(), subAssignment.GetScope()) {
 					// theoretically, we prevent broken assignments. in practice, its best to
 					// assume they may exist and to not allow them to prevent an otherwsie
 					// valid update. We will still force all broken assignments to be
@@ -277,7 +310,7 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *accessv
 					continue
 				}
 
-				if !scopedrole.RoleIsAssignableAtScope(role, subAssignment.GetScope()) {
+				if !scopedaccess.RoleIsAssignableAtScope(role, subAssignment.GetScope()) {
 					return nil, trace.BadParameter("update of scoped role %q would invalidate assignment %q which assigns it to user %q at scope %q", role.GetMetadata().GetName(), assignment.GetMetadata().GetName(), assignment.GetSpec().GetUser(), subAssignment.GetScope())
 				}
 			}
@@ -308,12 +341,12 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *accessv
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.UpdateScopedRoleResponse{
+	return &scopedaccessv1.UpdateScopedRoleResponse{
 		Role: scopedRoleWithRevision(role, revision),
 	}, nil
 }
 
-func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *accessv1.DeleteScopedRoleRequest) (*accessv1.DeleteScopedRoleResponse, error) {
+func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
 	roleName := req.GetName()
 	if roleName == "" {
 		return nil, trace.BadParameter("missing scoped role name in delete request")
@@ -373,10 +406,10 @@ func (s *ScopedAccessService) DeleteScopedRole(ctx context.Context, req *accessv
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.DeleteScopedRoleResponse{}, nil
+	return &scopedaccessv1.DeleteScopedRoleResponse{}, nil
 }
 
-func (s *ScopedAccessService) GetScopedRoleAssignment(ctx context.Context, req *accessv1.GetScopedRoleAssignmentRequest) (*accessv1.GetScopedRoleAssignmentResponse, error) {
+func (s *ScopedAccessService) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
 	assignmentName := req.GetName()
 	if assignmentName == "" {
 		return nil, trace.BadParameter("missing scoped role assignment name in get request")
@@ -395,19 +428,51 @@ func (s *ScopedAccessService) GetScopedRoleAssignment(ctx context.Context, req *
 		return nil, trace.Wrap(err)
 	}
 
-	if err := scopedrole.WeakValidateAssignment(assignment); err != nil {
+	if err := scopedaccess.WeakValidateAssignment(assignment); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.GetScopedRoleAssignmentResponse{
+	return &scopedaccessv1.GetScopedRoleAssignmentResponse{
 		Assignment: assignment,
+	}, nil
+}
+
+// ListScopedRoleAssignments returns a paginated list of scoped role assignments.
+// NOTE: this method is only used by local auth caches, and doesn't implement sorting, filtering, or pagination.
+func (s *ScopedAccessService) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	if req.GetPageSize() != 0 {
+		return nil, trace.NotImplemented("page size limits are not implemented for direct backend scoped role assignment reads")
+	}
+
+	if req.GetResourceScope() != nil {
+		return nil, trace.NotImplemented("filtering by resource scope is not implemented for direct backend scoped role assignment reads")
+	}
+
+	if req.GetAssignedScope() != nil {
+		return nil, trace.NotImplemented("filtering by assigned scope is not implemented for direct backend scoped role assignment reads")
+	}
+
+	if req.GetPageToken() != "" {
+		return nil, trace.NotImplemented("pagination is not implemented for direct backend scoped role assignment reads")
+	}
+
+	var out []*scopedaccessv1.ScopedRoleAssignment
+	for assignment, err := range s.StreamScopedRoleAssignments(ctx) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, assignment)
+	}
+
+	return &scopedaccessv1.ListScopedRoleAssignmentsResponse{
+		Assignments: out,
 	}, nil
 }
 
 // StreamScopedRoleAssignments returns a stream of all scoped role assignments in the backend. Malformed assignments are skipped.
 // Returned assignments have had weak validation applied.
-func (s *ScopedAccessService) StreamScopedRoleAssignments(ctx context.Context) stream.Stream[*accessv1.ScopedRoleAssignment] {
-	return func(yield func(*accessv1.ScopedRoleAssignment, error) bool) {
+func (s *ScopedAccessService) StreamScopedRoleAssignments(ctx context.Context) stream.Stream[*scopedaccessv1.ScopedRoleAssignment] {
+	return func(yield func(*scopedaccessv1.ScopedRoleAssignment, error) bool) {
 		startKey := scopedRoleAssignmentKey("")
 		params := backend.ItemsParams{
 			StartKey: startKey,
@@ -428,7 +493,7 @@ func (s *ScopedAccessService) StreamScopedRoleAssignments(ctx context.Context) s
 				continue
 			}
 
-			if err := scopedrole.WeakValidateAssignment(assignment); err != nil {
+			if err := scopedaccess.WeakValidateAssignment(assignment); err != nil {
 				// per-assignment errors are logged and skipped
 				s.logger.WarnContext(ctx, "skipping scoped role assignment due to validation error", "error", err, "key", logutils.StringerAttr(item.Key))
 				continue
@@ -441,20 +506,20 @@ func (s *ScopedAccessService) StreamScopedRoleAssignments(ctx context.Context) s
 	}
 }
 
-func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, req *accessv1.CreateScopedRoleAssignmentRequest) (*accessv1.CreateScopedRoleAssignmentResponse, error) {
+func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
 	assignment := req.GetAssignment()
 	if assignment == nil {
 		return nil, trace.BadParameter("missing scoped role assignment in create request")
 	}
 
-	if err := scopedrole.StrongValidateAssignment(assignment); err != nil {
+	if err := scopedaccess.StrongValidateAssignment(assignment); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// independently enforce the max number of roles per assignment limit here since not all validation
 	// may necessarily enforce it, but it is a hard-limit for the backend impl.
-	if len(assignment.GetSpec().GetAssignments()) > scopedrole.MaxRolesPerAssignment {
-		return nil, trace.BadParameter("scoped role assignment resource %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), scopedrole.MaxRolesPerAssignment)
+	if len(assignment.GetSpec().GetAssignments()) > scopedaccess.MaxRolesPerAssignment {
+		return nil, trace.BadParameter("scoped role assignment resource %q contains too many sub-assignments (max %d)", assignment.GetMetadata().GetName(), scopedaccess.MaxRolesPerAssignment)
 	}
 
 	item, err := scopedRoleAssignmentToItem(assignment)
@@ -478,6 +543,8 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 		},
 	}
 
+	assertedRoles := make(map[string]struct{})
+
 	// set up conditional actions for each assigned role lock
 	for _, subAssignment := range assignment.GetSpec().GetAssignments() {
 		// operation must verify that all associated roles have not been concurrently modified
@@ -489,7 +556,7 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 			return nil, trace.BadParameter("missing role revision for role %q in backend create (this is a bug)", subAssignment.GetRole())
 		}
 
-		rrsp, err := s.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+		rrsp, err := s.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 			Name: subAssignment.GetRole(),
 		})
 		if err != nil {
@@ -508,8 +575,14 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 		}
 
 		// verify that the role is assignable at the specified scope
-		if !scopedrole.RoleIsAssignableAtScope(rrsp.GetRole(), subAssignment.GetScope()) {
+		if !scopedaccess.RoleIsAssignableAtScope(rrsp.GetRole(), subAssignment.GetScope()) {
 			return nil, trace.BadParameter("scoped role %q is not configured to be assignable at scope %q", subAssignment.GetRole(), subAssignment.GetScope())
+		}
+
+		if _, ok := assertedRoles[subAssignment.GetRole()]; ok {
+			// a previous sub-assignment already caused us to assert the revision
+			// of this role, we can skip the assertion/lock update step.
+			continue
 		}
 
 		// assert that role is unchanged and modify associated role lock so that role modifications can
@@ -528,6 +601,8 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 				}),
 			},
 		}...)
+
+		assertedRoles[subAssignment.GetRole()] = struct{}{}
 	}
 
 	revision, err := s.bk.AtomicWrite(ctx, condacts)
@@ -539,18 +614,18 @@ func (s *ScopedAccessService) CreateScopedRoleAssignment(ctx context.Context, re
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.CreateScopedRoleAssignmentResponse{
+	return &scopedaccessv1.CreateScopedRoleAssignmentResponse{
 		Assignment: scopedRoleAssignmentWithRevision(assignment, revision),
 	}, nil
 }
 
-func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, req *accessv1.DeleteScopedRoleAssignmentRequest) (*accessv1.DeleteScopedRoleAssignmentResponse, error) {
+func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
 	assignmentName := req.GetName()
 	if assignmentName == "" {
 		return nil, trace.BadParameter("missing scoped role assignment name in delete request")
 	}
 
-	extant, err := s.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+	extant, err := s.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 		Name: assignmentName,
 	})
 	if err != nil {
@@ -623,7 +698,16 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 		},
 	}
 
+	lockedRoles := make(map[string]struct{})
+
 	for _, subAssignment := range extant.Assignment.GetSpec().GetAssignments() {
+
+		if _, ok := lockedRoles[subAssignment.GetRole()]; ok {
+			// a previous sub-assignment already caused us to update the lock
+			// of this role, we can skip this update step.
+			continue
+		}
+
 		// operation must modify all associated role locks to ensure that role operations can
 		// efficiently assert that no assigment related to the role has changed.
 		condacts = append(condacts, backend.ConditionalAction{
@@ -633,6 +717,8 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 				Value: newRoleAssignmentLockVal(subAssignment.GetRole()),
 			}),
 		})
+
+		lockedRoles[subAssignment.GetRole()] = struct{}{}
 	}
 
 	if _, err := s.bk.AtomicWrite(ctx, condacts); err != nil {
@@ -642,7 +728,7 @@ func (s *ScopedAccessService) DeleteScopedRoleAssignment(ctx context.Context, re
 		return nil, trace.Wrap(err)
 	}
 
-	return &accessv1.DeleteScopedRoleAssignmentResponse{}, nil
+	return &scopedaccessv1.DeleteScopedRoleAssignmentResponse{}, nil
 }
 
 func scopedRoleKey(roleName string) backend.Key {
@@ -681,8 +767,8 @@ func newRoleAssignmentLockVal(roleName string) []byte {
 	return []byte(rand.Text() + "-" + roleName)
 }
 
-func scopedRoleFromItem(item *backend.Item) (*accessv1.ScopedRole, error) {
-	var role accessv1.ScopedRole
+func scopedRoleFromItem(item *backend.Item) (*scopedaccessv1.ScopedRole, error) {
+	var role scopedaccessv1.ScopedRole
 	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, &role); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -697,7 +783,7 @@ func scopedRoleFromItem(item *backend.Item) (*accessv1.ScopedRole, error) {
 	return &role, nil
 }
 
-func scopedRoleToItem(role *accessv1.ScopedRole) (backend.Item, error) {
+func scopedRoleToItem(role *scopedaccessv1.ScopedRole) (backend.Item, error) {
 	if role.GetMetadata() == nil {
 		return backend.Item{}, trace.BadParameter("missing metadata in scoped role")
 	}
@@ -718,8 +804,8 @@ func scopedRoleToItem(role *accessv1.ScopedRole) (backend.Item, error) {
 	}, nil
 }
 
-func scopedRoleAssignmentFromItem(item *backend.Item) (*accessv1.ScopedRoleAssignment, error) {
-	var assignment accessv1.ScopedRoleAssignment
+func scopedRoleAssignmentFromItem(item *backend.Item) (*scopedaccessv1.ScopedRoleAssignment, error) {
+	var assignment scopedaccessv1.ScopedRoleAssignment
 	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, &assignment); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -733,7 +819,7 @@ func scopedRoleAssignmentFromItem(item *backend.Item) (*accessv1.ScopedRoleAssig
 	return &assignment, nil
 }
 
-func scopedRoleAssignmentToItem(assignment *accessv1.ScopedRoleAssignment) (backend.Item, error) {
+func scopedRoleAssignmentToItem(assignment *scopedaccessv1.ScopedRoleAssignment) (backend.Item, error) {
 	if assignment.GetMetadata() == nil {
 		return backend.Item{}, trace.BadParameter("missing metadata in scoped role assignment")
 	}
@@ -755,14 +841,14 @@ func scopedRoleAssignmentToItem(assignment *accessv1.ScopedRoleAssignment) (back
 }
 
 // scopedRoleWithRevision creates a copy of the provided role with an updated revision.
-func scopedRoleWithRevision(role *accessv1.ScopedRole, revision string) *accessv1.ScopedRole {
+func scopedRoleWithRevision(role *scopedaccessv1.ScopedRole, revision string) *scopedaccessv1.ScopedRole {
 	role = apiutils.CloneProtoMsg(role)
 	role.Metadata.Revision = revision
 	return role
 }
 
 // scopedRoleAssignmentWithRevision creates a shallow copy of the provided assignment with an updated revision.
-func scopedRoleAssignmentWithRevision(assignment *accessv1.ScopedRoleAssignment, revision string) *accessv1.ScopedRoleAssignment {
+func scopedRoleAssignmentWithRevision(assignment *scopedaccessv1.ScopedRoleAssignment, revision string) *scopedaccessv1.ScopedRoleAssignment {
 	assignment = apiutils.CloneProtoMsg(assignment)
 	assignment.Metadata.Revision = revision
 	return assignment

--- a/lib/services/local/scoped_access_test.go
+++ b/lib/services/local/scoped_access_test.go
@@ -30,11 +30,11 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend/memory"
-	scopedrole "github.com/gravitational/teleport/lib/scopes/roles"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 // TestScopedRoleEvents verifies the expected behavior of backend events for the ScopedRole family of types.
@@ -58,10 +58,10 @@ func TestScopedRoleEvents(t *testing.T) {
 	watcher, err := events.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{
 			{
-				Kind: scopedrole.KindScopedRole,
+				Kind: scopedaccess.KindScopedRole,
 			},
 			{
-				Kind: scopedrole.KindScopedRoleAssignment,
+				Kind: scopedaccess.KindScopedRoleAssignment,
 			},
 		},
 	})
@@ -85,19 +85,19 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpInit, event.Type)
 
 	// Create a ScopedRole and verify create event is well-formed.
-	role := &accessv1.ScopedRole{
-		Kind: scopedrole.KindScopedRole,
+	role := &scopedaccessv1.ScopedRole{
+		Kind: scopedaccess.KindScopedRole,
 		Metadata: &headerv1.Metadata{
 			Name: "test-role",
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleSpec{
+		Spec: &scopedaccessv1.ScopedRoleSpec{
 			AssignableScopes: []string{"/foo", "/bar"},
 		},
 		Version: types.V1,
 	}
 
-	crsp, err := service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+	crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: role,
 	})
 	require.NoError(t, err)
@@ -105,11 +105,11 @@ func TestScopedRoleEvents(t *testing.T) {
 	event = getNextEvent()
 	require.Equal(t, types.OpPut, event.Type)
 
-	resource := (event.Resource).(types.Resource153UnwrapperT[*accessv1.ScopedRole]).UnwrapT()
+	resource := (event.Resource).(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRole]).UnwrapT()
 	require.Empty(t, cmp.Diff(crsp.Role, resource, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// delete the role and verify delete event is well-formed.
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name: role.Metadata.Name,
 	})
 	require.NoError(t, err)
@@ -118,29 +118,29 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpDelete, event.Type)
 
 	require.Empty(t, cmp.Diff(&types.ResourceHeader{
-		Kind: scopedrole.KindScopedRole,
+		Kind: scopedaccess.KindScopedRole,
 		Metadata: types.Metadata{
 			Name: role.Metadata.Name,
 		},
 	}, event.Resource.(*types.ResourceHeader), protocmp.Transform()))
 
 	// recreate scoped role so that we can use it for testing assignment events
-	crsp, err = service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+	crsp, err = service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: role,
 	})
 	require.NoError(t, err)
 
 	_ = getNextEvent() // drain the role create event
 
-	assignment := &accessv1.ScopedRoleAssignment{
-		Kind: scopedrole.KindScopedRoleAssignment,
+	assignment := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: &headerv1.Metadata{
 			Name: uuid.New().String(),
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleAssignmentSpec{
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: "alice",
-			Assignments: []*accessv1.Assignment{
+			Assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  role.Metadata.Name,
 					Scope: "/foo",
@@ -150,7 +150,7 @@ func TestScopedRoleEvents(t *testing.T) {
 		Version: types.V1,
 	}
 
-	acrsp, err := service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	acrsp, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment,
 		RoleRevisions: map[string]string{
 			role.Metadata.Name: crsp.Role.Metadata.Revision,
@@ -160,11 +160,11 @@ func TestScopedRoleEvents(t *testing.T) {
 
 	event = getNextEvent()
 	require.Equal(t, types.OpPut, event.Type)
-	assignmentResource := (event.Resource).(types.Resource153UnwrapperT[*accessv1.ScopedRoleAssignment]).UnwrapT()
+	assignmentResource := (event.Resource).(types.Resource153UnwrapperT[*scopedaccessv1.ScopedRoleAssignment]).UnwrapT()
 	require.Empty(t, cmp.Diff(acrsp.Assignment, assignmentResource, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// delete the assignment and verify delete event is well-formed.
-	_, err = service.DeleteScopedRoleAssignment(ctx, &accessv1.DeleteScopedRoleAssignmentRequest{
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name: assignment.Metadata.Name,
 	})
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestScopedRoleEvents(t *testing.T) {
 	require.Equal(t, types.OpDelete, event.Type)
 
 	require.Empty(t, cmp.Diff(&types.ResourceHeader{
-		Kind: scopedrole.KindScopedRoleAssignment,
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: types.Metadata{
 			Name: assignment.Metadata.Name,
 		},
@@ -197,36 +197,36 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 
 	service := NewScopedAccessService(backend)
 
-	basicRoles := []*accessv1.ScopedRole{
+	basicRoles := []*scopedaccessv1.ScopedRole{
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "basic-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/foo"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "basic-02",
 			},
 			Scope: "/bar",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/bar/**"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "basic-03",
 			},
 			Scope: "/baz",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/baz/**"},
 			},
 			Version: types.V1,
@@ -237,7 +237,7 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 
 	// verify the expected behavior of CreateScopedRole
 	for _, role := range basicRoles {
-		crsp, err := service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+		crsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 			Role: role,
 		})
 		require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 		require.Empty(t, cmp.Diff(role, crsp.Role, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
 		// Check that the role can be retrieved.
-		grsp, err := service.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+		grsp, err := service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 			Name: role.Metadata.Name,
 		})
 		require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	require.Len(t, revisions, len(basicRoles))
 
 	// verify that create fails if the role already exists
-	_, err = service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+	_, err = service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 		Role: basicRoles[0],
 	})
 	require.Error(t, err)
@@ -268,7 +268,7 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	basic01Mod.Spec.AssignableScopes = []string{"/foo", "/bar"}
 	basic01Mod.Metadata.Revision = revisions[0]
 
-	ursp, err := service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
+	ursp, err := service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
 		Role: basic01Mod,
 	})
 	require.NoError(t, err)
@@ -276,14 +276,14 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	require.Empty(t, cmp.Diff(basic01Mod, ursp.Role, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
 	// verify that update really happened
-	grsp, err := service.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+	grsp, err := service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: basic01Mod.Metadata.Name,
 	})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(ursp.Role, grsp.Role, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// verify that update fails if the revision is wrong
-	_, err = service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
+	_, err = service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
 		Role: basic01Mod,
 	})
 	require.Error(t, err)
@@ -293,22 +293,22 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	basic01Mod = apiutils.CloneProtoMsg(ursp.Role)
 	basic01Mod.Scope = "/foo"
 
-	_, err = service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
+	_, err = service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
 		Role: basic01Mod,
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
 
 	// verify that update fails if the role does not exist
-	_, err = service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
-		Role: &accessv1.ScopedRole{
-			Kind: scopedrole.KindScopedRole,
+	_, err = service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name:     "non-existent",
 				Revision: revisions[0],
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/foo"},
 			},
 			Version: types.V1,
@@ -318,14 +318,14 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that delete fails if the role does not exist
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name: "non-existent",
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that delete fails if the revision does not match
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name:     basicRoles[0].Metadata.Name,
 		Revision: revisions[0],
 	})
@@ -333,27 +333,27 @@ func TestScopedRoleBasicCRUD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify successful unconditional delete
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name: basicRoles[0].Metadata.Name,
 	})
 	require.NoError(t, err)
 
 	// verify that the role is gone
-	_, err = service.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+	_, err = service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: basicRoles[0].Metadata.Name,
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
 	// verify successful conditional delete
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name:     basicRoles[1].Metadata.Name,
 		Revision: revisions[1],
 	})
 	require.NoError(t, err)
 
 	// verify that the role is gone
-	_, err = service.GetScopedRole(ctx, &accessv1.GetScopedRoleRequest{
+	_, err = service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 		Name: basicRoles[1].Metadata.Name,
 	})
 	require.Error(t, err)
@@ -377,36 +377,36 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 
 	service := NewScopedAccessService(backend)
 
-	roles := []*accessv1.ScopedRole{
+	roles := []*scopedaccessv1.ScopedRole{
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-02",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/foo"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-03",
 			},
 			Scope: "/foo",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/foo"},
 			},
 			Version: types.V1,
@@ -417,7 +417,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 
 	// Create the roles.
 	for _, role := range roles {
-		rsp, err := service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+		rsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 			Role: role,
 		})
 		require.NoError(t, err)
@@ -427,15 +427,15 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 
 	// basic root assignment to test standard CRD operations with (initially invalid,
 	// will be modified later to be valid)
-	assignment01 := &accessv1.ScopedRoleAssignment{
-		Kind: scopedrole.KindScopedRoleAssignment,
+	assignment01 := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: &headerv1.Metadata{
 			Name: uuid.New().String(),
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleAssignmentSpec{
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: "alice",
-			Assignments: []*accessv1.Assignment{
+			Assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "role-02", // not assignable to root
 					Scope: "/",
@@ -446,7 +446,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	}
 
 	// check that assignment to root fails since the target role is only assignable to /foo
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-02": roleRevisions[1],
@@ -458,7 +458,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	// check that assignment with an invalid resource scope fails
 	assignment01.Spec.Assignments[0].Role = "role-01" // fix role to be assignable to root
 	assignment01.Scope = "/foo"                       // invalid scope for root assignment
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -469,7 +469,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 
 	// check that assignment of correct role still fails if revision is incorrect
 	assignment01.Scope = "/" // fix scope to be valid for root assignment
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[1], // revision of role-02, not role-01
@@ -479,7 +479,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// check that assignment of correct role with correct revision works
-	crsp, err := service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	crsp, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -490,14 +490,14 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.Empty(t, cmp.Diff(crsp.Assignment, assignment01, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
 	// Check that the assignment can be retrieved.
-	grsp, err := service.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+	grsp, err := service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 		Name: assignment01.Metadata.Name,
 	})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(crsp.Assignment, grsp.Assignment, protocmp.Transform() /* deliberately not ignoring revision */))
 
 	// verify that create fails if the assignment already exists
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -507,7 +507,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that delete of assignment with incorrect revision fails
-	_, err = service.DeleteScopedRoleAssignment(ctx, &accessv1.DeleteScopedRoleAssignmentRequest{
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name:     assignment01.Metadata.Name,
 		Revision: roleRevisions[0],
 	})
@@ -515,29 +515,29 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that delete of assignment with correct revision works
-	_, err = service.DeleteScopedRoleAssignment(ctx, &accessv1.DeleteScopedRoleAssignmentRequest{
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name:     assignment01.Metadata.Name,
 		Revision: crsp.Assignment.Metadata.Revision,
 	})
 	require.NoError(t, err)
 
 	// verify that the assignment is gone
-	_, err = service.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+	_, err = service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 		Name: assignment01.Metadata.Name,
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err), "expected NotFound error, got %v", err)
 
 	// set up a more non-trivial assignment with multiple sub-assignments
-	assignment02 := &accessv1.ScopedRoleAssignment{
-		Kind: scopedrole.KindScopedRoleAssignment,
+	assignment02 := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: &headerv1.Metadata{
 			Name: uuid.New().String(),
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleAssignmentSpec{
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: "bob",
-			Assignments: []*accessv1.Assignment{
+			Assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "role-01",
 					Scope: "/foo",
@@ -556,7 +556,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	}
 
 	// verify that assignment with a mix of conflicting and correct resource scopes fails
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment02,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -569,7 +569,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 
 	// verify that a mix of valid and invalid role revisions fails
 	assignment02.Spec.Assignments = assignment02.Spec.Assignments[:2] // remove role-03 assignment
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment02,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -580,7 +580,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// verify that assignment with some but not all of the role revisions fails
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment02,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -591,7 +591,7 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
 
 	// verify that assignment with all of the role revisions works
-	crsp, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	crsp, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment02,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -603,11 +603,51 @@ func TestScopedRoleAssignmentBasicCRD(t *testing.T) {
 	require.Empty(t, cmp.Diff(crsp.Assignment, assignment02, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
 	// Check that the assignment can be retrieved
-	grsp, err = service.GetScopedRoleAssignment(ctx, &accessv1.GetScopedRoleAssignmentRequest{
+	grsp, err = service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
 		Name: assignment02.Metadata.Name,
 	})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(crsp.Assignment, grsp.Assignment, protocmp.Transform() /* deliberately not ignoring revision */))
+
+	// create an assignment that assigns the same role at multiple separate scopes (covers a specific
+	// bug where original impl would construct invalid conditional actions when multiple sub-assignments
+	// are made for the same role).
+	assignment03 := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
+		Metadata: &headerv1.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: "/",
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			User: "carol",
+			Assignments: []*scopedaccessv1.Assignment{
+				{
+					Role:  "role-01",
+					Scope: "/foo",
+				},
+				{
+					Role:  "role-01",
+					Scope: "/bar",
+				},
+			},
+		},
+		Version: types.V1,
+	}
+
+	// check that creation of assignment works
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: assignment03,
+		RoleRevisions: map[string]string{
+			"role-01": roleRevisions[0],
+		},
+	})
+	require.NoError(t, err)
+
+	// verify that deletion of assignment works
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: assignment03.Metadata.Name,
+	})
+	require.NoError(t, err)
 }
 
 // TestScopedRoleAssignmentInteraction verifies the expected interaction rules between scoped roles and
@@ -627,47 +667,47 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 
 	service := NewScopedAccessService(backend)
 
-	roles := []*accessv1.ScopedRole{
+	roles := []*scopedaccessv1.ScopedRole{
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-01",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-02",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/foo"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-03",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/bar"},
 			},
 			Version: types.V1,
 		},
 		{
-			Kind: scopedrole.KindScopedRole,
+			Kind: scopedaccess.KindScopedRole,
 			Metadata: &headerv1.Metadata{
 				Name: "role-04",
 			},
 			Scope: "/",
-			Spec: &accessv1.ScopedRoleSpec{
+			Spec: &scopedaccessv1.ScopedRoleSpec{
 				AssignableScopes: []string{"/bin"},
 			},
 			Version: types.V1,
@@ -678,7 +718,7 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 
 	// Create the roles.
 	for _, role := range roles {
-		rsp, err := service.CreateScopedRole(ctx, &accessv1.CreateScopedRoleRequest{
+		rsp, err := service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
 			Role: role,
 		})
 		require.NoError(t, err)
@@ -687,15 +727,15 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 	}
 
 	// set up a non-trivial assignment with multiple sub-assignments
-	assignment01 := &accessv1.ScopedRoleAssignment{
-		Kind: scopedrole.KindScopedRoleAssignment,
+	assignment01 := &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
 		Metadata: &headerv1.Metadata{
 			Name: uuid.New().String(),
 		},
 		Scope: "/",
-		Spec: &accessv1.ScopedRoleAssignmentSpec{
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
 			User: "alice",
-			Assignments: []*accessv1.Assignment{
+			Assignments: []*scopedaccessv1.Assignment{
 				{
 					Role:  "role-01",
 					Scope: "/foo",
@@ -713,7 +753,7 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 		Version: types.V1,
 	}
 
-	crsp, err := service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	crsp, err := service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],
@@ -726,14 +766,14 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 	require.Empty(t, cmp.Diff(crsp.Assignment, assignment01, protocmp.Transform(), protocmp.IgnoreFields(&headerv1.Metadata{}, "revision")))
 
 	// check that unrelated role can be deleted
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name:     "role-04",
 		Revision: roleRevisions[3],
 	})
 	require.NoError(t, err)
 
 	// check that deleting a role referenced by an assignment fails
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name:     "role-01",
 		Revision: roleRevisions[0],
 	})
@@ -744,14 +784,14 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 	updatedRole := apiutils.CloneProtoMsg(roles[1])
 	updatedRole.Spec.AssignableScopes = []string{"/bin"} // role-02 is now assignable to /bin, not /foo
 	updatedRole.Metadata.Revision = roleRevisions[1]
-	_, err = service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
+	_, err = service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
 		Role: updatedRole,
 	})
 	require.Error(t, err)
 	require.True(t, trace.IsBadParameter(err), "expected BadParameter error, got %v", err)
 
 	// check that deletion of a role s.t. it would invalidate an assignment fails
-	_, err = service.DeleteScopedRole(ctx, &accessv1.DeleteScopedRoleRequest{
+	_, err = service.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
 		Name:     "role-02",
 		Revision: roleRevisions[1],
 	})
@@ -759,20 +799,20 @@ func TestScopedRoleAssignmentInteraction(t *testing.T) {
 	require.True(t, trace.IsCompareFailed(err), "expected CompareFailed error, got %v", err)
 
 	// delete the assignment
-	_, err = service.DeleteScopedRoleAssignment(ctx, &accessv1.DeleteScopedRoleAssignmentRequest{
+	_, err = service.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
 		Name:     assignment01.Metadata.Name,
 		Revision: crsp.Assignment.Metadata.Revision,
 	})
 	require.NoError(t, err)
 
 	// check that update of role now succeeds
-	urrsp, err := service.UpdateScopedRole(ctx, &accessv1.UpdateScopedRoleRequest{
+	urrsp, err := service.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
 		Role: updatedRole,
 	})
 	require.NoError(t, err)
 
 	// check that recreate of assignment would now fail due to conflicting role
-	_, err = service.CreateScopedRoleAssignment(ctx, &accessv1.CreateScopedRoleAssignmentRequest{
+	_, err = service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
 		Assignment: assignment01,
 		RoleRevisions: map[string]string{
 			"role-01": roleRevisions[0],

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -37,6 +37,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -292,6 +293,10 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindInferenceSecret, nil
 	case types.KindInferencePolicy, "inference_policies":
 		return types.KindInferencePolicy, nil
+	case scopedaccess.KindScopedRole, scopedaccess.KindScopedRole + "s", "scopedrole", "scopedroles":
+		return scopedaccess.KindScopedRole, nil
+	case scopedaccess.KindScopedRoleAssignment, scopedaccess.KindScopedRoleAssignment + "s", "scopedroleassignment", "scopedroleassignments":
+		return scopedaccess.KindScopedRoleAssignment, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }
@@ -976,6 +981,26 @@ func UnmarshalProtoResource[T ProtoResourcePtr[U], U any](data []byte, opts ...M
 		resource.GetMetadata().Expires = timestamppb.New(cfg.Expires)
 	}
 	return resource, nil
+}
+
+// UnmarshalProtoResourceArray unmarshals an array of ProtoResources from JSON using [UnmarshalProtoResource] on each
+// individual element.
+func UnmarshalProtoResourceArray[T ProtoResourcePtr[U], U any](data []byte, opts ...MarshalOption) ([]T, error) {
+	var msgs []json.RawMessage
+	if err := json.Unmarshal(data, &msgs); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resources := make([]T, 0, len(msgs))
+	for _, msg := range msgs {
+		resource, err := UnmarshalProtoResource[T](msg, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
 }
 
 // FastMarshalProtoResourceDeprecated marshals a ProtoResource to JSON using [utils.FastMarshal] and respecting [opts].

--- a/lib/services/scoped.go
+++ b/lib/services/scoped.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"context"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+)
+
+// ScopedAccess provides an API for managing scoped access-control resources.
+type ScopedAccess interface {
+	ScopedAccessReader
+	ScopedAccessWriter
+}
+
+// ScopedAccessReader provides an interface for reading scoped access resources.
+type ScopedAccessReader interface {
+	ScopedRoleReader
+	ScopedRoleAssignmentReader
+}
+
+// ScopedAccessWriter provides an interface for writing scoped access resources.
+type ScopedAccessWriter interface {
+	ScopedRoleWriter
+	ScopedRoleAssignmentWriter
+}
+
+// ScopedRoleReader provides an interface for reading scoped roles.
+type ScopedRoleReader interface {
+	// GetScopedRole gets a scoped role by name.
+	GetScopedRole(context.Context, *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error)
+
+	// ListScopedRoles returns a paginated list of scoped roles.
+	ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error)
+}
+
+// ScopedRoleWriter provides an interface for writing scoped roles.
+type ScopedRoleWriter interface {
+	// CreateScopedRole creates a new scoped role.
+	CreateScopedRole(context.Context, *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error)
+
+	// UpdateScopedRole updates a scoped role.
+	UpdateScopedRole(context.Context, *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error)
+
+	// DeleteScopedRole deletes a scoped role.
+	DeleteScopedRole(context.Context, *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error)
+}
+
+// ScopedRoleAssignmentReader provides an interface for reading scoped role assignments.
+type ScopedRoleAssignmentReader interface {
+	// GetScopedRoleAssignment gets a scoped role assignment by name.
+	GetScopedRoleAssignment(context.Context, *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error)
+
+	// ListScopedRoleAssignments returns a paginated list of scoped role assignments.
+	ListScopedRoleAssignments(context.Context, *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error)
+}
+
+// ScopedRoleAssignmentWriter provides an interface for writing scoped role assignments.
+type ScopedRoleAssignmentWriter interface {
+	// CreateScopedRoleAssignment creates a new scoped role assignment.
+	CreateScopedRoleAssignment(context.Context, *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error)
+
+	// DeleteScopedRoleAssignment deletes a scoped role assignment.
+	DeleteScopedRoleAssignment(context.Context, *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error)
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -42,6 +42,7 @@ import (
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -2154,6 +2155,69 @@ func (c *healthCheckConfigCollection) writeText(w io.Writer, verbose bool) error
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type scopedRoleCollection struct {
+	items []*scopedaccessv1.ScopedRole
+}
+
+func (c *scopedRoleCollection) resources() []types.Resource {
+	out := make([]types.Resource, 0, len(c.items))
+	for _, item := range c.items {
+		out = append(out, types.Resource153ToLegacy(item))
+	}
+	return out
+}
+
+func (c *scopedRoleCollection) writeText(w io.Writer, verbose bool) error {
+	headers := []string{"Scope", "Name"}
+	var rows [][]string
+	for _, item := range c.items {
+		rows = append(rows, []string{
+			item.GetScope(),
+			item.GetMetadata().GetName(),
+		})
+	}
+
+	t := asciitable.MakeTable(headers, rows...)
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type scopedRoleAssignmentCollection struct {
+	items []*scopedaccessv1.ScopedRoleAssignment
+}
+
+func (c *scopedRoleAssignmentCollection) resources() []types.Resource {
+	out := make([]types.Resource, 0, len(c.items))
+	for _, item := range c.items {
+		out = append(out, types.Resource153ToLegacy(item))
+	}
+	return out
+}
+
+func (c *scopedRoleAssignmentCollection) writeText(w io.Writer, verbose bool) error {
+	headers := []string{"Scope", "Name", "Assigns"}
+	var rows [][]string
+
+	for _, item := range c.items {
+		var assigns []string
+		for _, subAssignment := range item.GetSpec().GetAssignments() {
+			assigns = append(assigns, fmt.Sprintf("%s@%s", subAssignment.GetRole(), subAssignment.GetScope()))
+		}
+
+		rows = append(rows, []string{
+			item.GetScope(),
+			item.GetMetadata().GetName(),
+			strings.Join(assigns, ", "),
+		})
+	}
+
+	t := asciitable.MakeTable(headers, rows...)
+
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -54,6 +54,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -73,6 +74,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -194,6 +196,8 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindInferenceModel:                     rc.createInferenceModel,
 		types.KindInferenceSecret:                    rc.createInferenceSecret,
 		types.KindInferencePolicy:                    rc.createInferencePolicy,
+		scopedaccess.KindScopedRole:                  rc.createScopedRole,
+		scopedaccess.KindScopedRoleAssignment:        rc.createScopedRoleAssignment,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:                               rc.updateUser,
@@ -222,6 +226,8 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindHealthCheckConfig:                  rc.updateHealthCheckConfig,
 		types.KindInferenceModel:                     rc.updateInferenceModel,
 		types.KindInferencePolicy:                    rc.updateInferencePolicy,
+		scopedaccess.KindScopedRole:                  rc.updateScopedRole,
+		scopedaccess.KindScopedRoleAssignment:        rc.updateScopedRoleAssignment,
 	}
 	rc.config = config
 
@@ -1237,6 +1243,82 @@ func (rc *ResourceCommand) updateWorkloadIdentityX509IssuerOverride(ctx context.
 	return nil
 }
 
+func (rc *ResourceCommand) createScopedRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	if rc.IsForced() {
+		return trace.BadParameter("scoped role creation does not support --force")
+	}
+
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRole](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := client.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: r,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(
+		rc.Stdout,
+		scopedaccess.KindScopedRole+" %q has been created\n",
+		r.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func (rc *ResourceCommand) updateScopedRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRole](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err = client.ScopedAccessServiceClient().UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: r,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(
+		rc.Stdout,
+		scopedaccess.KindScopedRole+" %q has been updated\n",
+		r.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func (rc *ResourceCommand) createScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	if rc.IsForced() {
+		return trace.BadParameter("scoped role assignment creation does not support --force")
+	}
+
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRoleAssignment](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	rsp, err := client.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: r,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Fprintf(
+		rc.Stdout,
+		scopedaccess.KindScopedRoleAssignment+" %q has been created\n",
+		rsp.GetAssignment().GetMetadata().GetName(), // must extract from rsp since assignment names are generated server-side
+	)
+
+	return nil
+}
+
+func (rc *ResourceCommand) updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	return trace.NotImplemented("scoped_role_assignment resources do not support updates")
+}
+
 func (rc *ResourceCommand) createSigstorePolicy(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	r, err := services.UnmarshalProtoResource[*workloadidentityv1pb.SigstorePolicy](raw.Raw, services.DisallowUnknown())
 	if err != nil {
@@ -2234,6 +2316,28 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		fmt.Fprintf(
 			rc.Stdout,
 			types.KindWorkloadIdentityX509IssuerOverride+" %q has been deleted\n",
+			rc.ref.Name,
+		)
+	case scopedaccess.KindScopedRole:
+		if _, err := client.ScopedAccessServiceClient().DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+			Name: rc.ref.Name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprintf(
+			rc.Stdout,
+			scopedaccess.KindScopedRole+" %q has been deleted\n",
+			rc.ref.Name,
+		)
+	case scopedaccess.KindScopedRoleAssignment:
+		if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+			Name: rc.ref.Name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprintf(
+			rc.Stdout,
+			scopedaccess.KindScopedRoleAssignment+" %q has been deleted\n",
 			rc.ref.Name,
 		)
 	case types.KindSigstorePolicy:
@@ -3594,6 +3698,64 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	case types.KindInferencePolicy:
 		policies, err := rc.getInferencePolicies(ctx, client)
 		return policies, trace.Wrap(err)
+	case scopedaccess.KindScopedRole:
+		if rc.ref.Name != "" {
+			rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+				Name: rc.ref.Name,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return &scopedRoleCollection{items: []*scopedaccessv1.ScopedRole{rsp.Role}}, nil
+		}
+
+		var items []*scopedaccessv1.ScopedRole
+		var cursor string
+		for {
+			rsp, err := client.ScopedAccessServiceClient().ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{
+				PageToken: cursor,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			items = append(items, rsp.Roles...)
+			cursor = rsp.NextPageToken
+			if cursor == "" {
+				break
+			}
+		}
+		return &scopedRoleCollection{items: items}, nil
+	case scopedaccess.KindScopedRoleAssignment:
+		if rc.ref.Name != "" {
+			rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+				Name: rc.ref.Name,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return &scopedRoleAssignmentCollection{items: []*scopedaccessv1.ScopedRoleAssignment{rsp.Assignment}}, nil
+		}
+
+		var items []*scopedaccessv1.ScopedRoleAssignment
+		var cursor string
+		for {
+			rsp, err := client.ScopedAccessServiceClient().ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{
+				PageToken: cursor,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			items = append(items, rsp.Assignments...)
+			cursor = rsp.NextPageToken
+			if cursor == "" {
+				break
+			}
+		}
+		return &scopedRoleAssignmentCollection{items: items}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
This PR backports some older scopes work that got lost in the shuffle during the initial v18 freeze (https://github.com/gravitational/teleport/pull/55190 and https://github.com/gravitational/teleport/pull/56331).