### PR TITLE
Remove access requests from clusters service

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
@@ -18,15 +18,13 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
 
-import {
-  AccessRequest,
-  ResourceID,
-} from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+import { ResourceID } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
 import { wait, waitForever } from 'shared/utils/wait';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import {
   makeAccessRequest,
+  makeLoggedInUser,
   makeRootCluster,
 } from 'teleterm/services/tshd/testHelpers';
 import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
@@ -159,7 +157,10 @@ export function ResourceRequestAlreadyAssumed() {
     });
 
   return (
-    <ShowState appContext={appContext} assumedRequests={[smallAccessRequest]} />
+    <ShowState
+      appContext={appContext}
+      activeRequests={[smallAccessRequest.id]}
+    />
   );
 }
 
@@ -175,14 +176,36 @@ export function RequestWithManyResources() {
   return <ShowState appContext={appContext} />;
 }
 
+export function AssumedRequestWithNoDetails() {
+  const appContext = new MockAppContext();
+  appContext.tshd.getAccessRequests = () =>
+    new MockedUnaryCall({
+      totalCount: 0,
+      startKey: '',
+      requests: [],
+    });
+
+  return (
+    <ShowState
+      appContext={appContext}
+      activeRequests={['34488748-0c91-463e-ac93-a5dd21eeec8a']}
+    />
+  );
+}
+
 function ShowState({
-  assumedRequests = [],
+  activeRequests = [],
   appContext,
 }: {
-  assumedRequests?: AccessRequest[];
+  activeRequests?: string[];
   appContext: MockAppContext;
 }) {
-  appContext.addRootCluster(rootCluster);
+  appContext.addRootCluster({
+    ...rootCluster,
+    loggedInUser: makeLoggedInUser({
+      activeRequests: activeRequests,
+    }),
+  });
   appContext.clustersService.assumeRoles = async () => {
     await wait(1000);
     throw new Error(
@@ -195,15 +218,17 @@ function ShowState({
       'connection error: desc = "transport: Error while dialing: failed to dial: unable to establish proxy stream\\n\\trpc error: code = Unavailable desc'
     );
   };
-  appContext.tshd.getAccessRequest = input => {
+  appContext.tshd.getAccessRequest = async input => {
+    const allRequests = await appContext.tshd.getAccessRequests({
+      clusterUri: rootCluster.uri,
+    });
+    const request = allRequests.response.requests.find(
+      a => a.id === input.accessRequestId
+    );
     return new MockedUnaryCall({
-      request: assumedRequests.find(a => a.id === input.accessRequestId),
+      request,
     });
   };
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.get(rootCluster.uri).loggedInUser.activeRequests =
-      assumedRequests.map(a => a.id);
-  });
 
   useLayoutEffect(() => {
     (

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
@@ -195,12 +195,14 @@ function ShowState({
       'connection error: desc = "transport: Error while dialing: failed to dial: unable to establish proxy stream\\n\\trpc error: code = Unavailable desc'
     );
   };
+  appContext.tshd.getAccessRequest = input => {
+    return new MockedUnaryCall({
+      request: assumedRequests.find(a => a.id === input.accessRequestId),
+    });
+  };
   appContext.clustersService.setState(draftState => {
-    draftState.clusters.get(rootCluster.uri).loggedInUser.assumedRequests =
-      assumedRequests.reduce((requestsMap, request) => {
-        requestsMap[request.id] = request;
-        return requestsMap;
-      }, {});
+    draftState.clusters.get(rootCluster.uri).loggedInUser.activeRequests =
+      assumedRequests.map(a => a.id);
   });
 
   useLayoutEffect(() => {

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.test.tsx
@@ -25,6 +25,7 @@ import { render } from 'design/utils/testing';
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import {
   makeAccessRequest,
+  makeLoggedInUser,
   makeRootCluster,
 } from 'teleterm/services/tshd/testHelpers';
 import { SelectorMenu } from 'teleterm/ui/AccessRequests/SelectorMenu';
@@ -41,23 +42,19 @@ import { AccessRequestsContextProvider } from './AccessRequestsContext';
 
 test('assuming or dropping a request refreshes resources', async () => {
   const appContext = new MockAppContext();
+  const accessRequest = makeAccessRequest();
   const cluster = makeRootCluster({
     features: { advancedAccessWorkflows: true, isUsageBasedBilling: false },
+    loggedInUser: makeLoggedInUser({ activeRequests: [accessRequest.id] }),
   });
   appContext.addRootCluster(cluster);
   jest.spyOn(appContext.clustersService, 'dropRoles');
   const refreshListener = jest.fn();
-  const accessRequest = makeAccessRequest();
   appContext.tshd.getAccessRequest = () => {
     return new MockedUnaryCall({
       request: accessRequest,
     });
   };
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.get(cluster.uri).loggedInUser.activeRequests = [
-      accessRequest.id,
-    ];
-  });
 
   render(
     <MockAppContextProvider appContext={appContext}>
@@ -88,21 +85,35 @@ test('assuming or dropping a request refreshes resources', async () => {
   expect(refreshListener).toHaveBeenCalledTimes(1);
 });
 
-test('displays the request ID if assumed request details cannot be fetched', async () => {
+test('assumed request are always visible, even if getAccessRequests no longer returns them', async () => {
+  const requestA = makeAccessRequest({
+    id: '67bea2b6-9390-43a5-af47-c391561dbfba',
+    resources: [],
+    roles: ['access-a'],
+  });
+  const requestB = makeAccessRequest({
+    id: '34488748-0c91-463e-ac93-a5dd21eeec8a',
+    resources: [],
+    roles: ['access-b'],
+  });
   const appContext = new MockAppContext();
   const cluster = makeRootCluster({
     features: { advancedAccessWorkflows: true, isUsageBasedBilling: false },
+    loggedInUser: makeLoggedInUser({
+      activeRequests: [requestB.id, 'request-with-details-not-available'],
+    }),
   });
   appContext.addRootCluster(cluster);
-  jest.spyOn(appContext.clustersService, 'dropRoles');
-  appContext.tshd.getAccessRequest = () => {
-    return new MockedUnaryCall(undefined, new Error('Request does not exist'));
+
+  appContext.tshd.getAccessRequests = () => {
+    return new MockedUnaryCall({ requests: [requestA] });
   };
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.get(cluster.uri).loggedInUser.activeRequests = [
-      'some-id',
-    ];
-  });
+  appContext.tshd.getAccessRequest = ({ accessRequestId }) => {
+    if (accessRequestId !== requestB.id) {
+      throw new Error(`Request ${accessRequestId} not found`);
+    }
+    return new MockedUnaryCall({ request: requestB });
+  };
 
   render(
     <MockAppContextProvider appContext={appContext}>
@@ -119,13 +130,14 @@ test('displays the request ID if assumed request details cannot be fetched', asy
   const accessRequestsMenu = await screen.findByTitle('Access Requests');
   await userEvent.click(accessRequestsMenu);
 
-  const item = await screen.findByText('some-id');
-  await userEvent.click(item);
-  expect(appContext.clustersService.dropRoles).toHaveBeenCalledTimes(1);
-  expect(appContext.clustersService.dropRoles).toHaveBeenCalledWith(
-    cluster.uri,
-    ['some-id']
-  );
+  // Even though getAccessRequests only returned requestA, the UI always displays the assumed requests:
+  // - requestB, which details exists in the useAssumedRequests cache
+  // - request-with-details-not-available, which is shown using only its ID (details missing)
+  expect(await screen.findByText('access-a')).toBeInTheDocument();
+  expect(await screen.findByText('access-b')).toBeInTheDocument();
+  expect(
+    await screen.findByText('request-with-details-not-available')
+  ).toBeInTheDocument();
 });
 
 function RequestRefreshSubscriber(props: {

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { UseQueryResult } from '@tanstack/react-query';
 import { formatDistanceToNow, isPast } from 'date-fns';
 import { ComponentType, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css, useTheme } from 'styled-components';
@@ -25,7 +26,7 @@ import * as Icon from 'design/Icon';
 import { IconProps } from 'design/Icon/Icon';
 import { MenuItemSectionLabel } from 'design/Menu/MenuItem';
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
-import { AccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+import { AccessRequest as GenAccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
 import { RequestableResourceKind } from 'shared/components/AccessRequests/NewRequest';
 import { getResourcesOrRolesFromRequest } from 'shared/components/AccessRequests/Shared/Shared';
 import {
@@ -55,6 +56,11 @@ import {
 } from '../TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 import { useAccessRequestsContext } from './AccessRequestsContext';
 
+type AccessRequest = Pick<
+  GenAccessRequest,
+  'expires' | 'id' | 'resources' | 'roles' | 'state' | 'user'
+>;
+
 export function SelectorMenu() {
   const [open, setOpen] = useState(false);
   // Captures a snapshot of the assumed request when the menu opens.
@@ -62,7 +68,7 @@ export function SelectorMenu() {
   // Prevents requests from shifting when they are assumed or dropped
   // while the menu is open.
   const [assumedSnapshot, setAssumedSnapshot] = useState<
-    Map<string, AccessRequest>
+    Map<string, UseQueryResult<AccessRequest>>
   >(() => new Map());
   const {
     canUse,
@@ -99,14 +105,19 @@ export function SelectorMenu() {
   // The same thing would happen if the API call to fetch requests failed.
   // We need to make sure that the assumed roles are always visible.
   const assumedAndAssumableRequests = useMemo(() => {
-    const allRequests = [...(assumableRequests.data || [])];
-    assumed.forEach(assumedRequest => {
-      if (
-        !allRequests.find(
-          fetchedRequest => fetchedRequest.id === assumedRequest.id
-        )
-      ) {
-        allRequests.push(assumedRequest);
+    const allRequests: AccessRequest[] = [...(assumableRequests.data || [])];
+    Array.from(assumed).forEach(([assumedRequestId, assumedRequestQuery]) => {
+      const exists = allRequests.some(r => r.id === assumedRequestId);
+
+      if (!exists) {
+        const fallbackRequest = {
+          id: assumedRequestId,
+          resources: [],
+          roles: [],
+          state: '',
+          user: '',
+        };
+        allRequests.push(assumedRequestQuery.data || fallbackRequest);
       }
     });
     return allRequests;
@@ -339,6 +350,18 @@ function RequestItem(props: {
     assumeOrDropAttempt.status === 'processing' ||
     !canAssumeResourceRequest;
 
+  const clippedRequestItems = clipRequestItems(items).map((i, index, array) => {
+    const { Icon, name } = i;
+    const isLast = index === array.length - 1;
+    return (
+      <Flex key={`name-${index}`} gap={1}>
+        {Icon && <Icon size="small" />}
+        {name}
+        {!isLast && ','}
+      </Flex>
+    );
+  });
+
   return (
     <StyledMenuItemContainer
       assumed={props.isAssumed}
@@ -363,17 +386,9 @@ function RequestItem(props: {
           `}
         >
           <Flex gap={1} flexWrap="wrap">
-            {clipRequestItems(items).map((i, index, array) => {
-              const { Icon, name } = i;
-              const isLast = index === array.length - 1;
-              return (
-                <Flex key={`name-${index}`} gap={1}>
-                  {Icon && <Icon size="small" />}
-                  {name}
-                  {!isLast && ','}
-                </Flex>
-              );
-            })}
+            {clippedRequestItems.length
+              ? clippedRequestItems
+              : props.request.id}
           </Flex>
           <P3
             css={`
@@ -383,7 +398,7 @@ function RequestItem(props: {
             {getAccessRequestStatusText({
               canAssumeResourceRequest,
               attempt: assumeOrDropAttempt,
-              expires: props.request.expires,
+              expires: props.request?.expires,
               isAssumed: props.isAssumed,
             })}
           </P3>
@@ -448,14 +463,17 @@ function getAccessRequestIconStatus(
 
 function getAccessRequestStatusText(args: {
   attempt: Attempt<unknown>;
-  expires: Timestamp;
+  expires: Timestamp | undefined;
   isAssumed: boolean;
   canAssumeResourceRequest: boolean;
 }) {
-  const expirationDate = Timestamp.toDate(args.expires);
-  const expiresIn = isPast(expirationDate)
-    ? 'Expired'
-    : `Expires in ${formatDistanceToNow(Timestamp.toDate(args.expires))}`;
+  const expirationDate = args.expires && Timestamp.toDate(args.expires);
+
+  const expiresIn = !expirationDate
+    ? 'Unknown expiration'
+    : isPast(expirationDate)
+      ? 'Expired'
+      : `Expires in ${formatDistanceToNow(expirationDate)}`;
 
   if (args.attempt.status === 'error') {
     return `Could not update access: ${args.attempt.statusText}`;

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
@@ -98,12 +98,10 @@ export function SelectorMenu() {
     [fetchRequestsAttempt, username]
   );
 
-  // Ensure that the assumed requests are always displayed in the menu.
-  // It's possible that the user assumed a request that was later deleted.
-  // If they refreshed the list after that, the request would be gone there, but
-  // still displayed in the status bar.
-  // The same thing would happen if the API call to fetch requests failed.
-  // We need to make sure that the assumed roles are always visible.
+  // Ensure assumed requests are always shown.
+  // If a request was deleted after being assumed, or if the API call to fetch
+  // requests fails, add the cached assumed requests to the list
+  // (or at least their request IDs if full details aren’t available).
   const assumedAndAssumableRequests = useMemo(() => {
     const allRequests: AccessRequest[] = [...(assumableRequests.data || [])];
     Array.from(assumed).forEach(([assumedRequestId, assumedRequestQuery]) => {
@@ -386,6 +384,7 @@ function RequestItem(props: {
           `}
         >
           <Flex gap={1} flexWrap="wrap">
+            {/*Only fallback requests have no roles/resources.*/}
             {clippedRequestItems.length
               ? clippedRequestItems
               : props.request.id}

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
@@ -397,7 +397,7 @@ function RequestItem(props: {
             {getAccessRequestStatusText({
               canAssumeResourceRequest,
               attempt: assumeOrDropAttempt,
-              expires: props.request?.expires,
+              expires: props.request.expires,
               isAssumed: props.isAssumed,
             })}
           </P3>

--- a/web/packages/teleterm/src/ui/AccessRequests/index.ts
+++ b/web/packages/teleterm/src/ui/AccessRequests/index.ts
@@ -18,3 +18,4 @@
 
 export * from './AccessRequestsContext';
 export { SelectorMenu as AccessRequestsMenu } from './SelectorMenu';
+export * from './useAssumedRequests';

--- a/web/packages/teleterm/src/ui/AccessRequests/useAssumedRequests.ts
+++ b/web/packages/teleterm/src/ui/AccessRequests/useAssumedRequests.ts
@@ -43,7 +43,7 @@ export const useAssumedRequests = (
   return useQueries({
     queries: activeRequests.map(id => ({
       // Only run this background query when the cluster is connected.
-      enabled: cluster.connected,
+      enabled: cluster?.connected,
       queryKey: ['assumedAccessRequests', uri, id],
       // Fetch once and always use cached value.
       staleTime: Infinity,

--- a/web/packages/teleterm/src/ui/AccessRequests/useAssumedRequests.ts
+++ b/web/packages/teleterm/src/ui/AccessRequests/useAssumedRequests.ts
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQueries, UseQueryResult } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { AccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
+import { RootClusterUri } from 'teleterm/ui/uri';
+
+/**
+ * Keeps request details for assumed request IDs.
+ * Once loaded from the server, the details are cached indefinitely.
+ */
+export const useAssumedRequests = (
+  uri: RootClusterUri
+): Map<string, UseQueryResult<AccessRequest>> => {
+  const appContext = useAppContext();
+  const cluster = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.clusters.get(uri), [uri])
+  );
+
+  const activeRequests = cluster?.loggedInUser.activeRequests || [];
+
+  return useQueries({
+    queries: activeRequests.map(id => ({
+      // Only run this background query when the cluster is connected.
+      enabled: cluster.connected,
+      queryKey: ['assumedAccessRequests', uri, id],
+      // Fetch once and always use cached value.
+      staleTime: Infinity,
+      queryFn: async () => {
+        const { response } = await appContext.tshd.getAccessRequest({
+          clusterUri: uri,
+          accessRequestId: id,
+        });
+        return response.request;
+      },
+      // Attach ID for the map below.
+      meta: { id },
+    })),
+    combine: results => {
+      return results.reduce((map, data, index) => {
+        const id = activeRequests[index];
+        map.set(id, data);
+        return map;
+      }, new Map<string, UseQueryResult<AccessRequest>>());
+    },
+  });
+};

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { ComponentPropsWithoutRef } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -33,6 +34,15 @@ import { ThemeProvider } from './ThemeProvider';
 import { ConnectionsContextProvider } from './TopBar/Connections/connectionsContext';
 import { VnetContextProvider } from './Vnet/vnetContext';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
 export const App: React.FC<{
   ctx: AppContext;
   launchDeepLink?: ComponentPropsWithoutRef<typeof DeepLinks>['launchDeepLink'];
@@ -42,19 +52,21 @@ export const App: React.FC<{
       <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
-            <AppUpdaterContextProvider>
-              <ResourcesContextProvider>
-                <ConnectionsContextProvider>
-                  <VnetContextProvider>
-                    <ThemeProvider>
-                      <DeepLinks launchDeepLink={launchDeepLink} />
+            <QueryClientProvider client={queryClient}>
+              <AppUpdaterContextProvider>
+                <ResourcesContextProvider>
+                  <ConnectionsContextProvider>
+                    <VnetContextProvider>
+                      <ThemeProvider>
+                        <DeepLinks launchDeepLink={launchDeepLink} />
 
-                      <AppInitializer />
-                    </ThemeProvider>
-                  </VnetContextProvider>
-                </ConnectionsContextProvider>
-              </ResourcesContextProvider>
-            </AppUpdaterContextProvider>
+                        <AppInitializer />
+                      </ThemeProvider>
+                    </VnetContextProvider>
+                  </ConnectionsContextProvider>
+                </ResourcesContextProvider>
+              </AppUpdaterContextProvider>
+            </QueryClientProvider>
           </AppContextProvider>
         </DndProvider>
       </StyledApp>

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
@@ -57,13 +57,13 @@ export function useReviewAccessRequest({
     useCallback(
       () =>
         retry(async () => {
-          const request = await ctx.clustersService.getAccessRequest(
-            rootClusterUri,
-            requestId
-          );
-          return makeUiAccessRequest(request);
+          const { response } = await ctx.tshd.getAccessRequest({
+            clusterUri: rootClusterUri,
+            accessRequestId: requestId,
+          });
+          return makeUiAccessRequest(response.request);
         }),
-      [ctx.clustersService, requestId, retry, rootClusterUri]
+      [ctx.tshd, requestId, retry, rootClusterUri]
     )
   );
   const [deleteRequestAttempt, runDeleteRequest] = useAsync(() =>

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/ReviewAccessRequest/useReviewAccessRequest.ts
@@ -47,7 +47,6 @@ export function useReviewAccessRequest({
 
   const { localClusterUri: clusterUri, rootClusterUri } = useWorkspaceContext();
   const loggedInUser = useWorkspaceLoggedInUser();
-  const assumed = ctx.clustersService.getAssumedRequests(rootClusterUri);
 
   const retry = useCallback(
     <T>(action: () => Promise<T>) => retryWithRelogin(ctx, clusterUri, action),
@@ -119,7 +118,7 @@ export function useReviewAccessRequest({
 
   function getFlags(request: AccessRequest): RequestFlags {
     if (loggedInUser) {
-      return getRequestFlags(request, loggedInUser, assumed);
+      return getRequestFlags(request, loggedInUser);
     }
     return undefined;
   }
@@ -164,12 +163,11 @@ export function useReviewAccessRequest({
 
 function getRequestFlags(
   request: AccessRequest,
-  user: tsh.LoggedInUser,
-  assumedMap: Record<string, tsh.AccessRequest>
+  user: tsh.LoggedInUser
 ): RequestFlags {
   const ownRequest = request.user === user.name;
   const canAssume = ownRequest && request.state === 'APPROVED';
-  const isAssumed = !!assumedMap[request.id];
+  const isAssumed = !!user.activeRequests.includes(request.id);
   const canDelete = true;
 
   const reviewed = request.reviews.find(r => r.author === user.name);

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -41,7 +41,6 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
   const { rootClusterUri, documentsService } = useWorkspaceContext();
   const { fetchRequestsAttempt, fetchRequests } = useAccessRequestsContext();
 
-  const assumed = ctx.clustersService.getAssumedRequests(rootClusterUri);
   const loggedInUser = useWorkspaceLoggedInUser();
 
   function goBack() {
@@ -79,7 +78,7 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
     doc,
     getRequests: fetchRequests,
     getFlags: (accessRequest: AccessRequest) =>
-      makeFlags(accessRequest, assumed, loggedInUser),
+      makeFlags(accessRequest, loggedInUser),
     goBack,
   };
 }
@@ -114,12 +113,11 @@ export function makeUiAccessRequest(request: TshdAccessRequest) {
 // TODO(gzdunek): Replace with a function from `DocumentAccessRequests/useReviewAccessRequest`.
 export function makeFlags(
   request: AccessRequest,
-  assumed: Record<string, TshdAccessRequest>,
   loggedInUser: LoggedInUser
 ): RequestFlags {
   const ownRequest = request.user === loggedInUser?.name;
   const canAssume = ownRequest && request.state === 'APPROVED';
-  const isAssumed = !!assumed[request.id];
+  const isAssumed = loggedInUser?.activeRequests.includes(request.id);
 
   const isPromoted =
     request.state === 'PROMOTED' && !!request.promotedAccessListTitle;

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -194,13 +194,7 @@ test('sync root cluster', async () => {
 
   await service.syncAndWatchRootClusterWithErrorHandling(clusterUri);
 
-  const clusterMockWithRequests = {
-    ...clusterMock,
-    loggedInUser: { ...clusterMock.loggedInUser, assumedRequests: {} },
-  };
-  expect(service.findCluster(clusterUri)).toStrictEqual(
-    clusterMockWithRequests
-  );
+  expect(service.findCluster(clusterUri)).toStrictEqual(clusterMock);
   expect(service.findCluster(leafClusterMock.uri)).toStrictEqual(
     leafClusterMock
   );

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -277,13 +277,6 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     return response.clusters;
   }
 
-  /** @deprecated Use getAssumedRequests function instead of the method on ClustersService. */
-  getAssumedRequests(
-    rootClusterUri: uri.RootClusterUri
-  ): Record<string, AccessRequest> {
-    return getAssumedRequests(this.state, rootClusterUri);
-  }
-
   /** Assumes roles for the given requests. */
   async assumeRoles(
     rootClusterUri: uri.RootClusterUri,

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -292,18 +292,6 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     await this.syncRootCluster(rootClusterUri);
   }
 
-  async getAccessRequest(
-    rootClusterUri: uri.RootClusterUri,
-    requestId: string
-  ) {
-    const { response } = await this.client.getAccessRequest({
-      clusterUri: rootClusterUri,
-      accessRequestId: requestId,
-    });
-
-    return response.request;
-  }
-
   async reviewAccessRequest(params: ReviewAccessRequestRequest) {
     const { response } = await this.client.reviewAccessRequest(params);
     this.usageService.captureAccessRequestReview(params.rootClusterUri);


### PR DESCRIPTION
I removed fetching access requests from clusters service that we planned a long time ago.

Previously, these requests were used in four places:
* Two of them only needed request IDs, so I switched them to use `LoggedInUser.activeRequests`.
* The other two: the status bar and the top bar request selector show request data.
Fetching these requests is now handled using React Query, which is really nice because it can cache queries by key. This means we don't have to worry about multiple network requests coming from different parts of the UI.

The only part I wasn’t entirely sure about was how to handle errors when fetching requests. Previously, this was part of `syncCluster`, so any errors would show up as notifications. However, the status bar and top bar request selector have very limited space, so I decided to display a fallback (the request ID) without showing an error. Here is my reasoning:
* The request selector fetches all requests anyway. We only add requests fetched from `LoggedInUser.activeRequests` if they aren’t already in the list. This can occur if a request was removed after being assumed, in which case we display the version from the React Query cache. I don't think it happens too often.
* Dropping and re-assuming a request triggers a network request that fetches the details (if the initial fetch failed), which may resolve the issue.
* Even without the full details, the UI remains usable: users can still drop or assume requests, and tsh operates using IDs exclusively.