### PR TITLE
Refactor Desktop Connection Proxy / Improve Error Handling on Teardown

### DIFF
--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -308,7 +308,7 @@ func (c *ConnProxy) Run() error {
 			defer func() {
 				// Call close on the other side of the connection.
 				// This should wake them up.
-				*e = errors.Join(*e, c.client.Close())
+				*e = errors.Join(*e, dst.Close())
 			}()
 			// Copy from server to client
 			*e = messageCopy(dst, src)

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -227,7 +227,7 @@ func NewReadWriteInterceptor(src MessageReadWriteCloser, readInterceptor, writeI
 	}
 }
 
-// WriteMessage passes the message to the write interceptor (if provded)
+// WriteMessage passes the message to the write interceptor (if provided)
 // for omition or modification before writing the message to the underlying
 // writer.
 func (i *ReadWriteInterceptor) WriteMessage(m Message) error {

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -285,7 +285,11 @@ func (i *ReadWriteInterceptor) WriteMessage(m Message) error {
 		return err
 	}
 
-	for _, msg := range removeNilMessages(out) {
+	for _, msg := range out {
+		if msg == nil {
+			continue
+		}
+
 		if err = i.src.WriteMessage(msg); err != nil {
 			return err
 		}

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -351,13 +351,12 @@ func (c *ConnProxy) Run() error {
 	var clientToServerErr, serverToClientErr error
 	wg.Go(func() {
 		err := copyMessages(c.client, c.server)
-		serverToClientErr = errors.Join(err, c.client.Close())
+		serverToClientErr = trace.NewAggregate(err, c.client.Close())
 	})
 	wg.Go(func() {
 		err := copyMessages(c.server, c.client)
-		clientToServerErr = errors.Join(err, c.server.Close())
+		clientToServerErr = trace.NewAggregate(err, c.server.Close())
 	})
 	wg.Wait()
-
-	return errors.Join(clientToServerErr, serverToClientErr)
+	return trace.NewAggregate(clientToServerErr, serverToClientErr)
 }

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -295,5 +295,6 @@ func TestInterceptor(t *testing.T) {
 	testConn.readChan <- mockMessage("noreplace")
 	// "omit" message should be dropped, so the next message is "noreplace"
 	msg, err = interceptedRWC.ReadMessage()
+	require.NoError(t, err)
 	assert.Equal(t, "noreplace", string(msg.(mockMessage)))
 }

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -20,10 +20,14 @@ package tdp
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"net"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,4 +87,167 @@ func (f fakeTrackingConn) LocalAddr() net.Addr {
 
 func (f fakeTrackingConn) RemoteAddr() net.Addr {
 	return f.remote
+}
+
+func newMockRWC() rwc {
+	return rwc{
+		readChan:  make(chan Message, 10),
+		writeChan: make(chan Message, 10),
+	}
+}
+
+type rwc struct {
+	closeErr   error
+	readError  error
+	writeError error
+	readChan   chan Message
+	writeChan  chan Message
+	once       sync.Once
+}
+
+func (r *rwc) ReadMessage() (Message, error) {
+	if msg, ok := <-r.readChan; ok {
+		return msg, nil
+	}
+	return nil, fmt.Errorf("read failed: %w", r.readError)
+}
+
+func (r *rwc) WriteMessage(m Message) error {
+	if r.writeError != nil {
+		return fmt.Errorf("write failed: %w", r.writeError)
+	}
+	if r.writeChan != nil {
+		r.writeChan <- m
+		return nil
+	}
+	panic("invariant violation")
+}
+
+func (r *rwc) Close() error {
+	r.once.Do(func() {
+		close(r.readChan)
+		close(r.writeChan)
+	})
+	return r.closeErr
+}
+
+type mockMessage string
+
+func (m mockMessage) Encode() ([]byte, error) {
+	return []byte(string(m)), nil
+}
+
+func TestConnProxy(t *testing.T) {
+	// distinguished errors to use for validation
+	clientReadErr := errors.New("failed client")
+	serverReadErr := errors.New("failed server")
+	clientCloseError := errors.New("client close error")
+	serverCloseError := errors.New("server close error")
+	writeError := errors.New("something went wrong")
+
+	t.Run("error-handling", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			setupFn  func(t *testing.T, client, server *rwc)
+			expectFn func(t *testing.T, proxyError error)
+		}{
+			{
+				name: "bidirectional-copy-no-errors",
+				setupFn: func(t *testing.T, clientConn, serverConn *rwc) {
+					// Message copied from client to server
+					clientConn.readChan <- mockMessage("hello server!")
+					msg := <-serverConn.writeChan
+					assert.Equal(t, "hello server!", string(msg.(mockMessage)))
+
+					// Message copied from server to client
+					serverConn.readChan <- mockMessage("hello client!")
+					msg = <-clientConn.writeChan
+					assert.Equal(t, "hello client!", string(msg.(mockMessage)))
+
+					// Both sides return EOF, no errors will be reported
+					serverConn.readError = io.EOF
+					clientConn.readError = io.EOF
+					_ = serverConn.Close()
+				},
+				expectFn: func(t *testing.T, proxyError error) {
+					require.NoError(t, proxyError)
+				},
+			},
+			{
+				name: "server-write-error",
+				setupFn: func(t *testing.T, clientConn, serverConn *rwc) {
+					serverConn.writeError = writeError
+					serverConn.readError = io.EOF
+					// Copy from client to server will fail
+					clientConn.readChan <- mockMessage("hello server!")
+					// Write error should be returned
+					serverConn.Close()
+				},
+				expectFn: func(t *testing.T, proxyError error) {
+					assert.ErrorIs(t, proxyError, writeError)
+				},
+			},
+			{
+				// Same as server-write-error, but swapped
+				name: "client-write-error",
+				setupFn: func(t *testing.T, clientConn, serverConn *rwc) {
+					clientConn.writeError = writeError
+					clientConn.readError = io.EOF
+					// Copy from server to client will fail
+					serverConn.readChan <- mockMessage("hello client!")
+					// Write error should be returned
+					clientConn.Close()
+				},
+				expectFn: func(t *testing.T, proxyError error) {
+					assert.ErrorIs(t, proxyError, writeError)
+				},
+			},
+			{
+				// Same as server and client read both fail
+				name: "server-and-client-read-error",
+				setupFn: func(t *testing.T, clientConn, serverConn *rwc) {
+					clientConn.readError = clientReadErr
+					serverConn.readError = serverReadErr
+					clientConn.Close()
+				},
+				expectFn: func(t *testing.T, proxyError error) {
+					// Both errors should be found in the error chain
+					assert.ErrorIs(t, proxyError, clientReadErr)
+					assert.ErrorIs(t, proxyError, serverReadErr)
+				},
+			},
+			{
+				// Same as server and client read both fail
+				name: "close-errors-returned",
+				setupFn: func(t *testing.T, clientConn, serverConn *rwc) {
+					// Both sides return EOF from read, but return errors on clos
+					serverConn.closeErr = serverCloseError
+					clientConn.closeErr = clientCloseError
+					serverConn.readError = io.EOF
+					clientConn.readError = io.EOF
+					_ = serverConn.Close()
+				},
+				expectFn: func(t *testing.T, proxyError error) {
+					// Both errors should be found in the error chain
+					assert.ErrorIs(t, proxyError, clientCloseError)
+					assert.ErrorIs(t, proxyError, serverCloseError)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				clientConn := newMockRWC()
+				serverConn := newMockRWC()
+				proxy := NewConnProxy(&clientConn, &serverConn)
+				proxyError := make(chan error)
+				go func() {
+					proxyError <- proxy.Run()
+				}()
+
+				test.setupFn(t, &clientConn, &serverConn)
+				test.expectFn(t, <-proxyError)
+			})
+		}
+	})
 }

--- a/lib/srv/desktop/tdp/conn_test.go
+++ b/lib/srv/desktop/tdp/conn_test.go
@@ -318,3 +318,28 @@ func TestInterceptor(t *testing.T) {
 	_, err = interceptedRWC.ReadMessage()
 	require.Error(t, err)
 }
+
+func TestRemoveNilMessages(t *testing.T) {
+	tests := []struct {
+		msgs        []Message
+		expectedLen int
+	}{
+		{msgs: []Message{nil}, expectedLen: 0},
+		{msgs: []Message{nil, nil}, expectedLen: 0},
+		{msgs: []Message{MFA{}, nil}, expectedLen: 1},
+		{msgs: []Message{nil, MFA{}}, expectedLen: 1},
+		{msgs: []Message{nil, MFA{}, nil}, expectedLen: 1},
+		{msgs: []Message{MFA{}, nil, MFA{}}, expectedLen: 2},
+		{msgs: []Message{MFA{}, nil, nil, MFA{}}, expectedLen: 2},
+		{msgs: []Message{MFA{}, nil, nil, MFA{}, nil, nil, MFA{}}, expectedLen: 3},
+		{msgs: []Message{MFA{}, MFA{}, MFA{}}, expectedLen: 3},
+	}
+
+	for _, test := range tests {
+		result := removeNilMessages(test.msgs)
+		require.Len(t, result, test.expectedLen)
+		for _, msg := range result {
+			assert.NotNil(t, msg)
+		}
+	}
+}

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -144,7 +144,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		directoryAccessProvider: s,
 	}
 
-	tdpConnProxy := tdp.NewConnProxy(downstreamRW, conn, func(tdpConn *tdp.Conn, message tdp.Message) (tdp.Message, error) {
+	intercept := func(_ *tdp.Conn, message tdp.Message) (tdp.Message, error) {
 		msg, intErr := fsHandle.process(message, func(message tdp.Message) error {
 			return trace.Wrap(tdpConn.WriteMessage(message))
 		})
@@ -156,7 +156,9 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 			}, nil
 		}
 		return msg, nil
-	})
+	}
+
+	tdpConnProxy := tdp.NewConnProxy2(tdp.NewConn(downstreamRW), tdp.NewConn(conn))
 
 	return trace.Wrap(tdpConnProxy.Run())
 }

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -156,7 +156,11 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 				Severity: tdp.SeverityWarning,
 			}}, nil
 		}
