### PR TITLE
[v18] Remove OSS link in prerequisite partial

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,8 +1,7 @@
 {{ edition="Teleport" clients="`tctl` and `tsh` clients" }}
 
-- A running {{ edition }} cluster. If you want to get started with Teleport,
-  [sign up](https://goteleport.com/signup) for a free trial or [set up a demo
-  environment](../linux-demo.mdx).
+- A running {{ edition }} cluster. If you do not have one, read [Getting
+  Started](../get-started.mdx).
 
 - The {{ clients }}.
 


### PR DESCRIPTION
Backport #58833 to branch/v18