### PR TITLE
RFD 246: Install, upgrade, and operations documentation organization

### DIFF
--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -188,8 +188,21 @@ Note: these are best understood by opening https://goteleport.com/docs and follo
 - "Zero Trust Access -> Cluster management" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clouds"
 - "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Platform -> Installation -> Installing Self-Hosted Clusters -> Kubernetes" (many subsections)
 - "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clusters" (remaining sections)
-- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (instead of including agent install instructions, which are not necessary for MWI)
+- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (or vice-versa, at MWI team discretion.)
 - "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters -> Access Graph"
 - "Enroll Resources -> Joining Teleport Agents" moves to "Platform -> Installation -> Installing Teleport Agents" (such that Enroll Resources is always use-case driven, and links to Platform -> Installation for Azure, GCP, etc, instructions.)
 
 Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant, and vice-versa.
+
+### Confusing Workflow Reference
+
+This list is an incomplete collection of various flows we need to fix. See the Action Plan above for additional examples.
+
+1. If a Cloud user following "Enroll Resource -> Applications" needs the agent for their application to run on Kubernetes with ArgoCD, they must
+   follow "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm", even though the instructions are not related to
+   Access or Self-Hosted. Instead, they could follow a link to "Platform -> Installation -> Installing Teleport Agents" and immediately see
+   "Platform -> Installation -> Installing Teleport Agents -> Kubernetes -> ArgoCD".
+2. "Introduction -> Installation -> macOS" says that `teleport` is supported on macOS, but provides no guidance for configuring or using it.
+3. "Introduction -> Installation -> Amazon EC2" links to AMIs and one possible Self-Hosted specific guide, but has no agent install guide.
+4. Agent install docs live under "Introduction -> Upgrading -> Managed Updates for Agents (v2)", instead of a clear Installation page.
+

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -63,7 +63,7 @@ that the user is guided to the correct page regardless of their starting point.
 
 ## Details
 
-### Overview of All Components with Customer-Managed Operational Lifecycles
+### Overview of All Components with Customer-Managed Operational Lifecycle
 
 Teleport includes a large number of independently installable components that require dedicated installation
 instructions for an even larger number of target platforms:
@@ -151,7 +151,7 @@ The following organization is proposed, nested under a top-level Platform sectio
    2. Upgrading Teleport Client Tools
    3. Upgrading Self-Hosted Teleport Clusters
    4. Upgrading Teleport Plugins & Integrations
