### PR TITLE
[v18] [docs][AWSIC] Adds docs for rotating SCIM token with `tctl`

### DIFF
--- a/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/aws-iam-identity-center.mdx
@@ -60,3 +60,4 @@ user and automatically unassign once the Access Request expires.
 - [Migrating Okta-managed AWS IAM Identity Center integration to Teleport](migrating-identity-center-from-okta-to-teleport.mdx)
 - [Using the AWS CLI tools with Teleport and AWS IAM Identity Center](using-aws-cli.mdx)
 - [Advanced Identity Center Options](advanced-options.mdx)
+- [Rotating the AWS IAM Identity Center SCIM Token](maintenance.mdx)

--- a/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rotating the AWS IAM Identity Center SCIM token
-description: How to update the AWS IAM Identity Center SCIM in Teleport
+description: How to update the AWS IAM Identity Center SCIM token in Teleport
 tags:
  - identity-governance
  - how-to

--- a/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
@@ -16,6 +16,15 @@ Teleport provisions AWS users and groups into AWS IAM Identity Center via
 IAM Identity Center using a bearer token. By their nature bearer tokens need to be 
 rotated occasionally to maintain security.
 
+## Generating the token
+
+You can generate the new SCIM bearer token by following the AWS IAM Identity Center
+[Rotate an access token](https://docs.aws.amazon.com/singlesignon/latest/userguide/rotate-token.html)
+user guide.
+
+Be sure to capture the token value displayed at the end of the AWS token creation
+flow, as AWS will not display it again.
+
 ## Rotating the token
 
 <Admonition>

--- a/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
@@ -1,0 +1,42 @@
+---
+title: Rotating the AWS IAM Identity Center SCIM token
+description: How to update the AWS IAM Identity Center SCIM in Teleport
+tags:
+ - identity-governance
+ - how-to
+ - aws
+---
+
+This guide will show you how to rotate the SCIM bearer token in Teleport using `tctl`. 
+
+## How it works
+
+Teleport provisions AWS users and groups into AWS IAM Identity Center via 
+[SCIM](https://scim.org/). The Teleport SCIM client authenticates itself to AWS 
+IAM Identity Center using a bearer token. By their nature bearer tokens need to be 
+rotated occasionally to maintain security.
+
+## Rotating the token
+
+<Admonition>
+This functionality is only available in `tctl` and cannot yet be done in the Teleport UI.
+</Admonition>
+
+```shell
+$ tctl plugins rotate awsic ${TOKEN}
+```
+
+Once the SCIM token is updated Teleport will check to see if the actual token
+value has changed. If so, Teleport will automatically restart the Identity Center
+integration for it to pick up and use the new token.
+
+## Disabling token validation
+
+By default, `tctl` will validate that the supplied token can be used to successfully
+authenticate with the configured SCIM service. If, for example, the target SCIM
+is unavailable and you want to force the token rotation you can disable the token
+validation with the `--no-validate-token` flag. 
+
+```shell
+$ tctl plugins rotate awsic --no-validate-token ${TOKEN}
+```

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2202,6 +2202,41 @@ $ tctl plugins install okta \
     --no-appgroup-sync
 ```
 
+## tctl plugins rotate awsic
+
+Rotate the bearer token used by Teleport to authenticate with the AWS IAM Identity
+Center SCIM service when provisioning AWS users and groups.
+
+By default, `tctl` will validate that the token can be used to authenticate with
+the SCIM service configured in the integration. Use the `--no-validate-token`
+flag to disable token validation.
+
+```code
+$ tctl plugins rotate awsic [<flags>] <token>
+```
+
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--plugin-name` | `aws-identity-center` | string | The name of the AWS IAM Identity Center integration to target | 
+| `--[no-]validate-token` | `--validate-token` | none | Validates the supplied token against the configured SCIM server |
+
+### Examples
+
+Rotate the SCIM bearer token without displaying the token in your command history
+
+```code
+$ tctl plugins rotate awsic $(cat ./aws-iam-ic-bearer-token)
+```
+
+Rotate the the SCIM bearer token for a custom integration enrollment that does not
+have the default name set by the guided enrollment flow.
+
+```code
+$ tctl plugins rotate awsic --plugin-name "my-custom-ic-integration" ${TOKEN_VALUE}
+```
+
 ## tctl version
 
 Print the version of your `tctl` binary:

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2219,8 +2219,8 @@ $ tctl plugins rotate awsic [<flags>] <token>
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--plugin-name` | `aws-identity-center` | string | The name of the AWS IAM Identity Center integration to target | 
-| `--[no-]validate-token` | `--validate-token` | none | Validates the supplied token against the configured SCIM server |
+| `--plugin-name` | | string | Optionally override the name of the AWS IAM Identity Center integration to target | 
+| `--[no-]validate-token` | `--validate-token` | none | Enables or disables validating the supplied token against the configured SCIM server |
 
 ### Examples
 


### PR DESCRIPTION
Backport #59116 to branch/v18