### PR TITLE
connect: check for existing https in app address before adding

### DIFF
--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -101,9 +101,9 @@ export function getAppAddrWithProtocol(source: App): string {
   const isTcp = endpointUri && endpointUri.startsWith('tcp://');
   const isCloud = endpointUri && endpointUri.startsWith('cloud://');
   const isMCPStdio = endpointUri && endpointUri.startsWith('mcp+stdio://');
-  const httpsPublicAddr = publicAddr.startsWith('https://');
+  const isHttpsPublicAddr = publicAddr.startsWith('https://');
   let addrWithProtocol = endpointUri;
-  if (publicAddr && !httpsPublicAddr) {
+  if (publicAddr && !isHttpsPublicAddr) {
     if (isCloud) {
       addrWithProtocol = `cloud://${publicAddr}`;
     } else if (isTcp) {

--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -101,8 +101,9 @@ export function getAppAddrWithProtocol(source: App): string {
   const isTcp = endpointUri && endpointUri.startsWith('tcp://');
   const isCloud = endpointUri && endpointUri.startsWith('cloud://');
   const isMCPStdio = endpointUri && endpointUri.startsWith('mcp+stdio://');
+  const httpsPublicAddr = publicAddr.startsWith('https://');
   let addrWithProtocol = endpointUri;
-  if (publicAddr) {
+  if (publicAddr && !httpsPublicAddr) {
     if (isCloud) {
       addrWithProtocol = `cloud://${publicAddr}`;
     } else if (isTcp) {

--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -101,9 +101,8 @@ export function getAppAddrWithProtocol(source: App): string {
   const isTcp = endpointUri && endpointUri.startsWith('tcp://');
   const isCloud = endpointUri && endpointUri.startsWith('cloud://');
   const isMCPStdio = endpointUri && endpointUri.startsWith('mcp+stdio://');
-  const isHttpsPublicAddr = publicAddr.startsWith('https://');
   let addrWithProtocol = endpointUri;
-  if (publicAddr && !isHttpsPublicAddr) {
+  if (publicAddr) {
     if (isCloud) {
       addrWithProtocol = `cloud://${publicAddr}`;
     } else if (isTcp) {
@@ -111,7 +110,10 @@ export function getAppAddrWithProtocol(source: App): string {
     } else if (isMCPStdio) {
       addrWithProtocol = `mcp+stdio://${publicAddr}`;
     } else {
-      addrWithProtocol = `https://${publicAddr}`;
+      // publicAddr for Identity Center account app is a URL with scheme.
+      addrWithProtocol = publicAddr.startsWith('https://')
+        ? publicAddr
+        : `https://${publicAddr}`;
     }
   }
 


### PR DESCRIPTION
This handles the app address building to check if a `https` was already in the address. Currently AWS identity center shows as `https://https://` in Teleport connect

<img width="1418" height="161" alt="image" src="https://github.com/user-attachments/assets/3b10f58b-400b-429c-af42-e68df10433e7" />
