### PR TITLE
MWI: Store aggregated bot instance by version metric

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service.pb.go
@@ -25,6 +25,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -374,11 +375,104 @@ func (*SubmitHeartbeatResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_machineid_v1_bot_instance_service_proto_rawDescGZIP(), []int{5}
 }
 
+// The request for BotInstanceMetrics.
+type BotInstanceMetricsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BotInstanceMetricsRequest) Reset() {
+	*x = BotInstanceMetricsRequest{}
+	mi := &file_teleport_machineid_v1_bot_instance_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BotInstanceMetricsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BotInstanceMetricsRequest) ProtoMessage() {}
+
+func (x *BotInstanceMetricsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_machineid_v1_bot_instance_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BotInstanceMetricsRequest.ProtoReflect.Descriptor instead.
+func (*BotInstanceMetricsRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_machineid_v1_bot_instance_service_proto_rawDescGZIP(), []int{6}
+}
+
+// The response from BotInstanceMetrics, containing pre-aggregated metrics about
+// tbot version usage etc.
+type BotInstanceMetricsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The time at which the metrics were last re-calculated.
+	UpdatedAt *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// The number of instances of `tbot` broken down by version number.
+	CountByVersion map[string]int64 `protobuf:"bytes,2,rep,name=count_by_version,json=countByVersion,proto3" json:"count_by_version,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *BotInstanceMetricsResponse) Reset() {
+	*x = BotInstanceMetricsResponse{}
+	mi := &file_teleport_machineid_v1_bot_instance_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BotInstanceMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BotInstanceMetricsResponse) ProtoMessage() {}
+
+func (x *BotInstanceMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_machineid_v1_bot_instance_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BotInstanceMetricsResponse.ProtoReflect.Descriptor instead.
+func (*BotInstanceMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_machineid_v1_bot_instance_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *BotInstanceMetricsResponse) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+func (x *BotInstanceMetricsResponse) GetCountByVersion() map[string]int64 {
+	if x != nil {
+		return x.CountByVersion
+	}
+	return nil
+}
+
 var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescriptor
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
@@ -399,12 +493,21 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"instanceId\"i\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
 	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\"\x19\n" +
-	"\x17SubmitHeartbeatResponse2\xbd\x03\n" +
+	"\x17SubmitHeartbeatResponse\"\x1b\n" +
+	"\x19BotInstanceMetricsRequest\"\x8b\x02\n" +
+	"\x1aBotInstanceMetricsResponse\x129\n" +
+	"\n" +
+	"updated_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12o\n" +
+	"\x10count_by_version\x18\x02 \x03(\v2E.teleport.machineid.v1.BotInstanceMetricsResponse.CountByVersionEntryR\x0ecountByVersion\x1aA\n" +
+	"\x13CountByVersionEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\x03R\x05value:\x028\x012\xb8\x04\n" +
 	"\x12BotInstanceService\x12b\n" +
 	"\x0eGetBotInstance\x12,.teleport.machineid.v1.GetBotInstanceRequest\x1a\".teleport.machineid.v1.BotInstance\x12s\n" +
 	"\x10ListBotInstances\x12..teleport.machineid.v1.ListBotInstancesRequest\x1a/.teleport.machineid.v1.ListBotInstancesResponse\x12\\\n" +
 	"\x11DeleteBotInstance\x12/.teleport.machineid.v1.DeleteBotInstanceRequest\x1a\x16.google.protobuf.Empty\x12p\n" +
-	"\x0fSubmitHeartbeat\x12-.teleport.machineid.v1.SubmitHeartbeatRequest\x1a..teleport.machineid.v1.SubmitHeartbeatResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1;machineidv1b\x06proto3"
+	"\x0fSubmitHeartbeat\x12-.teleport.machineid.v1.SubmitHeartbeatRequest\x1a..teleport.machineid.v1.SubmitHeartbeatResponse\x12y\n" +
+	"\x12BotInstanceMetrics\x120.teleport.machineid.v1.BotInstanceMetricsRequest\x1a1.teleport.machineid.v1.BotInstanceMetricsResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1;machineidv1b\x06proto3"
 
 var (
 	file_teleport_machineid_v1_bot_instance_service_proto_rawDescOnce sync.Once
@@ -418,7 +521,7 @@ func file_teleport_machineid_v1_bot_instance_service_proto_rawDescGZIP() []byte 
 	return file_teleport_machineid_v1_bot_instance_service_proto_rawDescData
 }
 
-var file_teleport_machineid_v1_bot_instance_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_machineid_v1_bot_instance_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*GetBotInstanceRequest)(nil),      // 0: teleport.machineid.v1.GetBotInstanceRequest
 	(*ListBotInstancesRequest)(nil),    // 1: teleport.machineid.v1.ListBotInstancesRequest
@@ -426,28 +529,36 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*DeleteBotInstanceRequest)(nil),   // 3: teleport.machineid.v1.DeleteBotInstanceRequest
 	(*SubmitHeartbeatRequest)(nil),     // 4: teleport.machineid.v1.SubmitHeartbeatRequest
 	(*SubmitHeartbeatResponse)(nil),    // 5: teleport.machineid.v1.SubmitHeartbeatResponse
-	(*types.SortBy)(nil),               // 6: types.SortBy
-	(*BotInstance)(nil),                // 7: teleport.machineid.v1.BotInstance
-	(*BotInstanceStatusHeartbeat)(nil), // 8: teleport.machineid.v1.BotInstanceStatusHeartbeat
-	(*emptypb.Empty)(nil),              // 9: google.protobuf.Empty
+	(*BotInstanceMetricsRequest)(nil),  // 6: teleport.machineid.v1.BotInstanceMetricsRequest
+	(*BotInstanceMetricsResponse)(nil), // 7: teleport.machineid.v1.BotInstanceMetricsResponse
+	nil,                                // 8: teleport.machineid.v1.BotInstanceMetricsResponse.CountByVersionEntry
+	(*types.SortBy)(nil),               // 9: types.SortBy
+	(*BotInstance)(nil),                // 10: teleport.machineid.v1.BotInstance
+	(*BotInstanceStatusHeartbeat)(nil), // 11: teleport.machineid.v1.BotInstanceStatusHeartbeat
+	(*timestamppb.Timestamp)(nil),      // 12: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),              // 13: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
-	6, // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
-	7, // 1: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
-	8, // 2: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
-	0, // 3: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1, // 4: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	3, // 5: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	4, // 6: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	7, // 7: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	2, // 8: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	9, // 9: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	5, // 10: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	7, // [7:11] is the sub-list for method output_type
-	3, // [3:7] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	9,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
+	10, // 1: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
+	11, // 2: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
+	12, // 3: teleport.machineid.v1.BotInstanceMetricsResponse.updated_at:type_name -> google.protobuf.Timestamp
+	8,  // 4: teleport.machineid.v1.BotInstanceMetricsResponse.count_by_version:type_name -> teleport.machineid.v1.BotInstanceMetricsResponse.CountByVersionEntry
+	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	3,  // 7: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	4,  // 8: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	6,  // 9: teleport.machineid.v1.BotInstanceService.BotInstanceMetrics:input_type -> teleport.machineid.v1.BotInstanceMetricsRequest
+	10, // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	2,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	13, // 12: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	5,  // 13: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	7,  // 14: teleport.machineid.v1.BotInstanceService.BotInstanceMetrics:output_type -> teleport.machineid.v1.BotInstanceMetricsResponse
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }
@@ -462,7 +573,7 @@ func file_teleport_machineid_v1_bot_instance_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_machineid_v1_bot_instance_service_proto_rawDesc), len(file_teleport_machineid_v1_bot_instance_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_grpc.pb.go
@@ -34,10 +34,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BotInstanceService_GetBotInstance_FullMethodName    = "/teleport.machineid.v1.BotInstanceService/GetBotInstance"
-	BotInstanceService_ListBotInstances_FullMethodName  = "/teleport.machineid.v1.BotInstanceService/ListBotInstances"
-	BotInstanceService_DeleteBotInstance_FullMethodName = "/teleport.machineid.v1.BotInstanceService/DeleteBotInstance"
-	BotInstanceService_SubmitHeartbeat_FullMethodName   = "/teleport.machineid.v1.BotInstanceService/SubmitHeartbeat"
+	BotInstanceService_GetBotInstance_FullMethodName     = "/teleport.machineid.v1.BotInstanceService/GetBotInstance"
+	BotInstanceService_ListBotInstances_FullMethodName   = "/teleport.machineid.v1.BotInstanceService/ListBotInstances"
+	BotInstanceService_DeleteBotInstance_FullMethodName  = "/teleport.machineid.v1.BotInstanceService/DeleteBotInstance"
+	BotInstanceService_SubmitHeartbeat_FullMethodName    = "/teleport.machineid.v1.BotInstanceService/SubmitHeartbeat"
+	BotInstanceService_BotInstanceMetrics_FullMethodName = "/teleport.machineid.v1.BotInstanceService/BotInstanceMetrics"
 )
 
 // BotInstanceServiceClient is the client API for BotInstanceService service.
@@ -54,6 +55,8 @@ type BotInstanceServiceClient interface {
 	DeleteBotInstance(ctx context.Context, in *DeleteBotInstanceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// SubmitHeartbeat submits a heartbeat for a BotInstance.
 	SubmitHeartbeat(ctx context.Context, in *SubmitHeartbeatRequest, opts ...grpc.CallOption) (*SubmitHeartbeatResponse, error)
+	// BotInstanceMetrics returns the pre-aggregated metrics about BotInstances.
+	BotInstanceMetrics(ctx context.Context, in *BotInstanceMetricsRequest, opts ...grpc.CallOption) (*BotInstanceMetricsResponse, error)
 }
 
 type botInstanceServiceClient struct {
@@ -104,6 +107,16 @@ func (c *botInstanceServiceClient) SubmitHeartbeat(ctx context.Context, in *Subm
 	return out, nil
 }
 
+func (c *botInstanceServiceClient) BotInstanceMetrics(ctx context.Context, in *BotInstanceMetricsRequest, opts ...grpc.CallOption) (*BotInstanceMetricsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BotInstanceMetricsResponse)
+	err := c.cc.Invoke(ctx, BotInstanceService_BotInstanceMetrics_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BotInstanceServiceServer is the server API for BotInstanceService service.
 // All implementations must embed UnimplementedBotInstanceServiceServer
 // for forward compatibility.
@@ -118,6 +131,8 @@ type BotInstanceServiceServer interface {
 	DeleteBotInstance(context.Context, *DeleteBotInstanceRequest) (*emptypb.Empty, error)
 	// SubmitHeartbeat submits a heartbeat for a BotInstance.
 	SubmitHeartbeat(context.Context, *SubmitHeartbeatRequest) (*SubmitHeartbeatResponse, error)
+	// BotInstanceMetrics returns the pre-aggregated metrics about BotInstances.
+	BotInstanceMetrics(context.Context, *BotInstanceMetricsRequest) (*BotInstanceMetricsResponse, error)
 	mustEmbedUnimplementedBotInstanceServiceServer()
 }
 
@@ -139,6 +154,9 @@ func (UnimplementedBotInstanceServiceServer) DeleteBotInstance(context.Context, 
 }
 func (UnimplementedBotInstanceServiceServer) SubmitHeartbeat(context.Context, *SubmitHeartbeatRequest) (*SubmitHeartbeatResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SubmitHeartbeat not implemented")
+}
+func (UnimplementedBotInstanceServiceServer) BotInstanceMetrics(context.Context, *BotInstanceMetricsRequest) (*BotInstanceMetricsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BotInstanceMetrics not implemented")
 }
 func (UnimplementedBotInstanceServiceServer) mustEmbedUnimplementedBotInstanceServiceServer() {}
 func (UnimplementedBotInstanceServiceServer) testEmbeddedByValue()                            {}
@@ -233,6 +251,24 @@ func _BotInstanceService_SubmitHeartbeat_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BotInstanceService_BotInstanceMetrics_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BotInstanceMetricsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BotInstanceServiceServer).BotInstanceMetrics(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BotInstanceService_BotInstanceMetrics_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BotInstanceServiceServer).BotInstanceMetrics(ctx, req.(*BotInstanceMetricsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BotInstanceService_ServiceDesc is the grpc.ServiceDesc for BotInstanceService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -255,6 +291,10 @@ var BotInstanceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SubmitHeartbeat",
 			Handler:    _BotInstanceService_SubmitHeartbeat_Handler,
+		},
+		{
+			MethodName: "BotInstanceMetrics",
+			Handler:    _BotInstanceService_BotInstanceMetrics_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package teleport.machineid.v1;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 import "teleport/legacy/types/types.proto";
 import "teleport/machineid/v1/bot_instance.proto";
 
@@ -78,6 +79,21 @@ message SubmitHeartbeatResponse {
   // Empty
 }
 
+// The request for BotInstanceMetrics.
+message BotInstanceMetricsRequest {
+  // Empty
+}
+
+// The response from BotInstanceMetrics, containing pre-aggregated metrics about
+// tbot version usage etc.
+message BotInstanceMetricsResponse {
+  // The time at which the metrics were last re-calculated.
+  google.protobuf.Timestamp updated_at = 1;
+
+  // The number of instances of `tbot` broken down by version number.
+  map<string, int64> count_by_version = 2;
+}
+
 // BotInstanceService provides functions to record and manage bot instances.
 service BotInstanceService {
   // GetBotInstance returns the specified BotInstance resource.
@@ -88,4 +104,6 @@ service BotInstanceService {
   rpc DeleteBotInstance(DeleteBotInstanceRequest) returns (google.protobuf.Empty);
   // SubmitHeartbeat submits a heartbeat for a BotInstance.
   rpc SubmitHeartbeat(SubmitHeartbeatRequest) returns (SubmitHeartbeatResponse);
+  // BotInstanceMetrics returns the pre-aggregated metrics about BotInstances.
+  rpc BotInstanceMetrics(BotInstanceMetricsRequest) returns (BotInstanceMetricsResponse);
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5568,6 +5568,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err, "creating bot instance service")
 	}
 	machineidv1pb.RegisterBotInstanceServiceServer(server, botInstanceService)
+	go botInstanceService.RunMetricsRefresher(cfg.AuthServer.CloseContext())
 
 	workloadIdentityService, err := machineidv1.NewWorkloadIdentityService(machineidv1.WorkloadIdentityServiceConfig{
 		Authorizer: cfg.Authorizer,


### PR DESCRIPTION
See: [RFD 0222 - Bot Instances at Scale](https://github.com/gravitational/teleport/pull/57888)

This PR adds a new gRPC endpoint to the bot instances service: `BotInstanceMetrics` which currently returns the instance count broken down by `tbot` version. This will form the basis of the "upgrade status" visualization.
