### PR TITLE
Remove unused dev features from Connect

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -19,7 +19,7 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import { app, dialog, globalShortcut, nativeTheme, shell } from 'electron';
+import { app, dialog, nativeTheme, shell } from 'electron';
 
 import { CUSTOM_PROTOCOL } from 'shared/deepLinks';
 import { ensureError } from 'shared/utils/error';
@@ -123,7 +123,6 @@ async function initializeApp(): Promise<void> {
       }
     };
 
-    globalShortcut.unregisterAll();
     await Promise.all([appStateFileStorage.write(), disposeMainProcess()]); // none of them can throw
     app.exit();
   });

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -113,25 +113,6 @@ async function initializeApp(): Promise<void> {
     return;
   }
 
-  //TODO(gzdunek): Make sure this is not needed after migrating to Vite.
-  app.on(
-    'certificate-error',
-    (event, webContents, url, error, certificate, callback) => {
-      // allow certs errors for localhost:8080
-      if (
-        settings.dev &&
-        new URL(url).host === 'localhost:8080' &&
-        error === 'net::ERR_CERT_AUTHORITY_INVALID'
-      ) {
-        event.preventDefault();
-        callback(true);
-      } else {
-        callback(false);
-        console.error(error);
-      }
-    }
-  );
-
   app.on('will-quit', async event => {
     event.preventDefault();
     const disposeMainProcess = async () => {


### PR DESCRIPTION
1. Relaunching the app with F6 reopens the app with a blank screen.
  In logs there is: 
  ```
electron: Failed to load URL: http://localhost:8080/ with error: ERR_CONNECTION_REFUSE
  ```
  which likely means that the Vite dev server has been killed. I'm not sure for how long this is broken, I haven't used it for a long time. Probably not worth fixing as we can run the app in the watch mode (`pnpm start-term -w`).
2. Handling cert errors doesn't do anything as the UI is severed over the plain HTTP. AFAIR this was added during Windows support work, but I just tested the dev version on Windows and didn't encounter any issues.