### PR TITLE
Send non-reviewable AccessLists to back of sort

### DIFF
--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -300,7 +300,7 @@ func AccessListNameIndexKey(al *accesslist.AccessList) string {
 // AccessListAuditDateIndexKey returns the DateOnly formatted next audit date
 // followed by the resource name for disambiguation.
 func AccessListAuditDateIndexKey(al *accesslist.AccessList) string {
-	if al.Spec.Audit.NextAuditDate.IsZero() {
+	if !al.IsReviewable() || al.Spec.Audit.NextAuditDate.IsZero() {
 		// Use last lexical character to ensure that ACLs without an audit date
 		// appear at the end when sorted. Otherwise we would compare against
 		// `0001-01-01 00:00:00` which would sort first, but actually means

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -520,11 +520,12 @@ func TestCreateAccessListNextKey(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name        string
-		indexName   string
-		expected    string
-		expectError bool
-		withNoAudit bool
+		name          string
+		indexName     string
+		expected      string
+		expectError   bool
+		withNoAudit   bool
+		notReviewable bool
 	}{
 		{
 			name:      "name index",
@@ -543,6 +544,12 @@ func TestCreateAccessListNextKey(t *testing.T) {
 			withNoAudit: true,
 		},
 		{
+			name:          "auditNextDate non-reviewable",
+			indexName:     "auditNextDate",
+			expected:      "z/test-access-list",
+			notReviewable: true,
+		},
+		{
 			name:      "title index",
 			indexName: "title",
 			expected:  "F9IN0Q3PE8/test-access-list",
@@ -558,6 +565,9 @@ func TestCreateAccessListNextKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.withNoAudit {
 				al.Spec.Audit.NextAuditDate = time.Time{}
+			}
+			if tt.notReviewable {
+				al.Spec.Type = accesslist.Static
 			}
 			result, err := CreateAccessListNextKey(al, tt.indexName)
 			if tt.expectError {


### PR DESCRIPTION
If an access list is not elible for review, we should sort it to the back of the "auditNextDate" sort index, similar to time.IsZero