### PR TITLE
Update deadlinks in tbot log messages

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -588,7 +588,7 @@ func ReadConfig(reader io.ReadSeeker, manualMigration bool) (*BotConfig, error) 
 	case V1, "":
 		if !manualMigration {
 			log.WarnContext(
-				context.TODO(), "Deprecated config version (V1) detected. Attempting to perform an on-the-fly in-memory migration to latest version. Please persist the config migration by following the guidance at https://goteleport.com/docs/reference/machine-id/v14-upgrade-guide/")
+				context.TODO(), "Deprecated config version (V1) detected. Attempting to perform an on-the-fly in-memory migration to latest version. Please persist the config migration using `tbot migrate`.")
 		}
 		config := &configV1{}
 		if err := decoder.Decode(config); err != nil {
@@ -598,7 +598,7 @@ func ReadConfig(reader io.ReadSeeker, manualMigration bool) (*BotConfig, error) 
 		if err != nil {
 			return nil, trace.WithUserMessage(
 				trace.Wrap(err, "migrating v1 config"),
-				"Failed to migrate. See https://goteleport.com/docs/reference/machine-id/v14-upgrade-guide/",
+				"Failed to migrate. Please contact Teleport support or use https://goteleport.com/docs/reference/machine-id/configuration/ to manually migrate your configuration.",
 			)
 		}
 		return latestConfig, nil


### PR DESCRIPTION
We removed this documentation page as the deprecation of the v1 configuration occurred a long time ago, however, links within log messages still directed users towards it. To my knowledge, we've never actually had a reported failure with this migration since it was introduced - and in the last year or so, I've not come across any support tickets or customer interactions where the v1 configuration was still in use.