### PR TITLE
[v18] Terraform: Fix issue for Access Lists with empty grants

### DIFF
--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -273,10 +273,6 @@ func convertOwnersToProto(owners []accesslist.Owner) []*accesslistv1.AccessListO
 }
 
 func convertGrantsToProto(grants accesslist.Grants) *accesslistv1.AccessListGrants {
-	if len(grants.Roles) == 0 && len(grants.Traits) == 0 {
-		return nil
-	}
-
 	return &accesslistv1.AccessListGrants{
 		Roles:  grants.Roles,
 		Traits: traitv1.ToProto(grants.Traits),


### PR DESCRIPTION
Backport #58972 to branch/v18

changelog: Fixed a bug preventing users to create access lists with empty grants through Terraform.
