### PR TITLE
fix: enhance multi-resource editing in tctl edit

### DIFF
--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -21,6 +21,7 @@ package common
 import (
 	"context"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -147,7 +148,6 @@ func testEditGithubConnector(t *testing.T, clt *authclient.Client) {
 
 		collection := &connectorsCollection{github: []types.GithubConnector{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the connector and validate that the expected field is updated.
@@ -185,7 +185,6 @@ func testEditRole(t *testing.T, clt *authclient.Client) {
 
 		collection := &roleCollection{roles: []types.Role{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the role and validate that the expected field is updated.
@@ -225,7 +224,6 @@ func testEditUser(t *testing.T, clt *authclient.Client) {
 
 		collection := &userCollection{users: []types.User{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the user and validate that the expected field is updated.
@@ -263,7 +261,6 @@ func testEditClusterNetworkingConfig(t *testing.T, clt *authclient.Client) {
 
 		collection := &netConfigCollection{netConfig: expected}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the cnc and validate that the expected field is updated.
@@ -302,7 +299,6 @@ func testEditAuthPreference(t *testing.T, clt *authclient.Client) {
 
 		collection := &authPrefCollection{authPref: expected}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the cap and validate that the expected field is updated.
@@ -340,7 +336,6 @@ func testEditSessionRecordingConfig(t *testing.T, clt *authclient.Client) {
 
 		collection := &recConfigCollection{recConfig: expected}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the src and validate that the expected field is updated.
@@ -438,7 +433,6 @@ func testEditOIDCConnector(t *testing.T, clt *authclient.Client) {
 
 		collection := &connectorsCollection{oidc: []types.OIDCConnector{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the connector and validate that the expected field is updated.
@@ -507,7 +501,6 @@ func testEditSAMLConnector(t *testing.T, clt *authclient.Client) {
 
 		collection := &connectorsCollection{saml: []types.SAMLConnector{expected}}
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
-
 	}
 
 	// Edit the connector and validate that the expected field is updated.
@@ -690,4 +683,68 @@ func testEditDynamicWindowsDesktop(t *testing.T, clt *authclient.Client) {
 	require.NoError(t, err)
 	expected.SetRevision(actual.GetRevision())
 	require.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
+}
+
+func TestMultipleRoles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	log := logtest.NewLogger()
+	process, err := testenv.NewTeleportProcess(t.TempDir(), testenv.WithLogger(log))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	roleNames := []string{"test-role1", "test-role2"}
+	for _, name := range roleNames {
+		expected, err := types.NewRole(name, types.RoleSpecV6{})
+		require.NoError(t, err, "creating initial role resource")
+		_, err = rootClient.CreateRole(ctx, expected.(*types.RoleV6))
+		require.NoError(t, err, "persisting initial role resource")
+	}
+
+	roles, err := rootClient.GetRoles(ctx)
+	require.NoError(t, err)
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+		for _, role := range roles {
+			if !slices.Contains(roleNames, role.GetName()) {
+				continue
+			}
+			role.SetLogins(types.Allow, []string{"abcdef"})
+		}
+
+		collection := &roleCollection{roles: roles}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+	}
+
+	// Edit the role and validate that the expected field is updated.
+	_, err = runEditCommand(t, rootClient, []string{"edit", "roles"},
+		withEditor(editor),
+	)
+	require.NoError(t, err, "expected editing role to succeed")
+
+	for _, role := range roles {
+		actual, err := rootClient.GetRole(ctx, role.GetName())
+		require.NoError(t, err, "retrieving role after edit")
+
+		assert.Equal(t, role.GetLogins(types.Allow), actual.GetLogins(types.Allow), "logins should have been modified by edit")
+		require.Empty(t, cmp.Diff(role, actual, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+
+		switch {
+		case !slices.Contains(roleNames, role.GetName()):
+			require.Equal(t, role.GetRevision(), actual.GetRevision(), "revision should not have been modified by edit")
+		default:
+			require.NotEqual(t, role.GetRevision(), actual.GetRevision(), "revision should have been modified by edit")
+		}
+	}
 }


### PR DESCRIPTION
This PR enhances tctl edit command to support multiple resources such as when editing all roles.

`tctl edit roles`

Now, all updated roles are reflected into the backend and not only the first one.

Changelog: Support multiple resource editing in `tctl edit` when editing collections

Fixes #38531