### PR TITLE
Prevent user upsert/delete on a role with a specific label

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1173,6 +1173,11 @@ const (
 	// number to aid future migrations. Label value is expected to be a number.
 	TeleportResourceRevision = TeleportInternalLabelPrefix + "revision"
 
+	// TeleportManagedResourceLabel is a label used to identity a resource that
+	// is managed by other Teleport resource. Roles with this label will not
+	// be modifiable by users even with RBAC.
+	TeleportManagedResourceLabel = TeleportInternalLabelPrefix + "managed-by"
+
 	// SystemResource are resources that will be automatically created and overwritten on startup. Users
 	// should not change these resources.
 	SystemResource = "system"

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4733,6 +4733,10 @@ func (a *ServerWithRoles) CreateRole(ctx context.Context, role types.Role) (type
 		return nil, trace.Wrap(err)
 	}
 
+	if err := checkForTeleportManagedResourceLabel(RoleActionCreate, role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if err := a.validateRole(role); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4762,6 +4766,10 @@ func (a *ServerWithRoles) UpdateRole(ctx context.Context, role types.Role) (type
 	}
 
 	if err := a.context.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := checkForTeleportManagedResourceLabel(RoleActionUpdate, role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -4799,6 +4807,16 @@ func (a *ServerWithRoles) UpsertRole(ctx context.Context, role types.Role) (type
 	// Support reused MFA for bulk tctl create requests.
 	if err := a.context.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if oldRole != nil {
+		if err := checkForTeleportManagedResourceLabel(RoleActionUpdate, role); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		if err := checkForTeleportManagedResourceLabel(RoleActionCreate, role); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err := a.validateRole(role); err != nil {
@@ -4891,6 +4909,10 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	}
 
 	if err := a.context.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := checkForTeleportManagedResourceLabel(RoleActionDelete, role); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Roles with label key `teleport.internal/managed-by` will prevent user role modification (even if user has the RBAC for roles).

There exists a label `teleport.internal/resource-type: system` where we assume users won't modify the role but nothing prevents them from modifying it with `tctl`. To preserve existing behavior (eg: allow deleting system roles) and avoid unintentional behavior, a new label was created.

An example usage of this label is for [templated access lists](https://github.com/gravitational/teleport/pull/58297) where we preserve a roles spec in the access list, and Teleport upserts the role based on this spec. If a user modifies the role created by Teleport, it'll become out of sync with what is defined in the access list.