### PR TITLE
refactor new join flow

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -51,20 +51,12 @@ type ClientInit struct {
 	TokenName string `protobuf:"bytes,2,opt,name=token_name,json=tokenName,proto3" json:"token_name,omitempty"`
 	// SystemRole is the system role requested, e.g. Proxy, Node, Instance, Bot.
 	SystemRole string `protobuf:"bytes,3,opt,name=system_role,json=systemRole,proto3" json:"system_role,omitempty"`
-	// PublicTlsKey is the public key requested for the subject of the x509 certificate.
-	// It must be encoded in PKIX, ASN.1 DER form.
-	PublicTlsKey []byte `protobuf:"bytes,4,opt,name=public_tls_key,json=publicTlsKey,proto3" json:"public_tls_key,omitempty"`
-	// PublicSshKey is the public key requested for the subject of the SSH certificate.
-	// It must be encoded in SSH wire format.
-	PublicSshKey []byte `protobuf:"bytes,5,opt,name=public_ssh_key,json=publicSshKey,proto3" json:"public_ssh_key,omitempty"`
 	// ForwardedByProxy will be set to true when the message is forwarded by the
 	// Proxy service. When this is set the Auth service must ignore any
 	// any credentials authenticating the request, except for the purpose of
 	// accepting ProxySuppliedParams.
 	ForwardedByProxy        bool                            `protobuf:"varint,6,opt,name=forwarded_by_proxy,json=forwardedByProxy,proto3" json:"forwarded_by_proxy,omitempty"`
-	HostParams              *ClientInit_HostParams          `protobuf:"bytes,7,opt,name=host_params,json=hostParams,proto3,oneof" json:"host_params,omitempty"`
-	BotParams               *ClientInit_BotParams           `protobuf:"bytes,8,opt,name=bot_params,json=botParams,proto3,oneof" json:"bot_params,omitempty"`
-	ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,9,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof" json:"proxy_supplied_parameters,omitempty"`
+	ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,7,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof" json:"proxy_supplied_parameters,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -120,20 +112,6 @@ func (x *ClientInit) GetSystemRole() string {
 	return ""
 }
 
-func (x *ClientInit) GetPublicTlsKey() []byte {
-	if x != nil {
-		return x.PublicTlsKey
-	}
-	return nil
-}
-
-func (x *ClientInit) GetPublicSshKey() []byte {
-	if x != nil {
-		return x.PublicSshKey
-	}
-	return nil
-}
-
 func (x *ClientInit) GetForwardedByProxy() bool {
 	if x != nil {
 		return x.ForwardedByProxy
@@ -141,23 +119,333 @@ func (x *ClientInit) GetForwardedByProxy() bool {
 	return false
 }
 
-func (x *ClientInit) GetHostParams() *ClientInit_HostParams {
-	if x != nil {
-		return x.HostParams
-	}
-	return nil
-}
-
-func (x *ClientInit) GetBotParams() *ClientInit_BotParams {
-	if x != nil {
-		return x.BotParams
-	}
-	return nil
-}
-
 func (x *ClientInit) GetProxySuppliedParameters() *ClientInit_ProxySuppliedParams {
 	if x != nil {
 		return x.ProxySuppliedParameters
+	}
+	return nil
+}
+
+// PublicKeys holds public keys sent by the client requested subject keys for
+// issued certificates.
+type PublicKeys struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PublicTlsKey is the public key requested for the subject of the x509 certificate.
+	// It must be encoded in PKIX, ASN.1 DER form.
+	PublicTlsKey []byte `protobuf:"bytes,4,opt,name=public_tls_key,json=publicTlsKey,proto3" json:"public_tls_key,omitempty"`
+	// PublicSshKey is the public key requested for the subject of the SSH certificate.
+	// It must be encoded in SSH wire format.
+	PublicSshKey  []byte `protobuf:"bytes,5,opt,name=public_ssh_key,json=publicSshKey,proto3" json:"public_ssh_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PublicKeys) Reset() {
+	*x = PublicKeys{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PublicKeys) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PublicKeys) ProtoMessage() {}
+
+func (x *PublicKeys) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PublicKeys.ProtoReflect.Descriptor instead.
+func (*PublicKeys) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PublicKeys) GetPublicTlsKey() []byte {
+	if x != nil {
+		return x.PublicTlsKey
+	}
+	return nil
+}
+
+func (x *PublicKeys) GetPublicSshKey() []byte {
+	if x != nil {
+		return x.PublicSshKey
+	}
+	return nil
+}
+
+// HostParams holds parameters required for host joining.
+type HostParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PublicKeys holds the host public keys.
+	PublicKeys *PublicKeys `protobuf:"bytes,1,opt,name=public_keys,json=publicKeys,proto3" json:"public_keys,omitempty"`
+	// HostName is the user-friendly node name for the host. This comes from
+	// teleport.nodename in the service configuration and defaults to the
+	// hostname. It is encoded as a valid principal in issued certificates.
+	HostName string `protobuf:"bytes,2,opt,name=host_name,json=hostName,proto3" json:"host_name,omitempty"`
+	// AdditionalPrincipals is a list of additional principals requested.
+	AdditionalPrincipals []string `protobuf:"bytes,3,rep,name=additional_principals,json=additionalPrincipals,proto3" json:"additional_principals,omitempty"`
+	// DnsNames is a list of DNS names requested for inclusion in the x509 certificate.
+	DnsNames      []string `protobuf:"bytes,4,rep,name=dns_names,json=dnsNames,proto3" json:"dns_names,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostParams) Reset() {
+	*x = HostParams{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostParams) ProtoMessage() {}
+
+func (x *HostParams) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostParams.ProtoReflect.Descriptor instead.
+func (*HostParams) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *HostParams) GetPublicKeys() *PublicKeys {
+	if x != nil {
+		return x.PublicKeys
+	}
+	return nil
+}
+
+func (x *HostParams) GetHostName() string {
+	if x != nil {
+		return x.HostName
+	}
+	return ""
+}
+
+func (x *HostParams) GetAdditionalPrincipals() []string {
+	if x != nil {
+		return x.AdditionalPrincipals
+	}
+	return nil
+}
+
+func (x *HostParams) GetDnsNames() []string {
+	if x != nil {
+		return x.DnsNames
+	}
+	return nil
+}
+
+// BotParams holds parameters required for bot joining.
+type BotParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PublicKeys holds the bot public keys.
+	PublicKeys *PublicKeys `protobuf:"bytes,1,opt,name=public_keys,json=publicKeys,proto3" json:"public_keys,omitempty"`
+	// Expires is a desired time of the expiry of the returned certificates.
+	Expires       *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=expires,proto3,oneof" json:"expires,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BotParams) Reset() {
+	*x = BotParams{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BotParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BotParams) ProtoMessage() {}
+
+func (x *BotParams) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BotParams.ProtoReflect.Descriptor instead.
+func (*BotParams) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *BotParams) GetPublicKeys() *PublicKeys {
+	if x != nil {
+		return x.PublicKeys
+	}
+	return nil
+}
+
+func (x *BotParams) GetExpires() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Expires
+	}
+	return nil
+}
+
+// ClientParams holds either host or bot join parameters.
+type ClientParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*ClientParams_HostParams
+	//	*ClientParams_BotParams
+	Payload       isClientParams_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClientParams) Reset() {
+	*x = ClientParams{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientParams) ProtoMessage() {}
+
+func (x *ClientParams) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientParams.ProtoReflect.Descriptor instead.
+func (*ClientParams) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ClientParams) GetPayload() isClientParams_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *ClientParams) GetHostParams() *HostParams {
+	if x != nil {
+		if x, ok := x.Payload.(*ClientParams_HostParams); ok {
+			return x.HostParams
+		}
+	}
+	return nil
+}
+
+func (x *ClientParams) GetBotParams() *BotParams {
+	if x != nil {
+		if x, ok := x.Payload.(*ClientParams_BotParams); ok {
+			return x.BotParams
+		}
+	}
+	return nil
+}
+
+type isClientParams_Payload interface {
+	isClientParams_Payload()
+}
+
+type ClientParams_HostParams struct {
+	HostParams *HostParams `protobuf:"bytes,1,opt,name=host_params,json=hostParams,proto3,oneof"`
+}
+
+type ClientParams_BotParams struct {
+	BotParams *BotParams `protobuf:"bytes,2,opt,name=bot_params,json=botParams,proto3,oneof"`
+}
+
+func (*ClientParams_HostParams) isClientParams_Payload() {}
+
+func (*ClientParams_BotParams) isClientParams_Payload() {}
+
+// TokenInit is sent by the client in response to the ServerInit message for
+// the Token join method.
+//
+// The Token method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: TokenInit
+// 4. server->client: Result
+type TokenInit struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams  *ClientParams `protobuf:"bytes,1,opt,name=client_params,json=clientParams,proto3" json:"client_params,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TokenInit) Reset() {
+	*x = TokenInit{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TokenInit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TokenInit) ProtoMessage() {}
+
+func (x *TokenInit) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TokenInit.ProtoReflect.Descriptor instead.
+func (*TokenInit) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *TokenInit) GetClientParams() *ClientParams {
+	if x != nil {
+		return x.ClientParams
 	}
 	return nil
 }
@@ -168,6 +456,7 @@ type JoinRequest struct {
 	// Types that are valid to be assigned to Payload:
 	//
 	//	*JoinRequest_ClientInit
+	//	*JoinRequest_TokenInit
 	Payload       isJoinRequest_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -175,7 +464,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[1]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -187,7 +476,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[1]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -200,7 +489,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{1}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *JoinRequest) GetPayload() isJoinRequest_Payload {
@@ -219,6 +508,15 @@ func (x *JoinRequest) GetClientInit() *ClientInit {
 	return nil
 }
 
+func (x *JoinRequest) GetTokenInit() *TokenInit {
+	if x != nil {
+		if x, ok := x.Payload.(*JoinRequest_TokenInit); ok {
+			return x.TokenInit
+		}
+	}
+	return nil
+}
+
 type isJoinRequest_Payload interface {
 	isJoinRequest_Payload()
 }
@@ -227,21 +525,30 @@ type JoinRequest_ClientInit struct {
 	ClientInit *ClientInit `protobuf:"bytes,1,opt,name=client_init,json=clientInit,proto3,oneof"`
 }
 
+type JoinRequest_TokenInit struct {
+	TokenInit *TokenInit `protobuf:"bytes,2,opt,name=token_init,json=tokenInit,proto3,oneof"`
+}
+
 func (*JoinRequest_ClientInit) isJoinRequest_Payload() {}
+
+func (*JoinRequest_TokenInit) isJoinRequest_Payload() {}
 
 // ServerInit is the first message sent from the server in response to the
 // ClientInit message.
 type ServerInit struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// JoinMethod is the name of the selected join method.
-	JoinMethod    string `protobuf:"bytes,1,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	JoinMethod string `protobuf:"bytes,1,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
+	// SignatureAlgorithmSuite is the name of the signature algorithm suite
+	// currently configured for the cluster.
+	SignatureAlgorithmSuite string `protobuf:"bytes,2,opt,name=signature_algorithm_suite,json=signatureAlgorithmSuite,proto3" json:"signature_algorithm_suite,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *ServerInit) Reset() {
 	*x = ServerInit{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[2]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -253,7 +560,7 @@ func (x *ServerInit) String() string {
 func (*ServerInit) ProtoMessage() {}
 
 func (x *ServerInit) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[2]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -266,12 +573,19 @@ func (x *ServerInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerInit.ProtoReflect.Descriptor instead.
 func (*ServerInit) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{2}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ServerInit) GetJoinMethod() string {
 	if x != nil {
 		return x.JoinMethod
+	}
+	return ""
+}
+
+func (x *ServerInit) GetSignatureAlgorithmSuite() string {
+	if x != nil {
+		return x.SignatureAlgorithmSuite
 	}
 	return ""
 }
@@ -285,7 +599,7 @@ type Challenge struct {
 
 func (x *Challenge) Reset() {
 	*x = Challenge{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[3]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -297,7 +611,7 @@ func (x *Challenge) String() string {
 func (*Challenge) ProtoMessage() {}
 
 func (x *Challenge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[3]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -310,7 +624,7 @@ func (x *Challenge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Challenge.ProtoReflect.Descriptor instead.
 func (*Challenge) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{3}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{8}
 }
 
 // Result is the final message sent from the cluster back to the client, it
@@ -318,25 +632,18 @@ func (*Challenge) Descriptor() ([]byte, []int) {
 // and issued certificates.
 type Result struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// TlsCert is an X.509 certificate encoded in ASN.1 DER form.
-	TlsCert []byte `protobuf:"bytes,1,opt,name=tls_cert,json=tlsCert,proto3" json:"tls_cert,omitempty"`
-	// TlsCaCerts is a list of TLS certificate authorities that the agent should trust.
-	// Each certificate is encoding in ASN.1 DER form.
-	TlsCaCerts [][]byte `protobuf:"bytes,2,rep,name=tls_ca_certs,json=tlsCaCerts,proto3" json:"tls_ca_certs,omitempty"`
-	// SshCert is an SSH certificate encoded in SSH wire format.
-	SshCert []byte `protobuf:"bytes,3,opt,name=ssh_cert,json=sshCert,proto3" json:"ssh_cert,omitempty"`
-	// SshCaKey is a list of SSH certificate authority public keys that the agent should trust.
-	// Each CA key is encoded in SSH wire format.
-	SshCaKeys [][]byte `protobuf:"bytes,4,rep,name=ssh_ca_keys,json=sshCaKeys,proto3" json:"ssh_ca_keys,omitempty"`
-	// HostId is the unique ID assigned to the host.
-	HostId        *string `protobuf:"bytes,5,opt,name=host_id,json=hostId,proto3,oneof" json:"host_id,omitempty"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*Result_HostResult
+	//	*Result_BotResult
+	Payload       isResult_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[4]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -348,7 +655,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[4]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -361,42 +668,224 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{4}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *Result) GetTlsCert() []byte {
+func (x *Result) GetPayload() isResult_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *Result) GetHostResult() *HostResult {
+	if x != nil {
+		if x, ok := x.Payload.(*Result_HostResult); ok {
+			return x.HostResult
+		}
+	}
+	return nil
+}
+
+func (x *Result) GetBotResult() *BotResult {
+	if x != nil {
+		if x, ok := x.Payload.(*Result_BotResult); ok {
+			return x.BotResult
+		}
+	}
+	return nil
+}
+
+type isResult_Payload interface {
+	isResult_Payload()
+}
+
+type Result_HostResult struct {
+	HostResult *HostResult `protobuf:"bytes,1,opt,name=host_result,json=hostResult,proto3,oneof"`
+}
+
+type Result_BotResult struct {
+	BotResult *BotResult `protobuf:"bytes,2,opt,name=bot_result,json=botResult,proto3,oneof"`
+}
+
+func (*Result_HostResult) isResult_Payload() {}
+
+func (*Result_BotResult) isResult_Payload() {}
+
+// Certificates holds issued certificates and cluster CAs.
+type Certificates struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// TlsCert is an X.509 certificate encoded in ASN.1 DER form.
+	TlsCert []byte `protobuf:"bytes,1,opt,name=tls_cert,json=tlsCert,proto3" json:"tls_cert,omitempty"`
+	// TlsCaCerts is a list of TLS certificate authorities that the client should trust.
+	// Each certificate is encoding in ASN.1 DER form.
+	TlsCaCerts [][]byte `protobuf:"bytes,2,rep,name=tls_ca_certs,json=tlsCaCerts,proto3" json:"tls_ca_certs,omitempty"`
+	// SshCert is an SSH certificate encoded in SSH wire format.
+	SshCert []byte `protobuf:"bytes,3,opt,name=ssh_cert,json=sshCert,proto3" json:"ssh_cert,omitempty"`
+	// SshCaKey is a list of SSH certificate authority public keys that the client should trust.
+	// Each CA key is encoded in SSH wire format.
+	SshCaKeys     [][]byte `protobuf:"bytes,4,rep,name=ssh_ca_keys,json=sshCaKeys,proto3" json:"ssh_ca_keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Certificates) Reset() {
+	*x = Certificates{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Certificates) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Certificates) ProtoMessage() {}
+
+func (x *Certificates) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Certificates.ProtoReflect.Descriptor instead.
+func (*Certificates) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *Certificates) GetTlsCert() []byte {
 	if x != nil {
 		return x.TlsCert
 	}
 	return nil
 }
 
-func (x *Result) GetTlsCaCerts() [][]byte {
+func (x *Certificates) GetTlsCaCerts() [][]byte {
 	if x != nil {
 		return x.TlsCaCerts
 	}
 	return nil
 }
 
-func (x *Result) GetSshCert() []byte {
+func (x *Certificates) GetSshCert() []byte {
 	if x != nil {
 		return x.SshCert
 	}
 	return nil
 }
 
-func (x *Result) GetSshCaKeys() [][]byte {
+func (x *Certificates) GetSshCaKeys() [][]byte {
 	if x != nil {
 		return x.SshCaKeys
 	}
 	return nil
 }
 
-func (x *Result) GetHostId() string {
-	if x != nil && x.HostId != nil {
-		return *x.HostId
+// HostResult holds results for host joining.
+type HostResult struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Certificates holds issued certificates and cluster CAs.
+	Certificates *Certificates `protobuf:"bytes,1,opt,name=certificates,proto3" json:"certificates,omitempty"`
+	// HostId is the unique ID assigned to the host.
+	HostId        string `protobuf:"bytes,2,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostResult) Reset() {
+	*x = HostResult{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostResult) ProtoMessage() {}
+
+func (x *HostResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostResult.ProtoReflect.Descriptor instead.
+func (*HostResult) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *HostResult) GetCertificates() *Certificates {
+	if x != nil {
+		return x.Certificates
+	}
+	return nil
+}
+
+func (x *HostResult) GetHostId() string {
+	if x != nil {
+		return x.HostId
 	}
 	return ""
+}
+
+// HostResult holds results for bot joining.
+type BotResult struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Certificates holds issued certificates and cluster CAs.
+	Certificates  *Certificates `protobuf:"bytes,1,opt,name=certificates,proto3" json:"certificates,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BotResult) Reset() {
+	*x = BotResult{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BotResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BotResult) ProtoMessage() {}
+
+func (x *BotResult) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BotResult.ProtoReflect.Descriptor instead.
+func (*BotResult) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *BotResult) GetCertificates() *Certificates {
+	if x != nil {
+		return x.Certificates
+	}
+	return nil
 }
 
 // JoinResponse is the message type sent from the server to the joining client.
@@ -414,7 +903,7 @@ type JoinResponse struct {
 
 func (x *JoinResponse) Reset() {
 	*x = JoinResponse{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[5]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -426,7 +915,7 @@ func (x *JoinResponse) String() string {
 func (*JoinResponse) ProtoMessage() {}
 
 func (x *JoinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[5]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -439,7 +928,7 @@ func (x *JoinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinResponse.ProtoReflect.Descriptor instead.
 func (*JoinResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{5}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *JoinResponse) GetPayload() isJoinResponse_Payload {
@@ -506,120 +995,6 @@ func (*JoinResponse_Challenge) isJoinResponse_Payload() {}
 
 func (*JoinResponse_Result) isJoinResponse_Payload() {}
 
-// HostParams holds parameters that are specific to host joining and
-// irrelevant to bot joining.
-type ClientInit_HostParams struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// HostName is the user-friendly node name for the host. This comes from
-	// teleport.nodename in the service configuration and defaults to the
-	// hostname. It is encoded as a valid principal in issued certificates.
-	HostName string `protobuf:"bytes,1,opt,name=host_name,json=hostName,proto3" json:"host_name,omitempty"`
-	// AdditionalPrincipals is a list of additional principals requested.
-	AdditionalPrincipals []string `protobuf:"bytes,2,rep,name=additional_principals,json=additionalPrincipals,proto3" json:"additional_principals,omitempty"`
-	// DnsNames is a list of DNS names requested for inclusion in the x509 certificate.
-	DnsNames      []string `protobuf:"bytes,3,rep,name=dns_names,json=dnsNames,proto3" json:"dns_names,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ClientInit_HostParams) Reset() {
-	*x = ClientInit_HostParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[6]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ClientInit_HostParams) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ClientInit_HostParams) ProtoMessage() {}
-
-func (x *ClientInit_HostParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[6]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ClientInit_HostParams.ProtoReflect.Descriptor instead.
-func (*ClientInit_HostParams) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{0, 0}
-}
-
-func (x *ClientInit_HostParams) GetHostName() string {
-	if x != nil {
-		return x.HostName
-	}
-	return ""
-}
-
-func (x *ClientInit_HostParams) GetAdditionalPrincipals() []string {
-	if x != nil {
-		return x.AdditionalPrincipals
-	}
-	return nil
-}
-
-func (x *ClientInit_HostParams) GetDnsNames() []string {
-	if x != nil {
-		return x.DnsNames
-	}
-	return nil
-}
-
-// BotParams holds parameters that are specific to bot joining and irrelevant
-// to host joining.
-type ClientInit_BotParams struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Expires is a desired time of the expiry of the returned certificates.
-	Expires       *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=expires,proto3,oneof" json:"expires,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ClientInit_BotParams) Reset() {
-	*x = ClientInit_BotParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[7]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ClientInit_BotParams) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ClientInit_BotParams) ProtoMessage() {}
-
-func (x *ClientInit_BotParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[7]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ClientInit_BotParams.ProtoReflect.Descriptor instead.
-func (*ClientInit_BotParams) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{0, 1}
-}
-
-func (x *ClientInit_BotParams) GetExpires() *timestamppb.Timestamp {
-	if x != nil {
-		return x.Expires
-	}
-	return nil
-}
-
 // ProxySuppliedParams holds parameters set by the Proxy when nodes join
 // via the proxy address. They must only be trusted if the incoming join
 // request is authenticated as the Proxy.