-3. Operations - New page, explains what it means to operate Teleport (backups, troubleshooting, speciality config like KMS, multi-region, etc.)
+3. Operations - New page, explains what it means to operate Teleport (backups, troubleshooting, specialty config like KMS, multi-region, etc.)
    1. Operating Teleport Agents
    2. Operating Teleport Client Tools
    3. Operating Self-Hosted Teleport Clusters

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -1,0 +1,185 @@
+---
+authors: Stephen Levine (stephen.levine@goteleport.com)
+state: draft
+---
+
+# RFD 223 - Installation and Upgrade Documentation Organization
+
+# Required Approvers
+* Engineering: @klizhentas || @r0mant
+* Product / Design: @roraback && @ptgott
+
+## What
+
+When users get started with Teleport, they often look for pages of documentation related to downloading and installing
+a Teleport component that they need to use.
+
+This RFD proposes that we reorganize our documentation to make it easier to find these pages.
+
+## Why
+
+Currently, it can be difficult for users to find this documentation because it lives in different places depending
+on the component, target OS/platform, and other factors.
+
+For example, a common user workflow is installing a Teleport agent on an EC2 instance and connecting it to the cluster.
+Users who do not read the documentation and follow the instructions in the Teleport Web UI have an easy path forward
+that involves executing a single command.
+
+However, a user who attempts to read the documentation might follow a path that looks like this:
+
+1. Navigates to goteleport.com/docs
+2. Finds no information in the sidebar about installation or upgrading
+3. Clicks each sidebar item and finds "Installation" under "Introduction"
+4. Clicks "Installation," then "Linux"
+5. Sees instructions for installing a Teleport cluster, continues to scroll down to agent
+6. Runs an install script that results in an auto-updating agent that is not configured
+7. Sees that they need to manually enroll the agent, clicks "Enroll Resources"
+8. Clicks "Linux Servers (section)"
+9. Sees a page with four different guides that are named very similarly
+10. Clicks the "Getting Started Guide", or may get directed there by clicking one of the other guides
+11. Sees the install script instructions again, along with other outdated installation instructions
+12. Finds and executes manual joining instructions, which are unnecessary if the Web UI is used.
+
+The Teleport Downloads page has a similar issue that is actively being worked on.
+
+This RFD proposes that we add three new top-level sections:
+
+1. "Installation"
+2. "Upgrading"
+3. "Operations"
+
+These sections would cover all Teleport components.
+
+Notably, these sections differ from the marketing categories for our product features because they are cross-cutting,
+operational, and generally do not involve in-product UX workflows.
+Users install Teleport first, ensure they have a way to upgrade it, ensure they have day-two operations like backups
+configured, and then they (or different end-users) dive into the product itself.
+
+If this results in too many top-level sections, a single "Installation & Operation" section may suffice.
+
+## Details
+
+### Overview of All Components with Customer-Managed Operational Lifecycles
+
+Teleport includes a large number of independently installable components that require dedicated installation
+instructions for an even larger number of target platforms:
+
+1. Cluster Installation
+  1. Self-Hosted on Linux
+  2. Self-Hosted on Kubernetes
+    1. Digital Ocean
+    2. Helm
+    3. Helm with ArgoCD
+    4. EKS
+    5. GKE
+    6. AKS
+    7. IBM Cloud
+    8. Helm “Custom”
+  3. Self-Hosted on Docker
+  4. Self-Hosted on EC2
+  5. Self-Hosted on GCP
+  6. Self-Hosted on OCI
+  7. Self-Hosted on Azure
+  8. Self-Hosted via Source Code
+2. Agent Installation
+  1. Agent on Kubernetes
+  2. Agent on Docker
+  3. Agent on EC2
+    1. Teleport AMI
+    2. Custom AMI
+  4. Agent on GCP
+  5. Agent on OCI
+  6. Agent on Azure
+3. Client Installation
+  1. Human
+    1. Linux
+      1. Resource Access via tsh
+      2. Resource Access via Connect
+      3. Cluster Admin via tctl
+    2. MacOS
+      1. Resource Access via tsh
+      2. Resource Access via Connect
+      3. Cluster Admin via tctl
+    3. Windows
+      1. Resource Access via tsh
+      2. Resource Access via Connect
+      3. Cluster Admin via tctl
+  2. Machine
+    1. Linux
+      1. Resource Access via tbot
+    2. MacOS
+      1. Resource Access via tbot
+    3. Windows
+      1. Resource Access via tbot
+4. Integrations
+  1. Plugins
+    1. Event Handler
+    2. Discord
+    3. Email
+    4. JIRA
+    5. Mattermost
+    6. Slack
+    7. Msteams
+    8. Datadog
+    9. Pagerduty
+  2. Configuration Systems
+    1. Kubernetes API via Teleport Operator
+    2. Terraform via Teleport Terraform Provider
+
+Users will generally know which target platform they need to perform the installation on, but they may not know
+which Teleport component they need to install.
+
+
+### Proposed Organization
+
+I propose the following organization, from the top-level:
+
+1. Installation - New page, maps each use case for Teleport to the correct component
+   1. Installing Teleport Agents
+   2. Installing Teleport Client Tools
+   3. Installing Self-Hosted Teleport Clusters
+   4. Installing Teleport Plugins & Integrations
+2. Upgrading - New page, explains the relevance and importance of upgrading each component
+   1. Upgrading Teleport Agents
+   2. Upgrading Teleport Client Tools
+   3. Upgrading Self-Hosted Teleport Clusters
+   4. Upgrading Teleport Plugins & Integrations
+3. Operations - New page, explains what it means to operate Teleport (backups, troubleshooting, speciality config like KMS, multi-region, etc.)
+   1. Operating Teleport Agents
+   2. Operating Teleport Client Tools
+   3. Operating Self-Hosted Teleport Clusters
+   4. Operating Teleport Plugins & Integrations
+
+Notably, any cluster operations that are not handled by Cloud should be included under the marketing-branded sections, not Operations.
+For example, a guide to configuring a cluster to support AWS KMS would be included in Operating Self-Hosted Teleport Clusters, while
+a guide for getting started with Teleport roles would be included in the "Zero Trust Access" section.
+
+Installation instructions should not be complete user guides that include in-product configuration.
+Installation instructions should link to user guides when they are more appropriate, and user guides should link to
+(or import) installation instructions where needed.
+
+### Proposed Action Plan
+
+The proposed action plan is iterative.
+It does not involve a large re-write of any existing documentation, and relies on links between sections where appropriate.
+
+Note: these are best understood by opening https://goteleport.com/docs and following from the top.
+
+- Create new sections and new pages described above.
+- For each existing installation page, separate agent, client, and cluster sections into new pages. No single guide or instruction page should address more than one.
+- "Installation -> Installing Teleport Agents" contains a link to "Enrolling Resources" with separate "Custom Agent Installation" instructions
+- "Introduction -> Installation" moves to "Installation"
+- "Introduction -> Upgrading" moves to "Upgrading"
+- "Introduction -> Migrate Teleport Plans" moves to "User Guides"
+- "Zero Trust Access -> Exporting Teleport Audit Events" contains links to "Installation -> Installing Teleport Plugins & Integrations -> Event Exporter", and vice-versa
+- "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only)
+- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Installation" (subsections as appropriate)
+- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Run Teleport as a Daemon" moves to "Installation -> Installing Teleport Agents -> Linux Servers"
+- "Zero Trust Access -> Cluster management" moves to "Operations -> Operating Self-Hosted Teleport Clouds"
+- "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Installation -> Installing Self-Hosted Clusters -> Kubernetes"
+- "Zero Trust Access -> Self-Hosting Teleport" moves to "Operations -> Operating Self-Hosted Teleport Clusters"
+- "Zero Trust Access -> Using the Teleport API" moves to "User Guides"
+- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (instead of including agent install instructions)
+- "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters"
+
+Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant.

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -42,11 +42,12 @@ However, a user who attempts to read the documentation might follow a path that 
 
 The Teleport Downloads page has a similar issue that is actively being addressed.
 
-This RFD proposes that we add one new top-level "Platform" section, with three subsections:
+This RFD proposes that we add one new top-level "Platform" section, with at least two subsections:
 
-1. "Installation"
-2. "Upgrading"
-3. "Operations"
+1. Platform
+   1. Installation
+   2. Upgrading
+   3. (Other sections, e.g., "High Availability" or "Backup & Restore")
 
 These sections would cover all Teleport components.
 Installation sections will cover setup for Managed Updates, and link to more details Upgrading docs where appropriate.
@@ -60,6 +61,9 @@ A complete user story for a Teleport installation workflow may need to involve i
 For example, it is common to configure roles after installing a self-hosted cluster.
 As we cannot repeat these instructions for every combination of component and target platform, we can rely on cross-linking to ensure
 that the user is guided to the correct page regardless of their starting point.
+
+This organizational structure will be especially useful when the installation portion of a workflow may vary significantly on different
+cloud platforms, Linux distributions, etc.
 
 ## Details
 
@@ -151,14 +155,14 @@ The following organization is proposed, nested under a top-level Platform sectio
    2. Upgrading Teleport Client Tools
    3. Upgrading Self-Hosted Teleport Clusters
    4. Upgrading Teleport Plugins & Integrations
-3. Operations - New page, explains what it means to operate Teleport (backups, troubleshooting, specialty config like KMS, multi-region, etc.)
-   1. Operating Teleport Agents
-   2. Operating Teleport Client Tools
-   3. Operating Self-Hosted Teleport Clusters
-   4. Operating Teleport Plugins & Integrations
+3. (Other operational sections) - New pages, explains what it means to operate Teleport (backups, troubleshooting, specialty config like KMS, multi-region, etc.)
+   1. (Operating) Teleport Agents
+   2. (Operating) Teleport Client Tools
+   3. (Operating) Self-Hosted Teleport Clusters
+   4. (Operating) Teleport Plugins & Integrations
 
 Notably, cluster operations that are not handled by Cloud should be included under the marketing-branded sections, not Platform.
