### PR TITLE
Add client tools managed updates strategies

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -454,6 +454,9 @@ type AutoUpdateSettings struct {
 	ToolsVersion string `json:"tools_version"`
 	// ToolsAutoUpdate indicates if the requesting tools client should be updated.
 	ToolsAutoUpdate bool `json:"tools_auto_update"`
+	// ToolsAutoUpdateStrategies defines the list of strategies that mus be followed
+	// by client tools (such as restriction to downgrade).
+	ToolsAutoUpdateStrategies []string `json:"tools_auto_update_strategies"`
 	// AgentVersion defines the version of teleport that agents enrolled into autoupdates should run.
 	AgentVersion string `json:"agent_version"`
 	// AgentAutoUpdate indicates if the requesting agent should attempt to update now.

--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -38,6 +38,66 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// AutoUpdateToolsStrategy defines additional strategy that must be applied
+// for client tools to decide if update must be initiated.
+type AutoUpdateToolsStrategy int32
+
+const (
+	// AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED is unspecified strategy.
+	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED AutoUpdateToolsStrategy = 0
+	// AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE is strategy that restricts client tools to downgrade.
+	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE AutoUpdateToolsStrategy = 1
+	// AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE is strategy that restricts client tools
+	// to upgrade/downgrade minor version.
+	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE AutoUpdateToolsStrategy = 2
+	// AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE is strategy that restricts client tools
+	// to upgrade/downgrade patch version
+	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE AutoUpdateToolsStrategy = 3
+)
+
+// Enum value maps for AutoUpdateToolsStrategy.
+var (
+	AutoUpdateToolsStrategy_name = map[int32]string{
+		0: "AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED",
+		1: "AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE",
+		2: "AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE",
+		3: "AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE",
+	}
+	AutoUpdateToolsStrategy_value = map[string]int32{
+		"AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED":         0,
+		"AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE":        1,
+		"AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE": 2,
+		"AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE": 3,
+	}
+)
+
+func (x AutoUpdateToolsStrategy) Enum() *AutoUpdateToolsStrategy {
+	p := new(AutoUpdateToolsStrategy)
+	*p = x
+	return p
+}
+
+func (x AutoUpdateToolsStrategy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AutoUpdateToolsStrategy) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[0].Descriptor()
+}
+
+func (AutoUpdateToolsStrategy) Type() protoreflect.EnumType {
+	return &file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[0]
+}
+
+func (x AutoUpdateToolsStrategy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AutoUpdateToolsStrategy.Descriptor instead.
+func (AutoUpdateToolsStrategy) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP(), []int{0}
+}
+
 // AutoUpdateAgentGroupState represents the agent group state. This state controls whether the agents from this group
 // should install the start version, the target version, and if they should update immediately or wait.
 type AutoUpdateAgentGroupState int32
@@ -91,11 +151,11 @@ func (x AutoUpdateAgentGroupState) String() string {
 }
 
 func (AutoUpdateAgentGroupState) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[0].Descriptor()
