### PR TITLE
[v18] Fix client tools managed updates sequential update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1177,7 +1177,7 @@ integration:  $(TEST_LOG_DIR) ensure-gotestsum
 INTEGRATION_KUBE_REGEX := TestKube.*
 .PHONY: integration-kube
 integration-kube: FLAGS ?= -v -race
-integration-kube: PACKAGES = $(shell go list ./... | grep 'integration\([^s]\|$$\)')
+integration-kube: PACKAGES = $(shell go list ./... | grep 'integration\([^s]\|$$\)' | grep -v 'integration/autoupdate')
 integration-kube: $(TEST_LOG_DIR) ensure-gotestsum
 	@echo KUBECONFIG is: $(KUBECONFIG), TEST_KUBE: $(TEST_KUBE)
 	$(CGOFLAG) go test -json -run "$(INTEGRATION_KUBE_REGEX)" $(PACKAGES) $(FLAGS) \
@@ -1227,8 +1227,8 @@ lint-tools: lint-build-tooling lint-backport
 
 #
 # Checks that testing symbols and the testify library is not included in binaries.
-# 
-# 
+#
+#
 .PHONY: lint-test-symbols
 lint-test-symbols: ensure-goda
 	@testing_count=`goda tree "reach(github.com/gravitational/teleport/tool/...:all, testing)" | tee /dev/stderr | wc -l | tr -d ' '`; \

