### PR TITLE
[v18] tctl oidc helper

### DIFF
--- a/integration/tctl_token_kube_test.go
+++ b/integration/tctl_token_kube_test.go
@@ -1,0 +1,328 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/bintest/v3"
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
+	"github.com/gravitational/teleport/lib/kube/token"
+	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/tool/tctl/common"
+)
+
+func setupCLusterForTCTLTokensKubeTests(t *testing.T, log *slog.Logger) (*helpers.TeleInstance, string, string) {
+	// This test is not Parallel because of the metrics black hole.
+	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
+
+	// Test setup: creating a teleport instance running auth and proxy
+	clusterName := "root.example.com"
+	cfg := helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      log.With("test_component", "test-instance"),
+	}
+	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
+	rc := helpers.NewInstance(t, cfg)
+
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = filepath.Join(testDir, "data")
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.SSH.Enabled = false
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.Version = "v3"
+	rcConf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+
+	// Test setup: create a test user that can create tokens.
+	testUsername := "test-user"
+	role, err := types.NewRole("test-role", types.RoleSpecV6{
+		Options: types.RoleOptions{},
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				{
+					Resources: []string{types.KindToken, types.KindBot},
+					Verbs:     []string{types.VerbRead, types.VerbCreate, types.VerbList, types.VerbUpdate},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	rc.AddUserWithRole(testUsername, role)
+
+	// Test setup: starting the Teleport instance
+	err = rc.CreateEx(t, nil, rcConf)
+	require.NoError(t, err)
+
+	err = rc.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, rc.StopAll())
+	})
+
+	return rc, testUsername, role.GetName()
+}
+
+// TestTCTLTokenConfigureKubeCommand_OIDC validates that the command `tctl tokens configure-kube --join-with oidc`
+// can run against a fake Kubernetes cluster, a Teleport cluster service and
+// generates a join token that allows workload from the kubernetes cluster to join.
+func TestTCTLTokenConfigureKubeCommand_OIDC(t *testing.T) {
+	const (
+		testKubeContext = "test-context"
+		testNamespace   = "test-namespace"
+		testRelease     = "test-release"
+		testBotName     = "test-bot"
+	)
+
+	log := logtest.NewLogger()
+
+	rc, testUsername, testRoleName := setupCLusterForTCTLTokensKubeTests(t, log)
+
+	// Test setup: obtaining and authclient connected via the proxy.
+	clt := getAuthClientForProxy(t, rc, testUsername, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	pong, err := clt.Ping(ctx)
+	require.NoError(t, err)
+
+	_, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+		Bot: &machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: testBotName,
+			},
+			Spec: &machineidv1.BotSpec{
+				Roles: []string{testRoleName},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	addr, err := rc.Process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Test setup: creating a fake Kubernetes OIDC provider.
+	idp, err := fakeissuer.NewIDP(log.With("test_component", "fakeissuer"))
+	require.NoError(t, err)
+	kubectlOIDConfig := struct {
+		Issuer                 string   `json:"issuer"`
+		JWKSURI                string   `json:"jwks_uri"`
+		ResponseTypesSupported []string `json:"response_types_supported"`
+		SubjectTypesSupported  []string `json:"subject_types_supported"`
+		IDTokenSigningAlgs     []string `json:"id_token_signing_algs_values_supported"`
+	}{
+		Issuer:                 idp.IssuerURL(),
+		JWKSURI:                "not currently used",
+		ResponseTypesSupported: []string{"id_token"},
+		SubjectTypesSupported:  []string{"public"},
+		IDTokenSigningAlgs:     []string{"RS256"},
+	}
+	kubectlOIDConfigResponse, err := json.Marshal(kubectlOIDConfig)
+	require.NoError(t, err)
+
+	// Test setup: creating a mock kubectl binary simulating our cluster.
+	kubectlMock, err := bintest.NewMock("kubectl")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, kubectlMock.Close())
+	})
+
+	kubectlMock.Expect("config", "current-context").AndWriteToStdout(testKubeContext)
+	kubectlMock.Expect("--context", testKubeContext, "get", "--raw=/.well-known/openid-configuration").AndWriteToStdout(string(kubectlOIDConfigResponse))
+
+	// Test execution: create the tctl command.
+	stdout := &bytes.Buffer{}
+	tctlCfg := &servicecfg.Config{}
+	err = tctlCfg.SetAuthServerAddresses([]utils.NetAddr{*addr})
+	require.NoError(t, err)
+	tctlCommand := common.TokensCommand{
+		Stdout:     stdout,
+		BinKubectl: kubectlMock.Path,
+	}
+
+	tempDir := t.TempDir()
+	app := kingpin.New("test", "test")
+	tctlCommand.Initialize(app, nil, tctlCfg)
+	_, err = app.Parse([]string{"tokens", "configure-kube", "--join-with", "oidc", "-s", testRelease, "--bot", testBotName, "--namespace", testNamespace, "--out", tempDir + "/values.yaml"})
+	require.NoError(t, err)
+
+	// Test execution: run the command and validate it doesn't error.
+	err = tctlCommand.ConfigureKube(ctx, clt)
+	require.NoError(t, err)
+
+	// Test validation: obtain a kubernetes JWT from our fake IDP.
+	kubeToken, err := idp.IssueKubeToken("random-pod-name", testNamespace, testRelease, pong.ClusterName)
+	require.NoError(t, err)
+
+	tokenPath := tempDir + "/token"
+	t.Setenv(token.EnvVarCustomKubernetesTokenPath, tokenPath)
+	require.NoError(t, os.WriteFile(tokenPath, []byte(kubeToken), 0600))
+
+	// Test validation: configure a bot to join using our JWT and the token created by the tctl command.
+	botConfig := &embeddedtbot.BotConfig{
+		AuthServer: rc.Auth,
+		Onboarding: onboarding.Config{
+			TokenValue: testKubeContext + "-" + testBotName,
+			JoinMethod: types.JoinMethodKubernetes,
+		},
+		CredentialLifetime: bot.CredentialLifetime{
+			TTL:             time.Hour,
+			RenewalInterval: time.Hour,
+		},
+		Insecure: true,
+	}
+
+	// Test validation: run the bot and make sure it can join the cluster.
+	bot, err := embeddedtbot.New(botConfig, log.With("test_component", "tbot"))
+	require.NoError(t, err)
+	_, err = bot.Preflight(t.Context())
+	require.NoError(t, err)
+}
+
+// TestTCTLTokenConfigureKubeCommand_JWKS validates that the command `tctl tokens configure-kube --join-with jwks`
+// can run against a fake Kubernetes cluster, a Teleport cluster service and
+// generates a join token that allows workload from the kubernetes cluster to join.
+func TestTCTLTokenConfigureKubeCommand_JWKS(t *testing.T) {
+	const (
+		testKubeContext = "test-context"
+		testNamespace   = "test-namespace"
+		testRelease     = "test-release"
+		testBotName     = "test-bot"
+	)
+
+	log := logtest.NewLogger()
+
+	rc, testUsername, testRoleName := setupCLusterForTCTLTokensKubeTests(t, log)
+
+	// Test setup: obtaining and authclient connected via the proxy.
+	clt := getAuthClientForProxy(t, rc, testUsername, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	pong, err := clt.Ping(ctx)
+	require.NoError(t, err)
+
+	_, err = clt.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{
+		Bot: &machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: testBotName,
+			},
+			Spec: &machineidv1.BotSpec{
+				Roles: []string{testRoleName},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	addr, err := rc.Process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Test setup: creating a fake Kubernetes OIDC provider.
+	signer, err := fakeissuer.NewKubernetesSigner(clockwork.NewRealClock())
+	require.NoError(t, err)
+	kubectlJWKSResponse, err := signer.GetMarshaledJWKS()
+	require.NoError(t, err)
+
+	// Test setup: creating a mock kubectl binary simulating our cluster.
+	kubectlMock, err := bintest.NewMock("kubectl")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, kubectlMock.Close())
+	})
+
+	kubectlMock.Expect("config", "current-context").AndWriteToStdout(testKubeContext)
+	kubectlMock.Expect("--context", testKubeContext, "get", "--raw=/openid/v1/jwks").AndWriteToStdout(kubectlJWKSResponse)
+
+	// Test execution: create the tctl command.
+	stdout := &bytes.Buffer{}
+	tctlCfg := &servicecfg.Config{}
+	err = tctlCfg.SetAuthServerAddresses([]utils.NetAddr{*addr})
+	require.NoError(t, err)
+	tctlCommand := common.TokensCommand{
+		Stdout:     stdout,
+		BinKubectl: kubectlMock.Path,
+	}
+
+	tempDir := t.TempDir()
+	app := kingpin.New("test", "test")
+	tctlCommand.Initialize(app, nil, tctlCfg)
+	_, err = app.Parse([]string{"tokens", "configure-kube", "--join-with", "jwks", "-s", testRelease, "--bot", testBotName, "--namespace", testNamespace, "--out", tempDir + "/values.yaml"})
+	require.NoError(t, err)
+
+	// Test execution: run the command and validate it doesn't error.
+	err = tctlCommand.ConfigureKube(ctx, clt)
+	require.NoError(t, err)
+
+	// Test validation: obtain a kubernetes JWT from our fake IDP.
+	kubeToken, err := signer.SignServiceAccountJWT("random-pod-name", testNamespace, testRelease, pong.ClusterName)
+	require.NoError(t, err)
+
+	tokenPath := tempDir + "/token"
+	t.Setenv(token.EnvVarCustomKubernetesTokenPath, tokenPath)
+	require.NoError(t, os.WriteFile(tokenPath, []byte(kubeToken), 0600))
+
+	// Test validation: configure a bot to join using our JWT and the token created by the tctl command.
+	botConfig := &embeddedtbot.BotConfig{
+		AuthServer: rc.Auth,
+		Onboarding: onboarding.Config{
+			TokenValue: testKubeContext + "-" + testBotName,
+			JoinMethod: types.JoinMethodKubernetes,
+		},
+		CredentialLifetime: bot.CredentialLifetime{
+			TTL:             time.Hour,
+			RenewalInterval: time.Hour,
+		},
+		Insecure: true,
+	}
+
+	// Test validation: run the bot and make sure it can join the cluster.
+	bot, err := embeddedtbot.New(botConfig, log.With("test_component", "tbot"))
+	require.NoError(t, err)
+	_, err = bot.Preflight(t.Context())
+	require.NoError(t, err)
+
+}

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 const (
@@ -75,8 +76,8 @@ const (
 )
 
 var (
-	agentRepoURL        = url.URL{Scheme: "https", Host: "charts.releases.teleport.dev"}
-	agentStagingRepoURL = url.URL{Scheme: "https", Host: "charts.releases.development.teleport.dev"}
+	agentRepoURL        = teleportassets.HelmRepoURL()
+	agentStagingRepoURL = teleportassets.HelmStagingRepoURL()
 )
 
 // EnrollEKSClusterResult contains result for a single EKS cluster enrollment, if it was successful 'Error' will be nil

--- a/lib/oidc/fakeissuer/kubesigner.go
+++ b/lib/oidc/fakeissuer/kubesigner.go
@@ -102,17 +102,21 @@ func (s *KubernetesSigner) SignServiceAccountJWT(pod, namespace, serviceAccount,
 			// The Kubernetes JWKS join method rejects tokens valid more than 30 minutes.
 			Expiry: jwt.NewNumericDate(now.Add(29 * time.Minute)),
 		},
-		Kubernetes: &tokenclaims.KubernetesSubClaim{
-			Namespace: namespace,
-			ServiceAccount: &tokenclaims.ServiceAccountSubClaim{
-				Name: serviceAccount,
-				UID:  uuid.New().String(),
-			},
-			Pod: &tokenclaims.PodSubClaim{
-				Name: pod,
-				UID:  uuid.New().String(),
-			},
-		},
+		Kubernetes: kubeClaims(pod, namespace, serviceAccount),
 	}
 	return s.signWithClaims(claims)
