### PR TITLE
Add tags to three Zero Trust Access docs sections

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
@@ -5,6 +5,7 @@ h1: Store Teleport Private Keys in AWS KMS
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 This guide will show you how to set up your Teleport cluster to use the AWS Key

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
@@ -4,6 +4,7 @@ description: "Deploying a high-availability multi-region Teleport cluster using 
 tags:
  - conceptual
  - platform-wide
+ - aws
 ---
 
 This deployment architecture features two important design decisions:

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 This guide is designed to accompany our [reference starter-cluster Terraform code](https://github.com/gravitational/teleport/tree/branch/v(=teleport.major_version=)/examples/aws/terraform/starter-cluster#teleport-terraform-aws-ami-simple-example)

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/gcp.mdx
@@ -4,6 +4,7 @@ description: How to install and configure Teleport on GCP
 tags:
  - conceptual
  - platform-wide
+ - google-cloud
 ---
 
 We've created this guide to give customers an overview of how to deploy a

--- a/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
@@ -5,6 +5,7 @@ h1: Store Teleport Private Keys in Google Cloud KMS
 tags:
  - how-to
  - platform-wide
+ - google-cloud
 ---
 
 This guide will show you how to set up your Teleport Cluster to use the Google

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm.mdx
@@ -1,6 +1,9 @@
 ---
 title: Guides for running Teleport using Helm via ArgoCD
 description: How to install and configure Teleport Kubernetes agent using Helm and ArgoCD
+tags:
+ - platform-wide
+ - how-to
 ---
 
 Teleport can provide secure, unified access to your Kubernetes clusters. This

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
@@ -4,6 +4,7 @@ description: Install and configure an HA Teleport cluster using an AWS EKS clust
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 In this guide, we'll use Teleport Helm charts to set up a high-availability Teleport cluster that runs on AWS EKS.

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/azure.mdx
@@ -4,6 +4,7 @@ description: Install and configure an HA Teleport cluster using a Microsoft Azur
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 In this guide, we'll go through how to set up a High Availability Teleport

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
@@ -4,6 +4,7 @@ description: Provides guidance for planning a strategy for restoring a self-host
 tags:
  - how-to
  - platform-wide
+ - aws
 ---
 
 In case of an outage in your cloud provider region, you need to ensure that you

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -4,6 +4,7 @@ description: Install and configure an HA Teleport cluster using a Google Cloud G
 tags:
  - how-to
  - platform-wide
+ - google-cloud
 ---
 
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes

--- a/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/datadog.mdx
@@ -4,6 +4,7 @@ description: How to configure the Teleport Event Handler plugin and Fluentd to s
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 Datadog is a SAAS monitoring and security platform. In this guide, we'll explain

--- a/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/elastic-stack.mdx
@@ -4,6 +4,7 @@ description: "How to configure Teleport's Event Handler plugin to send audit eve
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 Teleport's Event Handler plugin receives audit events from the Teleport Auth

--- a/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
@@ -3,6 +3,7 @@ title: Exporting Teleport Audit Events
 description: Learn how to export Teleport audit events to your log management solution.
 tags:
  - zero-trust
+ - audit
 ---
 
 The Teleport Auth Service emits audit logs when users and services interact with

--- a/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/fluentd.mdx
@@ -5,6 +5,7 @@ videoBanner: HAqxs4rBv2c
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 Fluentd is an open source data collector for a unified logging layer. In this

--- a/docs/pages/zero-trust-access/export-audit-events/panther.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/panther.mdx
@@ -4,6 +4,7 @@ description: How to configure the Teleport Event Handler plugin and Fluentd to s
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 Panther is a cloud-native security analytics platform. In this guide, we'll explain

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -4,6 +4,7 @@ description: How to configure the Teleport Event Handler plugin to send audit lo
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 Teleport's Event Handler plugin receives audit logs from the Teleport Auth

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
@@ -4,6 +4,7 @@ description: Use infrastructure-as-code tooling to register Agentless OpenSSH se
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 In this guide, you will see how to register in Teleport your OpenSSH nodes

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
@@ -4,6 +4,7 @@ description: Use infrastructure-as-code tooling to create Teleport users and rol
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 In this guide, you will see how to create users and grant them roles through

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -4,6 +4,7 @@ h1: "Terraform Starter: Enroll Infrastructure"
 description: Explains how to deploy a pool of Teleport Agents so you can apply dynamic resources to enroll your infrastructure with Teleport.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 *This guide is Part One of the Teleport Terraform starter guide. Read the

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -5,6 +5,7 @@ description: Explains how to manage Teleport roles and authentication connectors
 tags:
  - get-started
  - zero-trust
+ - privileged-access
 ---
 
 *This guide is Part Two of the Teleport Terraform starter guide. Read the


### PR DESCRIPTION
Tag pages in the following sections of the Zero Trust Access docs with the appropriate use case and cloud provider tags:

- Deploy a Cluster
- Export Audit Events
- Infrastructure as Code

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

Note that not all pages in these sections warrant a use case or cloud provider tag.