### PR TITLE
[v18] Tag guides by cloud provider and use case

### DIFF
--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -4,6 +4,7 @@ description: How to configure graphical database clients for Teleport database a
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide describes how to configure popular graphical database clients to

--- a/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
@@ -1,6 +1,11 @@
 ---
 title: Database Access for MCP
 description: How to configure MCP clients to use Teleport databases as MCP servers.
+tags:
+ - mcp
+ - infrastructure-identity
+ - zero-trust
+ - how-to
 ---
 
 This guide explains how to connect to your **PostgreSQL** Teleport databases with MCP clients.

--- a/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
@@ -1,6 +1,11 @@
 ---
 title: MCP Access
 description: How to configure MCP clients to use MCP servers served by Teleport.
+tags:
+ - mcp
+ - how-to
+ - zero-trust
+ - infrastructure-identity
 ---
 
 This guide explains how to configure MCP clients to access MCP servers served by

--- a/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
@@ -5,6 +5,7 @@ h1: Secure Agentic AI with Teleport Zero Trust Access
 tags:
  - conceptual
  - zero-trust
+ - ai
 ---
 
 Secure Large Language Model (LLM) interactions with infrastructure using Teleport's secure 

--- a/docs/pages/connect-your-client/notifications.mdx
+++ b/docs/pages/connect-your-client/notifications.mdx
@@ -4,6 +4,7 @@ description: Provides a detailed breakdown of Teleport's notification system.
 tags:
  - conceptual
  - platform-wide
+ - resiliency
 ---
 
 Teleport's notification system allows users to be notified of various events, updates, and warnings in real time.

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -4,6 +4,8 @@ description: This reference shows you how to use PuTTY to connect to SSH nodes a
 tags:
  - conceptual
  - platform-wide
+ - zero-trust
+ - infrastructure-identity
 ---
 
 This guide will show you how to use the Teleport client tool `tsh` to add saved sessions for use

--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -4,6 +4,7 @@ description: Using VNet
 tags:
  - how-to
  - zero-trust
+ - infrastructure-identity
 ---
 
 This guide explains how to use VNet to connect to TCP applications and SSH

--- a/docs/pages/identity-security/access-graph/access-graph.mdx
+++ b/docs/pages/identity-security/access-graph/access-graph.mdx
@@ -3,6 +3,7 @@ title: "Self-Hosting Teleport Access Graph"
 description: Explains how to deploy Access Graph alongside a self-hosted Teleport cluster.
 tags:
  - identity-security
