### PR TITLE
docs(backends): remove unused s3:DeleteObject* actions from IAM policy

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -1107,8 +1107,6 @@ You'll need to replace these values in the policy example below:
                 "s3:ListMultipartUploadParts",
                 "s3:GetObjectVersion",
                 "s3:GetObject",
-                "s3:DeleteObjectVersion",
-                "s3:DeleteObject",
                 "s3:AbortMultipartUpload"
             ],
             "Effect": "Allow",


### PR DESCRIPTION
[`s3:DeleteObject` and `s3:DeleteObjectVersion` are only used in tests](https://github.com/search?q=repo%3Agravitational%2Fteleport%20deleteobject&type=code), so these permissions are not needed when using Athena backend for audit logs.