-		return []tdp.Message{msg}, nil
+
+		if msg != nil {
+			return []tdp.Message{msg}, nil
+		}
+		return nil, nil
 	}, nil))
 
 	return trace.Wrap(tdpConnProxy.Run())

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -586,6 +586,9 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 
 	}
 
+	// Run joins and returns any read, write, or close errors from each side of the
+	// connection proxy. We can inspect this singular error chain for any "real"
+	// network errors (as opposed to errors that are expected from a normal teardown).
 	err = proxy.Run()
 	if utils.IsOKNetworkError(err) {
 		err = nil

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -538,10 +538,11 @@ func (d desktopPinger) Ping(ctx context.Context) error {
 // proxyWebsocketConn does a bidrectional copy between the websocket
 // connection to the browser (ws) and the mTLS connection to Windows
 // Desktop Serivce (wds)
-func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, log *slog.Logger, version string) error {
-	_ = context.AfterFunc(ctx, func() {
+func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, _ *slog.Logger, version string) error {
+	stopFn := context.AfterFunc(ctx, func() {
 		ws.Close()
 	})
+	defer stopFn()
 
 	latencySupported, err := utils.MinVerWithoutPreRelease(version, "17.5.0")
 	if err != nil {

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -567,7 +567,7 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 	serverConn := tdp.NewConn(wds)
 
 	interceptedServerConn := tdp.NewReadWriteInterceptor(serverConn, f, nil)
-	proxy := tdp.NewConnProxy2(clientConn, interceptedServerConn)
+	proxy := tdp.NewConnProxy(clientConn, interceptedServerConn)
 	if latencySupported {
 		pinger := desktopPinger{
 			server: serverConn,

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -550,7 +550,7 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 	}
 
 	pings := make(chan tdp.Ping)
-	serverReadInterceptor := func(msg tdp.Message) (tdp.Message, error) {
+	serverReadInterceptor := func(msg tdp.Message) ([]tdp.Message, error) {
 		if ping, ok := msg.(tdp.Ping); ok {
 			if !latencySupported {
 				return nil, trace.BadParameter("received unexpected Ping message from server (this is a bug)")
@@ -561,7 +561,7 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 			}
 			return nil, nil
 		}
-		return msg, nil
+		return []tdp.Message{msg}, nil
 	}
 
 	clientConn := tdp.NewConn(&WebsocketIO{Conn: ws})

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -539,10 +539,12 @@ func (d desktopPinger) Ping(ctx context.Context) error {
 // connection to the browser (ws) and the mTLS connection to Windows
 // Desktop Serivce (wds)
 func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, _ *slog.Logger, version string) error {
-	stopFn := context.AfterFunc(ctx, func() {
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
 		ws.Close()
-	})
-	defer stopFn()
+		wds.Close()
+	}()
 
 	latencySupported, err := utils.MinVerWithoutPreRelease(version, "17.5.0")
 	if err != nil {

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -577,16 +577,12 @@ func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, 
 
 		go monitorLatency(ctx, clockwork.NewRealClock(), ws, pinger,
 			latency.ReporterFunc(func(ctx context.Context, stats latency.Statistics) error {
-				lstats := tdp.LatencyStats{
+				return clientConn.WriteMessage(tdp.LatencyStats{
 					ClientLatency: uint32(stats.Client),
 					ServerLatency: uint32(stats.Server),
-				}
-
-				_ = clientConn.WriteMessage(lstats)
-				return nil
+				})
 			}),
 		)
-
 	}
 
 	// Run joins and returns any read, write, or close errors from each side of the

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -244,7 +244,7 @@ func (h *Handler) createDesktopConnection(
 	// this blocks until the connection is closed
 	handleProxyWebsocketConnErr(
 		ctx,
-		proxyWebsocketConn(ctx, ws, serviceConnTLS, log, version),
+		proxyWebsocketConn(ctx, ws, serviceConnTLS, version),
 		log,
 	)
 
@@ -538,7 +538,7 @@ func (d desktopPinger) Ping(ctx context.Context) error {
 // proxyWebsocketConn does a bidrectional copy between the websocket
 // connection to the browser (ws) and the mTLS connection to Windows
 // Desktop Serivce (wds)
-func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, _ *slog.Logger, version string) error {
+func proxyWebsocketConn(ctx context.Context, ws *websocket.Conn, wds *tls.Conn, version string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
 		cancel()


### PR DESCRIPTION
Refactor the connection proxy and message interception code to improve composability and separate concerns. 
At a high level:
- Refactor the connection proxy (`ConnProxy`) to depend on simple interfaces, and remove logic regarding network errors or message interception. 
- Move message interception logic into a new `ReadWriteInterceptor` type, which can be passed to the connection proxy in lieu of a plain connection.
- Move inspection of network errors up to the caller. The owner of the websocket and TLS connections has the necessary context to inspect and act on these errors.


Test Plan:
- [X] Add unit tests for new interceptors
- [X] Add unit tests for new `ConnProxy` implementation that verify both happy path and errors returned by underlying connections.
- [X] Manually validate that desktop connections succeed and that graceful termination does not log an error
- [X] Repeat manual test above using a v18 release of the desktop agent
