### PR TITLE
Invalidate Docusaurus cache on lint test builds

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -163,4 +163,7 @@ jobs:
 
       - name: Test the docs build
         working-directory: docs
-        run: yarn build
+        # Before the build, invalidate the Docusaurus-managed
+        # node_modules/.cache directory, which the GHA runner may have retrieved
+        # during a hit of the cache used for this workflow.
+        run: yarn clear && yarn build


### PR DESCRIPTION
The Lint (Docs) GitHub Actions job caches the `node_modules` directory to save time installing dependencies when testing the docs build. However, `node_modules` also includes caches managed by Docuscaurus. As a result, builds that retrieve `node_modules` content from the cache can inadvertently pull build artifacts from other `Lint (Docs)` runs.

This change runs `yarn clear` before `yarn build` to invalidate the local Docuscaurus cache before building the docs.