### PR TITLE
[v17] Update the semaphore expiry in AcquireSemaphoreWithRetry

### DIFF
--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -240,6 +240,11 @@ type AcquireSemaphoreWithRetryConfig struct {
 	Service types.Semaphores
 	Request types.AcquireSemaphoreRequest
 	Retry   retryutils.LinearConfig
+	// TTL, if set, will be used to set the expiry of the request.
+	TTL time.Duration
+	// Now, if set, will be used instead of time.Now when calculating the expiry
+	// of the request.
+	Now func() time.Time
 }
 
 // AcquireSemaphoreWithRetry tries to acquire the semaphore according to the
@@ -249,9 +254,16 @@ func AcquireSemaphoreWithRetry(ctx context.Context, req AcquireSemaphoreWithRetr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if req.Now == nil {
+		req.Now = time.Now
+	}
 	var lease *types.SemaphoreLease
 	err = retry.For(ctx, func() (err error) {
-		lease, err = req.Service.AcquireSemaphore(ctx, req.Request)
+		r := req.Request
+		if req.TTL > 0 {
+			r.Expires = req.Now().Add(req.TTL)
+		}
+		lease, err = req.Service.AcquireSemaphore(ctx, r)
 		return trace.Wrap(err)
 	})
 	if err != nil {

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -305,10 +305,6 @@ func (c *IAM) processTask(ctx context.Context, task iamTask) error {
 			SemaphoreName: configurator.cfg.identity.GetName(),
 			MaxLeases:     1,
 			Holder:        c.cfg.HostID,
-
-			// If the semaphore fails to release for some reason, it will expire in a
-			// minute on its own.
-			Expires: c.cfg.Clock.Now().Add(time.Minute),
 		},
 
 		// Retry with some jitters up to twice of the semaphore expire time.
@@ -317,6 +313,11 @@ func (c *IAM) processTask(ctx context.Context, task iamTask) error {
 			Max:    2 * time.Minute,
 			Jitter: retryutils.HalfJitter,
 		},
+
+		// If the semaphore fails to release for some reason, it will expire in a
+		// minute on its own.
+		TTL: time.Minute,
+		Now: c.cfg.Clock.Now,
 	})
 	if err != nil {
 		c.iamPolicyStatus.Store(task.database.GetName(), types.IAMPolicyStatus_IAM_POLICY_STATUS_FAILED)

--- a/lib/srv/db/common/autousers.go
+++ b/lib/srv/db/common/autousers.go
@@ -185,7 +185,6 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			// in a user's name from being rejected by the backend when creating the semaphore.
 			SemaphoreName: hex.EncodeToString([]byte(sessionCtx.Database.GetName() + "-" + sessionCtx.DatabaseUser)),
 			MaxLeases:     1,
-			Expires:       a.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -194,5 +193,7 @@ func (a *UserProvisioner) makeAcquireSemaphoreConfig(sessionCtx *Session) servic
 			Max:   time.Second,
 			Clock: a.Clock,
 		},
+		TTL: time.Minute,
+		Now: a.Clock.Now,
 	}
 }

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -475,7 +475,6 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			SemaphoreKind: "gcp-mysql-token",
 			SemaphoreName: fmt.Sprintf("%v-%v", sessionCtx.Database.GetName(), sessionCtx.DatabaseUser),
 			MaxLeases:     1,
-			Expires:       e.Clock.Now().Add(time.Minute),
 		},
 		// If multiple connections are being established simultaneously to the
 		// same database as the same user, retry for a few seconds.
@@ -484,6 +483,8 @@ func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services
 			Max:   time.Second,
 			Clock: e.Clock,
 		},
+		TTL: time.Minute,
+		Now: e.Clock.Now,
 	}
 }
 

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -511,12 +511,12 @@ func (u *HostUserManagement) doWithUserLock(f func(types.SemaphoreLease) error) 
 				SemaphoreKind: types.SemaphoreKindHostUserModification,
 				SemaphoreName: "host_user_modification",
 				MaxLeases:     1,
-				Expires:       time.Now().Add(time.Second * 20),
 			},
 			Retry: retryutils.LinearConfig{
 				Step: time.Second * 5,
 				Max:  time.Minute,
 			},
+			TTL: 20 * time.Second,
 		})
 
 	if err != nil {


### PR DESCRIPTION
Backport #59372 to branch/v17

changelog: Fixed database IAM configurator potentially getting stuck and never recovering (#59290)
