### PR TITLE
Add tags to two Zero Trust Access docs sections

### DIFF
--- a/docs/pages/zero-trust-access/compliance-frameworks/compliance-frameworks.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/compliance-frameworks.mdx
@@ -3,6 +3,7 @@ title: "Compliance Frameworks"
 description: "How to use Teleport's access controls to streamline compliance without sacrificing productivity."
 tags:
  - zero-trust
+ - audit
 ---
 
 Teleport makes it easier for your organization to achieve compliance with

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -4,6 +4,7 @@ description: How to configure SSH, Kubernetes, database, and web app access to b
 tags:
  - conceptual
  - zero-trust
+ - audit
 ---
 
 Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure.

--- a/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
@@ -5,6 +5,7 @@ h1: SOC 2 Compliance for SSH, Kubernetes, Databases, Desktops, and Web Apps
 tags:
  - conceptual
  - zero-trust
+ - audit
 ---
 
 Teleport is designed to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high

--- a/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
@@ -4,6 +4,7 @@ description: Explains how you can configure a trust relationship and manage acce
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 <Admonition type="note">

--- a/docs/pages/zero-trust-access/management/admin/users.mdx
+++ b/docs/pages/zero-trust-access/management/admin/users.mdx
@@ -4,6 +4,7 @@ description: Learn how to manage local users in Teleport. Local users are stored
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 In Teleport, **local users** are users managed directly via Teleport, rather

--- a/docs/pages/zero-trust-access/management/external-audit-storage.mdx
+++ b/docs/pages/zero-trust-access/management/external-audit-storage.mdx
@@ -4,6 +4,7 @@ description: Store audit logs and session recordings on your own infrastructure 
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/zero-trust-access/management/guides/awsoidc-integration-rds.mdx
+++ b/docs/pages/zero-trust-access/management/guides/awsoidc-integration-rds.mdx
@@ -5,6 +5,8 @@ tocDepth: 3
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 The AWS RDS enrollment wizard is available in your Teleport cluster Web UI as

--- a/docs/pages/zero-trust-access/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/zero-trust-access/management/guides/awsoidc-integration.mdx
@@ -3,7 +3,8 @@ title: AWS OIDC Integration
 description: How to connect your AWS account with Teleport and provide access to AWS resources.
 tags:
  - how-to
- - zero-trust
+ - platform-wide
+ - aws
 ---
 
 This guide explains how to set up the Teleport AWS OIDC integration.

--- a/docs/pages/zero-trust-access/management/guides/datadog.mdx
+++ b/docs/pages/zero-trust-access/management/guides/datadog.mdx
@@ -4,7 +4,7 @@ description: How to export Teleport metrics and logs to Datadog
 h1: Export Teleport metrics and logs to Datadog
 tags:
  - conceptual
