### PR TITLE
Close scoped access cache on auth shutdown

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2157,6 +2157,12 @@ func (a *Server) Close() error {
 		}
 	}
 
+	if a.scopedAccessCache != nil {
+		if err := a.scopedAccessCache.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	if a.AccessRequestCache != nil {
 		if err := a.AccessRequestCache.Close(); err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
While debugging a test I noticed lots of log output indicating this cache wasn't being closed:

```
{"timestamp":"2025-09-08T13:37:03-07:00","level":"debug","caller":"auth/grpcserver.go:355","message":"Flushed and closed the stream","component":"auth:grpc"}
{"timestamp":"2025-09-08T13:37:03-07:00","level":"info","caller":"access/access.go:213","message":"attempting re-init of scoped access cache after delay","delay":1738656709}
{"timestamp":"2025-09-08T13:37:03-07:00","level":"warning","caller":"access/access.go:207","message":"scoped access cache failed","error":"failed to create watcher: cannot register watcher, buffer is closed"}
{"timestamp":"2025-09-08T13:37:04-07:00","level":"info","caller":"access/access.go:213","message":"attempting re-init of scoped access cache after delay","delay":1836789667}
{"timestamp":"2025-09-08T13:37:04-07:00","level":"warning","caller":"access/access.go:207","message":"scoped access cache failed","error":"failed to create watcher: cannot register watcher, buffer is closed"}
{"timestamp":"2025-09-08T13:37:04-07:00","level":"info","caller":"access/access.go:213","message":"attempting re-init of scoped access cache after delay","delay":1922385291}
{"timestamp":"2025-09-08T13:37:04-07:00","level":"warning","caller":"access/access.go:207","message":"scoped access cache failed","error":"failed to create watcher: cannot register watcher, buffer is closed"}
```

This PR just closes the scoped access cache when the auth server is closed.