### PR TITLE
[flaky test] TestDatabaseAccess/AgentState/WithResourceMatchers

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -341,12 +341,13 @@ func WaitForDatabaseServers(t *testing.T, authServer *auth.Server, dbs []service
 func WaitForDatabaseService(t *testing.T, authServer *auth.Server, hostUUID string) {
 	t.Helper()
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp, err := authServer.ListResources(t.Context(), proto.ListResourcesRequest{
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := authServer.ListResources(ctx, proto.ListResourcesRequest{
 			ResourceType: types.KindDatabaseService,
 		})
-		require.NoError(collect, err)
-		require.Contains(collect, slices.Collect(types.ResourceNames(resp.Resources)), hostUUID)
+		require.NoError(t, err)
+		require.Contains(t, slices.Collect(types.ResourceNames(resp.Resources)), hostUUID)
 	}, 10*time.Second, 200*time.Millisecond, "database service not started")
 }
 


### PR DESCRIPTION
related:
- #17543 
- #19169

The readiness check failed because the process hasn't received any heartbeats to turn the state to OK yet.

In the previous [fix](https://github.com/gravitational/teleport/pull/19169), `WaitForDatabaseServers` has been added to wait for the db server heartbeats.

However, the flaky test can still happen in `TestDatabaseAccess/AgentState/WithResourceMatchers` since there is _NO_ static databases to wait for. The flaky test can be easily simulated by adding a `time.Sleep` in `startServiceHeartbeat`:
https://github.com/gravitational/teleport/blob/ef3aaa98020cc3e7813015369a0918f6413ed18d/lib/srv/db/server.go#L1000-L1004

Now adding a `WaitForDatabaseService` check for `WithResourceMatchers` case.