### PR TITLE
Tag MWI docs pages by use case and cloud

### DIFF
--- a/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
@@ -4,6 +4,7 @@ description: Managing AI Agents with Machine & Workload Identity
 labels:
  - conceptual
  - mwi
+ - ai
 ---
 
 ## Enforce access and privileges for agents

--- a/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
+++ b/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
@@ -4,6 +4,7 @@ description: Managing hybrid and multi-cloud systems with Machine & Workload Ide
 labels:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Machine & Workload Identity streamlines hybrid and multi-cloud operations while reducing management costs. 

--- a/docs/pages/machine-workload-identity/iac-mwi.mdx
+++ b/docs/pages/machine-workload-identity/iac-mwi.mdx
@@ -4,6 +4,7 @@ description: Configuring IaC with Machine & Workload Identity
 labels:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Machine & Workload Identity replaces long-lived static secrets in Infrastructure-as-Code (IaC) tools with short-lived, 

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/access-guides.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/access-guides.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID to enable secure access to Teleport resources
 layout: tocless-doc
 tags:
  - mwi
+ - infrastructure-identity
 ---
 
 These guides cover how to configure a deployed Machine ID to produce credentials

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/ansible.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/ansible.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID with Ansible
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/applications.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/applications.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID to access applications
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID to enable Argo CD to connect to external Kube
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes. It

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/databases.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/databases.mdx
@@ -5,6 +5,7 @@ description: How to use Machine ID to access database servers
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/kubernetes.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID to access Kubernetes clusters
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/mcp.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/mcp.mdx
@@ -4,6 +4,8 @@ description: How to use Machine & Workload Identity to access MCP servers
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - mcp
 ---
 
 Teleport protects and control access to Model Context Protocol (MCP) servers.

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/ssh.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID to access servers via SSH
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/tctl.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/tctl.mdx
@@ -4,6 +4,7 @@ description: How to use Machine ID with tctl to manage your Teleport configurati
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/aws.mdx
@@ -4,6 +4,8 @@ description: How to install and configure Machine ID on an AWS EC2 instance
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - aws
 ---
 
 This guide shows you how to deploy `tbot` on Amazon Web Services and connect it to your Teleport cluster.

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -4,6 +4,8 @@ description: How to install and configure Machine ID on Azure DevOps.
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - azure
 ---
 
 In this guide, you will configure Machine ID's agent, `tbot`, to run within a

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure.mdx
@@ -4,6 +4,8 @@ description: How to install and configure Machine ID on an Azure VM
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - azure
 ---
 
 In this guide, you will install Machine ID's agent, `tbot` on an Azure VM. The

--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on Bitbucket Pipelines
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 In this guide, you will configure Machine ID's agent, `tbot`, to run within a

--- a/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on CircleCI
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 The first step to set up Machine ID is to deploy the `tbot` binary and join a

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gcp.mdx
@@ -4,6 +4,8 @@ description: How to install and configure Machine ID on a GCP VM
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - google-cloud
 ---
 
 This guide explains how to deploy Machine ID on Google Cloud Platform (GCP) by

--- a/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on GitHub Actions
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on GitLab CI
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on Jenkins
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes-oidc.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes-oidc.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on Kubernetes with OIDC
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 This guide shows you how to deploy the Machine ID daemon `tbot` on a Kubernetes

--- a/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on Kubernetes with Static J
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 This guide shows you how to deploy the Machine ID daemon `tbot`, on a Kubernetes

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux-tpm.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux-tpm.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on a Linux host and use a T
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 This page explains how to deploy Machine ID on a Linux host, and use the

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Machine ID on a Linux host
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 This page explains how to deploy Machine ID on a Linux host.

--- a/docs/pages/machine-workload-identity/machine-id/faq.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/faq.mdx
@@ -4,6 +4,7 @@ description: Frequently asked questions about Teleport Machine ID
 tags:
  - faq
  - mwi
+ - infrastructure-identity
 ---
 
 This page provides answers to frequently asked questions about Machine ID. For a

--- a/docs/pages/machine-workload-identity/machine-id/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/getting-started.mdx
@@ -4,6 +4,7 @@ description: Getting started with Teleport Machine ID
 tags:
  - get-started
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/machine-id/introduction.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/introduction.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Machine ID enables machines, such as CI/CD workflows, to securely

