### PR TITLE
[v17] Terraform: Do not require teleport_access_list.spec.grants

### DIFF
--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -55,12 +55,12 @@ Optional:
 Required:
 
 - `audit` (Attributes) audit describes the frequency that this Access List must be audited. (see [below for nested schema](#nested-schema-for-specaudit))
-- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `owners` (Attributes List) owners is a list of owners of the Access List. (see [below for nested schema](#nested-schema-for-specowners))
 
 Optional:
 
 - `description` (String) description is an optional plaintext description of the Access List.
+- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the Access List. For a membership to an Access List to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
@@ -97,6 +97,15 @@ Optional:
 
 
 
+### Nested Schema for `spec.owners`
+
+Optional:
+
+- `description` (String) description is the plaintext description of the owner and why they are an owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `name` (String) name is the username of the owner.
+
+
 ### Nested Schema for `spec.grants`
 
 Optional:
@@ -111,15 +120,6 @@ Optional:
 - `key` (String) key is the name of the trait.
 - `values` (List of String) values is the list of trait values.
 
-
-
-### Nested Schema for `spec.owners`
-
-Optional:
-
-- `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
 
 
 ### Nested Schema for `spec.membership_requires`

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -97,12 +97,12 @@ Optional:
 Required:
 
 - `audit` (Attributes) audit describes the frequency that this Access List must be audited. (see [below for nested schema](#nested-schema-for-specaudit))
-- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `owners` (Attributes List) owners is a list of owners of the Access List. (see [below for nested schema](#nested-schema-for-specowners))
 
 Optional:
 
 - `description` (String) description is an optional plaintext description of the Access List.
+- `grants` (Attributes) grants describes the access granted by membership to this Access List. (see [below for nested schema](#nested-schema-for-specgrants))
 - `membership_requires` (Attributes) membership_requires describes the requirements for a user to be a member of the Access List. For a membership to an Access List to be effective, the user must meet the requirements of Membership_requires and must be in the members list. (see [below for nested schema](#nested-schema-for-specmembership_requires))
 - `owner_grants` (Attributes) owner_grants describes the access granted by owners to this Access List. (see [below for nested schema](#nested-schema-for-specowner_grants))
 - `ownership_requires` (Attributes) ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list. (see [below for nested schema](#nested-schema-for-specownership_requires))
@@ -139,6 +139,15 @@ Optional:
 
 
 
+### Nested Schema for `spec.owners`
+
+Optional:
+
+- `description` (String) description is the plaintext description of the owner and why they are an owner.
+- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
+- `name` (String) name is the username of the owner.
+
+
 ### Nested Schema for `spec.grants`
 
 Optional:
@@ -153,15 +162,6 @@ Optional:
 - `key` (String) key is the name of the trait.
 - `values` (List of String) values is the list of trait values.
 
-
-
-### Nested Schema for `spec.owners`
-
-Optional:
-
-- `description` (String) description is the plaintext description of the owner and why they are an owner.
-- `membership_kind` (Number) membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.
-- `name` (String) name is the username of the owner.
 
 
 ### Nested Schema for `spec.membership_requires`

--- a/integrations/terraform/protoc-gen-terraform-accesslist.yaml
+++ b/integrations/terraform/protoc-gen-terraform-accesslist.yaml
@@ -53,7 +53,6 @@ required_fields:
     - "Metadata.name"
     - "AccessList.header.version"
     - "AccessList.spec.owners"
-    - "AccessList.spec.grants"
     - "AccessList.spec.audit"
     - "AccessList.spec.audit.recurrence"
     - "AccessList.spec.audit.recurrence.frequency"

--- a/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
+++ b/integrations/terraform/tfschema/accesslist/v1/accesslist_terraform.go
@@ -188,7 +188,7 @@ func GenSchemaAccessList(ctx context.Context) (github_com_hashicorp_terraform_pl
 						},
 					}),
 					Description: "grants describes the access granted by membership to this Access List.",
-					Required:    true,
+					Optional:    true,
 				},
 				"membership_requires": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{


### PR DESCRIPTION
Backport #59121 to branch/v17

changelog: Terraform provider: Allow creating access lists without setting spec.grants.