### PR TITLE
docs: correct ec2 manual discovery link

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -20,8 +20,8 @@ instance and join it to the cluster as a Teleport-protected server. `teleport`
 commands allow you to create IAM policies that enable the Discovery Service to
 enroll EC2 instances as servers in your Teleport cluster.
 
-To manual configure IAM policies and SSM documents instead, read [Manual EC2
-Auto-Discovery Configuration](ec2-discovery-guided.mdx).
+To manually configure IAM policies and SSM documents instead, read [Manual EC2
+Auto-Discovery Configuration](ec2-discovery-manual.mdx).
 
 ## Prerequisites
 


### PR DESCRIPTION
This link next to "To manual configure IAM policies and SSM documents instead" is pointing to itself (same page):

https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided/

Updated to https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual/ and corrected grammar.