### PR TITLE
Update `--mfa-mode` and `TELEPORT_MFA_MODE` reference docs for SSO MFA

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -645,7 +645,6 @@ Below is a list of environment variables supported by Teleport Connect for Node 
 |----------|---------|------------------|-------------|
 | `TELEPORT_MFA_MODE` | `auto` | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
 | `TELEPORT_ADD_KEYS_TO_AGENT` | `auto` | `auto`, `no`, `yes`, or `only` | Controls how keys are added to a local SSH agent. "auto" adds the keys only if the agent supports SSH certificates, "no" never attempts to add them, "yes" always attempts to add them, "only" always attempts to add the keys to the agent but it does not save them on disk. |
-| `TELEPORT_HEADLESS_SKIP_CONFIRM` | `false` | `true` or `false` | Skips the confirmation prompt for Headless Authentication approval and instead prompts for MFA immediately. | 
 | `TELEPORT_NO_RESUME` | `false` | `true` or `false` | Disables SSH connection resumption. |
 
 For example, instead of settings `ssh.addKeysToAgent=no`, you could set `TELEPORT_ADD_KEYS_TO_AGENT=no` in

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -633,6 +633,15 @@ Below is the list of the supported config properties.
   It should not be modified.
 </Admonition>
 
+### tsh Environment Variables
+
+Under the hood, Teleport Connect uses `tsh` for several of its features. As a result, Teleport Connect
+will respect [tsh Environment Variables](../reference/cli/tsh.mdx#tsh-environment-variables) in many cases.
+This can make it easier to share common settings between `tsh` into your Teleport Connect App.
+
+For example, instead of settings `ssh.addKeysToAgent=no`, you could set `TELEPORT_ADD_KEYS_TO_AGENT=no` in
+your shell startup file to configure both `tsh` and Teleport Connect.
+
 ### Configuring keyboard shortcuts
 
 A valid shortcut contains at least one modifier and a single key code, for example `Shift+Tab`.

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -633,11 +633,20 @@ Below is the list of the supported config properties.
   It should not be modified.
 </Admonition>
 
-### tsh Environment Variables
+### `tsh ssh` environment variables
 
-Under the hood, Teleport Connect uses `tsh` for several of its features. As a result, Teleport Connect
-will respect [tsh Environment Variables](../reference/cli/tsh.mdx#tsh-environment-variables) in many cases.
-This can make it easier to share common settings between `tsh` into your Teleport Connect App.
+Under the hood, Teleport Connect uses `tsh ssh` to connect to Nodes. As a result,
+Teleport Connect will respect many [tsh Environment Variables](../reference/cli/tsh.mdx#tsh-environment-variables)
+related to `tsh ssh`. This can make it easier to share common settings between `tsh` into your Teleport Connect App.
+
+Below is a list of environment variables supported by Teleport Connect for Node connections:
+
+| Property | Default | Allowed Value(s) | Description |
+|----------|---------|------------------|-------------|
+| `TELEPORT_MFA_MODE` | `auto` | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
+| `TELEPORT_ADD_KEYS_TO_AGENT` | `auto` | `auto`, `no`, `yes`, or `only` | Controls how keys are added to a local SSH agent. "auto" adds the keys only if the agent supports SSH certificates, "no" never attempts to add them, "yes" always attempts to add them, "only" always attempts to add the keys to the agent but it does not save them on disk. |
+| `TELEPORT_HEADLESS_SKIP_CONFIRM` | `false` | `true` or `false` | Skips the confirmation prompt for Headless Authentication approval and instead prompts for MFA immediately. | 
+| `TELEPORT_NO_RESUME` | `false` | `true` or `false` | Disables SSH connection resumption. |
 
 For example, instead of settings `ssh.addKeysToAgent=no`, you could set `TELEPORT_ADD_KEYS_TO_AGENT=no` in
 your shell startup file to configure both `tsh` and Teleport Connect.

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -633,20 +633,6 @@ Below is the list of the supported config properties.
   It should not be modified.
 </Admonition>
 
-### `tsh ssh` environment variables
-
-Under the hood, Teleport Connect uses `tsh ssh` to connect to SSH servers. As a result,
-Teleport Connect will respect many [tsh environment variables](../reference/cli/tsh.mdx#tsh-environment-variables)
-related to `tsh ssh`. This can make it easier to share common settings between `tsh` and Teleport Connect.
-
-Below is a list of environment variables supported by Teleport Connect for SSH connections:
-
-| Property | Default | Allowed Value(s) | Description |
-|----------|---------|------------------|-------------|
-| `TELEPORT_MFA_MODE` | `auto` | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
-| `TELEPORT_ADD_KEYS_TO_AGENT` | `auto` | `auto`, `no`, `yes`, or `only` | Controls how keys are added to a local SSH agent. "auto" adds the keys only if the agent supports SSH certificates, "no" never attempts to add them, "yes" always attempts to add them, "only" always attempts to add the keys to the agent but it does not save them on disk. |
-| `TELEPORT_NO_RESUME` | `false` | `true` or `false` | Disables SSH connection resumption. |
-
 ### Configuring keyboard shortcuts
 
 A valid shortcut contains at least one modifier and a single key code, for example `Shift+Tab`.
@@ -664,6 +650,20 @@ Available key codes:
 - `F1` to `F24`
 - `,`, `.`, `/`, `\`, `` ` ``, `-`, `=`, `;`, `'`, `[`, `]`
 - `Space`, `Tab`, `CapsLock`, `NumLock`, `ScrollLock`, `Backspace`, `Delete`, `Insert`, `Enter`, `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Escape`, `IntlBackslash`
+
+### `tsh ssh` environment variables
+
+Under the hood, Teleport Connect uses `tsh ssh` to connect to SSH servers. As a result,
+Teleport Connect will respect many [tsh environment variables](../reference/cli/tsh.mdx#tsh-environment-variables)
+related to `tsh ssh`. This can make it easier to share common settings between `tsh` and Teleport Connect.
+
+Below is a list of environment variables supported by Teleport Connect for SSH connections:
+
+| Property | Default | Allowed Value(s) | Description |
+|----------|---------|------------------|-------------|
+| `TELEPORT_MFA_MODE` | `auto` | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
+| `TELEPORT_ADD_KEYS_TO_AGENT` | `auto` | `auto`, `no`, `yes`, or `only` | Controls how keys are added to a local SSH agent. "auto" adds the keys only if the agent supports SSH certificates, "no" never attempts to add them, "yes" always attempts to add them, "only" always attempts to add the keys to the agent but it does not save them on disk. |
+| `TELEPORT_NO_RESUME` | `false` | `true` or `false` | Disables SSH connection resumption. |
 
 ## Telemetry
 

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -635,11 +635,11 @@ Below is the list of the supported config properties.
 
 ### `tsh ssh` environment variables
 
-Under the hood, Teleport Connect uses `tsh ssh` to connect to Nodes. As a result,
-Teleport Connect will respect many [tsh Environment Variables](../reference/cli/tsh.mdx#tsh-environment-variables)
-related to `tsh ssh`. This can make it easier to share common settings between `tsh` into your Teleport Connect App.
+Under the hood, Teleport Connect uses `tsh ssh` to connect to SSH servers. As a result,
+Teleport Connect will respect many [tsh environment variables](../reference/cli/tsh.mdx#tsh-environment-variables)
+related to `tsh ssh`. This can make it easier to share common settings between `tsh` and Teleport Connect.
 
-Below is a list of environment variables supported by Teleport Connect for Node connections:
+Below is a list of environment variables supported by Teleport Connect for SSH connections:
 
 | Property | Default | Allowed Value(s) | Description |
 |----------|---------|------------------|-------------|

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -647,9 +647,6 @@ Below is a list of environment variables supported by Teleport Connect for SSH c
 | `TELEPORT_ADD_KEYS_TO_AGENT` | `auto` | `auto`, `no`, `yes`, or `only` | Controls how keys are added to a local SSH agent. "auto" adds the keys only if the agent supports SSH certificates, "no" never attempts to add them, "yes" always attempts to add them, "only" always attempts to add the keys to the agent but it does not save them on disk. |
 | `TELEPORT_NO_RESUME` | `false` | `true` or `false` | Disables SSH connection resumption. |
 
-For example, instead of settings `ssh.addKeysToAgent=no`, you could set `TELEPORT_ADD_KEYS_TO_AGENT=no` in
-your shell startup file to configure both `tsh` and Teleport Connect.
-
 ### Configuring keyboard shortcuts
 
 A valid shortcut contains at least one modifier and a single key code, for example `Shift+Tab`.

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -17,7 +17,7 @@ Environment variables configure your tsh client and can help you avoid using fla
 | Environment Variable | Description | Example Value |
 | - | - | - |
 | TELEPORT_AUTH | Any defined [authentication connector](../access-controls/authentication.mdx), including `passwordless` and `local` (i.e., no authentication connector) | okta |
-| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | otp |
+| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | auto, cross-platform, platform, otp, sso |
 | TELEPORT_CLUSTER | Name of a Teleport root or leaf cluster | cluster.example.com |
 | TELEPORT_LOGIN | Login name to be used by default on the remote host | root |
 | TELEPORT_LOGIN_BIND_ADDR | Address in the form of host:port to bind to for login command webhook | host:port |
@@ -43,7 +43,7 @@ Environment variables configure your tsh client and can help you avoid using fla
 | `--cert-format` | `standard` | `standard` or `oldssh` | SSH certificate format. `oldssh` supports older versions of OpenSSH servers that do not allow for custom metadata, which is how Teleport encodes a user's roles in their SSH certificate. |
 | `--insecure` | none | none | Do not verify the server's certificate and host name. Use only in test environments. |
 | `--auth` | `local` | Any defined [authentication connector](../access-controls/authentication.mdx), including `passwordless` and `local` (i.e., no authentication connector) | Specify the type of authentication connector to use. |
-| `--mfa-mode` | auto | `auto`, `cross-platform`, `platform` or `otp` | Preferred mode for MFA and Passwordless assertions. |
+| `--mfa-mode` | auto | `auto`, `cross-platform`, `platform`, `otp`, or `sso` | Preferred mode for MFA and Passwordless assertions. |
 | `--skip-version-check` | none | none | Skip version checking between server and client. |
 | `-d, --debug` | none | none | Verbose logging to stdout |
 | `-J, --jumphost` | none | A jump host | SSH jumphost |

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -17,18 +17,18 @@ Environment variables configure your tsh client and can help you avoid using fla
 | Environment Variable | Description | Example Value |
 | - | - | - |
 | TELEPORT_AUTH | Any defined [authentication connector](../access-controls/authentication.mdx), including `passwordless` and `local` (i.e., no authentication connector) | okta |
-| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | auto, cross-platform, platform, otp, sso |
 | TELEPORT_CLUSTER | Name of a Teleport root or leaf cluster | cluster.example.com |
 | TELEPORT_LOGIN | Login name to be used by default on the remote host | root |
 | TELEPORT_LOGIN_BIND_ADDR | Address in the form of host:port to bind to for login command webhook | host:port |
 | TELEPORT_LOGIN_BROWSER | Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser. | none |
 | TELEPORT_PROXY | Address of the Teleport proxy server | cluster.example.com:3080 |
+| TELEPORT_HEADLESS | Use headless authentication | true, false, 1, 0 |
 | TELEPORT_HOME | Home location for tsh configuration and data | /directory |
 | TELEPORT_USER | A Teleport user name | alice |
 | TELEPORT_ADD_KEYS_TO_AGENT | Specifies if the user certificate should be stored on the running SSH agent | yes, no, auto, only |
 | TELEPORT_USE_LOCAL_SSH_AGENT | Disable or enable local SSH agent integration | true, false |
 | TELEPORT_GLOBAL_TSH_CONFIG | Override location of global `tsh` config file from default `/etc/tsh.yaml` | /opt/teleport/tsh.yaml |
-| TELEPORT_HEADLESS | Use headless authentication | true, false, 1, 0 |
+| TELEPORT_MFA_MODE | Preferred mode for MFA and Passwordless assertions | auto, cross-platform, platform, otp, sso |
 | TELEPORT_IDENTITY_FILE | File path to identity file | /opt/identity |
 
 ## tsh global flags

--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -185,11 +185,11 @@ func (c *CLIPrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 	// If there are multiple options and we chose one without it being specifically
 	// requested by the user, notify the user about it and how to request a specific method.
 	if len(availableMethods) > len(chosenMethods) && len(chosenMethods) > 0 && !userSpecifiedMethod {
+		availableMethodsString := strings.ToLower(strings.Join(availableMethods, ","))
 		const msg = "" +
 			"Available MFA methods [%v]. Continuing with %v.\n" +
-			"If you wish to perform MFA with another method, specify with flag --mfa-mode=<%v>.\n\n"
-
-		fmt.Fprintf(c.writer(), msg, strings.Join(availableMethods, ", "), strings.Join(chosenMethods, " and "), strings.ToLower(strings.Join(availableMethods, ",")))
+			"If you wish to perform MFA with another method, specify with flag --mfa-mode=<%v> or environment variable TELEPORT_MFA_MODE=<%v>.\n\n"
+		fmt.Fprintf(c.writer(), msg, strings.Join(availableMethods, ", "), strings.Join(chosenMethods, " and "), availableMethodsString, availableMethodsString)
 	}
 
 	// We should never prompt for OTP when per-session MFA is enabled. As long as other MFA methods are available,

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -159,7 +159,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK prefer webauthn over sso",
 			expectStdOut: "" +
 				"Available MFA methods [WEBAUTHN, SSO]. Continuing with WEBAUTHN.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso>.\n\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso> or environment variable TELEPORT_MFA_MODE=<webauthn,sso>.\n\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -175,7 +175,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK prefer webauthn+otp over sso",
 			expectStdOut: "" +
 				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp>.\n\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\n\n" +
 				"Tap any security key or enter a code from a OTP device\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -195,7 +195,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK prefer sso over otp",
 			expectStdOut: "" +
 				"Available MFA methods [SSO, OTP]. Continuing with SSO.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.\n\n",
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp> or environment variable TELEPORT_MFA_MODE=<sso,otp>.\n\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				TOTP:         &proto.TOTPChallenge{},
 				SSOChallenge: &proto.SSOChallenge{},
@@ -213,7 +213,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK prefer webauthn over otp when stdin hijack disallowed",
 			expectStdOut: "" +
 				"Available MFA methods [WEBAUTHN, OTP]. Continuing with WEBAUTHN.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,otp>.\n\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,otp>.\n\n" +
 				"Tap any security key\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -229,7 +229,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK webauthn or otp with stdin hijack allowed, choose webauthn",
 			expectStdOut: "" +
 				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp>.\n\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\n\n" +
 				"Tap any security key or enter a code from a OTP device\n",
 			challenge: &proto.MFAAuthenticateChallenge{
 				WebauthnChallenge: &webauthnpb.CredentialAssertion{},
@@ -249,7 +249,7 @@ func TestCLIPrompt(t *testing.T) {
 			name: "OK webauthn or otp with stdin hijack allowed, choose otp",
 			expectStdOut: "" +
 				"Available MFA methods [WEBAUTHN, SSO, OTP]. Continuing with WEBAUTHN and OTP.\n" +
-				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp>.\n\n" +
+				"If you wish to perform MFA with another method, specify with flag --mfa-mode=<webauthn,sso,otp> or environment variable TELEPORT_MFA_MODE=<webauthn,sso,otp>.\n\n" +
 				"Tap any security key or enter a code from a OTP device\n",
 			stdin: "123456",
 			challenge: &proto.MFAAuthenticateChallenge{


### PR DESCRIPTION
This PR updates the `--mfa-mode` and `TELEPORT_MFA_MODE` reference docs for SSO MFA. It also updates the `tsh` MFA prompt to mention `TELEPORT_MFA_MODE` and adds a section to the Teleport Connect configuration docs to mention `tsh` Environment Variables.

Updates https://github.com/gravitational/teleport/issues/58825