### PR TITLE
docs: update machine-id deployments to use cluster install scripts

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -165,14 +165,15 @@ pool:
 
 steps:
 - script: |
-    wget https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  displayName: 'Download and extract Teleport'
-- env:
+    curl "https://example.teleport.sh:443/scripts/install.sh" | sudo bash
+    tbot start -c tbot.yaml
+  displayName: 'Install Teleport and start tbot'
+  env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     TELEPORT_ANONYMOUS_TELEMETRY: 1
-  script: ./teleport/tbot start -c tbot.yaml
 ```
+
+Replace `example.teleport.sh:443` with the address of your Teleport Proxy Service.
 
 Note the inclusion of the `SYSTEM_ACCESSTOKEN` environment variable. This
 variable must be populated in any step where `tbot` is run.

--- a/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/azure-devops.mdx
@@ -130,7 +130,7 @@ Create `tbot.yaml` within your repository:
 
 ```yaml
 version: v2
-proxy_server: example.teleport.sh:443
+proxy_server: <Var name="example.teleport.sh" />:443
 onboarding:
   join_method: azure_devops
   token: example-bot
@@ -143,7 +143,7 @@ outputs: []
 
 Replace:
 
-- `example.teleport.sh:443` with the address of your Teleport Proxy Service or
+- <Var name="example.teleport.sh" /> with the address of your Teleport Proxy Service or
 Auth Service. Prefer using the address of the Teleport Proxy Service.
 - `example-bot` with the name of the token you created in the second step
 
@@ -165,7 +165,7 @@ pool:
 
 steps:
 - script: |
-    curl "https://example.teleport.sh:443/scripts/install.sh" | sudo bash
+    curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | sudo bash
     tbot start -c tbot.yaml
   displayName: 'Install Teleport and start tbot'
   env:
@@ -173,7 +173,7 @@ steps:
     TELEPORT_ANONYMOUS_TELEMETRY: 1
 ```
 
-Replace `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+Replace <Var name="example.teleport.sh"/> with the address of your Teleport Proxy Service.
 
 Note the inclusion of the `SYSTEM_ACCESSTOKEN` environment variable. This
 variable must be populated in any step where `tbot` is run.

--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -121,14 +121,16 @@ pipelines:
           oidc: true
           script:
             # Install Teleport
-            - curl "https://example.teleport.sh:443/scripts/install.sh" | bash
+            - curl "https://<Var name="example.teleport.sh:443"/>/scripts/install.sh" | bash
 
             # Run `tbot` in identity mode for SSH access
-            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=example.teleport.sh:443 --token=bot-bitbucket --oneshot
+            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=<Var name="example.teleport.sh:443"/> --token=bot-bitbucket --oneshot
 
             # Make use of the generated SSH credentials
             - ssh -F ./tbot-user/ssh_config user@node.example.teleport.sh echo "hello world"
 ```
+
+Replace <Var name="example.teleport.sh:443"/> with the address of your Teleport Proxy Service.
 
 This example will start `tbot` in identity mode to generate SSH credentials.
 Refer to the [`tbot start` documentation](../../../reference/cli/tbot.mdx#tbot-start)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -121,16 +121,16 @@ pipelines:
           oidc: true
           script:
             # Install Teleport
-            - curl "https://<Var name="example.teleport.sh:443"/>/scripts/install.sh" | bash
+            - curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | bash
 
             # Run `tbot` in identity mode for SSH access
-            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=<Var name="example.teleport.sh:443"/> --token=bot-bitbucket --oneshot
+            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=<Var name="example.teleport.sh"/>:443 --token=bot-bitbucket --oneshot
 
             # Make use of the generated SSH credentials
             - ssh -F ./tbot-user/ssh_config user@node.example.teleport.sh echo "hello world"
 ```
 
