### PR TITLE
[v18] Bump controller-tools to 0.19 as 0.14 breaks with go 1.25

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -213,8 +213,7 @@ $(LOCALBIN):
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.16.2
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Backport #59185 to branch/v18