### PR TITLE
Fix link in Kube access error messages

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -210,6 +210,11 @@
       "permanent": true
     },
     {
+      "source": "/kubernetes-ssh/",
+      "destination": "/enroll-resources/kubernetes-access/controls/",
+      "permanent": true
+    },
+    {
       "source": "/machine-id/introduction/",
       "destination": "/machine-workload-identity/machine-id/introduction/",
       "permanent": true

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -259,10 +259,10 @@ func checkImpersonationPermissions(ctx context.Context, cluster string, sarClien
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {
-			return trace.Wrap(err, "failed to verify impersonation permissions for Kubernetes: %v; this may be due to missing the SelfSubjectAccessReview permission on the ClusterRole used by the proxy; please make sure that proxy has all the necessary permissions: https://goteleport.com/teleport/docs/kubernetes-ssh/#impersonation", err)
+			return trace.Wrap(err, "failed to verify impersonation permissions for Kubernetes: %v; this may be due to missing the SelfSubjectAccessReview permission on the ClusterRole used by the proxy; please make sure that proxy has all the necessary permissions: https://goteleport.com/docs/enroll-resources/kubernetes-access/controls/#enabling-impersonation", err)
 		}
 		if !resp.Status.Allowed {
-			return trace.AccessDenied("proxy can't impersonate Kubernetes %s at the cluster level; please make sure that proxy has all the necessary permissions: https://goteleport.com/teleport/docs/kubernetes-ssh/#impersonation", resource)
+			return trace.AccessDenied("proxy can't impersonate Kubernetes %s at the cluster level; please make sure that proxy has all the necessary permissions: https://goteleport.com/docs/enroll-resources/kubernetes-access/controls/#enabling-impersonation", resource)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #58946

Replaces broken link with working link in `checkImpersonationPermissions()`
- Broken link: https://goteleport.com/teleport/docs/kubernetes-ssh/#impersonation
- Fixed link: https://goteleport.com/docs/enroll-resources/kubernetes-access/controls/#enabling-impersonation


Affects versions:
- `v16`, `v17`, `v18`, `v19` 