### PR TITLE
Add recording type to slots

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
@@ -267,6 +267,6 @@ test('allows custom action slot', async () => {
   const customAction = screen.getByTestId('custom-action');
 
   expect(customAction).toBeInTheDocument();
-  expect(actionSlot).toHaveBeenCalledWith(mockRecording.sid);
+  expect(actionSlot).toHaveBeenCalledWith(mockRecording.sid, 'ssh');
   expect(customAction).toHaveTextContent('Custom Action');
 });

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -94,8 +94,7 @@ export function RecordingItem({
   );
 
   const actions = useMemo(
-    () =>
-      actionSlot ? actionSlot(recording.sid, recording.recordingType) : null,
+    () => actionSlot?.(recording.sid, recording.recordingType),
     [actionSlot, recording.sid, recording.recordingType]
   );
 

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -44,15 +44,19 @@ import { rotate360 } from 'design/keyframes';
 import Text from 'design/Text';
 
 import cfg from 'teleport/config';
-import type { Recording, RecordingType } from 'teleport/services/recordings';
+import {
+  type Recording,
+  type RecordingType,
+} from 'teleport/services/recordings';
+import { RECORDING_TYPES_WITH_THUMBNAILS } from 'teleport/services/recordings/recordings';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import { RecordingThumbnail } from './RecordingThumbnail';
 import { Density, ViewMode } from './ViewSwitcher';
 
-// ActionSlot is a function that takes a sessionId and returns a ReactNode, for placing
-// a button on each session recording.
-export type ActionSlot = (sessionId: string) => ReactNode;
+// ActionSlot is a function that takes a sessionId and the type of the recording,
+// and returns a ReactNode, for placing a button on each session recording.
+export type ActionSlot = (sessionId: string, type: RecordingType) => ReactNode;
 
 export interface RecordingItemProps {
   actionSlot?: ActionSlot;
@@ -61,8 +65,6 @@ export interface RecordingItemProps {
   thumbnailStyles: string;
   viewMode: ViewMode;
 }
-
-const recordingTypesWithThumbnails: RecordingType[] = ['ssh', 'k8s'];
 
 export function RecordingItem({
   actionSlot,
@@ -92,11 +94,12 @@ export function RecordingItem({
   );
 
   const actions = useMemo(
-    () => (actionSlot ? actionSlot(recording.sid) : null),
-    [actionSlot, recording.sid]
+    () =>
+      actionSlot ? actionSlot(recording.sid, recording.recordingType) : null,
+    [actionSlot, recording.sid, recording.recordingType]
   );
 
-  const hasThumbnail = recordingTypesWithThumbnails.includes(
+  const hasThumbnail = RECORDING_TYPES_WITH_THUMBNAILS.includes(
     recording.recordingType
   );
 

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
@@ -28,6 +28,7 @@ import { useLocalStorage } from 'shared/hooks/useLocalStorage';
 
 import { useFullscreen } from 'teleport/components/hooks/useFullscreen';
 import cfg from 'teleport/config';
+import { type RecordingType } from 'teleport/services/recordings';
 import { useSuspenseGetRecordingMetadata } from 'teleport/services/recordings/hooks';
 import { KeysEnum } from 'teleport/services/storageService';
 import { formatSessionRecordingDuration } from 'teleport/SessionRecordings/list/RecordingItem';
@@ -38,7 +39,7 @@ import {
   type RecordingTimelineHandle,
 } from 'teleport/SessionRecordings/view/Timeline/RecordingTimeline';
 
-export type SummarySlot = (sessionId: string) => ReactNode;
+export type SummarySlot = (sessionId: string, type: RecordingType) => ReactNode;
 
 interface RecordingWithMetadataProps {
   clusterId: string;
@@ -111,8 +112,8 @@ export function RecordingWithMetadata({
   }, [fullscreen]);
 
   const summary = useMemo(
-    () => summarySlot?.(sessionId),
-    [summarySlot, sessionId]
+    () => summarySlot?.(sessionId, data.metadata.type),
+    [summarySlot, sessionId, data.metadata.type]
   );
 
   const startTime = new Date(data.metadata.startTime * 1000);

--- a/web/packages/teleport/src/services/recordings/recordings.ts
+++ b/web/packages/teleport/src/services/recordings/recordings.ts
@@ -122,3 +122,5 @@ export async function fetchRecordingThumbnail(
 
   return response as SessionRecordingThumbnail;
 }
+
+export const RECORDING_TYPES_WITH_THUMBNAILS: RecordingType[] = ['ssh', 'k8s'];


### PR DESCRIPTION
This adds the recording type to the slot functions, so the function can decide whether to show the summary button based on the recording type (without having to fetch the data first)

I moved the `recordingTypesWithThumbnails` constant to the service instead, matching how the enterprise part of this PR defines the recording types with summaries
