### PR TITLE
Handle sessions that do not have metadata but do have a summary

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -333,7 +333,7 @@ function ThumbnailError({ children }: PropsWithChildren) {
   );
 }
 
-function getRecordingTypeInfo(type: RecordingType): {
+export function getRecordingTypeInfo(type: RecordingType): {
   icon: ComponentType<IconProps>;
   label: string;
 } {

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
@@ -24,6 +24,7 @@ import Flex from 'design/Flex';
 import Indicator from 'design/Indicator';
 
 import type { RecordingType } from 'teleport/services/recordings';
+import { RECORDING_TYPES_WITH_METADATA } from 'teleport/services/recordings/recordings';
 import { DesktopPlayer } from 'teleport/SessionRecordings/view/DesktopPlayer';
 import { TtyRecordingPlayer } from 'teleport/SessionRecordings/view/player/tty/TtyRecordingPlayer';
 import SshPlayer, {
@@ -88,21 +89,26 @@ export function RecordingPlayer({
     );
   }
 
+  const sshPlayer = (
+    <SshPlayer
+      ref={ref}
+      onTimeChange={onTimeChange}
+      onToggleSidebar={onToggleSidebar}
+      sid={sessionId}
+      clusterId={clusterId}
+      durationMs={durationMs}
+      onToggleTimeline={onToggleTimeline}
+    />
+  );
+
+  if (!RECORDING_TYPES_WITH_METADATA.includes(recordingType)) {
+    // For recording types without metadata (e.g., database), render the legacy SshPlayer directly.
+    return sshPlayer;
+  }
+
   return (
     <Container>
-      <ErrorBoundary
-        fallback={
-          <SshPlayer
-            ref={ref}
-            onTimeChange={onTimeChange}
-            onToggleSidebar={onToggleSidebar}
-            sid={sessionId}
-            clusterId={clusterId}
-            durationMs={durationMs}
-            onToggleTimeline={onToggleTimeline}
-          />
-        }
-      >
+      <ErrorBoundary fallback={sshPlayer}>
         <Suspense fallback={<RecordingPlayerLoading />}>
           <TtyRecordingPlayer
             clusterId={clusterId}

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingPlayer.tsx
@@ -103,7 +103,7 @@ export function RecordingPlayer({
 
   if (!RECORDING_TYPES_WITH_METADATA.includes(recordingType)) {
     // For recording types without metadata (e.g., database), render the legacy SshPlayer directly.
-    return sshPlayer;
+    return <Container>{sshPlayer}</Container>;
   }
 
   return (

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithMetadata.tsx
@@ -22,7 +22,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Flex from 'design/Flex';
-import { ChevronLeft, Terminal } from 'design/Icon';
+import { ChevronLeft } from 'design/Icon';
 import { H3 } from 'design/Text';
 import { useLocalStorage } from 'shared/hooks/useLocalStorage';
 
@@ -31,7 +31,10 @@ import cfg from 'teleport/config';
 import { type RecordingType } from 'teleport/services/recordings';
 import { useSuspenseGetRecordingMetadata } from 'teleport/services/recordings/hooks';
 import { KeysEnum } from 'teleport/services/storageService';
-import { formatSessionRecordingDuration } from 'teleport/SessionRecordings/list/RecordingItem';
+import {
+  formatSessionRecordingDuration,
+  getRecordingTypeInfo,
+} from 'teleport/SessionRecordings/list/RecordingItem';
 import { RecordingPlayer } from 'teleport/SessionRecordings/view/RecordingPlayer';
 import type { PlayerHandle } from 'teleport/SessionRecordings/view/SshPlayer';
 import {
@@ -119,6 +122,8 @@ export function RecordingWithMetadata({
   const startTime = new Date(data.metadata.startTime * 1000);
   const endTime = new Date(data.metadata.endTime * 1000);
 
+  const { icon: Icon, label } = getRecordingTypeInfo(data.metadata.type);
+
   useEffect(() => {
     if (!timelineRef.current || timelineHidden) {
       return;
@@ -163,9 +168,9 @@ export function RecordingWithMetadata({
             </Flex>
 
             <Flex alignItems="center" gap={3} px={3}>
-              <Terminal />
+              <Icon size="small" />
 
-              <H3>SSH Session</H3>
+              <H3>{label}</H3>
             </Flex>
 
             <InfoGrid>

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithSummary.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithSummary.tsx
@@ -1,0 +1,188 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import Flex from 'design/Flex';
+import { ChevronLeft } from 'design/Icon';
+import { H3 } from 'design/Text';
+import { ErrorSuspenseWrapper } from 'shared/components/ErrorSuspenseWrapper/ErrorSuspenseWrapper';
+import { useLocalStorage } from 'shared/hooks/useLocalStorage';
+
+import cfg from 'teleport/config';
+import { type RecordingType } from 'teleport/services/recordings';
+import { VALID_RECORDING_TYPES } from 'teleport/services/recordings/recordings';
+import { KeysEnum } from 'teleport/services/storageService';
+import { getRecordingTypeInfo } from 'teleport/SessionRecordings/list/RecordingItem';
+import { RecordingPlayer } from 'teleport/SessionRecordings/view/RecordingPlayer';
+import {
+  RecordingPlayerError,
+  RecordingPlayerLoading,
+  RecordingPlayerWithLoadDuration,
+} from 'teleport/SessionRecordings/view/ViewSessionRecordingRoute';
+import type { SummarySlot } from 'teleport/SessionRecordings/view/RecordingWithMetadata';
+
+interface RecordingWithSummaryProps {
+  clusterId: string;
+  durationMs: number;
+  sessionId: string;
+  recordingType: RecordingType;
+  summarySlot: SummarySlot;
+}
+
+export function RecordingWithSummary({
+  clusterId,
+  durationMs,
+  recordingType,
+  sessionId,
+  summarySlot,
+}: RecordingWithSummaryProps) {
+  const [sidebarHidden, setSidebarHidden] = useLocalStorage(
+    KeysEnum.SESSION_RECORDING_SIDEBAR_HIDDEN,
+    false
+  );
+
+  const summary = useMemo(
+    () => summarySlot(sessionId, recordingType),
+    [summarySlot, sessionId, recordingType]
+  );
+
+  const toggleSidebar = useCallback(() => {
+    // setSidebarHidden(prev => !prev) does not work with useLocalStorage, it stops working after the first toggle
+    setSidebarHidden(!sidebarHidden);
+  }, [sidebarHidden, setSidebarHidden]);
+
+  const { icon: Icon, label } = getRecordingTypeInfo(recordingType);
+
+  const validRecordingType = VALID_RECORDING_TYPES.includes(recordingType);
+  const validDuration = Number.isInteger(durationMs) && durationMs > 0;
+
+  const shouldFetchSessionDuration = !validRecordingType || !validDuration;
+
+  let player = (
+    <RecordingPlayer
+      clusterId={clusterId}
+      sessionId={sessionId}
+      durationMs={durationMs}
+      recordingType={recordingType}
+      onToggleSidebar={toggleSidebar}
+    />
+  );
+
+  if (shouldFetchSessionDuration) {
+    player = (
+      <ErrorSuspenseWrapper
+        errorComponent={RecordingPlayerError}
+        loadingComponent={RecordingPlayerLoading}
+      >
+        <RecordingPlayerWithLoadDuration
+          clusterId={clusterId}
+          sessionId={sessionId}
+          onToggleSidebar={toggleSidebar}
+        />
+      </ErrorSuspenseWrapper>
+    );
+  }
+
+  if (!summary) {
+    return player;
+  }
+
+  return (
+    <Grid sidebarHidden={sidebarHidden}>
+      <Player>{player}</Player>
+
+      {!sidebarHidden && (
+        <Sidebar>
+          <Flex
+            flexDirection="column"
+            gap={4}
+            pt={3}
+            minHeight={0}
+            height="100%"
+          >
+            <Flex pl={3} pr={2} justifyContent="space-between">
+              <BackLink to={cfg.getRecordingsRoute(clusterId)}>
+                <ChevronLeft size="small" />
+                Back to Session Recordings
+              </BackLink>
+            </Flex>
+
+            <Flex alignItems="center" gap={3} px={3}>
+              <Icon size="small" />
+
+              <H3>{label}</H3>
+            </Flex>
+
+            <Summary>{summary}</Summary>
+          </Flex>
+        </Sidebar>
+      )}
+    </Grid>
+  );
+}
+
+const Grid = styled.div<{ sidebarHidden: boolean }>`
+  background: ${p => p.theme.colors.levels.sunken};
+  display: grid;
+  grid-template-areas: ${p =>
+    p.sidebarHidden ? `'recording recording'` : `'sidebar recording'`};
+  grid-template-columns: 1fr 4fr;
+  grid-template-rows: 1fr auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const Player = styled.div`
+  grid-area: recording;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
+const Sidebar = styled.div`
+  grid-area: sidebar;
+  border-right: 1px solid ${p => p.theme.colors.spotBackground[1]};
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Summary = styled.div`
+  border-top: 1px solid ${p => p.theme.colors.spotBackground[1]};
+  overflow-y: auto;
+  height: 100%;
+  flex: 1;
+  min-height: 0;
+  padding: ${p => p.theme.space[3]}px ${p => p.theme.space[3]}px 0;
+`;
+
+const BackLink = styled(Link)`
+  color: ${p => p.theme.colors.text.slightlyMuted};
+  text-decoration: none;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space[2]}px;
+`;

--- a/web/packages/teleport/src/SessionRecordings/view/RecordingWithSummary.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/RecordingWithSummary.tsx
@@ -32,12 +32,12 @@ import { VALID_RECORDING_TYPES } from 'teleport/services/recordings/recordings';
 import { KeysEnum } from 'teleport/services/storageService';
 import { getRecordingTypeInfo } from 'teleport/SessionRecordings/list/RecordingItem';
 import { RecordingPlayer } from 'teleport/SessionRecordings/view/RecordingPlayer';
+import type { SummarySlot } from 'teleport/SessionRecordings/view/RecordingWithMetadata';
 import {
   RecordingPlayerError,
   RecordingPlayerLoading,
   RecordingPlayerWithLoadDuration,
 } from 'teleport/SessionRecordings/view/ViewSessionRecordingRoute';
-import type { SummarySlot } from 'teleport/SessionRecordings/view/RecordingWithMetadata';
 
 interface RecordingWithSummaryProps {
   clusterId: string;

--- a/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyPlayer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyPlayer.ts
@@ -44,12 +44,18 @@ export class TtyPlayer extends Player<TtyEvent> {
   private terminal: Terminal | null = null;
   private playing = false;
   private logger = new Logger('TtyPlayer');
+  private size: TerminalSize;
 
   constructor(
     private theme: DefaultTheme,
-    private size: TerminalSize
+    size: TerminalSize
   ) {
     super();
+
+    this.size = {
+      cols: size.cols ?? 80,
+      rows: size.rows ?? 24,
+    };
   }
 
   override init(element: HTMLElement) {

--- a/web/packages/teleport/src/services/recordings/recordings.ts
+++ b/web/packages/teleport/src/services/recordings/recordings.ts
@@ -124,3 +124,11 @@ export async function fetchRecordingThumbnail(
 }
 
 export const RECORDING_TYPES_WITH_THUMBNAILS: RecordingType[] = ['ssh', 'k8s'];
+export const RECORDING_TYPES_WITH_METADATA: RecordingType[] = ['ssh', 'k8s'];
+
+export const VALID_RECORDING_TYPES: RecordingType[] = [
+  'ssh',
+  'k8s',
+  'desktop',
+  'database',
+];


### PR DESCRIPTION
This adds a fallback for recording types that do not have metadata generated for them yet, but do have a session summary (i.e. database recordings)

Also updates the player component to always render the legacy player for database sessions as they are not supported by the new playback endpoint yet

Also fixes the metadata view to show the correct icon/type of recording, it was statically set to "SSH Session" 

changelog: Database recordings now show the session summary if it is available