### PR TITLE
[v18] Enforce max username length for new users and identifier-first login matching

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -597,6 +597,10 @@ const MaxHTTPRequestSize = 10 * 1024 * 1024
 // to prevent resource exhaustion attacks.
 const MaxHTTPResponseSize = 10 * 1024 * 1024
 
+// MaxUsernameLength is the maximum allowed length (characters) for usernames.
+// This limit prevents sending extremely long usernames that could clog up logs or exhaust resources.
+const MaxUsernameLength = 1000
+
 const (
 	// CertificateFormatOldSSH is used to make Teleport interoperate with older
 	// versions of OpenSSH.

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
@@ -153,6 +154,15 @@ type authAuditProps struct {
 	userOrigin     apievents.UserOrigin
 }
 
+// trimUsername truncates the length of a username to the maximum allowed length, if needed.
+func trimUsername(username string) string {
+	if len(username) <= teleport.MaxUsernameLength {
+		return username
+	}
+
+	return username[:teleport.MaxUsernameLength] + "..."
+}
+
 func (a *Server) emitAuthAuditEvent(ctx context.Context, props authAuditProps) error {
 	event := &apievents.UserLogin{
 		Metadata: apievents.Metadata{
@@ -163,7 +173,7 @@ func (a *Server) emitAuthAuditEvent(ctx context.Context, props authAuditProps) e
 			Success: true,
 		},
 		UserMetadata: apievents.UserMetadata{
-			User:       props.username,
+			User:       trimUsername(props.username),
 			UserOrigin: props.userOrigin,
 		},
 		Method: events.LoginMethodLocal,

--- a/lib/auth/users/usersv1/service.go
+++ b/lib/auth/users/usersv1/service.go
@@ -224,6 +224,10 @@ func (s *Service) CreateUser(ctx context.Context, req *userspb.CreateUserRequest
 		return nil, trace.Wrap(err)
 	}
 
+	if len(req.User.GetName()) > teleport.MaxUsernameLength {
+		return nil, trace.BadParameter("username exceeds maximum length of %d characters", teleport.MaxUsernameLength)
+	}
+
 	if err := authCtx.CheckAccessToKind(types.KindUser, types.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base32"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -247,6 +248,18 @@ func TestCreateUser(t *testing.T) {
 	createEvent, ok = event.(*apievents.UserCreate)
 	require.True(t, ok, "expected a UserCreate event got %T", event)
 	assert.Equal(t, "alice", createEvent.UserMetadata.User)
+}
+
+func TestCreateUserMaxLength(t *testing.T) {
+	t.Parallel()
+	env, err := newTestEnv()
+	require.NoError(t, err, "creating test service")
+
+	user, err := types.NewUser(strings.Repeat("A", 1001))
+	require.NoError(t, err)
+	user.AddRole("access")
+	_, err = env.CreateUser(t.Context(), &userspb.CreateUserRequest{User: user.(*types.UserV2)})
+	require.Error(t, err, "creating a user with a username too long should fail")
 }
 
 func TestDeleteUser(t *testing.T) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2030,6 +2030,9 @@ func (h *Handler) getUserMatchedAuthConnectors(w http.ResponseWriter, r *http.Re
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if req.Username != "" && len(req.Username) > teleport.MaxUsernameLength {
+		return nil, trace.BadParameter("username exceeds maximum length of %d characters", teleport.MaxUsernameLength)
+	}
 
 	githubConns, err := h.cfg.ProxyClient.GetGithubConnectors(r.Context(), false)
 	if err != nil {


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/57638 to branch/v18