### PR TITLE
Fix `tctl` marshaling of Bot resource

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1255,7 +1255,7 @@ type botCollection struct {
 func (c *botCollection) resources() []types.Resource {
 	resources := make([]types.Resource, len(c.bots))
 	for i, b := range c.bots {
-		resources[i] = types.Resource153ToLegacy(b)
+		resources[i] = types.ProtoResource153ToLegacy(b)
 	}
 	return resources
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/59409

The Bot resource is a Proto RFD 153 resource. In the current state of `tctl`, we were using the stdlib JSON marshaler, but, the protojson unmarshaler, this was leading to errors like `ERROR: proto: syntax error (line 1:81): unexpected token {` when trying to `tctl create` or `tctl edit` a Bot. The specific field that was causing the issue was `google.protobuf.Duration`.

Before:

```
╰─➤  ./tctl-dev-leaf get bot/local-expression-workload-id
kind: bot
metadata:
  labels:
    test: bar
  name: local-expression-workload-id
spec:
  max_session_ttl:
    seconds: 43200
  roles:
  - expression-wid-issuer
  traits:
  - name: prefix_paths
    values:
    - dev-foo
    - dev-bar
status:
  role_name: bot-local-expression-workload-id
  user_name: bot-local-expression-workload-id
version: v1
```

After:

```
╰─➤  ./tctl-dev-leaf get bot/local-expression-workload-id
kind: bot
metadata:
  labels:
    test: bar
  name: local-expression-workload-id
spec:
  max_session_ttl: 43200s
  roles:
  - expression-wid-issuer
  traits:
  - name: prefix_paths
    values:
    - dev-foo
    - dev-bar
status:
  role_name: bot-local-expression-workload-id
  user_name: bot-local-expression-workload-id
version: v1
```

changelog: Fix `tctl edit` producing an error when trying to modify a Bot resource