### PR TITLE
Add tags to four Zero Trust Access docs sections

### DIFF
--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -4,6 +4,7 @@ description: Learn how to use the Teleport API to start agents automatically whe
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can use Teleport's API to automatically register resources in your

--- a/docs/pages/zero-trust-access/api/rbac.mdx
+++ b/docs/pages/zero-trust-access/api/rbac.mdx
@@ -4,6 +4,7 @@ description: Use Teleport's API to automatically generate Teleport roles based o
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 You can use the Teleport gRPC API to generate roles automatically based on an

--- a/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
+++ b/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
@@ -4,6 +4,7 @@ description: Hardware Key Support
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide explains how to configure Teleport authentication using

--- a/docs/pages/zero-trust-access/authentication/headless.mdx
+++ b/docs/pages/zero-trust-access/authentication/headless.mdx
@@ -4,6 +4,7 @@ description: Headless Authentication
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 Headless Authentication provides a secure way to authenticate with Teleport on

--- a/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
+++ b/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
@@ -4,6 +4,7 @@ description: How to enable IP pinning for Teleport users
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 <Admonition type="warning">

--- a/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
+++ b/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
@@ -9,6 +9,7 @@ keywords:
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 Teleport allows multiple users to join the same SSH or `kubectl exec` session.

--- a/docs/pages/zero-trust-access/authentication/login-rules/guide.mdx
+++ b/docs/pages/zero-trust-access/authentication/login-rules/guide.mdx
@@ -4,6 +4,7 @@ description: Set up Login Rules to transform user traits
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 Login Rules define logic that transforms the external traits of a user who signs

--- a/docs/pages/zero-trust-access/authentication/login-rules/login-rules.mdx
+++ b/docs/pages/zero-trust-access/authentication/login-rules/login-rules.mdx
@@ -5,6 +5,7 @@ layout: tocless-doc
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 When users log in to your Teleport cluster with a configured SSO provider,

--- a/docs/pages/zero-trust-access/authentication/mfa-for-admin-actions.mdx
+++ b/docs/pages/zero-trust-access/authentication/mfa-for-admin-actions.mdx
@@ -4,6 +4,7 @@ description: Require MFA checks to perform administrative actions.
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 Teleport can be configured to require additional multi-factor authentication

--- a/docs/pages/zero-trust-access/authentication/passwordless.mdx
+++ b/docs/pages/zero-trust-access/authentication/passwordless.mdx
@@ -5,6 +5,7 @@ videoBanner: GA37qqB6Lmk
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide shows you how to provide passwordless and usernameless authentication

--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -5,6 +5,7 @@ videoBanner: j8Ze7HhjFGw
 tags:
  - conceptual
  - zero-trust
+ - resiliency
 ---
 
 Teleport supports requiring additional multi-factor authentication checks

--- a/docs/pages/zero-trust-access/authentication/webauthn.mdx
+++ b/docs/pages/zero-trust-access/authentication/webauthn.mdx
@@ -5,6 +5,7 @@ videoBanner: vQgKkD4ZRDU
 tags:
  - how-to
  - zero-trust
+ - resiliency
 ---
 
 This guide aims to help you fortify your identity infrastructure and mitigate the risks associated with IdP weaknesses.

--- a/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
@@ -4,6 +4,7 @@ description: How to assign static and command-based dynamic labels to Teleport r
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport allows you to add arbitrary key-value pairs to applications, servers,

--- a/docs/pages/zero-trust-access/rbac-get-started/rbac-get-started.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/rbac-get-started.mdx
@@ -1,6 +1,10 @@
 ---
 title: Get Started with Role-Based Access Control
 description: Provides an introduction to the Teleport role-based access control system.
+tags:
+ - privileged-access
+ - conceptual
+ - zero-trust
 ---
 
 Teleport's role-based access control (RBAC) enables you to set fine-grained

--- a/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
@@ -2,6 +2,10 @@
 title: Getting Started With Teleport Access Controls
 description: Teleport Role-Based Access Control.
 tocDepth: 3
+tags:
+ - privileged-access
+ - how-to
+ - zero-trust
 ---
 
 Teleport Role-Based Access Control (RBAC) is a system for managing who can

--- a/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
@@ -4,6 +4,7 @@ description: This guide explains templating in Teleport roles. Templates allow y
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 As organizations grow, infrastructure teams have to figure out how to define

--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -5,6 +5,7 @@ h1: Single Sign-On with Active Directory Federation Services
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide will explain how to configure Active Directory Federation Services

--- a/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport access with Microsoft Entra ID (formerly 
 labels:
  - how-to
  - zero-trust
+ - privileged-access
+ - azure
 ---
 
 This guide shows how to configure Microsoft Entra ID (formerly Azure AD) as an 

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport access with Microsoft Entra ID (formerly 
 tags:
  - how-to
  - zero-trust
+ - privileged-access
+ - azure
 ---
 
 This guide will cover how to configure Microsoft Entra ID (formerly Azure AD) as

--- a/docs/pages/zero-trust-access/sso/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/github-sso.mdx
@@ -5,6 +5,7 @@ videoBanner: XjgN2WWFCX8
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide explains how to set up GitHub Single Sign On (SSO) so you can

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -5,6 +5,7 @@ h1: Teleport SSO Authentication with GitLab
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide will cover how to configure [GitLab](https://www.gitlab.com/) to issue

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -5,6 +5,8 @@ videoBanner: WTLWc6nnPfk
 tags:
  - how-to
  - zero-trust
+ - privileged-access
+ - google-cloud
 ---
 
 This guide explains how to configure [Google Workspace](https://workspace.google.com/)

--- a/docs/pages/zero-trust-access/sso/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/keycloak.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport access with Keycloak
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide explains how to configure Keycloak to issue

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport access with OAuth2 or OpenID connect (OID
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide will explain how to configure an SSO provider using [OpenID

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -5,6 +5,7 @@ videoBanner: SM4Am-i8cj4
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 This guide covers how to configure [Okta](https://www.okta.com/) to provide

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -5,6 +5,7 @@ h1: Teleport Authentication with OneLogin
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 import SquareIcon from "@version/docs/img/sso/onelogin/teleport.png"

--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -4,6 +4,7 @@ description: How to set up single sign-on (SSO) using Teleport
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 Teleport users can log in to servers, Kubernetes clusters, databases, web


### PR DESCRIPTION
Tag pages in the following sections of the Zero Trust Access docs with the appropriate use case and cloud provider tags:

- API
- Authentication
- RBAC Getting Started
- SSO

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

Note that not all pages in these sections warrant a use case or cloud provider tag.

This change also corrects pages with missing or inaccurate tags.