### PR TITLE
Bump minimum required macOS version to Monterey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 19.0.0 (xx/xx/xx)
+
+### Breaking changes
+
+#### macOS 12
+
+The minimum version of macOS required to run Teleport or associated client tools
+is now macOS 12 (Monterey).
+
 ## 18.0.0 (xx/xx/xx)
 
 ### Breaking changes

--- a/Makefile
+++ b/Makefile
@@ -328,8 +328,8 @@ endif
 
 ifeq ("$(OS)","darwin")
 # Set the minimum version for macOS builds for Go, Rust and Xcode builds.
-# (as of Go 1.23 we require macOS 11)
-MINIMUM_SUPPORTED_MACOS_VERSION = 11.0
+# (as of Go 1.25 we require macOS 12)
+MINIMUM_SUPPORTED_MACOS_VERSION = 12.0
 MACOSX_VERSION_MIN_FLAG = -mmacosx-version-min=$(MINIMUM_SUPPORTED_MACOS_VERSION)
 
 # Go

--- a/docs/pages/installation/macos.mdx
+++ b/docs/pages/installation/macos.mdx
@@ -6,7 +6,7 @@ tags:
 - platform-wide
 ---
 
-This guide explains how to install Teleport on macOS. 
+This guide explains how to install Teleport on macOS.
 
 For an overview of Teleport installation methods and supported platforms, see
 [Installation](./installation.mdx).
@@ -15,7 +15,7 @@ For an overview of Teleport installation methods and supported platforms, see
 ## Operating system support
 | Operating System | `teleport` Daemon | `tctl` Admin Tool | `tsh` and Teleport Connect User Clients [1] | Web UI (via the browser) | `tbot` Daemon |
 | - | - | - | - | - | - |
-| macOS 11+  (Big Sur)| yes | yes | yes | yes | yes |
+| macOS 12+  (Monterey) | yes | yes | yes | yes | yes |
 
 \[1] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See
   [Using Teleport Connect](../connect-your-client/teleport-connect.mdx) for usage and installation*.

--- a/lib/web/scripts/node-join/README.md
+++ b/lib/web/scripts/node-join/README.md
@@ -45,7 +45,7 @@ Things it doesn't do (yet):
   - Architectures
     - x86_64
     - aarch64
-  - macOS 11.0+
+  - macOS 12.0+
     - uses `.tar.gz` tarball package
 
 ## Arguments


### PR DESCRIPTION
With the Go 1.25 bump, Teleport now requires macOS 12.

Depends on #58875.