-For example, a guide to configuring a cluster to support AWS KMS would be included in Operating Self-Hosted Teleport Clusters, while
+For example, a guide to configuring a cluster to support AWS KMS would be included in Platform -> KMS -> Self-Hosted Teleport Clusters, while
 a guide for getting started with Teleport roles would be included in the "Zero Trust Access" section.
 The only exception to this rule is global, shared configuration that is directly related to platform operations and does not
 fit into the marketing-branded sections. For example, some of the `cluster_*` or `autoupdate_*` resources may be described in Platform.
@@ -181,18 +185,20 @@ Note: these are best understood by opening https://goteleport.com/docs and follo
 - "Introduction -> Installation" moves to "Platform -> Installation"
 - "Introduction -> Upgrading" moves to "Platform -> Upgrading"
 - "Introduction -> Migrate Teleport Plans" moves to "Platform -> Cloud" (tentative)
-- "Zero Trust Access -> Exporting Teleport Audit Events" contains links to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Event Exporter", and vice-versa
+- Client installation docs present under "User Guides" appear in "Platform -> Installation" as well (or link where more appropriate)
+- "Zero Trust Access -> Exporting Teleport Audit Events" and "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Event Exporter" include the same content or cross-link where appropriate. An Auditing section may be created in ZTA as well.
 - "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only, with cross-linking)
 - "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Platform -> Installation" (subsections as appropriate)
 - "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Run Teleport as a Daemon" moves to "Platform -> Installation -> Installing Teleport Agents -> Linux Servers"
-- "Zero Trust Access -> Cluster management" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clouds"
+- "Zero Trust Access -> Cluster management" moves to "Platform -> (new sections) -> Self-Hosted Teleport Clusters"
 - "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Platform -> Installation -> Installing Self-Hosted Clusters -> Kubernetes" (many subsections)
-- "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clusters" (remaining sections)
+- "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> (new sections) -> Self-Hosted Teleport Clusters" (for remaining sections)
 - "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (or vice-versa, at MWI team discretion.)
+- "Identity Governance -> Just-in-Time Access Request Plugins" become more discoverable via a link from "Platform -> Installation -> Access Request Plugins" (may move in the future if, e.g., per-OS docs are needed)
 - "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters -> Access Graph"
 - "Enroll Resources -> Joining Teleport Agents" moves to "Platform -> Installation -> Installing Teleport Agents" (such that Enroll Resources is always use-case driven, and links to Platform -> Installation for Azure, GCP, etc, instructions.)
 
-Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant, and vice-versa.
+Marketing-branded sections may link to Installation, Upgrading, or other Platform sections where relevant, and vice-versa.
 
 ### Confusing Workflow Reference
 

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -180,7 +180,7 @@ Note: these are best understood by opening https://goteleport.com/docs and follo
 - "Installation -> Installing Teleport Agents" contains a link to "Enrolling Resources" with separate "Custom Agent Installation" instructions
 - "Introduction -> Installation" moves to "Platform -> Installation"
 - "Introduction -> Upgrading" moves to "Platform -> Upgrading"
-- "Introduction -> Migrate Teleport Plans" moves to "User Guides"
+- "Introduction -> Migrate Teleport Plans" moves to "Platform -> Cloud" (tentative)
 - "Zero Trust Access -> Exporting Teleport Audit Events" contains links to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Event Exporter", and vice-versa
 - "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only, with cross-linking)
 - "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Platform -> Installation" (subsections as appropriate)
@@ -188,7 +188,8 @@ Note: these are best understood by opening https://goteleport.com/docs and follo
 - "Zero Trust Access -> Cluster management" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clouds"
 - "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Platform -> Installation -> Installing Self-Hosted Clusters -> Kubernetes" (many subsections)
 - "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clusters" (remaining sections)
-- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (instead of including agent install instructions)
+- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (instead of including agent install instructions, which are not necessary for MWI)
 - "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters -> Access Graph"
+- "Enroll Resources -> Joining Teleport Agents" moves to "Platform -> Installation -> Installing Teleport Agents" (such that Enroll Resources is always use-case driven, and links to Platform -> Installation for Azure, GCP, etc, instructions.)
 
 Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant, and vice-versa.

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -40,22 +40,26 @@ However, a user who attempts to read the documentation might follow a path that 
 11. Sees the install script instructions again, along with other outdated installation instructions
 12. Finds and executes manual joining instructions, which are unnecessary if the Web UI is used.
 
-The Teleport Downloads page has a similar issue that is actively being worked on.
+The Teleport Downloads page has a similar issue that is actively being addressed.
 
-This RFD proposes that we add three new top-level sections:
+This RFD proposes that we add one new top-level "Platform" section, with three subsections:
 
 1. "Installation"
 2. "Upgrading"
 3. "Operations"
 
 These sections would cover all Teleport components.
+Installation sections will cover setup for Managed Updates, and link to more details Upgrading docs where appropriate.
 
-Notably, these sections differ from the marketing categories for our product features because they are cross-cutting,
-operational, and generally do not involve in-product UX workflows.
+Notably, the Platform section differs from the marketing-branded categories for our product features because it is cross-cutting,
+operational, and (in most cases) does not involve in-product UX workflows.
 Users install Teleport first, ensure they have a way to upgrade it, ensure they have day-two operations like backups
 configured, and then they (or different end-users) dive into the product itself.
 
-If this results in too many top-level sections, a single "Installation & Operation" section may suffice.
+A complete user story for a Teleport installation workflow may need to involve in-product configuration.
+For example, it is common to configure roles after installing a self-hosted cluster.
+As we cannot repeat these instructions for every combination of component and target platform, we can rely on cross-linking to ensure
+that the user is guided to the correct page regardless of their starting point.
 
 ## Details
 
