### PR TITLE
Adding decryption to documented KMS policies

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
@@ -60,10 +60,10 @@ are the default, but other backends can also be configured:
 - [Google Cloud KMS](../../../../zero-trust-access/deploy-a-cluster/gcp-kms.mdx)
 - [HSM](../../../../zero-trust-access/deploy-a-cluster/hsm.mdx)
 
-If your cluster is already configured to use one of these backends, you may need
-to add permission for Teleport to use decryption functions. For example, the AWS
-KMS backend will require adding the `kms:Decrypt` action to Teleport's role
-policy.
+If your cluster is already configured to use any of these backends, you should
+ensure Teleport has permission to use their decryption functions. For example,
+the AWS KMS backend will require adding the `kms:Decrypt` action to Teleport's
+role policy.
 
 It is required that all Teleport Auth Service instances have access to the
 exact same encryption keys in order to ensure all recorded sessions are always

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
@@ -60,6 +60,11 @@ are the default, but other backends can also be configured:
 - [Google Cloud KMS](../../../../zero-trust-access/deploy-a-cluster/gcp-kms.mdx)
 - [HSM](../../../../zero-trust-access/deploy-a-cluster/hsm.mdx)
 
+If your cluster is already configured to use one of these backends, you may need
+to add permission for Teleport to use decryption functions. For example, the AWS
+KMS backend will require adding the `kms:Decrypt` action to Teleport's role
+policy.
+
 It is required that all Teleport Auth Service instances have access to the
 exact same encryption keys in order to ensure all recorded sessions are always
 replayable. This means shared access to keys in AWS KMS and GCP KMS backends,

--- a/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
@@ -72,7 +72,7 @@ Start by creating the following AWS IAM policy in your account.
             "Condition": {
                 "StringEquals": {
                     "aws:RequestTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>",
-                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
+                    "aws:ResourceTag/TeleportClusterEncryption": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
                 }
             }
         },
@@ -84,12 +84,14 @@ Start by creating the following AWS IAM policy in your account.
                 "kms:ScheduleKeyDeletion",
                 "kms:DescribeKey",
                 "kms:ListResourceTags",
-                "kms:Sign"
+                "kms:Sign",
+                "kms:Decrypt",
             ],
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
+                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>",
+                    "aws:ResourceTag/TeleportClusterEncryption": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
                 }
             }
         }

--- a/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
@@ -79,6 +79,7 @@ includedPermissions:
 - cloudkms.cryptoKeyVersions.create
 - cloudkms.cryptoKeyVersions.destroy
 - cloudkms.cryptoKeyVersions.useToSign
+- cloudkms.cryptoKeyVersions.useToDecrypt
 - cloudkms.cryptoKeyVersions.viewPublicKey
 ```
 


### PR DESCRIPTION
This PR updates the suggested AWS KMS and GCP KMS policies to include decryption in addition to signing.
