### PR TITLE
[cache] enable remaining pagination tests

### DIFF
--- a/lib/cache/access_monitoring_rule_test.go
+++ b/lib/cache/access_monitoring_rule_test.go
@@ -39,7 +39,7 @@ func TestAccessMonitoringRules(t *testing.T) {
 
 	testResources153(t, p, testFuncs[*accessmonitoringrulesv1.AccessMonitoringRule]{
 		newResource: func(name string) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-			return newAccessMonitoringRule(t), nil
+			return newAccessMonitoringRule(t, name), nil
 		},
 		create: func(ctx context.Context, i *accessmonitoringrulesv1.AccessMonitoringRule) error {
 			_, err := p.accessMonitoringRules.CreateAccessMonitoringRule(ctx, i)
@@ -53,7 +53,7 @@ func TestAccessMonitoringRules(t *testing.T) {
 			return err
 		},
 		deleteAll: p.accessMonitoringRules.DeleteAllAccessMonitoringRules,
-	}, withSkipPaginationTest())
+	})
 }
 
 func TestListAccessMonitoringRulesWithFilter(t *testing.T) {

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -77,7 +77,7 @@ func TestBotInstanceCache(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return p.botInstanceService.DeleteAllBotInstances(ctx)
 		},
-	}, withSkipPaginationTest())
+	})
 }
 
 // TestBotInstanceCachePaging tests that items from the cache are paginated.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1925,7 +1925,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindKubeWaitingContainer:              newKubeWaitingContainer(t),
 		types.KindNotification:                      types.Resource153ToLegacy(newUserNotification(t, "test")),
 		types.KindGlobalNotification:                types.Resource153ToLegacy(newGlobalNotification(t, "test")),
-		types.KindAccessMonitoringRule:              types.Resource153ToLegacy(newAccessMonitoringRule(t)),
+		types.KindAccessMonitoringRule:              types.Resource153ToLegacy(newAccessMonitoringRule(t, "test")),
 		types.KindCrownJewel:                        types.Resource153ToLegacy(newCrownJewel(t, "test")),
 		types.KindDatabaseObject:                    types.Resource153ToLegacy(newDatabaseObject(t, "test")),
 		types.KindAccessGraphSettings:               types.Resource153ToLegacy(newAccessGraphSettings(t)),
@@ -2505,12 +2505,14 @@ func newGlobalNotification(t *testing.T, title string) *notificationsv1.GlobalNo
 	return notification
 }
 
-func newAccessMonitoringRule(t *testing.T) *accessmonitoringrulesv1.AccessMonitoringRule {
+func newAccessMonitoringRule(t *testing.T, name string) *accessmonitoringrulesv1.AccessMonitoringRule {
 	t.Helper()
 	notification := &accessmonitoringrulesv1.AccessMonitoringRule{
-		Kind:     types.KindAccessMonitoringRule,
-		Version:  types.V1,
-		Metadata: &headerv1.Metadata{},
+		Kind:    types.KindAccessMonitoringRule,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
 		Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
 			Notification: &accessmonitoringrulesv1.Notification{
 				Name: "test",

--- a/lib/cache/crown_jewel_test.go
+++ b/lib/cache/crown_jewel_test.go
@@ -48,5 +48,5 @@ func TestCrownJewel(t *testing.T) {
 			return p.crownJewels.ListCrownJewels(ctx, int64(pageSize), pageToken)
 		},
 		deleteAll: p.crownJewels.DeleteAllCrownJewels,
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -220,5 +220,5 @@ func TestDatabaseObjects(t *testing.T) {
 			}
 			return nil
 		},
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/health_check_config_test.go
+++ b/lib/cache/health_check_config_test.go
@@ -65,5 +65,5 @@ func TestHealthCheckConfig(t *testing.T) {
 		deleteAll: p.healthCheckConfig.DeleteAllHealthCheckConfigs,
 		cacheList: p.cache.ListHealthCheckConfigs,
 		cacheGet:  p.cache.GetHealthCheckConfig,
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/identitycenter_test.go
+++ b/lib/cache/identitycenter_test.go
@@ -71,7 +71,7 @@ func TestIdentityCenterAccount(t *testing.T) {
 		deleteAll: fixturePack.identityCenter.DeleteAllIdentityCenterAccounts,
 		cacheList: fixturePack.cache.ListIdentityCenterAccounts,
 		cacheGet:  fixturePack.cache.GetIdentityCenterAccount,
-	}, withSkipPaginationTest())
+	})
 }
 
 func newIdentityCenterPrincipalAssignment(id string) *identitycenterv1.PrincipalAssignment {
@@ -123,7 +123,7 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 			r, err := fixturePack.cache.GetPrincipalAssignment(ctx, services.PrincipalAssignmentID(id))
 			return r, trace.Wrap(err)
 		},
