### PR TITLE
docs: use automatic toc for ig idps

### DIFF
--- a/docs/pages/identity-governance/idps/idps.mdx
+++ b/docs/pages/identity-governance/idps/idps.mdx
@@ -9,9 +9,5 @@ tags:
 Users can authenticate to both internal and external applications
 through the use of a built in identity provider in Teleport.
 
-- [SAML Guide](saml-guide.mdx): A guide for setting up an example application to integration with the SAML identity provider.
-- [SAML RBAC](saml-idp-rbac.mdx): Learn how to manage access to the SAML IdP service provider.
-- [SAML Attribute Mapping](saml-attribute-mapping.mdx): A reference on how attribute mapping works in Teleport and how to
-use it to assert custom user attribute name and values in a SAML response.
-- [Use Teleport's SAML Provider to authenticate with Grafana](saml-grafana.mdx): Configure Grafana to authenticate using Teleport identities.
+<DocCardList />
 - [SAML Reference](../../reference/access-controls/saml-idp.mdx): A reference for Teleport's SAML identity provider.


### PR DESCRIPTION
Use automatic listing approach. Some items like Azure weren't included.