### PR TITLE
[v17] Desktop Access: Fix Stack Overflow

### DIFF
--- a/lib/srv/desktop/audit_compactor.go
+++ b/lib/srv/desktop/audit_compactor.go
@@ -132,10 +132,12 @@ func (s *fileOperationsBucket) compactEvents() iter.Seq[fileOperationEvent] {
 
 // compact finds the longest contiguous set of reads/writes following the given 'event'.
 func (s *fileOperationsBucket) compact(event fileOperationEvent, eventsByOffset map[uint64][]fileOperationEvent) ([]fileOperationEvent, uint64) {
+	eventLength := event.GetLength()
 	// Determine the offset at which the next contiguous segment must start.
-	offset := event.GetOffset() + event.GetLength()
-	// Consule the map for any events with this offset.
-	if len(eventsByOffset[offset]) > 0 {
+	offset := event.GetOffset() + eventLength
+	// Consult the map for any events with this offset.
+	// Skip events with length 0
+	if eventLength > 0 && len(eventsByOffset[offset]) > 0 {
 		// There may be multiple candidate segments to follow.
 		// Try each of them out and select the longest contiguous set of segments
 		var winner []fileOperationEvent

--- a/lib/srv/desktop/audit_compactor.go
+++ b/lib/srv/desktop/audit_compactor.go
@@ -249,7 +249,14 @@ type readEvent struct {
 	*events.DesktopSharedDirectoryRead
 }
 
-func (r *readEvent) SetLength(len uint64)        { r.Length = uint32(len) }
+func toUint32(len uint64) uint32 {
+	if len > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(len)
+}
+
+func (r *readEvent) SetLength(len uint64)        { r.Length = toUint32(len) }
 func (r *readEvent) GetLength() uint64           { return uint64(r.Length) }
 func (r *readEvent) GetOffset() uint64           { return r.Offset }
 func (r *readEvent) GetPath() string             { return r.Path }
@@ -261,7 +268,7 @@ type writeEvent struct {
 	*events.DesktopSharedDirectoryWrite
 }
 
-func (r *writeEvent) SetLength(len uint64)        { r.Length = uint32(len) }
+func (r *writeEvent) SetLength(len uint64)        { r.Length = toUint32(len) }
 func (r *writeEvent) GetLength() uint64           { return uint64(r.Length) }
 func (r *writeEvent) GetOffset() uint64           { return r.Offset }
 func (r *writeEvent) GetPath() string             { return r.Path }

--- a/lib/srv/desktop/audit_compactor.go
+++ b/lib/srv/desktop/audit_compactor.go
@@ -250,10 +250,7 @@ type readEvent struct {
 }
 
 func toUint32(len uint64) uint32 {
-	if len > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(len)
+	return uint32(min(math.MaxUint32, len))
 }
 
 func (r *readEvent) SetLength(len uint64)        { r.Length = toUint32(len) }

--- a/lib/srv/desktop/audit_compactor_test.go
+++ b/lib/srv/desktop/audit_compactor_test.go
@@ -93,6 +93,20 @@ func TestAuditCompactor(t *testing.T) {
 
 	})
 
+	t.Run("zero-length-event", func(t *testing.T) {
+		auditEvents = auditEvents[:0]
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+			compactor.handleRead(ctx, newReadEvent("foo", 1, 0, 0))
+			compactor.handleRead(ctx, newReadEvent("foo", 1, 0, 0))
+
+			compactor.flush(ctx)
+			// events with length zero should be ignored
+			require.Len(t, auditEvents, 2)
+			assert.Contains(t, auditEvents, newReadEvent("foo", 1, 0, 0))
+		})
+	})
+
 	t.Run("complex", func(t *testing.T) {
 		auditEvents = auditEvents[:0]
 		ctx := t.Context()

--- a/lib/srv/desktop/audit_compactor_test.go
+++ b/lib/srv/desktop/audit_compactor_test.go
@@ -128,7 +128,7 @@ func TestAuditCompactor(t *testing.T) {
 			compactor.handleRead(ctx, secondEvent)
 
 			compactor.flush(ctx)
-			// events with length zero should be ignored
+			// events with length zero should be ignored (not compacted)
 			require.Len(t, auditEvents, 2)
 			assert.Contains(t, auditEvents, firstEvent)
 			assert.Contains(t, auditEvents, secondEvent)


### PR DESCRIPTION
Backport #59502 to branch/v17

changelog: Fixed a crash in Teleport's Windows Desktop Service introduced in 17.7.3. Compaction of certain shared directory read/write audit events could result in a stack overflow error.