### PR TITLE
Limit bots command recommendation to filename not possible full path

### DIFF
--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -28,6 +28,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
@@ -201,7 +202,8 @@ func (c *BotsCommand) ListBots(ctx context.Context, client *authclient.Client) e
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())
 
-		fmt.Fprintf(c.stdout, "\nTo view active instances of a bot, run:\n\n> %s bots instances list [name]\n", os.Args[0])
+		executableFileName := filepath.Base(os.Args[0])
+		fmt.Fprintf(c.stdout, "\nTo view active instances of a bot, run:\n\n> %s bots instances list [name]\n", executableFileName)
 	} else {
 		err := utils.WriteJSONArray(c.stdout, bots)
 		if err != nil {
@@ -650,10 +652,11 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 	}
 	fmt.Fprintln(c.stdout, t.AsBuffer().String())
 
-	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", os.Args[0])
+	executableFileName := filepath.Base(os.Args[0])
+	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", executableFileName)
 
 	if c.botName != "" {
-		fmt.Fprintf(c.stdout, "\nTo onboard a new instance for this bot, run:\n\n> %s bots instances add %s\n", os.Args[0], c.botName)
+		fmt.Fprintf(c.stdout, "\nTo onboard a new instance for this bot, run:\n\n> %s bots instances add %s\n", executableFileName, c.botName)
 	}
 
 	return nil


### PR DESCRIPTION
Update to show the executable filename and not possibly show a full path. In the case of auto client updates the following can display. This would happen if the user had for example installed `18.2.2` on their MacOS and the auto client update is on `18.2.1`.

```bash
$ tctl bots ls
Bot                User                   Roles
------------------ ---------------------- --------------
abc123             bot-abc123             access

To view active instances of a bot, run:

> /Users/stevenmartin/.tsh/bin/ce66bea8-ab46-4ca6-92f1-8b2d234bd5d1-update-pkg-v2/tctl-18.2.2.pkg/Payload/tctl.app/Contents/MacOS/tctl bots instances list [name]
```

to
```bash
$ tctl bots ls
Bot                User                   Roles
------------------ ---------------------- --------------
abc123             bot-abc123             access

To view active instances of a bot, run:

> tctl bots instances list [name]
```