+ - access-risks
 ---
 
 If you run a self-hosted Teleport cluster, using Access Graph (part of

--- a/docs/pages/identity-security/access-graph/identity-activity-center.mdx
+++ b/docs/pages/identity-security/access-graph/identity-activity-center.mdx
@@ -4,6 +4,8 @@ description: Explains how to enable Identity Activity Center.
 tags:
  - how-to
  - identity-security
+ - aws
+ - access-risks
 ---
 
 In this guide, you will set up the infrastructure required

--- a/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
@@ -4,6 +4,7 @@ description: How to deploy Access Graph on self-hosted clusters using Helm.
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 Using Teleport Identity Security with Access Graph on a self-hosted Teleport cluster requires

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -4,6 +4,7 @@ description: Describes how to deploy Access Graph on self-hosted clusters.
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 This guide shows you how to set up Teleport Access Graph in a self-hosted

--- a/docs/pages/identity-security/crown-jewels.mdx
+++ b/docs/pages/identity-security/crown-jewels.mdx
@@ -4,6 +4,7 @@ description: Describes how to use Access Graph Crown Jewels to see permission ch
 tags:
  - conceptual
  - identity-security
+ - access-risks
 ---
 
 Access Graph's Crown Jewel feature allows you to track changes to access for

--- a/docs/pages/identity-security/how-to-use.mdx
+++ b/docs/pages/identity-security/how-to-use.mdx
@@ -4,6 +4,7 @@ description: Explore identity risks and access pathways with dashboards, graph v
 tags:
  - conceptual
  - identity-security
+ - access-risks
 ---
 
 Teleport Identity Security helps teams expose and eliminate hidden risk in their infrastructure. 

--- a/docs/pages/identity-security/identity-security.mdx
+++ b/docs/pages/identity-security/identity-security.mdx
@@ -4,6 +4,7 @@ description: An overview of Teleport Identity Security.
 videoBanner: Vg5R6vpZffg
 tags:
  - identity-security
+ - access-risks
 ---
 
 Teleport Identity Security unifies management of access policies across your infrastructure.

--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -4,6 +4,8 @@ description: Describes how to import and visualize AWS accounts access patterns 
 tags:
  - conceptual
  - identity-security
+ - aws
+ - access-risks
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access relationships in seconds,

--- a/docs/pages/identity-security/integrations/azure-sync.mdx
+++ b/docs/pages/identity-security/integrations/azure-sync.mdx
@@ -4,6 +4,8 @@ description: Describes how to import and visualize Azure subscription access pat
 tags:
  - how-to
  - identity-security
+ - azure
+ - access-risks
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access

--- a/docs/pages/identity-security/integrations/entra-id.mdx
+++ b/docs/pages/identity-security/integrations/entra-id.mdx
@@ -4,6 +4,8 @@ description: Describes how to import and visualize Entra ID policies using Ident
 tags:
  - how-to
  - identity-security
+ - azure
+ - access-risks
 ---
 
 The Microsoft Entra ID integration in Teleport Identity Governance synchronizes your Entra ID directory into your Teleport cluster,

--- a/docs/pages/identity-security/integrations/github.mdx
+++ b/docs/pages/identity-security/integrations/github.mdx
@@ -4,6 +4,7 @@ description: Describes how to import and correlate GitHub Audit Logs and Access 
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 This guide walks you through configuring Identity Security to import

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -4,6 +4,7 @@ description: Describes how to synchronize GitLab access patterns using Identity 
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 Gain insights into access patterns within your GitLab account using Identity Security with Access Graph. By scanning all

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -4,6 +4,7 @@ description: Integrations in Access Graph with Identity Security.
 tags:
  - conceptual
  - identity-security
+ - access-risks
 ---
 
 Teleport can integrate with identity providers (IdPs) like Okta and AWS OIDC 

--- a/docs/pages/identity-security/integrations/netiq.mdx
+++ b/docs/pages/identity-security/integrations/netiq.mdx
@@ -4,6 +4,7 @@ description: Describes how to synchronize OpenTex NetIQ access patterns using Id
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 Gain insights into your NetIQ organization

--- a/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
@@ -4,6 +4,7 @@ description: Describes how to enable SSH Key Scanning using Identity Security an
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 Using Identity Security with Access Graph, you can gain insights on how SSH keys are used within your environment. By scanning

--- a/docs/pages/identity-security/integrations/teleport.mdx
+++ b/docs/pages/identity-security/integrations/teleport.mdx
@@ -4,6 +4,7 @@ description: Describes how to import and correlate Teleport Audit Logs using Ide
 tags:
  - how-to
  - identity-security
+ - access-risks
 ---
 
 In this guide, you will configure your Teleport cluster to forward

--- a/docs/pages/identity-security/policy-connections.mdx
+++ b/docs/pages/identity-security/policy-connections.mdx
@@ -4,6 +4,7 @@ description: Connections in Access Graph with Identity Security.
 tags:
  - conceptual
  - identity-security
+ - access-risks
 ---
 
 Identity Security with Access Graph shows the relationships between users, roles, and resources. 

--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -4,7 +4,7 @@ description: Describes how to use Teleport Identity security to summarize sessio
 labels:
   - conceptual
   - identity-security
-  - AI
+  - ai
 ---
 
 Teleport Identity Security allows you to generate and view session recording

--- a/docs/pages/installation/amazon-ec2.mdx
+++ b/docs/pages/installation/amazon-ec2.mdx
@@ -4,6 +4,7 @@ description: Deploy Teleport on Amazon EC2 using pre-built AMIs with Teleport pr
 tags:
  - platform-wide
  - reference
+ - aws
 ---
 
 We provide pre-built `amd64` and `arm64` Amazon Linux 2023 based EC2 AMIs with


### PR DESCRIPTION
Backports #58867

Tag pages in the following sections of the docs with the appropriate use case and cloud provider tags.

- Connect your client
- Identity Security
- Installation

Cloud provider and use case are common categories that matter for Teleport users, so we can implement these tags across the docs to allow readers to find useful content.

Note that not all pages in these sections warrant a use case or cloud provider tag.