### PR TITLE
docs: Adding links for product headers on docs homepage

### DIFF
--- a/docs/pages/includes/homepage/products.mdx
+++ b/docs/pages/includes/homepage/products.mdx
@@ -9,6 +9,7 @@ import ISSvg from "@site/src/components/Icon/teleport-svg/identity-security.svg"
     {
       id: 'zero-trust-access',
       title: 'Zero Trust Access',
+      href: './zero-trust-access/',
       description: 'Easy access to all your infrastructure on a foundation of cryptographic identity',
       iconColor: '#EEEAFA',
       iconComponent: zeroTrustSvg,
@@ -78,6 +79,7 @@ import ISSvg from "@site/src/components/Icon/teleport-svg/identity-security.svg"
     {
       id: 'machine-workload-identity',
       title: 'Machine and Workload Identity',
+      href: './machine-workload-identity/',
       description: 'Replace long-lived secrets with identity-based authentication and authorization',
       iconColor: '#EEEAFA',
       iconComponent: MWISvg,
@@ -117,6 +119,7 @@ import ISSvg from "@site/src/components/Icon/teleport-svg/identity-security.svg"
     {
       id: 'identity-governance',
       title: 'Identity Governance',
+      href: './identity-governance/',
       description: 'Manage identities by enforcing principles of least privilege and zero trust',
       iconColor: '#EEEAFA',
       iconComponent: IGSvg,
@@ -161,6 +164,7 @@ import ISSvg from "@site/src/components/Icon/teleport-svg/identity-security.svg"
     {
       id: 'identity-security',
       title: 'Identity Security',
+      href: './identity-security/',
       description: 'Visualize access paths and identify security risks across your infrastructure',
       iconColor: '#EEEAFA',
       iconComponent: ISSvg,


### PR DESCRIPTION
Product headings on docs homepage were not linked. This PR adds links for each of the four products pointing to their respective pages.