### PR TITLE
[v18] fix sftp via proxy recording mode

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -295,14 +295,6 @@ func (h *AuthHandlers) CheckX11Forward(ctx *ServerContext) error {
 	return trace.AccessDenied("x11 forwarding not permitted")
 }
 
-func (h *AuthHandlers) CheckFileCopying(ctx *ServerContext) error {
-	if ctx.Identity.AccessPermit != nil && ctx.Identity.AccessPermit.SshFileCopy {
-		return nil
-	}
-
-	return trace.Wrap(errRoleFileCopyingNotPermitted)
-}
-
 // CheckPortForward checks if port forwarding is allowed for the users RoleSet.
 func (h *AuthHandlers) CheckPortForward(addr string, ctx *ServerContext, requestedMode decisionpb.SSHPortForwardMode) error {
 	if ctx.Identity.AccessPermit == nil {
@@ -781,6 +773,7 @@ type proxyingPermit struct {
 	PrivateKeyPolicy      keys.PrivateKeyPolicy
 	LockTargets           []types.LockTarget
 	MaxConnections        int64
+	SSHFileCopy           bool
 	DisconnectExpiredCert time.Time
 	MappedRoles           []string
 	SessionRecordingMode  constants.SessionRecordingMode
@@ -826,6 +819,7 @@ func (a *ahLoginChecker) evaluateProxying(ident *sshca.Identity, ca types.CertAu
 		PrivateKeyPolicy:      privateKeyPolicy,
 		LockTargets:           lockTargets,
 		MaxConnections:        accessChecker.MaxConnections(),
+		SSHFileCopy:           accessChecker.CanCopyFiles(),
 		DisconnectExpiredCert: getDisconnectExpiredCertFromSSHIdentity(accessChecker, authPref, ident),
 		MappedRoles:           accessInfo.Roles,
 		SessionRecordingMode:  accessChecker.SessionRecordingMode(constants.SessionRecordingServiceSSH),

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -739,6 +739,11 @@ func (c *ServerContext) CheckFileCopyingAllowed() error {
 		return nil
 	}
 
+	// check if proxying permit is defined and authorizes file copying
+	if permit := c.Identity.ProxyingPermit; permit != nil && permit.SSHFileCopy {
+		return nil
+	}
+
 	return trace.Wrap(errRoleFileCopyingNotPermitted)
 }
 

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -46,6 +46,7 @@ func TestCheckSFTPAllowed(t *testing.T) {
 		name                 string
 		nodeAllowFileCopying bool
 		permit               *decisionpb.SSHAccessPermit
+		proxyingPermit       *proxyingPermit
 		sessionPolicies      []*types.SessionRequirePolicy
 		expectedErr          error
 	}{
@@ -78,6 +79,22 @@ func TestCheckSFTPAllowed(t *testing.T) {
 			nodeAllowFileCopying: true,
 			permit: &decisionpb.SSHAccessPermit{
 				SshFileCopy: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:                 "proxying role disallowed",
+			nodeAllowFileCopying: true,
+			proxyingPermit: &proxyingPermit{
+				SSHFileCopy: false,
+			},
+			expectedErr: errRoleFileCopyingNotPermitted,
+		},
+		{
+			name:                 "proxying role allowed",
+			nodeAllowFileCopying: true,
+			proxyingPermit: &proxyingPermit{
+				SSHFileCopy: true,
 			},
 			expectedErr: nil,
 		},
@@ -125,6 +142,7 @@ func TestCheckSFTPAllowed(t *testing.T) {
 			)
 
 			ctx.Identity.AccessPermit = tt.permit
+			ctx.Identity.ProxyingPermit = tt.proxyingPermit
 
 			err := ctx.CheckSFTPAllowed(nil)
 			if tt.expectedErr == nil {


### PR DESCRIPTION
Backport #58951 to branch/v18

changelog: Fixed an issue where SSH file copying attempts would be spuriously denied in proxy recording mode
