### PR TITLE
deflake `TestResizeTerminal`

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1911,9 +1911,7 @@ func TestResizeTerminal(t *testing.T) {
 	eventsChan := make(chan apievents.AuditEvent, 10)
 	isInitialResizeComplete := make(chan struct{})
 	go func() {
-		var (
-			once sync.Once
-		)
+		var once sync.Once
 		for {
 			select {
 			case <-t.Context().Done():

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -45,6 +45,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -205,6 +206,8 @@ type webSuiteConfig struct {
 
 	disableDiskBasedRecording bool
 
+	onSessionRecordEvent func(ctx context.Context, sid session.ID, pe apievents.PreparedSessionEvent) error
+
 	uiConfig webclient.UIConfig
 
 	// Custom "HealthCheckAppServer" function. Can be used to avoid dialing app
@@ -268,6 +271,17 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 
 	if cfg.disableDiskBasedRecording {
 		authCfg.Auth.AuditLog = events.NewDiscardAuditLog()
+		if cfg.onSessionRecordEvent != nil {
+			streamer, err := events.NewCallbackStreamer(
+				events.CallbackStreamerConfig{
+					// Inner emits events to the underlying store
+					Inner:         events.NewDiscardStreamer(),
+					OnRecordEvent: cfg.onSessionRecordEvent,
+				},
+			)
+			require.NoError(t, err)
+			authCfg.Auth.Streamer = streamer
+		}
 	}
 
 	s.server, err = authtest.NewTestServer(authCfg)
@@ -280,6 +294,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		recConfig.SetMode(types.RecordAtNodeSync)
 		_, err := s.server.AuthServer.AuthServer.UpsertSessionRecordingConfig(context.Background(), recConfig)
 		require.NoError(t, err)
+
 	}
 
 	// Register the auth server, since test auth server doesn't start its own
@@ -1891,7 +1906,55 @@ func TestUIConfig(t *testing.T) {
 
 func TestResizeTerminal(t *testing.T) {
 	t.Parallel()
-	s := newWebSuiteWithConfig(t, webSuiteConfig{disableDiskBasedRecording: true})
+	const fooUser = "foo"
+
+	eventsChan := make(chan apievents.AuditEvent, 10)
+	isInitialResizeComplete := make(chan struct{})
+	go func() {
+		var (
+			once sync.Once
+		)
+		for {
+			select {
+			case <-t.Context().Done():
+				return
+			case evt, ok := <-eventsChan:
+				if !ok {
+					return
+				}
+				// we are only interested in resize events
+				if evt.GetType() != events.ResizeEvent {
+					continue
+				}
+				resize, ok := evt.(*apievents.Resize)
+				assert.True(t, ok)
+
+				// we are only interested in resize events from foo user with 100x100 terminal size
+				// which is the initial size the client connects with.
+				if resize.GetUser() != fooUser || resize.TerminalSize != "100:100" {
+					continue
+				}
+
+				// signal that the initial resize events have been processed
+				// by the server
+				once.Do(func() {
+					close(isInitialResizeComplete)
+				})
+
+			}
+		}
+	}()
+
+	s := newWebSuiteWithConfig(t, webSuiteConfig{
+		disableDiskBasedRecording: true,
+		onSessionRecordEvent: func(ctx context.Context, sid session.ID, pe apievents.PreparedSessionEvent) error {
+			select {
+			case eventsChan <- pe.GetAuditEvent():
+			case <-ctx.Done():
+			}
+			return nil
+		},
+	})
 	sid := session.NewID()
 
 	ctx, cancel := context.WithCancel(s.ctx)
@@ -1902,7 +1965,7 @@ func TestResizeTerminal(t *testing.T) {
 	ws2Messages := make(chan *terminal.Envelope)
 	// Create a new user "foo", open a terminal to a new session
 	term, err := connectToHost(ctx, connectConfig{
-		pack:  s.authPack(t, "foo"),
+		pack:  s.authPack(t, fooUser),
 		host:  s.node.ID(),
 		proxy: s.webServer.Listener.Addr().String(),
 		handlers: map[string]terminal.WSHandlerFunc{
@@ -1913,6 +1976,22 @@ func TestResizeTerminal(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, term.Close()) })
+
+	// The client connects to the server with an initial terminal size of 100x100.
+	// We must ensure the server processes this initial resize event before proceeding
+	// with bar joining the session and sending a new resize event.
+	// This is done by waiting for the resize event to be recorded
+	// by the onSessionRecordEvent callback above.
+	// If this does not happen within 10 seconds, the test fails.
+	// This ensures that the bar user joining never receives any possible
+	// pending resize events from foo creating the session.
+	select {
+	case <-isInitialResizeComplete:
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "", "timeout waiting for initial resize events")
+	case <-t.Context().Done():
+		require.FailNow(t, "", "test context done: %v", t.Context().Err())
+	}
 
 	sess := term.GetSession()
 	// Wait for session to have started


### PR DESCRIPTION
On `TestResizeTerminal` test flow, a session is created by a user `foo`. Once the session is created, the user `foo` sends a resize event to set the terminal size to `100x100`.

Once the session tracker is available, another user `bar` joins the session and sends two resize events - one for joining and another because it also sets the terminal size to 100x100.

To avoid resize loops, Teleport prevents the resize sender to receive the resize event it generated. Thus, this test validates if the user `bar` never receives the two resize events it triggers when joining the session.

The issue arrises from the fact that the code didn't ensure that the initial resize event triggered by user `foo` was properly handled before `bar` joins. This means that `bar` was receiving a resize event that `foo` triggered before `bar` joined the session but the server only processed it afterwards as you can see in the log bellow:

```
    apiserver_test.go:1970:
        	Error Trace:	/__w/teleport/teleport/lib/web/apiserver_test.go:1970
        	Error:      	terminal 2 should not have received a resize event: %v
        	Test:       	TestResizeTerminal
        	Messages:   	Version:"1" Type:"a" Payload:"{\"cluster_name\":\"localhost\",\"code\":\"T2002I\",\"ei\":3,\"event\":\"resize\",\"login\":\"root\",\"namespace\":\"default\",\"private_key_policy\":\"none\",\"server_addr\":\"127.0.0.1:44619\",\"server_hostname\":\"node\",\"server_id\":\"node\",\"server_version\":\"18.2.1\",\"sid\":\"b14a7676-4e43-48a0-b260-7ff5379d1790\",\"size\":\"100:100\",\"time\":\"2025-09-15T13:52:51.217Z\",\"uid\":\"01e9ca35-27d9-428d-ad20-5c9b43267b0f\",\"user\":\"foo\",\"user_cluster_name\":\"localhost\",\"user_kind\":1,\"user_roles\":[\"user:foo\"]}"
```

This caused the test to fail because the test expected `bar` to never receive any resize event.

This PR deflakes the test by ensuring we catch the initial resize event before `bar` joins the session.

Fixes #13607