### PR TITLE
Change "tctl create -f cap.yaml" error message.

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -3837,7 +3837,8 @@ func checkCreateResourceWithOrigin(storedRes types.ResourceWithOrigin, resDesc s
 func checkUpdateResourceWithOrigin(storedRes types.ResourceWithOrigin, resDesc string, confirm bool) error {
 	managedByStatic := storedRes.Origin() == types.OriginConfigFile
 	if managedByStatic && !confirm {
-		return trace.BadParameter(`The %s resource is managed by static configuration. We recommend removing configuration from teleport.yaml, restarting the servers and trying this command again.
+		return trace.BadParameter(`The %s resource is managed by static configuration in your Auth Service teleport.yaml.
+You can either statically set the authentication configuration there, or unset the "auth_service.authentication" field and dynamically manage the config via the "cluster_auth_preference" resource.
 
 If you would still like to proceed, re-run the command with the --confirm flag.`, resDesc)
 	}


### PR DESCRIPTION
The current "we recommend to unset the teleport.yaml config" error message is harmful in most cases because:

- CAP is a feature made to allow Teleport Cloud users to configure auth. This is made for cases where the team running Teleport is not the team configuring Teleport. This is only the case in Teleport Cloud.
- Setting the authentication preference while deploying the cluster provides a better user experience:
    - less configuration steps
    - config lives in a single plce
    - clusters can be cloned/redeployed without human intervention
- All Teleport recommended deployment methods (Helm Chart, AWS Terraform) set the auth config. This recommendation is not compatible with any of our IAC methods.

For all those reasons, this error message is misleading, causes confusion for users and support load for us.