+}
+
+func kubeClaims(pod, namespace, serviceAccount string) *tokenclaims.KubernetesSubClaim {
+	return &tokenclaims.KubernetesSubClaim{
+		Namespace: namespace,
+		ServiceAccount: &tokenclaims.ServiceAccountSubClaim{
+			Name: serviceAccount,
+			UID:  uuid.New().String(),
+		},
+		Pod: &tokenclaims.PodSubClaim{
+			Name: pod,
+			UID:  uuid.New().String(),
+		},
+	}
 }

--- a/lib/utils/teleportassets/teleportassets.go
+++ b/lib/utils/teleportassets/teleportassets.go
@@ -20,12 +20,29 @@ package teleportassets
 
 import (
 	"fmt"
+	"net/url"
+	"os"
 
 	"github.com/coreos/go-semver/semver"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/modules"
 )
+
+// IMPORTANT SECURITY WARNING:
+// Do not dynamically switch between production and staging CDNs. This is sadly
+// done in several places in Teleport, we should remove those instead of
+// adding new ones.
+// The main reasons are:
+//  - Staging CDN is only for development convenience, this should never be used
+//    by any Teleport user in production
+//  - Staging CDN doesn't offer the same security guarantees as the production
+//    one. Allowing a production binary to pull from the staging CDN is a
+//    security vulnerability.
+//  - the heuristic "pre-release is set, so we should use the staging CDN" is
+//    weak and will break. In the past we had a single CDN, we are considering
+//    adding other ones (so we can cut customer-specific builds, with higher
+//    levels of security than the current staging CDN).
 
 const (
 	// TeleportReleaseCDN is the Teleport CDN URL for release builds.
@@ -101,4 +118,38 @@ func distrolessImageName(buildType string) string {
 		return distrolessTeleportEntImage
 	}
 	return distrolessTeleportOSSImage
+}
+
+const (
+	HelmRepoURLEnvVar    = "TELEPORT_HELM_REPO_URL"
+	HelmProductionDomain = "charts.releases.teleport.dev"
+	HelmStagingDomain    = "charts.releases.development.teleport.dev"
+)
+
+// HelmRepoURL returns the URL of the Teleport Helm repository.
+// If the TELEPORT_HELM_REPO_URL override is set, it is used.
+// If the environment variable value is malformed, it is silently ignored.
+func HelmRepoURL() *url.URL {
+	if providedURL := os.Getenv(HelmRepoURLEnvVar); providedURL != "" {
+		parsedURL, err := url.Parse(providedURL)
+		if err == nil {
+			return parsedURL
+		}
+	}
+	return &url.URL{
+		Scheme: "https",
+		Host:   HelmProductionDomain,
+	}
+}
+
+// HelmStagingRepoURL returns the URL of the Teleport Helm staging repository.
+// Deprecated: Do not dynamically switch between Helm repos.
+// See security warning in the teleportassets lib.
+// This function is for backward compatibility.
+// Use HelmRepoURL + TELEPORT_HELM_REPO_URL instead.
+func HelmStagingRepoURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   HelmStagingDomain,
+	}
 }

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -113,7 +113,7 @@ func runLockCommand(t *testing.T, client *authclient.Client, args []string) erro
 func runTokensCommand(t *testing.T, client *authclient.Client, args []string) (*bytes.Buffer, error) {
 	var stdoutBuff bytes.Buffer
 	command := &TokensCommand{
-		stdout: &stdoutBuff,
+		Stdout: &stdoutBuff,
 	}
 
 	args = append([]string{"tokens"}, args...)

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,6 +27,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"slices"
 	"sort"
 	"strings"
@@ -33,10 +35,16 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/ghodss/yaml"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/gravitational/trace"
+	oidcclient "github.com/zitadel/oidc/v3/pkg/client"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -45,9 +53,11 @@ import (
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/teleportassets"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -95,6 +105,26 @@ type TokensCommand struct {
 	// dbURI is the address the database is reachable at.
 	dbURI string
 
+	// serviceAccountName is the Kubernetes Service Account the token should allow joining with.
+	serviceAccountName string
+	// namespace is the Kubernetes namespace the token should allow joining from
+	namespace string
+	// kubeContext is the kubectl context used to discover the Kubernetes cluster.
+	kubeContext string
+
+	kubeName string
+
+	tokenName string
+	// botName is the name of the bot the token allow joining as.
+	botName string
+	// outputPath is the path of the output file containing the Helm values
+	outputPath string
+	// updateGroup is the name of the update group for version detection and the generated values.yaml
+	updateGroup string
+	// kubeJoinType is the kubernetes join method type. Can be 'oidc' or 'static_jwks'.
+	kubeJoinType string
+	force        bool
+
 	// ttl is how long the token will live for.
 	ttl time.Duration
 
@@ -110,8 +140,13 @@ type TokensCommand struct {
 	// tokenList is used to view all tokens that Teleport knows about.
 	tokenList *kingpin.CmdClause
 
-	// stdout allows to switch the standard output source. Used in tests.
-	stdout io.Writer
+	// tokenKubeOIDC is used to discover the OIDC provider of a Kube cluster and create the corresponding join token.
+	tokenKubeOIDC *kingpin.CmdClause
+
+	// Stdout allows to switch the standard output source. Used in tests.
+	Stdout io.Writer
+	// BinKubectl is the path to the kubectl binary. Used in tests.
+	BinKubectl string
 }
 
 // Initialize allows TokenCommand to plug itself into the CLI parser
@@ -148,8 +183,22 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 	c.tokenList.Flag("with-secrets", "Do not redact join tokens").BoolVar(&c.withSecrets)
 	c.tokenList.Flag("labels", labelHelp).StringVar(&c.labels)
 
-	if c.stdout == nil {
-		c.stdout = os.Stdout
+	// "tctl tokens configure-kube-oidc ..."
+	c.tokenKubeOIDC = tokens.Command("configure-kube", "Creates a token allowing workload from the Kubernetes cluster to join the Teleport cluster.")
+	c.tokenKubeOIDC.Flag("join-with", "Kubernetes joining type, possible values are 'oidc', 'jwks', and 'auto'. See https://goteleport.com/docs/reference/join-methods/#kubernetes-kubernetes for more details.").Short('j').Default("auto").StringVar(&c.kubeJoinType)
+	c.tokenKubeOIDC.Flag("out", "Path of the output file.").Short('o').Default("./values.yaml").StringVar(&c.outputPath)
+	c.tokenKubeOIDC.Flag("context", "Kubernetes context to use. When not set, defaults to the active context.").StringVar(&c.kubeContext)
+	c.tokenKubeOIDC.Flag("cluster-name", "Name of the Kubernetes cluster. When not set, defaults to the context name.").StringVar(&c.kubeName)
+	c.tokenKubeOIDC.Flag("token-name", "Optional name of the created join token. When not set, default to '<CLUSTER_NAME>(-<BOT_NAME>)'").StringVar(&c.tokenName)
+	c.tokenKubeOIDC.Flag("bot", "Name of the the bot that this token will grant access to. When set, creates a bot token. Overrides --type").StringVar(&c.botName)
+	c.tokenKubeOIDC.Flag("type", "Type(s) of token to add, e.g. --type=kube,app,db,discovery,proxy,etc").Default("kube,app,discovery").StringVar(&c.tokenType)
+	c.tokenKubeOIDC.Flag("service-account", "Name of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is the release name.").Short('s').Required().StringVar(&c.serviceAccountName)
+	c.tokenKubeOIDC.Flag("namespace", "Namespace of the Kubernetes Service Account using the token. For 'teleport-kube-agent' and 'tbot' Helm charts, this is release namespace.").Short('n').Default("teleport").StringVar(&c.namespace)
+	c.tokenKubeOIDC.Flag("update-group", "Optional update group used for version detection and agent updater configuration").StringVar(&c.updateGroup)
+	c.tokenKubeOIDC.Flag("force", "Force the token creation, even if the token already exists").Default("false").Short('f').BoolVar(&c.force)
+
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
 	}
 }
 
@@ -163,6 +212,8 @@ func (c *TokensCommand) TryRun(ctx context.Context, cmd string, clientFunc commo
 		commandFunc = c.Del
 	case c.tokenList.FullCommand():
 		commandFunc = c.List
+	case c.tokenKubeOIDC.FullCommand():
+		commandFunc = c.ConfigureKube
 	default:
 		return false, nil
 	}
@@ -246,11 +297,11 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Fprint(c.stdout, string(data))
+		fmt.Fprint(c.Stdout, string(data))
 
 		return nil
 	case teleport.Text:
-		fmt.Fprintln(c.stdout, token)
+		fmt.Fprintln(c.Stdout, token)
 		return nil
 	}
 
