### PR TITLE
Fixing multipart upload of encrypted recordings to S3

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2564,7 +2564,9 @@ func (c *Client) UploadEncryptedRecording(ctx context.Context, sessionID string,
 	}
 
 	var uploadedParts []*recordingencryptionv1pb.Part
-	var partNumber int64
+	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
+	// configured for the auth service
+	var partNumber int64 = 1
 	for part, err := range parts {
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -649,7 +649,9 @@ func (l *AuditLog) UploadEncryptedRecording(ctx context.Context, sessionID strin
 	}
 
 	var streamParts []StreamPart
-	var partNumber int64
+	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
+	// configured for the auth service
+	var partNumber int64 = 1
 	for part, err := range parts {
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
This PR begins multipart uploads of encrypted recordings at part number 1 instead of 0 in order to comply with S3's `UploadPart` API. This is consistent with uploads of non-encrypted recordings which increment the part number to 1 from 0 on slice creation.

changelog: Fixed an issue that prevented uploading encrypted recordings using the S3 session recording backend.