### PR TITLE
[v17] Terraform: Fix issue for Access Lists with empty grants

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -273,10 +273,6 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 }
 
 func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
-	if len(grants.Roles) == 0 && len(grants.Traits) == 0 {
-		return nil
-	}
-
 	return &accesslistv1.AccessListGrants{
 		Roles:  grants.Roles,
 		Traits: traitv1.ToProto(grants.Traits),

--- a/api/types/accesslist/convert/v1/accesslist_test.go
+++ b/api/types/accesslist/convert/v1/accesslist_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	stdcmp "cmp"
 	"testing"
 	"time"
 
@@ -455,7 +456,31 @@ func TestConvAccessList(t *testing.T) {
 			got := ToProto(acl)
 			require.NoError(t, err)
 
+			// See [Test_convertGrantsToProto_never_nil] why that is.
+			tt.input.Spec.Grants = stdcmp.Or(tt.input.Spec.Grants, &accesslistv1.AccessListGrants{})
+			tt.input.Spec.OwnerGrants = stdcmp.Or(tt.input.Spec.OwnerGrants, &accesslistv1.AccessListGrants{})
+
 			require.Equal(t, tt.input, got)
 		})
 	}
+}
+
+func Test_convertGrantsToProto_never_nil(t *testing.T) {
+	// We can't convert empty (owner) grants to nil because, when grants are
+	// not specified in Terraform, that causes it to error with:
+	//
+	// 	teleport_access_list.test_direct: Creating...
+	// 	╷
+	// 	│ Error: Provider produced inconsistent result after apply
+	// 	│
+	// 	│ When applying changes to teleport_access_list.test_direct, provider "provider[\"terraform.releases.teleport.dev/gravitational/teleport\"]" produced
+	// 	│ an unexpected new value: .spec.grants: was cty.ObjectVal(map[string]cty.Value{"roles":cty.ListValEmpty(cty.String),
+	// 	│ "traits":cty.ListValEmpty(cty.Object(map[string]cty.Type{"key":cty.String, "values":cty.List(cty.String)}))}), but now null.
+	// 	│
+	// 	│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+	// 	╵
+	//
+	// See https://github.com/gravitational/teleport/issues/58948
+	emptyGrants := accesslist.Grants{}
+	require.NotNil(t, convertGrantsToProto(emptyGrants))
 }


### PR DESCRIPTION
Backport #58972 to branch/v17

changelog: Fixed a bug preventing users to create access lists with empty grants through Terraform.
