### PR TITLE
[v17] improve trusted cluster updates

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -159,7 +159,10 @@ func (a *Server) createTrustedCluster(ctx context.Context, tc types.TrustedClust
 	}
 
 	// Force name to the name of the trusted cluster.
-	tc.SetName(remoteCAs[0].GetClusterName())
+	if actualName := remoteCAs[0].GetClusterName(); actualName != tc.GetName() {
+		a.logger.WarnContext(ctx, "trusted cluster resource name did not match root cluster name. resource will be renamed. this will become an error in future versions, please update your configuration to match the root cluster name", "resource_name", tc.GetName(), "root_cluster_name", actualName)
+		tc.SetName(actualName)
+	}
 
 	// perform some configuration on the remote CAs
 	configureCAsForTrustedCluster(tc, remoteCAs)
@@ -611,7 +614,10 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *au
 	_, err = a.CreateRemoteClusterInternal(ctx, remoteCluster, []types.CertAuthority{remoteCA})
 	if err != nil {
 		if trace.IsAlreadyExists(err) {
-			return nil, trace.AlreadyExists("leaf cluster %q or a cert authority with the same name is already registered with this root cluster, if you are attempting to re-join try removing the existing "+types.KindRemoteCluster+" resource from the root cluster first", remoteClusterName)
+			// note that we deliberately suppress the AlreadyExists error here as this situation
+			// requires admin intervention and the direct caller is prevented by the trusted cluster
+			// security model from taking any corrective action.
+			return nil, trace.Errorf("leaf cluster name %q conflicts with an existing cluster or ca registered with root cluster %q, if re-joining remove the existing "+types.KindRemoteCluster+" resource from the root, if attempting to update check that the name of your resource matches the root cluster name", remoteClusterName, domainName)
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -370,7 +370,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 			CAs:   []types.CertAuthority{leafClusterCA},
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "already registered")
+		require.Contains(t, err.Error(), "conflicts with an existing cluster or ca")
 	})
 
 	t.Run("Host User and Database CA are returned by default", func(t *testing.T) {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -432,18 +432,11 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *aut
 	// TODO(bernardjkim) consider using UpsertTrustedClusterV2 in VX.0.0
 	out, err := client.UpsertTrustedCluster(ctx, tc)
 	if err != nil {
-		// If force is used and UpsertTrustedCluster returns trace.AlreadyExists,
-		// this means the user tried to upsert a cluster whose exact match already
-		// exists in the backend, nothing needs to occur other than happy message
-		// that the trusted cluster has been created.
-		if rc.force && trace.IsAlreadyExists(err) {
-			out = tc
-		} else {
-			return trace.Wrap(err)
-		}
+		return trace.Wrap(err)
 	}
+
 	if out.GetName() != tc.GetName() {
-		fmt.Printf("WARNING: trusted cluster %q resource has been renamed to match remote cluster name %q\n", name, out.GetName())
+		fmt.Printf("WARNING: trusted cluster resource %q has been renamed to match root cluster name %q. this will become an error in future teleport versions, please update your configuration to use the correct name.\n", name, out.GetName())
 	}
 	fmt.Printf("trusted cluster %q has been %v\n", out.GetName(), UpsertVerb(exists, rc.force))
 	return nil


### PR DESCRIPTION
Backport #58008 to branch/v17

changelog: fixed an issue that would cause trusted cluster resource updates to fail silently.
