### PR TITLE
docs: moving SCIM section under Identity Governance

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1491,12 +1491,12 @@
     },
     {
       "source": "/admin-guides/management/guides/scim/sailpoint/",
-      "destination": "/zero-trust-access/management/guides/scim/sailpoint/",
+      "destination": "/identity-governance/scim/sailpoint/",
       "permanent": true
     },
     {
       "source": "/admin-guides/management/guides/scim/",
-      "destination": "/zero-trust-access/management/guides/scim/",
+      "destination": "/identity-governance/scim/",
       "permanent": true
     },
     {
@@ -2302,6 +2302,16 @@
     {
       "source": "/zero-trust-access/infrastructure-as-code/terraform-starter/rbac/",
       "destination": "/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/scim/",
+      "destination": "/identity-governance/scim/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/management/guides/scim/sailpoint/",
+      "destination": "/identity-governance/scim/sailpoint/",
       "permanent": true
     }
   ]

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -140,7 +140,7 @@ for details on setting up and configuring SCIM support.
 You can also set up Teleport to integrate with a SCIM provider to automatically
 synchronize SCIM group memberships with Teleport Access Lists. For details, see
 the [SCIM integration
-documentation](zero-trust-access/management/guides/scim/scim.mdx).
+documentation](identity-governance/scim/scim.mdx).
 
 ## Why do I see an alert that some agents are out of date?
 

--- a/docs/pages/identity-governance/scim/sailpoint.mdx
+++ b/docs/pages/identity-governance/scim/sailpoint.mdx
@@ -26,7 +26,7 @@ The exact configuration steps may vary slightly depending on your version of Sai
 Create a new SCIM connector in SailPoint at: Applications > Application Definition > Add New Application.
 Select **SCIM 2.0** as the application type and provide the required configuration details:
 
-![SailPoint Connector Details](../../../../../img/sailpoint/sailpoint-1.png)
+![SailPoint Connector Details](../../../img/sailpoint/sailpoint-1.png)
 
 Navigate to the Teleport SCIM Integration page and copy the OAuth 2.0 details and the SCIM base URL.
 <Admonition type="info">
@@ -42,15 +42,15 @@ In the SailPoint SCIM application configuration view, populate the configuration
 
 Click **Test Connection** to verify that the connection is successful:
 
-![SailPoint SCIM Oauth](../../../../../img/sailpoint/sailspoint-scim-config.png)
+![SailPoint SCIM Oauth](../../../img/sailpoint/sailspoint-scim-config.png)
 
 ### Configure SCIM schema discovery
 
 Under  **Configuration -> Schema**, click **Discover Schema Attributes** on both the **Accounts** and **Groups** tabs to retrieve the schema attributes:
-![Account Schema Discovery](../../../../../img/sailpoint/sailpoint-3.png)
-![Group Schema Discovery](../../../../../img/sailpoint/sailpoint-4.png)
+![Account Schema Discovery](../../../img/sailpoint/sailpoint-3.png)
+![Group Schema Discovery](../../../img/sailpoint/sailpoint-4.png)
 Go to the **Provisioning Policy** section, and create a **Create Policy** that maps the `userName` SCIM attribute to the user’s email address:
-![User Provisioning settings](../../../../../img/sailpoint/sailpoint-5.png)
+![User Provisioning settings](../../../img/sailpoint/sailpoint-5.png)
 Save all changes.
 
 #### Configure SCIM group aggregation in SailPoint
@@ -60,18 +60,18 @@ SailPoint group aggregation enables the retrieval of SCIM-type Access Lists into
 This allows you to import Teleport Access Lists into SailPoint and manage membership directly through SailPoint with the changes being reflected in Teleport Access Lists.
 
 Navigate to **Setup > Tasks -> New Task -> Group Aggregation** in SailPoint.
-![Select Aggregation](../../../../../img/sailpoint/sailpoint-6.png)
+![Select Aggregation](../../../img/sailpoint/sailpoint-6.png)
 Select the **Teleport SCIM Connector**, then click **Save and Execute** to run the aggregation task.
-![Configure Aggregation](../../../../../img/sailpoint/sailpoint-7.png)
+![Configure Aggregation](../../../img/sailpoint/sailpoint-7.png)
 If the aggregation completes successfully,
 you should see the imported Access Lists `type: "scim"` from Teleport in SailPoint under: **Applications > Entitlement Catalog**
 
-![Aggregation Result](../../../../../img/sailpoint/sailpoint-8.png)
+![Aggregation Result](../../../img/sailpoint/sailpoint-8.png)
 
 ## Step 2/2: Submit Access Requests to SailPoint Group Entitlement (Optional)
 
 Go to **Manage > Manage User Access > Manage User Access** in SailPoint.
 Submit an Access Request for a mapped Access List (as represented by a group
 entitlement in SailPoint).
-![Access request](../../../../../img/sailpoint/sailpoint-9.png)
+![Access request](../../../img/sailpoint/sailpoint-9.png)
 Once the request is approved, the user will be added to the appropriate Access List in Teleport.

--- a/docs/pages/identity-governance/scim/scim.mdx
+++ b/docs/pages/identity-governance/scim/scim.mdx
@@ -1,6 +1,6 @@
 ---
-title: SCIM – Access List Membership Delegation to SCIM providers
-description: How to manage Access List membership using  SCIM integration
+title: SCIM Integration
+description: How to manage Access List membership using SCIM integration
 tags:
 - how-to
 - identity-governance
@@ -89,7 +89,7 @@ Teleport provides a guided Web UI-based configuration flow for the SCIM integrat
 
 In the Teleport Web UI, go to **"Add new integration"** and select **SCIM**.
 
-![Plugin Install](../../../../../img/sailpoint/plugin-install.png)
+![Plugin Install](../../../img/sailpoint/plugin-install.png)
 
 
 Select the **SAML connector** to associate SCIM-provisioned users with SSO logins.
@@ -97,7 +97,7 @@ Select the **SAML connector** to associate SCIM-provisioned users with SSO login
 - By default, SSO users in Teleport are ephemeral.
 - SCIM provisioning ensures users are persistently created and managed by External Identity management system via SCIM protocol.
 
-![Connector Selection](../../../../../img/sailpoint/plugin-connector.png)
+![Connector Selection](../../../img/sailpoint/plugin-connector.png)
 
 
 Click **Continue** to proceed to the **SCIM Credentials** screen.


### PR DESCRIPTION
The SCIM integration lived at `/docs/zero-trust-access/management/guides/scim/` under zero trust access. But these docs are about Access Lists so should live under Identity Governance as an integration. This PR moves this section into identity governance at `/identity-governance/scim/`, fixes a few breaking links due to the change, and add the appropriate redirects.