### PR TITLE
Make the filelog cursor time-aware to avoid getting stuck

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3376,7 +3376,7 @@ func TestSearchClusterEvents(t *testing.T) {
 			},
 			Result:        []apievents.AuditEvent{sessionStart},
 			TestStartKey:  true,
-			StartKeyValue: sessionStart.GetID(),
+			StartKeyValue: fmt.Sprintf("%s/%d", sessionStart.GetID(), sessionStart.GetTime().UnixNano()),
 		},
 		{
 			Comment: "Query session start and session end events with limit and given start key",


### PR DESCRIPTION
Fixes the second part of https://github.com/gravitational/teleport/issues/58365 (filelog event streaming is broken). See https://github.com/gravitational/teleport/pull/58765 for the first part.

Filelog event streaming was broken because, unlike other event backend, filelog was not discarding invalid cursors (before the window with ascending order, and after the window in descending order).

In such case, as the file containing the event referenced in the cursor was not loaded in memory, the event was never found, and the query never started/returned events. This led to the issue observed by @programmerq in #58365 .

The fix is to introduce a new cursor format for filelog, including time information to detect and recover from such queries. The new cursor format is `<event-uuid>/<event-time unix nanosecond>`.

changelog: Fixed a bug causing the event-handler to get stuck on single-node Teleport clusters storing events on the filesystem.

