### PR TITLE
Remove tags from the docs home page

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -4,9 +4,6 @@ title: "The Teleport Infrastructure Identity Platform"
 description: Read an overview of the Teleport Access Platform. Learn how to implement Zero Trust Security across all your infrastructure for enhanced protection and streamlined access control.
 tocDepth: 3
 template: "landing-page"
-tags:
- - get-started
- - platform-wide
 ---
 
 import applicationSvg from "@site/src/components/Icon/teleport-svg/application.svg";


### PR DESCRIPTION
The docs home page is a special case, the first page a user sees when they visit the docs site (i.e., without navigating to a specific page from a search engine). As a result, it does not make sense to display this page in lists of pages with a particular tag, since in that case, it would not be the first page a user sees.