@@ -87,6 +91,7 @@ instructions for an even larger number of target platforms:
    3. Agent on EC2
       1. Teleport AMI
       2. Custom AMI
+      3. Via Deploy Service / AWS OIDC
    4. Agent on GCP
    5. Agent on OCI
    6. Agent on Azure
@@ -129,10 +134,12 @@ instructions for an even larger number of target platforms:
 Users will generally know which target platform they need to perform the installation on, but they may not know
 which Teleport component they need to install.
 
+A Teleport user may need to mix and match instructions for their use case.
+For example, they may need to install a self-hosted cluster on GKE, deploy an agent into EKS, and then configure the agent to allow App access.
 
 ### Proposed Organization
 
-I propose the following organization, from the top-level:
+The following organization is proposed, nested under a top-level Platform section:
 
 1. Installation - New page, maps each use case for Teleport to the correct component
    1. Installing Teleport Agents
@@ -150,9 +157,12 @@ I propose the following organization, from the top-level:
    3. Operating Self-Hosted Teleport Clusters
    4. Operating Teleport Plugins & Integrations
 
-Notably, any cluster operations that are not handled by Cloud should be included under the marketing-branded sections, not Operations.
+Notably, cluster operations that are not handled by Cloud should be included under the marketing-branded sections, not Platform.
 For example, a guide to configuring a cluster to support AWS KMS would be included in Operating Self-Hosted Teleport Clusters, while
 a guide for getting started with Teleport roles would be included in the "Zero Trust Access" section.
+The only exception to this rule is global, shared configuration that is directly related to platform operations and does not
+fit into the marketing-branded sections. For example, some of the `cluster_*` or `autoupdate_*` resources may be described in Platform.
+These are generally optional for Cloud users to configure.
 
 Installation instructions should not be complete user guides that include in-product configuration.
 Installation instructions should link to user guides when they are more appropriate, and user guides should link to
@@ -168,18 +178,17 @@ Note: these are best understood by opening https://goteleport.com/docs and follo
 - Create new sections and new pages described above.
 - For each existing installation page, separate agent, client, and cluster sections into new pages. No single guide or instruction page should address more than one.
 - "Installation -> Installing Teleport Agents" contains a link to "Enrolling Resources" with separate "Custom Agent Installation" instructions
-- "Introduction -> Installation" moves to "Installation"
-- "Introduction -> Upgrading" moves to "Upgrading"
+- "Introduction -> Installation" moves to "Platform -> Installation"
+- "Introduction -> Upgrading" moves to "Platform -> Upgrading"
 - "Introduction -> Migrate Teleport Plans" moves to "User Guides"
-- "Zero Trust Access -> Exporting Teleport Audit Events" contains links to "Installation -> Installing Teleport Plugins & Integrations -> Event Exporter", and vice-versa
-- "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only)
-- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Installation" (subsections as appropriate)
-- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Run Teleport as a Daemon" moves to "Installation -> Installing Teleport Agents -> Linux Servers"
-- "Zero Trust Access -> Cluster management" moves to "Operations -> Operating Self-Hosted Teleport Clouds"
-- "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Installation -> Installing Self-Hosted Clusters -> Kubernetes"
-- "Zero Trust Access -> Self-Hosting Teleport" moves to "Operations -> Operating Self-Hosted Teleport Clusters"
-- "Zero Trust Access -> Using the Teleport API" moves to "User Guides"
+- "Zero Trust Access -> Exporting Teleport Audit Events" contains links to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Event Exporter", and vice-versa
+- "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only, with cross-linking)
+- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Platform -> Installation" (subsections as appropriate)
+- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Run Teleport as a Daemon" moves to "Platform -> Installation -> Installing Teleport Agents -> Linux Servers"
+- "Zero Trust Access -> Cluster management" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clouds"
+- "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Platform -> Installation -> Installing Self-Hosted Clusters -> Kubernetes" (many subsections)
+- "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> Operations -> Operating Self-Hosted Teleport Clusters" (remaining sections)
 - "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (instead of including agent install instructions)
-- "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters"
+- "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters -> Access Graph"
 
-Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant.
+Marketing-branded sections may link to Installation, Upgrading, or Operations sections where relevant, and vice-versa.

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -65,66 +65,66 @@ Teleport includes a large number of independently installable components that re
 instructions for an even larger number of target platforms:
 
 1. Cluster Installation
-  1. Self-Hosted on Linux
-  2. Self-Hosted on Kubernetes
-    1. Digital Ocean
-    2. Helm
-    3. Helm with ArgoCD
-    4. EKS
-    5. GKE
-    6. AKS
-    7. IBM Cloud
-    8. Helm “Custom”
-  3. Self-Hosted on Docker
-  4. Self-Hosted on EC2
-  5. Self-Hosted on GCP
-  6. Self-Hosted on OCI
-  7. Self-Hosted on Azure
-  8. Self-Hosted via Source Code
+   1. Self-Hosted on Linux
+   2. Self-Hosted on Kubernetes
+      1. Digital Ocean
+      2. Helm
+      3. Helm with ArgoCD
+      4. EKS
+      5. GKE
+      6. AKS
+      7. IBM Cloud
+      8. Helm “Custom”
+   3. Self-Hosted on Docker
+   4. Self-Hosted on EC2
+   5. Self-Hosted on GCP
+   6. Self-Hosted on OCI
+   7. Self-Hosted on Azure
+   8. Self-Hosted via Source Code
 2. Agent Installation
-  1. Agent on Kubernetes
-  2. Agent on Docker
-  3. Agent on EC2
-    1. Teleport AMI
-    2. Custom AMI
-  4. Agent on GCP
-  5. Agent on OCI
-  6. Agent on Azure
+   1. Agent on Kubernetes
+   2. Agent on Docker
+   3. Agent on EC2
+      1. Teleport AMI
+      2. Custom AMI
+   4. Agent on GCP
+   5. Agent on OCI
+   6. Agent on Azure
 3. Client Installation
