### PR TITLE
Tag three Enroll Resources docs sections

### DIFF
--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,6 +3,7 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The guides in this section explain how to protect applications with

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -4,6 +4,8 @@ description: How to use AWS IAM Roles Anywhere with Teleport for AWS Console and
 labels:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 Teleport integrates with AWS IAM Roles Anywhere to provide AWS Console and CLI access.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -4,6 +4,8 @@ description: How to access AWS with Teleport application access.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 <Admonition type="tip">

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -4,6 +4,8 @@ description: How to enable secure access to Azure CLIs on Azure Kubernetes Servi
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 (!docs/pages/includes/application-access/azure-intro.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -4,6 +4,8 @@ description: How to enable secure access to Azure CLIs.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 (!docs/pages/includes/application-access/azure-intro.mdx!)

--- a/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/cloud-apis.mdx
@@ -3,6 +3,7 @@ title: "Securing Access to Cloud APIs"
 description: "How to use Teleport to achieve secure access while managing your cloud-based infrastructure."
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can use Teleport to provide secure access to your cloud provider's APIs.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -4,6 +4,8 @@ description: How to enable secure access to Google Cloud APIs.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 You can use Teleport to manage access to CLI tools that interact with Google

--- a/docs/pages/enroll-resources/application-access/controls.mdx
+++ b/docs/pages/enroll-resources/application-access/controls.mdx
@@ -4,6 +4,7 @@ description: Role-Based Access Control (RBAC) for Teleport application access.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 This article describes access control concepts particularly relevant to the

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -5,6 +5,7 @@ videoBanner: cvW4b96aPL0
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This tutorial demonstrates how to configure secure access to an application 

--- a/docs/pages/enroll-resources/application-access/guides/amazon-athena.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/amazon-athena.mdx
@@ -4,6 +4,8 @@ description: How to access Amazon Athena with Teleport
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/application-access/guides/api-access.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/api-access.mdx
@@ -4,6 +4,7 @@ description: How to access REST APIs with Teleport application access.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Application Service can be used to access applications' (REST or

--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -4,6 +4,7 @@ description: In this getting started guide, learn how to connect an application 
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide shows you how to enroll a web application with your Teleport cluster

--- a/docs/pages/enroll-resources/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/dynamic-registration.mdx
@@ -4,6 +4,7 @@ description: Register/unregister apps without restarting Teleport.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Dynamic app registration allows Teleport administrators to register new apps (or

--- a/docs/pages/enroll-resources/application-access/guides/dynamodb.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/dynamodb.mdx
@@ -4,6 +4,8 @@ description: How to access Amazon DynamoDB through the Teleport Application Serv
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 You can configure the Teleport Application Service to enable secure access to

--- a/docs/pages/enroll-resources/application-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/guides.mdx
@@ -4,6 +4,7 @@ description: Guides for configuring Teleport application access.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 These guides explain how to use the Teleport Application Service, which allows

--- a/docs/pages/enroll-resources/application-access/guides/ha.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/ha.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport application access in a Highly Available 
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can deploy the Application Service in a Highly Available (HA) configuration

--- a/docs/pages/enroll-resources/application-access/guides/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/tcp.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport for accessing plain TCP apps
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can provide access to any TCP-based application. This allows users to

--- a/docs/pages/enroll-resources/application-access/guides/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/vnet.mdx
@@ -4,6 +4,7 @@ description: How to configure custom DNS zones for VNet
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 VNet automatically proxies connections made to TCP applications available under the public address

--- a/docs/pages/enroll-resources/application-access/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/introduction.mdx
@@ -3,6 +3,7 @@ title: Introduction to Enrolling Applications
 description: How to set up Teleport to protect applications and cloud provider APIs
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can provide secure access to applications and cloud provider APIs.

--- a/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
@@ -4,6 +4,7 @@ description: How to use JWT authentication with Elasticsearch
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
@@ -4,6 +4,7 @@ description: How to use JWT tokens for authentication with Teleport application 
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport sends a JWT token signed with Teleport's authority with each request

--- a/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
@@ -4,6 +4,7 @@ description: Guides for using Teleport application access JWT authentication.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 These guides explain how web apps behind the Teleport Application Service can

--- a/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
@@ -4,6 +4,7 @@ description: Describes common issues and solutions for access to applications pr
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This section describes common issues that you might encounter in managing access to applications

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -3,6 +3,7 @@ title: Teleport Auto-Discovery
 description: "Learn how to use the Teleport Discovery Service, which automatically enrolls resources by query APIs"
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Discovery Service automatically detects resources in your

--- a/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport to auto-discover AWS databases.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 Teleport can be configured to discover AWS-hosted databases automatically and

--- a/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
@@ -4,6 +4,7 @@ description: Detailed guides for configuring database discovery.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can be configured to discover databases automatically and register

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
@@ -4,6 +4,7 @@ description: Detailed guide for configuring Kubernetes Application Discovery.
 tags:
  - get-started
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can automatically detect applications running in your Kubernetes

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
@@ -3,6 +3,7 @@ title: "Enroll Kubernetes Services as Teleport Applications"
 description: "Teleport can automatically detect applications running in your Kubernetes clusters and register them with Teleport for secure access."
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can automatically detect applications running in your Kubernetes

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -4,6 +4,8 @@ description: How to configure auto-discovery of AWS EKS clusters in Teleport.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 EKS Auto-Discovery can automatically

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -4,6 +4,8 @@ description: Auto-Discovery of AKS clusters in Azure cloud.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 AKS Auto-Discovery can automatically

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -4,6 +4,8 @@ description: How to configure auto-discovery of Google Kubernetes Engine cluster
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 The Teleport Discovery Service can automatically register your Google Kubernetes

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
@@ -4,6 +4,7 @@ description: Detailed guides for configuring Kubernetes Clusters Discovery.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Kubernetes Clusters Discovery allows Kubernetes clusters

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport to automatically enroll Azure virtual mac
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - azure
 ---
 
 This guide shows you how to set up automatic server discovery for Azure virtual

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport EC2 auto-discovery using Teleport to conf
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 This guide shows you how to configure Teleport to automatically enroll EC2

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport EC2 auto-discovery with manually configur
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 This guide shows you how to configure Teleport to automatically enroll EC2

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport to automatically enroll EC2 instances.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - aws
 ---
 
 This guide shows you how to configure Teleport to automatically enroll EC2

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -4,6 +4,8 @@ description: How to configure Teleport to automatically enroll GCP compute insta
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
+ - google-cloud
 ---
 
 This guide shows you how to set up automatic server discovery for Google Compute

--- a/docs/pages/enroll-resources/auto-discovery/servers/servers.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/servers.mdx
@@ -3,6 +3,7 @@ title: Server Auto-Discovery
 description: You can set up the Teleport Discovery Service to automatically enroll servers in your infrastructure.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Discovery Service can connect to your cloud provider and

--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -5,6 +5,7 @@ videoBanner: LnaRP0xKWRI
 tags:
  - get-started
  - zero-trust
+ - infrastructure-identity
 ---
 
 You can protect a server with Teleport by running the Teleport SSH Service on

--- a/docs/pages/enroll-resources/server-access/guides/ansible.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ansible.mdx
@@ -4,6 +4,7 @@ description: Using Teleport with Ansible
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Ansible uses the OpenSSH client by default. Teleport supports SSH protocol and

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -5,6 +5,7 @@ h1: Linux Auditing System (auditd)
 tags:
  - how-to
  - zero-trust
+ - audit
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -6,6 +6,7 @@ videoBanner: 8uO5H-iYw5A
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
@@ -1,10 +1,10 @@
 ---
 title: Encrypted Session Recordings
 description: How to enable encrypted session recordings using your CA key backend.
-labels:
+tags:
   - how-to
   - zero-trust
-  - data-protection
+  - resiliency
 ---
 
 Encrypted session recordings allow Teleport users to enable at-rest encryption

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
@@ -1,10 +1,10 @@
 ---
 title: Rotating Session Recording Encryption Keys
 description: How to rotate automatically provisioned session recording encryption keys.
-labels:
+tags:
   - how-to
   - zero-trust
-  - data-protection
+  - resiliency
 ---
 
 This guide explains how to rotate encryption keys for session recordings using

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -1,10 +1,10 @@
 ---
 title: Rotating Manual Session Recording Encryption Keys
 description: How to rotate automatically provisioned session recording encryption keys.
-labels:
+tags:
   - how-to
   - zero-trust
-  - data-protection
+  - resiliency
 ---
 
 This guide explains how to rotate encryption keys for session recordings.

--- a/docs/pages/enroll-resources/server-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/guides.mdx
@@ -4,6 +4,7 @@ description: Teleport server access guides.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 - [Using Teleport with PAM](ssh-pam.mdx): How to configure Teleport SSH with PAM (Pluggable Authentication Modules).

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport to automatically create transient host us
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport's SSH Service can be configured to automatically create local Unix users

--- a/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
@@ -5,6 +5,7 @@ h1: SFTP with JetBrains IDE
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 JetBrain's IDEs, like PyCharm, GoLand, and IntelliJ, allow browsing, copying, and editing files on a remote server

--- a/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
@@ -4,6 +4,7 @@ description: Use Recording Proxy Mode to capture OpenSSH server activity
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport Recording Proxy Mode was added to allow Teleport users

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -5,6 +5,7 @@ h1: Remote Development With Visual Studio Code
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide explains how to use Teleport and Visual Studio Code's remote SSH extension.

--- a/docs/pages/enroll-resources/server-access/introduction.mdx
+++ b/docs/pages/enroll-resources/server-access/introduction.mdx
@@ -5,6 +5,7 @@ videoBanner: EsEvO5ndNDI
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport consolidates SSH access across all environments, decreases

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -6,6 +6,7 @@ videoBanner: x0eYFUEIOrM
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 In this guide, we will show you how to configure Teleport in agentless mode and

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -5,6 +5,7 @@ videoBanner: x0eYFUEIOrM
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 In this guide, we will show you how to configure the OpenSSH server `sshd` to

--- a/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
@@ -4,6 +4,7 @@ description: Teleport Agentless OpenSSH integration guides.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 - [Agentless OpenSSH Integration](openssh-agentless.mdx): How to use Teleport in agentless mode on systems with OpenSSH and `sshd`.

--- a/docs/pages/enroll-resources/server-access/rbac.mdx
+++ b/docs/pages/enroll-resources/server-access/rbac.mdx
@@ -4,6 +4,7 @@ description: Role-based access control (RBAC) for Teleport server access.
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 You can use Teleport's role-based access control (RBAC) system to set up

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,6 +3,7 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 The guides in this section explain how to protect Linux servers with

--- a/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
+++ b/docs/pages/enroll-resources/server-access/troubleshooting-server.mdx
@@ -4,6 +4,7 @@ description: Describes common issues and solutions for access to servers.
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This section describes common issues that you might encounter in managing access to servers


### PR DESCRIPTION
Tag pages in the following sections of the docs with the appropriate use case and cloud provider tags:

- Enroll Applications
- Auto-Discovery
- Enroll Servers

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

This change also fixes missing tags.

Note that not all pages in these sections warrant a use case or cloud provider tag.