+	return file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[1].Descriptor()
 }
 
 func (AutoUpdateAgentGroupState) Type() protoreflect.EnumType {
-	return &file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[0]
+	return &file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[1]
 }
 
 func (x AutoUpdateAgentGroupState) Number() protoreflect.EnumNumber {
@@ -104,7 +164,7 @@ func (x AutoUpdateAgentGroupState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutoUpdateAgentGroupState.Descriptor instead.
 func (AutoUpdateAgentGroupState) EnumDescriptor() ([]byte, []int) {
-	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP(), []int{0}
+	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP(), []int{1}
 }
 
 // AutoUpdateAgentRolloutState represents the rollout state. This tells if Teleport started updating agents from the
@@ -156,11 +216,11 @@ func (x AutoUpdateAgentRolloutState) String() string {
 }
 
 func (AutoUpdateAgentRolloutState) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[1].Descriptor()
+	return file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[2].Descriptor()
 }
 
 func (AutoUpdateAgentRolloutState) Type() protoreflect.EnumType {
-	return &file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[1]
+	return &file_teleport_autoupdate_v1_autoupdate_proto_enumTypes[2]
 }
 
 func (x AutoUpdateAgentRolloutState) Number() protoreflect.EnumNumber {
@@ -169,7 +229,7 @@ func (x AutoUpdateAgentRolloutState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutoUpdateAgentRolloutState.Descriptor instead.
 func (AutoUpdateAgentRolloutState) EnumDescriptor() ([]byte, []int) {
-	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP(), []int{1}
+	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP(), []int{2}
 }
 
 // AutoUpdateConfig is a config singleton used to configure cluster
@@ -307,7 +367,10 @@ func (x *AutoUpdateConfigSpec) GetAgents() *AutoUpdateConfigSpecAgents {
 type AutoUpdateConfigSpecTools struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Mode defines state of the client tools auto update.
-	Mode          string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	Mode string `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	// Custom strategies for modifying behavior when updates are applied.
+	// For example: protecting against client tool downgrades or ignoring patch updates.
+	Strategies    []AutoUpdateToolsStrategy `protobuf:"varint,2,rep,packed,name=strategies,proto3,enum=teleport.autoupdate.v1.AutoUpdateToolsStrategy" json:"strategies,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -347,6 +410,13 @@ func (x *AutoUpdateConfigSpecTools) GetMode() string {
 		return x.Mode
 	}
 	return ""
+}
+
+func (x *AutoUpdateConfigSpecTools) GetStrategies() []AutoUpdateToolsStrategy {
+	if x != nil {
+		return x.Strategies
+	}
+	return nil
 }
 
 // AutoUpdateConfigSpecAgents encodes the parameters of automatic agent updates.
@@ -1629,9 +1699,12 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"\x04spec\x18\x05 \x01(\v2,.teleport.autoupdate.v1.AutoUpdateConfigSpecR\x04spec\"\xc3\x01\n" +
 	"\x14AutoUpdateConfigSpec\x12G\n" +
 	"\x05tools\x18\x02 \x01(\v21.teleport.autoupdate.v1.AutoUpdateConfigSpecToolsR\x05tools\x12J\n" +
-	"\x06agents\x18\x03 \x01(\v22.teleport.autoupdate.v1.AutoUpdateConfigSpecAgentsR\x06agentsJ\x04\b\x01\x10\x02R\x10tools_autoupdate\"/\n" +
+	"\x06agents\x18\x03 \x01(\v22.teleport.autoupdate.v1.AutoUpdateConfigSpecAgentsR\x06agentsJ\x04\b\x01\x10\x02R\x10tools_autoupdate\"\x80\x01\n" +
 	"\x19AutoUpdateConfigSpecTools\x12\x12\n" +
-	"\x04mode\x18\x01 \x01(\tR\x04mode\"\x8e\x02\n" +
+	"\x04mode\x18\x01 \x01(\tR\x04mode\x12O\n" +
+	"\n" +
+	"strategies\x18\x02 \x03(\x0e2/.teleport.autoupdate.v1.AutoUpdateToolsStrategyR\n" +
+	"strategies\"\x8e\x02\n" +
 	"\x1aAutoUpdateConfigSpecAgents\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x1a\n" +
 	"\bstrategy\x18\x02 \x01(\tR\bstrategy\x12Y\n" +
@@ -1728,7 +1801,12 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"updater_id\x18\x01 \x01(\tR\tupdaterId\x12\x17\n" +
 	"\ahost_id\x18\x02 \x01(\tR\x06hostId\x12\x1a\n" +
 	"\bhostname\x18\x03 \x01(\tR\bhostname\x12\x18\n" +
-	"\asuccess\x18\x04 \x01(\bR\asuccess*\xa1\x02\n" +
+	"\asuccess\x18\x04 \x01(\bR\asuccess*\xda\x01\n" +
+	"\x17AutoUpdateToolsStrategy\x12*\n" +
+	"&AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED\x10\x00\x12+\n" +
+	"'AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE\x10\x01\x122\n" +
+	".AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE\x10\x02\x122\n" +
+	".AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE\x10\x03*\xa1\x02\n" +
 	"\x19AutoUpdateAgentGroupState\x12-\n" +
 	")AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED\x10\x00\x12+\n" +
 	"'AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED\x10\x01\x12(\n" +
@@ -1755,74 +1833,76 @@ func file_teleport_autoupdate_v1_autoupdate_proto_rawDescGZIP() []byte {
 	return file_teleport_autoupdate_v1_autoupdate_proto_rawDescData
 }
 
-var file_teleport_autoupdate_v1_autoupdate_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_teleport_autoupdate_v1_autoupdate_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_teleport_autoupdate_v1_autoupdate_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_teleport_autoupdate_v1_autoupdate_proto_goTypes = []any{
-	(AutoUpdateAgentGroupState)(0),                // 0: teleport.autoupdate.v1.AutoUpdateAgentGroupState
-	(AutoUpdateAgentRolloutState)(0),              // 1: teleport.autoupdate.v1.AutoUpdateAgentRolloutState
-	(*AutoUpdateConfig)(nil),                      // 2: teleport.autoupdate.v1.AutoUpdateConfig
-	(*AutoUpdateConfigSpec)(nil),                  // 3: teleport.autoupdate.v1.AutoUpdateConfigSpec
-	(*AutoUpdateConfigSpecTools)(nil),             // 4: teleport.autoupdate.v1.AutoUpdateConfigSpecTools
-	(*AutoUpdateConfigSpecAgents)(nil),            // 5: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents
-	(*AgentAutoUpdateSchedules)(nil),              // 6: teleport.autoupdate.v1.AgentAutoUpdateSchedules
-	(*AgentAutoUpdateGroup)(nil),                  // 7: teleport.autoupdate.v1.AgentAutoUpdateGroup
-	(*AutoUpdateVersion)(nil),                     // 8: teleport.autoupdate.v1.AutoUpdateVersion
-	(*AutoUpdateVersionSpec)(nil),                 // 9: teleport.autoupdate.v1.AutoUpdateVersionSpec
-	(*AutoUpdateVersionSpecTools)(nil),            // 10: teleport.autoupdate.v1.AutoUpdateVersionSpecTools
-	(*AutoUpdateVersionSpecAgents)(nil),           // 11: teleport.autoupdate.v1.AutoUpdateVersionSpecAgents
-	(*AutoUpdateAgentRollout)(nil),                // 12: teleport.autoupdate.v1.AutoUpdateAgentRollout
-	(*AutoUpdateAgentRolloutSpec)(nil),            // 13: teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec
-	(*AutoUpdateAgentRolloutStatus)(nil),          // 14: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus
-	(*AutoUpdateAgentRolloutStatusGroup)(nil),     // 15: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup
-	(*AutoUpdateAgentReport)(nil),                 // 16: teleport.autoupdate.v1.AutoUpdateAgentReport
-	(*AutoUpdateAgentReportSpec)(nil),             // 17: teleport.autoupdate.v1.AutoUpdateAgentReportSpec
-	(*AutoUpdateAgentReportSpecGroup)(nil),        // 18: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup
-	(*AutoUpdateAgentReportSpecGroupVersion)(nil), // 19: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroupVersion
-	(*AutoUpdateAgentReportSpecOmitted)(nil),      // 20: teleport.autoupdate.v1.AutoUpdateAgentReportSpecOmitted
-	(*Canary)(nil),                                // 21: teleport.autoupdate.v1.Canary
-	nil,                                           // 22: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry
-	nil,                                           // 23: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry
-	(*v1.Metadata)(nil),                           // 24: teleport.header.v1.Metadata
-	(*durationpb.Duration)(nil),                   // 25: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                 // 26: google.protobuf.Timestamp
+	(AutoUpdateToolsStrategy)(0),                  // 0: teleport.autoupdate.v1.AutoUpdateToolsStrategy
+	(AutoUpdateAgentGroupState)(0),                // 1: teleport.autoupdate.v1.AutoUpdateAgentGroupState
+	(AutoUpdateAgentRolloutState)(0),              // 2: teleport.autoupdate.v1.AutoUpdateAgentRolloutState
+	(*AutoUpdateConfig)(nil),                      // 3: teleport.autoupdate.v1.AutoUpdateConfig
+	(*AutoUpdateConfigSpec)(nil),                  // 4: teleport.autoupdate.v1.AutoUpdateConfigSpec
+	(*AutoUpdateConfigSpecTools)(nil),             // 5: teleport.autoupdate.v1.AutoUpdateConfigSpecTools
+	(*AutoUpdateConfigSpecAgents)(nil),            // 6: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents
+	(*AgentAutoUpdateSchedules)(nil),              // 7: teleport.autoupdate.v1.AgentAutoUpdateSchedules
+	(*AgentAutoUpdateGroup)(nil),                  // 8: teleport.autoupdate.v1.AgentAutoUpdateGroup
+	(*AutoUpdateVersion)(nil),                     // 9: teleport.autoupdate.v1.AutoUpdateVersion
+	(*AutoUpdateVersionSpec)(nil),                 // 10: teleport.autoupdate.v1.AutoUpdateVersionSpec
+	(*AutoUpdateVersionSpecTools)(nil),            // 11: teleport.autoupdate.v1.AutoUpdateVersionSpecTools
+	(*AutoUpdateVersionSpecAgents)(nil),           // 12: teleport.autoupdate.v1.AutoUpdateVersionSpecAgents
+	(*AutoUpdateAgentRollout)(nil),                // 13: teleport.autoupdate.v1.AutoUpdateAgentRollout
+	(*AutoUpdateAgentRolloutSpec)(nil),            // 14: teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec
+	(*AutoUpdateAgentRolloutStatus)(nil),          // 15: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus
+	(*AutoUpdateAgentRolloutStatusGroup)(nil),     // 16: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup
+	(*AutoUpdateAgentReport)(nil),                 // 17: teleport.autoupdate.v1.AutoUpdateAgentReport
+	(*AutoUpdateAgentReportSpec)(nil),             // 18: teleport.autoupdate.v1.AutoUpdateAgentReportSpec
+	(*AutoUpdateAgentReportSpecGroup)(nil),        // 19: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup
+	(*AutoUpdateAgentReportSpecGroupVersion)(nil), // 20: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroupVersion
+	(*AutoUpdateAgentReportSpecOmitted)(nil),      // 21: teleport.autoupdate.v1.AutoUpdateAgentReportSpecOmitted
+	(*Canary)(nil),                                // 22: teleport.autoupdate.v1.Canary
+	nil,                                           // 23: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry
+	nil,                                           // 24: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry
+	(*v1.Metadata)(nil),                           // 25: teleport.header.v1.Metadata
+	(*durationpb.Duration)(nil),                   // 26: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                 // 27: google.protobuf.Timestamp
 }
 var file_teleport_autoupdate_v1_autoupdate_proto_depIdxs = []int32{
-	24, // 0: teleport.autoupdate.v1.AutoUpdateConfig.metadata:type_name -> teleport.header.v1.Metadata
-	3,  // 1: teleport.autoupdate.v1.AutoUpdateConfig.spec:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpec
-	4,  // 2: teleport.autoupdate.v1.AutoUpdateConfigSpec.tools:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpecTools
-	5,  // 3: teleport.autoupdate.v1.AutoUpdateConfigSpec.agents:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpecAgents
-	25, // 4: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents.maintenance_window_duration:type_name -> google.protobuf.Duration
-	6,  // 5: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents.schedules:type_name -> teleport.autoupdate.v1.AgentAutoUpdateSchedules
-	7,  // 6: teleport.autoupdate.v1.AgentAutoUpdateSchedules.regular:type_name -> teleport.autoupdate.v1.AgentAutoUpdateGroup
-	24, // 7: teleport.autoupdate.v1.AutoUpdateVersion.metadata:type_name -> teleport.header.v1.Metadata
-	9,  // 8: teleport.autoupdate.v1.AutoUpdateVersion.spec:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpec
-	10, // 9: teleport.autoupdate.v1.AutoUpdateVersionSpec.tools:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpecTools
-	11, // 10: teleport.autoupdate.v1.AutoUpdateVersionSpec.agents:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpecAgents
-	24, // 11: teleport.autoupdate.v1.AutoUpdateAgentRollout.metadata:type_name -> teleport.header.v1.Metadata
-	13, // 12: teleport.autoupdate.v1.AutoUpdateAgentRollout.spec:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec
-	14, // 13: teleport.autoupdate.v1.AutoUpdateAgentRollout.status:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus
-	25, // 14: teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec.maintenance_window_duration:type_name -> google.protobuf.Duration
-	15, // 15: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.groups:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup
-	1,  // 16: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.state:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutState
-	26, // 17: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.start_time:type_name -> google.protobuf.Timestamp
-	26, // 18: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.time_override:type_name -> google.protobuf.Timestamp
-	26, // 19: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.start_time:type_name -> google.protobuf.Timestamp
-	0,  // 20: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.state:type_name -> teleport.autoupdate.v1.AutoUpdateAgentGroupState
-	26, // 21: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.last_update_time:type_name -> google.protobuf.Timestamp
-	21, // 22: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.canaries:type_name -> teleport.autoupdate.v1.Canary
-	24, // 23: teleport.autoupdate.v1.AutoUpdateAgentReport.metadata:type_name -> teleport.header.v1.Metadata
-	17, // 24: teleport.autoupdate.v1.AutoUpdateAgentReport.spec:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpec
-	26, // 25: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.timestamp:type_name -> google.protobuf.Timestamp
-	22, // 26: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.groups:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry
-	20, // 27: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.omitted:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecOmitted
-	23, // 28: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.versions:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry
-	18, // 29: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry.value:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup
-	19, // 30: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry.value:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroupVersion
-	31, // [31:31] is the sub-list for method output_type
-	31, // [31:31] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	25, // 0: teleport.autoupdate.v1.AutoUpdateConfig.metadata:type_name -> teleport.header.v1.Metadata
+	4,  // 1: teleport.autoupdate.v1.AutoUpdateConfig.spec:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpec
+	5,  // 2: teleport.autoupdate.v1.AutoUpdateConfigSpec.tools:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpecTools
+	6,  // 3: teleport.autoupdate.v1.AutoUpdateConfigSpec.agents:type_name -> teleport.autoupdate.v1.AutoUpdateConfigSpecAgents
+	0,  // 4: teleport.autoupdate.v1.AutoUpdateConfigSpecTools.strategies:type_name -> teleport.autoupdate.v1.AutoUpdateToolsStrategy
+	26, // 5: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents.maintenance_window_duration:type_name -> google.protobuf.Duration
+	7,  // 6: teleport.autoupdate.v1.AutoUpdateConfigSpecAgents.schedules:type_name -> teleport.autoupdate.v1.AgentAutoUpdateSchedules
+	8,  // 7: teleport.autoupdate.v1.AgentAutoUpdateSchedules.regular:type_name -> teleport.autoupdate.v1.AgentAutoUpdateGroup
+	25, // 8: teleport.autoupdate.v1.AutoUpdateVersion.metadata:type_name -> teleport.header.v1.Metadata
+	10, // 9: teleport.autoupdate.v1.AutoUpdateVersion.spec:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpec
+	11, // 10: teleport.autoupdate.v1.AutoUpdateVersionSpec.tools:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpecTools
+	12, // 11: teleport.autoupdate.v1.AutoUpdateVersionSpec.agents:type_name -> teleport.autoupdate.v1.AutoUpdateVersionSpecAgents
+	25, // 12: teleport.autoupdate.v1.AutoUpdateAgentRollout.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 13: teleport.autoupdate.v1.AutoUpdateAgentRollout.spec:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec
+	15, // 14: teleport.autoupdate.v1.AutoUpdateAgentRollout.status:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus
+	26, // 15: teleport.autoupdate.v1.AutoUpdateAgentRolloutSpec.maintenance_window_duration:type_name -> google.protobuf.Duration
+	16, // 16: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.groups:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup
+	2,  // 17: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.state:type_name -> teleport.autoupdate.v1.AutoUpdateAgentRolloutState
+	27, // 18: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.start_time:type_name -> google.protobuf.Timestamp
+	27, // 19: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatus.time_override:type_name -> google.protobuf.Timestamp
+	27, // 20: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.start_time:type_name -> google.protobuf.Timestamp
+	1,  // 21: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.state:type_name -> teleport.autoupdate.v1.AutoUpdateAgentGroupState
+	27, // 22: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.last_update_time:type_name -> google.protobuf.Timestamp
+	22, // 23: teleport.autoupdate.v1.AutoUpdateAgentRolloutStatusGroup.canaries:type_name -> teleport.autoupdate.v1.Canary
+	25, // 24: teleport.autoupdate.v1.AutoUpdateAgentReport.metadata:type_name -> teleport.header.v1.Metadata
+	18, // 25: teleport.autoupdate.v1.AutoUpdateAgentReport.spec:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpec
+	27, // 26: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.timestamp:type_name -> google.protobuf.Timestamp
+	23, // 27: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.groups:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry
+	21, // 28: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.omitted:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecOmitted
+	24, // 29: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.versions:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry
+	19, // 30: teleport.autoupdate.v1.AutoUpdateAgentReportSpec.GroupsEntry.value:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup
+	20, // 31: teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroup.VersionsEntry.value:type_name -> teleport.autoupdate.v1.AutoUpdateAgentReportSpecGroupVersion
+	32, // [32:32] is the sub-list for method output_type
+	32, // [32:32] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_teleport_autoupdate_v1_autoupdate_proto_init() }
@@ -1835,7 +1915,7 @@ func file_teleport_autoupdate_v1_autoupdate_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_autoupdate_v1_autoupdate_proto_rawDesc), len(file_teleport_autoupdate_v1_autoupdate_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -47,12 +47,9 @@ const (
 	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED AutoUpdateToolsStrategy = 0
 	// AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE is strategy that restricts client tools to downgrade.
 	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE AutoUpdateToolsStrategy = 1
-	// AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE is strategy that restricts client tools
-	// to upgrade/downgrade minor version.
-	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE AutoUpdateToolsStrategy = 2
-	// AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE is strategy that restricts client tools
-	// to upgrade/downgrade patch version
-	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE AutoUpdateToolsStrategy = 3
+	// AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE is strategy that restricts client tools
+	// to downgrade major version.
+	AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE AutoUpdateToolsStrategy = 2
 )
 
 // Enum value maps for AutoUpdateToolsStrategy.
@@ -60,14 +57,12 @@ var (
 	AutoUpdateToolsStrategy_name = map[int32]string{
 		0: "AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED",
 		1: "AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE",
-		2: "AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE",
-		3: "AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE",
+		2: "AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE",
 	}
 	AutoUpdateToolsStrategy_value = map[string]int32{
-		"AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED":         0,
-		"AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE":        1,
-		"AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE": 2,
-		"AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE": 3,
+		"AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED":            0,
+		"AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE":           1,
+		"AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE": 2,
 	}
 )
 
@@ -1801,12 +1796,11 @@ const file_teleport_autoupdate_v1_autoupdate_proto_rawDesc = "" +
 	"updater_id\x18\x01 \x01(\tR\tupdaterId\x12\x17\n" +
 	"\ahost_id\x18\x02 \x01(\tR\x06hostId\x12\x1a\n" +
 	"\bhostname\x18\x03 \x01(\tR\bhostname\x12\x18\n" +
-	"\asuccess\x18\x04 \x01(\bR\asuccess*\xda\x01\n" +
+	"\asuccess\x18\x04 \x01(\bR\asuccess*\xa9\x01\n" +
 	"\x17AutoUpdateToolsStrategy\x12*\n" +
 	"&AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED\x10\x00\x12+\n" +
-	"'AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE\x10\x01\x122\n" +
-	".AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE\x10\x02\x122\n" +
-	".AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE\x10\x03*\xa1\x02\n" +
+	"'AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE\x10\x01\x125\n" +
+	"1AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE\x10\x02*\xa1\x02\n" +
 	"\x19AutoUpdateAgentGroupState\x12-\n" +
 	")AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED\x10\x00\x12+\n" +
 	"'AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED\x10\x01\x12(\n" +

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -41,10 +41,28 @@ message AutoUpdateConfigSpec {
   AutoUpdateConfigSpecAgents agents = 3;
 }
 
+// AutoUpdateToolsStrategy defines additional strategy that must be applied
+// for client tools to decide if update must be initiated.
+enum AutoUpdateToolsStrategy {
+  // AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED is unspecified strategy.
+  AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED = 0;
+  // AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE is strategy that restricts client tools to downgrade.
+  AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE = 1;
+  // AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE is strategy that restricts client tools
+  // to upgrade/downgrade minor version.
+  AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE = 2;
+  // AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE is strategy that restricts client tools
+  // to upgrade/downgrade patch version
+  AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE = 3;
+}
+
 // AutoUpdateConfigSpecTools encodes the parameters for client tools auto updates.
 message AutoUpdateConfigSpecTools {
   // Mode defines state of the client tools auto update.
   string mode = 1;
+  // Custom strategies for modifying behavior when updates are applied.
+  // For example: protecting against client tool downgrades or ignoring patch updates.
+  repeated AutoUpdateToolsStrategy strategies = 2;
 }
 
 // AutoUpdateConfigSpecAgents encodes the parameters of automatic agent updates.

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -48,12 +48,9 @@ enum AutoUpdateToolsStrategy {
   AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED = 0;
   // AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE is strategy that restricts client tools to downgrade.
   AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE = 1;
-  // AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE is strategy that restricts client tools
-  // to upgrade/downgrade minor version.
-  AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE = 2;
-  // AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE is strategy that restricts client tools
-  // to upgrade/downgrade patch version
-  AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE = 3;
+  // AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE is strategy that restricts client tools
+  // to downgrade major version.
+  AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE = 2;
 }
 
 // AutoUpdateConfigSpecTools encodes the parameters for client tools auto updates.

--- a/api/types/autoupdate/config.go
+++ b/api/types/autoupdate/config.go
@@ -92,10 +92,8 @@ func TransformStrategyToPb(strategy string) autoupdate.AutoUpdateToolsStrategy {
 	switch strategy {
 	case ToolStrategyNoDowngrade:
 		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE
-	case ToolStrategyIgnoreMinorUpdate:
-		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE
-	case ToolStrategyIgnorePatchUpdate:
-		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE
+	case ToolStrategyIgnoreMajorDowngrade:
+		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE
 	default:
 		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED
 	}
@@ -106,10 +104,8 @@ func TransformPbToStrategy(strategy autoupdate.AutoUpdateToolsStrategy) string {
 	switch strategy {
 	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE:
 		return ToolStrategyNoDowngrade
-	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE:
-		return ToolStrategyIgnoreMinorUpdate
-	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE:
-		return ToolStrategyIgnorePatchUpdate
+	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MAJOR_DOWNGRADE:
+		return ToolStrategyIgnoreMajorDowngrade
 	default:
 		return ""
 	}

--- a/api/types/autoupdate/config.go
+++ b/api/types/autoupdate/config.go
@@ -87,6 +87,34 @@ func ValidateAutoUpdateConfig(c *autoupdate.AutoUpdateConfig) error {
 	return nil
 }
 
+// TransformStrategyToPb transform human-readable strategy name to protobuf enum value.
+func TransformStrategyToPb(strategy string) autoupdate.AutoUpdateToolsStrategy {
+	switch strategy {
+	case ToolStrategyNoDowngrade:
+		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE
+	case ToolStrategyIgnoreMinorUpdate:
+		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE
+	case ToolStrategyIgnorePatchUpdate:
+		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE
+	default:
+		return autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_UNSPECIFIED
+	}
+}
+
+// TransformPbToStrategy transform protobuf enum value to human-readable strategy name.
+func TransformPbToStrategy(strategy autoupdate.AutoUpdateToolsStrategy) string {
+	switch strategy {
+	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE:
+		return ToolStrategyNoDowngrade
+	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE:
+		return ToolStrategyIgnoreMinorUpdate
+	case autoupdate.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_PATCH_UPDATE:
+		return ToolStrategyIgnorePatchUpdate
+	default:
+		return ""
+	}
+}
+
 func checkAgentSchedules(c *autoupdate.AutoUpdateConfig) error {
 	// Validate groups
 	groups := c.Spec.Agents.GetSchedules().GetRegular()

--- a/api/types/autoupdate/constants.go
+++ b/api/types/autoupdate/constants.go
@@ -24,12 +24,9 @@ const (
 
 	// ToolStrategyNoDowngrade is strategy that denies downgrading client tools.
 	ToolStrategyNoDowngrade = "no-downgrade"
-	// ToolStrategyIgnoreMinorUpdate is strategy that denies to upgrade/downgrade
-	// if minor version is changed.
-	ToolStrategyIgnoreMinorUpdate = "ignore-minor-update"
-	// ToolStrategyIgnorePatchUpdate is strategy that denies to upgrade/downgrade
-	// if patch version is changed.
-	ToolStrategyIgnorePatchUpdate = "ignore-patch-update"
+	// ToolStrategyIgnoreMajorDowngrade is strategy that denies to downgrade
+	// if major version is changed.
+	ToolStrategyIgnoreMajorDowngrade = "ignore-major-downgrade"
 
 	// AgentsUpdateModeEnabled enabled agent automatic updates.
 	AgentsUpdateModeEnabled = "enabled"

--- a/api/types/autoupdate/constants.go
+++ b/api/types/autoupdate/constants.go
@@ -22,6 +22,15 @@ const (
 	// ToolsUpdateModeDisabled disables client tools automatic updates.
 	ToolsUpdateModeDisabled = "disabled"
 
+	// ToolStrategyNoDowngrade is strategy that denies downgrading client tools.
+	ToolStrategyNoDowngrade = "no-downgrade"
+	// ToolStrategyIgnoreMinorUpdate is strategy that denies to upgrade/downgrade
+	// if minor version is changed.
+	ToolStrategyIgnoreMinorUpdate = "ignore-minor-update"
+	// ToolStrategyIgnorePatchUpdate is strategy that denies to upgrade/downgrade
+	// if patch version is changed.
+	ToolStrategyIgnorePatchUpdate = "ignore-patch-update"
+
 	// AgentsUpdateModeEnabled enabled agent automatic updates.
 	AgentsUpdateModeEnabled = "enabled"
 	// AgentsUpdateModeDisabled disables agent automatic updates.

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
@@ -66,4 +66,5 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |mode|string|Mode defines state of the client tools auto update.|
+|strategies|[]|Custom strategies for modifying behavior when updates are applied. For example: protecting against client tool downgrades or ignoring patch updates.|
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
@@ -71,6 +71,7 @@ Optional:
 Optional:
 
 - `mode` (String) Mode defines state of the client tools auto update.
+- `strategies` (List of Number) Custom strategies for modifying behavior when updates are applied. For example: protecting against client tool downgrades or ignoring patch updates.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
@@ -109,6 +109,7 @@ Optional:
 Optional:
 
 - `mode` (String) Mode defines state of the client tools auto update.
+- `strategies` (List of Number) Custom strategies for modifying behavior when updates are applied. For example: protecting against client tool downgrades or ignoring patch updates.
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateconfigsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateconfigsv1.yaml
@@ -104,6 +104,14 @@ spec:
                   mode:
                     description: Mode defines state of the client tools auto update.
                     type: string
+                  strategies:
+                    description: 'Custom strategies for modifying behavior when updates
+                      are applied. For example: protecting against client tool downgrades
+                      or ignoring patch updates.'
+                    items:
+                      x-kubernetes-int-or-string: true
+                    nullable: true
+                    type: array
                 type: object
             type: object
           status:

--- a/integration/autoupdate/tools/updater_tsh_test.go
+++ b/integration/autoupdate/tools/updater_tsh_test.go
@@ -151,6 +151,56 @@ func TestSequentialUpdate(t *testing.T) {
 	}
 }
 
+// TestUpdateStrategy runs test cluster with defined strategy. We set the "no-downgrade" strategy
+// and set to the cluster latest version then older version to check that update is ignored.
+func TestUpdateStrategy(t *testing.T) {
+	ctx := context.Background()
+
+	rootServer, _, installDir := bootstrapTestServer(t)
+
+	// Assign alias to the login command for test cluster.
+	proxyAddr, err := rootServer.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Fetch compiled test binary and install to tools dir [v1.0.0].
+	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
+	require.NoError(t, updater.Update(ctx, testVersions[0]))
+	tshPath, err := updater.ToolPath("tsh", testVersions[0])
+	require.NoError(t, err)
+
+	strategy := autoupdatev1pb.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE
+
+	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeEnabled, testVersions[3], strategy)
+
+	cmd := exec.CommandContext(ctx, tshPath,
+		"login", "--proxy", proxyAddr.String(), "--insecure", "--user", "alice", "--auth", constants.LocalConnector)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	// Run version command to verify that login command executed auto update and
+	// tsh was upgraded to [testVersion].
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	matchVersion(t, string(out), testVersions[3])
+
+	// Set to the cluster downgraded version, update in such case must be ignored.
+	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeEnabled, testVersions[2], strategy)
+	cmd = exec.CommandContext(ctx, tshPath,
+		"login", "--proxy", proxyAddr.String(), "--insecure", "--user", "alice", "--auth", constants.LocalConnector)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	out, err = cmd.Output()
+	require.NoError(t, err)
+	matchVersion(t, string(out), testVersions[3])
+}
+
 // TestLoginWithUpdaterAndProfile runs test cluster with disabled managed updates for client tools,
 // verifies that if we set env variable during login we keep using updated version.
 //
@@ -378,12 +428,13 @@ func bootstrapTestServer(t *testing.T) (*service.TeleportProcess, string, string
 	return rootServer, homeDir, installDir
 }
 
-func setupManagedUpdates(t *testing.T, server *auth.Server, muMode string, muVersion string) {
+func setupManagedUpdates(t *testing.T, server *auth.Server, muMode string, muVersion string, strategies ...autoupdatev1pb.AutoUpdateToolsStrategy) {
 	t.Helper()
 	ctx := context.Background()
 	config, err := autoupdate.NewAutoUpdateConfig(&autoupdatev1pb.AutoUpdateConfigSpec{
 		Tools: &autoupdatev1pb.AutoUpdateConfigSpecTools{
-			Mode: muMode,
+			Mode:       muMode,
+			Strategies: strategies,
 		},
 	})
 	require.NoError(t, err)

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateconfigsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateconfigsv1.yaml
@@ -104,6 +104,14 @@ spec:
                   mode:
                     description: Mode defines state of the client tools auto update.
                     type: string
+                  strategies:
+                    description: 'Custom strategies for modifying behavior when updates
+                      are applied. For example: protecting against client tool downgrades
+                      or ignoring patch updates.'
+                    items:
+                      x-kubernetes-int-or-string: true
+                    nullable: true
+                    type: array
                 type: object
             type: object
           status:

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -184,7 +184,7 @@ func DownloadUpdate(ctx context.Context, name string, insecure bool) error {
 		ctxUpdate, cancel := stacksignal.GetSignalHandler().NotifyContext(ctx)
 		defer cancel()
 		err := updater.Update(ctxUpdate, resp.Version)
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrNoBaseURL) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrCancelUpdate) {
 			return trace.Wrap(err)
 		}
 	}
@@ -199,7 +199,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	// is required if the user passed in the TELEPORT_TOOLS_VERSION
 	// explicitly.
 	err := updater.Update(ctxUpdate, toolsVersion)
-	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrNoBaseURL) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ErrCancelUpdate) {
 		slog.ErrorContext(ctx, "Failed to update tools version", "error", err, "version", toolsVersion)
 		// Continue executing the current version of the client tools (tsh, tctl)
 		// to avoid potential issues with update process (timeout, missing version).

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -546,13 +546,8 @@ func validateUpdateByStrategy(strategies []string, requestedVersion, localVersio
 		return ErrCancelUpdate
 	}
 
-	if slices.Contains(strategies, types.ToolStrategyIgnorePatchUpdate) &&
-		localSemVer.Major == requestedSemVer.Major && localSemVer.Minor == requestedSemVer.Minor {
-		return ErrCancelUpdate
-	}
-
-	if slices.Contains(strategies, types.ToolStrategyIgnoreMinorUpdate) &&
-		localSemVer.Major == requestedSemVer.Major {
+	if slices.Contains(strategies, types.ToolStrategyIgnoreMajorDowngrade) &&
+		localSemVer.Major > requestedSemVer.Major {
 		return ErrCancelUpdate
 	}
 

--- a/lib/autoupdate/tools/updater_test.go
+++ b/lib/autoupdate/tools/updater_test.go
@@ -1,0 +1,121 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/api/types/autoupdate"
+)
+
+// TestValidateUpdateByStrategy verifies strategies upgrade/downgrade cancellation.
+func TestValidateUpdateByStrategy(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name             string
+		strategies       []string
+		requestedVersion string
+		localVersion     string
+		err              error
+		errMessage       string
+	}{
+		{
+			name:             "invalid-requested-version",
+			strategies:       []string{},
+			requestedVersion: "100.0dev",
+			localVersion:     "1.0.0",
+			errMessage:       "100.0dev is not in dotted-tri format",
+		},
+		{
+			name:             "invalid-local-version",
+			strategies:       []string{},
+			requestedVersion: "1.0.0",
+			localVersion:     "100.0dev",
+			errMessage:       "100.0dev is not in dotted-tri format",
+		},
+		{
+			name:             "no-downgrade-restrict",
+			strategies:       []string{autoupdate.ToolStrategyNoDowngrade},
+			requestedVersion: "1.0.0",
+			localVersion:     "3.0.0",
+			err:              ErrCancelUpdate,
+		},
+		{
+			name:             "no-downgrade-upgrade",
+			strategies:       []string{autoupdate.ToolStrategyNoDowngrade},
+			requestedVersion: "2.0.0",
+			localVersion:     "1.0.0",
+			err:              nil,
+		},
+		{
+			name:             "ignore-major-downgrade-restrict",
+			strategies:       []string{autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "1.0.0",
+			localVersion:     "2.0.0",
+			err:              ErrCancelUpdate,
+		},
+		{
+			name:             "ignore-major-downgrade-minor-downgrade",
+			strategies:       []string{autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "2.0.0",
+			localVersion:     "2.2.0",
+			err:              nil,
+		},
+		{
+			name:             "ignore-major-downgrade-upgrade",
+			strategies:       []string{autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "3.0.0",
+			localVersion:     "2.2.0",
+			err:              nil,
+		},
+		{
+			name:             "combined-minor-downgrade",
+			strategies:       []string{autoupdate.ToolStrategyNoDowngrade, autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "2.0.0",
+			localVersion:     "2.2.0",
+			err:              ErrCancelUpdate,
+		},
+		{
+			name:             "combined-minor-patch-downgrade",
+			strategies:       []string{autoupdate.ToolStrategyNoDowngrade, autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "2.2.0",
+			localVersion:     "2.2.1",
+			err:              ErrCancelUpdate,
+		},
+		{
+			name:             "combined-upgrade",
+			strategies:       []string{autoupdate.ToolStrategyNoDowngrade, autoupdate.ToolStrategyIgnoreMajorDowngrade},
+			requestedVersion: "2.2.2",
+			localVersion:     "2.2.1",
+			err:              nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUpdateByStrategy(tt.strategies, tt.requestedVersion, tt.localVersion)
+			if tt.errMessage != "" {
+				assert.Contains(t, err.Error(), tt.errMessage)
+			} else {
+				assert.ErrorIs(t, err, tt.err)
+			}
+		})
+	}
+}

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -46,7 +46,7 @@ import (
 var (
 	// ErrCancelUpdate is general error for canceling update without breaking
 	// execution.
-	ErrCancelUpdate = errors.New("client tools update is cancelled")
+	ErrCancelUpdate = errors.New("client tools update is canceled")
 	// ErrVersionCheck is returned when the downloaded version fails
 	// to execute for version identification.
 	ErrVersionCheck = errors.New("version check failed")

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -44,9 +44,9 @@ import (
 )
 
 var (
-	// ErrNoBaseURL is returned when `TELEPORT_CDN_BASE_URL` must be set
-	// in order to proceed with managed updates.
-	ErrNoBaseURL = errors.New("baseURL is not defined")
+	// ErrCancelUpdate is general error for canceling update without breaking
+	// execution.
+	ErrCancelUpdate = errors.New("client tools update is cancelled")
 	// ErrVersionCheck is returned when the downloaded version fails
 	// to execute for version identification.
 	ErrVersionCheck = errors.New("version check failed")
@@ -199,7 +199,7 @@ func teleportPackageURLs(ctx context.Context, uriTmpl string, baseURL, version s
 	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
 	if m.BuildType() == modules.BuildOSS && envBaseURL == "" {
 		slog.WarnContext(ctx, "Client tools updates are disabled as they are licensed under AGPL. To use Community Edition builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
-		return nil, ErrNoBaseURL
+		return nil, ErrCancelUpdate
 	}
 
 	var flags autoupdate.InstallFlags

--- a/tool/tctl/common/autoupdate_command.go
+++ b/tool/tctl/common/autoupdate_command.go
@@ -101,7 +101,7 @@ func (c *AutoUpdateCommand) Initialize(app *kingpin.Application, ccf *tctlcfg.Gl
 
 	c.toolsStrategyCmd = clientToolsCmd.Command("strategies", "Sets the client tools strategies when update must be applied depends on client version.")
 	c.toolsStrategyCmd.Arg("strategies", "List of the strategies that must be overridden for cluster").EnumsVar(&c.toolsStrategies,
-		autoupdate.ToolStrategyNoDowngrade, autoupdate.ToolStrategyIgnoreMinorUpdate, autoupdate.ToolStrategyIgnorePatchUpdate)
+		autoupdate.ToolStrategyNoDowngrade, autoupdate.ToolStrategyIgnoreMajorDowngrade)
 	c.toolsStrategyCmd.Flag("clear", "Removes the target version, Teleport will default to its current proxy version.").BoolVar(&c.clear)
 
 	agentsCmd := autoUpdateCmd.Command("agents", "Manage agents auto update configuration.")

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -90,14 +90,13 @@ func TestClientToolsAutoUpdateCommands(t *testing.T) {
 	assert.Equal(t, "1.2.3", version.Spec.Tools.TargetVersion)
 
 	// Set the strategy to ensure that it was saved for cluster configuration.
-	_, err = runAutoUpdateCommand(t, authClient, []string{"client-tools", "strategies", "no-downgrade", "ignore-minor-update"})
+	_, err = runAutoUpdateCommand(t, authClient, []string{"client-tools", "strategies", "no-downgrade"})
 	require.NoError(t, err)
 
 	config, err = authClient.GetAutoUpdateConfig(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, []autoupdatepb.AutoUpdateToolsStrategy{
 		autoupdatepb.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE,
-		autoupdatepb.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE,
 	}, config.Spec.Tools.Strategies)
 
 	getBuf, err := runAutoUpdateCommand(t, authClient, []string{"client-tools", "status", "--format=json"})

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -89,6 +89,17 @@ func TestClientToolsAutoUpdateCommands(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1.2.3", version.Spec.Tools.TargetVersion)
 
+	// Set the strategy to ensure that it was saved for cluster configuration.
+	_, err = runAutoUpdateCommand(t, authClient, []string{"client-tools", "strategies", "no-downgrade", "ignore-minor-update"})
+	require.NoError(t, err)
+
+	config, err = authClient.GetAutoUpdateConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []autoupdatepb.AutoUpdateToolsStrategy{
+		autoupdatepb.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_NO_DOWNGRADE,
+		autoupdatepb.AutoUpdateToolsStrategy_AUTO_UPDATE_TOOLS_STRATEGY_IGNORE_MINOR_UPDATE,
+	}, config.Spec.Tools.Strategies)
+
 	getBuf, err := runAutoUpdateCommand(t, authClient, []string{"client-tools", "status", "--format=json"})
 	require.NoError(t, err)
 	response := mustDecodeJSON[getResponse](t, getBuf)


### PR DESCRIPTION
In this PR, I added update strategies for client tools managed updates, allowing a cluster to be configured with the following options:
- **no-downgrade** — prevents downgrading client tools during an update.
- **ignore-major-downgrade** — prevents downgrading across major versions (e.g., 19.x.x → 18.x.x is restricted, 19.2.x → 19.1.x, 19.2.2 → 19.2.1 are allowed).


Changelog: Client tools managed updates can be restricted using custom strategies
Related: https://github.com/gravitational/cloud/issues/14225