### PR TITLE
Reduce `TestAppAccess/TestAppServersHA` test flakiness

### DIFF
--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -1061,6 +1061,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 			require.NoError(t, srv.Close())
 		})
 		waitForAppServer(t, p.leafCluster.Tunnel, p.leafAppClusterName, srv, configs[i].Apps.Apps)
+		waitForAppServer(t, p.rootCluster.Tunnel, p.leafAppClusterName, srv, configs[i].Apps.Apps)
 	}
 
 	return servers

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -44,6 +44,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils/iterutils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
@@ -914,16 +915,16 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})
-		waitForAppServer(t, p.rootCluster.Tunnel, p.rootAppClusterName, configs[i].Apps.Apps)
+		waitForAppServer(t, p.rootCluster.Tunnel, p.rootAppClusterName, srv, configs[i].Apps.Apps)
 	}
 
 	return servers
 }
 
-func waitForAppServer(t *testing.T, tunnel reversetunnelclient.Server, name string, apps []servicecfg.App) {
+func waitForAppServer(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, srv *service.TeleportProcess, apps []servicecfg.App) {
 	// Make sure that the app server is ready to accept connections.
 	// The remote site cache needs to be filled with new registered application services.
-	waitForAppInClusterCache(t, tunnel, name, apps)
+	waitForAppInClusterCache(t, tunnel, clusterName, srv, apps)
 }
 
 func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions) []*service.TeleportProcess {
@@ -1059,14 +1060,31 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 		t.Cleanup(func() {
 			require.NoError(t, srv.Close())
 		})
-		waitForAppServer(t, p.leafCluster.Tunnel, p.leafAppClusterName, configs[i].Apps.Apps)
+		waitForAppServer(t, p.leafCluster.Tunnel, p.leafAppClusterName, srv, configs[i].Apps.Apps)
 	}
 
 	return servers
 }
 
-func waitForAppInClusterCache(t *testing.T, server reversetunnelclient.Server, clusterName string, cfgApps []servicecfg.App) {
+// waitForAppInClusterCache ensures the applications is present on the cache.
+// Given that the applications might be already served by other application
+// agent, we must assert the applications are served by the provided server.
+func waitForAppInClusterCache(t *testing.T, server reversetunnelclient.Server, clusterName string, srv *service.TeleportProcess, cfgApps []servicecfg.App) {
+	t.Helper()
+
 	ctx := t.Context()
+	hostID, err := srv.WaitForHostID(ctx)
+	require.NoError(t, err)
+
+	type appHost struct {
+		appID  string
+		hostID string
+	}
+
+	wantNames := sliceutils.Map(cfgApps, func(app servicecfg.App) appHost {
+		return appHost{appID: app.Name, hostID: hostID}
+	})
+
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		cluster, err := server.Cluster(ctx, clusterName)
 		require.NoError(t, err)
@@ -1077,11 +1095,10 @@ func waitForAppInClusterCache(t *testing.T, server reversetunnelclient.Server, c
 		apps, err := ap.GetApplicationServers(ctx, apidefaults.Namespace)
 		require.NoError(t, err)
 
-		wantNames := sliceutils.Map(cfgApps, func(app servicecfg.App) string {
-			return app.Name
-		})
 		require.Subset(t,
-			slices.Collect(types.ResourceNames(apps)),
+			slices.Collect(iterutils.Map(func(appServer types.AppServer) appHost {
+				return appHost{appID: appServer.GetApp().GetName(), hostID: appServer.GetHostID()}
+			}, slices.Values(apps))),
 			wantNames,
 		)
 	}, time.Minute*2, time.Millisecond*200)


### PR DESCRIPTION
Related to #13568

The `waitForAppServer` function only verified that the served apps were in the cache. This was insufficient for the HA test, since stopped app servers could still report the application (either due to cache expiration or incomplete agent shutdown), leading the `startAppServers` function to return, and causing app requests to be made before the app servers could handle them.

This PR updates the waiting function to take into account the newly started server, ensuring that not only is the application in the cache, but the started server is serving it.