### PR TITLE
Update the semaphore expiry in AcquireSemaphoreWithRetry

### DIFF
--- a/lib/srv/db/common/autousers.go
+++ b/lib/srv/db/common/autousers.go
@@ -185,7 +185,6 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			// in a user's name from being rejected by the backend when creating the semaphore.
 			SemaphoreName: hex.EncodeToString([]byte(sessionCtx.Database.GetName() + "-" + sessionCtx.DatabaseUser)),
 			MaxLeases:     1,
-			Expires:       a.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -194,5 +193,7 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			Max:   time.Second,
 			Clock: a.Clock,
 		},
+		TTL: time.Minute,
+		Now: a.Clock.Now,
 	}
 }

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -499,7 +499,6 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			SemaphoreKind: "gcp-mysql-token",
 			SemaphoreName: fmt.Sprintf("%v-%v", sessionCtx.Database.GetName(), sessionCtx.DatabaseUser),
 			MaxLeases:     1,
-			Expires:       e.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -508,6 +507,8 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			Max:   time.Second,
 			Clock: e.Clock,
 		},
+		TTL: time.Minute,
+		Now: e.Clock.Now,
 	}
 }
 

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -533,12 +533,12 @@ func (u *HostUserManagement) doWithUserLock(f func(types.SemaphoreLease) error) 
 				SemaphoreKind: types.SemaphoreKindHostUserModification,
 				SemaphoreName: "host_user_modification",
 				MaxLeases:     1,
-				Expires:       time.Now().Add(userLeaseDuration),
 			},
 			Retry: retryutils.LinearConfig{
 				Step: time.Second * 5,
 				Max:  time.Minute,
 			},
+			TTL: userLeaseDuration,
 		})
 
 	if err != nil {


### PR DESCRIPTION
The `AcquireSemaphoreWithRetry` function takes a `types.AcquireSemaphoreRequest` which is passed directly to `(api/types.Semaphore).AcquireSemaphore` even if the retry loop has made it so the clock has advanced past the expiry of the request. This PR makes it so that the expiry of the request is recalculated right before every attempt. The parameter is currently optional to avoid breaking callers in e, it'll be made mandatory after the enterprise code is updated.

Fixes #59290

Changelog: Fixed database IAM configurator potentially getting stuck and never recovering (#59290)