### PR TITLE
Connect: Use consistent width for buttons in unified resources

### DIFF
--- a/web/packages/design/src/Button/buttons.story.tsx
+++ b/web/packages/design/src/Button/buttons.story.tsx
@@ -85,7 +85,8 @@ export const Buttons = () => {
             </Fragment>
           ))}
         </tbody>
-      </Table>{' '}
+      </Table>
+
       <Flex gap={3}>
         <ButtonPrimary>Primary</ButtonPrimary>
         <ButtonPrimaryBorder>Primary (border)</ButtonPrimaryBorder>
@@ -93,12 +94,14 @@ export const Buttons = () => {
         <ButtonBorder>Border</ButtonBorder>
         <ButtonWarning>Warning</ButtonWarning>
       </Flex>
+
       <Flex gap={3} alignItems="center">
         <Button size="extra-large">Extra large</Button>
         <Button size="large">Large</Button>
         <Button size="medium">Medium</Button>
         <Button size="small">Small</Button>
       </Flex>
+
       <Flex flexDirection="column" gap={3} alignItems="flex-start">
         <Input
           defaultValue="Padding of buttons below should match padding of this input"
@@ -117,19 +120,23 @@ export const Buttons = () => {
           Small with input alignment
         </Button>
       </Flex>
+
       <Button block>block = true</Button>
+
       <Flex gap={3}>
         <Button disabled>Disabled</Button>
         <Box className="teleport-button__force-focus-visible">
           <Button>Focused</Button>
         </Box>
       </Flex>
+
       <Flex gap={3}>
         <ButtonPrimary gap={2}>
           <icons.AddUsers />
           Add users
         </ButtonPrimary>
       </Flex>
+
       <Flex gap={3} alignItems="center">
         <ButtonWithMenu
           text="Button with menu"
@@ -169,6 +176,27 @@ export const Buttons = () => {
           {menuItemsForButtonWithMenu}
         </ButtonWithMenu>
       </Flex>
+
+      <Stack gap={3}>
+        <ButtonWithMenu
+          text={`width={${constantWidth}}`}
+          width={constantWidth}
+          size="small"
+          onClick={() => alert('Button with menu')}
+        >
+          {menuItemsForButtonWithMenu}
+        </ButtonWithMenu>
+
+        <ButtonWithMenu
+          text={`buttonWidth={${constantWidth}}`}
+          buttonWidth={constantWidth}
+          size="small"
+          onClick={() => alert('Button with menu')}
+        >
+          {menuItemsForButtonWithMenu}
+        </ButtonWithMenu>
+      </Stack>
+
       <Flex gap={3}>
         <Button as="a" href="https://example.com" target="_blank">
           Link as button
@@ -183,10 +211,12 @@ export const Buttons = () => {
           <icons.Link />
         </ButtonIcon>
       </Flex>
+
       <Flex gap={3}>
         <ButtonLink href="">Button Link</ButtonLink>
         <ButtonText>Button Text</ButtonText>
       </Flex>
+
       <Flex gap={3} flexDirection="column" alignItems="flex-start">
         {([2, 1, 0] as const).map(size => (
           <Flex gap={3} key={`size-${size}`}>
@@ -324,3 +354,5 @@ const Emphasis = styled.span`
   text-decoration-line: underline;
   text-decoration-color: red;
 `;
+
+const constantWidth = 150;

--- a/web/packages/design/src/ButtonWithMenu/ButtonWithMenu.tsx
+++ b/web/packages/design/src/ButtonWithMenu/ButtonWithMenu.tsx
@@ -60,6 +60,14 @@ export const ButtonWithMenu = <Element extends ElementType = 'button'>(
     MenuIcon?: ComponentType<IconProps>;
     size?: ButtonSize;
     forwardedAs?: Element;
+    /**
+     * Width of just the Button part of the component. Ignored if width is set.
+     */
+    buttonWidth?: ComponentPropsWithoutRef<typeof Flex>['width'];
+    /**
+     * Width of the whole component (Button + menu Button). buttonWidth is ignored if width is set.
+     */
+    width?: ComponentPropsWithoutRef<typeof Flex>['width'];
   } & ComponentPropsWithoutRef<typeof ButtonBorder<Element>>
 ) => {
   const {
@@ -67,6 +75,8 @@ export const ButtonWithMenu = <Element extends ElementType = 'button'>(
     MenuIcon = icons.MoreVert,
     children,
     size = 'medium',
+    width,
+    buttonWidth,
     ...buttonBorderProps
   } = props;
 
@@ -74,7 +84,7 @@ export const ButtonWithMenu = <Element extends ElementType = 'button'>(
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <Flex>
+    <Flex width={width}>
       <ButtonBorder
         css={`
           border-top-right-radius: 0;
@@ -82,6 +92,7 @@ export const ButtonWithMenu = <Element extends ElementType = 'button'>(
         `}
         size={size}
         {...buttonBorderProps}
+        width={width ? '100%' : buttonWidth}
       >
         {text}
       </ButtonBorder>

--- a/web/packages/shared/components/AwsLaunchButton/AwsLaunchButton.tsx
+++ b/web/packages/shared/components/AwsLaunchButton/AwsLaunchButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { ComponentPropsWithRef } from 'react';
 import styled from 'styled-components';
 
 import { Box, ButtonBorder, Flex, Text } from 'design';
@@ -195,7 +195,7 @@ type Props = {
   awsRoles: AwsRole[];
   getLaunchUrl(arn: string): string;
   onLaunchUrl?(arn: string): void;
-  width?: string;
+  width?: ComponentPropsWithRef<typeof ButtonBorder>['width'];
   isAwsIdentityCenterApp?: boolean;
 };
 

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -18,6 +18,7 @@
 
 import React, {
   ChangeEvent,
+  ComponentPropsWithoutRef,
   useImperativeHandle,
   useRef,
   useState,
@@ -180,7 +181,7 @@ const LoginItemList = ({
   onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder: string;
-  width?: string;
+  width?: ComponentPropsWithoutRef<typeof Flex>['minWidth'];
   inputType?: MenuInputType;
 }) => {
   const content = getLoginItemListContent(items, getLoginItemsAttempt, onClick);

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -49,6 +49,7 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
       inputType = MenuInputType.INPUT,
       required = true,
       width,
+      buttonWidth,
       style,
     } = props;
     const [filter, setFilter] = useState('');
@@ -128,7 +129,7 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
     return (
       <React.Fragment>
         <ButtonComponent
-          width={alignButtonWidthToMenu ? width : null}
+          width={alignButtonWidthToMenu ? width : buttonWidth}
           textTransform={props.textTransform}
           size="small"
           ref={anchorRef}

--- a/web/packages/shared/components/MenuLogin/types.ts
+++ b/web/packages/shared/components/MenuLogin/types.ts
@@ -18,6 +18,7 @@
 
 import { ComponentPropsWithRef, ComponentType, CSSProperties } from 'react';
 
+import { Flex } from 'design';
 import { ButtonBorder } from 'design/Button';
 
 export type LoginItem = {
@@ -54,7 +55,15 @@ export type MenuLoginProps = {
   textTransform?: string;
   placeholder?: string;
   required?: boolean;
-  width?: ComponentPropsWithRef<typeof ButtonBorder>['width'];
+  /**
+   * Width of the displayed menu. If alignButtonWidthToMenu is true, then this is also the width of
+   * the button.
+   */
+  width?: ComponentPropsWithRef<typeof Flex>['width'];
+  /**
+   * Width of just the button. Ignored if alignButtonWidthToMenu is true.
+   */
+  buttonWidth?: ComponentPropsWithRef<typeof ButtonBorder>['width'];
   ButtonComponent?: ComponentType<ComponentPropsWithRef<typeof ButtonBorder>>;
   buttonText?: string;
   style?: CSSProperties;

--- a/web/packages/shared/components/MenuLogin/types.ts
+++ b/web/packages/shared/components/MenuLogin/types.ts
@@ -54,7 +54,7 @@ export type MenuLoginProps = {
   textTransform?: string;
   placeholder?: string;
   required?: boolean;
-  width?: string;
+  width?: ComponentPropsWithRef<typeof ButtonBorder>['width'];
   ButtonComponent?: ComponentType<ComponentPropsWithRef<typeof ButtonBorder>>;
   buttonText?: string;
   style?: CSSProperties;

--- a/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.story.tsx
+++ b/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.story.tsx
@@ -18,7 +18,7 @@
 
 import styled from 'styled-components';
 
-import { Flex, H3, MenuItem } from 'design';
+import { Box, Flex, H3, MenuItem, Stack, Text } from 'design';
 import { MenuInputType } from 'shared/components/MenuLogin';
 
 import { MenuLoginWithActionMenu as MenuLoginWithActionMenuComponent } from './MenuLoginWithActionMenu';
@@ -29,76 +29,116 @@ export default {
 
 export const MenuLoginWithActionMenu = () => {
   return (
-    <Flex
-      inline
-      p={4}
-      gap="128px"
-      justifyContent="flex-start"
-      bg="levels.surface"
-    >
-      <Example>
-        <H3>No logins</H3>
-        <MenuLoginWithActionMenuComponent
-          getLoginItems={() => []}
-          onSelect={() => null}
-          buttonText="Connect"
-          size="small"
-        >
-          {menuItems}
-        </MenuLoginWithActionMenuComponent>
-      </Example>
-      <Example>
-        <H3>Processing state</H3>
-        <MenuLoginWithActionMenuComponent
-          getLoginItems={() => new Promise(() => {})}
-          onSelect={() => null}
-          buttonText="Connect"
-          size="small"
-        >
-          {menuItems}
-        </MenuLoginWithActionMenuComponent>
-      </Example>
-      <Example>
-        <H3>With logins</H3>
-        <MenuLoginWithActionMenuComponent
-          size="small"
-          buttonText="Connect"
-          getLoginItems={() => urlItems}
-          onSelect={() => null}
-          placeholder="Select item to log in..."
-          inputType={MenuInputType.NONE}
-        >
-          {menuItems}
-        </MenuLoginWithActionMenuComponent>
-      </Example>
-      <Example>
-        <H3>With logins and search input</H3>
-        <MenuLoginWithActionMenuComponent
-          buttonText="Connect"
-          size="small"
-          getLoginItems={() => loginItems}
-          onSelect={() => null}
-          placeholder="search login"
-        >
-          {menuItems}
-        </MenuLoginWithActionMenuComponent>
-      </Example>
-      <Example>
-        <H3>Large button with custom width</H3>
-        <MenuLoginWithActionMenuComponent
-          size="large"
-          width="150px"
-          buttonText="Connect"
-          getLoginItems={() => urlItems}
-          onSelect={() => null}
-          placeholder="Select item to log in..."
-        >
-          {menuItems}
-        </MenuLoginWithActionMenuComponent>
-      </Example>
-    </Flex>
+    <Stack gap={4}>
+      <Flex
+        inline
+        p={4}
+        gap="128px"
+        justifyContent="flex-start"
+        bg="levels.surface"
+      >
+        <Example>
+          <H3>No logins</H3>
+          <MenuLoginWithActionMenuComponent
+            getLoginItems={() => []}
+            onSelect={() => null}
+            buttonText="Connect"
+            size="small"
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+        <Example>
+          <H3>Processing state</H3>
+          <MenuLoginWithActionMenuComponent
+            getLoginItems={() => new Promise(() => {})}
+            onSelect={() => null}
+            buttonText="Connect"
+            size="small"
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+        <Example>
+          <H3>With logins</H3>
+          <MenuLoginWithActionMenuComponent
+            size="small"
+            buttonText="Connect"
+            getLoginItems={() => urlItems}
+            onSelect={() => null}
+            placeholder="Select item to log in..."
+            inputType={MenuInputType.NONE}
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+        <Example>
+          <H3>With logins and search input</H3>
+          <MenuLoginWithActionMenuComponent
+            buttonText="Connect"
+            size="small"
+            getLoginItems={() => loginItems}
+            onSelect={() => null}
+            placeholder="search login"
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+        <Example>
+          <H3>Large button with custom width</H3>
+          <MenuLoginWithActionMenuComponent
+            size="large"
+            menuWidth="150px"
+            buttonText="Connect"
+            getLoginItems={() => urlItems}
+            onSelect={() => null}
+            placeholder="Select item to log in..."
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+      </Flex>
+
+      <Stack p={4} gap={3} bg="levels.surface">
+        <Example>
+          <Box>
+            <H3>width=&#123;{constantWidth}&#125;</H3>
+            <Text>Affects total component width</Text>
+          </Box>
+          <MenuLoginWithActionMenuComponent
+            width={constantWidth}
+            buttonText="Connect"
+            size="small"
+            getLoginItems={() => loginItems}
+            onSelect={() => null}
+            placeholder="search login"
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+
+        <Example>
+          <Box>
+            <H3>menuWidth=&#123;{constantWidth}&#125;</H3>
+            <Text>Affects button and menu width</Text>
+          </Box>
+          <MenuLoginWithActionMenuComponent
+            menuWidth={constantWidth}
+            buttonText="Connect"
+            size="small"
+            getLoginItems={() => loginItems}
+            onSelect={() => null}
+            placeholder="search login"
+          >
+            {menuItems}
+          </MenuLoginWithActionMenuComponent>
+        </Example>
+      </Stack>
+    </Stack>
   );
 };
+
+const constantWidth = 250;
 
 const Example = styled(Flex).attrs({
   gap: 2,

--- a/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
+++ b/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
@@ -16,7 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ReactElement, useRef, useState } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  ReactElement,
+  useRef,
+  useState,
+} from 'react';
 
 import { ButtonBorder, Flex, Menu, MenuItem } from 'design';
 import { ButtonSize } from 'design/Button';
@@ -67,7 +72,7 @@ export const MenuLoginWithActionMenu = ({
   getLoginItems: () => LoginItem[] | Promise<LoginItem[]>;
   /** Action menu items. */
   children: MenuItemComponent | MenuItemComponent[];
-  width?: string;
+  width?: ComponentPropsWithoutRef<typeof MenuLogin>['width'];
   size?: ButtonSize;
   /** Text for action menu search box or static label.  */
   placeholder?: string;

--- a/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
+++ b/web/packages/shared/components/MenuLoginWithActionMenu/MenuLoginWithActionMenu.tsx
@@ -53,6 +53,7 @@ export const MenuLoginWithActionMenu = ({
   onSelect,
   getLoginItems,
   children,
+  menuWidth,
   width,
   size = 'medium',
   placeholder,
@@ -72,7 +73,14 @@ export const MenuLoginWithActionMenu = ({
   getLoginItems: () => LoginItem[] | Promise<LoginItem[]>;
   /** Action menu items. */
   children: MenuItemComponent | MenuItemComponent[];
-  width?: ComponentPropsWithoutRef<typeof MenuLogin>['width'];
+  /**
+   * Width of just the MenuLogin part of the component. Ignored if width is set.
+   */
+  menuWidth?: ComponentPropsWithoutRef<typeof MenuLogin>['width'];
+  /**
+   * Width of the whole component (button of MenuLogin + ButtonBorder of action menu). menuWidth is ignored if width is set.
+   */
+  width?: ComponentPropsWithoutRef<typeof Flex>['width'];
   size?: ButtonSize;
   /** Text for action menu search box or static label.  */
   placeholder?: string;
@@ -82,9 +90,9 @@ export const MenuLoginWithActionMenu = ({
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <Flex>
+    <Flex width={width}>
       <MenuLogin
-        width={width}
+        width={width ? '100%' : menuWidth}
         inputType={inputType}
         onSelect={onSelect}
         textTransform="none"

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -498,7 +498,7 @@ function makeSamlAppLoginWithMenuButton(
       return (
         <MenuLoginWithActionMenu
           getLoginItems={() => makeSamlAppLoginOptions(launchUrls)}
-          width="100px"
+          menuWidth="100px"
           onSelect={() => {}} // login item rendered as <a> link for saml apps.
           buttonText="Log In"
           size="small"
@@ -515,7 +515,7 @@ function makeSamlAppLoginWithMenuButton(
   return (
     <ButtonWithMenu
       text="Log In"
-      width="100px"
+      buttonWidth="100px"
       size="small"
       target="_blank"
       href={ssoUrl}

--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -89,6 +89,10 @@ export function isWebApp(app: App): boolean {
   );
 }
 
+export function isMcp(app: App): boolean {
+  return app.endpointUri.startsWith('mcp+');
+}
+
 /**
  * Returns address with protocol which is an app protocol + a public address.
  * If the public address is empty, it falls back to the endpoint URI.

--- a/web/packages/teleterm/src/services/tshd/gateway.ts
+++ b/web/packages/teleterm/src/services/tshd/gateway.ts
@@ -102,3 +102,17 @@ export function getGatewayTargetUriKind(
   // However, at the moment that field is essentially of type string, so there's not much we can do
   // with regards to type safety.
 }
+
+/**
+ * Available types are listed here:
+ * https://github.com/gravitational/teleport/blob/v9.0.3/lib/defaults/defaults.go#L513-L530
+ *
+ * The list below can get out of sync with what tsh actually implements.
+ */
+export type GatewayProtocol =
+  | 'postgres'
+  | 'mysql'
+  | 'mongodb'
+  | 'cockroachdb'
+  | 'redis'
+  | 'sqlserver';

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -89,19 +89,3 @@ export {
  * @deprecated Import directly from gen-proto-ts instead.
  */
 export * from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
-
-/**
- * Available types are listed here:
- * https://github.com/gravitational/teleport/blob/v9.0.3/lib/defaults/defaults.go#L513-L530
- *
- * The list below can get out of sync with what tsh actually implements.
- *
- * @deprecated Move to a better suited file.
- */
-export type GatewayProtocol =
-  | 'postgres'
-  | 'mysql'
-  | 'mongodb'
-  | 'cockroachdb'
-  | 'redis'
-  | 'sqlserver';

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -69,7 +69,7 @@ const meta: Meta<StoryProps> = {
 export default meta;
 
 export function Story(props: StoryProps) {
-  const platform = props.vnet ? 'darwin' : 'win32';
+  const platform = props.vnet ? 'darwin' : 'linux';
   const appContext = new MockAppContext({ platform });
   prepareAppContext(appContext);
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -121,6 +121,12 @@ function Buttons(props: StoryProps) {
           <Text>SAML app</Text>
           <SamlApp />
         </Box>
+        <HoverTooltip tipContent="Connect doesn't support MCP apps properly yet but it renders a div with consintent width.">
+          <Box>
+            <Text>MCP</Text>
+            <Mcp />
+          </Box>
+        </HoverTooltip>
       </Flex>
       <Box>
         <Text>Server</Text>
@@ -254,6 +260,17 @@ function SamlApp() {
       app={makeApp({
         endpointUri: 'https://localhost:3000',
         samlApp: true,
+        uri: `${testCluster.uri}/apps/bar`,
+      })}
+    />
+  );
+}
+
+function Mcp() {
+  return (
+    <ConnectAppActionButton
+      app={makeApp({
+        endpointUri: 'mcp+stdio://localhost:3000',
         uri: `${testCluster.uri}/apps/bar`,
       })}
     />

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -46,6 +46,7 @@ import {
 type StoryProps = {
   vnet: boolean;
   lotsOfMenuItems: boolean;
+  singleColumn: boolean;
 };
 
 const meta: Meta<StoryProps> = {
@@ -53,6 +54,7 @@ const meta: Meta<StoryProps> = {
   component: Buttons,
   argTypes: {
     vnet: { control: { type: 'boolean' } },
+    singleColumn: { control: { type: 'boolean' } },
     lotsOfMenuItems: {
       control: { type: 'boolean' },
       description:
@@ -63,6 +65,7 @@ const meta: Meta<StoryProps> = {
   args: {
     vnet: true,
     lotsOfMenuItems: false,
+    singleColumn: false,
   },
 };
 
@@ -86,7 +89,11 @@ export function Story(props: StoryProps) {
 
 function Buttons(props: StoryProps) {
   return (
-    <Flex gap={4} flexWrap="wrap">
+    <Flex
+      gap={4}
+      flexWrap="wrap"
+      flexDirection={props.singleColumn ? 'column' : 'row'}
+    >
       <Flex gap={3} flexDirection="column">
         <Box>
           <Text>TCP app</Text>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -18,7 +18,13 @@
 
 import React from 'react';
 
-import { ButtonBorder, ButtonPrimary, ButtonWithMenu, MenuItem } from 'design';
+import {
+  ButtonBorder,
+  ButtonPrimary,
+  ButtonWithMenu,
+  Flex,
+  MenuItem,
+} from 'design';
 import {
   MenuItemSectionLabel,
   MenuItemSectionSeparator,
@@ -138,7 +144,12 @@ export function ConnectKubeActionButton(props: {
   }
 
   return (
-    <ButtonBorder textTransform="none" size="small" onClick={connect}>
+    <ButtonBorder
+      textTransform="none"
+      size="small"
+      onClick={connect}
+      width={buttonWidth}
+    >
       Connect
     </ButtonBorder>
   );
@@ -213,6 +224,7 @@ export function ConnectDatabaseActionButton(props: {
       )}
       textTransform="none"
       width="195px"
+      buttonWidth={buttonWidth}
       getLoginItems={() => getDatabaseUsers(appContext, props.database.uri)}
       onSelect={(_, user) => {
         connect(user);
@@ -422,7 +434,7 @@ export function AccessRequestButton(props: {
   return props.isResourceAdded ? (
     <ButtonPrimary
       textTransform="none"
-      width="124px"
+      width={buttonWidth}
       size="small"
       onClick={props.onClick}
     >
@@ -431,7 +443,7 @@ export function AccessRequestButton(props: {
   ) : (
     <ButtonBorder
       textTransform="none"
-      width="124px"
+      width={buttonWidth}
       size="small"
       onClick={props.onClick}
     >
@@ -455,23 +467,26 @@ export function ConnectWindowsDesktopActionButton(props: {
   }
 
   return (
-    <MenuLogin
-      textTransform="none"
-      width="195px"
-      getLoginItems={() =>
-        props.windowsDesktop.logins.map(l => ({ login: l, url: '' }))
-      }
-      onSelect={(_, user) => {
-        connect(user);
-      }}
-      transformOrigin={{
-        vertical: 'top',
-        horizontal: 'right',
-      }}
-      anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'right',
-      }}
-    />
+    <Flex width={buttonWidth}>
+      <MenuLogin
+        textTransform="none"
+        width="195px"
+        buttonWidth={buttonWidth}
+        getLoginItems={() =>
+          props.windowsDesktop.logins.map(l => ({ login: l, url: '' }))
+        }
+        onSelect={(_, user) => {
+          connect(user);
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+      />
+    </Flex>
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -60,6 +60,14 @@ import { DatabaseUri, routing } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import { useVnetContext, useVnetLauncher } from 'teleterm/ui/Vnet';
 
+/**
+ * Width that should be consistent across all displayed buttons.
+ *
+ * The list view of unified resources is not an actual table but a flexbox, so it depends on widths
+ * of elements to be consistent across rows so that they line up.
+ */
+const buttonWidth = 124;
+
 export function ConnectServerActionButton(props: {
   server: Server;
 }): React.JSX.Element {
@@ -105,10 +113,12 @@ export function ConnectServerActionButton(props: {
   };
 
   if (!isVnetSupported) {
-    return <MenuLogin {...commonProps} />;
+    return (
+      <MenuLogin {...commonProps} width={buttonWidth} alignButtonWidthToMenu />
+    );
   }
   return (
-    <MenuLoginWithActionMenu size="small" {...commonProps}>
+    <MenuLoginWithActionMenu size="small" {...commonProps} width={buttonWidth}>
       <MenuItem onClick={connectWithVnet}>Connect with VNet</MenuItem>
     </MenuLoginWithActionMenu>
   );
@@ -265,6 +275,7 @@ function AppButton(props: {
   if (props.app.awsConsole) {
     return (
       <AwsLaunchButton
+        width={buttonWidth}
         awsRoles={props.app.awsRoles}
         getLaunchUrl={arn =>
           getAwsAppLaunchUrl({
@@ -292,6 +303,7 @@ function AppButton(props: {
           rootCluster: props.rootCluster,
         })}
         target="_blank"
+        width={buttonWidth}
       >
         Log In
       </ButtonBorder>
@@ -313,6 +325,7 @@ function AppButton(props: {
         onClick={props.onLaunchUrl}
         target="_blank"
         title="Launch the app in the browser"
+        width={buttonWidth}
       >
         <MenuItem onClick={() => props.setUpGateway()}>
           Set up connection
@@ -329,6 +342,7 @@ function AppButton(props: {
         textTransform="none"
         size="small"
         onClick={() => props.connectWithVnet()}
+        width={buttonWidth}
       >
         <MenuItem onClick={() => props.setUpGateway()}>
           Connect without VNet
@@ -354,6 +368,7 @@ function AppButton(props: {
         textTransform="none"
         size="small"
         onClick={() => props.setUpGateway()}
+        width={buttonWidth}
       >
         <AvailableTargetPorts
           tcpPorts={props.app.tcpPorts}
@@ -369,6 +384,7 @@ function AppButton(props: {
       size="small"
       onClick={() => props.setUpGateway()}
       textTransform="none"
+      width={buttonWidth}
     >
       Connect
     </ButtonBorder>

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -44,7 +44,7 @@ import {
   getWebAppLaunchUrl,
   isWebApp,
 } from 'teleterm/services/tshd/app';
-import { GatewayProtocol } from 'teleterm/services/tshd/types';
+import { GatewayProtocol } from 'teleterm/services/tshd/gateway';
 import { appToAddrToCopy } from 'teleterm/services/vnet/app';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 
 import {
+  Box,
   ButtonBorder,
   ButtonPrimary,
   ButtonWithMenu,
@@ -48,6 +49,7 @@ import {
   getAwsAppLaunchUrl,
   getSamlAppSsoUrl,
   getWebAppLaunchUrl,
+  isMcp,
   isWebApp,
 } from 'teleterm/services/tshd/app';
 import { GatewayProtocol } from 'teleterm/services/tshd/gateway';
@@ -320,6 +322,13 @@ function AppButton(props: {
         Log In
       </ButtonBorder>
     );
+  }
+
+  if (isMcp(props.app)) {
+    // TODO(greedy52) decide what to do with MCP servers.
+    // In the meantime, display a box of specific width to make the other columns line up for MCP
+    // apps in the list view of unified resources.
+    return <Box width={buttonWidth} />;
   }
 
   if (isWebApp(props.app)) {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -59,7 +59,7 @@ import {
 } from 'shared/services/databases';
 import { waitForever } from 'shared/utils/wait';
 
-import { getAppAddrWithProtocol } from 'teleterm/services/tshd/app';
+import { getAppAddrWithProtocol, isMcp } from 'teleterm/services/tshd/app';
 import { getWindowsDesktopAddrWithoutDefaultPort } from 'teleterm/services/tshd/windowsDesktop';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useConnectMyComputerContext } from 'teleterm/ui/ConnectMyComputer';
@@ -579,7 +579,6 @@ const mapToSharedResource = (
     case 'app': {
       const { resource: app } = resource;
       const addrWithProtocol = getAppAddrWithProtocol(app);
-      const isMCP = addrWithProtocol.startsWith('mcp+');
 
       return {
         resource: {
@@ -593,13 +592,10 @@ const mapToSharedResource = (
           friendlyName: app.friendlyName,
           samlApp: app.samlApp,
           requiresRequest: resource.requiresRequest,
-          subKind: isMCP ? AppSubKind.MCP : undefined,
+          subKind: isMcp(app) ? AppSubKind.MCP : undefined,
         },
         ui: {
-          // TODO(greedy52) decide what to do with MCP servers.
-          ActionButton: isMCP ? undefined : (
-            <ConnectAppActionButton app={app} />
-          ),
+          ActionButton: <ConnectAppActionButton app={app} />,
         },
       };
     }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GatewayProtocol } from 'teleterm/services/tshd/types';
+import { GatewayProtocol } from 'teleterm/services/tshd/gateway';
 import { IAppContext } from 'teleterm/ui/types';
 import { DatabaseUri, routing } from 'teleterm/ui/uri';
 


### PR DESCRIPTION
Closes #58863.

This makes it so that the resources actually line up when using the list view of Unified Resources.

There are some components, such as `ButtonWithMenu`, that combine two of our design components and display them together. I feel like it'd be better if they didn't have to exist and it was possible to just render, say, ButtonBorder and then a Menu next to it. But our current design system doesn't make this easy and setting up something like `ButtonWithMenu` takes a ton of boilerplate that's currently encapsulated in that component.

In any case, those components already accepted the `width` prop, but what it actually ended up doing was setting the width of the "main" part of the component, so e.g., just the button itself. This wouldn't work for this scenario where we want to set the width of the whole component. I refactored it so that `width` sets the total width of the component and props like `buttonWidth` set the width of individual components if needed.

<details>
<summary>Before & after</summary>

Unified resources [before](https://drive.google.com/file/d/1ixIuZzYnHgc0T4QssYdszaF_8bgDXVF3/view?usp=drive_link) and [after](https://drive.google.com/file/d/1MKrVt2hgG3hBXI3AYaZmh6QKyKmkLW9P/view?usp=drive_link). Not sharing publicly because I don't want to advertise the resources on Ben's cluster. 😶

With VNet

| Before | After |
| --- | --- |
| <img width="176" height="922" alt="before-with-vnet" src="https://github.com/user-attachments/assets/78274963-4c41-409d-88d5-f016331f2b84" /> | <img width="176" height="922" alt="after-with-vnet" src="https://github.com/user-attachments/assets/9df1198e-ae17-4a79-8d7d-9f3c0bf0920b" /> |

Without VNet

| Before | After |
| --- | --- |
| <img width="176" height="922" alt="before-without-vnet" src="https://github.com/user-attachments/assets/004bbe7e-1759-493f-b15b-afb96a44a95e" /> | <img width="176" height="922" alt="after-without-vnet" src="https://github.com/user-attachments/assets/0fbab87c-88d2-4674-aead-1095a4f14471" /> |

</details>