### PR TITLE
Add Rust Toolchain File

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -62,11 +62,6 @@ jobs:
           cache: false
           go-version: ${{ env.GOLANG_VERSION }}
 
-      - name: Configure Rust Toolchain
-        run: |
-          rustup override set ${{ env.RUST_VERSION }}
-          rustup target add wasm32-unknown-unknown
-
       - name: Install wasm-deps
         run: make ensure-wasm-deps
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -187,7 +187,6 @@ jobs:
         run: |
           echo "Setting up Rust version ${RUST_VERSION}"
           rustup toolchain install ${RUST_VERSION} --component rustfmt,clippy
-          rustup override set ${RUST_VERSION}
           rustc --version
           cargo --version
           rustfmt --version

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -186,6 +186,7 @@ jobs:
       - name: Set up Rust
         run: |
           echo "Setting up Rust version ${RUST_VERSION}"
+          rustup component add rustfmt clippy
           rustc --version
           cargo --version
           rustfmt --version

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -186,7 +186,6 @@ jobs:
       - name: Set up Rust
         run: |
           echo "Setting up Rust version ${RUST_VERSION}"
-          rustup toolchain install ${RUST_VERSION} --component rustfmt,clippy
           rustc --version
           cargo --version
           rustfmt --version

--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -17,46 +17,15 @@ and updates are welcome!
       ```
 
 1. Install Rust
-    1. Install rustup
 
-        Install rustup with Homebrew:
+    Install rustup with Homebrew:
 
-        ```shell
-        brew install rustup
+    ```shell
+    brew install rustup
 
-        rustup-init
-        # Accept defaults
-        ```
-
-    1. Install and configure Rust toolchain
-        1. Find the required Rust version in
-            [`build.assets/versions.mk`](/build.assets/versions.mk)
-            (`RUST_VERSION`).
-
-        1. Install the Rust toolchain:
-
-            ```shell
-            # Replace <version> with the value of RUST_VERSION from build.assets/versions.mk (e.g., 1.81.0)
-            rustup toolchain install <version>
-            ```
-
-        1. Set the default Rust toolchain globally (applies to all projects):
-
-            ```shell
-            # Replace <version> with the value of RUST_VERSION from build.assets/versions.mk (e.g., 1.81.0)
-            rustup default <version>
-            ```
-
-            > **Note:** Using `rustup default <version>` sets the toolchain
-            > globally for your user. If you only want to override the toolchain
-            > for a specific project directory, use `rustup override set
-            > <version>` inside that directory instead.
-
-        1. Verify the installed version:
-
-            ```shell
-            rustc --version
-            ```
+    rustup-init
+    # Accept defaults
+    ```
 
 1. Install Node.js
     1. Find the required Node version in

--- a/Makefile
+++ b/Makefile
@@ -1874,7 +1874,7 @@ WASM_BINDGEN_VERSION = $(shell awk ' \
 print-wasm-bindgen-version:
 	@echo $(WASM_BINDGEN_VERSION)
 
-RUST_TOOLCHAIN_VERSION = $(shell awk '$$1 == "channel", $$2 = "=" { gsub(/"/, "", $$3); print $$3 }' rust-toolchain.toml )
+RUST_TOOLCHAIN_VERSION = $(shell awk '$$1 == "channel" && $$2 == "=" { gsub(/"/, "", $$3); print $$3 }' rust-toolchain.toml )
 
 .PHONY: print-rust-toolchain-version
 print-rust-toolchain-version:

--- a/Makefile
+++ b/Makefile
@@ -1863,7 +1863,7 @@ ensure-js-deps:
 ifeq ($(WEBASSETS_SKIP_BUILD),1)
 ensure-wasm-deps:
 else
-ensure-wasm-deps: ensure-wasm-bindgen ensure-wasm-opt rustup-install-wasm-toolchain
+ensure-wasm-deps: ensure-wasm-bindgen ensure-wasm-opt
 
 WASM_BINDGEN_VERSION = $(shell awk ' \
   $$1 == "name" && $$3 == "\"wasm-bindgen\"" { in_pkg=1; next } \
@@ -1889,7 +1889,6 @@ ensure-wasm-bindgen:
 		@echo wasm-bindgen-cli up-to-date: $(INSTALLED_VERSION) \
 	)
 endif
-
 
 .PHONY: ensure-wasm-opt
 ensure-wasm-opt: WASM_OPT_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-wasm-opt-version)
@@ -1920,10 +1919,6 @@ rustup-set-version: ; # obsoleted by toolchain file
 .PHONY: rustup-install-target-toolchain
 rustup-install-target-toolchain:
 	rustup target add $(RUST_TARGET_ARCH)
-
-.PHONY: rustup-install-wasm-toolchain
-rustup-install-wasm-toolchain:
-	rustup target add $(CARGO_WASM_TARGET)
 
 # changelog generates PR changelog between the provided base tag and the tip of
 # the specified branch.

--- a/Makefile
+++ b/Makefile
@@ -1874,6 +1874,12 @@ WASM_BINDGEN_VERSION = $(shell awk ' \
 print-wasm-bindgen-version:
 	@echo $(WASM_BINDGEN_VERSION)
 
+RUST_TOOLCHAIN_VERSION = $(shell awk '$$1 == "channel", $$2 = "=" { gsub(/"/, "", $$3); print $$3 }' rust-toolchain.toml )
+
+.PHONY: print-rust-toolchain-version
+print-rust-toolchain-version:
+	@echo $(RUST_TOOLCHAIN_VERSION)
+
 ensure-wasm-bindgen: NEED_VERSION = $(WASM_BINDGEN_VERSION)
 ensure-wasm-bindgen: INSTALLED_VERSION = $(word 2,$(shell wasm-bindgen --version 2>/dev/null))
 ensure-wasm-bindgen:
@@ -1908,21 +1914,16 @@ build-ui-e: ensure-js-deps ensure-wasm-deps
 docker-ui:
 	$(MAKE) -C build.assets ui
 
-.PHONY: rustup-set-version
-rustup-set-version: RUST_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-rust-version)
-rustup-set-version:
-	rustup override set $(RUST_VERSION)
-
 # rustup-install-target-toolchain ensures the required rust compiler is
 # installed to build for $(ARCH)/$(OS) for the version of rust we use, as
 # defined in build.assets/Makefile. It assumes that `rustup` is already
 # installed for managing the rust toolchain.
 .PHONY: rustup-install-target-toolchain
-rustup-install-target-toolchain: rustup-set-version
+rustup-install-target-toolchain:
 	rustup target add $(RUST_TARGET_ARCH)
 
 .PHONY: rustup-install-wasm-toolchain
-rustup-install-wasm-toolchain: rustup-set-version
+rustup-install-wasm-toolchain:
 	rustup target add $(CARGO_WASM_TARGET)
 
 # changelog generates PR changelog between the provided base tag and the tip of

--- a/Makefile
+++ b/Makefile
@@ -1883,19 +1883,13 @@ print-rust-toolchain-version:
 ensure-wasm-bindgen: NEED_VERSION = $(WASM_BINDGEN_VERSION)
 ensure-wasm-bindgen: INSTALLED_VERSION = $(word 2,$(shell wasm-bindgen --version 2>/dev/null))
 ensure-wasm-bindgen:
-ifneq ($(CI)$(FORCE),)
 	@: $(or $(NEED_VERSION),$(error Unknown wasm-bindgen version. Is it in Cargo.lock?))
 	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
 		cargo install wasm-bindgen-cli --force --locked --version "$(NEED_VERSION)", \
 		@echo wasm-bindgen-cli up-to-date: $(INSTALLED_VERSION) \
 	)
-else
-	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
-		@echo "Wrong wasm-bindgen version. Want $(NEED_VERSION) have $(INSTALLED_VERSION)"; \
-		echo "Run 'make $@ FORCE=true' to force installation." \
-	)
 endif
-endif
+
 
 .PHONY: ensure-wasm-opt
 ensure-wasm-opt: WASM_OPT_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-wasm-opt-version)

--- a/Makefile
+++ b/Makefile
@@ -1908,6 +1908,11 @@ build-ui-e: ensure-js-deps ensure-wasm-deps
 docker-ui:
 	$(MAKE) -C build.assets ui
 
+# TODO(rhammonds): Remove this target once all references to it have
+# been removed from e submodule and e ref is updated.
+.PHONY: rustup-set-version
+rustup-set-version: ; # obsoleted by toolchain file
+
 # rustup-install-target-toolchain ensures the required rust compiler is
 # installed to build for $(ARCH)/$(OS) for the version of rust we use, as
 # defined in build.assets/Makefile. It assumes that `rustup` is already

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -60,6 +60,9 @@ REQUIRE_HOST_ARCH = $(if $(filter-out $(ARCH),$(RUNTIME_ARCH)),$(error Cannot cr
 # responsible for building webassets.
 WASM_BINDGEN_VERSION ?= $(shell $(MAKE) -C .. --no-print-directory  print-wasm-bindgen-version)
 
+# Determine which version of rust is required to build rust components.
+RUST_VERSION ?= $(shell $(MAKE) -C .. --no-print-directory  print-rust-toolchain-version)
+
 # This determines which make target we call in this repo's top level Makefile when
 # make release in this Makefile is called. Currently this supports its default value
 # (release) and release-unix-preserving-webassets. See the release-arm target for

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -8,7 +8,6 @@ GOLANGCI_LINT_VERSION ?= v2.4.0
 # NOTE: Remember to update engines.node in package.json to match the major version.
 NODE_VERSION ?= 22.14.0
 
-# Run lint-rust check locally before merging code after you bump this.
 WASM_OPT_VERSION ?= 0.116.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,7 +9,6 @@ GOLANGCI_LINT_VERSION ?= v2.4.0
 NODE_VERSION ?= 22.14.0
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.81.0
 WASM_OPT_VERSION ?= 0.116.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.81.0"
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
This PR introduces a couple of changes that should reduce friction as we upgrade to newer versions of Rust and update our wasm-bindgen dependency:
1. Add a rust toolchain file that specifies the toolchain version and targets required to build our rust components. Rustup will automatically download, install, and utilize the toolchain specified in `rust-toolchain.toml`.
2. Automatically re-install `wasm-bindgen-cli` when we detect a version mismatch between the currently installed version and the `wasm-bindgen` version used to build our wasm module.
