### PR TITLE
[v18] lib/msgraph: Add auth error handling, logging, and `Client-Request-Id` header

### DIFF
--- a/api/types/msgraph.go
+++ b/api/types/msgraph.go
@@ -46,11 +46,11 @@ var (
 // https://learn.microsoft.com/en-us/graph/deployments
 func ValidateMSGraphEndpoints(loginEndpoint, graphEndpoint string) error {
 	if loginEndpoint != "" && !slices.Contains(validLoginEndpoints, loginEndpoint) {
-		return trace.BadParameter("expected login endpoints to be one of %q, got %q", validLoginEndpoints, loginEndpoint)
+		return trace.BadParameter("expected login endpoint to be one of %q, got %q", validLoginEndpoints, loginEndpoint)
 	}
 
 	if graphEndpoint != "" && !slices.Contains(validGraphEndpoints, graphEndpoint) {
-		return trace.BadParameter("expected graph endpoints to be one of %q, got %q", validGraphEndpoints, graphEndpoint)
+		return trace.BadParameter("expected graph endpoint to be one of %q, got %q", validGraphEndpoints, graphEndpoint)
 	}
 
 	return nil

--- a/lib/msgraph/client.go
+++ b/lib/msgraph/client.go
@@ -21,8 +21,10 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -31,13 +33,17 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // graphVersion is the default version of the MS Graph API endpoint.
@@ -88,6 +94,7 @@ type Config struct {
 	PageSize int
 	// GraphEndpoint specifies root domain of the Graph API.
 	GraphEndpoint string
+	Logger        *slog.Logger
 }
 
 // SetDefaults sets the default values for optional fields.
@@ -106,6 +113,9 @@ func (cfg *Config) SetDefaults() {
 	}
 	if cfg.GraphEndpoint == "" {
 		cfg.GraphEndpoint = types.MSGraphDefaultEndpoint
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.With(teleport.ComponentKey, "msgraph")
 	}
 }
 
@@ -130,6 +140,7 @@ type Client struct {
 	retryConfig   retryutils.RetryV2Config
 	baseURL       *url.URL
 	pageSize      int
+	logger        *slog.Logger
 }
 
 // NewClient returns a new client for the given config.
@@ -149,11 +160,14 @@ func NewClient(cfg Config) (*Client, error) {
 		retryConfig:   *cfg.RetryConfig,
 		baseURL:       base.JoinPath(graphVersion),
 		pageSize:      cfg.PageSize,
+		logger:        cfg.Logger,
 	}, nil
 }
 
 // request is the base function for HTTP API calls.
 // It implements retry handling in case of API throttling, see [https://learn.microsoft.com/en-us/graph/throttling].
+// If the response from the Graph API has status code outside of [200, 400) range, request attempts
+// to parse the response body as [GraphError] and if successful returns it as error.
 func (c *Client) request(ctx context.Context, method string, uri string, header http.Header, payload []byte) (*http.Response, error) {
 	var body io.ReadSeeker = nil
 	if len(payload) > 0 {
@@ -178,6 +192,16 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 		Scopes: scopes,
 	})
 	if err != nil {
+		authFailedError := &azidentity.AuthenticationFailedError{}
+		if ok := errors.As(err, &authFailedError); ok && authFailedError.RawResponse != nil &&
+			authFailedError.RawResponse.Body != nil {
+			resp := authFailedError.RawResponse
+			authError, conversionErr := readAuthError(resp.Body, resp.StatusCode)
+			resp.Body.Close()
+			if conversionErr == nil {
+				err = authError
+			}
+		}
 		return nil, trace.Wrap(err, "failed to get azure authentication token")
 	}
 	req.Header.Set("Authorization", "Bearer "+token.Token)
@@ -201,6 +225,10 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 			}
 		}
 
+		requestID := uuid.NewString()
+		// https://learn.microsoft.com/en-us/graph/best-practices-concept#reliability-and-support
+		req.Header.Set("client-request-id", requestID)
+
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, trace.Wrap(err) // hard I/O error, bail
@@ -210,8 +238,22 @@ func (c *Client) request(ctx context.Context, method string, uri string, header 
 			return resp, nil
 		}
 
