### PR TITLE
Tag pages with infrastructure-as-code

### DIFF
--- a/docs/pages/identity-governance/access-lists/terraform.mdx
+++ b/docs/pages/identity-governance/access-lists/terraform.mdx
@@ -2,6 +2,7 @@
 title: Managing Access Lists with Terraform
 description: Learn how to manage Access Lists and their members with Terraform.
 tags:
+ - infrastructure-as-code
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/integrations/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/terraform.mdx
@@ -4,6 +4,7 @@ description: Describes how to set up the Teleport Entra ID integration using Ter
 sidebar_position: 3
 tags:
  - teleport-as-idp
+ - infrastructure-as-code
  - how-to
  - identity-governance
  - azure

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -3,6 +3,7 @@ title: Machine ID with Argo CD
 description: How to use Machine ID to enable Argo CD to connect to external Kubernetes clusters
 tags:
  - ci-cd
+ - infrastructure-as-code
  - how-to
  - mwi
  - infrastructure-identity

--- a/docs/pages/reference/helm-reference/teleport-operator.mdx
+++ b/docs/pages/reference/helm-reference/teleport-operator.mdx
@@ -3,6 +3,7 @@ title: teleport-operator Chart Reference
 sidebar_label: teleport-operator
 description: Values that can be set using the teleport-operator Helm chart
 tags:
+ - infrastructure-as-code
  - reference
  - zero-trust
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/operator-resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/operator-resources.mdx
@@ -3,6 +3,7 @@ title: "Teleport Kubernetes Operator Resource Reference Guides"
 sidebar_label: Teleport Kubernetes Operator
 description: "Comprehensive guides to fields available in Kubernetes resources you can apply to manage Teleport resources with the Teleport Kubernetes operator"
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -3,6 +3,7 @@ title: TeleportAccessList
 description: Provides a comprehensive list of fields in the TeleportAccessList resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -3,6 +3,7 @@ title: TeleportAppV3
 description: Provides a comprehensive list of fields in the TeleportAppV3 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
@@ -3,6 +3,7 @@ title: TeleportAutoupdateConfigV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateConfigV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -3,6 +3,7 @@ title: TeleportAutoupdateVersionV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateVersionV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -3,6 +3,7 @@ title: TeleportBotV1
 description: Provides a comprehensive list of fields in the TeleportBotV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
@@ -3,6 +3,7 @@ title: TeleportDatabaseV3
 description: Provides a comprehensive list of fields in the TeleportDatabaseV3 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
@@ -3,6 +3,7 @@ title: TeleportGithubConnector
 description: Provides a comprehensive list of fields in the TeleportGithubConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
@@ -3,6 +3,7 @@ title: TeleportLoginRule
 description: Provides a comprehensive list of fields in the TeleportLoginRule resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
@@ -3,6 +3,7 @@ title: TeleportOIDCConnector
 description: Provides a comprehensive list of fields in the TeleportOIDCConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
@@ -3,6 +3,7 @@ title: TeleportOktaImportRule
 description: Provides a comprehensive list of fields in the TeleportOktaImportRule resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -3,6 +3,7 @@ title: TeleportOpenSSHEICEServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHEICEServerV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -3,6 +3,7 @@ title: TeleportOpenSSHServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHServerV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -3,6 +3,7 @@ title: TeleportProvisionToken
 description: Provides a comprehensive list of fields in the TeleportProvisionToken resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
@@ -3,6 +3,7 @@ title: TeleportRole
 description: Provides a comprehensive list of fields in the TeleportRole resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -3,6 +3,7 @@ title: TeleportRoleV6
 description: Provides a comprehensive list of fields in the TeleportRoleV6 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -3,6 +3,7 @@ title: TeleportRoleV7
 description: Provides a comprehensive list of fields in the TeleportRoleV7 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
@@ -3,6 +3,7 @@ title: TeleportRoleV8
 description: Provides a comprehensive list of fields in the TeleportRoleV8 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
@@ -3,6 +3,7 @@ title: TeleportSAMLConnector
 description: Provides a comprehensive list of fields in the TeleportSAMLConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
@@ -3,6 +3,7 @@ title: TeleportTrustedClusterV2
 description: Provides a comprehensive list of fields in the TeleportTrustedClusterV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
@@ -3,6 +3,7 @@ title: TeleportUser
 description: Provides a comprehensive list of fields in the TeleportUser resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
