### PR TITLE
Align msgraph client -  switch to fast unmarshal

### DIFF
--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -21,6 +21,8 @@ import (
 	"slices"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type GroupMember interface {
@@ -162,7 +164,7 @@ func decodeGroupMember(msg json.RawMessage) (GroupMember, error) {
 		Type string `json:"@odata.type"`
 	}
 
-	if err := json.Unmarshal(msg, &temp); err != nil {
+	if err := utils.FastUnmarshal(msg, &temp); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -171,11 +173,11 @@ func decodeGroupMember(msg json.RawMessage) (GroupMember, error) {
 	switch temp.Type {
 	case "#microsoft.graph.user":
 		var u *User
-		err = json.Unmarshal(msg, &u)
+		err = utils.FastUnmarshal(msg, &u)
 		member = u
 	case "#microsoft.graph.group":
 		var g *Group
-		err = json.Unmarshal(msg, &g)
+		err = utils.FastUnmarshal(msg, &g)
 		member = g
 	default:
 		// Return an error if we encounter a type we do not support.


### PR DESCRIPTION
### What

Use json-iterator in the msgraph library. 

The json-iterator/ is more efficient than std json library. 

For more details please see https://github.com/json-iterator/go?tab=readme-ov-file#benchmark

### Why
Needed for entraID sync with very large AD setup like 10M groups members. 