### PR TITLE
Add tags to three Reference sections

### DIFF
--- a/docs/pages/reference/access-controls/access-controls.mdx
+++ b/docs/pages/reference/access-controls/access-controls.mdx
@@ -4,6 +4,7 @@ sidebar_label: Access Controls
 description: Contains guides to configuring authentication and authorization in Teleport.
 tags:
  - zero-trust
+ - privileged-access
 ---
 
 The Teleport access controls reference guides provide comprehensive information

--- a/docs/pages/reference/access-controls/access-lists.mdx
+++ b/docs/pages/reference/access-controls/access-lists.mdx
@@ -5,6 +5,7 @@ description: An explanation and overview of Access Lists in Teleport.
 tags:
  - conceptual
  - identity-governance
+ - privileged-access
 ---
 
 Access Lists allow Teleport users to be granted long term access to resources

--- a/docs/pages/reference/access-controls/access-monitoring-rules.mdx
+++ b/docs/pages/reference/access-controls/access-monitoring-rules.mdx
@@ -5,6 +5,7 @@ description: An explanation and overview of Access Monitoring Rules.
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 Access Monitoring Rules allow administrators to monitor Access Requests and apply

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -4,6 +4,7 @@ description: A reference for Teleport's authentication connectors
 tags:
  - reference
  - zero-trust
+ - privileged-access
 ---
 
 Teleport authenticates users either via the Proxy Service or with an identity

--- a/docs/pages/reference/access-controls/login-rules.mdx
+++ b/docs/pages/reference/access-controls/login-rules.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - conceptual
  - zero-trust
+ - privileged-access
 ---
 
 This page provides details on the expression language that powers Login Rules.

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - reference
  - zero-trust
+ - privileged-access
 ---
 
 This guide shows you how to use Teleport roles to manage role-based access

--- a/docs/pages/reference/access-controls/saml-idp.mdx
+++ b/docs/pages/reference/access-controls/saml-idp.mdx
@@ -5,6 +5,7 @@ description: Reference documentation for the SAML identity provider
 tags:
  - conceptual
  - identity-governance
+ - infrastructure-identity
 ---
 
 This page provides details on the SAML identity provider available

--- a/docs/pages/reference/deployment/monitoring/audit.mdx
+++ b/docs/pages/reference/deployment/monitoring/audit.mdx
@@ -4,6 +4,7 @@ description: Reference of Teleport Audit Events and Session Records
 tags:
  - conceptual
  - platform-wide
+ - audit
 ---
 
 Teleport logs cluster activity by emitting various events into its audit log.

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/admin-guide.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/admin-guide.mdx
@@ -1,6 +1,10 @@
 ---
 title: Bound Keypair Joining Admin Guide
 description: "How to deploy and maintain bots in production with Bound Keypair Joining"
+tags:
+ - mwi
+ - conceptual
+ - infrastructure-identity
 ---
 
 This guide discusses various tasks users administering bots using Bound Keypair

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
@@ -2,6 +2,10 @@
 title: Bound Keypair Joining Reference
 sidebar_label: Bound Keypair Joining
 description: "Bound Keypair Joining: Reference and admin guide"
+tags:
+ - reference
+ - mwi
+ - infrastructure-identity
 ---
 
 Bound Keypair is a join method designed to provide the best features of

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/concepts.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/concepts.mdx
@@ -1,6 +1,10 @@
 ---
 title: Bound Keypair Joining Concepts
 description: "Learn the key components of Bound Keypair Joining"
+tags:
+ - mwi
+ - conceptual
+ - infrastructure-identity
 ---
 
 This page discusses the main concepts needed to understand Bound Keypair

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/getting-started.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/getting-started.mdx
@@ -1,6 +1,10 @@
 ---
 title: Deploying Machine ID with Bound Keypair Joining
 description: "How to install and configure Machine ID with Bound Keypair Joining"
+tags:
+ - mwi
+ - how-to
+ - infrastructure-identity
 ---
 
 In this guide, you will install Machine & Workload Identity's agent, `tbot`, on

--- a/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
@@ -6,6 +6,7 @@ tocDepth: 4
 tags:
  - reference
  - mwi
+ - infrastructure-identity
 ---
 
 This reference documents the various options that can be configured in the `tbot`

--- a/docs/pages/reference/machine-workload-identity/machine-id/github-actions.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/github-actions.mdx
@@ -4,6 +4,7 @@ description: Reference for GitHub Actions joining
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 This document acts a reference for GitHub Actions and Machine ID. You will find

--- a/docs/pages/reference/machine-workload-identity/machine-id/gitlab.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/gitlab.mdx
@@ -4,6 +4,7 @@ description: Reference for GitLab joining
 tags:
  - reference
  - mwi
+ - infrastructure-identity
 ---
 
 This document acts a reference for GitLab CI and Machine ID. You will find

--- a/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
@@ -4,6 +4,7 @@ description: Information about the attributes that can be used in templating and
 tags:
  - reference
  - mwi
+ - infrastructure-identity
 ---
 
 Attributes are features of an identity which you can use with the

--- a/docs/pages/reference/machine-workload-identity/workload-identity/configuration-resource-migration.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/configuration-resource-migration.mdx
@@ -4,6 +4,7 @@ description: Migrating to the new WorkloadIdentity resource configuration
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 The way that you configure Teleport Workload Identity is changing. If you are

--- a/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
@@ -4,6 +4,7 @@ description: Provides information about the `workload_identity_x509_issuer_overr
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 The X.509 issuer override functionality provides a way to replace the self-signed X.509 certificate used by Teleport as the issuer SPIFFE X509-SVID credentials with an issuing certificate of your choosing, together with an optional certificate chain. After configuring a default `workload_identity_x509_issuer_override` resource, all X509-SVID credentials issued to `tbot` or `tsh` will be issued by one of the issuers specified in the resource, and will include the appropriate certificate chain.

--- a/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
@@ -4,6 +4,7 @@ description: Information about performing revocations for issued workload identi
 tags:
  - conceptual
  - mwi
+ - resiliency
 ---
 
 The revocations mechanism provides a way to mark an issued X509 workload

--- a/docs/pages/reference/machine-workload-identity/workload-identity/sigstore-attestation.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/sigstore-attestation.mdx
@@ -4,6 +4,7 @@ description: Using Teleport's integration with Sigstore to ensure workload suppl
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 By using Teleport's integration with [Sigstore](https://sigstore.dev), you can

--- a/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -4,6 +4,7 @@ description: Information about the `tbot` Workload Identity API service and Work
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 The Workload Identity API service (`workload-identity-api`) is a configurable

--- a/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-resource.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-resource.mdx
@@ -4,6 +4,7 @@ description: Information about the WorkloadIdentity resource
 tags:
  - reference
  - mwi
+ - infrastructure-identity
 ---
 
 The WorkloadIdentity resource is used to define the structure of an identity

--- a/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity.mdx
@@ -4,6 +4,7 @@ sidebar_label: Workload Identity
 description: Configuration and CLI reference for Teleport Workload Identity
 tags:
  - mwi
+ - infrastructure-identity
 ---
 
 <DocCardList />


### PR DESCRIPTION
Tag pages in the following sections of the Reference docs with the appropriate use case and cloud provider tags:

- Access Controls
- Machine ID
- Monitoring
- Workload Identity

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

This change also fixes missing tags.

Note that not all pages in these sections warrant a use case or cloud provider tag.