### PR TITLE
EC2 Auto Discover: allow multiple teleport agents in the same instance

### DIFF
--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -21,12 +21,14 @@ package server
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -226,6 +228,8 @@ func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 				Matcher:             matcher,
 				Region:              region,
 				Document:            matcher.SSM.DocumentName,
+				InstallSuffix:       matcher.Params.Suffix,
+				UpdateGroup:         matcher.Params.UpdateGroup,
 				EC2Client:           ec2Client,
 				Labels:              matcher.Tags,
 				Integration:         matcher.Integration,
@@ -242,6 +246,8 @@ type ec2FetcherConfig struct {
 	Matcher             types.AWSMatcher
 	Region              string
 	Document            string
+	InstallSuffix       string
+	UpdateGroup         string
 	EC2Client           ec2.DescribeInstancesAPIClient
 	Labels              types.Labels
 	Integration         string
@@ -303,6 +309,8 @@ const (
 	ParamScriptName = "scriptName"
 	// ParamSSHDConfigPath is the path to the OpenSSH config file sent in the SSM Document
 	ParamSSHDConfigPath = "sshdConfigPath"
+	// ParamEnvVars is a parameter that contains environment variables to set before running the installation script.
+	ParamEnvVars = "env"
 )
 
 // awsEC2APIChunkSize is the max number of instances SSM will send commands to at a time
@@ -342,6 +350,22 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 			ParamScriptName:     cfg.Matcher.Params.ScriptName,
 			ParamSSHDConfigPath: cfg.Matcher.Params.SSHDConfig,
 		}
+	}
+
+	var envVars []string
+
+	// InstallSuffix and UpdateGroup should only contain alphanumeric characters and hyphens.
+	// Escape them anyway as another layer of safety.
+	if cfg.InstallSuffix != "" {
+		safeInstallSuffix := shsprintf.EscapeDefaultContext(cfg.InstallSuffix)
+		envVars = append(envVars, "TELEPORT_INSTALL_SUFFIX="+safeInstallSuffix)
+	}
+	if cfg.UpdateGroup != "" {
+		safeUpdateGroup := shsprintf.EscapeDefaultContext(cfg.UpdateGroup)
+		envVars = append(envVars, "TELEPORT_UPDATE_GROUP="+safeUpdateGroup)
+	}
+	if len(envVars) > 0 {
+		parameters["env"] = strings.Join(envVars, " ")
 	}
 
 	fetcher := ec2InstanceFetcher{

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -354,7 +354,7 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 
 	var envVars []string
 
-	// InstallSuffix and UpdateGroup should only contain alphanumeric characters and hyphens.
+	// InstallSuffix and UpdateGroup only contains alphanumeric characters and hyphens.
 	// Escape them anyway as another layer of safety.
 	if cfg.InstallSuffix != "" {
 		safeInstallSuffix := shsprintf.EscapeDefaultContext(cfg.InstallSuffix)

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -67,7 +67,7 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E $TELEPORT_BINARY ` + strings.Join(argsList, " ") + " $@"
+sudo -E "$TELEPORT_BINARY" ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -39,7 +39,7 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"`
 )
 
@@ -64,7 +64,10 @@ var (
 echo "Configuring the Teleport agent"
 
 set +x
-sudo /usr/local/bin/teleport ` + strings.Join(argsList, " ") + " $@"
+TELEPORT_BINARY=/usr/local/bin/teleport
+[ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
+
+sudo -E $TELEPORT_BINARY ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -42,14 +42,17 @@ curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
 chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-sudo "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"
 
 
 echo "Configuring the Teleport agent"
 
 set +x
-sudo /usr/local/bin/teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+TELEPORT_BINARY=/usr/local/bin/teleport
+[ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
+
+sudo -E $TELEPORT_BINARY install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -52,7 +52,7 @@ set +x
 TELEPORT_BINARY=/usr/local/bin/teleport
 [ -z "${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/${TELEPORT_INSTALL_SUFFIX}/bin/teleport
 
-sudo -E $TELEPORT_BINARY install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
+sudo -E "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -220,7 +220,7 @@ func (si *SSMInstaller) Run(ctx context.Context, req SSMRunRequest) error {
 		// Handle this error gracefully and ask the user to update the SSM Document.
 		_, hasEnvParam := params[ParamEnvVars]
 		if hasEnvParam {
-			return trace.BadParameter("%q param is missing in the SSM Document %s (%s), update the document to the latest version: %v", ParamEnvVars, req.DocumentName, req.Region, err)
+			return trace.BadParameter("%q param is missing in the SSM Document %s (%s), refer to https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual/ to update the document to the latest version: %v", ParamEnvVars, req.DocumentName, req.Region, err)
 		}
 
 		// The sshdConfigPath param only exists for non-agent installations of teleport (ie, openssh agents).

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -210,16 +210,25 @@ func (si *SSMInstaller) Run(ctx context.Context, req SSMRunRequest) error {
 		Parameters:   params,
 	})
 	if err != nil {
-		invalidParamErrorMessage := fmt.Sprintf("InvalidParameters: document %s does not support parameters", req.DocumentName)
-		_, hasSSHDConfigParam := params[ParamSSHDConfigPath]
-		if !strings.Contains(err.Error(), invalidParamErrorMessage) || !hasSSHDConfigParam {
+		// This might happen when teleport sends Parameters that are not part of the Document.
+		const invalidParamErrorMessage = "InvalidParameters"
+		if !strings.Contains(err.Error(), invalidParamErrorMessage) {
 			return trace.Wrap(err)
 		}
 
-		// This might happen when teleport sends Parameters that are not part of the Document.
-		// One example is when it uses the default SSM Document awslib.EC2DiscoverySSMDocument
-		// and Parameters include "sshdConfigPath" (only sent when installTeleport=false).
-		//
+		// The env param was added in v18.2.x, so older versions of the Document will reject it.
+		// Handle this error gracefully and ask the user to update the SSM Document.
+		_, hasEnvParam := params[ParamEnvVars]
+		if hasEnvParam {
+			return trace.BadParameter("%q param is missing in the SSM Document %s (%s), update the document to the latest version: %v", ParamEnvVars, req.DocumentName, req.Region, err)
+		}
+
+		// The sshdConfigPath param only exists for non-agent installations of teleport (ie, openssh agents).
+		// If the SSM Document does not support the sshdConfigPath param, but it was sent, the command will fail with an InvalidParameters error.
+		_, hasSSHDConfigParam := params[ParamSSHDConfigPath]
+		if !hasSSHDConfigParam {
+			return trace.Wrap(err)
+		}
 		// As a best effort, we try to call ssm.SendCommand again but this time without the "sshdConfigPath" param
 		// We must not remove the Param "sshdConfigPath" beforehand because customers might be using custom SSM Documents for ec2 auto discovery.
 		delete(params, ParamSSHDConfigPath)


### PR DESCRIPTION
This PR changes the EC2 Auto Discover flow to accept two new fields:
- Suffix: non-default location for the teleport artifacts (configuration, datadir and systemd unit name)
- Update Group: the (managed updates) update group for the deployment

Both configurations require that Managed Updates V2 is enabled for the cluster.

Because it uses non default paths, it allows multiple teleport agents to exist in the same instance.
As an example, this allows two teleport clusters to access the same EC2 instance.

changelog: Added support for multiple agents in EC2 Server auto discovery, allowing instance access from different Teleport clusters.

[RFD 224](https://github.com/gravitational/teleport/pull/58824)