### PR TITLE
Tag Enroll Database pages by cloud and use case

### DIFF
--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/auto-user-provisioning.mdx
@@ -3,6 +3,7 @@ title: Database Automatic User Provisioning
 description: Configure automatic user provisioning for databases.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/auto-user-provisioning/intro.mdx!)

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -5,6 +5,8 @@ description: Configure automatic user provisioning for Amazon Redshift.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -5,6 +5,7 @@ description: Configure automatic user provisioning for MariaDB.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -5,6 +5,7 @@ description: Configure automatic user provisioning for MongoDB.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -5,6 +5,7 @@ description: Configure automatic user provisioning for MySQL.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can automatically create an account in your MySQL database when a

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -5,6 +5,7 @@ description: Configure automatic user provisioning for PostgreSQL.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -3,6 +3,7 @@ title: Databases
 description: Teleport database access introduction, demo and resources.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can provide secure connections to your databases while improving both

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon Keyspaces (Ap
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Keyspaces (Apache Cassandra)" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
@@ -4,6 +4,8 @@ description: How to connect AWS databases in external AWS accounts to Teleport.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 You can deploy the Teleport Database Service with AWS IAM credentials in one

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -5,6 +5,8 @@ description: How to access Amazon DocumentDB with Teleport database access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon DocumentDB" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -5,6 +5,8 @@ description: How to access Amazon DynamoDB with Teleport database access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon DynamoDB" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-memorydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-memorydb.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon MemoryDB
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon MemoryDB for Redis and Valkey" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -5,6 +5,8 @@ description: How to access Amazon OpenSearch with Teleport database access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon OpenSearch" dbConfigure="via REST API with IAM Authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/elasticache-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/elasticache-serverless.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon ElastiCache S
 labels:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache Serverless" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
@@ -3,6 +3,8 @@ title: Enroll AWS Databases
 description: "Provides instructions on protecting databases in your AWS-managed infrastructure with Teleport."
 tags:
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 The guides in this section show you how to protect AWS-managed databases with

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -6,6 +6,8 @@ videoBanner: UFhT52d5bYg
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-oracle.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport Database Access with Amazon RDS Oracle wi
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS for Oracle" dbConfigure="with Kerberos authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon RDS Proxy for
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for MariaDB or MySQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon RDS Proxy for
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for PostgreSQL" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon RDS Proxy for
 tags:
  - how-to
  - zero-trust
+ - aws
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS proxy for Microsoft SQL Server" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon RDS and Auror
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon RDS or Aurora" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon ElastiCache f
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon ElastiCache" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Amazon Redshift Serv
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Amazon Redshift Serverless" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx
@@ -6,6 +6,8 @@ videoBanner: k2wz79XCexY
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with Active Directory authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Azure Database for P
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure PostgreSQL or MySQL" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Azure Cache for Redi
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure Cache for Redis" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Azure SQL Server usi
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Azure SQL Server" dbConfigure="with Microsoft Entra ID-based authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases.mdx
@@ -3,6 +3,8 @@ title: Enroll Azure Databases
 description: "Provides instructions on protecting databases in your Azure-managed infrastructure with Teleport."
 tags:
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 You can protect Azure-managed databases with Teleport. Learn how to enroll the

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/alloydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/alloydb.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with AlloyDB.
 labels:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="AlloyDB" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases.mdx
@@ -3,6 +3,8 @@ title: Enroll Google Cloud Databases
 description: "Provides instructions on protecting databases in your Google Cloud-managed infrastructure with Teleport."
 tags:
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 You can protect databases hosted on Google Cloud with Teleport. Read the

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with Cloud SQL for MySQL.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="MySQL on Google Cloud SQL" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -6,6 +6,8 @@ videoBanner: br9LZ3ZXqCk
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL on Google Cloud SQL" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -5,6 +5,8 @@ description: How to configure Teleport database access with GCP's Cloud Spanner.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Cloud Spanner" dbConfigure="with a service account"!)

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases.mdx
@@ -3,6 +3,7 @@ title: Enroll Cloud-Hosted Database Platforms
 description: "Provides instructions on protecting managed databases in your infrastructure with Teleport."
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can protect databases that are managed as a dedicated cloud platform.

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas.mdx
@@ -6,6 +6,7 @@ videoBanner: mu_ZKTjnFJ8
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="MongoDB Atlas" dbConfigure="with either mutual TLS or AWS IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Oracle Exadata.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Oracle Exadata" dbConfigure="with mTLS authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/snowflake.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Snowflake.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Snowflake" dbConfigure="with key pair authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Cassandra and Scylla
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Cassandra or ScyllaDB"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with ClickHouse.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Clickhouse integration allows you to enroll ClickHouse databases

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with self-hosted Cockroac
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="CockroachDB"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/elastic.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Elasticsearch.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Elasticsearch"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases.mdx
@@ -3,6 +3,7 @@ title: Enroll Self-Hosted Databases
 description: "Provides instructions on protecting self-hosted databases in your infrastructure with Teleport."
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can protect self-hosted databases with Teleport. Learn how to enroll your

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -6,6 +6,7 @@ videoBanner: 6lgVObxoLkc
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MongoDB"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with self-hosted MySQL/Ma
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="MySQL or MariaDB"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Oracle.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Oracle"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with self-hosted PostgreS
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="PostgreSQL"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Redis Cluster.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* vale messaging.protocol-products = NO */}

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access with Redis.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* vale messaging.protocol-products = NO */}

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -5,6 +5,7 @@ description: How to configure Microsoft SQL Server access with Active Directory 
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="Microsoft SQL Server" dbConfigure="with PKINIT authentication"!)

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database access for Vitess (MySQL protoco
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/self-hosted-introduction.mdx dbType="Vitess (MySQL)"!)

