### PR TITLE
Connect: Assign higher scores to search results from current workspace

### DIFF
--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -226,6 +226,10 @@ export const createAppConfigSchema = (settings: RuntimeSettings) => {
       .boolean()
       .default(!settings.dev)
       .describe('Controls whether the hardware key agent will be started.'),
+    'debug.searchResultsScore': z
+      .boolean()
+      .default(false)
+      .describe('Enables display of scores for search results.'),
   });
 };
 

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -370,11 +370,17 @@ function calculateScore(
     const field = searchResult.resource[match.field];
     const isMainField = mainResourceField[searchResult.kind] === match.field;
     const lengthScore = getLengthScore(searchTerm, field);
-    const weight = isMainField ? 5 : 2;
-    // Bonus multiplier for an exact match on the main field.
-    const exactMainMatchWeight = isMainField && lengthScore === 100 ? 1.25 : 1;
+    const isExactMatch = lengthScore === 100;
+    const mainFieldBoost = isMainField ? 5 : 2;
+    // Boost exact matches on the main field.
+    // Let's say there's two databases, "postgres" with no labels and "postgres-dev" with a
+    // engine:postgres label. If the user searches for "postgres", we want to show the "postgres"
+    // database first. Without this bonus multiplier, "postgres-dev" could end up being first as the
+    // search term "postgres" also matches the label.
+    const exactMainMatchBoost = isMainField && isExactMatch ? 1.25 : 1;
 
-    const resourceMatchScore = lengthScore * weight * exactMainMatchWeight;
+    const resourceMatchScore =
+      lengthScore * mainFieldBoost * exactMainMatchBoost;
     searchResultScore += resourceMatchScore;
   }
 

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -22,6 +22,7 @@ import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb'
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
+import { routing } from 'teleterm/ui/uri';
 import { assertUnreachable } from 'teleterm/ui/utils';
 
 import {
@@ -239,7 +240,8 @@ export function useFilterSearch() {
 /** Sorts and then returns top 10 results. */
 export function rankResults(
   searchResults: resourcesServiceTypes.SearchResult[],
-  search: string
+  search: string,
+  currentWorkspace: CurrentWorkspace
 ): ResourceSearchResult[] {
   const terms = search
     .split(' ')
@@ -264,7 +266,9 @@ export function rankResults(
   const collator = new Intl.Collator();
 
   return searchResults
-    .map(searchResult => calculateScore(populateMatches(searchResult, terms)))
+    .map(searchResult =>
+      calculateScore(populateMatches(searchResult, terms), currentWorkspace)
+    )
     .sort(
       (a, b) =>
         // Highest score first.
@@ -325,10 +329,13 @@ function populateMatches(
   return { ...searchResult, labelMatches, resourceMatches, score: 0 };
 }
 
+type CurrentWorkspace = { workspaceUri: string; localClusterUri: string };
+
 // TODO(ravicious): Extract the scoring logic to a function to better illustrate different weight
 // for different matches.
 function calculateScore(
-  searchResult: ResourceSearchResult
+  searchResult: ResourceSearchResult,
+  currentWorkspace: CurrentWorkspace
 ): ResourceSearchResult {
   let searchResultScore = 0;
 
@@ -362,10 +369,28 @@ function calculateScore(
     const { searchTerm } = match;
     const field = searchResult.resource[match.field];
     const isMainField = mainResourceField[searchResult.kind] === match.field;
-    const weight = isMainField ? 4 : 2;
+    const lengthScore = getLengthScore(searchTerm, field);
+    const weight = isMainField ? 5 : 2;
+    // Bonus multiplier for an exact match on the main field.
+    const exactMainMatchWeight = isMainField && lengthScore === 100 ? 1.25 : 1;
 
-    const resourceMatchScore = getLengthScore(searchTerm, field) * weight;
+    const resourceMatchScore = lengthScore * weight * exactMainMatchWeight;
     searchResultScore += resourceMatchScore;
+  }
+
+  // Extra points for belonging to the current workspace and the currently selected cluster.
+  const belongsToCurrentWorkspace = routing.belongsToProfile(
+    currentWorkspace.workspaceUri,
+    searchResult.resource.uri
+  );
+  const belongsToCurrentCluster =
+    currentWorkspace.localClusterUri ==
+    routing.ensureClusterUri(searchResult.resource.uri);
+  if (belongsToCurrentWorkspace) {
+    searchResultScore *= 1.1;
+  }
+  if (belongsToCurrentCluster) {
+    searchResultScore *= 1.1;
   }
 
   // Show resources that require access lower in the results.


### PR DESCRIPTION
Closes #51077.

This PR makes it so that search results from the current workspace and the current cluster receive a score boost. The aim is to show the results from the current workspace higher in case there are multiple close results across different clusters and workspaces.

This PR also gives a boost for results that include an exact match on the resource name. Sometimes close matches would be ranked above exact matches because in addition to a close match on the name they also matched on other fields (see example1 and example2 in the screenshots).

In the screenshots the current workspace and cluster is enterprise-local. In the version before, the exact match from that cluster wouldn't even show up above the fold.

| Before | After |
| --- | --- |
| <img width="696" height="407" alt="enterprise-example-before" src="https://github.com/user-attachments/assets/6ac2378b-c630-40a8-b0d0-6a7c7671666d" /> | <img width="696" height="407" alt="enterprise-example-after" src="https://github.com/user-attachments/assets/6248bf30-d587-48b6-a073-ebe3c7a8d24a" /> |

Another thing added in this PR is a new config option `debug.searchResultsScore` which helps with debugging scores. The debug display isn't pretty, but at least if someone runs into some weird behavior with the scoring algorithm we'll have a slightly better view into the situation.

<img width="696" height="407" alt="debug" src="https://github.com/user-attachments/assets/80cb42d0-c5a5-4a49-af90-ef5afe1fc709" />

---

As a sidenote I have to say that we're reaching the absolute limits of the scoring algorithm. The current approach which scores resource fields based on how many characters they match is showing it seams. If there are further problems with it, it'd be best to completely rewrite it with some good foundational principles in place.