### PR TITLE
TestIntegrations/PortForwarding: Increase timeout for `waitForSessionToBeEstablished`

### DIFF
--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -280,11 +280,11 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			cl.Stdin = term
 			cl.Labels = tt.labels
 
-			sshSessionCtx, sshSessionCancel := context.WithCancel(context.Background())
+			sshSessionCtx, sshSessionCancel := context.WithCancel(t.Context())
 			go cl.SSH(sshSessionCtx, []string{})
 			defer sshSessionCancel()
 
-			timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			timeout, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 			defer cancel()
 			_, err = waitForSessionToBeEstablished(timeout, apidefaults.Namespace, site)
 			require.NoError(t, err)

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -280,9 +280,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			cl.Stdin = term
 			cl.Labels = tt.labels
 
-			sshSessionCtx, sshSessionCancel := context.WithCancel(t.Context())
-			go cl.SSH(sshSessionCtx, []string{})
-			defer sshSessionCancel()
+			go cl.SSH(t.Context(), []string{})
 
 			timeout, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 			defer cancel()


### PR DESCRIPTION
I saw this test time out. This PR increases the timeout from 5s to 15s.

```
    port_forwarding_test.go:290: 
        	Error Trace:	/__w/teleport/teleport/integration/port_forwarding_test.go:290
        	Error:      	Received unexpected error:
        	            	context deadline exceeded
        	Test:       	TestIntegrations/PortForwarding/Enabled_with_labels
```

https://github.com/gravitational/teleport/actions/runs/17909484825/job/50917477425#step:6:1482