### PR TITLE
Fix invalid Labels prop in Enroll EKS discover flow

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -738,10 +738,19 @@ func installKubeAgent(ctx context.Context, cfg installKubeAgentParams) error {
 	return nil
 }
 
-func kubeAgentLabels(kubeCluster types.KubeCluster, resourceID string, extraLabels map[string]string) map[string]string {
-	labels := make(map[string]string)
-	maps.Copy(labels, extraLabels)
-	maps.Copy(labels, kubeCluster.GetStaticLabels())
+func kubeAgentLabels(kubeCluster types.KubeCluster, resourceID string, extraLabels map[string]string) map[string]any {
+	// Labels property in the `teleport-kube-agent` chart is defined as object.
+	// Object values are of map[string]any type, so we need to use `any`.
+	labels := make(map[string]any)
+
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+
+	for k, v := range kubeCluster.GetStaticLabels() {
+		labels[k] = v
+	}
+
 	labels[types.InternalResourceIDLabel] = resourceID
 
 	return labels

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -647,8 +647,7 @@ func TestKubeAgentLabels(t *testing.T) {
 		resourceID,
 		extraLabels,
 	)
-
-	expectedLabels := map[string]string{
+	expectedLabels := map[string]any{
 		"priority":                      "yes",
 		"region":                        "us-east-1",
 		"custom":                        "yes",


### PR DESCRIPTION
Labels property in the `teleport-kube-agent` chart is defined as object.
https://github.com/gravitational/teleport/blob/1ccc849cd0d9d58eed5ce84ca156330cb5d18c03/examples/chart/teleport-kube-agent/values.schema.json#L338-L342

Object values are of `map[string]any` type, so we need to use `any`.

This change was introduced [helm@3.18.5](https://github.com/helm/helm/releases/tag/v3.18.5), when they changed the jsonschema library, which stopped accepting `map[string]string` go-types for the `object` json-schema types.

<details>
<summary>Demo</summary>
Before
<img width="1138" height="520" alt="image" src="https://github.com/user-attachments/assets/c556dc8f-8a29-4f0b-8ec5-eafbfe5e6fab" />


After
<img width="1116" height="596" alt="image" src="https://github.com/user-attachments/assets/0b08d1e7-9f5d-4bd6-908c-892e3cb40a49" />
<img width="1150" height="518" alt="image" src="https://github.com/user-attachments/assets/8f6619b3-1ea6-4220-a683-e64d29ece50c" />

</details>

changelog: Fix issue preventing auto enrollment of EKS clusters when using the Web UI.