### PR TITLE
[v18] Terraform: Do not require teleport_access_list.spec.grants

### DIFF
--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -54,34 +54,18 @@ Optional:
 
 Required:
 
-- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `owners` (Attributes List) owners is a list of owners of the Access List. (see [below for nested schema](#nested-schema-for-specowners))
 
 Optional:
 
 - `audit` (Attributes) audit describes the frequency that this Access List must be audited. (see [below for nested schema](#nested-schema-for-specaudit))
 - `description` (String) description is an optional plaintext description of the Access List.
+- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the Access List. For a membership to an Access List to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
 - `type` (String) type can be an empty string which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
-
-### Nested Schema for `spec.grants`
-
-Optional:
-
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
-
-### Nested Schema for `spec.grants.traits`
-
-Optional:
-
-- `key` (String) key is the name of the trait.
-- `values` (List of String) values is the list of trait values.
-
-
 
 ### Nested Schema for `spec.owners`
 
@@ -113,6 +97,22 @@ Optional:
 
 - `day_of_month` (Number) day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
 - `frequency` (Number) frequency is the frequency of reviews. This represents the period in months between two reviews. Supported values are 0, 1, 3, 6, and 12.
+
+
+
+### Nested Schema for `spec.grants`
+
+Optional:
+
+- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
+- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+
+### Nested Schema for `spec.grants.traits`
+
+Optional:
+
+- `key` (String) key is the name of the trait.
+- `values` (List of String) values is the list of trait values.
 
 
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -99,34 +99,18 @@ Optional:
 
 Required:
 
-- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `owners` (Attributes List) owners is a list of owners of the Access List. (see [below for nested schema](#nested-schema-for-specowners))
 
 Optional:
 
 - `audit` (Attributes) audit describes the frequency that this Access List must be audited. (see [below for nested schema](#nested-schema-for-specaudit))
 - `description` (String) description is an optional plaintext description of the Access List.
+- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the Access List. For a membership to an Access List to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
 - `title` (String) title is a plaintext short description of the Access List.
 - `type` (String) type can be an empty string which denotes a regular Access List, "scim" which represents an Access List created from SCIM group or "static" for Access Lists managed by IaC tools.
-
-### Nested Schema for `spec.grants`
-
-Optional:
-
-- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
-- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
-
-### Nested Schema for `spec.grants.traits`
-
-Optional:
-
-- `key` (String) key is the name of the trait.
-- `values` (List of String) values is the list of trait values.
-
-
 
 ### Nested Schema for `spec.owners`
 
@@ -158,6 +142,22 @@ Optional:
 
 - `day_of_month` (Number) day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.
 - `frequency` (Number) frequency is the frequency of reviews. This represents the period in months between two reviews. Supported values are 0, 1, 3, 6, and 12.
+
+
+
+### Nested Schema for `spec.grants`
+
+Optional:
+
+- `roles` (List of String) roles are the roles that are granted to users who are members of the Access List.
+- `traits` (Attributes List) traits are the traits that are granted to users who are members of the Access List. (see [below for nested schema](#nested-schema-for-specgrantstraits))
+
+### Nested Schema for `spec.grants.traits`
+
+Optional:
+
+- `key` (String) key is the name of the trait.
+- `values` (List of String) values is the list of trait values.
 
 
 

--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -70,7 +70,6 @@ required_fields:
     - "Metadata.name"
     - "AccessList.header.version"
     - "AccessList.spec.owners"
-    - "AccessList.spec.grants"
     - "Member.header.version"
     - "Member.spec.access_list"
     - "Member.spec.membership_kind"

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -188,7 +188,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						},
 					}),
 					Description: "grants describes the access granted by membership to this Access List.",
-					Required:    true,
+					Optional:    true,
 				},
 				"membership_requires": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{


### PR DESCRIPTION
Backport #59121 to branch/v18

changelog: Terraform provider: Allow creating access lists without setting spec.grants.
