### PR TITLE
[v18] Add initial support for generating MCP configuration for VSCode and Claude Code

### DIFF
--- a/lib/client/mcp/config/claude.go
+++ b/lib/client/mcp/config/claude.go
@@ -60,6 +60,6 @@ func LoadClaudeConfigFromDefaultPath() (*FileConfig, error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "finding Claude Desktop config path")
 	}
-	config, err := LoadConfigFromFile(configPath)
+	config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
 	return config, trace.Wrap(err)
 }

--- a/lib/client/mcp/config/claude.go
+++ b/lib/client/mcp/config/claude.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/gravitational/trace"
+)
+
+// claudeServersKey defines the JSON key used by Claude to store MCP servers
+// config.
+const claudeServersKey = "mcpServers"
+
+// DefaultClaudeConfigPath returns the default path for the Claude Desktop config.
+//
+// https://modelcontextprotocol.io/quickstart/user
+//
+// macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
+// Windows: %APPDATA%\Claude\claude_desktop_config.json
+func DefaultClaudeConfigPath() (string, error) {
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		// os.UserConfigDir:
+		// On Darwin, it returns $HOME/Library/Application Support.
+		// On Windows, it returns %AppData%.
+		configDir, err := os.UserConfigDir()
+		if err != nil {
+			return "", trace.ConvertSystemError(err)
+		}
+		return filepath.Join(configDir, "Claude", "claude_desktop_config.json"), nil
+
+	default:
+		// TODO(greedy52) there is no official Claude Desktop for linux yet. The
+		// unofficial one uses the same path as above.
+		return "", trace.NotImplemented("Claude Desktop is not supported on OS %s", runtime.GOOS)
+	}
+}
+
+// LoadClaudeConfigFromDefaultPath loads the Claude Desktop's config from the
+// default path.
+func LoadClaudeConfigFromDefaultPath() (*FileConfig, error) {
+	configPath, err := DefaultClaudeConfigPath()
+	if err != nil {
+		return nil, trace.Wrap(err, "finding Claude Desktop config path")
+	}
+	config, err := LoadConfigFromFile(configPath)
+	return config, trace.Wrap(err)
+}

--- a/lib/client/mcp/config/claude.go
+++ b/lib/client/mcp/config/claude.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package config
 
 import (

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package claude
+package config
 
 import (
 	"bytes"
@@ -25,49 +25,13 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/tidwall/pretty"
 	"github.com/tidwall/sjson"
+	"slices"
 )
-
-// DefaultConfigPath returns the default path for the Claude Desktop config.
-//
-// https://modelcontextprotocol.io/quickstart/user
-//
-// macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-// Windows: %APPDATA%\Claude\claude_desktop_config.json
-func DefaultConfigPath() (string, error) {
-	switch runtime.GOOS {
-	case "darwin", "windows":
-		// os.UserConfigDir:
-		// On Darwin, it returns $HOME/Library/Application Support.
-		// On Windows, it returns %AppData%.
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			return "", trace.ConvertSystemError(err)
-		}
-		return filepath.Join(configDir, "Claude", "claude_desktop_config.json"), nil
-
-	default:
-		// TODO(greedy52) there is no official Claude Desktop for linux yet. The
-		// unofficial one uses the same path as above.
-		return "", trace.NotImplemented("Claude Desktop is not supported on OS %s", runtime.GOOS)
-	}
-}
-
-// GlobalCursorPath returns the default path for Cursor global MCP configuration.
-//
-// https://docs.cursor.com/context/mcp#configuration-locations
-func GlobalCursorPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	return filepath.Join(homeDir, ".cursor", "mcp.json"), nil
-}
 
 // MCPServer contains details to launch an MCP server.
 //
@@ -98,7 +62,7 @@ func (s *MCPServer) GetEnv(key string) (string, bool) {
 	return value, ok
 }
 
-// Config represents a Claude Desktop config.
+// Config represents a MCP servers config.
 //
 // Config preserves unknown fields and ordering from the original JSON when
 // saving, by using the sjson lib.
@@ -108,38 +72,43 @@ type Config struct {
 	mcpServers            map[string]MCPServer
 	configData            []byte
 	isOriginalJSONCompact bool
+	format                ConfigFormat
 }
 
 // NewConfig creates an empty config.
