### PR TITLE
Add tags to four Enroll Resources docs sections

### DIFF
--- a/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
+++ b/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
@@ -4,6 +4,7 @@ description: Explains how to edit the services that are running on a Teleport Ag
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 A single Teleport Agent can run multiple services. This guide shows you how to

--- a/docs/pages/enroll-resources/agents/agents.mdx
+++ b/docs/pages/enroll-resources/agents/agents.mdx
@@ -4,6 +4,7 @@ description: Deploy Agents to enroll resources in your infrastructure with Telep
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can use Teleport to protect infrastructure resources like servers and

--- a/docs/pages/enroll-resources/agents/aws-ec2.mdx
+++ b/docs/pages/enroll-resources/agents/aws-ec2.mdx
@@ -4,6 +4,8 @@ description: Use the EC2 join method to add services to your Teleport cluster on
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 This guide explains how to use the **EC2 join method** to configure Teleport

--- a/docs/pages/enroll-resources/agents/aws-iam.mdx
+++ b/docs/pages/enroll-resources/agents/aws-iam.mdx
@@ -4,6 +4,8 @@ description: Use the IAM join method to add services to your Teleport cluster on
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 This guide explains how to use the **IAM join method** to configure Teleport

--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -4,6 +4,8 @@ description: Use the Azure join method to join Teleport services to your Telepor
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 This guide will explain how to use the **Azure join method** to configure

--- a/docs/pages/enroll-resources/agents/gcp.mdx
+++ b/docs/pages/enroll-resources/agents/gcp.mdx
@@ -4,6 +4,8 @@ description: Use the GCP join method to add services to your Teleport cluster.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 This guide will explain how to use the **GCP join method** to configure Teleport

--- a/docs/pages/enroll-resources/agents/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-token.mdx
@@ -4,6 +4,7 @@ description: This guide shows you how to join a Teleport instance to your cluste
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/agents/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/kubernetes.mdx
@@ -4,6 +4,7 @@ description: Use Kubernetes ServiceAccount tokens to join services running in th
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide will explain how to use the **Kubernetes join method** to configure

--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -4,6 +4,7 @@ description: Use the Oracle join method to add services to your Teleport cluster
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide will explain how to use the **Oracle join method** to configure

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide demonstrates how to connect an Active Directory domain and how to log

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,6 +3,7 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The guides in this section explain how to protect Windows desktops with

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -4,6 +4,7 @@ description: Teleport desktop Directory Sharing lets you easily send files to a 
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Directory Sharing is a Teleport feature of that makes it easy to move files

--- a/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/desktop-access/dynamic-registration.mdx
@@ -4,6 +4,7 @@ description: Register/unregister Windows desktops without restarting Teleport.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Dynamic Windows desktop registration allows Teleport administrators to register

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -5,6 +5,7 @@ videoBanner: 9DyKQbg4ORc
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide demonstrates how to configure Teleport to provide secure, passwordless access

--- a/docs/pages/enroll-resources/desktop-access/introduction.mdx
+++ b/docs/pages/enroll-resources/desktop-access/introduction.mdx
@@ -5,6 +5,7 @@ videoBanner: n2h0GisWdss
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 The topics in this guide describe how to configure Teleport to provide secure, passwordless

--- a/docs/pages/enroll-resources/desktop-access/rbac.mdx
+++ b/docs/pages/enroll-resources/desktop-access/rbac.mdx
@@ -4,6 +4,7 @@ description: Role-based access control (RBAC) for desktops protected by Teleport
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 Teleport's RBAC allows administrators to set up granular access policies for

--- a/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/desktop-access/troubleshooting.mdx
@@ -4,6 +4,7 @@ description: Common issues and resolutions for Teleport's desktop access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Common issues and resolution steps.

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -4,6 +4,7 @@ description: How the Teleport Kubernetes Service applies RBAC to manage access t
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 This guide explains the way the Teleport Kubernetes Service applies role-based

--- a/docs/pages/enroll-resources/kubernetes-access/faq.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/faq.mdx
@@ -4,6 +4,7 @@ description: Frequently asked questions about Teleport Kubernetes Access
 tags:
  - faq
  - zero-trust
