### PR TITLE
MWI: Add `tbot copy-binaries` subcommand

### DIFF
--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -18,5 +18,6 @@ RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/
 
 FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging/opt/teleport/system/bin/tbot /usr/local/bin/tbot
+COPY --from=teleport /opt/staging/opt/teleport/system/bin/fdpass-teleport /usr/local/bin/fdpass-teleport
 ENTRYPOINT ["/usr/local/bin/tbot"]
 CMD ["start"]

--- a/lib/tbot/cli/copy_binaries.go
+++ b/lib/tbot/cli/copy_binaries.go
@@ -1,0 +1,47 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+// CopyBinariesCommand includes fields for `tbot copy-binaries`
+type CopyBinariesCommand struct {
+	*genericExecutorHandler[CopyBinariesCommand]
+
+	// IncludeFDPass specifies whether or not `fdpass-teleport` should be
+	// copied.
+	IncludeFDPass bool
+
+	// DestinationDir is the directory into which the tbot binary (and
+	// optionally fdpass) should be written.
+	DestinationDir string
+}
+
+// NewCopyBinariesCommand initializes the `tbot copy-binaries` subcommand and
+// its fields.
+func NewCopyBinariesCommand(app KingpinClause, action func(*CopyBinariesCommand) error) *CopyBinariesCommand {
+	cmd := app.Command("copy-binaries", "Copies this tbot binary to a given destination")
+	cmd.Interspersed(true)
+
+	c := &CopyBinariesCommand{}
+	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
+
+	cmd.Flag("include-fdpass", "If set, also copy `fdpass-teleport`. It must be available in the same path as `tbot`.").BoolVar(&c.IncludeFDPass)
+	cmd.Arg("destination-dir", "The destination path to write the copy of the tbot binary").Required().StringVar(&c.DestinationDir)
+
+	return c
+}

--- a/tool/tbot/copy_binaries.go
+++ b/tool/tbot/copy_binaries.go
@@ -25,8 +25,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gravitational/teleport/lib/tbot/cli"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/tbot/cli"
 )
 
 const (

--- a/tool/tbot/copy_binaries.go
+++ b/tool/tbot/copy_binaries.go
@@ -1,0 +1,100 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/teleport/lib/tbot/cli"
+	"github.com/gravitational/trace"
+)
+
+const (
+	// fdpassBinaryName is the name of the fdpass binary
+	fdpassBinaryName = "fdpass-teleport"
+
+	// tbotBinaryName is the name of the tbot binary
+	tbotBinaryName = "tbot"
+)
+
+// copyBinary copies a binary from the source to the destination. It assumes
+// 0755 permissions.
+func copyBinary(src, dest string) error {
+	inputFile, err := os.Open(src)
+	if err != nil {
+		return trace.Wrap(err, "opening source file: %s", src)
+	}
+	defer inputFile.Close()
+
+	destFile, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return trace.Wrap(err, "opening destination for writing: %s", dest)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, inputFile)
+	if err != nil {
+		return trace.Wrap(err, "copying file contents: %s", src)
+	}
+
+	return nil
+}
+
+// onCopyBinariesCommand runs `tbot copy-binaries`
+func onCopyBinariesCommand(ctx context.Context, cmd *cli.CopyBinariesCommand) error {
+	selfPath, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err, "determining current executable")
+	}
+
+	stat, err := os.Stat(cmd.DestinationDir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(cmd.DestinationDir, 0755); err != nil {
+			return trace.Wrap(err, "creating destination directory: %s", cmd.DestinationDir)
+		}
+	} else if err != nil {
+		return trace.Wrap(err, "could not resolve destination directory: %s", cmd.DestinationDir)
+	} else if !stat.IsDir() {
+		return trace.BadParameter("invalid destination directory: %s", cmd.DestinationDir)
+	}
+
+	tbotDest := filepath.Join(cmd.DestinationDir, tbotBinaryName)
+	if err := copyBinary(selfPath, tbotDest); err != nil {
+		return trace.Wrap(err, "copying %s binary", tbotBinaryName)
+	}
+	log.InfoContext(ctx, "Copied tbot to destination", "path", tbotDest)
+
+	if cmd.IncludeFDPass {
+		fdpassPath := filepath.Join(filepath.Dir(selfPath), fdpassBinaryName)
+		fdpassDest := filepath.Join(cmd.DestinationDir, fdpassBinaryName)
+		if err := copyBinary(fdpassPath, fdpassDest); err != nil {
+			return trace.Wrap(err, "copying %s binary", fdpassBinaryName)
+		}
+
+		log.InfoContext(ctx, "Copied fdpass-teleport to destination", "path", fdpassDest)
+	}
+
+	log.InfoContext(ctx, "Binaries have been copied successfully", "destination", cmd.DestinationDir)
+
+	return nil
+}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -123,6 +123,10 @@ func Run(args []string, stdout io.Writer) error {
 			return onKeypairCreateCommand(ctx, globalCfg, keypairCreateCmd)
 		}),
 
+		cli.NewCopyBinariesCommand(app, func(cbc *cli.CopyBinariesCommand) error {
+			return onCopyBinariesCommand(ctx, cbc)
+		}),
+
 		// `start` and `configure` commands
 		cli.NewLegacyCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
 		cli.NewLegacyCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),


### PR DESCRIPTION
This adds a trivial `tbot copy-binaries <destination>` subcommand to copy tbot itself - and optionally `fdpass-teleport` - into a given destination directory.

This command is useful for (among other possible use cases) copying binaries from a Kubernetes initContainer so `tbot` or `fdpass-teleport` can be executed from that environment. This is currently impossible to do using our distroless images as they do not have a usable shell.

Additionally, this adds `fdpass-teleport` to our tbot-distroless image, which currently does not include it.

changelog: Added `tbot copy-binaries` command to simplify using tbot as a Kubernetes sidecar