- - zero-trust
+ - platform-wide
 ---
 
 Datadog has an [officially maintained integration](https://docs.datadoghq.com/integrations/teleport/) for Teleport.

--- a/docs/pages/zero-trust-access/management/guides/ec2-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/ec2-tags.mdx
@@ -5,6 +5,8 @@ h1: Sync EC2 Tags and Teleport Node Labels
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 When running on an AWS EC2 instance, Teleport will automatically detect and import EC2 tags as

--- a/docs/pages/zero-trust-access/management/guides/gcp-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/gcp-tags.mdx
@@ -5,6 +5,8 @@ h1: Sync GCP Tags/Labels and Teleport Agent labels
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 When running on an Google Compute Engine instance, Teleport will automatically detect and import GCP

--- a/docs/pages/zero-trust-access/management/guides/github-integration.mdx
+++ b/docs/pages/zero-trust-access/management/guides/github-integration.mdx
@@ -4,6 +4,7 @@ description:  How to use Teleport's short-lived SSH certificates with the GitHub
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can proxy Git commands and use short-lived SSH certificates to

--- a/docs/pages/zero-trust-access/management/guides/oracle-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/oracle-tags.mdx
@@ -5,6 +5,7 @@ h1: Sync Oracle Cloud tags and Teleport Agent labels
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 When running on an Oracle Cloud (OCI) Compute instance, Teleport will

--- a/docs/pages/zero-trust-access/management/guides/scim/sailpoint.mdx
+++ b/docs/pages/zero-trust-access/management/guides/scim/sailpoint.mdx
@@ -1,6 +1,10 @@
 ---
 title: SCIM SailPoint Integration
 description: How to Configure SCIM Connector in SailPoint to manage Access List membership
+tags:
+- how-to
+- identity-governance
+- privileged-access
 ---
 
 

--- a/docs/pages/zero-trust-access/management/guides/scim/scim.mdx
+++ b/docs/pages/zero-trust-access/management/guides/scim/scim.mdx
@@ -1,7 +1,10 @@
 ---
 title: SCIM – Access List Membership Delegation to SCIM providers
 description: How to manage Access List membership using  SCIM integration
-
+tags:
+- how-to
+- identity-governance
+- privileged-access
 ---
 
 The SCIM integration between **SCIM providers** and **Teleport** enables automated

--- a/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - how-to
  - platform-wide
+ - resiliency
 ---
 
 Components of a Teleport cluster authenticate to one another using either X.509

--- a/docs/pages/zero-trust-access/management/operations/db-ca-migrations.mdx
+++ b/docs/pages/zero-trust-access/management/operations/db-ca-migrations.mdx
@@ -4,6 +4,7 @@ description: How to complete Teleport Database CA migrations.
 tags:
  - conceptual
  - zero-trust
+ - resiliency
 ---
 
 In Teleport, self-hosted databases must be configured with certificates to

--- a/docs/pages/zero-trust-access/management/security/client-timeout.mdx
+++ b/docs/pages/zero-trust-access/management/security/client-timeout.mdx
@@ -4,6 +4,7 @@ description: How to implement idle client timeouts.
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 The `client_idle_timeout` in Teleport is a configurable setting that helps improve security by terminating inactive sessions after a specified period. It can be applied globally or per role, 

--- a/docs/pages/zero-trust-access/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/zero-trust-access/management/security/reduce-blast-radius.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport to minimize the scope of security breache
 tags:
  - conceptual
  - platform-wide
+ - resiliency
 ---
 
 Teleport encourages users to practice defense in depth so that every component of their infrastructure is safe against attacks, even if an attacker is partially successful. You can configure Teleport to add layers of protection to your cluster when users authenticate or request elevated privileges. In this guide, we will show you how to:

--- a/docs/pages/zero-trust-access/management/security/restrict-privileges.mdx
+++ b/docs/pages/zero-trust-access/management/security/restrict-privileges.mdx
@@ -4,6 +4,7 @@ description: Explains the risks of root-level access to Teleport-protected resou
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 As an administrator, you need to make informed decisions about when and how to grant

--- a/docs/pages/zero-trust-access/management/security/revoking-access.mdx
+++ b/docs/pages/zero-trust-access/management/security/revoking-access.mdx
@@ -3,6 +3,7 @@ title: Revoking Access
 description: Learn how to revoke access before Teleport certificates expire
 tags:
  - platform-wide
+ - resiliency
 ---
 
 Teleport's approach to using short-lived certificates for all infrastructure

--- a/docs/pages/zero-trust-access/management/security/security.mdx
+++ b/docs/pages/zero-trust-access/management/security/security.mdx
@@ -3,6 +3,7 @@ title: Secure Practices for Teleport Clusters
 description: Highlights recommended practices and ways to harden security for your Teleport cluster.
 tags:
  - zero-trust
+ - resiliency
 ---
 
 To help ensure that Teleport can protect your infrastructure in a production environment, you should 

--- a/docs/pages/zero-trust-access/management/security/selinux.mdx
+++ b/docs/pages/zero-trust-access/management/security/selinux.mdx
@@ -4,6 +4,7 @@ description: "How to configure SELinux to enforce Teleport SSH Service."
 tags:
  - conceptual
  - zero-trust
+ - resiliency
 ---
 
 <Admonition type="note">


### PR DESCRIPTION
Tag pages in the following sections of the Zero Trust Access docs with the appropriate use case and cloud provider tags:

- Compliance Frameworks
- Management

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

Note that not all pages in these sections warrant a use case or cloud provider tag.

This change also corrects pages with missing or inaccurate tags.