### PR TITLE
V18 windows terraform plugin support

### DIFF
--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -11,7 +11,20 @@ BUILDFLAGS ?= $(ADDFLAGS) -trimpath -ldflags '-w -s'
 # CGO must NOT be enabled as hashicorp cloud does not support running providers using on CGO.
 CGOFLAG ?= CGO_ENABLED=0
 
+# base name for release archive (used for .tar.gz packaging across all platforms)
 RELEASE = terraform-provider-teleport-v$(VERSION)-$(OS)-$(ARCH)-bin
+
+# executable extension (.exe) for windows specific builds
+EXEEXT =
+ifeq ($(OS),windows)
+  EXEEXT = .exe
+endif
+
+# filename of the compiled binary $(BUILDDIR)
+BINARY_NAME = terraform-provider-teleport$(EXEEXT)
+
+# windows terraform provider filename as it will appear on downloads page
+WINDOWS_DOWNLOAD_FILENAME := terraform-provider-teleport-v$(VERSION)-windows-$(ARCH)$(EXEEXT)
 
 .PHONY: tfclean
 tfclean:
@@ -25,12 +38,15 @@ clean: tfclean
 	rm -rf $(PROVIDER_PATH)*
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(RELEASE).tar.gz
+	rm -rf $(RELEASE)$(EXEEXT)
 	go clean
 
 .PHONY: build
 build: clean
 # Turning off GOWORK to prevent missing package errors.
-	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "kustomize_disable_go_plugin_support" -o $(BUILDDIR)/terraform-provider-teleport $(BUILDFLAGS)
+	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) \
+		go build -tags "kustomize_disable_go_plugin_support,terraformprovider" \
+		-o $(BUILDDIR)/$(BINARY_NAME) $(BUILDFLAGS)
 
 build-darwin-universal: $(addprefix $(BUILDDIR)/terraform-provider-teleport_,arm64 amd64)
 	lipo -create -output $(BUILDDIR)/terraform-provider-teleport $^
@@ -151,10 +167,18 @@ endif
 .PHONY: release
 ifeq ($(OS),darwin)
 release: darwin-signed-build
-else
-release: build
-endif
 	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
+else ifeq ($(OS),linux)
+release: build
+	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
+else ifeq ($(OS),windows)
+release: build
+	# copy the built windows binary to its final release filename for public downloads
+	cp $(BUILDDIR)/$(BINARY_NAME) $(WINDOWS_DOWNLOAD_FILENAME)
+	# package ony the binary file into a .tar.gz archive, the release service will repackage this into a .zip
+	# for the Terraform registry
+	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz $(BINARY_NAME)
+endif
 
 TERRAFORM_EXISTS := $(shell terraform -version 2>/dev/null | grep 'Terraform v1.')
 CURRENT_ULIMIT := $(shell ulimit -n)

--- a/lib/client/terminal/terminal_noop.go
+++ b/lib/client/terminal/terminal_noop.go
@@ -1,0 +1,71 @@
+//go:build terraformprovider
+
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package terminal
+
+import (
+	"io"
+
+	"github.com/gravitational/trace"
+)
+
+type Terminal struct {
+	signalEmitter
+
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func New(stdin io.Reader, stdout, stderr io.Writer) (*Terminal, error) {
+	return nil, trace.NotImplemented("not implemented")
+}
+
+func (t *Terminal) Stdin() io.Reader {
+	return t.stdin
+}
+
+func (t *Terminal) Stdout() io.Writer {
+	return t.stdout
+}
+
+func (t *Terminal) Stderr() io.Writer {
+	return t.stderr
+}
+
+func (t *Terminal) InitRaw(input bool) error {
+	return trace.NotImplemented("not implemented")
+}
+
+func (t *Terminal) IsAttached() bool {
+	return false
+}
+
+func (t *Terminal) Size() (width int16, height int16, err error) {
+	return 0, 0, trace.NotImplemented("not implemented")
+}
+
+func (t *Terminal) Resize(width, height int16) error {
+	return trace.NotImplemented("not implemented")
+}
+
+func (t *Terminal) Close() error {
+	return trace.NotImplemented("not implemented")
+}

--- a/lib/client/terminal/terminal_unix.go
+++ b/lib/client/terminal/terminal_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !terraformprovider
 
 /*
  * Teleport

--- a/lib/client/terminal/terminal_windows.go
+++ b/lib/client/terminal/terminal_windows.go
@@ -1,3 +1,5 @@
+//go:build !terraformprovider
+
 /*
  * Teleport
  * Copyright (C) 2023  Gravitational, Inc.


### PR DESCRIPTION
V18 windows terraform plugin support https://github.com/gravitational/teleport/pull/58678

changelog: Terraform Provider is now supported on Windows machines