### PR TITLE
Align User Login State Generator

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -422,6 +422,15 @@ func (g *Generator) Refresh(ctx context.Context, user types.User, ulsService ser
 		return nil, trace.Wrap(err)
 	}
 
+	// Set the full state directly on the user object.
+	// We cannot rely Upsert/Get User login state because the next webhook that calls GetUserLogin
+	// might receive stale data.
+	// Instead of using Upsert/Get calls to pass the object through the login hooks chain,
+	// the login hook updates the user object directly.
+	// TODO(smallinsky): Consider removing the user login state approach entirely, as it currently only mirrors the user state.
+	user.SetRoles(uls.GetRoles())
+	user.SetTraits(uls.GetTraits())
+
 	uls, err = ulsService.UpsertUserLoginState(ctx, uls)
 	return uls, trace.Wrap(err)
 }


### PR DESCRIPTION
### What


Our RBAC is entirely realy on the user login state https://github.com/gravitational/teleport/blob/master/lib/auth/methods.go#L111

UserLoginState represents the final RBAC state. Each flow uses the traits and roles generated by UserLoginState as the source of truth that that is used to generate user trails/roles in final user certificate. 

Currently, three webhooks call GetUserLoginState to retrieve the roles and traits produced by (g *Generator) Refresh and saved via UpsertUserLoginState.

However, when a cache is involved, GetUserLoginState may return outdated information. To avoid this, instead of relying on UpsertUserLoginState / GetUserLoginState calls in the webhook chain, we can update the user object directly and pass it along to the next webhook. This way, the flow does not depend on GetUserLoginState, which can return inconsistent data depending on cache synchronization timing.


I have added a caching call instead in backend for the GetUserLoginState call in: 

https://github.com/gravitational/teleport.e/pull/7295

https://github.com/gravitational/teleport/pull/59299/files#diff-2edecd0eaed32a62db0bbe12d1288324e15cf5cb293edb99388876536225de61R1339

####  this change is needed to increate user login time by not calling the  backend to get the updated to date roles/trailts view generated by login hooks.


Related https://github.com/gravitational/teleport.e/pull/7297
