### PR TITLE
docs: fix instructions for creating DynamoDB events table

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -1007,6 +1007,7 @@
     "timechart",
     "timedatectl",
     "timekey",
+    "timesearch",
     "tlogs",
     "tlscacerts",
     "tlscert",

--- a/docs/pages/includes/dynamodb-iam-policy.mdx
+++ b/docs/pages/includes/dynamodb-iam-policy.mdx
@@ -44,7 +44,15 @@ The audit event table must have the following attribute definitions:
 |`CreatedAtDate`|`S`|
 |`CreatedAt`|`N`|
 
-The table must also have the following key schema elements:
+The table must have the following key schema elements:
+
+|Name|Type|
+|---|---|
+|`SessionID`|`HASH`|
+|`EventIndex`|`RANGE`|
+
+The table must also have a global secondary index named `timesearchV2` with the
+following key schema elements:
 
 |Name|Type|
 |---|---|


### PR DESCRIPTION
The instructions for creating the events table manually were incorrect. Update them to match the behavior of Teleport when it creates the table.

Closes #58628