### PR TITLE
docs: add required roles for client managed updates

### DIFF
--- a/docs/pages/upgrading/client-tools-managed-updates.mdx
+++ b/docs/pages/upgrading/client-tools-managed-updates.mdx
@@ -133,6 +133,9 @@ If there is no active session, but a versioned binary exists in the tools direct
 
 ### Cluster-wide using `tctl`
 
+To configure client tool managed updates settings in your cluster, you must have access to the
+`autoupdate_config` and `autoupdate_version` resources. By default, the `editor` role can modify both resources.
+
 To enable or disable client tools managed updates in the cluster, use the following command:
 
 ```code

--- a/docs/pages/upgrading/client-tools-managed-updates.mdx
+++ b/docs/pages/upgrading/client-tools-managed-updates.mdx
@@ -134,7 +134,7 @@ If there is no active session, but a versioned binary exists in the tools direct
 ### Cluster-wide using `tctl`
 
 To configure client tool managed updates in your cluster, you must have access to the
-`autoupdate_config` and `autoupdate_version` resources. By default, the `editor` role can modify both resources.
+`autoupdate_config` and `autoupdate_version` resources. By default, the `editor` role can modify both resources. Note that `autoupdate_version` is managed for you on Cloud clusters, and cannot be edited.
 
 To enable or disable client tools managed updates in the cluster, use the following command:
 

--- a/docs/pages/upgrading/client-tools-managed-updates.mdx
+++ b/docs/pages/upgrading/client-tools-managed-updates.mdx
@@ -133,7 +133,7 @@ If there is no active session, but a versioned binary exists in the tools direct
 
 ### Cluster-wide using `tctl`
 
-To configure client tool managed updates settings in your cluster, you must have access to the
+To configure client tool managed updates in your cluster, you must have access to the
 `autoupdate_config` and `autoupdate_version` resources. By default, the `editor` role can modify both resources.
 
 To enable or disable client tools managed updates in the cluster, use the following command:


### PR DESCRIPTION
Like managed updates include the required role access to manage client updates.  The `autoupdate_version` just requires `read` access but not sure if we want to get that detailed.