### PR TITLE
fix starting an SFTP server when under SELinux enforcement

### DIFF
--- a/lib/selinux/teleport_ssh.te
+++ b/lib/selinux/teleport_ssh.te
@@ -84,8 +84,25 @@ files_type(teleport_ssh_upgrade_data_t);
 # creation of initial process
 ##
 init_daemon_domain(teleport_ssh_t, teleport_ssh_exec_t)
-# needed if run manually from terminal
-allow teleport_ssh_t teleport_ssh_exec_t:file { exec_file_perms lock entrypoint map };
+# Allow any domain to execute Teleport; using 'domain' instead of a
+# specific domain type matches all SELinux domains.
+#
+# This is needed for SFTP support, as Teleport re-execs itself to start
+# an SFTP server. To re-exec, Teleport creates a child process that 
+# configures a grandchild process appropriately (in this case that is 
+# the SFTP server process). The child process will set the SELinux exec
+# label depending on what host login is specified before launching the
+# grandchild. This ensures the grandchild will inherit the correct SELinux
+# context that the host login user should have.
+#
+# Therefore for SFTP to function properly with any user login all SELinux
+# domains must be allowed to exec Teleport, as we don't know what 
+# domains host users will have when writing this module.
+#
+# This shouldn't be a problem from a security perspective though, as 
+# Teleport won't be allowed to do anything the user couldn't do already
+# due to SELinux enforcement.
+allow domain teleport_ssh_exec_t:file { exec_file_perms lock entrypoint map };
 
 ##
 # files

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -106,7 +106,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	defer auditPipeIn.Close()
 
 	// Create child process to handle SFTP connection
-	execRequest, err := srv.NewExecRequest(serverCtx, teleport.SFTPSubsystem)
+	execRequest, err := srv.NewExecRequest(serverCtx, teleport.SFTPSubCommand)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Previously only system daemons (systemd) or Teleport itself was allowed to execute a labeled Teleport binary. This isn't an issue when handling interactive or non-interactive SSH sessions, unless a user tried to execute Teleport directly. The way SELinux support works in the SSH server is the re-exec child process looks up what the correct SELinux context (user, role and domain) should be for the session's login user and applies it. Then the process it creates (the grandchild that is the main target process) will inherit that context. This ensures users are enforce by SELinux as the system configuration says they should be.

It's an issue when handling SFTP sessions however, as Teleport re-execs itself twice (setup child process, SFTP server grandchild process). When the child changes it's SELinux context to that of the session's user that user will very likely not be allowed to execute Teleport, resulting in a failure to start the SFTP server and handle the session.

The fix is to allow any SELinux domain to execute Teleport, as we can't know when writing the module what domains need to be allowed; it's almost guaranteed depending on what packages are installed the SELinux domains available on my system are different than a customers.

changelog: Fix handling SFTP file transfers when the SSH agent is enforced by SELinux