-		graphError, err := readError(resp.Body)
-		resp.Body.Close()
+		respBody, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			c.logger.WarnContext(req.Context(), "Failed to close http.Responde body", "error", err)
+		}
+
+		c.logger.DebugContext(req.Context(), "Request failed",
+			"body", string(respBody),
+			"status", resp.StatusCode,
+			"url", req.URL,
+			"client_request_id", requestID,
+		)
+
+		graphError, err := readError(respBody, resp.StatusCode)
 		if err != nil {
 			lastErr = err // error while reading the graph error, relay
 		} else if graphError != nil {

--- a/lib/msgraph/creds.go
+++ b/lib/msgraph/creds.go
@@ -1,0 +1,89 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// VerifyCredentials checks if the credentials supplied to the client can be used to authenticate to
+// the Graph API and if they're authorized to get specific resources.
+package msgraph
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+
+	"github.com/gravitational/trace"
+)
+
+var (
+	// ErrTenantNotFound is returned by [Client.VerifyCredentials] when getting a token fails due to
+	// the tenant not being found. It might also point to the subscription no longer being active.
+	ErrTenantNotFound = errors.New("tenant not found")
+	// ErrInvalidCredentials is returned by [Client.VerifyCredentials] when getting a token fails due
+	// to an invalid client ID or secret.
+	ErrInvalidCredentials = errors.New("invalid Graph API credentials")
+	// ErrClientUnauthorized is returned by [Client.VerifyCredentials] in a situation where the app
+	// either doesn't have the permission required to access certain resources or the permission
+	// hasn't been grated by the administrator yet.
+	ErrClientUnauthorized = errors.New("authentication was successful but application does not have necessary permissions")
+)
+
+// IsCredentialsError determines whether err is one of the special errors returned by
+// [Client.VerifyCredentials].
+func IsCredentialsError(err error) bool {
+	return errors.Is(err, ErrTenantNotFound) ||
+		errors.Is(err, ErrInvalidCredentials) ||
+		errors.Is(err, ErrClientUnauthorized)
+}
+
+// VerifyCredentials expects getResourcesFunc to call a method on [Client]. It then inspects the
+// returned error to check for Graph or token errors related to credentials being insufficient in
+// some way.
+func (c *Client) VerifyCredentials(ctx context.Context, getResourcesFunc func(ctx context.Context, client *Client) error) error {
+	err := getResourcesFunc(ctx, c)
+
+	graphError := &GraphError{}
+	isGraphError := errors.As(err, &graphError)
+	authError := &AuthError{}
+	isAuthError := errors.As(err, &authError)
+
+	switch {
+	case isAuthError &&
+		(slices.Contains(authError.DiagCodes, DiagCodeTenantNotFound) ||
+			slices.Contains(authError.DiagCodes, DiagCodeInvalidTenantIdentifier)):
+		return trace.Wrap(ErrTenantNotFound, authError.ErrorDescription)
+
+	case isAuthError && authError.StatusCode == http.StatusBadRequest &&
+		authError.ErrorCode == "unauthorized_client":
+		// It likely means that the provided client ID doesn't exist under this tenant.
+		// https://login.microsoftonline.com/error?code=700016
+		return trace.Wrap(ErrInvalidCredentials, authError.ErrorDescription)
+
+	case isAuthError && authError.StatusCode == http.StatusUnauthorized:
+		// It likely means that the provided client secret doesn't match the client ID.
+		// https://login.microsoftonline.com/error?code=7000215
+		return trace.Wrap(ErrInvalidCredentials, authError.ErrorDescription)
+
+	case isGraphError && graphError.StatusCode == http.StatusUnauthorized:
+		// In this situation, the Graph API returns a very verbose and unhelpful error, hence why it's
+		// caught here and a more specific error is returned. On the off chance that the Graph API
+		// starts returning a more helpful message, let's also log it.
+		c.logger.WarnContext(ctx, "Graph API status unauthorized", "error", err)
+		return trace.Wrap(ErrClientUnauthorized)
+
+	default:
+		return trace.Wrap(err, "verifying Graph API credentials")
+	}
+}

