### PR TITLE
Add env param to SSM Doc used for EC2 auto discovery

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -115,6 +115,10 @@ parameters:
   scriptName:
     type: String
     description: "(Required) The Teleport installer script to use when joining the cluster."
+  env:
+    type: String
+    description: "Environment variables exported to the script. Format 'ENV=var FOO=bar'"
+    default: "X=$X"
 mainSteps:
 - action: aws:downloadContent
   name: downloadContent
@@ -128,7 +132,7 @@ mainSteps:
   inputs:
     timeoutSeconds: '300'
     runCommand:
-      - /bin/sh /tmp/installTeleport.sh "{{ token }}"
+      - export {{ env }}; /bin/sh /tmp/installTeleport.sh "{{ token }}"
 ```
 
 ## Step 4/7. Install Teleport on the Discovery Node
@@ -248,6 +252,10 @@ parameters:
   scriptName:
     type: String
     description: "(Required) The Teleport installer script to use when joining the cluster."
+  env:
+    type: String
+    description: "Environment variables exported to the script. Format 'ENV=var FOO=bar'"
+    default: "X=$X"
 mainSteps:
 - action: aws:downloadContent
   name: downloadContent
@@ -261,7 +269,7 @@ mainSteps:
   inputs:
     timeoutSeconds: '300'
     runCommand:
-      - /bin/sh /tmp/installTeleport.sh "{{ token }}"
+      -  export {{ env }}; /bin/sh /tmp/installTeleport.sh "{{ token }}"
 ```
 
 ### Step 4/5. Update Teleport configuration

--- a/lib/cloud/aws/ssm_documents.go
+++ b/lib/cloud/aws/ssm_documents.go
@@ -63,6 +63,10 @@ parameters:
   scriptName:
     type: String
     description: "(Required) The Teleport installer script to use when joining the cluster."
+  env:
+    type: String
+    description: "Environment variables exported to the script. Format 'ENV=var FOO=bar'"
+    default: "X=$X"
 mainSteps:
 - action: aws:downloadContent
   name: downloadContent
@@ -76,7 +80,7 @@ mainSteps:
   inputs:
     timeoutSeconds: '300'
     runCommand:
-      - /bin/sh %s "{{ token }}"
+      - export {{ env }}; /bin/sh %s "{{ token }}"
 `, installTeleportPath, proxy, installTeleportPath)
 }
 

--- a/lib/integrations/awsoidc/testdata/TestEC2SSMIAMConfigOutput.golden
+++ b/lib/integrations/awsoidc/testdata/TestEC2SSMIAMConfigOutput.golden
@@ -42,7 +42,7 @@ CreateDocument: {
                 "action": "aws:runShellScript",
                 "inputs": {
                     "runCommand": [
-                        "/bin/sh /tmp/installTeleport.sh \"{{ token }}\""
+                        "export {{ env }}; /bin/sh /tmp/installTeleport.sh \"{{ token }}\""
                     ],
                     "timeoutSeconds": "300"
                 },
@@ -50,6 +50,11 @@ CreateDocument: {
             }
         ],
         "parameters": {
+            "env": {
+                "default": "X=$X",
+                "description": "Environment variables exported to the script. Format 'ENV=var FOO=bar'",
+                "type": "String"
+            },
             "scriptName": {
                 "description": "(Required) The Teleport installer script to use when joining the cluster.",
                 "type": "String"


### PR DESCRIPTION
This PR adds a new param, `env` which will be used to inject environment variables into the script.

This will be useful for injecting the TELEPORT_INSTALL_SUFFIX and TELEPORT_UPDATE_GROUP used by `teleport-update` and, soon, `teleport install autodiscover-node` command.

This param is also flexible enough to allows to inject other env vars which we might need in the future, without needing to change the SSM Document which can be tedious for end-users.

Context [RFD 224](https://github.com/gravitational/teleport/pull/58824)