### PR TITLE
deflake `TestMFAAuthenticateChallenge_IsMFARequiredApp` test

### DIFF
--- a/integration/web/web_test.go
+++ b/integration/web/web_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/defaults"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
@@ -174,7 +175,8 @@ func TestMFAAuthenticateChallenge_IsMFARequiredApp(t *testing.T) {
 				FQDNHint:    "root-app.root",
 			},
 			expectMFARequired: false,
-		}, {
+		},
+		{
 			name: "root-app-mfa",
 			resolveAppParams: web.ResolveAppParams{
 				AppName:     "root-app-mfa",
@@ -192,7 +194,8 @@ func TestMFAAuthenticateChallenge_IsMFARequiredApp(t *testing.T) {
 				FQDNHint:    "leaf-app.root",
 			},
 			expectMFARequired: false,
-		}, {
+		},
+		{
 			name: "leaf-app-mfa",
 			resolveAppParams: web.ResolveAppParams{
 				AppName:     "leaf-app-mfa",
@@ -326,4 +329,20 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 		require.NoError(t, err)
 		require.Len(t, rts, 1)
 	}, time.Second*10, time.Second)
+
+	tsrv, err := rootServer.GetReverseTunnelServer()
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		rts, err := tsrv.Cluster(ctx, leafServer.Config.Auth.ClusterName.GetClusterName())
+		require.NoError(t, err)
+		require.NotNil(t, rts)
+
+		require.Equal(t, 1, rts.GetTunnelsCount())
+
+		client, err := rts.CachingAccessPoint()
+		require.NoError(t, err)
+		appS, err := client.GetApplicationServers(ctx, defaults.Namespace)
+		require.Len(t, appS, 2)
+	}, time.Second*10, time.Second)
+
 }

--- a/integration/web/web_test.go
+++ b/integration/web/web_test.go
@@ -322,13 +322,13 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 		rt, err := rootServer.GetAuthServer().GetTunnelConnections(leafServer.Config.Auth.ClusterName.GetClusterName())
 		require.NoError(t, err)
 		require.Len(t, rt, 1)
-	}, time.Second*10, time.Second)
+	}, time.Second*10, 200*time.Millisecond)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		rts, err := rootServer.GetAuthServer().GetRemoteClusters(ctx)
 		require.NoError(t, err)
 		require.Len(t, rts, 1)
-	}, time.Second*10, time.Second)
+	}, time.Second*10, 200*time.Millisecond)
 
 	tsrv, err := rootServer.GetReverseTunnelServer()
 	require.NoError(t, err)
@@ -342,7 +342,8 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 		client, err := rts.CachingAccessPoint()
 		require.NoError(t, err)
 		appS, err := client.GetApplicationServers(ctx, defaults.Namespace)
+		require.NoError(t, err)
 		require.Len(t, appS, 2)
-	}, time.Second*10, time.Second)
+	}, time.Second*10, 200*time.Millisecond)
 
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -717,7 +717,7 @@ func nextProcessID() int32 {
 	return atomic.AddInt32(&processID, 1)
 }
 
-// GetReverseTunnelServer returns the process' reverse tunnel server
+// GetReverseTunnelServer returns the process's reverse tunnel server
 // or an error if it is not configured.
 // Reverse tunnel server is used by proxies to accept incoming
 // reverse tunnels from nodes/clusters.

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib"
@@ -464,10 +463,5 @@ func SetupTrustedCluster(ctx context.Context, t *testing.T, rootServer, leafServ
 		require.NotNil(t, rts)
 
 		require.Equal(t, 1, rts.GetTunnelsCount())
-
-		client, err := rts.CachingAccessPoint()
-		require.NoError(t, err)
-		appS, err := client.GetApplicationServers(ctx, defaults.Namespace)
-		require.Len(t, appS, 2)
 	}, time.Second*10, time.Second)
 }


### PR DESCRIPTION
`TestMFAAuthenticateChallenge_IsMFARequiredApp` relies on root-leaf cluster to test MFA requirements for different applications.

The issue happens when the leaf cluster is able to upsert itself into root auth server but it's not yet fully connected to root proxy and so when the proxy tried to dial back to retrieve the registered app servers, the request failed.

This PR fixes that by waiting for the root cluster proxy to be able to dial to leaf auth server to retrieve the leaf's application servers.

Fixes #59148