--- a/lib/msgraph/creds_test.go
+++ b/lib/msgraph/creds_test.go
@@ -1,0 +1,172 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package msgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyCredentials(t *testing.T) {
+	resourceID := "foo"
+	graphErr := &GraphError{}
+	mux := http.NewServeMux()
+	mux.Handle(fmt.Sprintf("GET /v1.0/applications(appId='%s')", resourceID),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			graphResponse := &graphErrorResponse{
+				Error: graphErr,
+			}
+			body, err := json.Marshal(graphResponse)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			w.WriteHeader(graphErr.StatusCode)
+			_, err = w.Write(body)
+			assert.NoError(t, err)
+		}))
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(func() { srv.Close() })
+
+	tests := []struct {
+		name         string
+		tokenErr     error
+		graphErr     *GraphError
+		errAssertion require.ErrorAssertionFunc
+	}{
+		{
+			name: "tenant not found",
+			tokenErr: authErrorToSDKAuthFailedError(t, &AuthError{
+				ErrorCode:        "invalid_request",
+				ErrorDescription: "tenant not found",
+				DiagCodes:        []int{DiagCodeTenantNotFound},
+				StatusCode:       400,
+			}),
+			errAssertion: errorIs(ErrTenantNotFound),
+		},
+		{
+			name: "invalid tenant identifier",
+			tokenErr: authErrorToSDKAuthFailedError(t, &AuthError{
+				ErrorCode:        "invalid_request",
+				ErrorDescription: "tenant not found",
+				DiagCodes:        []int{DiagCodeInvalidTenantIdentifier},
+				StatusCode:       400,
+			}),
+			errAssertion: errorIs(ErrTenantNotFound),
+		},
+		{
+			name: "invalid client ID",
+			tokenErr: authErrorToSDKAuthFailedError(t, &AuthError{
+				ErrorCode:        "unauthorized_client",
+				ErrorDescription: "app not found",
+				StatusCode:       400,
+			}),
+			errAssertion: errorIs(ErrInvalidCredentials),
+		},
+		{
+			name: "invalid client secret",
+			tokenErr: authErrorToSDKAuthFailedError(t, &AuthError{
+				ErrorCode:        "invalid_client",
+				ErrorDescription: "invalid client secret provided",
+				StatusCode:       401,
+			}),
+			errAssertion: errorIs(ErrInvalidCredentials),
+		},
+		{
+			name: "insufficient permissions",
+			graphErr: &GraphError{
+				StatusCode: 401,
+				Code:       "InvalidAuthenticationToken",
+				Message:    "invalid authentication token",
+			},
+			errAssertion: errorIs(ErrClientUnauthorized),
+		},
+		{
+			name:         "unknown token error",
+			tokenErr:     errors.New("something went wrong with token"),
+			errAssertion: errorIsNotCredentialsError,
+		},
+		{
+			name: "unknown graph error",
+			graphErr: &GraphError{
+				StatusCode: 400,
+				Code:       "whoops",
+				Message:    "something went wrong",
+			},
+			errAssertion: errorIsNotCredentialsError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// There's no way to clear an error from [fake.TokenCredential] once it's set, hence why
+			// together with a client it needs to be created within each individual test.
+			tokenProvider := &fake.TokenCredential{}
+			client, err := NewClient(Config{
+				TokenProvider: tokenProvider,
+				HTTPClient:    newHTTPClient(srv),
+			})
+			require.NoError(t, err)
+
+			if tt.tokenErr != nil {
+				tokenProvider.SetError(tt.tokenErr)
+			}
+			graphErr = tt.graphErr
+
+			err = client.VerifyCredentials(t.Context(), func(ctx context.Context, client *Client) error {
+				_, err := client.GetApplication(ctx, resourceID)
+				return err
+			})
+			tt.errAssertion(t, err)
+		})
+	}
+}
+
+func authErrorToSDKAuthFailedError(t *testing.T, authErr *AuthError) *azidentity.AuthenticationFailedError {
+	b, err := json.Marshal(authErr)
+	require.NoError(t, err)
+
+	sdkErr := azidentity.AuthenticationFailedError{}
+	sdkErr.RawResponse = &http.Response{
+		Body:       io.NopCloser(bytes.NewReader(b)),
+		StatusCode: authErr.StatusCode,
+	}
+
+	return &sdkErr
+}
+
+func errorIs(target error) require.ErrorAssertionFunc {
+	return func(t require.TestingT, err error, _ ...any) {
+		require.ErrorIs(t, err, target)
+	}
+}
+
+func errorIsNotCredentialsError(t require.TestingT, err error, _ ...any) {
+	require.Error(t, err)
+	require.False(t, IsCredentialsError(err))
+}