@@ -636,7 +1011,7 @@ type ClientInit_ProxySuppliedParams struct {
 
 func (x *ClientInit_ProxySuppliedParams) Reset() {
 	*x = ClientInit_ProxySuppliedParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[8]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -648,7 +1023,7 @@ func (x *ClientInit_ProxySuppliedParams) String() string {
 func (*ClientInit_ProxySuppliedParams) ProtoMessage() {}
 
 func (x *ClientInit_ProxySuppliedParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[8]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -661,7 +1036,7 @@ func (x *ClientInit_ProxySuppliedParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientInit_ProxySuppliedParams.ProtoReflect.Descriptor instead.
 func (*ClientInit_ProxySuppliedParams) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{0, 2}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{0, 0}
 }
 
 func (x *ClientInit_ProxySuppliedParams) GetRemoteAddr() string {
@@ -682,7 +1057,7 @@ var File_teleport_join_v1_joinservice_proto protoreflect.FileDescriptor
 
 const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf7\x06\n" +
+	"\"teleport/join/v1/joinservice.proto\x12\x10teleport.join.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa0\x03\n" +
 	"\n" +
 	"ClientInit\x12$\n" +
 	"\vjoin_method\x18\x01 \x01(\tH\x00R\n" +
@@ -690,50 +1065,70 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\n" +
 	"token_name\x18\x02 \x01(\tR\ttokenName\x12\x1f\n" +
 	"\vsystem_role\x18\x03 \x01(\tR\n" +
-	"systemRole\x12$\n" +
-	"\x0epublic_tls_key\x18\x04 \x01(\fR\fpublicTlsKey\x12$\n" +
-	"\x0epublic_ssh_key\x18\x05 \x01(\fR\fpublicSshKey\x12,\n" +
-	"\x12forwarded_by_proxy\x18\x06 \x01(\bR\x10forwardedByProxy\x12M\n" +
-	"\vhost_params\x18\a \x01(\v2'.teleport.join.v1.ClientInit.HostParamsH\x01R\n" +
-	"hostParams\x88\x01\x01\x12J\n" +
-	"\n" +
-	"bot_params\x18\b \x01(\v2&.teleport.join.v1.ClientInit.BotParamsH\x02R\tbotParams\x88\x01\x01\x12q\n" +
-	"\x19proxy_supplied_parameters\x18\t \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x03R\x17proxySuppliedParameters\x88\x01\x01\x1a{\n" +
-	"\n" +
-	"HostParams\x12\x1b\n" +
-	"\thost_name\x18\x01 \x01(\tR\bhostName\x123\n" +
-	"\x15additional_principals\x18\x02 \x03(\tR\x14additionalPrincipals\x12\x1b\n" +
-	"\tdns_names\x18\x03 \x03(\tR\bdnsNames\x1aR\n" +
-	"\tBotParams\x129\n" +
-	"\aexpires\x18\t \x01(\v2\x1a.google.protobuf.TimestampH\x00R\aexpires\x88\x01\x01B\n" +
-	"\n" +
-	"\b_expires\x1a]\n" +
+	"systemRole\x12,\n" +
+	"\x12forwarded_by_proxy\x18\x06 \x01(\bR\x10forwardedByProxy\x12q\n" +
+	"\x19proxy_supplied_parameters\x18\a \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x1a]\n" +
 	"\x13ProxySuppliedParams\x12\x1f\n" +
 	"\vremote_addr\x18\x01 \x01(\tR\n" +
 	"remoteAddr\x12%\n" +
 	"\x0eclient_version\x18\x02 \x01(\tR\rclientVersionB\x0e\n" +
-	"\f_join_methodB\x0e\n" +
-	"\f_host_paramsB\r\n" +
-	"\v_bot_paramsB\x1c\n" +
-	"\x1a_proxy_supplied_parameters\"Y\n" +
+	"\f_join_methodB\x1c\n" +
+	"\x1a_proxy_supplied_parameters\"X\n" +
+	"\n" +
+	"PublicKeys\x12$\n" +
+	"\x0epublic_tls_key\x18\x04 \x01(\fR\fpublicTlsKey\x12$\n" +
+	"\x0epublic_ssh_key\x18\x05 \x01(\fR\fpublicSshKey\"\xba\x01\n" +
+	"\n" +
+	"HostParams\x12=\n" +
+	"\vpublic_keys\x18\x01 \x01(\v2\x1c.teleport.join.v1.PublicKeysR\n" +
+	"publicKeys\x12\x1b\n" +
+	"\thost_name\x18\x02 \x01(\tR\bhostName\x123\n" +
+	"\x15additional_principals\x18\x03 \x03(\tR\x14additionalPrincipals\x12\x1b\n" +
+	"\tdns_names\x18\x04 \x03(\tR\bdnsNames\"\x91\x01\n" +
+	"\tBotParams\x12=\n" +
+	"\vpublic_keys\x18\x01 \x01(\v2\x1c.teleport.join.v1.PublicKeysR\n" +
+	"publicKeys\x129\n" +
+	"\aexpires\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\aexpires\x88\x01\x01B\n" +
+	"\n" +
+	"\b_expires\"\x98\x01\n" +
+	"\fClientParams\x12?\n" +
+	"\vhost_params\x18\x01 \x01(\v2\x1c.teleport.join.v1.HostParamsH\x00R\n" +
+	"hostParams\x12<\n" +
+	"\n" +
+	"bot_params\x18\x02 \x01(\v2\x1b.teleport.join.v1.BotParamsH\x00R\tbotParamsB\t\n" +
+	"\apayload\"P\n" +
+	"\tTokenInit\x12C\n" +
+	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\"\x97\x01\n" +
 	"\vJoinRequest\x12?\n" +
 	"\vclient_init\x18\x01 \x01(\v2\x1c.teleport.join.v1.ClientInitH\x00R\n" +
-	"clientInitB\t\n" +
-	"\apayload\"-\n" +
+	"clientInit\x12<\n" +
+	"\n" +
+	"token_init\x18\x02 \x01(\v2\x1b.teleport.join.v1.TokenInitH\x00R\ttokenInitB\t\n" +
+	"\apayload\"i\n" +
 	"\n" +
 	"ServerInit\x12\x1f\n" +
 	"\vjoin_method\x18\x01 \x01(\tR\n" +
-	"joinMethod\"\v\n" +
-	"\tChallenge\"\xaa\x01\n" +
-	"\x06Result\x12\x19\n" +
+	"joinMethod\x12:\n" +
+	"\x19signature_algorithm_suite\x18\x02 \x01(\tR\x17signatureAlgorithmSuite\"\v\n" +
+	"\tChallenge\"\x92\x01\n" +
+	"\x06Result\x12?\n" +
+	"\vhost_result\x18\x01 \x01(\v2\x1c.teleport.join.v1.HostResultH\x00R\n" +
+	"hostResult\x12<\n" +
+	"\n" +
+	"bot_result\x18\x02 \x01(\v2\x1b.teleport.join.v1.BotResultH\x00R\tbotResultB\t\n" +
+	"\apayload\"\x86\x01\n" +
+	"\fCertificates\x12\x19\n" +
 	"\btls_cert\x18\x01 \x01(\fR\atlsCert\x12 \n" +
 	"\ftls_ca_certs\x18\x02 \x03(\fR\n" +
 	"tlsCaCerts\x12\x19\n" +
 	"\bssh_cert\x18\x03 \x01(\fR\asshCert\x12\x1e\n" +
-	"\vssh_ca_keys\x18\x04 \x03(\fR\tsshCaKeys\x12\x1c\n" +
-	"\ahost_id\x18\x05 \x01(\tH\x00R\x06hostId\x88\x01\x01B\n" +
+	"\vssh_ca_keys\x18\x04 \x03(\fR\tsshCaKeys\"i\n" +
 	"\n" +
-	"\b_host_id\"\xbe\x01\n" +
+	"HostResult\x12B\n" +
+	"\fcertificates\x18\x01 \x01(\v2\x1e.teleport.join.v1.CertificatesR\fcertificates\x12\x17\n" +
+	"\ahost_id\x18\x02 \x01(\tR\x06hostId\"O\n" +
+	"\tBotResult\x12B\n" +
+	"\fcertificates\x18\x01 \x01(\v2\x1e.teleport.join.v1.CertificatesR\fcertificates\"\xbe\x01\n" +
 	"\fJoinResponse\x122\n" +
 	"\x04init\x18\x01 \x01(\v2\x1c.teleport.join.v1.ServerInitH\x00R\x04init\x12;\n" +
 	"\tchallenge\x18\x02 \x01(\v2\x1b.teleport.join.v1.ChallengeH\x00R\tchallenge\x122\n" +
@@ -754,35 +1149,49 @@ func file_teleport_join_v1_joinservice_proto_rawDescGZIP() []byte {
 	return file_teleport_join_v1_joinservice_proto_rawDescData
 }
 
-var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_join_v1_joinservice_proto_goTypes = []any{
 	(*ClientInit)(nil),                     // 0: teleport.join.v1.ClientInit
-	(*JoinRequest)(nil),                    // 1: teleport.join.v1.JoinRequest
-	(*ServerInit)(nil),                     // 2: teleport.join.v1.ServerInit
-	(*Challenge)(nil),                      // 3: teleport.join.v1.Challenge
-	(*Result)(nil),                         // 4: teleport.join.v1.Result
-	(*JoinResponse)(nil),                   // 5: teleport.join.v1.JoinResponse
-	(*ClientInit_HostParams)(nil),          // 6: teleport.join.v1.ClientInit.HostParams
-	(*ClientInit_BotParams)(nil),           // 7: teleport.join.v1.ClientInit.BotParams
-	(*ClientInit_ProxySuppliedParams)(nil), // 8: teleport.join.v1.ClientInit.ProxySuppliedParams
-	(*timestamppb.Timestamp)(nil),          // 9: google.protobuf.Timestamp
+	(*PublicKeys)(nil),                     // 1: teleport.join.v1.PublicKeys
+	(*HostParams)(nil),                     // 2: teleport.join.v1.HostParams
+	(*BotParams)(nil),                      // 3: teleport.join.v1.BotParams
+	(*ClientParams)(nil),                   // 4: teleport.join.v1.ClientParams
+	(*TokenInit)(nil),                      // 5: teleport.join.v1.TokenInit
+	(*JoinRequest)(nil),                    // 6: teleport.join.v1.JoinRequest
+	(*ServerInit)(nil),                     // 7: teleport.join.v1.ServerInit
+	(*Challenge)(nil),                      // 8: teleport.join.v1.Challenge
+	(*Result)(nil),                         // 9: teleport.join.v1.Result
+	(*Certificates)(nil),                   // 10: teleport.join.v1.Certificates
+	(*HostResult)(nil),                     // 11: teleport.join.v1.HostResult
+	(*BotResult)(nil),                      // 12: teleport.join.v1.BotResult
+	(*JoinResponse)(nil),                   // 13: teleport.join.v1.JoinResponse
+	(*ClientInit_ProxySuppliedParams)(nil), // 14: teleport.join.v1.ClientInit.ProxySuppliedParams
+	(*timestamppb.Timestamp)(nil),          // 15: google.protobuf.Timestamp
 }
 var file_teleport_join_v1_joinservice_proto_depIdxs = []int32{
-	6, // 0: teleport.join.v1.ClientInit.host_params:type_name -> teleport.join.v1.ClientInit.HostParams
-	7, // 1: teleport.join.v1.ClientInit.bot_params:type_name -> teleport.join.v1.ClientInit.BotParams
-	8, // 2: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
-	0, // 3: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
-	2, // 4: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
-	3, // 5: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
-	4, // 6: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
-	9, // 7: teleport.join.v1.ClientInit.BotParams.expires:type_name -> google.protobuf.Timestamp
-	1, // 8: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
-	5, // 9: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
-	9, // [9:10] is the sub-list for method output_type
-	8, // [8:9] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	14, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
+	1,  // 1: teleport.join.v1.HostParams.public_keys:type_name -> teleport.join.v1.PublicKeys
+	1,  // 2: teleport.join.v1.BotParams.public_keys:type_name -> teleport.join.v1.PublicKeys
+	15, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
+	2,  // 4: teleport.join.v1.ClientParams.host_params:type_name -> teleport.join.v1.HostParams
+	3,  // 5: teleport.join.v1.ClientParams.bot_params:type_name -> teleport.join.v1.BotParams
+	4,  // 6: teleport.join.v1.TokenInit.client_params:type_name -> teleport.join.v1.ClientParams
+	0,  // 7: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
+	5,  // 8: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
+	11, // 9: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
+	12, // 10: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
+	10, // 11: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
+	10, // 12: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
+	7,  // 13: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
+	8,  // 14: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
+	9,  // 15: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
+	6,  // 16: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
+	13, // 17: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
+	17, // [17:18] is the sub-list for method output_type
+	16, // [16:17] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_teleport_join_v1_joinservice_proto_init() }
@@ -791,23 +1200,31 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		return
 	}
 	file_teleport_join_v1_joinservice_proto_msgTypes[0].OneofWrappers = []any{}
-	file_teleport_join_v1_joinservice_proto_msgTypes[1].OneofWrappers = []any{
-		(*JoinRequest_ClientInit)(nil),
+	file_teleport_join_v1_joinservice_proto_msgTypes[3].OneofWrappers = []any{}
+	file_teleport_join_v1_joinservice_proto_msgTypes[4].OneofWrappers = []any{
+		(*ClientParams_HostParams)(nil),
+		(*ClientParams_BotParams)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[4].OneofWrappers = []any{}
-	file_teleport_join_v1_joinservice_proto_msgTypes[5].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[6].OneofWrappers = []any{
+		(*JoinRequest_ClientInit)(nil),
+		(*JoinRequest_TokenInit)(nil),
+	}
+	file_teleport_join_v1_joinservice_proto_msgTypes[9].OneofWrappers = []any{
+		(*Result_HostResult)(nil),
+		(*Result_BotResult)(nil),
+	}
+	file_teleport_join_v1_joinservice_proto_msgTypes[13].OneofWrappers = []any{
 		(*JoinResponse_Init)(nil),
 		(*JoinResponse_Challenge)(nil),
 		(*JoinResponse_Result)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_join_v1_joinservice_proto_rawDesc), len(file_teleport_join_v1_joinservice_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -55,8 +55,8 @@ type ClientInit struct {
 	// Proxy service. When this is set the Auth service must ignore any
 	// any credentials authenticating the request, except for the purpose of
 	// accepting ProxySuppliedParams.
-	ForwardedByProxy        bool                            `protobuf:"varint,6,opt,name=forwarded_by_proxy,json=forwardedByProxy,proto3" json:"forwarded_by_proxy,omitempty"`
-	ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,7,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof" json:"proxy_supplied_parameters,omitempty"`
+	ForwardedByProxy        bool                            `protobuf:"varint,4,opt,name=forwarded_by_proxy,json=forwardedByProxy,proto3" json:"forwarded_by_proxy,omitempty"`
+	ProxySuppliedParameters *ClientInit_ProxySuppliedParams `protobuf:"bytes,5,opt,name=proxy_supplied_parameters,json=proxySuppliedParameters,proto3,oneof" json:"proxy_supplied_parameters,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -132,10 +132,10 @@ type PublicKeys struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// PublicTlsKey is the public key requested for the subject of the x509 certificate.
 	// It must be encoded in PKIX, ASN.1 DER form.
-	PublicTlsKey []byte `protobuf:"bytes,4,opt,name=public_tls_key,json=publicTlsKey,proto3" json:"public_tls_key,omitempty"`
+	PublicTlsKey []byte `protobuf:"bytes,1,opt,name=public_tls_key,json=publicTlsKey,proto3" json:"public_tls_key,omitempty"`
 	// PublicSshKey is the public key requested for the subject of the SSH certificate.
 	// It must be encoded in SSH wire format.
-	PublicSshKey  []byte `protobuf:"bytes,5,opt,name=public_ssh_key,json=publicSshKey,proto3" json:"public_ssh_key,omitempty"`
+	PublicSshKey  []byte `protobuf:"bytes,2,opt,name=public_ssh_key,json=publicSshKey,proto3" json:"public_ssh_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1066,8 +1066,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"token_name\x18\x02 \x01(\tR\ttokenName\x12\x1f\n" +
 	"\vsystem_role\x18\x03 \x01(\tR\n" +
 	"systemRole\x12,\n" +
-	"\x12forwarded_by_proxy\x18\x06 \x01(\bR\x10forwardedByProxy\x12q\n" +
-	"\x19proxy_supplied_parameters\x18\a \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x1a]\n" +
+	"\x12forwarded_by_proxy\x18\x04 \x01(\bR\x10forwardedByProxy\x12q\n" +
+	"\x19proxy_supplied_parameters\x18\x05 \x01(\v20.teleport.join.v1.ClientInit.ProxySuppliedParamsH\x01R\x17proxySuppliedParameters\x88\x01\x01\x1a]\n" +
 	"\x13ProxySuppliedParams\x12\x1f\n" +
 	"\vremote_addr\x18\x01 \x01(\tR\n" +
 	"remoteAddr\x12%\n" +
@@ -1076,8 +1076,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\x1a_proxy_supplied_parameters\"X\n" +
 	"\n" +
 	"PublicKeys\x12$\n" +
-	"\x0epublic_tls_key\x18\x04 \x01(\fR\fpublicTlsKey\x12$\n" +
-	"\x0epublic_ssh_key\x18\x05 \x01(\fR\fpublicSshKey\"\xba\x01\n" +
+	"\x0epublic_tls_key\x18\x01 \x01(\fR\fpublicTlsKey\x12$\n" +
+	"\x0epublic_ssh_key\x18\x02 \x01(\fR\fpublicSshKey\"\xba\x01\n" +
 	"\n" +
 	"HostParams\x12=\n" +
 	"\vpublic_keys\x18\x01 \x01(\v2\x1c.teleport.join.v1.PublicKeysR\n" +

--- a/api/gen/proto/go/teleport/join/v1/joinservice_grpc.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice_grpc.pb.go
@@ -70,8 +70,8 @@ type JoinServiceClient interface {
 	// The client must send an ClientInit message on the JoinRequest stream to
 	// initiate the join flow.
 	//
-	// The server will reply with a JoinResponse where the payload will vary
-	// based on the join method specified in the provision token.
+	// The server will reply with a ServerInit message, and subsequent messages
+	// on the stream will depend on the join method.
 	Join(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[JoinRequest, JoinResponse], error)
 }
 
@@ -130,8 +130,8 @@ type JoinServiceServer interface {
 	// The client must send an ClientInit message on the JoinRequest stream to
 	// initiate the join flow.
 	//
-	// The server will reply with a JoinResponse where the payload will vary
-	// based on the join method specified in the provision token.
+	// The server will reply with a ServerInit message, and subsequent messages
+	// on the stream will depend on the join method.
 	Join(grpc.BidiStreamingServer[JoinRequest, JoinResponse]) error
 	mustEmbedUnimplementedJoinServiceServer()
 }

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -38,7 +38,7 @@ message ClientInit {
   // Proxy service. When this is set the Auth service must ignore any
   // any credentials authenticating the request, except for the purpose of
   // accepting ProxySuppliedParams.
-  bool forwarded_by_proxy = 6;
+  bool forwarded_by_proxy = 4;
 
   // ProxySuppliedParams holds parameters set by the Proxy when nodes join
   // via the proxy address. They must only be trusted if the incoming join
@@ -50,7 +50,7 @@ message ClientInit {
     // ClientVersion is the Teleport version of the client attempting to join.
     string client_version = 2;
   }
-  optional ProxySuppliedParams proxy_supplied_parameters = 7;
+  optional ProxySuppliedParams proxy_supplied_parameters = 5;
 }
 
 // PublicKeys holds public keys sent by the client requested subject keys for
@@ -58,10 +58,10 @@ message ClientInit {
 message PublicKeys {
   // PublicTlsKey is the public key requested for the subject of the x509 certificate.
   // It must be encoded in PKIX, ASN.1 DER form.
-  bytes public_tls_key = 4;
+  bytes public_tls_key = 1;
   // PublicSshKey is the public key requested for the subject of the SSH certificate.
   // It must be encoded in SSH wire format.
-  bytes public_ssh_key = 5;
+  bytes public_ssh_key = 2;
 }
 
 // HostParams holds parameters required for host joining.

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -34,39 +34,11 @@ message ClientInit {
   string token_name = 2;
   // SystemRole is the system role requested, e.g. Proxy, Node, Instance, Bot.
   string system_role = 3;
-  // PublicTlsKey is the public key requested for the subject of the x509 certificate.
-  // It must be encoded in PKIX, ASN.1 DER form.
-  bytes public_tls_key = 4;
-  // PublicSshKey is the public key requested for the subject of the SSH certificate.
-  // It must be encoded in SSH wire format.
-  bytes public_ssh_key = 5;
   // ForwardedByProxy will be set to true when the message is forwarded by the
   // Proxy service. When this is set the Auth service must ignore any
   // any credentials authenticating the request, except for the purpose of
   // accepting ProxySuppliedParams.
   bool forwarded_by_proxy = 6;
-
-  // HostParams holds parameters that are specific to host joining and
-  // irrelevant to bot joining.
-  message HostParams {
-    // HostName is the user-friendly node name for the host. This comes from
-    // teleport.nodename in the service configuration and defaults to the
-    // hostname. It is encoded as a valid principal in issued certificates.
-    string host_name = 1;
-    // AdditionalPrincipals is a list of additional principals requested.
-    repeated string additional_principals = 2;
-    // DnsNames is a list of DNS names requested for inclusion in the x509 certificate.
-    repeated string dns_names = 3;
-  }
-  optional HostParams host_params = 7;
-
-  // BotParams holds parameters that are specific to bot joining and irrelevant
-  // to host joining.
-  message BotParams {
-    // Expires is a desired time of the expiry of the returned certificates.
-    optional google.protobuf.Timestamp expires = 9;
-  }
-  optional BotParams bot_params = 8;
 
   // ProxySuppliedParams holds parameters set by the Proxy when nodes join
   // via the proxy address. They must only be trusted if the incoming join
@@ -78,13 +50,68 @@ message ClientInit {
     // ClientVersion is the Teleport version of the client attempting to join.
     string client_version = 2;
   }
-  optional ProxySuppliedParams proxy_supplied_parameters = 9;
+  optional ProxySuppliedParams proxy_supplied_parameters = 7;
+}
+
+// PublicKeys holds public keys sent by the client requested subject keys for
+// issued certificates.
+message PublicKeys {
+  // PublicTlsKey is the public key requested for the subject of the x509 certificate.
+  // It must be encoded in PKIX, ASN.1 DER form.
+  bytes public_tls_key = 4;
+  // PublicSshKey is the public key requested for the subject of the SSH certificate.
+  // It must be encoded in SSH wire format.
+  bytes public_ssh_key = 5;
+}
+
+// HostParams holds parameters required for host joining.
+message HostParams {
+  // PublicKeys holds the host public keys.
+  PublicKeys public_keys = 1;
+  // HostName is the user-friendly node name for the host. This comes from
+  // teleport.nodename in the service configuration and defaults to the
+  // hostname. It is encoded as a valid principal in issued certificates.
+  string host_name = 2;
+  // AdditionalPrincipals is a list of additional principals requested.
+  repeated string additional_principals = 3;
+  // DnsNames is a list of DNS names requested for inclusion in the x509 certificate.
+  repeated string dns_names = 4;
+}
+
+// BotParams holds parameters required for bot joining.
+message BotParams {
+  // PublicKeys holds the bot public keys.
+  PublicKeys public_keys = 1;
+  // Expires is a desired time of the expiry of the returned certificates.
+  optional google.protobuf.Timestamp expires = 2;
+}
+
+// ClientParams holds either host or bot join parameters.
+message ClientParams {
+  oneof payload {
+    HostParams host_params = 1;
+    BotParams bot_params = 2;
+  }
+}
+
+// TokenInit is sent by the client in response to the ServerInit message for
+// the Token join method.
+//
+// The Token method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: TokenInit
+// 4. server->client: Result
+message TokenInit {
+  // ClientParams holds parameters for the specific type of client trying to join.
+  ClientParams client_params = 1;
 }
 
 // JoinRequest is the message type sent from the joining client to the server.
 message JoinRequest {
   oneof payload {
     ClientInit client_init = 1;
+    TokenInit token_init = 2;
   }
 }
 
@@ -93,6 +120,9 @@ message JoinRequest {
 message ServerInit {
   // JoinMethod is the name of the selected join method.
   string join_method = 1;
+  // SignatureAlgorithmSuite is the name of the signature algorithm suite
+  // currently configured for the cluster.
+  string signature_algorithm_suite = 2;
 }
 
 // Challenge is a challenge message sent from the server that the client must solve.
@@ -102,18 +132,38 @@ message Challenge {}
 // contains the result of the joining process including the assigned host ID
 // and issued certificates.
 message Result {
+  oneof payload {
+    HostResult host_result = 1;
+    BotResult bot_result = 2;
+  }
+}
+
+// Certificates holds issued certificates and cluster CAs.
+message Certificates {
   // TlsCert is an X.509 certificate encoded in ASN.1 DER form.
   bytes tls_cert = 1;
-  // TlsCaCerts is a list of TLS certificate authorities that the agent should trust.
+  // TlsCaCerts is a list of TLS certificate authorities that the client should trust.
   // Each certificate is encoding in ASN.1 DER form.
   repeated bytes tls_ca_certs = 2;
   // SshCert is an SSH certificate encoded in SSH wire format.
   bytes ssh_cert = 3;
-  // SshCaKey is a list of SSH certificate authority public keys that the agent should trust.
+  // SshCaKey is a list of SSH certificate authority public keys that the client should trust.
   // Each CA key is encoded in SSH wire format.
   repeated bytes ssh_ca_keys = 4;
+}
+
+// HostResult holds results for host joining.
+message HostResult {
+  // Certificates holds issued certificates and cluster CAs.
+  Certificates certificates = 1;
   // HostId is the unique ID assigned to the host.
-  optional string host_id = 5;
+  string host_id = 2;
+}
+
+// HostResult holds results for bot joining.
+message BotResult {
+  // Certificates holds issued certificates and cluster CAs.
+  Certificates certificates = 1;
 }
 
 // JoinResponse is the message type sent from the server to the joining client.
@@ -163,7 +213,7 @@ service JoinService {
   // The client must send an ClientInit message on the JoinRequest stream to
   // initiate the join flow.
   //
-  // The server will reply with a JoinResponse where the payload will vary
-  // based on the join method specified in the provision token.
+  // The server will reply with a ServerInit message, and subsequent messages
+  // on the stream will depend on the join method.
   rpc Join(stream JoinRequest) returns (stream JoinResponse);
 }

--- a/api/types/signaturealgorithmsuite.go
+++ b/api/types/signaturealgorithmsuite.go
@@ -37,6 +37,20 @@ func (s SignatureAlgorithmSuite) MarshalText() ([]byte, error) {
 	}
 }
 
+// SignatureAlgorithmSuiteToString converts a [SignatureAlgorithmSuite] to a user-friendly string.
+func SignatureAlgorithmSuiteToString(s SignatureAlgorithmSuite) string {
+	// The MarshalText impl directly above never returns an error.
+	text, _ := s.MarshalText()
+	return string(text)
+}
+
+// SignatureAlgorithmSuiteFromString parses a string to return a [SignatureAlgorithmSuite].
+func SignatureAlgorithmSuiteFromString(str string) (SignatureAlgorithmSuite, error) {
+	var suite SignatureAlgorithmSuite
+	err := suite.UnmarshalText([]byte(str))
+	return suite, trace.Wrap(err)
+}
+
 // UnmarshalJSON unmarshals a SignatureAlgorithmSuite and supports the custom
 // string format or numeric types matching an enum value.
 func (s *SignatureAlgorithmSuite) UnmarshalJSON(data []byte) error {

--- a/api/types/signaturealgorithmsuite.go
+++ b/api/types/signaturealgorithmsuite.go
@@ -20,28 +20,20 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// MarshalText marshals a SignatureAlgorithmSuite value to text. This gets used
-// by json.Marshal.
-func (s SignatureAlgorithmSuite) MarshalText() ([]byte, error) {
-	switch s {
-	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_LEGACY:
-		return []byte("legacy"), nil
-	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1:
-		return []byte("balanced-v1"), nil
-	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_FIPS_V1:
-		return []byte("fips-v1"), nil
-	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1:
-		return []byte("hsm-v1"), nil
-	default:
-		return []byte(s.String()), nil
-	}
-}
-
 // SignatureAlgorithmSuiteToString converts a [SignatureAlgorithmSuite] to a user-friendly string.
 func SignatureAlgorithmSuiteToString(s SignatureAlgorithmSuite) string {
-	// The MarshalText impl directly above never returns an error.
-	text, _ := s.MarshalText()
-	return string(text)
+	switch s {
+	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_LEGACY:
+		return "legacy"
+	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1:
+		return "balanced-v1"
+	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_FIPS_V1:
+		return "fips-v1"
+	case SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_HSM_V1:
+		return "hsm-v1"
+	default:
+		return s.String()
+	}
 }
 
 // SignatureAlgorithmSuiteFromString parses a string to return a [SignatureAlgorithmSuite].
@@ -49,6 +41,12 @@ func SignatureAlgorithmSuiteFromString(str string) (SignatureAlgorithmSuite, err
 	var suite SignatureAlgorithmSuite
 	err := suite.UnmarshalText([]byte(str))
 	return suite, trace.Wrap(err)
+}
+
+// MarshalText marshals a SignatureAlgorithmSuite value to text. This gets used
+// by json.Marshal.
+func (s SignatureAlgorithmSuite) MarshalText() ([]byte, error) {
+	return []byte(SignatureAlgorithmSuiteToString(s)), nil
 }
 
 // UnmarshalJSON unmarshals a SignatureAlgorithmSuite and supports the custom

--- a/buf.yaml
+++ b/buf.yaml
@@ -86,6 +86,8 @@ breaking:
   ignore:
     # TODO(codingllama): Remove ignore once the PDP API is stable.
     - api/proto/teleport/decision/v1alpha1
+    # TODO(nklaassen): Remove ignore once the new join API is stable.
+    - api/proto/teleport/join/v1
 
 plugins:
   - plugin:

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 )
 
@@ -52,23 +53,11 @@ type ClientInit struct {
 	TokenName string
 	// SystemRole is the system role requested, e.g. Proxy, Node, Instance, Bot.
 	SystemRole string
-	// PublicTlsKey is the public key requested for the subject of the x509 certificate.
-	// It must be encoded in PKIX, ASN.1 DER form.
-	PublicTLSKey []byte
-	// PublicSshKey is the public key requested for the subject of the SSH certificate.
-	// It must be encoded in SSH wire format.
-	PublicSSHKey []byte
 	// ForwardedByProxy will be set to true when the message is forwarded by the
 	// Proxy service. When this is set the Auth service must ignore any
 	// any credentials authenticating the request, except for the purpose of
 	// accepting ProxySuppliedParameters.
 	ForwardedByProxy bool
-	// HostParams holds parameters that are specific to host joining and
-	// irrelevant to bot joining.
-	HostParams *HostParams
-	// BotParams holds parameters that are specific to bot joining and
-	// irrelevant to host joining.
-	BotParams *BotParams
 	// ProxySuppliedParams holds parameters added by the Proxy when
 	// nodes join via the proxy address. They must only be trusted if the
 	// incoming join request is authenticated as the Proxy.
@@ -81,20 +70,6 @@ func (i *ClientInit) Check() error {
 		return trace.BadParameter("TokenName is required")
 	case i.SystemRole == "":
 		return trace.BadParameter("SystemRole is required")
-	case len(i.PublicTLSKey) == 0:
-		return trace.BadParameter("PublicTLSKey is required")
-	case len(i.PublicSSHKey) == 0:
-		return trace.BadParameter("PublicSSHKey is required")
-	case i.HostParams == nil && i.BotParams == nil:
-		return trace.BadParameter("HostParams or BotParams must be set")
-	case i.HostParams != nil && i.BotParams != nil:
-		return trace.BadParameter("HostParams and BotParams cannot both be set")
-	}
-	if err := i.HostParams.check(); err != nil {
-		return trace.Wrap(err, "checking HostParams")
-	}
-	if err := i.BotParams.check(); err != nil {
-		return trace.Wrap(err, "checking BotParams")
 	}
 	return nil
 }
@@ -110,9 +85,52 @@ type ProxySuppliedParams struct {
 	ClientVersion string
 }
 
+// TokenInit is sent by the client in response to the ServerInit message for
+// the Token join method.
+//
+// The Token method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: TokenInit
+// 4. server->client: Result
+type TokenInit struct {
+	embedRequest
+
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams ClientParams
+}
+
+func (i *TokenInit) Check() error {
+	return trace.Wrap(i.ClientParams.check(), "checking ClientParams")
+}
+
+// ClientParams holds either host or bot join parameters.
+type ClientParams struct {
+	HostParams *HostParams
+	BotParams  *BotParams
+}
+
+func (p *ClientParams) check() error {
+	switch {
+	case p.HostParams == nil && p.BotParams == nil:
+		return trace.BadParameter("HostParams or BotParams must be set")
+	case p.HostParams != nil && p.BotParams != nil:
+		return trace.BadParameter("HostParams and BotParams cannot both be set")
+	}
+	if err := p.HostParams.check(); err != nil {
+		return trace.Wrap(err, "checking HostParams")
+	}
+	if err := p.BotParams.check(); err != nil {
+		return trace.Wrap(err, "checking BotParams")
+	}
+	return nil
+}
+
 // HostParams holds parameters that are specific to host joining and
 // irrelevant to bot joining.
 type HostParams struct {
+	// PublicKeys holds the host public keys.
+	PublicKeys PublicKeys
 	// HostName is the user-friendly node name for the host. This comes from
 	// teleport.nodename in the service configuration and defaults to the
 	// hostname. It is encoded as a valid principal in issued certificates.
@@ -130,12 +148,14 @@ func (p *HostParams) check() error {
 	case p.HostName == "":
 		return trace.BadParameter("HostName is required")
 	}
-	return nil
+	return trace.Wrap(p.PublicKeys.check())
 }
 
 // BotParams holds parameters that are specific to bot joining and
 // irrelevant to host joining.
 type BotParams struct {
+	// PublicKeys holds the bot public keys.
+	PublicKeys PublicKeys
 	// Expires is a desired time of the expiry of certificates returned by
 	// registration.
 	Expires *time.Time
@@ -147,6 +167,27 @@ func (p *BotParams) check() error {
 		return nil
 	case p.Expires.IsZero():
 		return trace.BadParameter("Expires is required")
+	}
+	return trace.Wrap(p.PublicKeys.check())
+}
+
+// PublicKeys holds public keys sent by the client requested subject keys for
+// issued certificates.
+type PublicKeys struct {
+	// PublicTlsKey is the public key requested for the subject of the x509 certificate.
+	// It must be encoded in PKIX, ASN.1 DER form.
+	PublicTLSKey []byte
+	// PublicSshKey is the public key requested for the subject of the SSH certificate.
+	// It must be encoded in SSH wire format.
+	PublicSSHKey []byte
+}
+
+func (k *PublicKeys) check() error {
+	switch {
+	case len(k.PublicTLSKey) == 0:
+		return trace.BadParameter("PublicTLSKey is required")
+	case len(k.PublicSSHKey) == 0:
+		return trace.BadParameter("PublicSSHKey is required")
 	}
 	return nil
 }
@@ -162,24 +203,48 @@ type embedResponse struct{}
 
 func (*embedResponse) isResponse() {}
 
-// Result is the final message sent from the cluster back to the client, it
-// contains the result of the joining process including the assigned host ID
-// and issued certificates.
-type Result struct {
+// ServerInit is the first message sent from the server in response to the
+// ClientInit message.
+type ServerInit struct {
 	embedResponse
 
-	// TlsCert is an X.509 certificate encoded in ASN.1 DER form.
+	// JoinMethod is the name of the selected join method.
+	JoinMethod string
+	// SignatureAlgorithmSuite is the name of the signature algorithm suite
+	// currently configured for the cluster.
+	SignatureAlgorithmSuite types.SignatureAlgorithmSuite
+}
+
+// HostResult holds results for host joining.
+type HostResult struct {
+	embedResponse
+
+	// Certificates holds issued certificates and cluster CAs.
+	Certificates Certificates
+	// HostId is the unique ID assigned to the host.
+	HostID string
+}
+
+// HostResult holds results for bot joining.
+type BotResult struct {
+	embedResponse
+
+	// Certificates holds issued certificates and cluster CAs.
+	Certificates Certificates
+}
+
+// Certificates holds issued certificates and cluster CAs.
+type Certificates struct {
+	// TLSCert is an X.509 certificate encoded in ASN.1 DER form.
 	TLSCert []byte
-	// TlsCaCerts is a list of TLS certificate authorities that the agent should trust.
+	// TLSCACerts is a list of TLS certificate authorities that the client should trust.
 	// Each certificate is encoding in ASN.1 DER form.
 	TLSCACerts [][]byte
-	// SshCert is an SSH certificate encoded in SSH wire format.
+	// SSHCert is an SSH certificate encoded in SSH wire format.
 	SSHCert []byte
-	// SshCaKey is a list of SSH certificate authority public keys that the agent should trust.
+	// SSHCAKeys is a list of SSH certificate authority public keys that the client should trust.
 	// Each CA key is encoded in SSH wire format.
 	SSHCAKeys [][]byte
-	// HostId is the unique ID assigned to the host.
-	HostID *string
 }
 
 // ClientStream represents the client side of a join request stream.
@@ -229,4 +294,20 @@ func AssertRequestType[T Request](req Request) (T, error) {
 		var nul T
 		return nul, trace.BadParameter("expected client to send message of type %T, got %T", nul, req)
 	}
+}
+
+// RecvResponse calls [ClientStream.Recv] and asserts the expected type of
+// the received message, returning an appropriate error if the server sent a
+// message with an unexpected type.
+func RecvResponse[T Response](cs ClientStream) (T, error) {
+	var nul T
+	resp, err := cs.Recv()
+	if err != nil {
+		return nul, trace.Wrap(err)
+	}
+	typedResp, ok := resp.(T)
+	if !ok {
+		return nul, trace.BadParameter("expected server to send message of type %T, got %T", nul, resp)
+	}
+	return typedResp, nil
 }

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -225,7 +225,7 @@ type HostResult struct {
 	HostID string
 }
 
-// HostResult holds results for bot joining.
+// BotResult holds results for bot joining.
 type BotResult struct {
 	embedResponse
 

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -161,7 +161,7 @@ func TestJoin(t *testing.T) {
 		// its original certificate and the new token.
 		creds, err := clientCreds(signer, joinResult.Certificates)
 		require.NoError(t, err)
-		rejoinResult, signer, err := join(
+		rejoinResult, _, err := join(
 			t.Context(),
 			authService.TLS.Listener.Addr(),
 			creds,
@@ -325,7 +325,7 @@ func (p *fakeProxy) join(t *testing.T) {
 	result, err := messages.RecvResponse[*messages.HostResult](stream)
 	require.NoError(t, err)
 
-	// Save the host credentials we got from the succesful join.
+	// Save the host credentials we got from the successful join.
 	p.authenticatedAuthCreds, err = clientCreds(hostKeys.tls, result.Certificates)
 	require.NoError(t, err)
 }

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -92,10 +92,8 @@ func TestJoin(t *testing.T) {
 	t.Cleanup(func() { proxyListener.Close() })
 	proxy.runGRPCServer(t, proxyListener)
 
-	node := newFakeNode(t)
-
 	t.Run("invalid token", func(t *testing.T) {
-		_, err := node.join(
+		_, _, err := join(
 			t.Context(),
 			proxyListener.Addr(),
 			insecure.NewCredentials(),
@@ -119,8 +117,7 @@ func TestJoin(t *testing.T) {
 					ConnectionMetadata: apievents.ConnectionMetadata{
 						RemoteAddr: "127.0.0.1",
 					},
-					NodeName: "node",
-					Role:     "Instance",
+					Role: "Instance",
 				},
 				evt,
 				protocmp.Transform(),
@@ -133,7 +130,7 @@ func TestJoin(t *testing.T) {
 
 	t.Run("join and rejoin", func(t *testing.T) {
 		// Node joins by connecting to the proxy's gRPC service.
-		joinResult, err := node.join(
+		joinResult, signer, err := join(
 			t.Context(),
 			proxyListener.Addr(),
 			insecure.NewCredentials(),
@@ -142,8 +139,8 @@ func TestJoin(t *testing.T) {
 		// Make sure the result contains a host ID and expected certificate roles.
 		require.NoError(t, err)
 		require.NotNil(t, joinResult.HostID)
-		require.NotEmpty(t, *joinResult.HostID)
-		cert, err := x509.ParseCertificate(joinResult.TLSCert)
+		require.NotEmpty(t, joinResult.HostID)
+		cert, err := x509.ParseCertificate(joinResult.Certificates.TLSCert)
 		require.NoError(t, err)
 		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
 		require.NoError(t, err)
@@ -162,16 +159,16 @@ func TestJoin(t *testing.T) {
 		//
 		// It should get back its original host ID and the combined roles of
 		// its original certificate and the new token.
-		creds, err := clientCreds(node.hostKeys.tls, joinResult)
+		creds, err := clientCreds(signer, joinResult.Certificates)
 		require.NoError(t, err)
-		rejoinResult, err := node.join(
+		rejoinResult, signer, err := join(
 			t.Context(),
 			authService.TLS.Listener.Addr(),
 			creds,
 			token2.GetName(),
 		)
 		require.NoError(t, err)
-		cert, err = x509.ParseCertificate(rejoinResult.TLSCert)
+		cert, err = x509.ParseCertificate(rejoinResult.Certificates.TLSCert)
 		require.NoError(t, err)
 		identity, err = tlsca.FromSubject(cert.Subject, cert.NotAfter)
 		require.NoError(t, err)
@@ -193,7 +190,7 @@ func TestJoin(t *testing.T) {
 
 	t.Run("join and rejoin with bad token", func(t *testing.T) {
 		// Node joins by connecting to the proxy's gRPC service.
-		joinResult, err := node.join(
+		joinResult, signer, err := join(
 			t.Context(),
 			proxyListener.Addr(),
 			insecure.NewCredentials(),
@@ -202,9 +199,9 @@ func TestJoin(t *testing.T) {
 		require.NoError(t, err)
 
 		// Node the tries to rejoin with valid certs but an invalid token.
-		creds, err := clientCreds(node.hostKeys.tls, joinResult)
+		creds, err := clientCreds(signer, joinResult.Certificates)
 		require.NoError(t, err)
-		_, err = node.join(
+		_, _, err = join(
 			t.Context(),
 			authService.TLS.Listener.Addr(),
 			creds,
@@ -228,8 +225,7 @@ func TestJoin(t *testing.T) {
 					ConnectionMetadata: apievents.ConnectionMetadata{
 						RemoteAddr: "127.0.0.1",
 					},
-					NodeName: "node",
-					Role:     "Instance",
+					Role: "Instance",
 				},
 				evt,
 				protocmp.Transform(),
@@ -291,28 +287,46 @@ func (p *fakeProxy) join(t *testing.T) {
 	require.NoError(t, err)
 	joinClient := joinv1.NewClient(unauthenticatedAuthClt.JoinV1Client())
 
+	// Initiate the join request and get a client stream.
 	stream, err := joinClient.Join(t.Context())
 	require.NoError(t, err)
 
-	hostKeys, err := genHostKeys()
-	require.NoError(t, err)
+	// Send the ClientInit messaage.
 	require.NoError(t, stream.Send(&messages.ClientInit{
-		TokenName:    "token1",
-		SystemRole:   types.RoleProxy.String(),
-		PublicTLSKey: hostKeys.tlsPubKey,
-		PublicSSHKey: hostKeys.sshPubKey,
-		HostParams: &messages.HostParams{
-			HostName:             "proxy",
-			AdditionalPrincipals: []string{"proxy"},
+		TokenName:  "token1",
+		SystemRole: types.RoleInstance.String(),
+	}))
+
+	// Wait for the ServerInit response.
+	serverInit, err := messages.RecvResponse[*messages.ServerInit](stream)
+	require.NoError(t, err)
+
+	require.Equal(t, string(types.JoinMethodToken), serverInit.JoinMethod)
+
+	// Generate host keys with the suite from the ServerInit message.
+	hostKeys, err := genHostKeys(t.Context(), serverInit.SignatureAlgorithmSuite)
+	require.NoError(t, err)
+
+	// Send the TokenInit message.
+	require.NoError(t, stream.Send(&messages.TokenInit{
+		ClientParams: messages.ClientParams{
+			HostParams: &messages.HostParams{
+				PublicKeys: messages.PublicKeys{
+					PublicTLSKey: hostKeys.tlsPubKey,
+					PublicSSHKey: hostKeys.sshPubKey,
+				},
+				HostName:             "proxy",
+				AdditionalPrincipals: []string{"proxy"},
+			},
 		},
 	}))
-	resp, err := stream.Recv()
+
+	// Wait for the result from the server.
+	result, err := messages.RecvResponse[*messages.HostResult](stream)
 	require.NoError(t, err)
 
-	require.IsType(t, (*messages.Result)(nil), resp)
-	result := resp.(*messages.Result)
-
-	p.authenticatedAuthCreds, err = clientCreds(hostKeys.tls, result)
+	// Save the host credentials we got from the succesful join.
+	p.authenticatedAuthCreds, err = clientCreds(hostKeys.tls, result.Certificates)
 	require.NoError(t, err)
 }
 
@@ -343,67 +357,75 @@ func (p *fakeProxy) runGRPCServer(t *testing.T, l net.Listener) {
 	})
 }
 
-type fakeNode struct {
-	hostKeys *hostKeys
-}
-
-func newFakeNode(t *testing.T) *fakeNode {
-	hostKeys, err := genHostKeys()
-	require.NoError(t, err)
-	return &fakeNode{
-		hostKeys: hostKeys,
-	}
-}
-
-func (n *fakeNode) join(
+func join(
 	ctx context.Context,
 	addr net.Addr,
 	creds credentials.TransportCredentials,
 	token string,
-) (*messages.Result, error) {
+) (*messages.HostResult, crypto.Signer, error) {
 	conn, err := grpc.NewClient(addr.String(),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithStreamInterceptor(interceptors.GRPCClientStreamErrorInterceptor),
 	)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 	defer conn.Close()
 	joinClient := joinv1.NewClient(joinv1proto.NewJoinServiceClient(conn))
 
+	// Initiate the join request.
 	stream, err := joinClient.Join(ctx)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
+	// Send the ClientInit message.
 	err = stream.Send(&messages.ClientInit{
-		TokenName:    token,
-		PublicTLSKey: n.hostKeys.tlsPubKey,
-		PublicSSHKey: n.hostKeys.sshPubKey,
-		SystemRole:   types.RoleInstance.String(),
-		HostParams: &messages.HostParams{
-			HostName: "node",
-		},
+		TokenName:  token,
+		SystemRole: types.RoleInstance.String(),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
-	resp, err := stream.Recv()
+	// Wait for the ServerInit response.
+	serverInit, err := messages.RecvResponse[*messages.ServerInit](stream)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
-	result, ok := resp.(*messages.Result)
-	if !ok {
-		return nil, trace.Errorf("expected *messages.Result, got %T", resp)
+	// Generate host keys with the suite from the ServerInit message.
+	hostKeys, err := genHostKeys(ctx, serverInit.SignatureAlgorithmSuite)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
 	}
-	return result, nil
+
+	// Send the TokenInit message with the host keys.
+	if err := stream.Send(&messages.TokenInit{
+		ClientParams: messages.ClientParams{
+			HostParams: &messages.HostParams{
+				PublicKeys: messages.PublicKeys{
+					PublicTLSKey: hostKeys.tlsPubKey,
+					PublicSSHKey: hostKeys.sshPubKey,
+				},
+				HostName: "node",
+			},
+		},
+	}); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	// Wait for the result.
+	result, err := messages.RecvResponse[*messages.HostResult](stream)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return result, hostKeys.tls, nil
 }
 
-func clientCreds(tlsKey crypto.PrivateKey, result *messages.Result) (credentials.TransportCredentials, error) {
+func clientCreds(tlsKey crypto.PrivateKey, certs messages.Certificates) (credentials.TransportCredentials, error) {
 	caPool := x509.NewCertPool()
-	for _, caCertDER := range result.TLSCACerts {
+	for _, caCertDER := range certs.TLSCACerts {
 		caCert, err := x509.ParseCertificate(caCertDER)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -412,7 +434,7 @@ func clientCreds(tlsKey crypto.PrivateKey, result *messages.Result) (credentials
 	}
 	return credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{{
-			Certificate: [][]byte{result.TLSCert},
+			Certificate: [][]byte{certs.TLSCert},
 			PrivateKey:  tlsKey,
 		}},
 		RootCAs:    caPool,
@@ -427,8 +449,8 @@ type hostKeys struct {
 	sshPubKey []byte
 }
 
-func genHostKeys() (*hostKeys, error) {
-	signer, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+func genHostKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (*hostKeys, error) {
+	signer, err := cryptosuites.GenerateKey(ctx, cryptosuites.StaticAlgorithmSuite(suite), cryptosuites.HostIdentity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -21,13 +21,42 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 )
 
+// requestToMessage converts a gRPC JoinRequest into a protocol-agnostic [messages.Request].
 func requestToMessage(req *joinv1.JoinRequest) (messages.Request, error) {
 	switch msg := req.GetPayload().(type) {
 	case *joinv1.JoinRequest_ClientInit:
 		return clientInitToMessage(msg.ClientInit), nil
+	case *joinv1.JoinRequest_TokenInit:
+		return tokenInitToMessage(msg.TokenInit)
+	default:
+		return nil, trace.BadParameter("unrecognized join request message type %T", msg)
+	}
+}
+
+// requestFromMessage converts a [messages.Request] into a
+// [*joinv1.JoinRequest] to be sent over gRPC.
+func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
+	switch typedMsg := msg.(type) {
+	case *messages.ClientInit:
+		return &joinv1.JoinRequest{
+			Payload: &joinv1.JoinRequest_ClientInit{
+				ClientInit: clientInitFromMessage(typedMsg),
+			},
+		}, nil
+	case *messages.TokenInit:
+		tokenInit, err := tokenInitFromMessage(typedMsg)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &joinv1.JoinRequest{
+			Payload: &joinv1.JoinRequest_TokenInit{
+				TokenInit: tokenInit,
+			},
+		}, nil
 	default:
 		return nil, trace.BadParameter("unrecognized join request message type %T", msg)
 	}
@@ -38,24 +67,7 @@ func clientInitToMessage(req *joinv1.ClientInit) *messages.ClientInit {
 		JoinMethod:       req.JoinMethod,
 		TokenName:        req.TokenName,
 		SystemRole:       req.SystemRole,
-		PublicTLSKey:     req.PublicTlsKey,
-		PublicSSHKey:     req.PublicSshKey,
 		ForwardedByProxy: req.ForwardedByProxy,
-		HostParams:       &messages.HostParams{},
-	}
-	if hostParams := req.HostParams; hostParams != nil {
-		msg.HostParams = &messages.HostParams{
-			HostName:             hostParams.HostName,
-			AdditionalPrincipals: hostParams.AdditionalPrincipals,
-			DNSNames:             hostParams.DnsNames,
-		}
-	}
-	if botParams := req.BotParams; botParams != nil {
-		msg.BotParams = &messages.BotParams{}
-		if botParams.Expires != nil {
-			expires := botParams.Expires.AsTime()
-			msg.BotParams.Expires = &expires
-		}
 	}
 	if proxySuppliedParams := req.GetProxySuppliedParameters(); proxySuppliedParams != nil {
 		msg.ProxySuppliedParams = &messages.ProxySuppliedParams{
@@ -66,40 +78,12 @@ func clientInitToMessage(req *joinv1.ClientInit) *messages.ClientInit {
 	return msg
 }
 
-func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
-	switch typedMsg := msg.(type) {
-	case *messages.ClientInit:
-		return &joinv1.JoinRequest{
-			Payload: &joinv1.JoinRequest_ClientInit{
-				ClientInit: clientInitFromMessage(typedMsg),
-			},
-		}, nil
-	default:
-		return nil, trace.BadParameter("unrecognized join request message type %T", msg)
-	}
-}
-
 func clientInitFromMessage(msg *messages.ClientInit) *joinv1.ClientInit {
 	req := &joinv1.ClientInit{
 		JoinMethod:       msg.JoinMethod,
 		TokenName:        msg.TokenName,
 		SystemRole:       msg.SystemRole,
-		PublicTlsKey:     msg.PublicTLSKey,
-		PublicSshKey:     msg.PublicSSHKey,
 		ForwardedByProxy: msg.ForwardedByProxy,
-	}
-	if hostParams := msg.HostParams; hostParams != nil {
-		req.HostParams = &joinv1.ClientInit_HostParams{
-			HostName:             hostParams.HostName,
-			AdditionalPrincipals: hostParams.AdditionalPrincipals,
-			DnsNames:             hostParams.DNSNames,
-		}
-	}
-	if botParams := msg.BotParams; botParams != nil {
-		req.BotParams = &joinv1.ClientInit_BotParams{}
-		if botParams.Expires != nil {
-			req.BotParams.Expires = timestamppb.New(*botParams.Expires)
-		}
 	}
 	if proxySuppliedParams := msg.ProxySuppliedParams; proxySuppliedParams != nil {
 		req.ProxySuppliedParameters = &joinv1.ClientInit_ProxySuppliedParams{
@@ -110,12 +94,149 @@ func clientInitFromMessage(msg *messages.ClientInit) *joinv1.ClientInit {
 	return req
 }
 
-func responseFromMessage(resp messages.Response) (*joinv1.JoinResponse, error) {
-	switch msg := resp.(type) {
-	case *messages.Result:
+func tokenInitToMessage(req *joinv1.TokenInit) (*messages.TokenInit, error) {
+	clientParams, err := clientParamsToMessage(req.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &messages.TokenInit{
+		ClientParams: clientParams,
+	}, nil
+}
+
+func tokenInitFromMessage(msg *messages.TokenInit) (*joinv1.TokenInit, error) {
+	clientParams, err := clientParamsFromMessage(msg.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &joinv1.TokenInit{
+		ClientParams: clientParams,
+	}, nil
+}
+
+func clientParamsToMessage(req *joinv1.ClientParams) (messages.ClientParams, error) {
+	var msg messages.ClientParams
+	switch req.GetPayload().(type) {
+	case *joinv1.ClientParams_HostParams:
+		msg.HostParams = hostParamsToMessage(req.GetHostParams())
+	case *joinv1.ClientParams_BotParams:
+		msg.BotParams = botParamsToMessage(req.GetBotParams())
+	default:
+		return msg, trace.BadParameter("unrecognized ClientParams payload type %T", req.Payload)
+	}
+	return msg, nil
+}
+
+func clientParamsFromMessage(msg messages.ClientParams) (*joinv1.ClientParams, error) {
+	req := &joinv1.ClientParams{}
+	switch {
+	case msg.HostParams != nil:
+		req.Payload = &joinv1.ClientParams_HostParams{
+			HostParams: hostParamsFromMessage(msg.HostParams),
+		}
+	case msg.BotParams != nil:
+		req.Payload = &joinv1.ClientParams_BotParams{
+			BotParams: botParamsFromMessage(msg.BotParams),
+		}
+	default:
+		return nil, trace.BadParameter("ClientParams has no payload")
+	}
+	return req, nil
+}
+
+func hostParamsToMessage(req *joinv1.HostParams) *messages.HostParams {
+	return &messages.HostParams{
+		PublicKeys:           publicKeysToMessage(req.PublicKeys),
+		HostName:             req.HostName,
+		AdditionalPrincipals: req.AdditionalPrincipals,
+		DNSNames:             req.DnsNames,
+	}
+}
+
+func hostParamsFromMessage(msg *messages.HostParams) *joinv1.HostParams {
+	return &joinv1.HostParams{
+		PublicKeys:           publicKeysFromMessage(msg.PublicKeys),
+		HostName:             msg.HostName,
+		AdditionalPrincipals: msg.AdditionalPrincipals,
+		DnsNames:             msg.DNSNames,
+	}
+}
+
+func botParamsToMessage(req *joinv1.BotParams) *messages.BotParams {
+	msg := &messages.BotParams{
+		PublicKeys: publicKeysToMessage(req.PublicKeys),
+	}
+	if req.Expires != nil {
+		expires := req.Expires.AsTime()
+		msg.Expires = &expires
+	}
+	return msg
+}
+
+func botParamsFromMessage(msg *messages.BotParams) *joinv1.BotParams {
+	req := &joinv1.BotParams{
+		PublicKeys: publicKeysFromMessage(msg.PublicKeys),
+	}
+	if msg.Expires != nil {
+		req.Expires = timestamppb.New(*msg.Expires)
+	}
+	return req
+}
+
+func publicKeysToMessage(req *joinv1.PublicKeys) messages.PublicKeys {
+	return messages.PublicKeys{
+		PublicTLSKey: req.PublicTlsKey,
+		PublicSSHKey: req.PublicSshKey,
+	}
+}
+
+func publicKeysFromMessage(msg messages.PublicKeys) *joinv1.PublicKeys {
+	return &joinv1.PublicKeys{
+		PublicTlsKey: msg.PublicTLSKey,
+		PublicSshKey: msg.PublicSSHKey,
+	}
+}
+
+// responseToMessage converts a gRPC JoinResponse into a protocol-agnostic [messages.Response].
+func responseToMessage(resp *joinv1.JoinResponse) (messages.Response, error) {
+	switch typedResp := resp.Payload.(type) {
+	case *joinv1.JoinResponse_Init:
+		return serverInitToMessage(typedResp.Init)
+	case *joinv1.JoinResponse_Result:
+		return resultToMessage(typedResp.Result)
+	default:
+		return nil, trace.BadParameter("unrecognized join responsed message type %T", typedResp)
+	}
+}
+
+// responseFromMessage converts a [messages.Response] into a
+// [*joinv1.JoinResponse] to be sent over gRPC.
+func responseFromMessage(msg messages.Response) (*joinv1.JoinResponse, error) {
+	switch typedMsg := msg.(type) {
+	case *messages.ServerInit:
+		return &joinv1.JoinResponse{
+			Payload: &joinv1.JoinResponse_Init{
+				Init: serverInitFromMessage(typedMsg),
+			},
+		}, nil
+	case *messages.HostResult:
 		return &joinv1.JoinResponse{
 			Payload: &joinv1.JoinResponse_Result{
-				Result: resultFromMessage(msg),
+				Result: &joinv1.Result{
+					Payload: &joinv1.Result_HostResult{
+						HostResult: hostResultFromMessage(typedMsg),
+					},
+				},
+			},
+		}, nil
+	case *messages.BotResult:
+		return &joinv1.JoinResponse{
+			Payload: &joinv1.JoinResponse_Result{
+				Result: &joinv1.Result{
+					Payload: &joinv1.Result_BotResult{
+						BotResult: botResultFromMessage(typedMsg),
+					},
+				},
 			},
 		}, nil
 	default:
@@ -123,31 +244,75 @@ func responseFromMessage(resp messages.Response) (*joinv1.JoinResponse, error) {
 	}
 }
 
-func resultFromMessage(msg *messages.Result) *joinv1.Result {
-	return &joinv1.Result{
-		TlsCert:    msg.TLSCert,
-		TlsCaCerts: msg.TLSCACerts,
-		SshCert:    msg.SSHCert,
-		SshCaKeys:  msg.SSHCAKeys,
-		HostId:     msg.HostID,
+func serverInitToMessage(req *joinv1.ServerInit) (*messages.ServerInit, error) {
+	sas, err := types.SignatureAlgorithmSuiteFromString(req.SignatureAlgorithmSuite)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &messages.ServerInit{
+		JoinMethod:              req.JoinMethod,
+		SignatureAlgorithmSuite: sas,
+	}, nil
+}
+
+func serverInitFromMessage(msg *messages.ServerInit) *joinv1.ServerInit {
+	return &joinv1.ServerInit{
+		JoinMethod:              msg.JoinMethod,
+		SignatureAlgorithmSuite: types.SignatureAlgorithmSuiteToString(msg.SignatureAlgorithmSuite),
 	}
 }
 
-func responseToMessage(resp *joinv1.JoinResponse) (messages.Response, error) {
-	switch typedResp := resp.Payload.(type) {
-	case *joinv1.JoinResponse_Result:
-		return resultToMessage(typedResp.Result), nil
+func resultToMessage(resp *joinv1.Result) (messages.Response, error) {
+	switch resp.Payload.(type) {
+	case *joinv1.Result_HostResult:
+		return hostResultToMessage(resp.GetHostResult()), nil
+	case *joinv1.Result_BotResult:
+		return botResultToMessage(resp.GetBotResult()), nil
 	default:
-		return nil, trace.BadParameter("unrecognized join responsed message type %T", typedResp)
+		return nil, trace.BadParameter("unrecodgnize result payload type %T", resp.Payload)
 	}
 }
 
-func resultToMessage(resp *joinv1.Result) *messages.Result {
-	return &messages.Result{
-		TLSCert:    resp.TlsCert,
-		TLSCACerts: resp.TlsCaCerts,
-		SSHCert:    resp.SshCert,
-		SSHCAKeys:  resp.SshCaKeys,
-		HostID:     resp.HostId,
+func hostResultToMessage(resp *joinv1.HostResult) *messages.HostResult {
+	return &messages.HostResult{
+		Certificates: certificatesToMessage(resp.Certificates),
+		HostID:       resp.HostId,
+	}
+}
+
+func hostResultFromMessage(msg *messages.HostResult) *joinv1.HostResult {
+	return &joinv1.HostResult{
+		Certificates: certificatesFromMessage(&msg.Certificates),
+		HostId:       msg.HostID,
+	}
+}
+
+func botResultToMessage(resp *joinv1.BotResult) *messages.BotResult {
+	return &messages.BotResult{
+		Certificates: certificatesToMessage(resp.Certificates),
+	}
+}
+
+func botResultFromMessage(msg *messages.BotResult) *joinv1.BotResult {
+	return &joinv1.BotResult{
+		Certificates: certificatesFromMessage(&msg.Certificates),
+	}
+}
+
+func certificatesToMessage(certs *joinv1.Certificates) messages.Certificates {
+	return messages.Certificates{
+		TLSCert:    certs.TlsCert,
+		TLSCACerts: certs.TlsCaCerts,
+		SSHCert:    certs.SshCert,
+		SSHCAKeys:  certs.SshCaKeys,
+	}
+}
+
+func certificatesFromMessage(certs *messages.Certificates) *joinv1.Certificates {
+	return &joinv1.Certificates{
+		TlsCert:    certs.TLSCert,
+		TlsCaCerts: certs.TLSCACerts,
+		SshCert:    certs.SSHCert,
+		SshCaKeys:  certs.SSHCAKeys,
 	}
 }

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/internal/authz"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+// handleTokenJoin handles join attempts for the token join method.
+func (s *Server) handleTokenJoin(
+	stream messages.ServerStream,
+	authCtx *authz.Context,
+	clientInit *messages.ClientInit,
+	provisionToken types.ProvisionToken,
+) (messages.Response, error) {
+	// Receive the TokenInit message from the client.
+	tokenInit, err := messages.RecvRequest[*messages.TokenInit](stream)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Set any diagnostic info from the ClientParams.
+	setDiagnosticClientParams(stream.Diagnostic(), &tokenInit.ClientParams)
+
+	// There are no additional checks for the token join method, just make the
+	// result message and return it.
+	result, err := s.makeResult(
+		stream.Context(),
+		stream.Diagnostic(),
+		authCtx,
+		clientInit,
+		&tokenInit.ClientParams,
+		provisionToken,
+	)
+	return result, trace.Wrap(err)
+}


### PR DESCRIPTION
This PR refactors the join flow for the new join service in accordance with the RFD edits in https://github.com/gravitational/teleport.e/pull/7264

While implementing the client side of joining via the new service, I realized clients are currently requesting the current cluster signature algorithm suite prior to joining. Moving this into the join flow eliminates an RPC and should enable better debugging if the client doesn't understand a new signature algorithm suite for fails to generate keys, there will now be a join failed audit event.

Notably the token join flow has been updated from ClientInit->Result to ClientInit->ServerInit->TokenInit->Result where the ServerInit now contains the signature algorithm suite and the TokenInit message contains the client public keys. This should also align better with other join methods where the ServerInit message will aways need to be sent to inform the client of the join method, previously the `token` method was kind of a special case where the Result would be returned immediately.