-Replace <Var name="example.teleport.sh:443"/> with the address of your Teleport Proxy Service.
+Replace <Var name="example.teleport.sh"/> with the address of your Teleport Proxy Service.
 
 This example will start `tbot` in identity mode to generate SSH credentials.
 Refer to the [`tbot start` documentation](../../../reference/cli/tbot.mdx#tbot-start)

--- a/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/bitbucket.mdx
@@ -120,12 +120,11 @@ pipelines:
       - step:
           oidc: true
           script:
-            # Download and extract Teleport
-            - wget https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-            - tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+            # Install Teleport
+            - curl "https://example.teleport.sh:443/scripts/install.sh" | bash
 
             # Run `tbot` in identity mode for SSH access
-            - ./teleport/tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=example.teleport.sh:443 --token=bot-bitbucket --oneshot
+            - tbot start identity --destination=./tbot-user --join-method=bitbucket --proxy-server=example.teleport.sh:443 --token=bot-bitbucket --oneshot
 
             # Make use of the generated SSH credentials
             - ssh -F ./tbot-user/ssh_config user@node.example.teleport.sh echo "hello world"
@@ -138,7 +137,7 @@ access.
 
 If you're adapting an existing workflow, note these steps:
 1. Set `oidc: true` on the step properties so that step will be issued a token
-1. Download and extract a `.tar.gz` Teleport build
+1. Installs Teleport from your cluster's install script
 1. Run `tbot` with `--join-method=bitbucket`, `--token=example-bot` (or
    whichever name was configured in Step 3), and `--oneshot`
 

--- a/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
@@ -134,7 +134,7 @@ Create `tbot.yaml` within your repository:
 
 ```yaml
 version: v2
-proxy_server: example.teleport.sh:443
+proxy_server: <Var name="example.teleport.sh"/>:443
 onboarding:
   join_method: circleci
   token: example-bot
@@ -147,7 +147,7 @@ outputs: []
 
 Replace:
 
-- `example.teleport.sh:443` with the address of your Teleport Proxy or
+- <Var name="example.teleport.sh"/> with the address of your Teleport Proxy or
   Auth Service. Prefer using the address of a Teleport Proxy.
 - `example-bot` with the name of the token you created in the second step
 
@@ -172,7 +172,7 @@ jobs:
       - run:
           name: "Install Teleport"
           command: |
-            curl "https://example.teleport.sh:443/scripts/install.sh" | sudo bash
+            curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | sudo bash
       - run:
           name: "Run Machine ID"
           command: |
@@ -186,7 +186,7 @@ workflows:
             - teleport-access
 ```
 
-Replace `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+Replace <Var name="example.teleport.sh"/> with the address of your Teleport Proxy Service.
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
 telemetry. This helps us shape the future development of `tbot`. You can disable

--- a/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
@@ -172,10 +172,7 @@ jobs:
       - run:
           name: "Install Teleport"
           command: |
-            cd /tmp
-            curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-            tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-            sudo ./teleport/install
+            curl "https://example.teleport.sh:443/scripts/install.sh" | sudo bash
       - run:
           name: "Run Machine ID"
           command: |
@@ -188,6 +185,8 @@ workflows:
           context:
             - teleport-access
 ```
+
+Replace `example.teleport.sh:443` with the address of your Teleport Proxy Service.
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
 telemetry. This helps us shape the future development of `tbot`. You can disable

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
@@ -101,7 +101,7 @@ Create `tbot.yaml` within your repository:
 
 ```yaml
 version: v2
-proxy_server: example.teleport.sh:443
+proxy_server: <Var name="example.teleport.sh"/>:443
 onboarding:
   join_method: gitlab
   token: example-bot
@@ -114,7 +114,7 @@ outputs: []
 
 Replace:
 
-- `example.teleport.sh:443` with the address of your Teleport Proxy or
+- <Var name="example.teleport.sh"/> with the address of your Teleport Proxy or
   Auth Service. Prefer using the address of a Teleport Proxy.
 - `example-bot` with the name of the token you created in the second step
 
@@ -145,18 +145,18 @@ deploy-job:
       #
       # This helps the Teleport Auth Service know that the token is intended for
       # it, and not a different service or Teleport cluster.
-      aud: teleport.example.com
+      aud: <Var name="example.teleport.sh"/>
   script:
-    - curl "https://teleport.example.com:443/scripts/install.sh" | bash
+    - curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | bash
     - 'TELEPORT_ANONYMOUS_TELEMETRY=1 tbot start -c tbot.yaml'
 ```
 
 Replace:
 
-- 'teleport.example.com` for `aud` with the name of your Teleport cluster. This
+- <Var name="example.teleport.sh"/> for `aud` with the name of your Teleport cluster. This
   is not necessarily the address of your Teleport cluster and will not include
   a port or scheme (e.g. http/https).
-- `teleport.example.com:443` with the address of your Teleport Proxy Service.
+- <Var name="example.teleport.sh"/> with the address of your Teleport Proxy Service.
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
 telemetry. This helps us shape the future development of `tbot`. You can disable

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
@@ -147,16 +147,16 @@ deploy-job:
       # it, and not a different service or Teleport cluster.
       aud: teleport.example.com
   script:
-    - cd /tmp
-    - 'curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz'
-    - tar -xvf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    - sudo ./teleport/install
+    - curl "https://teleport.example.com:443/scripts/install.sh" | bash
     - 'TELEPORT_ANONYMOUS_TELEMETRY=1 tbot start -c tbot.yaml'
 ```
 
-Replace `teleport.example.com` with the name of your Teleport cluster. This
-is not necessarily the address of your Teleport cluster and will not include
-a port or scheme (e.g. http/https).
+Replace:
+
+- 'teleport.example.com` for `aud` with the name of your Teleport cluster. This
+  is not necessarily the address of your Teleport cluster and will not include
+  a port or scheme (e.g. http/https).
+- `teleport.example.com:443` with the address of your Teleport Proxy Service.
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage
 telemetry. This helps us shape the future development of `tbot`. You can disable


### PR DESCRIPTION
This updates the install step for Teleport to use the cluster's install script:
- Azure Devops
- CircleCI
- BitBucket
- GitLabCI

Using the install script uses the expected version for agents of the cluster and reduces the number of steps required.  The Azure Devops script was also throwing an error with the original docs version.

All of these script changes were deployed on the respective pipelines and confirmed.
