### PR TITLE
[v18] Enable oracle cloud joining in tbot

### DIFF
--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -59,6 +59,7 @@ var SupportedJoinMethods = []types.JoinMethod{
 	types.JoinMethodTPM,
 	types.JoinMethodTerraformCloud,
 	types.JoinMethodBitbucket,
+	types.JoinMethodOracle,
 	types.JoinMethodBoundKeypair,
 }
 

--- a/lib/tbot/bot/onboarding/config.go
+++ b/lib/tbot/bot/onboarding/config.go
@@ -41,6 +41,7 @@ var SupportedJoinMethods = []string{
 	string(types.JoinMethodToken),
 	string(types.JoinMethodTPM),
 	string(types.JoinMethodTerraformCloud),
+	string(types.JoinMethodOracle),
 	string(types.JoinMethodBoundKeypair),
 }
 


### PR DESCRIPTION
Backport #58990 to branch/v18

changelog: Enabled Oracle Cloud joining in Machine ID's `tbot` client
