### PR TITLE
[v17] include hostID in app access error

### DIFF
--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -193,6 +193,7 @@ func (c *ConnectionsHandler) withJWTTokenForwarder(ctx context.Context, sess *se
 			jwt:          jwt,
 			traits:       traits,
 			log:          c.log,
+			hostID:       c.cfg.HostID,
 		})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -51,6 +51,8 @@ type transportConfig struct {
 	jwt          string
 	traits       wrappers.Traits
 	log          *slog.Logger
+	// hostID is purely for troubleshooting purposes (put in the error messages)
+	hostID string
 }
 
 // Check validates configuration.
@@ -162,6 +164,10 @@ func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		if t.log.Enabled(r.Context(), slog.LevelDebug) {
 			t.log.DebugContext(r.Context(), "application request failed with a network error",
 				"raw_error", err, "human_error", strings.Join(strings.Fields(message), " "))
+		}
+
+		if t.hostID != "" {
+			message = message + "\n\nhostID: " + t.hostID
 		}
 
 		code := trace.ErrorToCode(err)

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -167,7 +167,7 @@ func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 
 		if t.hostID != "" {
-			message = message + "\n\nhostID: " + t.hostID
+			message = message + "\n\nThe ID of the Teleport Application Service instance that generated this error is " + t.hostID + "."
 		}
 
 		code := trace.ErrorToCode(err)


### PR DESCRIPTION
Backport #59390 to branch/v17

changelog: Improved app access error messages in case of network error.
