### PR TITLE
Mention `tsh` environment variables in help output

### DIFF
--- a/lib/utils/testutils/kingpin.go
+++ b/lib/utils/testutils/kingpin.go
@@ -33,7 +33,7 @@ func checkKingpinHelp(help, where string) (issues []KingpinHelpIssue) {
 	}
 
 	// Help should end with `.`, or `.)` in case the sentence is in brackets.
-	if !strings.HasSuffix(help, ".") && !strings.HasSuffix(help, ".)") {
+	if !strings.HasSuffix(help, ".") && !strings.HasSuffix(help, ".)") && !strings.Contains(help, ". ($") {
 		issues = append(issues, KingpinHelpIssue{
 			Where: where,
 			Value: help,

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -832,7 +832,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	}
 
 	envVarHelp := func(help string, envVar string) string {
-		return fmt.Sprintf("%v [env_var: %q]", help, envVar)
+		return fmt.Sprintf("%s. ($%s)", strings.TrimSuffix(help, "."), envVar)
 	}
 
 	// We need to parse the arguments before executing managed updates to identify


### PR DESCRIPTION
Currently, `tsh` environment variables are not easily discoverable. Some are described in this [docs page](https://goteleport.com/docs/reference/cli/tsh/), but many are left out due to being new, or perhaps being specific to a particular command (`TELEPORT_HEADLESS_SKIP_CONFIRM` is only relevant to the `tsh headless approve` command).

Rather than, or [in addition to](https://github.com/gravitational/teleport/pull/56205), keeping these docs more up to date, I think we should make these env vars discoverable directly through the use of `tsh` through the help output.

This PR introduces the following output:
```console
> tsh --help
Usage: tsh [<flags>] <command> [<args> ...]

Teleport Command Line Client.

Flags:
  -l, --login                    Remote host login. [env_var: "TELEPORT_LOGIN"]
      --proxy                    Teleport proxy address. [env_var: "TELEPORT_PROXY"]
      --user                     Teleport user, defaults to current local user. [env_var: "TELEPORT_USER"]
      --ttl                      Minutes to live for a session.
  -i, --identity                 Identity file. [env_var: "TELEPORT_IDENTITY_FILE"]
      --cert-format              SSH certificate format.
      --[no-]insecure            Do not verify server's certificate and host name. Use only in test environments.
      --auth                     Specify the name of authentication connector to use. [env_var: "TELEPORT_AUTH"]
      --[no-]skip-version-check  Skip version checking between server and client.
  -d, --[no-]debug               Verbose logging to stdout.
      --[no-]os-log              Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. More
                                 details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.
  -k, --add-keys-to-agent        Controls how keys are handled. Valid values are [auto no yes only]. [env_var: "TELEPORT_ADD_KEYS_TO_AGENT"]
      --[no-]enable-escape-sequences  
                                 Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.
      --bind-addr                Override host:port used when opening a browser for cluster logins. [env_var: "TELEPORT_LOGIN_BIND_ADDR"]
      --callback                 Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.
      --mfa-mode                 Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso).
      --[no-]headless            Use headless login. Shorthand for --auth=headless. [env_var: "TELEPORT_HEADLESS"]
      --mlock                    Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).
      --piv-slot                 Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d". [env_var: "TELEPORT_PIV_SLOT"]
  -J, --jumphost                 SSH jumphost.
```

Note: Ideally this would be handled by the CLI library in a new column, but this PR is just a quick stopgap.