-  1. Human
-    1. Linux
-      1. Resource Access via tsh
-      2. Resource Access via Connect
-      3. Cluster Admin via tctl
-    2. MacOS
-      1. Resource Access via tsh
-      2. Resource Access via Connect
-      3. Cluster Admin via tctl
-    3. Windows
-      1. Resource Access via tsh
-      2. Resource Access via Connect
-      3. Cluster Admin via tctl
-  2. Machine
-    1. Linux
-      1. Resource Access via tbot
-    2. MacOS
-      1. Resource Access via tbot
-    3. Windows
-      1. Resource Access via tbot
+   1. Human
+      1. Linux
+         1. Resource Access via tsh
+         2. Resource Access via Connect
+         3. Cluster Admin via tctl
+      2. MacOS
+         1. Resource Access via tsh
+         2. Resource Access via Connect
+         3. Cluster Admin via tctl
+      3. Windows
+         1. Resource Access via tsh
+         2. Resource Access via Connect
+         3. Cluster Admin via tctl
+   2. Machine
+      1. Linux
+         1. Resource Access via tbot
+      2. MacOS
+         1. Resource Access via tbot
+      3. Windows
+         1. Resource Access via tbot
 4. Integrations
-  1. Plugins
-    1. Event Handler
-    2. Discord
-    3. Email
-    4. JIRA
-    5. Mattermost
-    6. Slack
-    7. Msteams
-    8. Datadog
-    9. Pagerduty
-  2. Configuration Systems
-    1. Kubernetes API via Teleport Operator
-    2. Terraform via Teleport Terraform Provider
+   1. Plugins
+      1. Event Handler
+      2. Discord
+      3. Email
+      4. JIRA
+      5. Mattermost
+      6. Slack
+      7. Msteams
+      8. Datadog
+      9. Pagerduty
+   2. Configuration Systems
+      1. Kubernetes API via Teleport Operator
+      2. Terraform via Teleport Terraform Provider
 
 Users will generally know which target platform they need to perform the installation on, but they may not know
 which Teleport component they need to install.

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -18,8 +18,14 @@ This RFD proposes that we reorganize our documentation to make it easier to find
 
 ## Why
 
-Currently, it can be difficult for users to find this documentation because it lives in different places depending
-on the component, target OS/platform, and other factors.
+Currently, it is difficult for users to find installation documentation because it lives in different places depending
+on the component, target OS/platform, and other factors. Teleport includes multiple components that are interesting to
+different users, and each component has many different installation options depending on an individual user's environment.
+
+A company using Teleport may have:
+- Operators that need to know how to install a self-hosted cluster on their chosen cloud provider,
+- Individual operations teams that need to know how to install Teleport agents into a Kubernetes cluster hosted by a different cloud provider, and
+- Developers that need to know how to install Teleport clients on their local workstations.
 
 For example, a common user workflow is installing a Teleport agent on an EC2 instance and connecting it to the cluster.
 Users who do not read the documentation and follow the instructions in the Teleport Web UI have an easy path forward
@@ -28,34 +34,34 @@ that involves executing a single command.
 However, a user who attempts to read the documentation might follow a path that looks like this:
 
 1. Navigates to goteleport.com/docs
-2. Finds no information in the sidebar about installation or upgrading
-3. Clicks each sidebar item and finds "Installation" under "Introduction"
-4. Clicks "Installation," then "Linux"
-5. Sees instructions for installing a Teleport cluster, continues to scroll down to agent
-6. Runs an install script that results in an auto-updating agent that is not configured
-7. Sees that they need to manually enroll the agent, clicks "Enroll Resources"
-8. Clicks "Linux Servers (section)"
-9. Sees a page with four different guides that are named very similarly
-10. Clicks the "Getting Started Guide", or may get directed there by clicking one of the other guides
-11. Sees the install script instructions again, along with other outdated installation instructions
-12. Finds and executes manual joining instructions, which are unnecessary if the Web UI is used.
+2. Locates "Installation" under "Introduction"
+3. Clicks "Installation," then "Linux"
+4. Sees instructions for installing a Teleport cluster, continues to scroll down to agent
+5. Runs an install script that results in an auto-updating agent that is not configured
+6. Sees that they need to manually enroll the agent because they did not use the Web UI
+7. Clicks "Enroll Resources"
+8. Clicks "Linux Servers (section)", then "Introduction to Enrolling Servers"
+9. Clicks the "Getting Started Guide", or may get directed there by clicking one of the other guides
+10. Sees the install script instructions again, along with other outdated installation instructions
+11. Finds and executes manual joining instructions (which are unnecessary if the Web UI is used).
 
-The Teleport Downloads page has a similar issue that is actively being addressed.
+This RFD proposes that we add one new top-level "Install Teleport" section, with subsections that are organized by use case:
 
-This RFD proposes that we add one new top-level "Platform" section, with at least two subsections:
-
-1. Platform
-   1. Installation
-   2. Upgrading
-   3. (Other sections, e.g., "High Availability" or "Backup & Restore")
+1. Install Teleport
+   1. Installing Self-Hosted Teleport Clusters
+   2. Installing Teleport Agents to Connect Resources
+   3. Installing Teleport Clients for Human Access
+   4. Installing Teleport Clients for Machine Access
+   5. Installing Teleport Plugins & External Integrations
+   6. Generic Installation Instructions
 
 These sections would cover all Teleport components.
-Installation sections will cover setup for Managed Updates, and link to more details Upgrading docs where appropriate.
+Installation sections will cover setup for Managed Updates and link to more detailed Upgrading docs where appropriate.
 
-Notably, the Platform section differs from the marketing-branded categories for our product features because it is cross-cutting,
-operational, and (in most cases) does not involve in-product UX workflows.
-Users install Teleport first, ensure they have a way to upgrade it, ensure they have day-two operations like backups
-configured, and then they (or different end-users) dive into the product itself.
+Notably, the "Install Teleport" section differs from the marketing-branded categories for our product features because it is cross-cutting,
+operational, and (in general) does not focus on in-product UX workflows.
+Users install Teleport, ensure they have a way to upgrade it, ensure they have day-two operations like backups
+configured, and then they (or different end-users) dive into the product itself via the category sections.
 
 A complete user story for a Teleport installation workflow may need to involve in-product configuration.
 For example, it is common to configure roles after installing a self-hosted cluster.
