### PR TITLE
[v16] Fix `tctl` marshaling of Bot resource

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1195,7 +1195,7 @@ type botCollection struct {
 func (c *botCollection) resources() []types.Resource {
 	resources := make([]types.Resource, len(c.bots))
 	for i, b := range c.bots {
-		resources[i] = types.Resource153ToLegacy(b)
+		resources[i] = types.ProtoResource153ToLegacy(b)
 	}
 	return resources
 }


### PR DESCRIPTION
Backport #59477 to branch/v16

changelog: Fix `tctl edit` producing an error when trying to modify a Bot resource
