### PR TITLE
Simplify Kubernetes Operator reference index page

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/operator-resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/operator-resources.mdx
@@ -7,4 +7,26 @@ tags:
  - platform-wide
 ---
 
-<DocCardList />
+The Teleport Kubernetes operator allows cluster administrators to manage dynamic
+resources as Kubernetes resources using `kubectl` or a continuous deployment
+tool like Argo CD. The guides in this section of the documentation include
+comprehensive lists of fields for each supported resource.
+
+## Getting started with the Kubernetes operator
+
+If you are getting started with the Teleport Kubernetes operator, we recommend
+reading the [introductory
+guide](../../../zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx)
+to setting up and using the operator. 
+
+For guidance on using the Teleport Kubernetes operator to manage the dynamic
+resources that you would typically see in a Teleport cluster, such as roles and
+users, see [Managing
+Resources](../../../zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx).
+
+## Selecting a reference guide
+
+The Kubernetes operator resource reference guides are organized by resource
+version. Select a resource version from the sidebar to view supported fields.
+
+


### PR DESCRIPTION
The current list of guides is long and difficult to navigate. Instead, include a description of the section, recommend reading the Managing Resources guides for typical patterns, and indicate that there is one guide per resource version.

Another possibility would be to make the list of reference docs easier to navigate by formatting it as a table of resource names and descriptions. However, we currently do not include descriptions of resources when generating CRDs from resource proto messages.