--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -23,16 +23,18 @@ import (
 	"crypto"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/entitlements"
+	"github.com/gravitational/teleport/lib/autoupdate/tools"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -44,9 +46,19 @@ const (
 	TestBuild = "UPDATER_TEST_BUILD"
 )
 
-var (
-	version = teleport.Version
-)
+func init() {
+	path, err := os.Executable()
+	if err != nil {
+		return
+	}
+	// For the integration test we use a pattern where the version is encoded
+	// in the directory name to simplify usage and avoid recompiling each
+	// individual binary.
+	parts := strings.Split(path, string(filepath.Separator))
+	if len(parts) > 2 {
+		tools.Version = parts[len(parts)-2]
+	}
+}
 
 type TestModules struct{}
 
@@ -87,7 +99,7 @@ func (p *TestModules) LicenseExpiry() time.Time {
 
 // PrintVersion prints the Teleport version.
 func (p *TestModules) PrintVersion() {
-	fmt.Printf("Teleport v%v git\n", version)
+	fmt.Printf("Teleport v%v git\n", tools.Version)
 }
 
 // Features returns supported features

--- a/integration/autoupdate/tools/updater/tctl/main.go
+++ b/integration/autoupdate/tools/updater/tctl/main.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package main
+package tctl
 
 import (
 	"context"
@@ -27,7 +27,7 @@ import (
 	tctl "github.com/gravitational/teleport/tool/tctl/common"
 )
 
-func main() {
+func Main() {
 	ctx, cancel := stacksignal.GetSignalHandler().NotifyContext(context.Background())
 	defer cancel()
 

--- a/integration/autoupdate/tools/updater/tsh/main.go
+++ b/integration/autoupdate/tools/updater/tsh/main.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package main
+package tsh
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	tsh "github.com/gravitational/teleport/tool/tsh/common"
 )
 
-func main() {
+func Main() {
 	ctx, cancel := stacksignal.GetSignalHandler().NotifyContext(context.Background())
 	defer cancel()
 

--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -219,6 +219,7 @@ func TestUpdateForOSSBuild(t *testing.T) {
 
 	// Enable OSS build.
 	t.Setenv(updater.TestBuild, modules.BuildOSS)
+	t.Setenv(autoupdate.BaseURLEnvVar, "")
 
 	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
 	updater := tools.NewUpdater(

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -70,8 +70,7 @@ func newUpdater(toolsDir string) (*Updater, error) {
 func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecArgs []string) error {
 	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
 	// so we don't try to read te user home directory, fail, and log warnings.
-	toolsVersion := os.Getenv(teleportToolsVersionEnv)
-	if toolsVersion == teleportToolsVersionEnvDisabled || toolsVersion == teleportToolsVersionEnvDisabledLocal {
+	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled {
 		return nil
 	}
 
@@ -127,7 +126,7 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 func CheckAndUpdateRemote(ctx context.Context, currentProfileName string, insecure bool, reExecArgs []string) error {
 	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
 	// so we don't try to read te user home directory, fail, and log warnings.
-	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled {
+	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled && os.Getenv(teleportToolsVersionReExecEnv) == "" {
 		return nil
 	}
 

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -37,6 +37,8 @@ import (
 // Variables might to be overridden during compilation time for integration tests.
 var (
 	// Version is the current version of the Teleport.
+	// The variable is overloaded during integration tests to emulate different
+	// Teleport versions. See `integration/autoupdate/tools/updater/modules.go`.
 	Version = teleport.Version
 )
 
@@ -126,6 +128,9 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 func CheckAndUpdateRemote(ctx context.Context, currentProfileName string, insecure bool, reExecArgs []string) error {
 	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
 	// so we don't try to read te user home directory, fail, and log warnings.
+	// If we are re-executed, we ignore the "off" version because some previous Teleport versions
+	// are disabling execution too aggressively and this causes stuck updates.
+	// If "off" was set by the user, we would not be re-executed.
 	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled && os.Getenv(teleportToolsVersionReExecEnv) == "" {
 		return nil
 	}

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -36,15 +36,14 @@ import (
 
 // Variables might to be overridden during compilation time for integration tests.
 var (
-	// version is the current version of the Teleport.
-	version = teleport.Version
-	// baseURL is CDN URL for downloading official Teleport packages.
-	baseURL = autoupdate.DefaultBaseURL
+	// Version is the current version of the Teleport.
+	Version = teleport.Version
 )
 
 // newUpdater inits the updater with default base URL and creates directory
 // if it doesn't exist.
 func newUpdater(toolsDir string) (*Updater, error) {
+	baseURL := autoupdate.DefaultBaseURL
 	// Overrides default base URL for custom CDN for downloading updates.
 	if envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar); envBaseURL != "" {
 		baseURL = envBaseURL
@@ -55,7 +54,7 @@ func newUpdater(toolsDir string) (*Updater, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	return NewUpdater(toolsDir, version, WithBaseURL(baseURL)), nil
+	return NewUpdater(toolsDir, Version, WithBaseURL(baseURL)), nil
 }
 
 // CheckAndUpdateLocal verifies if the TELEPORT_TOOLS_VERSION environment variable
@@ -71,7 +70,8 @@ func newUpdater(toolsDir string) (*Updater, error) {
 func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecArgs []string) error {
 	// If client tools updates are explicitly disabled, we want to catch this as soon as possible
 	// so we don't try to read te user home directory, fail, and log warnings.
-	if os.Getenv(teleportToolsVersionEnv) == teleportToolsVersionEnvDisabled {
+	toolsVersion := os.Getenv(teleportToolsVersionEnv)
+	if toolsVersion == teleportToolsVersionEnvDisabled || toolsVersion == teleportToolsVersionEnvDisabledLocal {
 		return nil
 	}
 

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -213,6 +213,9 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 	proxyHost := utils.TryHost(proxyAddr)
 	// Check if the user has requested a specific version of client tools.
 	requestedVersion := os.Getenv(teleportToolsVersionEnv)
+	// If we are re-executed, we ignore the "off" version because some previous Teleport versions
+	// are disabling execution too aggressively and this causes stuck updates.
+	// If "off" was set by the user, we would not be re-executed.
 	if requestedVersion == teleportToolsVersionEnvDisabled && os.Getenv(teleportToolsVersionReExecEnv) != "" {
 		requestedVersion = ""
 	}

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -426,7 +426,9 @@ func (u *Updater) Exec(ctx context.Context, toolsVersion string, args []string) 
 	// To prevent re-execution loop we have to disable update logic for re-execution,
 	// by unsetting current tools version env variable and setting it to "off"
 	// if same version is requested to be re-executed.
-	if path == executablePath {
+	// We should also prevent further re-execution if the current version is run from
+	// the deprecated `~/.tsh/bin/tsh` path; otherwise, a downgrade could result in a loop.
+	if path == executablePath || executablePath == filepath.Join(u.toolsDir, filepath.Base(executablePath)) {
 		env = filterEnvs(env, []string{teleportToolsVersionEnv})
 		env = append(env, teleportToolsVersionEnv+"="+teleportToolsVersionEnvDisabled)
 		slog.DebugContext(ctx, "Disable re-execution")

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -253,4 +254,12 @@ func checkFreeSpace(path string, requested uint64) error {
 	}
 
 	return nil
+}
+
+// filterEnvs excludes environment variables by the list of the keys.
+func filterEnvs(envs []string, excludeKeys []string) []string {
+	return slices.DeleteFunc(envs, func(e string) bool {
+		parts := strings.SplitN(e, "=", 2)
+		return slices.Contains(excludeKeys, parts[0])
+	})
 }

--- a/lib/autoupdate/tools/utils_test.go
+++ b/lib/autoupdate/tools/utils_test.go
@@ -1,0 +1,52 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tools
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFilterEnv verifies excluding environment variables by the list of the keys.
+func TestFilterEnv(t *testing.T) {
+	env := "TEST_ENV_WITHOUT_FILTER"
+	env1 := "TEST_ENV_WITHOUT_FILTER1"
+	env2 := "TEST_ENV_WITHOUT_FILTER2"
+	env3 := "TEST_ENV_WITHOUT_FILTER3"
+
+	source := []string{
+		env3,
+		env,
+		fmt.Sprint(env1, "=", "test"),
+		fmt.Sprint(teleportToolsVersionEnv, "=", teleportToolsVersionEnvDisabled),
+		fmt.Sprint(env2, "=", "test"),
+		env3,
+		env,
+		env3,
+	}
+
+	assert.Equal(t, []string{
+		env,
+		fmt.Sprint(env1, "=", "test"),
+		fmt.Sprint(env2, "=", "test"),
+		env,
+	}, filterEnvs(source, []string{teleportToolsVersionEnv, env3}))
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5131,7 +5131,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			FeatureWatchInterval:      retryutils.HalfJitter(web.DefaultFeatureWatchInterval * 2),
 			DatabaseREPLRegistry:      cfg.DatabaseREPLRegistry,
 		}
-		webHandler, err := web.NewHandler(webConfig)
+		webHandler, err := web.NewHandler(webConfig, web.SetClock(process.Clock))
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/utils/packaging/unarchive_test.go
+++ b/lib/utils/packaging/unarchive_test.go
@@ -63,11 +63,10 @@ func TestPackaging(t *testing.T) {
 		require.NoError(t, err)
 		for tool, path := range toolsMap {
 			assert.FileExists(t, filepath.Join(extractDir, path), fmt.Sprintf("script: %q not found", tool))
+			data, err := os.ReadFile(filepath.Join(extractDir, path))
+			require.NoError(t, err)
+			assert.Equal(t, script, string(data))
 		}
-
-		data, err := os.ReadFile(filepath.Join(extractDir, "tsh"))
-		require.NoError(t, err)
-		assert.Equal(t, script, string(data))
 	})
 
 	t.Run("pkg", func(t *testing.T) {
@@ -107,11 +106,10 @@ func TestPackaging(t *testing.T) {
 		require.NoError(t, err)
 		for tool, path := range toolsMap {
 			assert.FileExists(t, filepath.Join(extractDir, path), fmt.Sprintf("script: %q not found", tool))
+			data, err := os.ReadFile(filepath.Join(extractDir, path))
+			require.NoError(t, err)
+			assert.Equal(t, script, string(data))
 		}
-
-		data, err := os.ReadFile(filepath.Join(extractDir, "tsh"))
-		require.NoError(t, err)
-		assert.Equal(t, script, string(data))
 	})
 }
 

--- a/lib/utils/packaging/unarchive_test.go
+++ b/lib/utils/packaging/unarchive_test.go
@@ -54,7 +54,7 @@ func TestPackaging(t *testing.T) {
 		require.NoError(t, err)
 
 		archivePath := filepath.Join(toolsDir, "tsh.tar.gz")
-		err = archive.CompressDirToTarGzFile(ctx, sourceDir, archivePath)
+		err = archive.CompressDirToTarGzFile(ctx, sourceDir, archivePath, archive.WithNoCompress())
 		require.NoError(t, err)
 		require.FileExists(t, archivePath, "archive not created")
 


### PR DESCRIPTION
Backport #58954 to branch/v18

changelog: Fixed client tools managed updates sequential update.
