### PR TITLE
Bump controller-tools to 0.19 as 0.14 breaks with go 1.25

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -213,8 +213,7 @@ $(LOCALBIN):
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.16.2
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Fixes the broken operator codegen ([example of failure](https://github.com/gravitational/teleport/actions/runs/17767636184/job/50494968345)).

We were using an older controller-runtime version. that relied on x/tools < 0.25 which is affected by https://github.com/golang/go/issues/74462 and is not compatible with go 1.25.

It seems the version change does not affect the generated code.