### PR TITLE
Server Auto Discover: handle suffix'd installations

### DIFF
--- a/lib/autoupdate/suffix.go
+++ b/lib/autoupdate/suffix.go
@@ -1,0 +1,22 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package autoupdate
+
+// InstallSuffixEnvVar specifies the Teleport install suffix.
+const InstallSuffixEnvVar = "TELEPORT_INSTALL_SUFFIX"

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -68,6 +68,16 @@ type AutoDiscoverNodeInstallerConfig struct {
 	// Eg, example.platform.sh
 	ProxyPublicAddr string
 
+	// InstallationManagedByTeleportUpdateWithSuffix indicates that a suffix was used to install teleport by teleport-update.
+	// When set, this command will use non-default file system paths:
+	// - teleport binary is located at: /opt/teleport/<suffix>/bin/teleport
+	// - systemd unit is located at: /etc/systemd/system/teleport_<suffix>.service
+	// - configuration must be written to: /etc/teleport_<suffix>.yaml
+	// - data directory must be set to: /var/lib/teleport_<suffix>
+	//
+	// This is in accordance with the teleport-update behavior.
+	InstallationManagedByTeleportUpdateWithSuffix string
+
 	// TeleportPackage contains the teleport package name.
 	// Allowed values: teleport, teleport-ent, teleport-ent-fips
 	TeleportPackage string
@@ -142,6 +152,13 @@ func (c *AutoDiscoverNodeInstallerConfig) checkAndSetDefaults() error {
 		c.autoUpgradesChannelURL = "https://" + c.ProxyPublicAddr + "/v1/webapi/automaticupgrades/channel/default"
 	}
 
+	if c.InstallationManagedByTeleportUpdateWithSuffix != "" {
+		// Only update it if not already set by the caller (only tests set it).
+		if c.binariesLocation.Teleport == "" {
+			c.binariesLocation.Teleport = filepath.Join(c.fsRootPrefix, "opt", "teleport", c.InstallationManagedByTeleportUpdateWithSuffix, "bin", "teleport")
+		}
+	}
+
 	c.binariesLocation.CheckAndSetDefaults()
 
 	if len(c.imdsProviders) == 0 {
@@ -211,6 +228,16 @@ var imdsClientTypeToJoinMethod = map[types.InstanceMetadataType]types.JoinMethod
 
 // Install teleport in the current system.
 func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
+	if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
+		slog.InfoContext(ctx, "Using non-default path for teleport installation",
+			"suffix", ani.InstallationManagedByTeleportUpdateWithSuffix,
+			"teleport_binary", ani.binariesLocation.Teleport,
+			"systemd_unit", ani.buildTeleportSystemdUnitName(),
+			"configuration_file", ani.buildTeleportConfigurationPath(),
+			"data_directory", ani.buildTeleportDataDirPath(),
+		)
+	}
+
 	// Ensure only one installer is running by locking the same file as the script installers.
 	lockFile := ani.buildAbsoluteFilePath(exclusiveInstallFileLock)
 	unlockFn, err := utils.FSTryWriteLock(lockFile)
@@ -233,6 +260,13 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 	// In the new autoupdate install flow, teleport-update should have already
 	// taken care of installing teleport.
 	if _, err := os.Stat(ani.binariesLocation.Teleport); err != nil {
+		// If teleport is not present and the installation is managed by teleport-update,
+		// then this is an error because teleport-update should have installed it.
+		// This prevents the installer from installing teleport in a different version and/or location than the one managed by teleport-update.
+		if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
+			return trace.BadParameter("teleport binary not found, ensure teleport-update installed it correctly: %v", err)
+		}
+
 		ani.Logger.InfoContext(ctx, "Installing teleport")
 		if err := ani.installTeleportFromRepo(ctx); err != nil {
 			return trace.Wrap(err)
@@ -264,13 +298,15 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 // - teleport was just installed and teleport.service is inactive
 // - teleport was already installed but the service is failing
 func (ani *AutoDiscoverNodeInstaller) enableAndRestartTeleportService(ctx context.Context) error {
-	systemctlEnableNowCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "enable", "teleport")
+	serviceName := ani.buildTeleportSystemdUnitName()
+
+	systemctlEnableNowCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "enable", serviceName)
 	systemctlEnableNowCMDOutput, err := systemctlEnableNowCMD.CombinedOutput()
 	if err != nil {
 		return trace.Wrap(err, string(systemctlEnableNowCMDOutput))
 	}
 
-	systemctlRestartCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "restart", "teleport")
+	systemctlRestartCMD := exec.CommandContext(ctx, ani.binariesLocation.Systemctl, "restart", serviceName)
 	systemctlRestartCMDOutput, err := systemctlRestartCMD.CombinedOutput()
 	if err != nil {
 		return trace.Wrap(err, string(systemctlRestartCMDOutput))
@@ -303,9 +339,13 @@ func (ani *AutoDiscoverNodeInstaller) configureTeleportNode(ctx context.Context,
 		return trace.BadParameter("Unsupported cloud provider: %v", imdsClient.GetType())
 	}
 
-	teleportYamlConfigurationPath := ani.buildAbsoluteFilePath(defaults.ConfigFilePath)
+	dataDirForNode := ani.buildTeleportDataDirPath()
+
+	teleportYamlConfigurationPath := ani.buildTeleportConfigurationPath()
 	teleportYamlConfigurationPathNew := teleportYamlConfigurationPath + teleportYamlConfigNewExtension
+
 	teleportNodeConfigureArgs := []string{"node", "configure", "--output=file://" + teleportYamlConfigurationPathNew,
+		fmt.Sprintf(`--data-dir=%s`, shsprintf.EscapeDefaultContext(dataDirForNode)),
 		fmt.Sprintf(`--proxy=%s`, shsprintf.EscapeDefaultContext(ani.ProxyPublicAddr)),
 		fmt.Sprintf(`--join-method=%s`, shsprintf.EscapeDefaultContext(string(joinMethod))),
 		fmt.Sprintf(`--token=%s`, shsprintf.EscapeDefaultContext(ani.TokenName)),
@@ -551,6 +591,32 @@ func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (m
 // buildAbsoluteFilePath creates the absolute file path
 func (ani *AutoDiscoverNodeInstaller) buildAbsoluteFilePath(path string) string {
 	return filepath.Join(ani.fsRootPrefix, path)
+}
+
+func (ani *AutoDiscoverNodeInstaller) buildTeleportConfigurationPath() string {
+	filePath := defaults.ConfigFilePath
+	if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
+		fileName := "teleport_" + ani.InstallationManagedByTeleportUpdateWithSuffix + ".yaml"
+		filePath = filepath.Join(filepath.Dir(defaults.ConfigFilePath), fileName)
+	}
+	return ani.buildAbsoluteFilePath(filePath)
+}
+
+func (ani *AutoDiscoverNodeInstaller) buildTeleportDataDirPath() string {
+	dataDirPath := defaults.DataDir
+	if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
+		dataDirName := "teleport_" + ani.InstallationManagedByTeleportUpdateWithSuffix
+		dataDirPath = filepath.Join(filepath.Dir(defaults.DataDir), dataDirName)
+	}
+	return ani.buildAbsoluteFilePath(dataDirPath)
+}
+
+func (ani *AutoDiscoverNodeInstaller) buildTeleportSystemdUnitName() string {
+	if ani.InstallationManagedByTeleportUpdateWithSuffix != "" {
+		return "teleport_" + ani.InstallationManagedByTeleportUpdateWithSuffix
+	}
+
+	return "teleport"
 }
 
 // linuxDistribution reads the current file system to detect the Linux Distro and Version of the current system.

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -50,8 +50,6 @@ Find out more at https://goteleport.com/docs/upgrading/agent-managed-updates`
 const (
 	// proxyServerEnvVar allows the proxy server address to be specified via env var.
 	proxyServerEnvVar = "TELEPORT_PROXY"
-	// installSuffixEnvVar specifies the Teleport install suffix.
-	installSuffixEnvVar = "TELEPORT_INSTALL_SUFFIX"
 	// installDirEnvVar specifies the Teleport install directory.
 	installDirEnvVar = "TELEPORT_INSTALL_DIR"
 	// pathEnvVar specifies the Teleport PATH for binary symlinks.
@@ -114,7 +112,7 @@ func Run(args []string) int {
 	app.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
 		Default(libutils.LogFormatText).EnumVar(&ccfg.LogFormat, libutils.LogFormatJSON, libutils.LogFormatText)
 	app.Flag("install-suffix", "Suffix for creating an agent installation outside of the default $PATH. Note: this changes the default data directory.").
-		Short('i').Envar(installSuffixEnvVar).StringVar(&ccfg.InstallSuffix)
+		Short('i').Envar(common.InstallSuffixEnvVar).StringVar(&ccfg.InstallSuffix)
 	app.Flag("install-dir", "Directory containing Teleport installations.").
 		Hidden().Envar(installDirEnvVar).StringVar(&ccfg.InstallDir)
 	app.Flag("insecure", "Insecure mode disables certificate verification. Do not use in production.").

--- a/tool/teleport/common/install.go
+++ b/tool/teleport/common/install.go
@@ -19,10 +19,12 @@ package common
 import (
 	"context"
 	"log/slog"
+	"os"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/autoupdate"
 	"github.com/gravitational/teleport/lib/srv/server/installer"
 	libutils "github.com/gravitational/teleport/lib/utils"
 )
@@ -73,6 +75,7 @@ func onInstallAutoDiscoverNode(cfg installAutoDiscoverNodeFlags) error {
 		AutoUpgrades:      autoUpgrades,
 		AzureClientID:     cfg.AzureClientID,
 		TokenName:         cfg.TokenName,
+		InstallationManagedByTeleportUpdateWithSuffix: os.Getenv(autoupdate.InstallSuffixEnvVar),
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Teleport can be installed using `teleport-update`. When installing teleport with a suffix (ie `teleport-update -i`) it will install teleport in non-default locations, as well as an expectation to use non-default locations for data directory and configuration and a different systemd unit name.

In this scenario, running `teleport install autodiscover` should use those non-default values.

This PR changes that command to consider those, and not the default ones when the `TELEPORT_INSTALL_SUFFIX` env var is set.

Context [RFD 224](https://github.com/gravitational/teleport/pull/58824)