### PR TITLE
ui: update aws anywhere Teleport docs link in enroll guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2283,6 +2283,11 @@
       "source": "/reference/workload-identity/",
       "destination": "/reference/machine-workload-identity/workload-identity/",
       "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/cloud-apis/aws-console-without-agent/",
+      "destination": "/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere/",
+      "permanent": true
     }
   ]
 }

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Guide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/Guide.tsx
@@ -48,7 +48,7 @@ const GuideReferenceLinks = {
   },
   TeleportSetUp: {
     title: 'Teleport AWS Console and CLI access: Set up access',
-    href: 'https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console-without-agent/#step-34-set-up-access',
+    href: 'https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere#step-34-set-up-access',
   },
 };
 


### PR DESCRIPTION
The link [aws console](https://goteleport.com/docs/enroll-resources/application-access/cloud-apis/aws-console-without-agent/) results in a 404. Updated to the current link and added a redirect for the role one.