### PR TITLE
Fix markdown formatting when the string is undefined

### DIFF
--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -137,6 +137,10 @@ const MAX_ITERATIONS = 10000;
  * default to disabling it.
  */
 function processMarkdown(text: string, options: MarkdownOptions): ReactNode[] {
+  if (!text) {
+    return [];
+  }
+
   const activeParsers = parsers.filter(p => {
     if (!p.condition) return true;
     return p.condition(options);


### PR DESCRIPTION
If the text is empty/undefined (unexpectedly), this fixes any potential cannot read `split` errors