### PR TITLE
[v18] Update the semaphore expiry in AcquireSemaphoreWithRetry

### DIFF
--- a/lib/srv/db/common/autousers.go
+++ b/lib/srv/db/common/autousers.go
@@ -185,7 +185,6 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			// in a user's name from being rejected by the backend when creating the semaphore.
 			SemaphoreName: hex.EncodeToString([]byte(sessionCtx.Database.GetName() + "-" + sessionCtx.DatabaseUser)),
 			MaxLeases:     1,
-			Expires:       a.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -194,5 +193,7 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			Max:   time.Second,
 			Clock: a.Clock,
 		},
+		TTL: time.Minute,
+		Now: a.Clock.Now,
 	}
 }

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -499,7 +499,6 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			SemaphoreKind: "gcp-mysql-token",
 			SemaphoreName: fmt.Sprintf("%v-%v", sessionCtx.Database.GetName(), sessionCtx.DatabaseUser),
 			MaxLeases:     1,
-			Expires:       e.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -508,6 +507,8 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			Max:   time.Second,
 			Clock: e.Clock,
 		},
+		TTL: time.Minute,
+		Now: e.Clock.Now,
 	}
 }
 

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -533,12 +533,12 @@ func (u *HostUserManagement) doWithUserLock(f func(types.SemaphoreLease) error) 
 				SemaphoreKind: types.SemaphoreKindHostUserModification,
 				SemaphoreName: "host_user_modification",
 				MaxLeases:     1,
-				Expires:       time.Now().Add(userLeaseDuration),
 			},
 			Retry: retryutils.LinearConfig{
 				Step: time.Second * 5,
 				Max:  time.Minute,
 			},
+			TTL: userLeaseDuration,
 		})
 
 	if err != nil {


### PR DESCRIPTION
Backport #59372 to branch/v18

changelog: Fixed database IAM configurator potentially getting stuck and never recovering (#59290)