+ - infrastructure-identity
 ---
 
 This page offers answers to frequently asked questions about Teleport's

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -5,6 +5,7 @@ videoBanner: 3AUGrOZ5me0
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide demonstrates how to enroll a Kubernetes cluster as a Teleport

--- a/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
@@ -4,6 +4,7 @@ description: Learn how Teleport can protect your Kubernetes clusters with RBAC, 
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport provides secure access to Kubernetes clusters:

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,6 +3,7 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The guides in this section explain how to protect Kubernetes clusters with

--- a/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport roles to access clusters, groups, users, 
 tags:
  - how-to
  - zero-trust
+ - privileged-access
 ---
 
 The Teleport Kubernetes Service is a proxy that sits between Kubernetes users

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -4,6 +4,7 @@ description: Register and unregister Kubernetes clusters without restarting a Te
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 With dynamic Kubernetes cluster registration, you can manage the Kubernetes

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -4,6 +4,7 @@ description: Connecting a Kubernetes cluster to Teleport with IAM joining.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 In this guide, we will show you how to register a Kubernetes cluster with

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
@@ -4,6 +4,7 @@ description: How to manually add a Kubernetes cluster to Teleport after creating
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 In some cases, you will want to register a Kubernetes cluster with Teleport

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -4,6 +4,7 @@ description: Connecting standalone Teleport installations to Kubernetes clusters
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 While you can register a Kubernetes cluster with Teleport by running the

--- a/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
@@ -4,6 +4,7 @@ description: Troubleshooting common issues with Kubernetes access
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This page describes common issues with Kubernetes and how to resolve them.

--- a/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
@@ -2,6 +2,10 @@
 title: Dynamic MCP Server Registration
 sidebar_position: 4
 description: Register/unregister MCP servers without restarting Teleport.
+tags:
+- how-to
+- zero-trust
+- mcp
 ---
 
 Dynamic MCP server registration allows Teleport administrators to register new

--- a/docs/pages/enroll-resources/mcp-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/mcp-access/getting-started.mdx
@@ -1,6 +1,10 @@
 ---
 title: MCP Access Getting Started Guide
 description: Getting started with Teleport MCP access.
+tags:
+- how-to
+- mcp
+- zero-trust
 ---
 
 Teleport can provide secure connections to your MCP (Model Context Protocol)

--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -1,6 +1,9 @@
 ---
 title: MCP Servers
 description: Guides to protecting MCP servers with Teleport
+tags:
+ - mcp
+ - zero-trust
 ---
 
 Teleport can provide secure connections to your MCP (Model Context Protocol)

--- a/docs/pages/enroll-resources/mcp-access/rbac.mdx
+++ b/docs/pages/enroll-resources/mcp-access/rbac.mdx
@@ -1,6 +1,10 @@
 ---
 title: MCP Access Controls
 description: Role-based access control (RBAC) for Teleport MCP access.
+tags:
+- conceptual
+- mcp
+- zero-trust
 ---
 
 You can use Teleport's role-based access control (RBAC) system to set up

--- a/docs/pages/enroll-resources/mcp-access/stdio.mdx
+++ b/docs/pages/enroll-resources/mcp-access/stdio.mdx
@@ -1,6 +1,10 @@
 ---
 title: MCP Access with Stdio MCP Server
 description: How to access MCP server with stdio transport.
+tags:
+- how-to
+- mcp
+- zero-trust
 ---
 
 Teleport can provide secure access to MCP servers with stdio transport.

--- a/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
@@ -1,6 +1,10 @@
 ---
 title: Troubleshooting MCP Access
 description: Describes common issues and solutions for access to MCP servers protected by Teleport.
+tags:
+- conceptual
+- zero-trust
+- mcp
 ---
 
 This section describes common issues that you might encounter in managing access


### PR DESCRIPTION
Tag pages in the following sections of the Zero Trust Access docs with the appropriate use case and cloud provider tags:

- Agents
- Enroll Desktops
- Enroll Kubernetes Clusters
- MCP

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

This change also corrects pages with missing or inaccurate tags.