### PR TITLE
Bump pnpm to 10.16.1 and add minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
   "engines": {
     "node": "^22"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,3 +41,5 @@ patchedDependencies:
   '@types/wicg-file-system-access@2023.10.6': web/patches/@types__wicg-file-system-access@2023.10.6.patch
   # Needed for roundRect support which was merged to jest-canvas-mock but not released.
   jest-canvas-mock@2.5.2: web/patches/jest-canvas-mock@2.5.2.patch
+# Do not install packages released less than 2 days (2880 minutes) ago
+minimumReleaseAge: 2880


### PR DESCRIPTION
Update the `pnpm` package manager to 10.16.1. The latest version introduces a security feature for delayed dependency updates. 

https://pnpm.io/blog/releases/10.16