### PR TITLE
[v16] [cache] unify generic resource test utility

### DIFF
--- a/lib/cache/resource_spiffe_federation_test.go
+++ b/lib/cache/resource_spiffe_federation_test.go
@@ -50,7 +50,7 @@ func TestSPIFFEFederations(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*machineidv1.SPIFFEFederation]{
+	testResources153(t, p, testFuncs[*machineidv1.SPIFFEFederation]{
 		newResource: func(s string) (*machineidv1.SPIFFEFederation, error) {
 			return newSPIFFEFederation(s), nil
 		},
@@ -72,5 +72,5 @@ func TestSPIFFEFederations(t *testing.T) {
 			return items, trace.Wrap(err)
 		},
 		cacheGet: p.cache.GetSPIFFEFederation,
-	})
+	}, withSkipPaginationTest())
 }

--- a/lib/cache/resource_workload_identity_test.go
+++ b/lib/cache/resource_workload_identity_test.go
@@ -48,7 +48,7 @@ func TestWorkloadIdentity(t *testing.T) {
 	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
-	testResources153(t, p, testFuncs153[*workloadidentityv1pb.WorkloadIdentity]{
+	testResources153(t, p, testFuncs[*workloadidentityv1pb.WorkloadIdentity]{
 		newResource: func(s string) (*workloadidentityv1pb.WorkloadIdentity, error) {
 			return newWorkloadIdentity(s), nil
 		},
@@ -70,5 +70,5 @@ func TestWorkloadIdentity(t *testing.T) {
 			return items, trace.Wrap(err)
 		},
 		cacheGet: p.cache.GetWorkloadIdentity,
-	})
+	}, withSkipPaginationTest())
 }


### PR DESCRIPTION
Backport #58204 to branch/v16

Note that the update test on cache RemoteClusters has been disabled. This is due to a problem in how the cache handles revisions for this resource type in v16.