### PR TITLE
Fix Teleport builds failing with `devbox` due to old MacOS SDK and new Go version

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -27,6 +27,7 @@
     "protobuf3_20@3.20.3",
     "pnpm@10.7.0",
     "gnumake@4.3",
+    "apple-sdk_12@12.3",
 
     "path:build.assets/flake#conditional",
     "path:build.assets/flake#grpc-tools",
@@ -39,7 +40,8 @@
     "init_hook": [
       "export TELEPORT_DEVBOX=1",
       "export PATH=\"$HOME/.cargo/bin:$PATH\"",
-      "type unset 2>/dev/null && unset GOROOT"
+      "type unset 2>/dev/null && unset GOROOT",
+      "unset DEVELOPER_DIR_FOR_TARGET"
     ]
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -49,6 +49,34 @@
         }
       }
     },
+    "apple-sdk_12@12.3": {
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#apple-sdk_12",
+      "source": "devbox-search",
+      "version": "12.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kvs20yk8vvs0201i1xczafjibvklcacc-apple-sdk-12.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kvs20yk8vvs0201i1xczafjibvklcacc-apple-sdk-12.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0lwhprmdl5qfhca48jhg3r9zsyv2a7p2-apple-sdk-12.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/0lwhprmdl5qfhca48jhg3r9zsyv2a7p2-apple-sdk-12.3"
+        }
+      }
+    },
     "bash@latest": {
       "last_modified": "2024-11-16T04:25:12Z",
       "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#bash",
@@ -360,6 +388,10 @@
           "store_path": "/nix/store/pxpns5vm111i6j3r3wbygaj99wbrm6h1-git-2.47.0"
         }
       }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-08-25T22:07:10Z",
+      "resolved": "github:NixOS/nixpkgs/84c256e42600cb0fdf25763b48d28df2f25a0c8b?lastModified=1756159630&narHash=sha256-ohMvsjtSVdT%2FbruXf5ClBh8ZYXRmD4krmjKrXhEvwMg%3D"
     },
     "gnumake@4.3": {
       "last_modified": "2022-12-08T11:15:29Z",
@@ -730,8 +762,8 @@
       }
     },
     "llvmPackages_14.clangUseLLVM@14.0.6": {
-      "last_modified": "2024-11-16T04:25:12Z",
-      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#llvmPackages_14.clangUseLLVM",
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#llvmPackages_14.clangUseLLVM",
       "source": "devbox-search",
       "version": "14.0.6",
       "systems": {
@@ -739,41 +771,41 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/b06905i89z5liqpgafazjwqxk9zrygfp-clang-wrapper-14.0.6",
+              "path": "/nix/store/nbyda6fn0r7pn315ijr5aga8zrbn8sia-clang-wrapper-14.0.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/b06905i89z5liqpgafazjwqxk9zrygfp-clang-wrapper-14.0.6"
+          "store_path": "/nix/store/nbyda6fn0r7pn315ijr5aga8zrbn8sia-clang-wrapper-14.0.6"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/1frmrf94mqlg64a5wdwpv5n76qi41ib7-clang-wrapper-14.0.6",
+              "path": "/nix/store/j0psmmm38r0jrxh61i3svcdyg92jxxc7-clang-wrapper-14.0.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/1frmrf94mqlg64a5wdwpv5n76qi41ib7-clang-wrapper-14.0.6"
+          "store_path": "/nix/store/j0psmmm38r0jrxh61i3svcdyg92jxxc7-clang-wrapper-14.0.6"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/92xfly2xhpvsids88fpbk0jh6qalh3py-clang-wrapper-14.0.6",
+              "path": "/nix/store/q0rzijanaqi8s4sjpd2zssz99027ji7n-clang-wrapper-14.0.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/92xfly2xhpvsids88fpbk0jh6qalh3py-clang-wrapper-14.0.6"
+          "store_path": "/nix/store/q0rzijanaqi8s4sjpd2zssz99027ji7n-clang-wrapper-14.0.6"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ds4bkq71imxzk67j6ssnlrn5mgzvgjqs-clang-wrapper-14.0.6",
+              "path": "/nix/store/gdvgcbwsfk6c1g5l6wnzs6v0sy9xf5nm-clang-wrapper-14.0.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ds4bkq71imxzk67j6ssnlrn5mgzvgjqs-clang-wrapper-14.0.6"
+          "store_path": "/nix/store/gdvgcbwsfk6c1g5l6wnzs6v0sy9xf5nm-clang-wrapper-14.0.6"
         }
       }
     },


### PR DESCRIPTION
Teleport builds using the `devbox shell` were failing since we upgraded our Go version to one which requires at least v12 of the MacOS SDK. By default, the nix stdenv will use the v11 MacOS SDK.

I've also had to include `unset DEVELOPER_DIR_FOR_TARGET` since there seems to be an internal conflict caused by DevBox that leads to `DEVELOPER_DIR` and `DEVELOPER_DIR_FOR_TARGET` being mismatched, which also causes builds to fail.

Frankly - I'm now very much of the mind that we should remove the devbox related functionality from the Teleport codebase. I'm fairly sure I'm the last person left using it, and, a lot of the functionality has broken over time (especially functionality I don't use day-to-day). I've raised this PR so we can at least have builds of the main teleport binary succeed if we don't decide to remove it. I'm also going to raise a PR to remove devbox seperately