@@ -144,64 +150,106 @@ which Teleport component they need to install.
 A Teleport user may need to mix and match instructions for their use case.
 For example, they may need to install a self-hosted cluster on GKE, deploy an agent into EKS, and then configure the agent to allow App access.
 
+To address this complexity, the top-level subsections divide users into categories to ensure any misnavigation happens early and is obvious to users.
+The top-level subsection names will be verbose to avoid misnavigation.
+
 ### Proposed Organization
 
-The following organization is proposed, nested under a top-level Platform section:
+The following organization is proposed as an ideal, nested under a top-level "Install Teleport" section:
 
-1. Installation - New page, maps each use case for Teleport to the correct component
-   1. Installing Teleport Agents
-   2. Installing Teleport Client Tools
-   3. Installing Self-Hosted Teleport Clusters
-   4. Installing Teleport Plugins & Integrations
-2. Upgrading - New page, explains the relevance and importance of upgrading each component
-   1. Upgrading Teleport Agents
-   2. Upgrading Teleport Client Tools
-   3. Upgrading Self-Hosted Teleport Clusters
-   4. Upgrading Teleport Plugins & Integrations
-3. (Other operational sections) - New pages, explains what it means to operate Teleport (backups, troubleshooting, specialty config like KMS, multi-region, etc.)
-   1. (Operating) Teleport Agents
-   2. (Operating) Teleport Client Tools
-   3. (Operating) Self-Hosted Teleport Clusters
-   4. (Operating) Teleport Plugins & Integrations
+1. Installing Self-Hosted Teleport Clusters
+   1. Installing Teleport Clusters on Kubernetes
+      1. Amazon EKS
+         1. Installation
+         2. Upgrading
+         3. (Other operational sections as appropriate, e.g., High Availability, Backups, Troubleshooting, etc.)
+      3. etc.
+   2. Installing Teleport Clusters on Linux Servers
+      1. Amazon EC2
+         1. Installation
+         2. Upgrading
+         3. (Other operational sections as appropriate, e.g., High Availability, Backups, Troubleshooting, etc.)
+      2. etc.
+2. Installing Teleport Agents to Connect Resources
+   1. Database Access
+      1. Amazon EC2
+         1. Installation
+         2. Upgrading
+   2. etc.
+3. Installing Teleport Clients for Human Access
+   1. Desktop Application (Teleport Connect)
+      1. macOS
+      2. etc.
+   2. CLI Access
+      1. macOS
+      2. etc.
+4. Installing Teleport Clients for Machine Access
+   1. Installing tbot
+      1. Install tbot on Linux Servers
+         1. Install tbot on Amazon EC2
+         2. etc.
+      2. Install tbot on Kubernetes
+      3. Install tbot in Github Actions
+      4. etc.
+5. Installing Teleport Plugins & External Integrations
+6. Generic Installation Instructions
 
