### PR TITLE
docs: update bitucket uuids example

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -71,8 +71,8 @@ spec:
     # allow specifies the rules by which the Auth Service determines if `tbot`
     # should be allowed to join.
     allow:
-    - workspace_uuid: <Var name="workspace-uuid" />
-      repository_uuid: <Var name="repository-uuid" />
+    - workspace_uuid: '<Var name="workspace-uuid" />'
+      repository_uuid: '<Var name="repository-uuid" />'
 ```
 
 Let's go over the token resource's fields in more detail:


### PR DESCRIPTION
uuids for bitbucket tokens in YAML need to be wrapped with`'`  or attempting to provision results in this error:

```bash
$ tctl create ./bot-token.yaml
ERROR: types.ProvisionTokenV2.Spec: types.ProvisionTokenSpecV2.Bitbucket: types.ProvisionTokenSpecV2Bitbucket.Allow: []*types.ProvisionTokenSpecV2Bitbucket_Rule: types.ProvisionTokenSpecV2Bitbucket_Rule.WorkspaceUUID: ReadString: expects " or n, but found {, error found in #10 byte of ...|ce_uuid":{"8b222c7d-|..., bigger context ...|d-162f-4630-b0de-02cff6b06b48}","workspace_uuid":{"8b222c7d-f12f-4a46-a7b0-62c1d19a3c16":null}}],"au|..
```