### PR TITLE
fix: deflake TestTerminalSizeRequest

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -351,10 +351,8 @@ func TestTerminalSizeRequest(t *testing.T) {
 		// initiating the client request for the window size to prevent flakiness.
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			size, err := f.ssh.srv.termHandlers.SessionRegistry.GetTerminalSize(sessionID)
-			if assert.NoError(t, err) {
-				return
-			}
-			assert.Empty(t, cmp.Diff(expectedSize, size, cmp.AllowUnexported(term.Winsize{})))
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expectedSize, *size, cmp.AllowUnexported(term.Winsize{})))
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// Send a request for the window size now that we know the window change


### PR DESCRIPTION
The following condition was inverted, it returned early if there was no error and never checked the terminal size. I know this for sure because when I fixed that (just switched to require) the following check never passed because it was comparing a pointer to a value which always has a diff (they are different types).
```
			if assert.NoError(t, err) {
				return
			}
```

Fixes https://github.com/gravitational/teleport/issues/36062