### PR TITLE
Move ssh session helper function to `api/sshutils`

### DIFF
--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -242,29 +242,3 @@ func TestSetEnvs(t *testing.T) {
 	default:
 	}
 }
-
-type mockSSHChannel struct {
-	ssh.Channel
-}
-
-func TestWrappedSSHConn(t *testing.T) {
-	sshCh := new(mockSSHChannel)
-	reqs := make(<-chan *ssh.Request)
-
-	// ensure that OpenChannel returns the same SSH channel and requests
-	// chan that wrappedSSHConn was given
-	wrappedConn := &wrappedSSHConn{
-		ch:   sshCh,
-		reqs: reqs,
-	}
-	retCh, retReqs, err := wrappedConn.OpenChannel("", nil)
-	require.NoError(t, err)
-	require.Equal(t, sshCh, retCh)
-	require.Equal(t, reqs, retReqs)
-
-	// ensure the wrapped SSH conn will panic if OpenChannel is called
-	// twice
-	require.Panics(t, func() {
-		wrappedConn.OpenChannel("", nil)
-	})
-}

--- a/api/utils/sshutils/session.go
+++ b/api/utils/sshutils/session.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutils
+
+import (
+	"sync/atomic"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+)
+
+// ChannelRequestCallback allows the handling of channel requests
+// to be customized. nil can be returned if you don't want
+// golang/x/crypto/ssh to handle the request.
+type ChannelRequestCallback func(req *ssh.Request) *ssh.Request
+
+// NewSession opens a new Session for this client.
+func NewSession(client *ssh.Client, callback ChannelRequestCallback) (*ssh.Session, error) {
+	// No custom request handling needed. We can use the basic golang/x/crypto/ssh implementation.
+	if callback == nil {
+		session, err := client.NewSession()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return session, nil
+	}
+
+	// open a session manually so we can take ownership of the
+	// requests chan
+	ch, originalReqs, openChannelErr := client.OpenChannel("session", nil)
+	if openChannelErr != nil {
+		return nil, trace.Wrap(openChannelErr)
+	}
+
+	handleReqs := originalReqs
+	if callback != nil {
+		reqs := make(chan *ssh.Request, cap(originalReqs))
+		handleReqs = reqs
+
+		// pass the channel requests to the provided callback and
+		// forward them to another chan so golang.org/x/crypto/ssh
+		// can handle Session exiting correctly
+		go func() {
+			defer close(reqs)
+
+			for req := range originalReqs {
+				if req := callback(req); req != nil {
+					reqs <- req
+				}
+			}
+		}()
+	}
+
+	session, err := newCryptoSSHSession(ch, handleReqs)
+	if err != nil {
+		_ = ch.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	return session, nil
+}
+
+// wrappedSSHConn allows an SSH session to be created while also allowing
+// callers to take ownership of the SSH channel requests chan.
+type wrappedSSHConn struct {
+	ssh.Conn
+
+	channelOpened atomic.Bool
+
+	ch   ssh.Channel
+	reqs <-chan *ssh.Request
+}
+
+func (f *wrappedSSHConn) OpenChannel(_ string, _ []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	if !f.channelOpened.CompareAndSwap(false, true) {
+		panic("WrappedSSHConn.OpenChannel called more than once")
+	}
+
+	return f.ch, f.reqs, nil
+}
+
+// newCryptoSSHSession allows callers to take ownership of the SSH
+// channel requests chan and allow callers to handle SSH channel requests.
+// golang.org/x/crypto/ssh.(Client).NewSession takes ownership of all
+// SSH channel requests and doesn't allow the caller to view or reply
+// to them, so this workaround is needed.
+func newCryptoSSHSession(ch ssh.Channel, reqs <-chan *ssh.Request) (*ssh.Session, error) {
+	return (&ssh.Client{
+		Conn: &wrappedSSHConn{
+			ch:   ch,
+			reqs: reqs,
+		},
+	}).NewSession()
+}

--- a/api/utils/sshutils/session_test.go
+++ b/api/utils/sshutils/session_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Gravitational, Inc
+// Copyright 2025 Gravitational, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/utils/sshutils/session_test.go
+++ b/api/utils/sshutils/session_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+type mockSSHChannel struct {
+	ssh.Channel
+}
+
+func TestWrappedSSHConn(t *testing.T) {
+	sshCh := new(mockSSHChannel)
+	reqs := make(<-chan *ssh.Request)
+
+	// ensure that OpenChannel returns the same SSH channel and requests
+	// chan that wrappedSSHConn was given
+	wrappedConn := &wrappedSSHConn{
+		ch:   sshCh,
+		reqs: reqs,
+	}
+	retCh, retReqs, err := wrappedConn.OpenChannel("", nil)
+	require.NoError(t, err)
+	require.Equal(t, sshCh, retCh)
+	require.Equal(t, reqs, retReqs)
+
+	// ensure the wrapped SSH conn will panic if OpenChannel is called
+	// twice
+	require.Panics(t, func() {
+		wrappedConn.OpenChannel("", nil)
+	})
+}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/pingconn"
 	"github.com/gravitational/teleport/api/utils/prompt"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/touchid"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
@@ -1262,7 +1263,7 @@ type TeleportClient struct {
 
 	// OnChannelRequest gets called when SSH channel requests are
 	// received. It's safe to keep it nil.
-	OnChannelRequest tracessh.ChannelRequestCallback
+	OnChannelRequest apisshutils.ChannelRequestCallback
 
 	// OnShellCreated gets called when the shell is created. It's
 	// safe to keep it nil.

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -49,6 +49,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -391,7 +392,7 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 // RunInteractiveShell creates an interactive shell on the node and copies stdin/stdout/stderr
 // to and from the node and local shell. This will block until the interactive shell on the node
 // is terminated.
-func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.SessionParticipantMode, sessToJoin types.SessionTracker, chanReqCallback tracessh.ChannelRequestCallback, beforeStart func(io.Writer)) error {
+func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.SessionParticipantMode, sessToJoin types.SessionTracker, chanReqCallback sshutils.ChannelRequestCallback, beforeStart func(io.Writer)) error {
 	ctx, span := c.Tracer.Start(
 		ctx,
 		"nodeClient/RunInteractiveShell",


### PR DESCRIPTION
In a follow up PR, I plan on providing extra session parameters via `client.OpenChannel("session", sessionParams)`. Before making these changes with no relation to the `api/observability/tracing/ssh` package, I wanted to move these helper functions to a more ubiquitous location.