@@ -3,6 +3,7 @@ title: TeleportWorkloadIdentityV1
 description: Provides a comprehensive list of fields in the TeleportWorkloadIdentityV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_list Terraform data-source
 sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_list_member Terraform data-source
 sidebar_label: access_list_member
 description: This page describes the supported values of the teleport_access_list_member data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_monitoring_rule Terraform data-source
 sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_app Terraform data-source
 sidebar_label: app
 description: This page describes the supported values of the teleport_app data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_auth_preference Terraform data-source
 sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_autoupdate_config Terraform data-source
 sidebar_label: autoupdate_config
 description: This page describes the supported values of the teleport_autoupdate_config data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_autoupdate_version Terraform data-source
 sidebar_label: autoupdate_version
 description: This page describes the supported values of the teleport_autoupdate_version data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_cluster_maintenance_config Terraform data-sour
 sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_cluster_networking_config Terraform data-sourc
 sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
@@ -2,6 +2,7 @@
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_database Terraform data-source
 sidebar_label: database
 description: This page describes the supported values of the teleport_database data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_dynamic_windows_desktop Terraform data-source
 sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_github_connector Terraform data-source
 sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_health_check_config Terraform data-source
 sidebar_label: health_check_config
 description: This page describes the supported values of the teleport_health_check_config data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_installer Terraform data-source
 sidebar_label: installer
 description: This page describes the supported values of the teleport_installer data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_login_rule Terraform data-source
 sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_oidc_connector Terraform data-source
 sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_okta_import_rule Terraform data-source
 sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_provision_token Terraform data-source
 sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_role Terraform data-source
 sidebar_label: role
 description: This page describes the supported values of the teleport_role data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_saml_connector Terraform data-source
 sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_session_recording_config Terraform data-source
 sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_static_host_user Terraform data-source
 sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_trusted_cluster Terraform data-source
 sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_trusted_device Terraform data-source
 sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_user Terraform data-source
 sidebar_label: user
 description: This page describes the supported values of the teleport_user data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_workload_identity Terraform data-source
 sidebar_label: workload_identity
 description: This page describes the supported values of the teleport_workload_identity data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_list Terraform resource
 sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_list_member Terraform resource
 sidebar_label: access_list_member
 description: This page describes the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_access_monitoring_rule Terraform resource
 sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_app Terraform resource
 sidebar_label: app
 description: This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_auth_preference Terraform resource
 sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_autoupdate_config Terraform resource
 sidebar_label: autoupdate_config
 description: This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_autoupdate_version Terraform resource
 sidebar_label: autoupdate_version
 description: This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_bot Terraform resource
 sidebar_label: bot
 description: This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_cluster_maintenance_config Terraform resource
 sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_cluster_networking_config Terraform resource
 sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_database Terraform resource
 sidebar_label: database
 description: This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_dynamic_windows_desktop Terraform resource
 sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_github_connector Terraform resource
 sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_health_check_config Terraform resource
 sidebar_label: health_check_config
 description: This page describes the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_installer Terraform resource
 sidebar_label: installer
 description: This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_login_rule Terraform resource
 sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_oidc_connector Terraform resource
 sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_okta_import_rule Terraform resource
 sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_provision_token Terraform resource
 sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
@@ -2,6 +2,7 @@
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_role Terraform resource
 sidebar_label: role
 description: This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_saml_connector Terraform resource
 sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_server Terraform resource
 sidebar_label: server
 description: This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_session_recording_config Terraform resource
 sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_static_host_user Terraform resource
 sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_trusted_cluster Terraform resource
 sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_trusted_device Terraform resource
 sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_user Terraform resource
 sidebar_label: user
 description: This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleport_workload_identity Terraform resource
 sidebar_label: workload_identity
 description: This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -2,6 +2,7 @@
 title: "Teleport Terraform Provider"
 description: Reference documentation of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/bound-keypair.mdx
@@ -3,6 +3,7 @@ title: Bound Keypair Joining Reference
 sidebar_label: Bound Keypair Joining
 description: "Bound Keypair Joining: Reference and admin guide"
 tags:
+ - infrastructure-as-code
  - reference
  - mwi
  - infrastructure-identity

--- a/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
@@ -4,6 +4,7 @@ sidebar_label: Configuration
 description: Configuration reference for Teleport Machine ID.
 tocDepth: 4
 tags:
+ - infrastructure-as-code
  - reference
  - mwi
  - infrastructure-identity