--- a/docs/pages/machine-workload-identity/machine-id/machine-id.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/machine-id.mdx
@@ -3,6 +3,7 @@ title: Machine ID
 description: Guides to using Machine ID, which allows you to provide secure access to your infrastructure from automated services.
 tags:
  - mwi
+ - infrastructure-identity
 ---
 
 This section includes guides to using Machine ID, which allows you to provide

--- a/docs/pages/machine-workload-identity/machine-id/manifesto.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/manifesto.mdx
@@ -4,6 +4,7 @@ description: A manifesto for Machine Identity
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 The world of machine identity is changing. Machines are trusted to complete

--- a/docs/pages/machine-workload-identity/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/troubleshooting.mdx
@@ -4,6 +4,7 @@ description: Troubleshooting common issues with Machine ID
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 This page provides resolution steps for issues that you may come across when

--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -3,6 +3,7 @@ title: "Teleport Machine & Workload Identity"
 description: "Provides information on Zero Trust Access & Flexible Workload Identity."
 tags:
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Machine & Workload Identity offers two complementary sets of capabilities for non-human entities in your infrastructure:

--- a/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
+++ b/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
@@ -4,6 +4,7 @@ description: Configuring CI/CD with Machine & Workload Identity
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Machine & Workload Identity eliminates the need for long-lived static secrets in CI/CD pipelines by issuing short-lived 

--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -4,6 +4,8 @@ description: Configuring AWS to accept Workload Identity JWTs as authentication 
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - aws
 ---
 
 Teleport Workload Identity issues flexible short-lived identities in JWT format.

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -4,6 +4,8 @@ description: Configuring AWS to accept Workload Identity certificates as authent
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - aws
 ---
 
 Teleport Workload Identity issues flexible short-lived identities in X.509

--- a/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
@@ -4,6 +4,8 @@ description: Configuring Azure to accept Workload Identity JWTs as authenticatio
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - azure
 ---
 
 Teleport Workload Identity issues flexible short-lived identities in JWT format.

--- a/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
@@ -4,6 +4,7 @@ description: Answers common questions and describes best practices for using Tel
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 This page covers common questions and best practices for using Teleport's

--- a/docs/pages/machine-workload-identity/workload-identity/federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/federation.mdx
@@ -4,6 +4,7 @@ description: An overview of the Teleport Workload Identity SPIFFE Federation fea
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Federation allows a relationship to be established between your Teleport

--- a/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -4,6 +4,8 @@ description: Configuring GCP to accept Workload Identity JWTs as authentication 
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
+ - google-cloud
 ---
 
 Teleport Workload Identity issues flexible short-lived identities in JWT format.

--- a/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
@@ -4,6 +4,7 @@ description: Getting started with Teleport Workload Identity for SPIFFE and Mach
 tags:
  - get-started
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport's Workload Identity issues flexible short-lived identities intended

--- a/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
@@ -4,6 +4,7 @@ description: Describes Teleport Workload Identity, which securely issues flexibl
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Teleport Workload Identity securely issues short-lived cryptographic identities

--- a/docs/pages/machine-workload-identity/workload-identity/jwt-svids.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/jwt-svids.mdx
@@ -4,6 +4,7 @@ description: An overview of the JWT SVIDs issued by Teleport Workload Identity
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 One type of credential that can be issued by Teleport Workload Identity is a

--- a/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/spiffe.mdx
@@ -4,6 +4,7 @@ description: Learn about Secure Production Identity Framework For Everyone (SPIF
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 SPIFFE (Secure Production Identity Framework For Everyone) is a set of standards

--- a/docs/pages/machine-workload-identity/workload-identity/tsh.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/tsh.mdx
@@ -4,6 +4,7 @@ description: Issuing SPIFFE SVIDs using Workload Identity and tsh
 tags:
  - how-to
  - mwi
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
@@ -3,6 +3,7 @@ title: Workload Identity
 description: Securely issue flexible short-lived identities to your workloads
 tags:
  - mwi
+ - infrastructure-identity
 ---
 
 The guides in this section explain how to use Workload Identity, which securely

--- a/docs/pages/machine-workload-identity/workload-mwi.mdx
+++ b/docs/pages/machine-workload-identity/workload-mwi.mdx
@@ -4,6 +4,7 @@ description: Managing Service to Service mTLS with Machine & Workload Identity
 labels:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 Using Workload Identity certificates reduces the risk of credential exfiltration and provides 


### PR DESCRIPTION
Tag pages in the MWI section of the docs with the appropriate use case and cloud provider tags. Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.