### PR TITLE
[v17] install-node.sh: Make Teleport process checking more robust

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -418,7 +418,7 @@ get_download_filename() { echo "${1##*/}"; }
 # gets the pid of any running teleport process (and converts newlines to spaces)
 get_teleport_pid() {
     check_exists_fatal pgrep xargs
-    pgrep teleport | xargs echo
+    pgrep -f "teleport start" | xargs echo
 }
 # returns a command which will start teleport using the config
 get_teleport_start_command() {


### PR DESCRIPTION
Backport #59452 to branch/v17

changelog: Made the check for a running Teleport process in the install-node.sh script more robust
