### PR TITLE
Add tags to remaining Reference sections

### DIFF
--- a/docs/pages/reference/agent-services/agent-services.mdx
+++ b/docs/pages/reference/agent-services/agent-services.mdx
@@ -4,6 +4,7 @@ h1: Agent Service References
 description: Includes guides to use while using the SSH Service, Database Service, and other Teleport Agent services.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 Use these reference guides to configure and run Teleport Agent services. For a

--- a/docs/pages/reference/agent-services/application-access.mdx
+++ b/docs/pages/reference/agent-services/application-access.mdx
@@ -5,6 +5,7 @@ description: Configuration and CLI reference documentation for Teleport applicat
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide describes interfaces and options for interacting with the Teleport

--- a/docs/pages/reference/agent-services/auto-discovery-reference/auto-discovery-reference.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/auto-discovery-reference.mdx
@@ -4,6 +4,7 @@ sidebar_label: Auto-Discovery
 description: Configuration reference for the Teleport Discovery Service.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 - [AWS IAM](aws-iam.mdx)

--- a/docs/pages/reference/agent-services/auto-discovery-reference/aws-iam.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/aws-iam.mdx
@@ -6,6 +6,7 @@ tocDepth: 3
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Discovery Service requires AWS IAM permissions to discover AWS

--- a/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
@@ -5,6 +5,7 @@ description: This guide is a comprehensive reference of configuration options fo
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 Kubernetes Application Discovery involves the Teleport Discovery Service,

--- a/docs/pages/reference/agent-services/database-access-reference/audit.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/audit.mdx
@@ -5,6 +5,7 @@ description: Audit events reference for Teleport database access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 

--- a/docs/pages/reference/agent-services/database-access-reference/aws.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/aws.mdx
@@ -5,6 +5,7 @@ description: AWS IAM policies for Teleport database access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 The Teleport Database Service requires IAM permissions for various tasks

--- a/docs/pages/reference/agent-services/database-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/cli.mdx
@@ -5,6 +5,7 @@ description: CLI reference for Teleport database access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 This reference shows you how to run common commands for managing Teleport

--- a/docs/pages/reference/agent-services/database-access-reference/configuration.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/configuration.mdx
@@ -5,6 +5,7 @@ description: Configuration reference for Teleport database access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide explains configuration options for the Teleport Database Service,

--- a/docs/pages/reference/agent-services/database-access-reference/database-access-reference.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/database-access-reference.mdx
@@ -4,6 +4,7 @@ sidebar_label: Database Access
 description: Configuration and CLI reference for the Teleport Database Service.
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 - [Configuration](configuration.mdx)

--- a/docs/pages/reference/agent-services/database-access-reference/labels.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/labels.mdx
@@ -5,6 +5,7 @@ description: Database labels reference for Teleport database access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport assigns system-defined labels to protected databases. This guide

--- a/docs/pages/reference/agent-services/desktop-access-reference/audit.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/audit.mdx
@@ -5,6 +5,7 @@ description: Audit events reference for Teleport desktop access.
 tags:
  - reference
  - zero-trust
+ - audit
 ---
 
 This guide lists the structures and field names of audit events related to

--- a/docs/pages/reference/agent-services/desktop-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/cli.mdx
@@ -5,6 +5,7 @@ description: CLI reference for Teleport desktop access.
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 The following `tctl` commands are used to manage the Teleport Windows Desktop

--- a/docs/pages/reference/agent-services/desktop-access-reference/clipboard.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/clipboard.mdx
@@ -4,6 +4,7 @@ description: Using Clipboard Sharing with Teleport desktop access.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport supports copying and pasting text between your browser and a remote

--- a/docs/pages/reference/agent-services/desktop-access-reference/configuration.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/configuration.mdx
@@ -5,6 +5,7 @@ description: Configuration reference for Teleport desktop access.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 `teleport.yaml` fields related to desktop access:

--- a/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
@@ -5,6 +5,7 @@ description: Comprehensive guides to configuring and auditing desktop access.
 layout: tocless-doc
 tags:
  - zero-trust
+ - infrastructure-identity
 ---
 
 - [Configuration](configuration.mdx): Configure Teleport desktop access.

--- a/docs/pages/reference/agent-services/desktop-access-reference/sessions.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/sessions.mdx
@@ -4,6 +4,7 @@ description: Recording and playing back Teleport desktop access sessions.
 tags:
  - conceptual
  - zero-trust
+ - audit
 ---
 
 Teleport supports recording and playback of desktop sessions.

--- a/docs/pages/reference/agent-services/desktop-access-reference/user-creation.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/user-creation.mdx
@@ -4,6 +4,7 @@ description: Using Automatic User Creation with Teleport desktop access.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport's Desktop Service can be configured to automatically create local

--- a/docs/pages/reference/agent-services/mcp-access.mdx
+++ b/docs/pages/reference/agent-services/mcp-access.mdx
@@ -2,6 +2,10 @@
 title: MCP Access Reference
 sidebar_label: MCP Access
 description: Configuration and CLI reference for Teleport MCP access.
+tags:
+- reference
+- zero-trust
+- mcp
 ---
 
 This guide describes interfaces and options for interacting with the Teleport

