### PR TITLE
install-node.sh: Make Teleport process checking more robust

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -419,7 +419,7 @@ get_download_filename() { echo "${1##*/}"; }
 # gets the pid of any running teleport process (and converts newlines to spaces)
 get_teleport_pid() {
     check_exists_fatal pgrep xargs
-    pgrep teleport | xargs echo
+    pgrep -f "teleport start" | xargs echo
 }
 # returns a command which will start teleport using the config
 get_teleport_start_command() {


### PR DESCRIPTION
A customer ran into an issue when running the `install-node.sh` script through `cloud-init` - their script is named something similar to `/run/install_teleport_init.sh`, so `pgrep teleport` matches on the PID of this script.

This PR changes the `pgrep` invocation to detect the full `teleport start` command, which should prevent future false positives.

changelog: Made the check for a running Teleport process in the install-node.sh script more robust