--- a/lib/msgraph/errors.go
+++ b/lib/msgraph/errors.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -40,11 +41,21 @@ type graphErrorResponse struct {
 }
 
 // GraphError defines the structure of errors returned from MS Graph API.
+// https://learn.microsoft.com/en-us/graph/errors#json-representation
 type GraphError struct {
-	Code       string       `json:"code,omitempty"`
-	Message    string       `json:"message,omitempty"`
-	InnerError *GraphError  `json:"innerError,omitempty"`
-	Details    []GraphError `json:"details,omitempty"`
+	// Code is the code for the error, e.g. "UnknownError", "BadRequest".
+	Code string `json:"code,omitempty"`
+	// Message is a developer ready message about the error that occurred. This shouldn't be displayed
+	// to the user directly.
+	Message string `json:"message,omitempty"`
+	// InnerError is an optional additional error object that is more specific than the top-level
+	// error.
+	InnerError *GraphError `json:"innerError,omitempty"`
+	// Details is an optional list of more error objects that provide a breakdown of multiple errors
+	// encountered while processing the request.
+	Details []GraphError `json:"details,omitempty"`
+	// StatusCode is the status code of the HTTP response that GraphError arrived with.
+	StatusCode int `json:"-"`
 }
 
 func (g *GraphError) Error() string {
@@ -60,13 +71,74 @@ func (g *GraphError) Error() string {
 	return strings.Join(parts, ": ")
 }
 
-func readError(r io.Reader) (*GraphError, error) {
+func readError(body []byte, statusCode int) (*GraphError, error) {
 	var errResponse graphErrorResponse
-	if err := json.NewDecoder(r).Decode(&errResponse); err != nil {
+	if err := json.Unmarshal(body, &errResponse); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if errResponse.Error != nil {
-		return errResponse.Error, nil
+	if errResponse.Error == nil {
+		return nil, nil
 	}
-	return nil, nil
+	graphError := errResponse.Error
+	graphError.StatusCode = statusCode
+	return graphError, nil
 }
+
+// AuthError is the error returned by [AzureTokenProvider.GetToken] indicating that an
+// authentication request has failed.
+// https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
+type AuthError struct {
+	// ErrorCode is the code string for the error, e.g. "invalid_client".
+	ErrorCode string `json:"error"`
+	// ErrorDescription is a specific error message that can help a developer identify the root cause
+	// of an authentication error.
+	ErrorDescription string `json:"error_description"`
+	// DiagCodes is a list of codes used by the security token service which map to specific reasons
+	// as to why a request have failed.
+	// https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes
+	DiagCodes  []int `json:"error_codes"`
+	StatusCode int   `json:"-"`
+}
+
+func (a *AuthError) Error() string {
+	var b strings.Builder
+	b.WriteString(a.ErrorDescription)
+	b.WriteString(" (")
+	b.WriteString(a.ErrorCode)
+	if len(a.DiagCodes) > 0 {
+		if len(a.DiagCodes) == 1 {
+			b.WriteString(", diag code ")
+		} else {
+			b.WriteString(", diag codes ")
+		}
+		for i, errorCode := range a.DiagCodes {
+			if i != 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(strconv.Itoa(errorCode))
+		}
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+func readAuthError(r io.Reader, statusCode int) (*AuthError, error) {
+	var authError AuthError
+	authError.StatusCode = statusCode
+	err := json.NewDecoder(r).Decode(&authError)
+	return &authError, trace.Wrap(err)
+}
+
+const (
+	// DiagCodeTenantNotFound is returned by the identity platform when the specific tenant doesn't
+	// exist. It might also mean that the tenant belongs to another cloud (see
+	// https://learn.microsoft.com/en-us/graph/deployments) or there are no active subscriptions for
+	// the tenant.
+	// https://login.microsoftonline.com/error?code=90002
+	DiagCodeTenantNotFound = 90002
+	// DiagCodeInvalidTenantIdentifier is returned by the identity platform when the identifier is
+	// neither a valid DNS name nor a valid external domain. This happes when the tenant is not a UUID
+	// and instead a regular string that doesn't match said requirements.
+	// https://login.microsoftonline.com/error?code=900023
+	DiagCodeInvalidTenantIdentifier = 900023
+)

--- a/lib/msgraph/errors_test.go
+++ b/lib/msgraph/errors_test.go
@@ -39,7 +39,7 @@ func TestUnmarshalGraphError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("valid", func(t *testing.T) {
-		graphError, err := readError(strings.NewReader(msGraphErrorPayload))
+		graphError, err := readError([]byte(msGraphErrorPayload), 400)
 		require.NoError(t, err)
 		require.NotNil(t, graphError)
 		expected := &GraphError{
@@ -48,18 +48,91 @@ func TestUnmarshalGraphError(t *testing.T) {
 			InnerError: &GraphError{
 				Code: "invalidRange",
 			},
+			StatusCode: 400,
 		}
 		require.Equal(t, expected, graphError)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		_, err := readError(strings.NewReader("invalid json"))
+		_, err := readError([]byte("invalid json"), 400)
 		require.Error(t, err)
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		graphError, err := readError(strings.NewReader("{}"))
+		graphError, err := readError([]byte("{}"), 400)
 		require.NoError(t, err)
 		require.Nil(t, graphError)
+	})
+}
+
+const authErrorPayload = `{
+  "error": "invalid_scope",
+  "error_description": "AADSTS70011: The provided value for the input parameter 'scope' isn't valid. The scope https://example.contoso.com/activity.read isn't valid.\r\nTrace ID: 0000aaaa-11bb-cccc-dd22-eeeeee333333\r\nCorrelation ID: aaaa0000-bb11-2222-33cc-444444dddddd\r\nTimestamp: 2016-01-09 02:02:12Z",
+  "error_codes": [
+    70011
+  ],
+  "timestamp": "2016-01-09 02:02:12Z",
+  "trace_id": "0000aaaa-11bb-cccc-dd22-eeeeee333333",
+  "correlation_id": "aaaa0000-bb11-2222-33cc-444444dddddd",
+  "error_uri":"https://login.microsoftonline.com/error?code=70011"
+}`
+
+func TestUnmarshalAuthError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		authError, err := readAuthError(strings.NewReader(authErrorPayload), 400)
+		require.NoError(t, err)
+		require.NotNil(t, authError)
+		expected := &AuthError{
+			ErrorCode:        "invalid_scope",
+			ErrorDescription: "AADSTS70011: The provided value for the input parameter 'scope' isn't valid. The scope https://example.contoso.com/activity.read isn't valid.\r\nTrace ID: 0000aaaa-11bb-cccc-dd22-eeeeee333333\r\nCorrelation ID: aaaa0000-bb11-2222-33cc-444444dddddd\r\nTimestamp: 2016-01-09 02:02:12Z",
+			DiagCodes:        []int{70011},
+			StatusCode:       400,
+		}
+		require.Equal(t, expected, authError)
+		expectedMessage := "AADSTS70011: The provided value for the input parameter 'scope' isn't valid. The scope https://example.contoso.com/activity.read isn't valid.\r\nTrace ID: 0000aaaa-11bb-cccc-dd22-eeeeee333333\r\nCorrelation ID: aaaa0000-bb11-2222-33cc-444444dddddd\r\nTimestamp: 2016-01-09 02:02:12Z " +
+			"(invalid_scope, diag code 70011)"
+		require.Equal(t, expectedMessage, authError.Error())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := readAuthError(strings.NewReader("invalid json"), 400)
+		require.Error(t, err)
+	})
+
+	t.Run("message", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			diagCodes []int
+			want      string
+		}{
+			{
+				name: "no diag codes",
+				want: "foo bar (invalid_client)",
+			},
+			{
+				name:      "one diag code",
+				diagCodes: []int{42},
+				want:      "foo bar (invalid_client, diag code 42)",
+			},
+			{
+				name:      "multiple diag codes",
+				diagCodes: []int{42, 37},
+				want:      "foo bar (invalid_client, diag codes 42, 37)",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				authError := &AuthError{
+					ErrorCode:        "invalid_client",
+					ErrorDescription: "foo bar",
+					DiagCodes:        tt.diagCodes,
+					StatusCode:       400,
+				}
+				require.Equal(t, tt.want, authError.Error())
+			})
+		}
 	})
 }


### PR DESCRIPTION
Backport #58661

idk why the bot wasn't able to backport this, locally git was able to auto-merge everything with no conflicts.