### PR TITLE
fix: session end event's participants

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -368,7 +368,7 @@ loop:
 				desktopSessionEnd.Code = DesktopSessionEndCode
 				desktopSessionEnd.ClusterName = e.ClusterName
 				desktopSessionEnd.StartTime = e.Time
-				desktopSessionEnd.Participants = append(desktopSessionEnd.Participants, e.User)
+				desktopSessionEnd.Participants = append(desktopSessionEnd.Participants, transformedUsername(e.UserMetadata, u.cfg.ClusterName))
 				desktopSessionEnd.Recorded = true
 				desktopSessionEnd.UserMetadata = e.UserMetadata
 				desktopSessionEnd.SessionMetadata = e.SessionMetadata
@@ -392,10 +392,10 @@ loop:
 				sshSessionEnd.InitialCommand = e.InitialCommand
 				sshSessionEnd.SessionRecording = e.SessionRecording
 				sshSessionEnd.Interactive = e.TerminalSize != ""
-				sshSessionEnd.Participants = append(sshSessionEnd.Participants, e.User)
+				sshSessionEnd.Participants = append(sshSessionEnd.Participants, transformedUsername(e.UserMetadata, u.cfg.ClusterName))
 
 			case *events.SessionJoin:
-				sshSessionEnd.Participants = append(sshSessionEnd.Participants, e.User)
+				sshSessionEnd.Participants = append(sshSessionEnd.Participants, transformedUsername(e.UserMetadata, u.cfg.ClusterName))
 			}
 
 		case err := <-errors:
@@ -439,4 +439,14 @@ loop:
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func transformedUsername(u events.UserMetadata, localCluster string) string {
+	return services.UsernameForCluster(
+		services.UsernameForClusterConfig{
+			User:              u.User,
+			OriginClusterName: u.UserClusterName,
+			LocalClusterName:  localCluster,
+		},
+	)
 }

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/recorder"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
+	"github.com/gravitational/teleport/lib/services"
 	tsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1323,7 +1324,14 @@ func (s *session) unlockedLeave(id uuid.UUID) (bool, error) {
 func (s *session) allParticipants() []string {
 	var participants []string
 	for _, p := range s.partiesHistorical {
-		participants = append(participants, p.Ctx.User.GetName())
+		username := services.UsernameForCluster(
+			services.UsernameForClusterConfig{
+				User:              p.Ctx.Identity.GetIdentity().Username,
+				OriginClusterName: p.Ctx.Identity.GetIdentity().OriginClusterName,
+				LocalClusterName:  p.Ctx.Identity.GetIdentity().TeleportCluster,
+			},
+		)
+		participants = append(participants, username)
 	}
 
 	return participants

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Audit defines an interface for database access audit events logger.
@@ -176,7 +177,15 @@ func (a *audit) OnSessionEnd(ctx context.Context, session *Session) {
 		ConnectionMetadata: MakeConnectionMetadata(session),
 		DatabaseMetadata:   MakeDatabaseMetadata(session),
 		StartTime:          session.StartTime,
-		Participants:       []string{session.Identity.GetUserMetadata().User},
+		Participants: []string{
+			services.UsernameForCluster(
+				services.UsernameForClusterConfig{
+					User:              session.Identity.Username,
+					OriginClusterName: session.Identity.OriginClusterName,
+					LocalClusterName:  session.Identity.TeleportCluster,
+				},
+			),
+		},
 	}
 	endTime := a.cfg.Clock.Now()
 	event.SetTime(endTime)

--- a/lib/srv/desktop/audit.go
+++ b/lib/srv/desktop/audit.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -151,7 +152,14 @@ func (d *desktopSessionAuditor) makeSessionEnd(recorded bool) *events.WindowsDes
 		Recorded:              recorded,
 
 		// There can only be 1 participant, desktop sessions are not join-able.
-		Participants: []string{userMetadata.User},
+		Participants: []string{
+			services.UsernameForCluster(
+				services.UsernameForClusterConfig{
+					User:              d.identity.Username,
+					OriginClusterName: d.identity.OriginClusterName,
+					LocalClusterName:  d.clusterName,
+				},
+			)},
 	}
 }
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1235,13 +1235,27 @@ func (s *session) emitSessionEndEvent() {
 	}
 
 	for _, p := range s.participants {
-		sessionEndEvent.Participants = append(sessionEndEvent.Participants, p.user)
+		username := services.UsernameForCluster(
+			services.UsernameForClusterConfig{
+				User:              p.user,
+				OriginClusterName: p.originCluster,
+				LocalClusterName:  ctx.ClusterName,
+			},
+		)
+		sessionEndEvent.Participants = append(sessionEndEvent.Participants, username)
 	}
 
 	// If there are 0 participants, this is an exec session.
 	// Use the user from the session context.
 	if len(s.participants) == 0 {
-		sessionEndEvent.Participants = []string{s.scx.Identity.TeleportUser}
+		username := services.UsernameForCluster(
+			services.UsernameForClusterConfig{
+				User:              s.scx.Identity.TeleportUser,
+				OriginClusterName: s.scx.Identity.OriginClusterName,
+				LocalClusterName:  ctx.ClusterName,
+			},
+		)
+		sessionEndEvent.Participants = []string{username}
 	}
 
 	preparedEvent, err := s.Recorder().PrepareSessionEvent(sessionEndEvent)


### PR DESCRIPTION
Similarly to #58853, session's end events also showed inconsistencies in participant fiedls for different protocols.

This created an issue where root users couldn't watch session recordings they participated depending on the protocol, while some local users could.

Since ithe session's participants field is a repeated string, we can't apply the same logic as in #58853, so we need to transform the username prior to emitting the session end events. This will allow leaf users to see their recordings.

Fixes #12324
Fixes gravitational/teleport-private#166

Changelog: Fixed a bug that prevented root users from viewing session recordings when they were participants.