### PR TITLE
Consolidate fake IDP libraries

### DIFF
--- a/integrations/terraform-mwi/provider/kubernetes_test.go
+++ b/integrations/terraform-mwi/provider/kubernetes_test.go
@@ -36,9 +36,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/integration/helpers"
-	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
@@ -155,7 +155,7 @@ func setupKubernetesAccessBot(
 	})
 	require.NoError(t, err)
 
-	fakeJoinSigner, err := fakejoin.NewKubernetesSigner(
+	fakeJoinSigner, err := fakeissuer.NewKubernetesSigner(
 		clockwork.NewRealClock(),
 	)
 	require.NoError(t, err)

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -34,9 +34,9 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
 	"github.com/gravitational/teleport/integrations/lib/testing/integration"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 
@@ -60,7 +60,7 @@ func TestTerraformJoin(t *testing.T) {
 
 	// Test setup: create a fake Kubernetes signer that will allow us to use the kubernetes/jwks join method
 	clock := clockwork.NewRealClock()
-	signer, err := fakejoin.NewKubernetesSigner(clock)
+	signer, err := fakeissuer.NewKubernetesSigner(clock)
 	require.NoError(t, err)
 
 	jwks, err := signer.GetMarshaledJWKS()
@@ -188,7 +188,7 @@ func TestTerraformJoinViaProxy(t *testing.T) {
 
 	// Test setup: create a fake Kubernetes signer that will allow us to use the kubernetes/jwks join method
 	clock := clockwork.NewRealClock()
-	signer, err := fakejoin.NewKubernetesSigner(clock)
+	signer, err := fakeissuer.NewKubernetesSigner(clock)
 	require.NoError(t, err)
 
 	jwks, err := signer.GetMarshaledJWKS()

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -67,6 +66,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -259,7 +259,7 @@ func TestBotJoinAttrs_Kubernetes(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	k8s, err := fakejoin.NewKubernetesSigner(srv.Clock())
+	k8s, err := fakeissuer.NewKubernetesSigner(srv.Clock())
 	require.NoError(t, err)
 	jwks, err := k8s.GetMarshaledJWKS()
 	require.NoError(t, err)

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/integrations/lib/testing/fakejoin"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/join"
@@ -65,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	libjwt "github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -252,7 +252,7 @@ func TestIssueWorkloadIdentityE2E(t *testing.T) {
 		},
 	}
 
-	k8s, err := fakejoin.NewKubernetesSigner(tp.clock)
+	k8s, err := fakeissuer.NewKubernetesSigner(tp.clock)
 	require.NoError(t, err)
 	jwks, err := k8s.GetMarshaledJWKS()
 	require.NoError(t, err)

--- a/lib/kube/token/claims/claims.go
+++ b/lib/kube/token/claims/claims.go
@@ -1,0 +1,57 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package claims
+
+import (
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+)
+
+// PodSubClaim are the Pod-specific claims we expect to find on a Kubernetes Service Account JWT.
+type PodSubClaim struct {
+	Name string `json:"name"`
+	UID  string `json:"uid"`
+}
+
+// ServiceAccountSubClaim are the Service Account-specific claims we expect to find on a Kubernetes Service Account JWT.
+type ServiceAccountSubClaim struct {
+	Name string `json:"name"`
+	UID  string `json:"uid"`
+}
+
+// KubernetesSubClaim are the Kubernetes-specific claims (under kubernetes.io)
+// we expect to find on a Kubernetes Service Account JWT.
+type KubernetesSubClaim struct {
+	Namespace      string                  `json:"namespace"`
+	ServiceAccount *ServiceAccountSubClaim `json:"serviceaccount"`
+	Pod            *PodSubClaim            `json:"pod"`
+}
+
+// ServiceAccountClaims are the claims we expect to find on a Kubernetes Service Account JWT.
+type ServiceAccountClaims struct {
+	jwt.Claims
+	Kubernetes *KubernetesSubClaim `json:"kubernetes.io"`
+}
+
+// OIDCServiceAccountClaims is a variant of `ServiceAccountClaims` intended for
+// use with the OIDC validator rather than plain JWKS.
+type OIDCServiceAccountClaims struct {
+	oidc.TokenClaims
+	Kubernetes *KubernetesSubClaim `json:"kubernetes.io"`
+}

--- a/lib/oidc/fakeissuer/oidc.go
+++ b/lib/oidc/fakeissuer/oidc.go
@@ -1,0 +1,150 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fakeissuer
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+
+	tokenclaims "github.com/gravitational/teleport/lib/kube/token/claims"
+)
+
+// IDP provides a minimal fake OIDC provider for use in tests
+type IDP struct {
+	log    *slog.Logger
+	signer *KubernetesSigner
+	server *httptest.Server
+}
+
+// NewIDP creates a IDP and starts its HTTP server.
+// The caller is responsible for shutting down the server by calling
+// IDP.Close().
+func NewIDP(log *slog.Logger) (*IDP, error) {
+	if log == nil {
+		return nil, trace.BadParameter("nil logger")
+	}
+	signer, err := NewKubernetesSigner(clockwork.NewRealClock())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	f := &IDP{
+		signer: signer,
+		log:    log,
+	}
+
+	providerMux := http.NewServeMux()
+	providerMux.HandleFunc(
+		"/.well-known/openid-configuration",
+		f.handleOpenIDConfig,
+	)
+	providerMux.HandleFunc(
+		"/.well-known/jwks",
+		f.handleJWKSEndpoint,
+	)
+
+	srv := httptest.NewServer(providerMux)
+	f.server = srv
+	return f, nil
+}
+
+// Close shuts down the server and blocks until all outstanding
+// requests on this server have completed.
+func (f *IDP) Close() {
+	f.server.Close()
+}
+
+// IssuerURL returns the URL of the fake IDP.
+func (f *IDP) IssuerURL() string {
+	return f.server.URL
+}
+
+func (f *IDP) handleOpenIDConfig(w http.ResponseWriter, r *http.Request) {
+	// mimic `kubectl get --raw /.well-known/openid-configuration` for an EKS cluster
+	response := map[string]any{
+		"claims_supported": []string{
+			"sub",
+			"iss",
+		},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"issuer":                                f.IssuerURL(),
+		"jwks_uri":                              f.IssuerURL() + "/.well-known/jwks",
+		"response_types_supported":              []string{"id_token"},
+		"scopes_supported":                      []string{"openid"},
+		"subject_types_supported":               []string{"public"},
+	}
+	responseBytes, err := json.Marshal(response)
+	if err != nil {
+		f.log.ErrorContext(r.Context(), "failed to marshal openid-configuration", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, err = w.Write(responseBytes)
+	if err != nil {
+		f.log.ErrorContext(r.Context(), "failed to write response", "error", err, "response", string(responseBytes))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (f *IDP) handleJWKSEndpoint(w http.ResponseWriter, r *http.Request) {
+	response, err := f.signer.GetMarshaledJWKS()
+	if err != nil {
+		f.log.ErrorContext(r.Context(), "failed to marshall JWKS", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, err = w.Write([]byte(response))
+	if err != nil {
+		f.log.ErrorContext(r.Context(), "failed to write JWKS response", "error", err, "response", response)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+// IssueToken makes the IDP sign a token for the
+// chosen claims and expiry.
+func (f *IDP) IssueToken(
+	issuer,
+	audience,
+	sub string,
+	issuedAt time.Time,
+	expiry time.Time,
+	k8s *tokenclaims.KubernetesSubClaim,
+) (string, error) {
+	claims := tokenclaims.OIDCServiceAccountClaims{
+		TokenClaims: oidc.TokenClaims{
+			Issuer:     issuer,
+			Subject:    sub,
+			Audience:   oidc.Audience{audience},
+			IssuedAt:   oidc.FromTime(issuedAt),
+			NotBefore:  oidc.FromTime(issuedAt),
+			Expiration: oidc.FromTime(expiry),
+		},
+		Kubernetes: k8s,
+	}
+
+	return f.signer.signWithClaims(claims)
+}

--- a/lib/oidc/token_validator.go
+++ b/lib/oidc/token_validator.go
@@ -33,7 +33,7 @@ import (
 // giving up.
 const providerTimeout = 15 * time.Second
 
-// Validate validates an OIDC ID token for the specified claims type.
+// ValidateToken validates an OIDC ID token for the specified claims type.
 func ValidateToken[C oidc.Claims](
 	ctx context.Context,
 	issuerURL string,


### PR DESCRIPTION
As I'm writing OIDC joining helpers, I need to test OIDC joining. We have several test OIDC implementations. This PR takes the 2 I know about, and merges them into a single library: `lib/oidc/fakeissuer`.