### PR TITLE
Pass teleport_version explicitly to AppUpdater 

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -48,7 +48,11 @@ import {
   TSH_AUTOUPDATE_ENV_VAR,
   TSH_AUTOUPDATE_OFF,
 } from 'teleterm/node/tshAutoupdate';
-import { AppUpdater, AppUpdaterStorage } from 'teleterm/services/appUpdater';
+import {
+  AppUpdater,
+  AppUpdaterStorage,
+  TELEPORT_TOOLS_VERSION_ENV_VAR,
+} from 'teleterm/services/appUpdater';
 import { subscribeToFileStorageEvents } from 'teleterm/services/fileStorage';
 import * as grpcCreds from 'teleterm/services/grpcCredentials';
 import {
@@ -170,7 +174,8 @@ export default class MainProcess {
         this.windowsManager
           .getWindow()
           .webContents.send(RendererIpc.AppUpdateEvent, event);
-      }
+      },
+      process.env[TELEPORT_TOOLS_VERSION_ENV_VAR]
     );
   }
 

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -19,7 +19,6 @@
 import { rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import process from 'process';
 
 import { app } from 'electron';
 import {
@@ -52,7 +51,7 @@ import {
   ClientToolsVersionGetter,
 } from './clientToolsUpdateProvider';
 
-const TELEPORT_TOOLS_VERSION_ENV_VAR = 'TELEPORT_TOOLS_VERSION';
+export const TELEPORT_TOOLS_VERSION_ENV_VAR = 'TELEPORT_TOOLS_VERSION';
 
 export class AppUpdater {
   private readonly logger = new Logger('AppUpdater');
@@ -69,6 +68,7 @@ export class AppUpdater {
     private readonly getClusterVersions: () => Promise<GetClusterVersionsResponse>,
     readonly getDownloadBaseUrl: () => Promise<string>,
     private readonly emit: (event: AppUpdateEvent) => void,
+    private versionEnvVar: string,
     /** Allows overring autoUpdater in tests. */
     private nativeUpdater: NativeUpdater = autoUpdater
   ) {
@@ -324,11 +324,10 @@ export class AppUpdater {
   }
 
   private async refreshAutoUpdatesStatus(): Promise<void> {
-    const versionEnvVar = process.env[TELEPORT_TOOLS_VERSION_ENV_VAR];
     const { managingClusterUri } = this.storage.get();
 
     this.autoUpdatesStatus = await resolveAutoUpdatesStatus({
-      versionEnvVar,
+      versionEnvVar: this.versionEnvVar,
       managingClusterUri,
       getClusterVersions: this.getClusterVersions,
     });


### PR DESCRIPTION
Because the process.env was not mocked in the tests, these tests would fail locally if you had TELEPORT_TOOLS_VERSION=off in your env vars locally (CI doesnt have this so they dont fail, this is just for local). This PR will remove that env var from a mock env var so they pass regardless of computer running them