### PR TITLE
chore: make event exporter respect context

### DIFF
--- a/integrations/event-handler/events_job.go
+++ b/integrations/event-handler/events_job.go
@@ -156,6 +156,7 @@ func (j *EventsJob) runPolling(ctx context.Context) error {
 	concurrency := max(j.app.Config.Concurrency/4, 3)
 
 	exporter, err := export.NewExporter(export.ExporterConfig{
+		Context:   ctx,
 		Client:    j.app.client,
 		StartDate: *startTime,
 		Export:    j.handleEventV2,

--- a/lib/events/export/date_exporter_test.go
+++ b/lib/events/export/date_exporter_test.go
@@ -111,6 +111,7 @@ func testDateExporterBasics(t *testing.T, randomFlake bool, batch bool) {
 		}
 	}
 	cfg := DateExporterConfig{
+		Context:      t.Context(),
 		Client:       clt,
 		Date:         now,
 		OnIdle:       onIdleFn,
@@ -281,6 +282,7 @@ func testDateExporterResume(t *testing.T, randomFlake bool) {
 	}
 
 	exporter, err := NewDateExporter(DateExporterConfig{
+		Context:      t.Context(),
 		Client:       clt,
 		Date:         now,
 		Export:       exportFn,
@@ -333,6 +335,7 @@ func testDateExporterResume(t *testing.T, randomFlake bool) {
 
 	// recreate exporter with state from previous run
 	exporter, err = NewDateExporter(DateExporterConfig{
+		Context:       t.Context(),
 		Client:        clt,
 		Date:          now,
 		Export:        exportFn,

--- a/lib/events/export/exporter_test.go
+++ b/lib/events/export/exporter_test.go
@@ -141,6 +141,7 @@ func testExportAll(t *testing.T, tc exportTestCase) {
 	idleCh := make(chan struct{})
 
 	exporter, err := NewExporter(ExporterConfig{
+		Context:      t.Context(),
 		Client:       tc.clt,
 		StartDate:    tc.startDate,
 		Export:       exportFn,

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -286,8 +286,9 @@ func (s *EventsSuite) EventExport(t *testing.T) {
 	var exporter *export.DateExporter
 	var err error
 	exporter, err = export.NewDateExporter(export.DateExporterConfig{
-		Client: s.Log,
-		Date:   baseTime,
+		Context: t.Context(),
+		Client:  s.Log,
+		Date:    baseTime,
 		Export: func(ctx context.Context, event *auditlogpb.ExportEventUnstructured) error {
 			exportedEvents.Add(1)
 			return nil

--- a/tool/tctl/common/loadtest_command.go
+++ b/tool/tctl/common/loadtest_command.go
@@ -414,6 +414,7 @@ func (c *LoadtestCommand) AuditEvents(ctx context.Context, client *authclient.Cl
 	}
 
 	exporter, err := export.NewExporter(export.ExporterConfig{
+		Context:       ctx,
 		Client:        client,
 		StartDate:     date,
 		PreviousState: state,


### PR DESCRIPTION
To be able to use the new synctest package in go1.25, any spawned goroutines must exit before the bubble completes.

Testing with event exporter fails because it wasn't respecting any context.