### PR TITLE
Unified resources card: Add a gap between the name and the button

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -231,13 +231,13 @@ export function ResourceCard({
           />
           {/* MinWidth is important to prevent descriptions from overflowing. */}
           <Flex flexDirection="column" flex="1" minWidth="0" ml={3} gap={1}>
-            <Flex flexDirection="row" alignItems="center">
+            <Flex flexDirection="row" alignItems="center" gap={1}>
               <SingleLineBox flex="1">
                 <HoverTooltip tipContent={name} showOnlyOnOverflow>
                   <Text typography="body1">{name}</Text>
                 </HoverTooltip>
               </SingleLineBox>
-              {hovered && <CopyButton name={name} mr={2} />}
+              {hovered && <CopyButton name={name} />}
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
               </ResourceActionButtonWrapper>


### PR DESCRIPTION
This came up during a review of https://github.com/gravitational/teleport/pull/59368. There's no gap between the name and the button, so it was possible for those two to line up.

| Before | After |
| --- | --- |
| <img width="432" height="116" alt="before" src="https://github.com/user-attachments/assets/08bf7f0b-4dba-484b-afdf-d85cd468b098" /> | <img width="432" height="116" alt="after" src="https://github.com/user-attachments/assets/2dcac7fc-e63f-48a7-a791-4c49640807dd" /> |
| <img width="432" height="116" alt="before-hover" src="https://github.com/user-attachments/assets/88a61b24-93c8-4002-9152-0079578f09b7" /> | <img width="432" height="116" alt="after-hover" src="https://github.com/user-attachments/assets/0649166d-e691-45ea-a85f-d46b829f533b" /> |