-Notably, cluster operations that are not handled by Cloud should be included under the marketing-branded sections, not Platform.
-For example, a guide to configuring a cluster to support AWS KMS would be included in Platform -> KMS -> Self-Hosted Teleport Clusters, while
+**However, we do not currently have content to fill most of these sections, and many of our existing pages are reused across platforms.**
+
+To account for this, the following organization is proposed as an actionable, short-term solution:
+
+1. Provisioning a Teleport Cloud Cluster
+   1. (Move Cloud cluster provisioning from Introduction -> Installation)
+   2. (Move Migrate Teleport Plans from Introduction -> Installation)
+   3. (Move Cloud Cluster Upgrades from Introduction -> Upgrading)
+2. Installing Self-Hosted Teleport Clusters
+   1. Installing Teleport Clusters on Kubernetes
+      1. (Move from ZTA -> Self-Hosting -> Helm Deployments
+      2. (Move from Introduction -> Upgrading -> Manual Upgrades -> Self-hosted Teleport clusters on Kubernetes)
+      2. Installing Access Graph | Links to Identity Security -> Self-Host TIS -> Helm
+      3. Installing Identity Activity Center | Links to Identity Security -> Self-Host TIS -> IAC
+   2. Installing Teleport Clusters on Linux Servers
+      1. (Move from VM-specific content of ZTA -> Self-Hosting -> Deployment Guides)
+      2. Installing Access Graph | Links to Identity Security -> Self-Host TIS -> Docker
+      3. Installing Identity Activity Center | Links to Identity Security -> Self-Host TIS -> IAC
+   3. (Move from other sections in ZTA -> Self-Hosting)
+3. Installing Teleport Agents to Connect Resources
+   1. Installing & Configuring Teleport Agents | Links to Enroll Resources
+   2. Managed Updates for Agents & Bots (v2) (Move from Upgrading)
+   3. Manual Upgrades
+      1. (Move from Introduction -> Upgrading -> Manual Upgrades -> Teleport Agents running on Kubernetes)
+      2. (Move from Introduction -> Upgrading -> Manual Upgrades -> Single Teleport binaries on Linux servers)
+4. Installing Teleport Clients for Human Access
+   1. Desktop Application (Teleport Connect) | Links to User Guide for Connect
+   2. CLI Access | Links to User Guide for tsh
+   3. Managed Updates for Clients (v2) (Move from Upgrading)
+5. Installing Teleport Clients for Machine Access
+   1. Installing & Configuring tbot | Links to M&WI -> Deploy tbot
+   2. Managed Updates for Agents & Bots (v2) | Links to Installing Teleport Agents to Connect Resources -> Managed Updates for Agents & Bots (v2)
+6. Installing Teleport Plugins & External Integrations
+   1. Just-in-Time Access Request Plugins | Links to Identity Governance -> Just-in-Time Access Request Plugins
+   2. Event Exporter | Links to ZTA -> Exporting Teleport Audit Events
+   3. Teleport Kubernetes Operator | Links to ZTA -> Infrastructure as Code -> Teleport Kubernetes Operator
+7. Generic Installation Instructions
+   1. Linux
+      1. (Move from ZTA -> Cluster management -> Run Teleport as a Daemon)
+   2. Docker
+   3. Source Code
+8. Uninstall Teleport
+   1. (Moved from Installation -> Uninstall Teleport)
+
+The Installing and Upgrading sections in Introduction will be removed entirely.
+
+Notably, cluster operations that are not handled by Cloud should be included in the marketing-branded sections (like Zero Trust Access), not in Install Teleport.
+For example, a guide to configuring a cluster to support AWS KMS would be included in Install Teleport -> Installing Self-Hosted Teleport Clusters -> KMS, while
 a guide for getting started with Teleport roles would be included in the "Zero Trust Access" section.
 The only exception to this rule is global, shared configuration that is directly related to platform operations and does not
-fit into the marketing-branded sections. For example, some of the `cluster_*` or `autoupdate_*` resources may be described in Platform.
+fit into the marketing-branded sections. For example, some of the `cluster_*` or `autoupdate_*` resources may be described in Install Teleport.
 These are generally optional for Cloud users to configure.
 
 Installation instructions should not be complete user guides that include in-product configuration.
 Installation instructions should link to user guides when they are more appropriate, and user guides should link to
 (or import) installation instructions where needed.
-
-### Proposed Action Plan
-
-The proposed action plan is iterative.
-It does not involve a large re-write of any existing documentation, and relies on links between sections where appropriate.
-
-Note: these are best understood by opening https://goteleport.com/docs and following from the top.
-
-- Create new sections and new pages described above.
-- For each existing installation page, separate agent, client, and cluster sections into new pages. No single guide or instruction page should address more than one.
-- "Installation -> Installing Teleport Agents" contains a link to "Enrolling Resources" with separate "Custom Agent Installation" instructions
-- "Introduction -> Installation" moves to "Platform -> Installation"
-- "Introduction -> Upgrading" moves to "Platform -> Upgrading"
-- "Introduction -> Migrate Teleport Plans" moves to "Platform -> Cloud" (tentative)
-- Client installation docs present under "User Guides" appear in "Platform -> Installation" as well (or link where more appropriate)
-- "Zero Trust Access -> Exporting Teleport Audit Events" and "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Event Exporter" include the same content or cross-link where appropriate. An Auditing section may be created in ZTA as well.
-- "Zero Trust Access -> Infrastructure as Code -> Teleport Kubernetes Operator" moves to "Platform -> Installation -> Installing Teleport Plugins & Integrations -> Teleport Kubernetes Operator" (install guides only, with cross-linking)
-- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Uninstall Teleport" moves to "Platform -> Installation" (subsections as appropriate)
-- "Zero Trust Access -> Cluster management -> Cluster Administration guides -> Run Teleport as a Daemon" moves to "Platform -> Installation -> Installing Teleport Agents -> Linux Servers"
-- "Zero Trust Access -> Cluster management" moves to "Platform -> (new sections) -> Self-Hosted Teleport Clusters"
-- "Zero Trust Access -> Self-Hosting Teleport -> Guides for running Teleport using Helm" moves to "Platform -> Installation -> Installing Self-Hosted Clusters -> Kubernetes" (many subsections)
-- "Zero Trust Access -> Self-Hosting Teleport" moves to "Platform -> (new sections) -> Self-Hosted Teleport Clusters" (for remaining sections)
-- "Machine & Workload Identity" -> Machine ID -> Deploy tbot" links to "Installation -> Installing Teleport Client Tools -> tbot" (or vice-versa, at MWI team discretion.)
-- "Identity Governance -> Just-in-Time Access Request Plugins" become more discoverable via a link from "Platform -> Installation -> Access Request Plugins" (may move in the future if, e.g., per-OS docs are needed)
-- "Identity Security -> Self-Hosting Teleport Access Graph" moves to "Installation -> Installing Self-Hosted Teleport Clusters -> Access Graph"
-- "Enroll Resources -> Joining Teleport Agents" moves to "Platform -> Installation -> Installing Teleport Agents" (such that Enroll Resources is always use-case driven, and links to Platform -> Installation for Azure, GCP, etc, instructions.)
-
-Marketing-branded sections may link to Installation, Upgrading, or other Platform sections where relevant, and vice-versa.
 
 ### Confusing Workflow Reference
 

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -175,10 +175,10 @@ These sections would be nested under a top-level "Install Teleport" section.
          3. (Other operational sections as appropriate, e.g., High Availability, Backups, Troubleshooting, etc.)
       2. etc.
 2. Installing Teleport Agents to Connect Resources
-   1. Database Access
-      1. Amazon EC2
-         1. Installation
-         2. Upgrading
+    1. Amazon EC2
+       1. Installation
+       2. Configuring services
+       3. Upgrading        
    2. etc.
 3. Installing Teleport Clients for Human Access
    1. Desktop Application (Teleport Connect)

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -220,7 +220,7 @@ For example, the following organization could be an actionable short-term soluti
       3. Installing Identity Activity Center | Links to Identity Security -> Self-Host TIS -> IAC
    3. (Move from other sections in ZTA -> Self-Hosting)
 3. Installing Teleport Agents to Connect Resources
-   1. Installing & Configuring Teleport Agents | Links to Enroll Resources
+   1. Installing & Configuring Teleport Agents (Move from Enroll Resources)
    2. Managed Updates for Agents & Bots (v2) (Move from Upgrading)
    3. Manual Upgrades
       1. (Move from Introduction -> Upgrading -> Manual Upgrades -> Teleport Agents running on Kubernetes)

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -167,7 +167,7 @@ These sections would be nested under a top-level "Install Teleport" section.
          1. Installation
          2. Upgrading
          3. (Other operational sections as appropriate, e.g., High Availability, Backups, Troubleshooting, etc.)
-      3. etc.
+      2. etc.
    2. Installing Teleport Clusters on Linux Servers
       1. Amazon EC2
          1. Installation
@@ -200,7 +200,9 @@ These sections would be nested under a top-level "Install Teleport" section.
 
 **However, we do not currently have content to fill most of these sections, and many of our existing pages are reused across platforms.**
 
-To account for this, the following organization is proposed as an actionable, short-term solution:
+To account for this, we can start by re-organizing existing content to match the general organizational principle proposed.
+
+For example, the following organization could be an actionable short-term solution until additional content is added:
 
 1. Provisioning a Teleport Cloud Cluster
    1. (Move Cloud cluster provisioning from Introduction -> Installation)
@@ -208,7 +210,7 @@ To account for this, the following organization is proposed as an actionable, sh
    3. (Move Cloud Cluster Upgrades from Introduction -> Upgrading)
 2. Installing Self-Hosted Teleport Clusters
    1. Installing Teleport Clusters on Kubernetes
-      1. (Move from ZTA -> Self-Hosting -> Helm Deployments
+      1. (Move from ZTA -> Self-Hosting -> Helm Deployments)
       2. (Move from Introduction -> Upgrading -> Manual Upgrades -> Self-hosted Teleport clusters on Kubernetes)
       2. Installing Access Graph | Links to Identity Security -> Self-Host TIS -> Helm
       3. Installing Identity Activity Center | Links to Identity Security -> Self-Host TIS -> IAC
@@ -242,7 +244,9 @@ To account for this, the following organization is proposed as an actionable, sh
 8. Uninstall Teleport
    1. (Moved from Installation -> Uninstall Teleport)
 
-The Installing and Upgrading sections in Introduction will be removed entirely.
+(Note that this is not a committed action plan and may change as we make progress.)
+
+The Installing and Upgrading sections in Introduction would be removed entirely.
 
 Notably, cluster operations that are not handled by Cloud should be included in the marketing-branded sections (like Zero Trust Access), not in Install Teleport.
 For example, a guide to configuring a cluster to support AWS KMS would be included in Install Teleport -> Installing Self-Hosted Teleport Clusters -> KMS, while

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -6,8 +6,8 @@ state: draft
 # RFD 223 - Installation and Upgrade Documentation Organization
 
 # Required Approvers
-* Engineering: @klizhentas || @r0mant
-* Product / Design: @roraback && @ptgott
+* R&D Owner: @roraback
+* Docs: @ptgott
 
 ## What
 

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -99,6 +99,9 @@ instructions for an even larger number of target platforms:
    4. Agent on GCP
    5. Agent on OCI
    6. Agent on Azure
+   7. Agent on Generic Linux
+   8. Agent on MacOS via Connect
+   9. Agent on MacOS via terminal
 3. Client Installation
    1. Human
       1. Linux

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -76,7 +76,9 @@ cloud platforms, Linux distributions, etc.
 ### Overview of All Components with Customer-Managed Operational Lifecycle
 
 Teleport includes a large number of independently installable components that require dedicated installation
-instructions for an even larger number of target platforms:
+instructions for an even larger number of target platforms.
+
+This is an enumeration of all possible installation targets (not a suggested organization, see further below):
 
 1. Cluster Installation
    1. Self-Hosted on Linux
@@ -155,7 +157,9 @@ The top-level subsection names will be verbose to avoid misnavigation.
 
 ### Proposed Organization
 
-The following organization is proposed as an ideal, nested under a top-level "Install Teleport" section:
+The following organization is proposed as an ideal, long-term plan.
+These sections would be nested under a top-level "Install Teleport" section.
+(See further below for a short-term plan using existing content.)
 
 1. Installing Self-Hosted Teleport Clusters
    1. Installing Teleport Clusters on Kubernetes

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -175,10 +175,10 @@ These sections would be nested under a top-level "Install Teleport" section.
          3. (Other operational sections as appropriate, e.g., High Availability, Backups, Troubleshooting, etc.)
       2. etc.
 2. Installing Teleport Agents to Connect Resources
-    1. Amazon EC2
-       1. Installation
-       2. Configuring services
-       3. Upgrading        
+   1. Amazon EC2 (cross links to "Enroll Resources" list after install, split by DB, App, etc.)
+      1. Installation
+      2. Configuring services
+      3. Upgrading        
    2. etc.
 3. Installing Teleport Clients for Human Access
    1. Desktop Application (Teleport Connect)

--- a/rfd/0223-install-docs.md
+++ b/rfd/0223-install-docs.md
@@ -6,8 +6,8 @@ state: draft
 # RFD 223 - Installation and Upgrade Documentation Organization
 
 # Required Approvers
-* R&D Owner: @roraback
-* Docs: @ptgott
+* R&D Owner: Kenny Roraback
+* Docs: Paul Gott
 
 ## What
 
@@ -152,8 +152,8 @@ which Teleport component they need to install.
 A Teleport user may need to mix and match instructions for their use case.
 For example, they may need to install a self-hosted cluster on GKE, deploy an agent into EKS, and then configure the agent to allow App access.
 
-To address this complexity, the top-level subsections divide users into categories to ensure any misnavigation happens early and is obvious to users.
-The top-level subsection names will be verbose to avoid misnavigation.
+To address this complexity, the top-level subsections divide users into categories to ensure any incorrect navigation happens early and is obvious to users.
+The top-level subsection names will be verbose to avoid incorrect navigation.
 
 ### Proposed Organization
 

--- a/rfd/0246-install-docs.md
+++ b/rfd/0246-install-docs.md
@@ -3,11 +3,11 @@ authors: Stephen Levine (stephen.levine@goteleport.com)
 state: draft
 ---
 
-# RFD 223 - Installation and Upgrade Documentation Organization
+# RFD 246 - Installation and Upgrade Documentation Organization
 
 # Required Approvers
-* R&D Owner: Kenny Roraback
-* Docs: Paul Gott
+* R&D Owner: @roraback
+* Docs: @ptgott
 
 ## What
 

--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -581,6 +581,7 @@
     "Przemko",
     "pseudocode",
     "psql",
+    "ptgott",
     "pubkey",
     "publickey",
     "pulumi",


### PR DESCRIPTION
This RFD proposes a new "Install" section in the docs to improve the Teleport installation and upgrade experience.

[Readable](https://github.com/gravitational/teleport/blob/rfd/0223-install-docs/rfd/0223-install-docs.md)

Goal (internal): https://github.com/gravitational/cloud/issues/14225