### PR TITLE
Web UI: bug(AWS OIDC integration): fix broken AWS Console IAM role link 

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -87,21 +87,23 @@ export function AwsOidcTitle({
               {status}
             </Label>
           </Flex>
-          <Flex gap={1}>
-            Role ARN:{' '}
-            <Link
-              target="_blank"
-              href={`https://console.aws.amazon.com/iamv2/home#/roles/details/${roleArnResourceName}`}
-            >
-              <Text
-                style={{
-                  fontFamily: theme.fonts.mono,
-                }}
+          {integration.spec && (
+            <Flex gap={1}>
+              Role ARN:{' '}
+              <Link
+                target="_blank"
+                href={`https://console.aws.amazon.com/iamv2/home#/roles/details/${roleArnResourceName}`}
               >
-                {integration.spec?.roleArn}
-              </Text>
-            </Link>
-          </Flex>
+                <Text
+                  style={{
+                    fontFamily: theme.fonts.mono,
+                  }}
+                >
+                  {integration.spec.roleArn}
+                </Text>
+              </Link>
+            </Flex>
+          )}
         </Flex>
       </Flex>
       <Flex gap={1} alignItems="center">

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -36,6 +36,7 @@ import {
 import type { EditableIntegrationFields } from 'teleport/Integrations/Operations/useIntegrationOperation';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
 import { IntegrationAwsOidc } from 'teleport/services/integrations';
+import { splitAwsIamArn } from 'teleport/services/integrations/aws';
 
 import { DashboardGuide, Ec2Guide, EksGuide, RdsGuide } from './guides';
 
@@ -65,6 +66,10 @@ export function AwsOidcTitle({
     integrationOps.clear();
   }
 
+  const { arnResourceName: roleArnResourceName } = splitAwsIamArn(
+    integration.spec?.roleArn
+  );
+
   return (
     <Flex mt={3} justifyContent="space-between" alignItems="center">
       <Flex alignItems="center" data-testid="aws-oidc-title">
@@ -86,7 +91,7 @@ export function AwsOidcTitle({
             Role ARN:{' '}
             <Link
               target="_blank"
-              href={`https://console.aws.amazon.com/iamv2/home#/roles/details/${integration.name}`}
+              href={`https://console.aws.amazon.com/iamv2/home#/roles/details/${roleArnResourceName}`}
             >
               <Text
                 style={{


### PR DESCRIPTION
## Problem

In the AWS OIDC integration, the Role ARN used by the integration is displayed with a link to the AWS Console. 

However, it is using integration name for the role name to generate the link. 

Clicking on the link leads to an invalid role

<img width="600" height="508" alt="image" src="https://github.com/user-attachments/assets/dcd068df-c253-457d-a20b-0c83c0b1f52b" />

_Screenshot_ 

## Expected Behavior

The link for the ARN goes to the corresponding IAM Role in the AWS Console

## Fix

Use the resource name from the IAM Role ARN to generate the AWS Console URL