### PR TITLE
[v16] Bump pnpm to 10.16.1 and add minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "tslib": "^2.6.3",
     "whatwg-fetch": "^3.6.20"
   },
-  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
   "engines": {
     "node": "^22"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,3 +32,5 @@ peerDependencyRules:
 # affect performance outside of docker.
 # https://github.com/gravitational/teleport/issues/46019
 packageImportMethod: clone-or-copy
+# Do not install packages released less than 2 days (2880 minutes) ago
+minimumReleaseAge: 2880


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/59195