### PR TITLE
Terraform: Fix issue for Access Lists with empty grants

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -273,10 +273,6 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 }
 
 func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
-	if len(grants.Roles) == 0 && len(grants.Traits) == 0 {
-		return nil
-	}
-
 	return &accesslistv1.AccessListGrants{
 		Roles:  grants.Roles,
 		Traits: traitv1.ToProto(grants.Traits),


### PR DESCRIPTION
Fix for issue https://github.com/gravitational/teleport/issues/58948

Backports:

- [x] https://github.com/gravitational/teleport/pull/59032
- [x] https://github.com/gravitational/teleport/pull/59031

changelog: Fixed a bug preventing users to create access lists with empty grants through Terraform.