--- a/docs/pages/enroll-resources/database-access/faq.mdx
+++ b/docs/pages/enroll-resources/database-access/faq.mdx
@@ -4,6 +4,7 @@ description: Frequently asked questions about Teleport database access.
 tags:
  - faq
  - zero-trust
+ - infrastructure-identity
 ---
 
 This page provides the answers to common questions about enrolling databases

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -4,6 +4,7 @@ description: Getting started with Teleport database access and AWS Aurora Postgr
 tags:
  - get-started
  - zero-trust
+ - infrastructure-identity
 ---
 
 (!docs/pages/includes/database-access/db-introduction.mdx dbType="PostgreSQL Amazon Aurora" dbConfigure="with IAM authentication"!)

--- a/docs/pages/enroll-resources/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/dynamic-registration.mdx
@@ -4,6 +4,7 @@ description: Register/unregister databases without restarting Teleport.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Dynamic database registration allows Teleport administrators to register new

--- a/docs/pages/enroll-resources/database-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/guides.mdx
@@ -4,6 +4,7 @@ description: Guides to possibilities for running the Teleport Database Service.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Database Service proxies connections to databases protected by

--- a/docs/pages/enroll-resources/database-access/guides/ha.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/ha.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport database access in a Highly Available (HA
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can deploy the Teleport Database Service in a Highly Available (HA)

--- a/docs/pages/enroll-resources/database-access/guides/health-checks.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/health-checks.mdx
@@ -5,6 +5,7 @@ description: How to configure Teleport database health checks and view target he
 tags:
 - conceptual
 - zero-trust
+- infrastructure-identity
 ---
 
 This documentation explains how to manage database health checks.

--- a/docs/pages/enroll-resources/database-access/rbac.mdx
+++ b/docs/pages/enroll-resources/database-access/rbac.mdx
@@ -4,6 +4,7 @@ description: Role-based access control (RBAC) for Teleport database access.
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 **Database Access Controls** is a Teleport feature that lets you configure

--- a/docs/pages/enroll-resources/database-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/database-access/troubleshooting.mdx
@@ -4,6 +4,7 @@ description: Common issues and resolutions for Teleport's Database Access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Common issues and resolution steps.


### PR DESCRIPTION
Tag pages in the Enroll Databases section of the docs with the appropriate use case and cloud provider tags.

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.