### PR TITLE
Clarify self-hosted Enterprise starter guidance

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
@@ -16,11 +16,9 @@ learn more about getting started with this deployment option and start planning
 your approach. Self-hosted Teleport Enterprise deployments typically take place
 in conversation with the team at Teleport.
 
-While designing a deployment, you can consult one of our two architectural
-overviews of a highly available, self-hosted Teleport cluster: 
-
-- [Single region](high-availability.mdx)
-- [Multiple regions](multi-region-blueprint.mdx)
+While designing a deployment, you can consult the [High
+Availability](high-availability.mdx) guide for the components of a production
+Teleport cluster. 
 
 ## Dedicated account dashboard
 

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-title: Self-Hosting Teleport
+title: Self-Hosting Teleport Enterprise
 description: "Guides to running a self-hosted Teleport cluster in production."
 tags:
  - platform-wide
@@ -7,6 +7,20 @@ tags:
 
 These guides show you how to run a self-hosted Teleport Enterprise cluster in
 production.
+
+## Getting started
+
+Self-hosted Teleport Enterprise subscriptions require a valid license. We
+recommend [reaching out to us directly](https://goteleport.com/contact-us/) to
+learn more about getting started with this deployment option and start planning
+your approach. Self-hosted Teleport Enterprise deployments typically take place
+in conversation with the team at Teleport.
+
+While designing a deployment, you can consult one of our two architectural
+overviews of a highly available, self-hosted Teleport cluster: 
+
+- [Single region](high-availability.mdx)
+- [Multiple regions](multi-region-blueprint.mdx)
 
 ## Dedicated account dashboard
 


### PR DESCRIPTION
Closes #8547

Make it more explicit in the self-hosted Teleport Enterprise index page that self-hosted deployents start with outreach to the Teleport team, and that the HA guide and multi-region blueprint are outlines to help a team plan a deployment that a customer designs in conversation with the Teleport team.

Otherwise, the implication is that the guides listed on the self-hosted Teleport Enterprise index page are sufficient for deploying a self-hosted cluster. There has been a longstanding request for Oracle Cloud guidance, and rather than expect these users to be self sufficient, explain that the recommended approach is to reach out to Teleport and model a deployment based on our architectural outlines.

Some new text in the self-hosted Enterprise index page is based on #57931.