### PR TITLE
Refactor health check protocol config

### DIFF
--- a/api/types/target_health.go
+++ b/api/types/target_health.go
@@ -25,8 +25,10 @@ import (
 type TargetHealthProtocol string
 
 const (
-	// TargetHealthProtocolTCP is a target health check protocol.
-	TargetHealthProtocolTCP TargetHealthProtocol = "TCP"
+	// TargetHealthProtocolTCP is the TCP target health check protocol.
+	TargetHealthProtocolTCP TargetHealthProtocol = "tcp"
+	// TargetHealthProtocolHTTP is the HTTP target health check protocol.
+	TargetHealthProtocolHTTP TargetHealthProtocol = "http"
 )
 
 // TargetHealthStatus is a target resource's health status.

--- a/lib/healthcheck/config.go
+++ b/lib/healthcheck/config.go
@@ -34,7 +34,6 @@ import (
 // [*healthcheckconfigv1.HealthCheckConfig] with defaults set.
 type healthCheckConfig struct {
 	name                  string
-	protocol              types.TargetHealthProtocol
 	interval              time.Duration
 	timeout               time.Duration
 	healthyThreshold      uint32
@@ -48,14 +47,11 @@ func newHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig) *healthChe
 	spec := cfg.GetSpec()
 	match := spec.GetMatch()
 	return &healthCheckConfig{
-		name:               cfg.GetMetadata().GetName(),
-		timeout:            cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
-		interval:           cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
-		healthyThreshold:   cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
-		unhealthyThreshold: cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
-		// we only support plain TCP health checks currently, but eventually we
-		// may add support for other protocols such as TLS or HTTP
-		protocol:              types.TargetHealthProtocolTCP,
+		name:                  cfg.GetMetadata().GetName(),
+		timeout:               cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
+		interval:              cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
+		healthyThreshold:      cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
+		unhealthyThreshold:    cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
 		databaseLabelMatchers: newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
 	}
 }
@@ -66,7 +62,6 @@ func (h *healthCheckConfig) equivalent(other *healthCheckConfig) bool {
 	return (h == nil && other == nil) ||
 		h != nil && other != nil &&
 			h.name == other.name &&
-			h.protocol == other.protocol &&
 			h.interval == other.interval &&
 			h.timeout == other.timeout &&
 			h.healthyThreshold == other.healthyThreshold &&

--- a/lib/healthcheck/config_test.go
+++ b/lib/healthcheck/config_test.go
@@ -77,7 +77,6 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				interval:           time.Second * 43,
 				healthyThreshold:   7,
 				unhealthyThreshold: 8,
-				protocol:           types.TargetHealthProtocolTCP,
 				databaseLabelMatchers: types.LabelMatchers{
 					Labels: types.Labels{
 						"foo": utils.Strings{"bar", "baz"},
@@ -95,7 +94,6 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				interval:           defaults.HealthCheckInterval,
 				healthyThreshold:   defaults.HealthCheckHealthyThreshold,
 				unhealthyThreshold: defaults.HealthCheckUnhealthyThreshold,
-				protocol:           types.TargetHealthProtocolTCP,
 				databaseLabelMatchers: types.LabelMatchers{
 					Labels:     types.Labels{},
 					Expression: `labels["*"] == "*"`,
@@ -139,7 +137,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			desc: "all fields equal",
 			a: &healthCheckConfig{
 				name:               "test",
-				protocol:           "http",
 				interval:           time.Second,
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
@@ -147,7 +144,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name:               "test",
-				protocol:           "http",
 				interval:           time.Second,
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
@@ -159,7 +155,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			desc: "all fields equal ignoring labels",
 			a: &healthCheckConfig{
 				name:                  "test",
-				protocol:              "http",
 				interval:              time.Second,
 				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
@@ -168,7 +163,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name:                  "test",
-				protocol:              "http",
 				interval:              time.Second,
 				timeout:               500 * time.Millisecond,
 				healthyThreshold:      3,
@@ -184,16 +178,6 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				name: "test2",
-			},
-			want: false,
-		},
-		{
-			desc: "different protocol",
-			a: &healthCheckConfig{
-				protocol: "http",
-			},
-			b: &healthCheckConfig{
-				protocol: "tcp",
 			},
 			want: false,
 		},

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -238,7 +238,6 @@ func (w *worker) run() {
 func (w *worker) startHealthCheckInterval(ctx context.Context) {
 	w.log.InfoContext(ctx, "Health checker started",
 		"health_check_config", w.healthCheckCfg.name,
-		"protocol", w.healthCheckCfg.protocol,
 		"interval", log.StringerAttr(w.healthCheckCfg.interval),
 		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
@@ -322,7 +321,6 @@ func (w *worker) updateHealthCheckConfig(ctx context.Context, newCfg *healthChec
 	}
 	w.log.DebugContext(ctx, "Updated health check config",
 		"health_check_config", w.healthCheckCfg.name,
-		"protocol", w.healthCheckCfg.protocol,
 		"interval", log.StringerAttr(w.healthCheckCfg.interval),
 		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
@@ -466,6 +464,7 @@ func (w *worker) setTargetHealthStatus(ctx context.Context, newStatus types.Targ
 	now := w.clock.Now()
 	w.targetHealth = types.TargetHealth{
 		Address:             strings.Join(w.lastResolvedEndpoints, ","),
+		Protocol:            string(types.TargetHealthProtocolTCP),
 		Status:              string(newStatus),
 		TransitionTimestamp: &now,
 		TransitionReason:    string(reason),
@@ -473,9 +472,6 @@ func (w *worker) setTargetHealthStatus(ctx context.Context, newStatus types.Targ
 	}
 	if w.lastResultErr != nil {
 		w.targetHealth.TransitionError = w.lastResultErr.Error()
-	}
-	if w.healthCheckCfg != nil {
-		w.targetHealth.Protocol = string(w.healthCheckCfg.protocol)
 	}
 }
 

--- a/lib/healthcheck/worker_test.go
+++ b/lib/healthcheck/worker_test.go
@@ -37,7 +37,8 @@ import (
 func Test_newUnstartedWorker(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	listener, err := net.Listen("tcp", "localhost:0")
+	protocol := string(types.TargetHealthProtocolTCP)
+	listener, err := net.Listen(protocol, "localhost:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
@@ -71,7 +72,7 @@ func Test_newUnstartedWorker(t *testing.T) {
 			},
 			wantHealth: types.TargetHealth{
 				Address:          "",
-				Protocol:         "",
+				Protocol:         protocol,
 				Status:           string(types.TargetHealthStatusUnknown),
 				TransitionReason: string(types.TargetHealthTransitionReasonDisabled),
 				Message:          "No health check config matches this resource",
@@ -96,7 +97,7 @@ func Test_newUnstartedWorker(t *testing.T) {
 			},
 			wantHealth: types.TargetHealth{
 				Address:          "",
-				Protocol:         "",
+				Protocol:         protocol,
 				Status:           string(types.TargetHealthStatusUnknown),
 				TransitionReason: string(types.TargetHealthTransitionReasonInit),
 				Message:          "Health checker initialized",


### PR DESCRIPTION
Part of Kubernetes health check integration.

- Removed unused `protocol` field from `healthCheckConfig`
- Changed `TargetHealthProtocolTCP` to lowercase for parameter use in `net.Dialer`
- Added `TargetHealthProtocolHTTP`

Relates to:
- #58413