### PR TITLE
Tag docs pages with `session-recording`

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -4,6 +4,7 @@ description: How to record your SSH session commands using BPF.
 h1: Enhanced Session Recording with BPF
 videoBanner: 8uO5H-iYw5A
 tags:
+ - session-recording
  - how-to
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx
@@ -2,9 +2,10 @@
 title: Encrypted Session Recordings
 description: How to enable encrypted session recordings using your CA key backend.
 tags:
-  - how-to
-  - zero-trust
-  - resiliency
+ - session-recording
+ - how-to
+ - zero-trust
+ - resiliency
 ---
 
 Encrypted session recordings allow Teleport users to enable at-rest encryption

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-keys.mdx
@@ -2,6 +2,7 @@
 title: Rotating Session Recording Encryption Keys
 description: How to rotate automatically provisioned session recording encryption keys.
 tags:
+  - session-recording
   - how-to
   - zero-trust
   - resiliency

--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -2,6 +2,7 @@
 title: Rotating Manual Session Recording Encryption Keys
 description: How to rotate automatically provisioned session recording encryption keys.
 tags:
+  - session-recording
   - how-to
   - zero-trust
   - resiliency

--- a/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
@@ -2,6 +2,7 @@
 title: Teleport Recording Proxy Mode
 description: Use Recording Proxy Mode to capture OpenSSH server activity
 tags:
+ - session-recording
  - how-to
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -2,7 +2,8 @@
 title: Session Recording Summaries
 sidebar_label: Summarize Session Recordings with AI
 description: Describes how to use Teleport Identity security to summarize session recordings with a language model.
-labels:
+tags:
+  - session-recording
   - conceptual
   - identity-security
   - ai

--- a/docs/pages/reference/agent-services/desktop-access-reference/sessions.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/sessions.mdx
@@ -2,6 +2,7 @@
 title: Session Recording and Playback
 description: Recording and playing back Teleport desktop access sessions.
 tags:
+ - session-recording
  - conceptual
  - zero-trust
  - audit

--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -2,6 +2,7 @@
 title: Teleport Session Recording
 description: An overview of Teleport's session recording and its configuration
 tags:
+ - session-recording
  - conceptual
  - zero-trust
  - audit


### PR DESCRIPTION
Using Teleport for session recording is a common use case. Tag pages with this use case so users can find related pages when looking for session recording content.