### PR TITLE
Update roles.mdx with clarity around users and roles visibility

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -281,7 +281,7 @@ allow:
 If this rule was declared in the `deny` section of a role definition, it would
 prohibit users from getting a list of active sessions. If a role does not allow
 access to list a resource, the user will not be able to view it in the Web UI
-or remotely with `tctl`.  The only exception is a user can always view their 
+or remotely with `tctl`.  The only exception is that a user can always view their 
 assigned roles and their own user information with `tctl`  You can see all of the
 available resources and verbs under the `allow` section in the example role
 configuration below.

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -281,7 +281,7 @@ allow:
 If this rule was declared in the `deny` section of a role definition, it would
 prohibit users from getting a list of active sessions. If a role does not allow
 access to list a resource, the user will not be able to view it in the Web UI
-or remotely with `l`.  The only exception is that a user can always view their 
+or remotely with `tctl`.  The only exception is that a user can always view their 
 assigned roles and their own user information with `tctl`.  You can see all of the
 available resources and verbs under the `allow` section in the example role
 configuration below.

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -279,7 +279,10 @@ allow:
 ```
 
 If this rule was declared in the `deny` section of a role definition, it would
-prohibit users from getting a list of active sessions. You can see all of the
+prohibit users from getting a list of active sessions. If a role does not allow
+access to list a resource, the user will not be able to view it in the Web UI
+or remotely with `tctl`.  The only exception is a user can always view their 
+assigned roles and their own user information with `tctl`  You can see all of the
 available resources and verbs under the `allow` section in the example role
 configuration below.
 

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -281,8 +281,8 @@ allow:
 If this rule was declared in the `deny` section of a role definition, it would
 prohibit users from getting a list of active sessions. If a role does not allow
 access to list a resource, the user will not be able to view it in the Web UI
-or remotely with `tctl`.  The only exception is that a user can always view their 
-assigned roles and their own user information with `tctl`  You can see all of the
+or remotely with `l`.  The only exception is that a user can always view their 
+assigned roles and their own user information with `tctl`.  You can see all of the
 available resources and verbs under the `allow` section in the example role
 configuration below.
 


### PR DESCRIPTION
based on customer feedback, adding clarity around why a user can see their own roles and user information remotely with `tctl` even when explicitly denied

https://github.com/gravitational/teleport/blob/642be764ce5395e7da312f9a839935862ea03425/lib/auth/auth_with_roles.go#L4778-L4790

~~~
> Profile URL:        https://teleport.plainsofconquest.com:443
  Logged in as:       paul-requests
  Cluster:            the-brains
  Roles:              test-role
  Kubernetes:         enabled
  Valid until:        2025-09-08 21:07:14 -0400 EDT [valid for 8h0m0s]
  Extensions:         login-ip, permit-port-forwarding, permit-pty, private-key-policy

paulschisa@Pauls-MacBook-Pro ~ % tctl get role
ERROR: access denied to perform action "list" on "role", access denied to perform action "read" on "role"

paulschisa@Pauls-MacBook-Pro ~ % tctl get role/access
ERROR: access denied to perform action "read" on "role"

paulschisa@Pauls-MacBook-Pro ~ % tctl get role/test-role
kind: role
metadata:
...
spec:
  allow: {}
  deny: {}
  options:
    cert_format: standard
    create_db_user: false
    create_desktop_user: false
    desktop_clipboard: true
    desktop_directory_sharing: true
    device_trust_mode: required-for-humans
    enhanced_recording:
    - command
    - network
    forward_agent: false
    idp:
      saml:
        enabled: false
    max_session_ttl: 8h0m0s
    pin_source_ip: false
    record_session:
      default: strict
      desktop: true
    ssh_file_copy: true
version: v7
paulschisa@Pauls-MacBook-Pro ~ % tctl get user
ERROR: access denied to perform action "read" on "user", access denied to perform action "list" on "user"

paulschisa@Pauls-MacBook-Pro ~ % tctl get user/paul-requests
kind: user
metadata:
...
~~~