### PR TITLE
[v17] Added install script query parameter for defining the teleport-update group

### DIFF
--- a/lib/web/scripts.go
+++ b/lib/web/scripts.go
@@ -36,7 +36,10 @@ import (
 	"github.com/gravitational/teleport/lib/web/scripts"
 )
 
-const insecureParamName = "insecure"
+const (
+	insecureParamName = "insecure"
+	groupParamName    = "group"
+)
 
 // installScriptHandle handles calls for "/scripts/install.sh" and responds with a bash script installing Teleport
 // by downloading and running `teleport-update`. This installation script does not start the agent, join it,
@@ -61,6 +64,9 @@ func (h *Handler) installScriptHandle(w http.ResponseWriter, r *http.Request, pa
 			return nil, trace.BadParameter("failed to parse insecure flag %q: %v", insecure, err)
 		}
 		opts.Insecure = v
+	}
+	if group := r.URL.Query().Get(groupParamName); group != "" {
+		opts.Group = group
 	}
 
 	script, err := scripts.GetInstallScript(r.Context(), opts)

--- a/lib/web/scripts/install.go
+++ b/lib/web/scripts/install.go
@@ -92,6 +92,9 @@ type InstallScriptOptions struct {
 	// the artifacts from the CDN.
 	// The agent install in insecure mode will not be able to automatically update.
 	Insecure bool
+	// Group is the group for agent installation used by 'teleport-update enable' command.
+	// Ignored by legacy script.
+	Group string
 }
 
 // Check validates that the minimal options are set.
@@ -138,6 +141,9 @@ func (o *InstallScriptOptions) oneOffParams() (params oneoff.OneOffScriptParams)
 	}
 
 	successMessage := "Teleport successfully installed."
+	if o.Group != "" {
+		args = append(args, "--group", shsprintf.EscapeDefaultContext(o.Group))
+	}
 	if o.Insecure {
 		args = append(args, "--insecure")
 		successMessage += " --insecure was used during installation, automatic updates will not work unless the Proxy Service presents a certificate trusted by the system."

--- a/lib/web/scripts/install_test.go
+++ b/lib/web/scripts/install_test.go
@@ -98,6 +98,24 @@ func TestGetInstallScript(t *testing.T) {
 			},
 		},
 		{
+			name: "Oneoff install with group",
+			opts: InstallScriptOptions{
+				AutoupdateStyle: UpdaterBinaryAutoupdate,
+				TeleportVersion: testVersion,
+				ProxyAddr:       testProxyAddr,
+				TeleportFlavor:  types.PackageNameOSS,
+				Group:           "development",
+			},
+			assertFn: func(t *testing.T, script string) {
+				require.Contains(t, script, "entrypoint='teleport-update'")
+				require.Contains(t, script, fmt.Sprintf("teleportVersion='v%s'", testVersion))
+				require.Contains(t, script, fmt.Sprintf("teleportFlavor='%s'", types.PackageNameOSS))
+				require.Contains(t, script, fmt.Sprintf("cdnBaseURL='%s'", teleportassets.CDNBaseURL()))
+				require.Contains(t, script, fmt.Sprintf("entrypointArgs='enable --proxy %s --group development'", testProxyAddr))
+				require.Contains(t, script, "packageSuffix='bin.tar.gz'")
+			},
+		},
+		{
 			name: "Oneoff install custom CDN",
 			opts: InstallScriptOptions{
 				AutoupdateStyle: UpdaterBinaryAutoupdate,


### PR DESCRIPTION
Backport #59011 to branch/v17

changelog: Install script allows specifying a group for agent installation with managed updates V2 enabled.
