### PR TITLE
Remove synctest experimental flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -978,7 +978,7 @@ test-go-unit: rdpclient
 test-go-unit: FLAGS ?= -race -shuffle on
 test-go-unit: SUBJECT ?= $(shell go list ./... | grep -vE 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
-	$(CGOFLAG) GOEXPERIMENT=synctest go test -json -tags "enablesynctest $(PAM_TAG) $(RDPCLIENT_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG) $(ADDTAGS)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) go test -json -tags "$(PAM_TAG) $(RDPCLIENT_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG) $(ADDTAGS)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 
@@ -1303,7 +1303,7 @@ fix-imports/host:
 		echo 'gci is not installed or is missing from PATH, consider installing it ("go install github.com/daixiang0/gci@latest") or use "make -C build.assets/ fix-imports"';\
 		exit 1;\
 	fi
-	GOEXPERIMENT=synctest gci write -s standard -s default  -s 'prefix(github.com/gravitational/teleport)' -s 'prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)' --skip-generated .
+	gci write -s standard -s default  -s 'prefix(github.com/gravitational/teleport)' -s 'prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)' --skip-generated .
 
 lint-build-tooling: GO_LINT_FLAGS ?=
 lint-build-tooling:

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -38,18 +38,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-/*
-This file uses the experimental testing/synctest package introduced with Go 1.24:
-
-    https://go.dev/blog/synctest
-
-When editing this file, you should set GOEXPERIMENT=synctest for your editor/LSP
-to ensure that the language server doesn't fail to recognize the package.
-
-This file is also protected by a build tag to ensure that `go test` doesn't fail
-for users who haven't set the environment variable.
-*/
-
 func TestProfileSyncerTestAndSetDefaults(t *testing.T) {
 	cache := &mockCache{}
 	keyStoreManager, err := keystore.NewManager(t.Context(), &servicecfg.KeystoreConfig{}, &keystore.Options{


### PR DESCRIPTION
Removes support for GOEXPIREMENT=synctest now that e has been updated to use the stable API introduced in Go 1.25.