### PR TITLE
[v18] fix: Add SSO MFA support to headless login 🐛 

### DIFF
--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -22,10 +22,13 @@ import styled from 'styled-components';
 import { Box, Flex, rotate360 } from 'design';
 import { Spinner } from 'design/Icon';
 
+import AuthnDialog from 'teleport/components/AuthnDialog';
 import HeadlessRequestDialog from 'teleport/components/HeadlessRequestDialog/HeadlessRequestDialog';
 import { useParams } from 'teleport/components/Router';
 import { CardAccept, CardDenied } from 'teleport/HeadlessRequest/Cards';
+import { shouldShowMfaPrompt, useMfa } from 'teleport/lib/useMfa';
 import auth from 'teleport/services/auth';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 export function HeadlessRequest() {
   const { requestId } = useParams<{ requestId: string }>();
@@ -35,6 +38,13 @@ export function HeadlessRequest() {
     status: 'pending',
     errorText: '',
     publicKey: null as PublicKeyCredentialRequestOptions,
+  });
+
+  const mfa = useMfa({
+    req: {
+      scope: MfaChallengeScope.HEADLESS_LOGIN,
+    },
+    isMfaRequired: true,
   });
 
   useEffect(() => {
@@ -100,38 +110,47 @@ export function HeadlessRequest() {
   }
 
   return (
-    <HeadlessRequestDialog
-      ipAddress={state.ipAddress}
-      onAccept={() => {
-        setState({ ...state, status: 'in-progress' });
+    <>
+      {
+        /* Show only one dialog at a time because too many dialogs can be confusing */
+        shouldShowMfaPrompt(mfa) ? (
+          <AuthnDialog mfaState={mfa} />
+        ) : (
+          <HeadlessRequestDialog
+            ipAddress={state.ipAddress}
+            onAccept={() => {
+              setState({ ...state, status: 'in-progress' });
 
-        auth
-          .headlessSsoAccept(requestId)
-          .then(setSuccess)
-          .catch(e => {
-            setState({
-              ...state,
-              status: 'error',
-              errorText: e.toString(),
-            });
-          });
-      }}
-      onReject={() => {
-        setState({ ...state, status: 'in-progress' });
+              auth
+                .headlessSsoAccept(mfa, requestId)
+                .then(setSuccess)
+                .catch(e => {
+                  setState({
+                    ...state,
+                    status: 'error',
+                    errorText: e.toString(),
+                  });
+                });
+            }}
+            onReject={() => {
+              setState({ ...state, status: 'in-progress' });
 
-        auth
-          .headlessSSOReject(requestId)
-          .then(setRejected)
-          .catch(e => {
-            setState({
-              ...state,
-              status: 'error',
-              errorText: e.toString(),
-            });
-          });
-      }}
-      errorText={state.errorText}
-    />
+              auth
+                .headlessSSOReject(requestId)
+                .then(setRejected)
+                .catch(e => {
+                  setState({
+                    ...state,
+                    status: 'error',
+                    errorText: e.toString(),
+                  });
+                });
+            }}
+            errorText={state.errorText}
+          />
+        )
+      }
+    </>
   );
 }
 

--- a/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
+++ b/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
@@ -59,7 +59,9 @@ export default function HeadlessRequestDialog({
               you, click Reject and contact your administrator.
               <br />
               <br />
-              If it was you, please use your hardware key to approve.
+              If it was you, Approve the request to continue. You will be
+              prompted to verify your identity in order to complete the
+              approval.
             </>
           )}
         </Text>

--- a/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
+++ b/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
@@ -59,7 +59,7 @@ export default function HeadlessRequestDialog({
               you, click Reject and contact your administrator.
               <br />
               <br />
-              If it was you, Approve the request to continue. You will be
+              If it was you, approve the request to continue. You will be
               prompted to verify your identity in order to complete the
               approval.
             </>

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -17,6 +17,7 @@
  */
 
 import cfg from 'teleport/config';
+import { MfaState } from 'teleport/lib/useMfa';
 import api from 'teleport/services/api';
 import {
   DeviceType,
@@ -228,20 +229,17 @@ const auth = {
     });
   },
 
-  headlessSsoAccept(transactionId: string) {
-    return auth
-      .getMfaChallenge({ scope: MfaChallengeScope.HEADLESS_LOGIN })
-      .then(challenge => auth.getMfaChallengeResponse(challenge))
-      .then(res => {
-        const request = {
-          action: 'accept',
-          mfaResponse: res,
-          // TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse.
-          webauthnAssertionResponse: res.webauthn_response,
-        };
+  headlessSsoAccept(mfa: MfaState, transactionId: string) {
+    return mfa.getChallengeResponse().then((res: MfaChallengeResponse) => {
+      const request = {
+        action: 'accept',
+        mfaResponse: res,
+        // TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse.
+        webauthnAssertionResponse: res.webauthn_response,
+      };
 
-        return api.put(cfg.getHeadlessSsoPath(transactionId), request);
-      });
+      return api.put(cfg.getHeadlessSsoPath(transactionId), request);
+    });
   },
 
   headlessSSOReject(transactionId: string) {


### PR DESCRIPTION
Backport #59051 to branch/v18

changelog: Fixed headless login so that it supports both WebAuthn and SSO for MFA