--- a/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/data-sources/data-sources.mdx
+++ b/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/data-sources/data-sources.mdx
@@ -2,6 +2,7 @@
 title: "MWI Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport MWI Terraform Provider"
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/data-sources/kubernetes.mdx
+++ b/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/data-sources/kubernetes.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleportmwi_kubernetes Terraform data-source
 sidebar_label: kubernetes
 description: This page describes the supported values of the teleportmwi_kubernetes data-source of the Teleport MWI Terraform provider.
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/ephemeral-resources/ephemeral-resources.mdx
+++ b/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/ephemeral-resources/ephemeral-resources.mdx
@@ -2,6 +2,7 @@
 title: "MWI Terraform ephemeral resources index"
 description: "Index of all the resources supported by the Teleport MWI Terraform Provider"
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/ephemeral-resources/kubernetes.mdx
+++ b/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/ephemeral-resources/kubernetes.mdx
@@ -3,6 +3,7 @@ title: Reference for the teleportmwi_kubernetes Terraform ephemeral resource
 sidebar_label: kubernetes
 description: This page describes the supported values of the teleportmwi_kubernetes ephemeral resource of the Teleport MWI Terraform provider.
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/terraform-provider-mwi.mdx
+++ b/docs/pages/reference/machine-workload-identity/terraform-provider-mwi/terraform-provider-mwi.mdx
@@ -2,8 +2,9 @@
 title: "Teleport MWI Terraform Provider"
 description: Reference documentation of the Teleport MWI Terraform provider.
 tags:
-  - reference
-  - mwi
+ - infrastructure-as-code
+ - reference
+ - mwi
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -4,6 +4,7 @@ description: How to configure Teleport in High Availability mode for AWS deploym
 h1: Running Teleport Enterprise in High Availability mode on AWS
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - how-to
  - platform-wide
  - aws

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -3,6 +3,7 @@ title: Teleport Single-Instance Deployment on AWS
 description: How to quickly configure Teleport on a single instance for testing in AWS.
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - how-to
  - platform-wide
  - aws

--- a/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
@@ -4,6 +4,7 @@ h1: Manage Teleport Resources with Infrastructure as Code
 description: An introduction to Teleport's dynamic resources, which make it possible to apply settings to remote clusters using infrastructure as code.
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - conceptual
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
@@ -2,6 +2,7 @@
 title: Creating Access Lists with IaC
 description: Use Infrastructure-as-Code tooling to create Access Lists.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
@@ -2,6 +2,7 @@
 title: Registering Agentless OpenSSH Servers with IaC
 description: Use infrastructure-as-code tooling to register Agentless OpenSSH servers in Teleport.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
@@ -2,6 +2,7 @@
 title: Import Teleport Resources into Terraform
 description: How to import your existing Teleport resources into Terraform
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
@@ -2,6 +2,7 @@
 title: Deploy Login Rules using Kubernetes Operator 
 description: Use Teleport's Kubernetes Operator to deploy Login Rules to your cluster
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
@@ -3,6 +3,7 @@ title: Deploy Login Rules via Terraform
 description: Use Teleport's Terraform Provider to deploy Login Rules to your cluster
 tags:
  - sso
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
@@ -3,6 +3,7 @@ title: "Managing Resources with Infrastructure as Code"
 description: Provides instructions on managing specific dynamic resources with tctl and the Teleport Terraform provider and Kubernetes operator.
 layout: tocless-doc
 tags:
+ - infrastructure-as-code
  - zero-trust
 ---
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/trusted-cluster.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/trusted-cluster.mdx
@@ -2,6 +2,7 @@
 title: Managing Trusted Clusters With IaC
 description: Use infrastructure-as-code tooling to create Teleport trusted clusters.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
@@ -2,6 +2,7 @@
 title: Managing Users And Roles With IaC
 description: Use infrastructure-as-code tooling to create Teleport users and roles.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
@@ -2,6 +2,7 @@
 title: Looking up values from secrets
 description: How to store sensitive values in a Kubernetes Secret and have the operator look them up.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-helm.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-helm.mdx
@@ -2,6 +2,7 @@
 title: Kubernetes Operator in teleport-cluster Helm chart
 description: Deploy the operator alongside your Helm-deployed Teleport Cluster.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
@@ -2,6 +2,7 @@
 title: Standalone Kubernetes Operator
 description: Run a standalone operator against a remote Teleport cluster such as Teleport Cloud.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
@@ -2,6 +2,7 @@
 title: Teleport Kubernetes Operator
 description: Easily manage Teleport resources from Kubernetes
 tags:
