### PR TITLE
Turn off react-hooks/preserve-manual-memoization ESLint rule

### DIFF
--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -156,6 +156,12 @@ export default tseslint.config(
           ([ruleName]) => [ruleName, 'warn']
         )
       ),
+      // This rule is noisy, its message does not explain how to address the issue and in the
+      // release candidate version it seems to report false positives. Turn it back on once those
+      // concerns are addressed.
+      // https://github.com/facebook/react/issues/34289
+      // https://github.com/facebook/react/issues/34313
+      'react-hooks/preserve-manual-memoization': 'off',
     },
   },
   {


### PR DESCRIPTION
This rule is noisy, its message does not explain how to address the issue and in the release candidate version it seems to report some false positives. Turn it back on once those concerns are addressed. There's at least one instance where the warnings from this rule were noisy enough that they made it harder to spot a warning from react-hooks/exhaustive-deps (https://github.com/gravitational/teleport/pull/58971#discussion_r2348734880).

Related issues:

* https://github.com/facebook/react/issues/34289
* https://github.com/facebook/react/issues/34313
 