### PR TITLE
[v18] Expose LDAP error when using locate option

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -384,6 +384,7 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 		return nil, trace.NotFound("no LDAP servers found for domain %q", c.Domain)
 	}
 
+	var lastErr error
 	for _, server := range servers {
 		conn, err := ldap.DialURL(
 			"ldaps://"+server,
@@ -396,6 +397,7 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 			conn.SetTimeout(ldapRequestTimeout)
 			return conn, nil
 		}
+		lastErr = err
 
 		if c.LocateServer.Enabled {
 			// If the connection fails and we're using LocateServer, log that a server failed.
@@ -403,5 +405,5 @@ func (c *LDAPConfig) createConnection(ctx context.Context, ldapTLSConfig *tls.Co
 		}
 	}
 
-	return nil, trace.NotFound("no LDAP servers responded successfully for domain %q", c.Domain)
+	return nil, trace.NotFound("no LDAP servers responded successfully for domain %q: %v", c.Domain, lastErr)
 }


### PR DESCRIPTION
When Teleport is configured to use the locate LDAP server feature, it wouldn't output a non-debug error upon failure to connect, which would make it harder to debug the issue. This change exposes the most recent error to the user.

Backport #59117 to branch/v18