+ - infrastructure-as-code
  - conceptual
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -4,6 +4,7 @@ sidebar_label: CI or Cloud
 description: How to manage dynamic resources using the Teleport Terraform provider from your CI pipelines or Cloud provider.
 tags:
  - ci-cd
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/dedicated-server.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/dedicated-server.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider on a Server
 sidebar_label: Dedicated Server
 description: How to manage dynamic resources using the Teleport Terraform provider from a dedicated deployment server with MachineID.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider Locally
 sidebar_label: Local Demos
 description: How to manage dynamic resources using the Teleport Terraform provider from your workstation.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -3,6 +3,7 @@ title: Run the Teleport Terraform Provider with Long-Lived Credentials
 sidebar_label: Long-Lived Credentials
 description: How to manage dynamic resources using the Teleport Terraform provider from anywhere with long-lived credentials.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx
@@ -4,6 +4,7 @@ sidebar_label: Spacelift
 description: How to manage dynamic resources using the Teleport Terraform provider on the Spacelift platform.
 tags:
  - ci-cd
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -4,6 +4,7 @@ sidebar_label: Terraform Cloud
 description: How to manage dynamic resources using the Teleport Terraform provider on HCP Terraform, Terraform Cloud, and Terraform Enterprise.
 tags:
  - ci-cd
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
@@ -3,6 +3,7 @@ title: Get Started with the Teleport Terraform Provider
 sidebar_label: Getting Started
 description: Provides an example to help you get started managing dynamic resources in a Teleport cluster using Terraform.
 tags:
+ - infrastructure-as-code
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -3,6 +3,7 @@ title: Teleport Terraform Provider
 description: How to manage dynamic resources using the Teleport Terraform provider.
 videoBanner: YgNHD4SS8dg
 tags:
+ - infrastructure-as-code
  - conceptual
  - zero-trust
 ---

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -49,6 +49,7 @@ title: {{.Title}}
 description: {{.Description}}
 tocDepth: 3
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/integrations/terraform-mwi/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform-mwi/templates/data-sources-index.mdx.tmpl
@@ -2,6 +2,7 @@
 title: "MWI Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport MWI Terraform Provider"
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/integrations/terraform-mwi/templates/data-sources.md.tmpl
+++ b/integrations/terraform-mwi/templates/data-sources.md.tmpl
@@ -3,6 +3,7 @@ title: Reference for the {{.Name}} Terraform data-source
 sidebar_label: {{ slice .Name (len "teleportmwi_") }}
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport MWI Terraform provider.
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/integrations/terraform-mwi/templates/ephemeral-resources-index.mdx.tmpl
+++ b/integrations/terraform-mwi/templates/ephemeral-resources-index.mdx.tmpl
@@ -2,6 +2,7 @@
 title: "MWI Terraform ephemeral resources index"
 description: "Index of all the resources supported by the Teleport MWI Terraform Provider"
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/integrations/terraform-mwi/templates/ephemeral-resources.md.tmpl
+++ b/integrations/terraform-mwi/templates/ephemeral-resources.md.tmpl
@@ -3,6 +3,7 @@ title: Reference for the {{.Name}} Terraform ephemeral resource
 sidebar_label: {{ slice .Name (len "teleportmwi_") }}
 description: This page describes the supported values of the {{.Name}} ephemeral resource of the Teleport MWI Terraform provider.
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/integrations/terraform-mwi/templates/index.md.tmpl
+++ b/integrations/terraform-mwi/templates/index.md.tmpl
@@ -2,6 +2,7 @@
 title: "Teleport MWI Terraform Provider"
 description: Reference documentation of the Teleport MWI Terraform provider.
 tags:
+  - infrastructure-as-code
   - reference
   - mwi
 ---

--- a/integrations/terraform/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform/templates/data-sources-index.mdx.tmpl
@@ -2,6 +2,7 @@
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -3,6 +3,7 @@ title: Reference for the {{.Name}} Terraform data-source
 sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -2,6 +2,7 @@
 title: "Teleport Terraform Provider"
 description: Reference documentation of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/integrations/terraform/templates/resources-index.mdx.tmpl
+++ b/integrations/terraform/templates/resources-index.mdx.tmpl
@@ -2,6 +2,7 @@
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -3,6 +3,7 @@ title: Reference for the {{.Name}} Terraform resource
 sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
 tags:
+ - infrastructure-as-code
  - reference
  - platform-wide
 ---


### PR DESCRIPTION
Using Teleport with infrastructure as code tools is a common use case. Tag pages with this use case so users can find related pages when looking for IaC content.