### PR TITLE
Allow control of service account.

### DIFF
--- a/examples/chart/event-handler/templates/_helpers.tpl
+++ b/examples/chart/event-handler/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Create the name of the service account to use
 */}}
 {{- define "event-handler.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "event-handler.fullname" .) .Values.serviceAccount.name }}
+{{- default .Release.Name .Values.serviceAccount.name -}}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "event-handler.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/examples/chart/event-handler/templates/serviceaccount.yaml
+++ b/examples/chart/event-handler/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "event-handler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "event-handler.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -225,6 +225,28 @@
             "default": {},
             "additionalProperties": true
         },
+        "serviceAccount": {
+            "$id": "#/properties/serviceAccount",
+            "type": "object",
+            "required": [],
+            "properties": {
+                "create": {
+                    "$id": "#properties/serviceAccount/create",
+                    "type": "boolean",
+                    "default": false
+                },
+                "name": {
+                    "$id": "#properties/serviceAccount/name",
+                    "type": "string",
+                    "default": ""
+                },
+                "automount": {
+                    "$id": "#properties/serviceAccount/automount",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
         "tls": {
             "$id": "#/properties/tls",
             "type": "object",

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -151,6 +151,16 @@ resources: {}
 
 nodeSelector: {}
 
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created. Default is false.
+  create: false
+  # The name of the ServiceAccount to use.
+  # If not set and serviceAccount.create is true, the name is generated using the release name.
+  # If create is false, the name will be used to reference an existing service account.
+  name: ""
+  # whether to automount the service account token.
+  automount: false
+
 # tls -- contains settings for mounting your own TLS material in the event-handler pod.
 # The event-handler does not expose a TLS server, so this is only used to trust CAs.
 tls:


### PR DESCRIPTION
The current behavior is to generate YAML with no `serviceAccountName` nor `automountServiceAccountToken` set. The Kubernetes default is to use the "default" service account, and mount the token. The principle of least privilege suggests that the pod in this chart should not get a token, because it does not interact with the Kubernetes API.