@@ -285,7 +336,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 			return trace.NotFound("cluster has no proxies")
 		}
 		setRoles := strings.ToLower(strings.Join(roles.StringSlice(), "\\,"))
-		return kubeMessageTemplate.Execute(c.stdout,
+		return kubeMessageTemplate.Execute(c.Stdout,
 			map[string]interface{}{
 				"auth_server": proxies[0].GetPublicAddr(),
 				"token":       token,
@@ -303,7 +354,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 		}
 		appPublicAddr := fmt.Sprintf("%v.%v", c.appName, proxies[0].GetPublicAddr())
 
-		return appMessageTemplate.Execute(c.stdout,
+		return appMessageTemplate.Execute(c.Stdout,
 			map[string]interface{}{
 				"token":           token,
 				"minutes":         c.ttl.Minutes(),
@@ -321,7 +372,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 		if len(proxies) == 0 {
 			return trace.NotFound("cluster has no proxies")
 		}
-		return dbMessageTemplate.Execute(c.stdout,
+		return dbMessageTemplate.Execute(c.Stdout,
 			map[string]interface{}{
 				"token":       token,
 				"minutes":     c.ttl.Minutes(),
@@ -332,17 +383,17 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 				"db_uri":      c.dbURI,
 			})
 	case roles.Include(types.RoleTrustedCluster):
-		fmt.Fprintf(c.stdout, trustedClusterMessage,
+		fmt.Fprintf(c.Stdout, trustedClusterMessage,
 			token,
 			int(c.ttl.Minutes()))
 	case roles.Include(types.RoleWindowsDesktop):
-		return desktopMessageTemplate.Execute(c.stdout,
+		return desktopMessageTemplate.Execute(c.Stdout,
 			map[string]interface{}{
 				"token":   token,
 				"minutes": c.ttl.Minutes(),
 			})
 	case roles.Include(types.RoleMDM):
-		return mdmTokenAddTemplate.Execute(c.stdout, map[string]interface{}{
+		return mdmTokenAddTemplate.Execute(c.Stdout, map[string]interface{}{
 			"token":   token,
 			"minutes": c.ttl.Minutes(),
 			"ca_pins": caPins,
@@ -366,7 +417,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 			}
 		}
 
-		return nodeMessageTemplate.Execute(c.stdout, map[string]interface{}{
+		return nodeMessageTemplate.Execute(c.Stdout, map[string]interface{}{
 			"token":       token,
 			"roles":       strings.ToLower(roles.String()),
 			"minutes":     int(c.ttl.Minutes()),
@@ -386,7 +437,7 @@ func (c *TokensCommand) Del(ctx context.Context, client *authclient.Client) erro
 	if err := client.DeleteToken(ctx, c.value); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Fprintf(c.stdout, "Token %s has been deleted\n", c.value)
+	fmt.Fprintf(c.Stdout, "Token %s has been deleted\n", c.value)
 	return nil
 }
 
@@ -486,7 +537,7 @@ func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) err
 	})
 
 	if len(tokens) == 0 && c.format == teleport.Text {
-		fmt.Fprintln(c.stdout, "No active tokens found.")
+		fmt.Fprintln(c.Stdout, "No active tokens found.")
 		return nil
 	}
 
@@ -500,18 +551,18 @@ func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) err
 
 	switch c.format {
 	case teleport.JSON:
-		err := utils.WriteJSONArray(c.stdout, tokens)
+		err := utils.WriteJSONArray(c.Stdout, tokens)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal tokens")
 		}
 	case teleport.YAML:
-		err := utils.WriteYAML(c.stdout, tokens)
+		err := utils.WriteYAML(c.Stdout, tokens)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal tokens")
 		}
 	case teleport.Text:
 		for _, token := range tokens {
-			fmt.Fprintln(c.stdout, nameFunc(token))
+			fmt.Fprintln(c.Stdout, nameFunc(token))
 		}
 	default:
 		tokensView := func() string {
@@ -528,7 +579,488 @@ func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) err
 			}
 			return table.AsBuffer().String()
 		}
-		fmt.Fprint(c.stdout, tokensView())
+		fmt.Fprint(c.Stdout, tokensView())
 	}
 	return nil
+}
+
+func pingAuthAndProxy(ctx context.Context, client *authclient.Client, updateGroup string, insecure bool) (*proto.PingResponse, *webclient.PingResponse, error) {
+	// detect proxy address
+	authPong, err := client.Ping(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "failed to ping Teleport Auth")
+	}
+
+	proxyAddr := authPong.GetProxyPublicAddr()
+	if proxyAddr == "" {
+		return &authPong, nil, trace.BadParameter("failed to discover Teleport proxy address, make sure the Teleport Proxy service is running with `public_addr` set")
+	}
+	// detect autoupdate version
+	proxyPong, err := webclient.Ping(&webclient.Config{
+		Context:     ctx,
+		ProxyAddr:   proxyAddr,
+		Insecure:    insecure,
+		UpdateGroup: updateGroup,
+	})
+	if err != nil {
+		return &authPong, nil, trace.Wrap(err, "failed to ping Teleport Proxy")
+	}
+	return &authPong, proxyPong, nil
+}
+
+func lookupKubeActiveContext(path string) (string, error) {
+	stdout, stderr, err := runKubectlCommand(path, []string{"config", "current-context"})
+	if err != nil {
+		return "", trace.Wrap(err, "calling kubectl: %s", stderr.String())
+	}
+	kubeContext := strings.TrimSpace(stdout.String())
+	if kubeContext == "" {
+		return "", trace.BadParameter("context not set, and no active kubectl context found")
+	}
+	return kubeContext, nil
+}
+
+func runKubectlCommand(kubectlPath string, args []string) (stdout, stderr bytes.Buffer, err error) {
+	cmd := exec.Cmd{
+		Path:      kubectlPath,
+		Args:      append([]string{kubectlPath}, args...),
+		Env:       os.Environ(),
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+		WaitDelay: 10 * time.Second,
+	}
+	if err := cmd.Run(); err != nil {
+		return stdout, stderr, trace.Wrap(err, "running `%s %s`", kubectlPath, args)
+	}
+
+	return stdout, stderr, nil
+}
+
+func detectOIDC(ctx context.Context, kubectlPath, kubeContext string) (*oidc.DiscoveryConfiguration, error) {
+	kubectlArgs := []string{"--context", kubeContext, "get", "--raw=/.well-known/openid-configuration"}
+	stdout, stderr, err := runKubectlCommand(kubectlPath, kubectlArgs)
+	if err != nil {
+		return nil, trace.Wrap(err, "running kubectl: %s", stderr.String())
+	}
+	var oidcResponse oidc.DiscoveryConfiguration
+
+	err = json.Unmarshal(stdout.Bytes(), &oidcResponse)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse oidc response: %s", stdout.String())
+	}
+
+	if oidcResponse.Issuer == "" {
+		return nil, trace.BadParameter("failed to discover OIDC issuer, empty Issuer field")
+	}
+
+	oidcDiscoverCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// hit OIDC provider
+	dc, err := oidcclient.Discover(oidcDiscoverCtx, oidcResponse.Issuer, otelhttp.DefaultClient)
+	if err != nil {
+		// TODO: explain that the cluster might ot have OIDC enabled
+		return nil, trace.Wrap(err, "failed to discover OIDC issuer, make sure the cluster has OIDC enabled")
+	}
+
+	return dc, nil
+}
+
+func detectJWKS(kubectlPath, kubeContext string) (*jose.JSONWebKeySet, error) {
+	kubectlArgs := []string{"--context", kubeContext, "get", "--raw=/openid/v1/jwks"}
+	stdout, stderr, err := runKubectlCommand(kubectlPath, kubectlArgs)
+	if err != nil {
+		return nil, trace.Wrap(err, "running kubectl: %s", stderr.String())
+	}
+
+	var jwks jose.JSONWebKeySet
+	err = json.Unmarshal(stdout.Bytes(), &jwks)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse JWKS: %s", stdout.String())
+	}
+
+	if len(jwks.Keys) == 0 {
+		return nil, trace.BadParameter("failed to discover JWKS, no keys found")
+	}
+
+	return &jwks, nil
+}
+
+// ConfigureKube is called to execute "tctl tokens configure-kube ..." command
+// This function is covered by an integration test in `integration/tctl_token_kube_test.go`.
+func (c *TokensCommand) ConfigureKube(ctx context.Context, client *authclient.Client) error {
+	// preflight checks
+	var roles types.SystemRoles
+	var err error
+	if c.botName != "" {
+		roles = types.SystemRoles{types.RoleBot}
+	} else {
+		// Parse string to see if it's a type of role that Teleport supports.
+		roles, err = types.ParseTeleportRoles(c.tokenType)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	var kubeJoinType types.KubernetesJoinType
+	switch c.kubeJoinType {
+	case "oidc":
+		kubeJoinType = types.KubernetesJoinTypeOIDC
+	case "jwks", "static_jwks", "static-jwks":
+		kubeJoinType = types.KubernetesJoinTypeStaticJWKS
+	case "auto":
+		kubeJoinType = types.KubernetesJoinTypeUnspecified
+	default:
+		return trace.BadParameter("unknown --join-with value %q, supported values are 'oidc', 'jwks', and 'auto'.", c.kubeJoinType)
+	}
+
+	kubectlPath := c.BinKubectl
+	if kubectlPath == "" {
+		kubectlPath, err = exec.LookPath("kubectl")
+		if err != nil {
+			return trace.Wrap(err, "looking up kubectl binary")
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "📡 Looking up Teleport cluster settings")
+
+	authPong, proxyPong, err := pingAuthAndProxy(ctx, client, c.updateGroup, client.Config().InsecureSkipVerify)
+	if err != nil {
+		return trace.Wrap(err, "looking up Teleport cluster settings")
+	}
+
+	proxyAddr := authPong.GetProxyPublicAddr()
+	if proxyAddr == "" {
+		return trace.BadParameter("failed to discover Teleport proxy address, make sure the Teleport Proxy service is running with `public_addr` set")
+	}
+	agentVersion := proxyPong.AutoUpdate.AgentVersion
+	if agentVersion == "" {
+		return trace.NotFound("failed to discover Teleport Agent version")
+	}
+
+	fmt.Fprintln(os.Stderr, "📁 Finding local kubectl context")
+	kubeContext := c.kubeContext
+
+	// If kube context not set, we look it up
+	if kubeContext == "" {
+		kubeContext, err = lookupKubeActiveContext(kubectlPath)
+		if err != nil {
+			return trace.Wrap(err, "looking up active kubectl context")
+		}
+	}
+
+	// If the kube name is not specified, we use the context name
+	kubeName := c.kubeName
+	if kubeName == "" {
+		kubeName = kubeContext
+	}
+
+	// If the token name is not specified, we use the kube name suffixed by the bot name.
+	tokenName := c.tokenName
+	if tokenName == "" {
+		tokenName = kubeName
+		if c.botName != "" {
+			tokenName = tokenName + "-" + c.botName
+		}
+	}
+
+	tokenParams := createKubeTokenParams{
+		kubeContext:  kubeContext,
+		kubeName:     kubeName,
+		kubeJoinType: kubeJoinType,
+		kubectlPath:  kubectlPath,
+
+		roles:          roles,
+		botName:        c.botName,
+		namespace:      c.namespace,
+		serviceAccount: c.serviceAccountName,
+		tokenName:      tokenName,
+		insecure:       client.Config().InsecureSkipVerify,
+		force:          c.force,
+	}
+
+	token, err := createKubeToken(ctx, client, tokenParams)
+	if err != nil {
+		return trace.Wrap(err, "creating token")
+	}
+
+	chartName := "teleport/teleport-kube-agent"
+	if c.botName != "" {
+		chartName = "teleport/tbot"
+	}
+
+	fmt.Fprintf(os.Stderr, "📝 Writing %s Helm values to: %q\n", chartName, c.outputPath)
+
+	var valueGenerator valueGeneratorFunc
+	if c.botName != "" {
+		valueGenerator = generateTbotValues
+	} else {
+		valueGenerator = generateAgentValues
+	}
+
+	values, err := valueGenerator(valueGeneratorParams{
+		botName:             c.botName,
+		roles:               roles,
+		proxyAddr:           proxyAddr,
+		enterprise:          proxyPong.Edition == modules.BuildEnterprise,
+		updateGroup:         c.updateGroup,
+		tokenName:           token.GetName(),
+		teleportClusterName: authPong.GetClusterName(),
+		kubeClusterName:     kubeName,
+	})
+	if err != nil {
+		return trace.Wrap(err, "error generating chart values")
+	}
+
+	if err := os.WriteFile(c.outputPath, values, 0644); err != nil {
+		return trace.Wrap(err, "error writing chart values to file %s", c.outputPath)
+	}
+
+	fmt.Fprintln(os.Stderr, "🚀 You can now deploy the Helm chart:")
+	os.Stderr.Write([]byte("\n"))
+
+	fmt.Println(craftHelmCommand(craftHelmCommandParams{
+		releaseName: c.serviceAccountName,
+		chartName:   chartName,
+		namespace:   c.namespace,
+		version:     proxyPong.AutoUpdate.AgentVersion,
+		valuesPath:  c.outputPath,
+		kubeContext: kubeContext,
+	}))
+	return nil
+}
+
+type createKubeTokenParams struct {
+	// kubernetes detection settings
+	kubeJoinType types.KubernetesJoinType
+	kubeContext  string
+	kubeName     string
+	kubectlPath  string
+
+	// token settings
+	roles          types.SystemRoles
+	botName        string
+	namespace      string
+	serviceAccount string
+	tokenName      string
+	insecure       bool
+	force          bool
+}
+
+func craftKubeOIDCToken(params createKubeTokenParams, dc *oidc.DiscoveryConfiguration) (types.ProvisionToken, error) {
+	if dc == nil {
+		return nil, trace.BadParameter("cannot create token for a nil discovery configuration")
+	}
+	// craft token for cluster
+	tokenSpec := types.ProvisionTokenSpecV2{
+		Roles:      params.roles,
+		JoinMethod: types.JoinMethodKubernetes,
+		BotName:    params.botName,
+		Kubernetes: &types.ProvisionTokenSpecV2Kubernetes{
+			Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+				{ServiceAccount: fmt.Sprintf("%s:%s", params.namespace, params.serviceAccount)},
+			},
+			Type: types.KubernetesJoinTypeOIDC,
+			OIDC: &types.ProvisionTokenSpecV2Kubernetes_OIDCConfig{
+				Issuer:                  dc.Issuer,
+				InsecureAllowHTTPIssuer: params.insecure,
+			},
+		},
+	}
+	token, err := types.NewProvisionTokenFromSpec(params.tokenName, time.Time{}, tokenSpec)
+	if err != nil {
+		return nil, trace.Wrap(err, "error crafting provision token for the Kube cluster")
+	}
+	return token, nil
+}
+
+func craftKubeJWKSToken(params createKubeTokenParams, jwks *jose.JSONWebKeySet) (types.ProvisionToken, error) {
+	if jwks == nil {
+		return nil, trace.BadParameter("cannot create token for a nil JWKS")
+	}
+	jwksBytes, err := json.Marshal(jwks)
+	if err != nil {
+		return nil, trace.Wrap(err, "error marshaling JWKS")
+	}
+
+	// craft token for cluster
+	tokenSpec := types.ProvisionTokenSpecV2{
+		Roles:      params.roles,
+		JoinMethod: types.JoinMethodKubernetes,
+		BotName:    params.botName,
+		Kubernetes: &types.ProvisionTokenSpecV2Kubernetes{
+			Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+				{ServiceAccount: fmt.Sprintf("%s:%s", params.namespace, params.serviceAccount)},
+			},
+			Type: types.KubernetesJoinTypeStaticJWKS,
+			StaticJWKS: &types.ProvisionTokenSpecV2Kubernetes_StaticJWKSConfig{
+				JWKS: string(jwksBytes),
+			},
+		},
+	}
+	token, err := types.NewProvisionTokenFromSpec(params.tokenName, time.Time{}, tokenSpec)
+	if err != nil {
+		return nil, trace.Wrap(err, "error crafting provision token for the Kube cluster")
+	}
+	return token, nil
+}
+
+func craftKubeToken(ctx context.Context, params createKubeTokenParams) (types.ProvisionToken, error) {
+	switch params.kubeJoinType {
+	case types.KubernetesJoinTypeUnspecified, types.KubernetesJoinTypeOIDC:
+		// We don't know if we should use OIDC or static JWKS so we try one, and fallback if it doesn't work.
+		fmt.Fprintf(os.Stderr, "🔎 Detecting OIDC provider for Kubernetes cluster %q\n", params.kubeName)
+		dc, err := detectOIDC(ctx, params.kubectlPath, params.kubeContext)
+		if err == nil {
+			token, err := craftKubeOIDCToken(params, dc)
+			return token, trace.Wrap(err, "creating OIDC provision token for cluster %q", params.kubeName)
+		}
+
+		// If the user explicitly asked for OIDC joining, we do a hard failure.
+		// Else we try JWKS.
+		if params.kubeJoinType == types.KubernetesJoinTypeOIDC {
+			return nil, trace.Wrap(err, "discovering OIDC provider for cluster %q", params.kubeName)
+		}
+
+		fmt.Fprintln(os.Stderr, "❌ Failed to detect OIDC provider, the cluster may not have a public OIDC provider. Falling back to static JWKS.")
+		fallthrough
+	case types.KubernetesJoinTypeStaticJWKS:
+		fmt.Fprintf(os.Stderr, "🔎 Detecting JWKS for Kubernetes cluster %q\n", params.kubeName)
+		jwks, err := detectJWKS(params.kubectlPath, params.kubeContext)
+		if err != nil {
+			return nil, trace.Wrap(err, "retrieving the JWKS for cluster %q", params.kubeName)
+		}
+		token, err := craftKubeJWKSToken(params, jwks)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating OIDC provision token for cluster %q", params.kubeName)
+		}
+		return token, nil
+	default:
+		return nil, trace.BadParameter("unknown join type: %v", params.kubeJoinType)
+	}
+}
+
+func createKubeToken(ctx context.Context, client *authclient.Client, params createKubeTokenParams) (types.ProvisionToken, error) {
+	token, err := craftKubeToken(ctx, params)
+	if err != nil {
+		return nil, trace.Wrap(err, "crafting token")
+	}
+	fmt.Fprintf(os.Stderr, "⚙️ Configuring trust by creating token %q\n", token.GetName())
+
+	if params.force {
+		err := client.UpsertToken(ctx, token)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to upsert provision token %q", token.GetName())
+		}
+	} else {
+		err := client.CreateToken(ctx, token)
+		if err != nil {
+			if trace.IsAlreadyExists(err) {
+				return nil, trace.AlreadyExists(
+					"token %q already exists, you can pick a different token name with --token-name, or overwrite the existing token with --force",
+					token.GetName(),
+				)
+			}
+			return nil, trace.Wrap(err, "failed to create provision token %q", token.GetName())
+		}
+	}
+	return token, nil
+}
+
+type craftHelmCommandParams struct {
+	releaseName string
+	chartName   string
+	namespace   string
+	version     string
+	valuesPath  string
+	kubeContext string
+}
+
+func craftHelmCommand(params craftHelmCommandParams) string {
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "helm repo add teleport %q; \n", teleportassets.HelmRepoURL().String())
+	sb.WriteString("helm repo update; \n")
+	fmt.Fprintf(sb, "helm upgrade --install %q %q", params.releaseName, params.chartName)
+	fmt.Fprintf(sb, "\\\n  --namespace %s --create-namespace ", params.namespace)
+	fmt.Fprintf(sb, "\\\n  --version %s ", params.version)
+	fmt.Fprintf(sb, "\\\n  --values %s ", params.valuesPath)
+	fmt.Fprintf(sb, "\\\n  --kube-context %s\n", params.kubeContext)
+	return sb.String()
+}
+
+type valueGeneratorParams struct {
+	botName             string
+	roles               types.SystemRoles
+	proxyAddr           string
+	enterprise          bool
+	updateGroup         string
+	tokenName           string
+	teleportClusterName string
+	kubeClusterName     string
+}
+type valueGeneratorFunc func(valueGeneratorParams) ([]byte, error)
+
+type TbotChartValues struct {
+	ClusterName          string `yaml:"clusterName"`
+	TeleportProxyAddress string `yaml:"teleportProxyAddress"`
+	DefaultOutput        struct {
+		SecretName string `yaml:"secretName"`
+	} `yaml:"defaultOutput"`
+	Token string `yaml:"token"`
+}
+
+func generateTbotValues(params valueGeneratorParams) ([]byte, error) {
+	tbotValues := TbotChartValues{
+		ClusterName:          params.teleportClusterName,
+		TeleportProxyAddress: params.proxyAddr,
+		DefaultOutput: struct {
+			SecretName string `yaml:"secretName"`
+		}{
+			SecretName: fmt.Sprintf("%s-output", params.botName),
+		},
+		Token: params.tokenName,
+	}
+	return yaml.Marshal(tbotValues)
+}
+
+type AgentChartValues struct {
+	Roles      string `yaml:"roles"`
+	ProxyAddr  string `yaml:"proxyAddr"`
+	Enterprise bool   `yaml:"enterprise"`
+	Updater    struct {
+		Enabled bool   `yaml:"enabled"`
+		Group   string `yaml:"group,omitempty"`
+	} `yaml:"updater,omitempty"`
+	JoinParams struct {
+		Method    string `yaml:"method"`
+		TokenName string `yaml:"tokenName"`
+	} `yaml:"joinParams"`
+	KubeClusterName     string `yaml:"kubeClusterName"`
+	TeleportClusterName string `yaml:"teleportClusterName"`
+}
+
+func generateAgentValues(params valueGeneratorParams) ([]byte, error) {
+	agentValues := AgentChartValues{
+		Roles:      strings.ToLower(params.roles.String()),
+		ProxyAddr:  params.proxyAddr,
+		Enterprise: params.enterprise,
+		Updater: struct {
+			Enabled bool   `yaml:"enabled"`
+			Group   string `yaml:"group,omitempty"`
+		}{
+			Enabled: true,
+			Group:   params.updateGroup,
+		},
+		JoinParams: struct {
+			Method    string `yaml:"method"`
+			TokenName string `yaml:"tokenName"`
+		}{
+			Method:    string(types.JoinMethodKubernetes),
+			TokenName: params.tokenName,
+		},
+		TeleportClusterName: params.teleportClusterName,
+		KubeClusterName:     params.kubeClusterName,
+	}
+
+	return yaml.Marshal(agentValues)
 }


### PR DESCRIPTION
Manual backport of #58455 to `branch/v18`

Changelog: Added `tctl tokens configure-kube` helper command to easily trust Kubernetes clusters and allow secure repeatable joining.