--- a/docs/pages/reference/agent-services/okta.mdx
+++ b/docs/pages/reference/agent-services/okta.mdx
@@ -5,6 +5,7 @@ description: Configuration and CLI reference documentation for Teleport Okta ser
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide describes interfaces and options for configuring the Teleport Okta

--- a/docs/pages/reference/architecture/agents.mdx
+++ b/docs/pages/reference/architecture/agents.mdx
@@ -5,6 +5,7 @@ tocDepth: 3
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 **Teleport Agents** route traffic to and from resources in your infrastructure.

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -5,6 +5,7 @@ h1: Teleport Authorization
 tags:
  - conceptual
  - platform-wide
+ - privileged-access
 ---
 
 Teleport handles both authentication and authorization.

--- a/docs/pages/reference/architecture/device-trust.mdx
+++ b/docs/pages/reference/architecture/device-trust.mdx
@@ -4,6 +4,7 @@ description: How Teleport Device Trust works.
 tags:
  - conceptual
  - identity-governance
+ - resiliency
 ---
 
 Device Trust leverages the macOS Secure Enclave, or TPM 2.0 on Linux and Windows

--- a/docs/pages/reference/architecture/kubernetes-applications-architecture.mdx
+++ b/docs/pages/reference/architecture/kubernetes-applications-architecture.mdx
@@ -4,6 +4,7 @@ description: Learn how Teleport automatically discovers applications running on 
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Kubernetes application auto-discovery consists of two parts:

--- a/docs/pages/reference/architecture/machine-id-architecture.mdx
+++ b/docs/pages/reference/architecture/machine-id-architecture.mdx
@@ -4,6 +4,7 @@ description: How Teleport Machine ID works.
 tags:
  - conceptual
  - mwi
+ - infrastructure-identity
 ---
 
 This section provides an overview of Teleport Machine ID's inner workings.

--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -4,6 +4,7 @@ description: An overview of Teleport's session recording and its configuration
 tags:
  - conceptual
  - zero-trust
+ - audit
 ---
 
 This page provides an overview of how Teleport records sessions and the various

--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -4,6 +4,7 @@ description: Deep dive into design of Teleport Trusted Clusters.
 tags:
  - conceptual
  - zero-trust
+ - infrastructure-identity
 ---
 
 Teleport can partition compute infrastructure into multiple clusters. A cluster

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the tbot Helm chart
 tags:
  - reference
  - mwi
+ - infrastructure-identity
 ---
 
 This chart deploys an instance of the [MachineID](../../machine-workload-identity/machine-id/introduction.mdx) agent,

--- a/docs/pages/reference/helm-reference/teleport-access-graph.mdx
+++ b/docs/pages/reference/helm-reference/teleport-access-graph.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-access-graph Helm chart
 tags:
  - reference
  - identity-security
+ - access-risks
 ---
 
 The `teleport-access-graph` Helm chart deploys the Access Graph service.

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-kube-agent Helm chart
 tags:
  - reference
  - zero-trust
+ - infrastructure-identity
 ---
 
 The `teleport-kube-agent` Helm chart is used to configure a Teleport Agent that

--- a/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-datadog Helm chart
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-datadog` Helm chart runs the Datadog Teleport plugin, which

--- a/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-discord Helm chart
 tags:
  - reference
  - zero-trust
+ - privileged-access
 ---
 
 The `teleport-plugin-discord` Helm chart is used to configure the Discord Teleport plugin, which allows users to receive Access Requests via channels or direct messages in Discord.

--- a/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-email Helm chart
 tags:
  - reference
  - zero-trust
+ - privileged-access
 ---
 
 The `teleport-plugin-email` Helm chart is used to configure the email Teleport plugin, which allows users to receive Access Requests via emails.

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-event-handler Helm
 tags:
  - reference
  - zero-trust
+ - audit
 ---
 
 The `teleport-plugin-event-handler` Helm chart is used to configure the Event Handler Teleport plugin which allows users to send events and session logs to a Fluentd instance for further processing or storage.

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-jira Helm chart
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-jira` Helm chart runs the Jira Teleport plugin, which

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-mattermost Helm ch
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-mattermost` Helm chart is used to configure the

--- a/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-msteams Helm chart
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-msteams` Helm chart is used to configure the MsTeams Teleport plugin, which allows users to receive Access Requests via channels or direct messages in MsTeams.

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-pagerduty Helm cha
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-pagerduty` Helm chart is used to configure the PagerDuty Teleport plugin, which allows users to receive Access Requests as pages via PagerDuty.

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -5,6 +5,7 @@ description: Values that can be set using the teleport-plugin-slack Helm chart
 tags:
  - reference
  - identity-governance
+ - privileged-access
 ---
 
 The `teleport-plugin-slack` Helm chart is used to configure the Slack Teleport plugin, which allows users to receive Access Requests via channels or direct messages in Slack.


### PR DESCRIPTION
Tag pages in the following sections of the Reference docs with the appropriate use case and cloud provider tags:

- Agent Services
- Architecture
- Helm references

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

This change also fixes missing tags.

Note that not all pages in these sections warrant a use case or cloud provider tag.