### PR TITLE
Bump shared-workflows ref in Lint (Docs)

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2 
+          ref: 6ea1f547eee108478e4dc576cc2128f2fb0e460a 
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Use the commit that corresponds to gravitational/shared-workflows#393, which fixes a bug in the workflow that rejects a PR that changes a section index page to a regular docs page.