### PR TITLE
Group x11 and agent forwarding requests in `tsh ssh` traces

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gravitational/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
@@ -245,7 +244,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context, chanReqCallback 
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		err = agent.RequestAgentForwarding(sess.Session)
+		err = sshagent.RequestAgentForwarding(ctx, sess)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/x11_session.go
+++ b/lib/client/x11_session.go
@@ -62,7 +62,7 @@ func (ns *NodeSession) handleX11Forwarding(ctx context.Context, sess *tracessh.S
 		return trace.Wrap(err)
 	}
 
-	if err := x11.RequestForwarding(sess.Session, ns.spoofedXAuthEntry); err != nil {
+	if err := x11.RequestForwarding(ctx, sess, ns.spoofedXAuthEntry); err != nil {
 		// Notify the user that x11 forwarding request failed regardless of debug level
 		fmt.Fprintln(os.Stderr, "X11 forwarding request failed")
 		slog.DebugContext(ctx, "X11 forwarding request error", "err", err)

--- a/lib/sshutils/x11/forward.go
+++ b/lib/sshutils/x11/forward.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
+
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 )
 
 const (
@@ -55,14 +57,14 @@ type ForwardRequestPayload struct {
 // authProto and authCookie are required to set up authentication with the Server. screenNumber is used
 // by the server to determine which screen should be connected to for X11 forwarding. singleConnection is
 // an optional argument to request X11 forwarding for a single connection.
-func RequestForwarding(sess *ssh.Session, xauthEntry *XAuthEntry) error {
+func RequestForwarding(ctx context.Context, sess *tracessh.Session, xauthEntry *XAuthEntry) error {
 	payload := ForwardRequestPayload{
 		AuthProtocol: xauthEntry.Proto,
 		AuthCookie:   xauthEntry.Cookie,
 		ScreenNumber: uint32(xauthEntry.Display.ScreenNumber),
 	}
 
-	ok, err := sess.SendRequest(ForwardRequest, true, ssh.Marshal(payload))
+	ok, err := sess.SendRequest(ctx, ForwardRequest, true, ssh.Marshal(payload))
 	if err != nil {
 		return trace.Wrap(err)
 	} else if !ok {


### PR DESCRIPTION
This PR fixes an issue where the existing spans for outgoing client requests weren't being grouped into the tsh ssh trace.

Before:

<img width="660" height="564" alt="image" src="https://github.com/user-attachments/assets/d2ac1aa3-4287-487c-944d-38b56ceec266" />

After:

<img width="1417" height="247" alt="image" src="https://github.com/user-attachments/assets/76e62c50-173f-4d75-8d13-1ef3d84e13b5" />
