### PR TITLE
WebDiscover: fix aws rds databases language

### DIFF
--- a/web/packages/teleport/src/Discover/Database/SetupAccess/AwsRdsAuthRequirements.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/AwsRdsAuthRequirements.tsx
@@ -121,7 +121,7 @@ export function AwsRdsAuthRequirements({
             documentation
           </Link>{' '}
           on how to enable IAM authentication on your{' '}
-          {wantAutoDiscover ? 'databses' : 'database'}.
+          {wantAutoDiscover ? 'databases' : 'database'}.
         </Box>
       )}
 


### PR DESCRIPTION
spelling fix