-	}, withSkipPaginationTest())
+	})
 }
 
 func newIdentityCenterAccountAssignment(id string) *identitycenterv1.AccountAssignment {
@@ -174,5 +174,5 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 			r, err := fixturePack.cache.GetAccountAssignment(ctx, services.IdentityCenterAccountAssignmentID(id))
 			return r.AccountAssignment, trace.Wrap(err)
 		},
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -41,16 +41,10 @@ func TestKubernetes(t *testing.T) {
 				Name: name,
 			}, types.KubernetesClusterSpecV3{})
 		},
-		create: p.kubernetes.CreateKubernetesCluster,
-		list: func(ctx context.Context, _ int, _ string) ([]types.KubeCluster, string, error) {
-			out, err := p.kubernetes.GetKubernetesClusters(ctx)
-			return out, "", trace.Wrap(err)
-		},
-		cacheGet: p.cache.GetKubernetesCluster,
-		cacheList: func(ctx context.Context, _ int, _ string) ([]types.KubeCluster, string, error) {
-			out, err := p.cache.GetKubernetesClusters(ctx)
-			return out, "", trace.Wrap(err)
-		},
+		create:    p.kubernetes.CreateKubernetesCluster,
+		list:      getAllAdapter(p.kubernetes.GetKubernetesClusters),
+		cacheGet:  p.cache.GetKubernetesCluster,
+		cacheList: getAllAdapter(p.cache.GetKubernetesClusters),
 		update:    p.kubernetes.UpdateKubernetesCluster,
 		deleteAll: p.kubernetes.DeleteAllKubernetesClusters,
 	}, withSkipPaginationTest())

--- a/lib/cache/networking_restrictions_test.go
+++ b/lib/cache/networking_restrictions_test.go
@@ -17,10 +17,7 @@
 package cache
 
 import (
-	"context"
 	"testing"
-
-	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -35,18 +32,9 @@ func TestNetworkRestrictions(t *testing.T) {
 		newResource: func(name string) (types.NetworkRestrictions, error) {
 			return types.NewNetworkRestrictions(), nil
 		},
-		create: p.restrictions.SetNetworkRestrictions,
-		list: func(ctx context.Context, _ int, _ string) ([]types.NetworkRestrictions, string, error) {
-			restrictions, err := p.restrictions.GetNetworkRestrictions(ctx)
-			return []types.NetworkRestrictions{restrictions}, "", trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context, _ int, _ string) ([]types.NetworkRestrictions, string, error) {
-			restrictions, err := p.cache.GetNetworkRestrictions(ctx)
-			if trace.IsNotFound(err) {
-				return nil, "", nil
-			}
-			return []types.NetworkRestrictions{restrictions}, "", trace.Wrap(err)
-		},
+		create:    p.restrictions.SetNetworkRestrictions,
+		list:      singletonListAdapter(p.restrictions.GetNetworkRestrictions),
+		cacheList: singletonListAdapter(p.cache.GetNetworkRestrictions),
 		deleteAll: p.restrictions.DeleteNetworkRestrictions,
 	}, withSkipPaginationTest()) // skip pagination test because NetworkRestrictions is a singleton resource
 }

--- a/lib/cache/notification_test.go
+++ b/lib/cache/notification_test.go
@@ -44,7 +44,7 @@ func TestUserNotifications(t *testing.T) {
 		list:      p.notifications.ListUserNotifications,
 		cacheList: p.cache.ListUserNotifications,
 		deleteAll: p.notifications.DeleteAllUserNotifications,
-	}, withSkipPaginationTest())
+	})
 }
 
 // TestGlobalNotifications tests that CRUD operations on global notification resources are
@@ -66,5 +66,5 @@ func TestGlobalNotifications(t *testing.T) {
 		list:      p.notifications.ListGlobalNotifications,
 		cacheList: p.cache.ListGlobalNotifications,
 		deleteAll: p.notifications.DeleteAllGlobalNotifications,
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/spiffe_federation_test.go
+++ b/lib/cache/spiffe_federation_test.go
@@ -62,5 +62,5 @@ func TestSPIFFEFederations(t *testing.T) {
 		deleteAll: p.spiffeFederations.DeleteAllSPIFFEFederations,
 		cacheList: p.cache.ListSPIFFEFederations,
 		cacheGet:  p.cache.GetSPIFFEFederation,
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/static_host_user_test.go
+++ b/lib/cache/static_host_user_test.go
@@ -45,5 +45,5 @@ func TestStaticHostUsers(t *testing.T) {
 		cacheList: p.cache.ListStaticHostUsers,
 		cacheGet:  p.cache.GetStaticHostUser,
 		deleteAll: p.staticHostUsers.DeleteAllStaticHostUsers,
-	}, withSkipPaginationTest())
+	})
 }


### PR DESCRIPTION
This commit enables the remaining pagination
coverage for resources that have paginated accessors.

Clean up some remaining tests to use adapters.