### PR TITLE
Tag pages with "ci-cd"

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -2,6 +2,7 @@
 title: Machine ID with Argo CD
 description: How to use Machine ID to enable Argo CD to connect to external Kubernetes clusters
 tags:
+ - ci-cd
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/circleci.mdx
@@ -2,6 +2,7 @@
 title: Deploying tbot on CircleCI
 description: How to install and configure Machine ID on CircleCI
 tags:
+ - ci-cd
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/github-actions.mdx
@@ -2,6 +2,7 @@
 title: Deploying tbot on GitHub Actions
 description: How to install and configure Machine ID on GitHub Actions
 tags:
+ - ci-cd
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/gitlab.mdx
@@ -2,6 +2,7 @@
 title: Deploying tbot on GitLab CI
 description: How to install and configure Machine ID on GitLab CI
 tags:
+ - ci-cd
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/jenkins.mdx
@@ -2,6 +2,7 @@
 title: Deploying tbot on Jenkins
 description: How to install and configure Machine ID on Jenkins
 tags:
+ - ci-cd
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
+++ b/docs/pages/machine-workload-identity/mwi-ci-cd.mdx
@@ -2,6 +2,7 @@
 title: CI/CD with Machine & Workload Identity
 description: Configuring CI/CD with Machine & Workload Identity
 tags:
+ - ci-cd
  - conceptual
  - mwi
  - infrastructure-identity

--- a/docs/pages/reference/machine-workload-identity/machine-id/github-actions.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/github-actions.mdx
@@ -2,6 +2,7 @@
 title: GitHub Actions
 description: Reference for GitHub Actions joining
 tags:
+ - ci-cd
  - conceptual
  - mwi
  - infrastructure-identity

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm.mdx
@@ -2,6 +2,7 @@
 title: Guides for running Teleport using Helm via ArgoCD
 description: How to install and configure Teleport Kubernetes agent using Helm and ArgoCD
 tags:
+ - ci-cd
  - platform-wide
  - how-to
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider in CI or Cloud
 sidebar_label: CI or Cloud
 description: How to manage dynamic resources using the Teleport Terraform provider from your CI pipelines or Cloud provider.
 tags:
+ - ci-cd
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider on Spacelift
 sidebar_label: Spacelift
 description: How to manage dynamic resources using the Teleport Terraform provider on the Spacelift platform.
 tags:
+ - ci-cd
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider on Terraform Cloud
 sidebar_label: Terraform Cloud
 description: How to manage dynamic resources using the Teleport Terraform provider on HCP Terraform, Terraform Cloud, and Terraform Enterprise.
 tags:
+ - ci-cd
  - how-to
  - zero-trust
 ---


### PR DESCRIPTION
Using Teleport to protect CI/CD pipelines is a common use case. Tag pages with this use case so users can find related pages when looking for CI/CD content.