### PR TITLE
Invalidate cached client when TLS cert changes

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -177,7 +177,7 @@ func (p *Profile) TLSConfig() (*tls.Config, error) {
 
 // Expiry returns the credential expiry.
 func (p *Profile) Expiry() (time.Time, bool) {
-	certPEMBlock, err := os.ReadFile(p.TLSCertPath())
+	certPEMBlock, err := p.TLSCert()
 	if err != nil {
 		return time.Time{}, false
 	}
@@ -186,6 +186,12 @@ func (p *Profile) Expiry() (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return cert.NotAfter, true
+}
+
+// TLSCert returns the profile's TLS certificate.
+func (p *Profile) TLSCert() ([]byte, error) {
+	certPEMBlock, err := os.ReadFile(p.TLSCertPath())
+	return certPEMBlock, trace.Wrap(err)
 }
 
 // RequireKubeLocalProxy returns true if this profile indicates a local proxy

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -523,6 +523,9 @@ type Config struct {
 
 	// SSOHost is the host of the SSO provider used to log in.
 	SSOHost string
+
+	// Dir is the directory of the profile.
+	Dir string
 }
 
 // CachePolicy defines cache policy for local clients
@@ -953,6 +956,7 @@ func (c *Config) LoadProfile(proxyAddr string) error {
 	c.SAMLSingleLogoutEnabled = profile.SAMLSingleLogoutEnabled
 	c.SSHDialTimeout = profile.SSHDialTimeout
 	c.SSOHost = profile.SSOHost
+	c.Dir = profile.Dir
 
 	c.AuthenticatorAttachment, err = parseMFAMode(profile.MFAMode)
 	if err != nil {
@@ -1021,6 +1025,7 @@ func (c *Config) Profile() *profile.Profile {
 		SAMLSingleLogoutEnabled:       c.SAMLSingleLogoutEnabled,
 		SSHDialTimeout:                c.SSHDialTimeout,
 		SSOHost:                       c.SSOHost,
+		Dir:                           c.Dir,
 	}
 }
 

--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -40,10 +40,6 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 		return nil, trace.BadParameter("cluster URI must be a root URI")
 	}
 
-	if err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	if req.Params == nil {
 		return nil, trace.BadParameter("missing login parameters")
 	}
@@ -90,10 +86,6 @@ func (s *Handler) LoginPasswordless(stream api.TerminalService_LoginPasswordless
 	// works around that. Thus we have to remove the teleterm-specific MFAPromptConstructor added by
 	// daemon.Service.ResolveClusterURI.
 	clusterClient.MFAPromptConstructor = nil
-
-	if err := s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
-		return trace.Wrap(err)
-	}
 
 	// Start the prompt flow.
 	if err := cluster.PasswordlessLogin(stream.Context(), stream); err != nil {

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -885,8 +885,7 @@ func (s *Service) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) er
 		kubeGw.ClearCerts()
 	}
 
-	// We have to reconnect using the updated cert.
-	return trace.Wrap(s.ClearCachedClientsForRoot(cluster.URI))
+	return nil
 }
 
 // ListKubernetesResourcesRequest defines a request to retrieve kube resources paginated.

--- a/tool/tsh/common/vnet_client_application.go
+++ b/tool/tsh/common/vnet_client_application.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/clientcache"
 	libhwk "github.com/gravitational/teleport/lib/hardwarekey"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/vnet"
 )
 
@@ -173,11 +172,6 @@ func (p *vnetClientApplication) getRootClusterCACertPoolPEM(ctx context.Context,
 }
 
 func (p *vnetClientApplication) retryWithRelogin(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
-	profileName, err := utils.Host(tc.WebProxyAddr)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Make sure the release the login mutex if we end up acquiring it.
 	didLock := false
 	defer func() {
@@ -199,9 +193,6 @@ func (p *vnetClientApplication) retryWithRelogin(ctx context.Context, tc *client
 			}
 			fmt.Printf("Login for cluster %s expired, attempting to log in again.\n", tc.SiteName)
 			return nil
-		}),
-		client.WithAfterLoginHook(func() error {
-			return trace.Wrap(p.clientCache.ClearForRoot(profileName), "clearing client cache after relogin")
 		}),
 		client.WithMakeCurrentProfile(false),
 	)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/44059
Contributes to https://github.com/gravitational/teleport/issues/25806

As described in the first issue, a relogin can race with another thread retrieving the client from the cache, which may result in the cache retaining an outdated client.

The problem with invalidating the cache will become even more visible once tsh and Connect start sharing the ~/.tsh directory. If a user logs in or assumes a role via tsh, Connect will receive a file system event and must decide whether to clear the cache (and I suspect we can run into some edge cases there).
Additionally, I'd like to avoid exposing any `ClientCache` related functionality outside of tsh, since it’s really just an implementation detail. Even now, it’s cumbersome to remember to clear the cache after login or assuming a role.

A better option is to shift that responsibility to the `ClientCache` itself. On any _get_ request, it can verify if the TLS certificate hasn’t changed since the client was created. This approach resolves the linked issue and eliminates the need to manually clear the cache (except logging out).