### PR TITLE
Tag docs pages with `teleport-as-idp`

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -2,6 +2,7 @@
 title: Protect Azure CLIs and APIs with Teleport
 description: How to enable secure access to Azure CLIs.
 tags:
+ - teleport-as-idp
  - how-to
  - zero-trust
  - infrastructure-identity

--- a/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/guide.mdx
@@ -2,6 +2,7 @@
 title: Getting Started with AWS IAM Identity Center integration
 description: Explains how to set up and use Teleport AWS IAM Identity Center integration.
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/entra-id/entra-id.mdx
+++ b/docs/pages/identity-governance/entra-id/entra-id.mdx
@@ -2,6 +2,7 @@
 title: Entra ID Integration
 description: Describes how Entra ID integration works in Teleport.
 tags:
+ - teleport-as-idp
  - identity-governance
  - azure
  - privileged-access

--- a/docs/pages/identity-governance/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/entra-id/terraform.mdx
@@ -3,6 +3,7 @@ title:  Configure the Entra ID Integration using Terraform
 description: Describes how to set up the Teleport Entra ID integration using Terraform
 sidebar_position: 3
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - azure

--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -3,6 +3,7 @@ title: SAML IdP Attribute Mapping
 description: How to map user attributes to custom SAML response
 h1: SAML Attribute Mapping
 tags:
+ - teleport-as-idp
  - conceptual
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
@@ -3,6 +3,7 @@ title: Access GCP Web Console and API with federated authentication
 description: Manage Google Cloud Platform (GCP) web console access with Teleport SAML IdP.
 h1: GCP Workforce Identity Federation with Teleport SAML IdP
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - google-cloud

--- a/docs/pages/identity-governance/idps/saml-grafana.mdx
+++ b/docs/pages/identity-governance/idps/saml-grafana.mdx
@@ -2,6 +2,7 @@
 title: Use Teleport's SAML Provider to authenticate with Grafana
 description: Configure Grafana to use identities provided by Teleport.
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - infrastructure-identity

--- a/docs/pages/identity-governance/idps/saml-guide.mdx
+++ b/docs/pages/identity-governance/idps/saml-guide.mdx
@@ -4,6 +4,7 @@ description: How to configure and use Teleport as a SAML identity provider.
 h1: Teleport as a SAML identity provider
 sidebar_position: 1
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - infrastructure-identity

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -2,6 +2,7 @@
 title: Access Azure Portal and CLI 
 description: Access Azure Portal and CLI by authenticating with Teleport SAML IdP
 tags:
+ - teleport-as-idp
  - how-to
  - identity-governance
  - azure


### PR DESCRIPTION
Using Teleport as an IdP is a use case we want to promote. Tag pages with this use case so users can find related pages when looking for Teleport-as-IdP content.