-func NewConfig() *Config {
+func NewConfig(format ConfigFormat) *Config {
 	return &Config{
 		mcpServers:            make(map[string]MCPServer),
 		configData:            []byte("{}"),
 		isOriginalJSONCompact: false,
+		format:                format,
 	}
 }
 
 // NewConfigFromJSON creates a config from JSON.
-func NewConfigFromJSON(data []byte) (*Config, error) {
-	config := struct {
-		MCPServers map[string]MCPServer `json:"mcpServers"`
-	}{}
+func NewConfigFromJSON(format ConfigFormat, data []byte) (*Config, error) {
+	var config map[string]json.RawMessage
 	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, trace.Wrap(err, "parsing Claude Desktop config")
+		return nil, trace.Wrap(err, "parsing config")
 	}
 
-	if config.MCPServers == nil {
-		config.MCPServers = map[string]MCPServer{}
+	servers := make(map[string]MCPServer)
+	if rawServers, ok := config[format.serversKey()]; ok {
+		if err := json.Unmarshal(rawServers, &servers); err != nil {
+			return nil, trace.Wrap(err, "parsing mcp servers config")
+		}
 	}
+
 	isOriginalJSONCompact, err := isJSONCompact(data)
 	if err != nil {
-		return nil, trace.Wrap(err, "parsing Claude Desktop config")
+		return nil, trace.Wrap(err, "parsing mcp servers config")
 	}
 
 	return &Config{
-		mcpServers:            config.MCPServers,
+		mcpServers:            servers,
 		configData:            data,
 		isOriginalJSONCompact: isOriginalJSONCompact,
+		format:                format,
 	}, nil
 }
 
@@ -192,6 +161,46 @@ const (
 	FormatJSONAuto FormatJSONOption = "auto"
 )
 
+// ConfigFormat specifies what is the MCP servers configuration format.
+type ConfigFormat string
+
+const (
+	// ConfigFormatClaude represents the Claude desktop and Claude Code formats.
+	ConfigFormatClaude ConfigFormat = "claude"
+	// ConfigFormatCursor respresents the Cursor format.
+	ConfigFormatCursor ConfigFormat = "cursor"
+	// ConfigFormatVSCode represents the VSCode format.
+	ConfigFormatVSCode ConfigFormat = "vscode"
+)
+
+// serversKey returns the MCP servers JSON key for the format.
+func (cf ConfigFormat) serversKey() string {
+	switch cf {
+	case ConfigFormatClaude, ConfigFormatCursor:
+		return claudeServersKey
+	case ConfigFormatVSCode:
+		return vsCodeServersKey
+	default:
+		return ""
+	}
+}
+
+// ConfigFormatFromPath tries to determine the config format based on its path.
+func ConfigFormatFromPath(configPath string) ConfigFormat {
+	switch {
+	case pathContains(configPath, vsCodeProjectDir):
+		return ConfigFormatVSCode
+	case pathContains(configPath, cursorProjectDir):
+		return ConfigFormatCursor
+	default:
+		return ConfigFormatClaude
+	}
+}
+
+func pathContains(path, dir string) bool {
+	return slices.Contains(strings.Split(filepath.Clean(path), string(filepath.Separator)), dir)
+}
+
 // Write writes the config to provided writer.
 func (c *Config) Write(w io.Writer, format FormatJSONOption) error {
 	data, err := c.formatConfigData(format)
@@ -212,22 +221,23 @@ type FileConfig struct {
 	configExists bool
 }
 
-// LoadConfigFromFile loads the Claude Desktop's config from the provided path.
+// LoadConfigFromFile loads the MCP config from the provided path.
 func LoadConfigFromFile(configPath string) (*FileConfig, error) {
+	format := ConfigFormatFromPath(configPath)
 	data, err := os.ReadFile(configPath)
 	switch {
 	case os.IsNotExist(err):
 		return &FileConfig{
-			Config:       NewConfig(),
+			Config:       NewConfig(format),
 			configPath:   configPath,
 			configExists: false,
 		}, nil
 
 	case err != nil:
-		return nil, trace.Wrap(trace.ConvertSystemError(err), "reading Claude Desktop config")
+		return nil, trace.Wrap(trace.ConvertSystemError(err), "reading mcp servers config")
 
 	default:
-		config, err := NewConfigFromJSON(data)
+		config, err := NewConfigFromJSON(format, data)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -238,28 +248,6 @@ func LoadConfigFromFile(configPath string) (*FileConfig, error) {
 			configExists: true,
 		}, nil
 	}
-}
-
-// LoadConfigFromDefaultPath loads the Claude Desktop's config from the default
-// path.
-func LoadConfigFromDefaultPath() (*FileConfig, error) {
-	configPath, err := DefaultConfigPath()
-	if err != nil {
-		return nil, trace.Wrap(err, "finding Claude Desktop config path")
-	}
-	config, err := LoadConfigFromFile(configPath)
-	return config, trace.Wrap(err)
-}
-
-// LoadConfigFromGlobalCursor loads the Cursor global MCP server configuration.
-func LoadConfigFromGlobalCursor() (*FileConfig, error) {
-	configPath, err := GlobalCursorPath()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	config, err := LoadConfigFromFile(configPath)
-	return config, trace.Wrap(err)
 }
 
 // Exists returns true if config file exists.
@@ -275,7 +263,7 @@ func (c *FileConfig) Path() string {
 // Save saves the updated config to the config path. Format defaults to "auto"
 // if empty.
 func (c *FileConfig) Save(format FormatJSONOption) error {
-	// Claude Desktop creates the config with 0644.
+	// Creates the config with 0644.
 	file, err := os.OpenFile(c.configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return trace.ConvertSystemError(err)
@@ -285,7 +273,7 @@ func (c *FileConfig) Save(format FormatJSONOption) error {
 }
 
 func (c *Config) mcpServerJSONPath(serverName string) string {
-	return "mcpServers." + serverName
+	return c.format.serversKey() + "." + serverName
 }
 
 func (c *Config) formatConfigData(format FormatJSONOption) ([]byte, error) {

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -229,7 +229,7 @@ func ConfigFormatFromPath(configPath string) ConfigFormat {
 		// Works for both, global and projects settings.
 		return ConfigFormatClaude // Cursor uses the same format as Claude.
 	default:
-		return DefaultConfigFormat
+		return ConfigFormatUnspecified
 	}
 }
 
@@ -258,8 +258,7 @@ type FileConfig struct {
 }
 
 // LoadConfigFromFile loads the MCP config from the provided path.
-func LoadConfigFromFile(configPath string) (*FileConfig, error) {
-	format := ConfigFormatFromPath(configPath)
+func LoadConfigFromFile(configPath string, format ConfigFormat) (*FileConfig, error) {
 	data, err := os.ReadFile(configPath)
 	switch {
 	case os.IsNotExist(err):

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -208,6 +208,18 @@ func (cf ConfigFormat) serversKey() string {
 	}
 }
 
+// String returns human readable config format name.
+func (cf ConfigFormat) String() string {
+	switch cf {
+	case ConfigFormatClaude:
+		return "Claude/Cursor"
+	case ConfigFormatVSCode:
+		return "VSCode"
+	default:
+		return "Unspecified"
+	}
+}
+
 // ConfigFormatFromPath tries to determine the config format based on its path.
 func ConfigFormatFromPath(configPath string) ConfigFormat {
 	switch {

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -25,12 +25,12 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/tidwall/pretty"
 	"github.com/tidwall/sjson"
-	"slices"
 )
 
 // MCPServer contains details to launch an MCP server.

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -173,6 +173,20 @@ const (
 	ConfigFormatVSCode ConfigFormat = "vscode"
 )
 
+// ParseConfigFormat parses configuration format from string.
+func ParseConfigFormat(s string) (ConfigFormat, error) {
+	switch ConfigFormat(s) {
+	case ConfigFormatClaude:
+		return ConfigFormatClaude, nil
+	case ConfigFormatCursor:
+		return ConfigFormatCursor, nil
+	case ConfigFormatVSCode:
+		return ConfigFormatVSCode, nil
+	}
+
+	return ConfigFormat(""), trace.BadParameter("unsupported config format")
+}
+
 // serversKey returns the MCP servers JSON key for the format.
 func (cf ConfigFormat) serversKey() string {
 	switch cf {
@@ -191,6 +205,7 @@ func ConfigFormatFromPath(configPath string) ConfigFormat {
 	case pathContains(configPath, vsCodeProjectDir):
 		return ConfigFormatVSCode
 	case pathContains(configPath, cursorProjectDir):
+		// Works for both, global and projects settings.
 		return ConfigFormatCursor
 	default:
 		return ConfigFormatClaude

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -225,7 +225,7 @@ func ConfigFormatFromPath(configPath string) ConfigFormat {
 	switch {
 	case pathContains(configPath, vsCodeProjectDir):
 		return ConfigFormatVSCode
-	case pathContains(configPath, cursorProjectDir):
+	case pathContains(configPath, cursorProjectDir), pathContains(configPath, claudeCodeFileName):
 		// Works for both, global and projects settings.
 		return ConfigFormatClaude // Cursor uses the same format as Claude.
 	default:

--- a/lib/client/mcp/config/config.go
+++ b/lib/client/mcp/config/config.go
@@ -165,32 +165,41 @@ const (
 type ConfigFormat string
 
 const (
+	// ConfigFormatUnspecified represents an unspecified format.
+	ConfigFormatUnspecified ConfigFormat = ""
 	// ConfigFormatClaude represents the Claude desktop and Claude Code formats.
 	ConfigFormatClaude ConfigFormat = "claude"
-	// ConfigFormatCursor respresents the Cursor format.
-	ConfigFormatCursor ConfigFormat = "cursor"
 	// ConfigFormatVSCode represents the VSCode format.
 	ConfigFormatVSCode ConfigFormat = "vscode"
 )
+
+// DefaultConfigFormat determines the dafault config format. This can be used
+// in cases where the format wasn't specified.
+const DefaultConfigFormat = ConfigFormatClaude
 
 // ParseConfigFormat parses configuration format from string.
 func ParseConfigFormat(s string) (ConfigFormat, error) {
 	switch ConfigFormat(s) {
 	case ConfigFormatClaude:
 		return ConfigFormatClaude, nil
-	case ConfigFormatCursor:
-		return ConfigFormatCursor, nil
 	case ConfigFormatVSCode:
 		return ConfigFormatVSCode, nil
+	case ConfigFormatUnspecified:
+		return ConfigFormatUnspecified, nil
 	}
 
-	return ConfigFormat(""), trace.BadParameter("unsupported config format")
+	return ConfigFormatUnspecified, trace.BadParameter("unsupported %q config format", s)
+}
+
+// IsSpecified returns whether the config format was specified or not.
+func (cf ConfigFormat) IsSpecified() bool {
+	return cf != ConfigFormatUnspecified
 }
 
 // serversKey returns the MCP servers JSON key for the format.
 func (cf ConfigFormat) serversKey() string {
 	switch cf {
-	case ConfigFormatClaude, ConfigFormatCursor:
+	case ConfigFormatClaude:
 		return claudeServersKey
 	case ConfigFormatVSCode:
 		return vsCodeServersKey
@@ -206,9 +215,9 @@ func ConfigFormatFromPath(configPath string) ConfigFormat {
 		return ConfigFormatVSCode
 	case pathContains(configPath, cursorProjectDir):
 		// Works for both, global and projects settings.
-		return ConfigFormatCursor
+		return ConfigFormatClaude // Cursor uses the same format as Claude.
 	default:
-		return ConfigFormatClaude
+		return DefaultConfigFormat
 	}
 }
 

--- a/lib/client/mcp/config/config_test.go
+++ b/lib/client/mcp/config/config_test.go
@@ -335,19 +335,6 @@ func TestReadDifferentConfigFormats(t *testing.T) {
 				require.Equal(tt, "npx", srv.Command)
 			},
 		},
-		"claude/default": {
-			filePath:  fileNamePath("claude_desktop_config.json"),
-			contents:  `{"mcpServers":{"everything": {"command": "npx", "args": []}}}`,
-			expectErr: require.NoError,
-			expectConfig: func(tt require.TestingT, i1 any, i2 ...any) {
-				config := i1.(*FileConfig)
-				servers := config.GetMCPServers()
-
-				srv, ok := servers["everything"]
-				require.True(tt, ok, `expected config to have "everything" mcp server configured`)
-				require.Equal(tt, "npx", srv.Command)
-			},
-		},
 		"empty config": {
 			filePath:     fileNamePath("file.json"),
 			contents:     ``,
@@ -359,7 +346,8 @@ func TestReadDifferentConfigFormats(t *testing.T) {
 			configPath := tc.filePath(t, t.TempDir())
 			require.NoError(t, os.WriteFile(configPath, []byte(tc.contents), 0600))
 
-			config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
+			format := ConfigFormatFromPath(configPath)
+			config, err := LoadConfigFromFile(configPath, format)
 			tc.expectErr(t, err)
 			tc.expectConfig(t, config)
 		})

--- a/lib/client/mcp/config/config_test.go
+++ b/lib/client/mcp/config/config_test.go
@@ -134,7 +134,7 @@ func TestFileConfig_sampleFile(t *testing.T) {
 }
 
 func TestConfig_Write(t *testing.T) {
-	for _, format := range []ConfigFormat{ConfigFormatClaude, ConfigFormatCursor, ConfigFormatVSCode} {
+	for _, format := range []ConfigFormat{ConfigFormatClaude, ConfigFormatVSCode} {
 		t.Run(format.serversKey(), func(t *testing.T) {
 			config := NewConfig(format)
 

--- a/lib/client/mcp/config/config_test.go
+++ b/lib/client/mcp/config/config_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package claude
+package config
 
 import (
 	"bytes"
@@ -134,17 +134,21 @@ func TestFileConfig_sampleFile(t *testing.T) {
 }
 
 func TestConfig_Write(t *testing.T) {
-	config := NewConfig()
+	for _, format := range []ConfigFormat{ConfigFormatClaude, ConfigFormatCursor, ConfigFormatVSCode} {
+		t.Run(format.serversKey(), func(t *testing.T) {
+			config := NewConfig(format)
 
-	mcpServer := MCPServer{
-		Command: "command",
+			mcpServer := MCPServer{
+				Command: "command",
+			}
+			mcpServer.AddEnv("foo", "bar")
+			require.NoError(t, config.PutMCPServer("test", mcpServer))
+			var buf bytes.Buffer
+
+			require.NoError(t, config.Write(&buf, FormatJSONCompact))
+			require.Equal(t, `{"`+format.serversKey()+`":{"test":{"command":"command","env":{"foo":"bar"}}}}`, buf.String())
+		})
 	}
-	mcpServer.AddEnv("foo", "bar")
-	require.NoError(t, config.PutMCPServer("test", mcpServer))
-	var buf bytes.Buffer
-
-	require.NoError(t, config.Write(&buf, FormatJSONCompact))
-	require.Equal(t, `{"mcpServers":{"test":{"command":"command","env":{"foo":"bar"}}}}`, buf.String())
 }
 
 func Test_isJSONCompact(t *testing.T) {
@@ -257,7 +261,7 @@ func TestReadableResourceURIs(t *testing.T) {
 		"random uri with params":   "teleport://random?hello=world&random=resource",
 	} {
 		t.Run(name, func(t *testing.T) {
-			config := NewConfig()
+			config := NewConfig(claudeServersKey)
 			mcpServer := MCPServer{
 				Command: "command",
 				Args:    []string{uri},
@@ -267,6 +271,97 @@ func TestReadableResourceURIs(t *testing.T) {
 			var buf bytes.Buffer
 			require.NoError(t, config.Write(&buf, FormatJSONCompact))
 			require.Contains(t, buf.String(), uri)
+		})
+	}
+}
+
+func TestReadDifferentConfigFormats(t *testing.T) {
+	fileNamePathWithDir := func(dir, fileName string) func(*testing.T, string) string {
+		return func(t *testing.T, basePath string) string {
+			path := filepath.Join(basePath, dir)
+			require.NoError(t, os.Mkdir(path, 0700))
+			return filepath.Join(path, fileName)
+		}
+	}
+
+	fileNamePath := func(fileName string) func(*testing.T, string) string {
+		return func(t *testing.T, basePath string) string {
+			return filepath.Join(basePath, fileName)
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		filePath     func(*testing.T, string) string
+		contents     string
+		expectErr    require.ErrorAssertionFunc
+		expectConfig require.ValueAssertionFunc
+	}{
+		"vscode": {
+			filePath:  fileNamePathWithDir(vsCodeProjectDir, "mcp.json"),
+			contents:  `{"servers":{"everything": {"command": "npx", "args": []}}}`,
+			expectErr: require.NoError,
+			expectConfig: func(tt require.TestingT, i1 any, i2 ...any) {
+				config := i1.(*FileConfig)
+				servers := config.GetMCPServers()
+
+				srv, ok := servers["everything"]
+				require.True(tt, ok, `expected config to have "everything" mcp server configured`)
+				require.Equal(tt, "npx", srv.Command)
+			},
+		},
+		"cursor": {
+			filePath:  fileNamePathWithDir(cursorProjectDir, "mcp.json"),
+			contents:  `{"mcpServers":{"everything": {"command": "npx", "args": []}}}`,
+			expectErr: require.NoError,
+			expectConfig: func(tt require.TestingT, i1 any, i2 ...any) {
+				config := i1.(*FileConfig)
+				servers := config.GetMCPServers()
+
+				srv, ok := servers["everything"]
+				require.True(tt, ok, `expected config to have "everything" mcp server configured`)
+				require.Equal(tt, "npx", srv.Command)
+			},
+		},
+		"claude-code": {
+			filePath:  fileNamePath(".mcp.json"),
+			contents:  `{"mcpServers":{"everything": {"command": "npx", "args": []}}}`,
+			expectErr: require.NoError,
+			expectConfig: func(tt require.TestingT, i1 any, i2 ...any) {
+				config := i1.(*FileConfig)
+				servers := config.GetMCPServers()
+
+				srv, ok := servers["everything"]
+				require.True(tt, ok, `expected config to have "everything" mcp server configured`)
+				require.Equal(tt, "npx", srv.Command)
+			},
+		},
+		"claude/default": {
+			filePath:  fileNamePath("claude_desktop_config.json"),
+			contents:  `{"mcpServers":{"everything": {"command": "npx", "args": []}}}`,
+			expectErr: require.NoError,
+			expectConfig: func(tt require.TestingT, i1 any, i2 ...any) {
+				config := i1.(*FileConfig)
+				servers := config.GetMCPServers()
+
+				srv, ok := servers["everything"]
+				require.True(tt, ok, `expected config to have "everything" mcp server configured`)
+				require.Equal(tt, "npx", srv.Command)
+			},
+		},
+		"empty config": {
+			filePath:     fileNamePath("file.json"),
+			contents:     ``,
+			expectErr:    require.Error,
+			expectConfig: require.Nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			configPath := tc.filePath(t, t.TempDir())
+			require.NoError(t, os.WriteFile(configPath, []byte(tc.contents), 0600))
+
+			config, err := LoadConfigFromFile(configPath)
+			tc.expectErr(t, err)
+			tc.expectConfig(t, config)
 		})
 	}
 }

--- a/lib/client/mcp/config/config_test.go
+++ b/lib/client/mcp/config/config_test.go
@@ -32,7 +32,7 @@ func TestFileConfig_fileNotExists(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 
-	config, err := LoadConfigFromFile(configPath)
+	config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
 	require.NoError(t, err)
 	require.NotNil(t, config)
 	require.False(t, config.Exists())
@@ -82,7 +82,7 @@ func TestFileConfig_sampleFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(sampleConfigJSON), 0600))
 
 	// load
-	config, err := LoadConfigFromFile(configPath)
+	config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
 	require.NoError(t, err)
 	require.NotNil(t, config)
 	require.True(t, config.Exists())
@@ -359,7 +359,7 @@ func TestReadDifferentConfigFormats(t *testing.T) {
 			configPath := tc.filePath(t, t.TempDir())
 			require.NoError(t, os.WriteFile(configPath, []byte(tc.contents), 0600))
 
-			config, err := LoadConfigFromFile(configPath)
+			config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
 			tc.expectErr(t, err)
 			tc.expectConfig(t, config)
 		})

--- a/lib/client/mcp/config/cursor.go
+++ b/lib/client/mcp/config/cursor.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// cursorProjectDir defines the Cursor project directory, where the MCP
+	// configuration is located.
+	//
+	// https://docs.cursor.com/en/context/mcp#configuration-locations
+	cursorProjectDir = ".cursor"
+)
+
+// GlobalCursorPath returns the default path for Cursor global MCP configuration.
+//
+// https://docs.cursor.com/context/mcp#configuration-locations
+func GlobalCursorPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return filepath.Join(homeDir, ".cursor", "mcp.json"), nil
+}
+
+// LoadConfigFromGlobalCursor loads the Cursor global MCP server configuration.
+func LoadConfigFromGlobalCursor() (*FileConfig, error) {
+	configPath, err := GlobalCursorPath()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config, err := LoadConfigFromFile(configPath)
+	return config, trace.Wrap(err)
+}

--- a/lib/client/mcp/config/cursor.go
+++ b/lib/client/mcp/config/cursor.go
@@ -50,6 +50,6 @@ func LoadConfigFromGlobalCursor() (*FileConfig, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	config, err := LoadConfigFromFile(configPath)
+	config, err := LoadConfigFromFile(configPath, ConfigFormatClaude)
 	return config, trace.Wrap(err)
 }

--- a/lib/client/mcp/config/cursor.go
+++ b/lib/client/mcp/config/cursor.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package config
 
 import (

--- a/lib/client/mcp/config/vscode.go
+++ b/lib/client/mcp/config/vscode.go
@@ -1,0 +1,14 @@
+package config
+
+const (
+	// vsCodeServersKey defines the JSON key used by VSCode to store MCP servers
+	// config.
+	//
+	// https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_manage-mcp-servers
+	vsCodeServersKey = "servers"
+	// vsCodeProjectDir defines the VSCode project directory, where the MCP
+	// configuration is located.
+	//
+	// https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_manage-mcp-servers
+	vsCodeProjectDir = ".vscode"
+)

--- a/lib/client/mcp/config/vscode.go
+++ b/lib/client/mcp/config/vscode.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package config
 
 const (

--- a/lib/client/mcp/config/vscode.go
+++ b/lib/client/mcp/config/vscode.go
@@ -27,4 +27,8 @@ const (
 	//
 	// https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_manage-mcp-servers
 	vsCodeProjectDir = ".vscode"
+	// claudeCodeFileName defines the Claude Code MCP servers file.
+	//
+	// https://docs.claude.com/en/docs/claude-code/mcp#project-scope
+	claudeCodeFileName = ".mcp.json"
 )

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -92,10 +92,10 @@ Examples:
   $ tsh mcp config --all --format=vscode
 
   Add all MCP servers to VSCode project
-  $ tsh mcp config --all -client-config=<path-to-project>/.vscode/mcp.json
+  $ tsh mcp config --all --client-config=<path-to-project>/.vscode/mcp.json
 
   Add all MCP servers to Claude Code project
-  $ tsh mcp config --all -client-config=<path-to-project>/.mcp.json
+  $ tsh mcp config --all --client-config=<path-to-project>/.mcp.json
 
   Search MCP servers with labels and add to the specified JSON file
   $ tsh mcp config --labels env=dev --client-config=my-config.json`

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -88,6 +88,18 @@ Examples:
   Add all MCP servers to Cursor
   $ tsh mcp config --all --client-config=cursor
 
+  Generate config for all MCP servers for VSCode
+  $ tsh mcp config --all --client-config=vscode
+
+  Add all MCP servers to VSCode project
+  $ tsh mcp config --all -client-config=<path-to-project>/.vscode/mcp.json
+
+  Generate config for all MCP servers for Claude Code
+  $ tsh mcp config --all --client-config=claude-code
+
+  Add all MCP servers to Claude Code project
+  $ tsh mcp config --all -client-config=<path-to-project>/.mcp.json
+
   Search MCP servers with labels and add to the specified JSON file
   $ tsh mcp config --labels env=dev --client-config=my-config.json`
 
@@ -101,6 +113,18 @@ Examples:
 
   Add the database configuration to Cursor
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=cursor my-db-resource
+
+  Generate database configuration for VSCode
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=vscode my-db-resource
+
+  Add the database configuration to VSCode project
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=<path-to-project>/.vscode/.mcp.json my-db-resource
+
+  Generate database configuration for Claude Code
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=claude-code my-db-resource
+
+  Add database configuration to Claude Code project
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=<path-to-project>/.mcp.json my-db-resource
 
   Add the database configuration to the specified JSON file
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=my-config.json my-db-resource

--- a/tool/tsh/common/help.go
+++ b/tool/tsh/common/help.go
@@ -89,13 +89,10 @@ Examples:
   $ tsh mcp config --all --client-config=cursor
 
   Generate config for all MCP servers for VSCode
-  $ tsh mcp config --all --client-config=vscode
+  $ tsh mcp config --all --format=vscode
 
   Add all MCP servers to VSCode project
   $ tsh mcp config --all -client-config=<path-to-project>/.vscode/mcp.json
-
-  Generate config for all MCP servers for Claude Code
-  $ tsh mcp config --all --client-config=claude-code
 
   Add all MCP servers to Claude Code project
   $ tsh mcp config --all -client-config=<path-to-project>/.mcp.json
@@ -115,13 +112,10 @@ Examples:
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=cursor my-db-resource
 
   Generate database configuration for VSCode
-  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=vscode my-db-resource
+  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --format=vscode my-db-resource
 
   Add the database configuration to VSCode project
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=<path-to-project>/.vscode/.mcp.json my-db-resource
-
-  Generate database configuration for Claude Code
-  $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=claude-code my-db-resource
 
   Add database configuration to Claude Code project
   $ tsh mcp db config --db-user=mydbuser --db-name=mydbname --client-config=<path-to-project>/.mcp.json my-db-resource

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -138,7 +138,11 @@ func (m *mcpClientConfigFlags) format() (mcpconfig.ConfigFormat, error) {
 		flagFormat   mcpconfig.ConfigFormat
 	)
 
-	if m.clientConfig != "" {
+	switch m.clientConfig {
+	case mcpClientConfigClaude, mcpClientConfigCursor:
+		configFormat = mcpconfig.ConfigFormatClaude
+	case "":
+	default:
 		configFormat = mcpconfig.ConfigFormatFromPath(m.clientConfig)
 	}
 

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -103,14 +103,14 @@ func (m *mcpClientConfigFlags) addToCmd(cmd *kingpin.CmdClause) {
 		StringVar(&m.configFormat)
 }
 
-func (m *mcpClientConfigFlags) loadConfig() (*mcpconfig.FileConfig, error) {
+func (m *mcpClientConfigFlags) loadConfig(configFormat mcpconfig.ConfigFormat) (*mcpconfig.FileConfig, error) {
 	switch m.clientConfig {
 	case mcpClientConfigClaude:
 		return mcpconfig.LoadClaudeConfigFromDefaultPath()
 	case mcpClientConfigCursor:
 		return mcpconfig.LoadConfigFromGlobalCursor()
 	default:
-		return mcpconfig.LoadConfigFromFile(m.clientConfig)
+		return mcpconfig.LoadConfigFromFile(m.clientConfig, configFormat)
 	}
 }
 
@@ -163,7 +163,7 @@ func (m *mcpClientConfigFlags) format() (mcpconfig.ConfigFormat, error) {
 		}
 
 		return mcpconfig.ConfigFormatUnspecified, trace.BadParameter(
-			"Configuration format mismatch. --client-config=%s option uses %q config format, but --format=%s was set. You can drop one of the flags or adjust the values to match.",
+			"Configuration format mismatch. --client-config=%s option uses %s config format, but --format=%s was set. You can drop one of the flags or adjust the values to match.",
 			m.clientConfig,
 			configFormat,
 			m.configFormat,
@@ -195,7 +195,7 @@ func runMCPConfig(cf *CLIConf, flags *mcpClientConfigFlags, exec mcpConfigExec) 
 	case "":
 		return trace.Wrap(exec.printInstructions(cf.Stdout(), format))
 	default:
-		config, err := flags.loadConfig()
+		config, err := flags.loadConfig(format)
 		if err != nil {
 			return trace.BadParameter("failed to load mcp configuration file at %q: %v", flags.clientConfig, err)
 		}

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -184,11 +184,16 @@ func runMCPConfig(cf *CLIConf, flags *mcpClientConfigFlags, exec mcpConfigExec) 
 		return trace.Wrap(err)
 	}
 
-	config, err := flags.loadConfig()
-	if err != nil {
-		return trace.BadParameter("failed to load mcp configuration file at %q: %v", flags.clientConfig, err)
+	switch flags.clientConfig {
+	case "":
+		return trace.Wrap(exec.printInstructions(cf.Stdout()))
+	default:
+		config, err := flags.loadConfig()
+		if err != nil {
+			return trace.BadParameter("failed to load mcp configuration file at %q: %v", flags.clientConfig, err)
+		}
+		return trace.Wrap(exec.updateConfig(cf.Stdout(), config))
 	}
-	return trace.Wrap(exec.updateConfig(cf.Stdout(), config))
 }
 
 // mcpConfig defines a subset of functions from mcpconfig.Config.
@@ -200,6 +205,8 @@ type mcpConfig interface {
 // mcpConfigExec defines the interface for generating install instructions and
 // directly updating the MCP config.
 type mcpConfigExec interface {
+	// printInstructions prints instructions on how to configure the MCP server.
+	printInstructions(io.Writer) error
 	// updateConfig directly updates the client config. It might also print
 	// information.
 	updateConfig(io.Writer, *mcpconfig.FileConfig) error

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -94,10 +94,10 @@ func (m *mcpClientConfigFlags) addToCmd(cmd *kingpin.CmdClause) {
 		"format",
 		fmt.Sprintf(
 			"Format specifies the configuration format (%s, %s, %s). If not provided it will assume format from the configuration file, When no configuration file is provided it defaults to %q.",
-			mcpconfig.ConfigFormatClaude,
-			mcpconfig.ConfigFormatVSCode,
+			string(mcpconfig.ConfigFormatClaude),
+			string(mcpconfig.ConfigFormatVSCode),
 			cursorConfigFormatAlias,
-			mcpconfig.DefaultConfigFormat,
+			string(mcpconfig.DefaultConfigFormat),
 		)).
 		IsSetByUser(&m.configFormatSetByUser).
 		StringVar(&m.configFormat)

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -399,13 +399,8 @@ func (c *mcpConfigCommand) maybeAddAutoReconnect(args []string) []string {
 	return append(args, "--no-auto-reconnect")
 }
 
-func (c *mcpConfigCommand) printInstructions(w io.Writer) error {
+func (c *mcpConfigCommand) printInstructions(w io.Writer, configFormat mcpconfig.ConfigFormat) error {
 	if err := c.fetchAndPrintResult(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	configFormat, err := c.clientConfig.format()
-	if err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -414,16 +409,11 @@ func (c *mcpConfigCommand) printInstructions(w io.Writer) error {
 		return trace.Wrap(err)
 	}
 
-	if _, err := fmt.Fprintln(w, "Here is a sample JSON configuration for launching Teleport MCP servers:"); err != nil {
+	if _, err := fmt.Fprintf(w, "Here is a sample JSON configuration for launching Teleport MCP servers using %s format:\n", configFormat); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := config.Write(w, mcpconfig.FormatJSONOption(c.clientConfig.jsonFormat)); err != nil {
 		return trace.Wrap(err)
-	}
-	if !c.autoReconnectSetByUser {
-		if err := c.printAutoReconnectHint(w); err != nil {
-			return trace.Wrap(err)
-		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return trace.Wrap(err)
@@ -451,16 +441,6 @@ Teleport MCP servers will be prefixed with "teleport-mcp-" in this
 configuration. You may need to restart your client to reload these new
 configurations.
 `, config.Path())
-	return trace.Wrap(err)
-}
-
-func (c *mcpConfigCommand) printAutoReconnectHint(w io.Writer) error {
-	_, err := fmt.Fprintln(w, `
-By default, tsh automatically starts a new remote MCP session if the previous
-one is interrupted by network issues or tsh session expiration.
-Auto-reconnection is recommended when MCP sessions are stateless across
-requests. To disable it, use the --no-auto-reconnect flag. If disabled, you may
-need to manually restart your client when encountering "disconnected" errors.`)
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -431,10 +431,6 @@ func (c *mcpConfigCommand) updateConfig(w io.Writer, config *mcpconfig.FileConfi
 		return trace.Wrap(err)
 	}
 
-	config, err := c.clientConfig.loadConfig()
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	if err := c.addMCPServersToConfig(config); err != nil {
 		return trace.Wrap(err)
 	}
@@ -443,7 +439,7 @@ func (c *mcpConfigCommand) updateConfig(w io.Writer, config *mcpconfig.FileConfi
 		return trace.Wrap(err)
 	}
 
-	_, err = fmt.Fprintf(c.cf.Stdout(), `Updated client configuration at:
+	_, err := fmt.Fprintf(c.cf.Stdout(), `Updated client configuration at:
 %s
 
 Teleport MCP servers will be prefixed with "teleport-mcp-" in this

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -404,7 +404,12 @@ func (c *mcpConfigCommand) printInstructions(w io.Writer) error {
 		return trace.Wrap(err)
 	}
 
-	config := mcpconfig.NewConfig(c.clientConfig.format())
+	configFormat, err := c.clientConfig.format()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	config := mcpconfig.NewConfig(configFormat)
 	if err := c.addMCPServersToConfig(config); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -404,7 +404,7 @@ func (c *mcpConfigCommand) printInstructions(w io.Writer) error {
 		return trace.Wrap(err)
 	}
 
-	config := mcpconfig.NewConfig(c.clientConfig.configFormat())
+	config := mcpconfig.NewConfig(c.clientConfig.format())
 	if err := c.addMCPServersToConfig(config); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/mcp_app_test.go
+++ b/tool/tsh/common/mcp_app_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/client/mcp/claude"
+	mcpconfig "github.com/gravitational/teleport/lib/client/mcp/config"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
@@ -383,18 +383,18 @@ func setupMockMCPConfig(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	config, err := claude.LoadConfigFromFile(configPath)
+	config, err := mcpconfig.LoadConfigFromFile(configPath)
 	require.NoError(t, err)
-	require.NoError(t, config.PutMCPServer("local-everything", claude.MCPServer{
+	require.NoError(t, config.PutMCPServer("local-everything", mcpconfig.MCPServer{
 		Command: "npx",
 		Args:    []string{"-y", "@modelcontextprotocol/server-everything"},
 	}))
-	require.NoError(t, config.Save(claude.FormatJSONPretty))
+	require.NoError(t, config.Save(mcpconfig.FormatJSONPretty))
 	return config.Path()
 }
 
 func mustHaveMCPServerNamesInConfig(t *testing.T, configPath string, wantNames []string) {
-	jsonConfig, err := claude.LoadConfigFromFile(configPath)
+	jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath)
 	require.NoError(t, err)
 	require.ElementsMatch(t,
 		wantNames,

--- a/tool/tsh/common/mcp_app_test.go
+++ b/tool/tsh/common/mcp_app_test.go
@@ -383,7 +383,7 @@ func setupMockMCPConfig(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	config, err := mcpconfig.LoadConfigFromFile(configPath)
+	config, err := mcpconfig.LoadConfigFromFile(configPath, mcpconfig.ConfigFormatClaude)
 	require.NoError(t, err)
 	require.NoError(t, config.PutMCPServer("local-everything", mcpconfig.MCPServer{
 		Command: "npx",
@@ -394,7 +394,7 @@ func setupMockMCPConfig(t *testing.T) string {
 }
 
 func mustHaveMCPServerNamesInConfig(t *testing.T, configPath string, wantNames []string) {
-	jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath)
+	jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath, mcpconfig.ConfigFormatClaude)
 	require.NoError(t, err)
 	require.ElementsMatch(t,
 		wantNames,

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -280,7 +280,12 @@ func (m *mcpDBConfigCommand) run() error {
 }
 
 func (m *mcpDBConfigCommand) printInstructions(w io.Writer) error {
-	config := mcpconfig.NewConfig(m.clientConfig.format())
+	configFormat, err := m.clientConfig.format()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	config := mcpconfig.NewConfig(configFormat)
 	// Since the database is being added to a "fresh" config file the database
 	// will always be new and we can ignore the additional message as well.
 	if _, _, err := m.addDatabaseToConfig(config, m.dbURI); err != nil {

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -279,12 +279,7 @@ func (m *mcpDBConfigCommand) run() error {
 	return trace.Wrap(runMCPConfig(m.cf, &m.clientConfig, m))
 }
 
-func (m *mcpDBConfigCommand) printInstructions(w io.Writer) error {
-	configFormat, err := m.clientConfig.format()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+func (m *mcpDBConfigCommand) printInstructions(w io.Writer, configFormat mcpconfig.ConfigFormat) error {
 	config := mcpconfig.NewConfig(configFormat)
 	// Since the database is being added to a "fresh" config file the database
 	// will always be new and we can ignore the additional message as well.
@@ -292,7 +287,7 @@ func (m *mcpDBConfigCommand) printInstructions(w io.Writer) error {
 		return trace.Wrap(err)
 	}
 
-	if _, err := fmt.Fprintln(w, "Here is a sample JSON configuration for launching Teleport MCP servers:"); err != nil {
+	if _, err := fmt.Fprintf(w, "Here is a sample JSON configuration for launching Teleport MCP servers using %s format:\n", configFormat); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := config.Write(w, mcpconfig.FormatJSONOption(m.clientConfig.jsonFormat)); err != nil {

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"net"
@@ -34,7 +35,7 @@ import (
 	dbmcp "github.com/gravitational/teleport/lib/client/db/mcp"
 	pgmcp "github.com/gravitational/teleport/lib/client/db/postgres/mcp"
 	"github.com/gravitational/teleport/lib/client/mcp"
-	"github.com/gravitational/teleport/lib/client/mcp/claude"
+	mcpconfig "github.com/gravitational/teleport/lib/client/mcp/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -216,6 +217,9 @@ type mcpDBConfigCommand struct {
 	siteName     string
 	overwriteEnv bool
 
+	// dbURI is the generated database MCP resource URI.
+	dbURI mcp.ResourceURI
+
 	// databasesGetter used to retrieve databases information. Can be mocked in
 	// tests.
 	databasesGetter databasesGetter
@@ -271,52 +275,46 @@ func (m *mcpDBConfigCommand) run() error {
 		return trace.BadParameter("You must specify --db-user and --db-name flags used to connect to the database")
 	}
 
-	dbURI := mcp.NewDatabaseResourceURI(m.siteName, db.GetName(), mcp.WithDatabaseUser(m.cf.DatabaseUser), mcp.WithDatabaseName(m.cf.DatabaseName))
-	switch {
-	case m.clientConfig.isSet():
-		return trace.Wrap(m.updateClientConfig(dbURI))
-	default:
-		return trace.Wrap(m.printJSONWithHint(dbURI))
-	}
+	m.dbURI = mcp.NewDatabaseResourceURI(m.siteName, db.GetName(), mcp.WithDatabaseUser(m.cf.DatabaseUser), mcp.WithDatabaseName(m.cf.DatabaseName))
+	return trace.Wrap(runMCPConfig(m.cf, &m.clientConfig, m))
 }
 
-func (m *mcpDBConfigCommand) printJSONWithHint(dbURI mcp.ResourceURI) error {
-	config := claude.NewConfig()
+func (m *mcpDBConfigCommand) printInstructions(w io.Writer) error {
+	config := mcpconfig.NewConfig(m.clientConfig.configFormat())
 	// Since the database is being added to a "fresh" config file the database
 	// will always be new and we can ignore the additional message as well.
-	if _, _, err := m.addDatabaseToConfig(config, dbURI); err != nil {
+	if _, _, err := m.addDatabaseToConfig(config, m.dbURI); err != nil {
 		return trace.Wrap(err)
 	}
 
-	w := m.cf.Stdout()
 	if _, err := fmt.Fprintln(w, "Here is a sample JSON configuration for launching Teleport MCP servers:"); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := config.Write(w, claude.FormatJSONOption(m.clientConfig.jsonFormat)); err != nil {
+	if err := config.Write(w, mcpconfig.FormatJSONOption(m.clientConfig.jsonFormat)); err != nil {
 		return trace.Wrap(err)
 	}
 	if _, err := fmt.Fprintf(w, `
 If you already have an entry for %q server, add the following database resource URI to the command arguments list:
 %s
 
-`, mcpDBConfigName, dbURI.String()); err != nil {
+`, mcpDBConfigName, m.dbURI.String()); err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(m.clientConfig.printHint(w))
+	return trace.Wrap(m.clientConfig.printFooterNotes(w))
 }
 
 // TODO(gabrielcorado): support updating multiple databases at once.
-func (m *mcpDBConfigCommand) updateClientConfig(dbURI mcp.ResourceURI) error {
+func (m *mcpDBConfigCommand) updateConfig(w io.Writer, config *mcpconfig.FileConfig) error {
 	config, err := m.clientConfig.loadConfig()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	preexistentDB, commandChanged, err := m.addDatabaseToConfig(config, dbURI)
+	preexistentDB, commandChanged, err := m.addDatabaseToConfig(config, m.dbURI)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := config.Save(claude.FormatJSONOption(m.clientConfig.jsonFormat)); err != nil {
+	if err := config.Save(mcpconfig.FormatJSONOption(m.clientConfig.jsonFormat)); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -328,7 +326,7 @@ func (m *mcpDBConfigCommand) updateClientConfig(dbURI mcp.ResourceURI) error {
 		EnvChanged    bool
 		OverwriteEnv  bool
 	}{
-		Name:          dbURI.GetDatabaseServiceName(),
+		Name:          m.dbURI.GetDatabaseServiceName(),
 		ConfigPath:    config.Path(),
 		ConfigName:    mcpDBConfigName,
 		PreexistentDB: preexistentDB,
@@ -342,7 +340,7 @@ func (m *mcpDBConfigCommand) updateClientConfig(dbURI mcp.ResourceURI) error {
 // addDatabaseToConfig adds the provided database, merging with existent
 // databases configured. This function returns a additional message to be
 // displayed to users.
-func (m *mcpDBConfigCommand) addDatabaseToConfig(config claudeConfig, dbURI mcp.ResourceURI) (bool, bool, error) {
+func (m *mcpDBConfigCommand) addDatabaseToConfig(config mcpConfig, dbURI mcp.ResourceURI) (bool, bool, error) {
 	var (
 		dbs        []string
 		updated    bool

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -280,7 +280,7 @@ func (m *mcpDBConfigCommand) run() error {
 }
 
 func (m *mcpDBConfigCommand) printInstructions(w io.Writer) error {
-	config := mcpconfig.NewConfig(m.clientConfig.configFormat())
+	config := mcpconfig.NewConfig(m.clientConfig.format())
 	// Since the database is being added to a "fresh" config file the database
 	// will always be new and we can ignore the additional message as well.
 	if _, _, err := m.addDatabaseToConfig(config, m.dbURI); err != nil {

--- a/tool/tsh/common/mcp_db.go
+++ b/tool/tsh/common/mcp_db.go
@@ -305,10 +305,6 @@ If you already have an entry for %q server, add the following database resource 
 
 // TODO(gabrielcorado): support updating multiple databases at once.
 func (m *mcpDBConfigCommand) updateConfig(w io.Writer, config *mcpconfig.FileConfig) error {
-	config, err := m.clientConfig.loadConfig()
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	preexistentDB, commandChanged, err := m.addDatabaseToConfig(config, m.dbURI)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/mcp_db_test.go
+++ b/tool/tsh/common/mcp_db_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	dbmcp "github.com/gravitational/teleport/lib/client/db/mcp"
 	clientmcp "github.com/gravitational/teleport/lib/client/mcp"
-	"github.com/gravitational/teleport/lib/client/mcp/claude"
+	mcpconfig "github.com/gravitational/teleport/lib/client/mcp/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
@@ -392,7 +392,7 @@ func TestMCPDBConfigCommand(t *testing.T) {
 			cmd := &mcpDBConfigCommand{
 				clientConfig: mcpClientConfigFlags{
 					clientConfig: configPath,
-					jsonFormat:   string(claude.FormatJSONPretty),
+					jsonFormat:   string(mcpconfig.FormatJSONPretty),
 				},
 				cf:              tc.cf,
 				ctx:             t.Context(),
@@ -407,7 +407,7 @@ func TestMCPDBConfigCommand(t *testing.T) {
 				return
 			}
 
-			jsonConfig, err := claude.LoadConfigFromFile(configPath)
+			jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath)
 			require.NoError(t, err)
 			mcpCmd, ok := jsonConfig.GetMCPServers()[mcpDBConfigName]
 			require.True(t, ok, "expected configuration to include database access server definition, but got nothing")
@@ -433,9 +433,9 @@ func setupMockDBMCPConfig(t *testing.T, cf *CLIConf, databasesURIs []string, add
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	config, err := claude.LoadConfigFromFile(configPath)
+	config, err := mcpconfig.LoadConfigFromFile(configPath)
 	require.NoError(t, err)
-	require.NoError(t, config.PutMCPServer("local-everything", claude.MCPServer{
+	require.NoError(t, config.PutMCPServer("local-everything", mcpconfig.MCPServer{
 		Command: "npx",
 		Args:    []string{"-y", "@modelcontextprotocol/server-everything"},
 	}))
@@ -446,7 +446,7 @@ func setupMockDBMCPConfig(t *testing.T, cf *CLIConf, databasesURIs []string, add
 		}
 		require.NoError(t, config.PutMCPServer(mcpDBConfigName, srv))
 	}
-	require.NoError(t, config.Save(claude.FormatJSONPretty))
+	require.NoError(t, config.Save(mcpconfig.FormatJSONPretty))
 	return config.Path()
 }
 

--- a/tool/tsh/common/mcp_db_test.go
+++ b/tool/tsh/common/mcp_db_test.go
@@ -407,7 +407,7 @@ func TestMCPDBConfigCommand(t *testing.T) {
 				return
 			}
 
-			jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath)
+			jsonConfig, err := mcpconfig.LoadConfigFromFile(configPath, mcpconfig.ConfigFormatClaude)
 			require.NoError(t, err)
 			mcpCmd, ok := jsonConfig.GetMCPServers()[mcpDBConfigName]
 			require.True(t, ok, "expected configuration to include database access server definition, but got nothing")
@@ -433,7 +433,7 @@ func setupMockDBMCPConfig(t *testing.T, cf *CLIConf, databasesURIs []string, add
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	config, err := mcpconfig.LoadConfigFromFile(configPath)
+	config, err := mcpconfig.LoadConfigFromFile(configPath, mcpconfig.ConfigFormatClaude)
 	require.NoError(t, err)
 	require.NoError(t, config.PutMCPServer("local-everything", mcpconfig.MCPServer{
 		Command: "npx",


### PR DESCRIPTION
Backport #57469 to branch/v18

changelog: Added support for generating VSCode and Claude Code MCP servers configurations to the `tsh mcp config` and `tsh mcp db config` commands.
