### PR TITLE
add new tctl resource handler types and logic

### DIFF
--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -120,7 +120,7 @@ func (c *AppsCommand) ListApps(ctx context.Context, clt *authclient.Client) erro
 
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
+		return trace.Wrap(coll.WriteText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -484,7 +484,7 @@ func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI authComman
 	case teleport.Text:
 		// auth servers don't have labels.
 		verbose := false
-		return sc.writeText(os.Stdout, verbose)
+		return sc.WriteText(os.Stdout, verbose)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -65,24 +65,20 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
 	"github.com/gravitational/teleport/tool/tctl/common/oktaassignment"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
-type ResourceCollection interface {
-	writeText(w io.Writer, verbose bool) error
-	resources() []types.Resource
-}
-
-// namedResourceCollection is an implementation of [ResourceCollection] that
+// namedResourceCollection is an implementation of [resources.Collection] that
 // displays resources in a table as a list of names and nothing else.
 type namedResourceCollection []types.Resource
 
-// resources implements [ResourceCollection].
-func (c namedResourceCollection) resources() []types.Resource {
+// Resources implements [resources.Collection].
+func (c namedResourceCollection) Resources() []types.Resource {
 	return c
 }
 
-// writeText implements [ResourceCollection].
-func (c namedResourceCollection) writeText(w io.Writer, verbose bool) error {
+// WriteText implements [resources.Collection].
+func (c namedResourceCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, override := range c {
 		t.AddRow([]string{override.GetName()})
@@ -94,14 +90,14 @@ type roleCollection struct {
 	roles []types.Role
 }
 
-func (r *roleCollection) resources() (res []types.Resource) {
+func (r *roleCollection) Resources() (res []types.Resource) {
 	for _, resource := range r.roles {
 		res = append(res, resource)
 	}
 	return res
 }
 
-func (r *roleCollection) writeText(w io.Writer, verbose bool) error {
+func (r *roleCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, r := range r.roles {
 		if r.GetName() == constants.DefaultImplicitRole {
@@ -131,14 +127,14 @@ type namespaceCollection struct {
 	namespaces []types.Namespace
 }
 
-func (n *namespaceCollection) resources() (r []types.Resource) {
+func (n *namespaceCollection) Resources() (r []types.Resource) {
 	for i := range n.namespaces {
 		r = append(r, &n.namespaces[i])
 	}
 	return r
 }
 
-func (n *namespaceCollection) writeText(w io.Writer, verbose bool) error {
+func (n *namespaceCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, n := range n.namespaces {
 		t.AddRow([]string{n.Metadata.Name})
@@ -178,14 +174,14 @@ type serverCollection struct {
 	servers []types.Server
 }
 
-func (s *serverCollection) resources() (r []types.Resource) {
+func (s *serverCollection) Resources() (r []types.Resource) {
 	for _, resource := range s.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (s *serverCollection) writeText(w io.Writer, verbose bool) error {
+func (s *serverCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, se := range s.servers {
 		labels := common.FormatLabels(se.GetAllLabels(), verbose)
@@ -217,14 +213,14 @@ type userCollection struct {
 	users []types.User
 }
 
-func (u *userCollection) resources() (r []types.Resource) {
+func (u *userCollection) Resources() (r []types.Resource) {
 	for _, resource := range u.users {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (u *userCollection) writeText(w io.Writer, verbose bool) error {
+func (u *userCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"User"})
 	for _, user := range u.users {
 		t.AddRow([]string{user.GetName()})
@@ -237,14 +233,14 @@ type authorityCollection struct {
 	cas []types.CertAuthority
 }
 
-func (a *authorityCollection) resources() (r []types.Resource) {
+func (a *authorityCollection) Resources() (r []types.Resource) {
 	for _, resource := range a.cas {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (a *authorityCollection) writeText(w io.Writer, verbose bool) error {
+func (a *authorityCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
 	for _, a := range a.cas {
 		for _, key := range a.GetTrustedSSHKeyPairs() {
@@ -274,14 +270,14 @@ type reverseTunnelCollection struct {
 	tunnels []types.ReverseTunnel
 }
 
-func (r *reverseTunnelCollection) resources() (res []types.Resource) {
+func (r *reverseTunnelCollection) Resources() (res []types.Resource) {
 	for _, resource := range r.tunnels {
 		res = append(res, resource)
 	}
 	return res
 }
 
-func (r *reverseTunnelCollection) writeText(w io.Writer, verbose bool) error {
+func (r *reverseTunnelCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "Dial Addresses"})
 	for _, tunnel := range r.tunnels {
 		t.AddRow([]string{
@@ -296,14 +292,14 @@ type oidcCollection struct {
 	connectors []types.OIDCConnector
 }
 
-func (c *oidcCollection) resources() (r []types.Resource) {
+func (c *oidcCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *oidcCollection) writeText(w io.Writer, verbose bool) error {
+func (c *oidcCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Issuer URL", "Additional Scope"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{
@@ -318,14 +314,14 @@ type samlCollection struct {
 	connectors []types.SAMLConnector
 }
 
-func (c *samlCollection) resources() (r []types.Resource) {
+func (c *samlCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *samlCollection) writeText(w io.Writer, verbose bool) error {
+func (c *samlCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "SSO URL"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
@@ -340,7 +336,7 @@ type connectorsCollection struct {
 	github []types.GithubConnector
 }
 
-func (c *connectorsCollection) resources() (r []types.Resource) {
+func (c *connectorsCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.oidc {
 		r = append(r, resource)
 	}
@@ -353,14 +349,14 @@ func (c *connectorsCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *connectorsCollection) writeText(w io.Writer, verbose bool) error {
+func (c *connectorsCollection) WriteText(w io.Writer, verbose bool) error {
 	if len(c.oidc) > 0 {
 		_, err := io.WriteString(w, "\nOIDC:\n")
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		oc := &oidcCollection{connectors: c.oidc}
-		err = oc.writeText(w, verbose)
+		err = oc.WriteText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -372,7 +368,7 @@ func (c *connectorsCollection) writeText(w io.Writer, verbose bool) error {
 			return trace.Wrap(err)
 		}
 		sc := &samlCollection{connectors: c.saml}
-		err = sc.writeText(w, verbose)
+		err = sc.WriteText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -384,7 +380,7 @@ func (c *connectorsCollection) writeText(w io.Writer, verbose bool) error {
 			return trace.Wrap(err)
 		}
 		gc := &githubCollection{connectors: c.github}
-		err = gc.writeText(w, verbose)
+		err = gc.WriteText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -397,14 +393,14 @@ type trustedClusterCollection struct {
 	trustedClusters []types.TrustedCluster
 }
 
-func (c *trustedClusterCollection) resources() (r []types.Resource) {
+func (c *trustedClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.trustedClusters {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *trustedClusterCollection) writeText(w io.Writer, verbose bool) error {
+func (c *trustedClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{
 		"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map",
 	})
@@ -426,14 +422,14 @@ type githubCollection struct {
 	connectors []types.GithubConnector
 }
 
-func (c *githubCollection) resources() (r []types.Resource) {
+func (c *githubCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.connectors {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *githubCollection) writeText(w io.Writer, verbose bool) error {
+func (c *githubCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Teams To Logins"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), formatTeamsToLogins(
@@ -456,14 +452,14 @@ type remoteClusterCollection struct {
 	remoteClusters []types.RemoteCluster
 }
 
-func (c *remoteClusterCollection) resources() (r []types.Resource) {
+func (c *remoteClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.remoteClusters {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *remoteClusterCollection) writeText(w io.Writer, verbose bool) error {
+func (c *remoteClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Status", "Last Heartbeat"})
 	for _, cluster := range c.remoteClusters {
 		lastHeartbeat := cluster.GetLastHeartbeat()
@@ -480,26 +476,26 @@ func formatLastHeartbeat(t time.Time) string {
 	return apiutils.HumanTimeFormat(t)
 }
 
-func writeJSON(c ResourceCollection, w io.Writer) error {
-	return utils.WriteJSONArray(w, c.resources())
+func writeJSON(c resources.Collection, w io.Writer) error {
+	return utils.WriteJSONArray(w, c.Resources())
 }
 
-func writeYAML(c ResourceCollection, w io.Writer) error {
-	return utils.WriteYAML(w, c.resources())
+func writeYAML(c resources.Collection, w io.Writer) error {
+	return utils.WriteYAML(w, c.Resources())
 }
 
 type semaphoreCollection struct {
 	sems []types.Semaphore
 }
 
-func (c *semaphoreCollection) resources() (r []types.Resource) {
+func (c *semaphoreCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.sems {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *semaphoreCollection) writeText(w io.Writer, verbose bool) error {
+func (c *semaphoreCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Kind", "Name", "LeaseID", "Holder", "Expires"})
 	for _, sem := range c.sems {
 		for _, ref := range sem.LeaseRefs() {
@@ -516,14 +512,14 @@ type appServerCollection struct {
 	servers []types.AppServer
 }
 
-func (a *appServerCollection) resources() (r []types.Resource) {
+func (a *appServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range a.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (a *appServerCollection) writeText(w io.Writer, verbose bool) error {
+func (a *appServerCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range a.servers {
 		app := server.GetApp()
@@ -556,14 +552,14 @@ type appCollection struct {
 	apps []types.Application
 }
 
-func (c *appCollection) resources() (r []types.Resource) {
+func (c *appCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.apps {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *appCollection) writeText(w io.Writer, verbose bool) error {
+func (c *appCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, app := range c.apps {
 		labels := common.FormatLabels(app.GetAllLabels(), verbose)
@@ -586,11 +582,11 @@ type authPrefCollection struct {
 	authPref types.AuthPreference
 }
 
-func (c *authPrefCollection) resources() (r []types.Resource) {
+func (c *authPrefCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.authPref}
 }
 
-func (c *authPrefCollection) writeText(w io.Writer, verbose bool) error {
+func (c *authPrefCollection) WriteText(w io.Writer, verbose bool) error {
 	var secondFactorStrings []string
 	for _, sf := range c.authPref.GetSecondFactors() {
 		sfString, err := sf.Encode()
@@ -610,11 +606,11 @@ type uiConfigCollection struct {
 	uiconfig types.UIConfig
 }
 
-func (c *uiConfigCollection) resources() (r []types.Resource) {
+func (c *uiConfigCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.uiconfig}
 }
 
-func (c *uiConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *uiConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Scrollback Lines", "Show Resources"})
 	t.AddRow([]string{strconv.FormatInt(int64(c.uiconfig.GetScrollbackLines()), 10), string(c.uiconfig.GetShowResources())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -625,11 +621,11 @@ type netConfigCollection struct {
 	netConfig types.ClusterNetworkingConfig
 }
 
-func (c *netConfigCollection) resources() (r []types.Resource) {
+func (c *netConfigCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.netConfig}
 }
 
-func (c *netConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *netConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Client Idle Timeout", "Keep Alive Interval", "Keep Alive Count Max", "Session Control Timeout"})
 	t.AddRow([]string{
 		c.netConfig.GetClientIdleTimeout().String(),
@@ -645,14 +641,14 @@ type maintenanceWindowCollection struct {
 	cmc types.ClusterMaintenanceConfig
 }
 
-func (c *maintenanceWindowCollection) resources() (r []types.Resource) {
+func (c *maintenanceWindowCollection) Resources() (r []types.Resource) {
 	if c.cmc == nil {
 		return nil
 	}
 	return []types.Resource{c.cmc}
 }
 
-func (c *maintenanceWindowCollection) writeText(w io.Writer, verbose bool) error {
+func (c *maintenanceWindowCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Type", "Params"})
 
 	agentUpgradeParams := "none"
@@ -676,11 +672,11 @@ type recConfigCollection struct {
 	recConfig types.SessionRecordingConfig
 }
 
-func (c *recConfigCollection) resources() (r []types.Resource) {
+func (c *recConfigCollection) Resources() (r []types.Resource) {
 	return []types.Resource{c.recConfig}
 }
 
-func (c *recConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *recConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Mode", "Proxy Checks Host Keys"})
 	t.AddRow([]string{c.recConfig.GetMode(), strconv.FormatBool(c.recConfig.GetProxyChecksHostKeys())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -702,7 +698,7 @@ func (w *writer) write(s string) {
 	}
 }
 
-func (c *netRestrictionsCollection) resources() (r []types.Resource) {
+func (c *netRestrictionsCollection) Resources() (r []types.Resource) {
 	r = append(r, c.netRestricts)
 	return
 }
@@ -714,7 +710,7 @@ func (c *netRestrictionsCollection) writeList(as []types.AddressCondition, w *wr
 	}
 }
 
-func (c *netRestrictionsCollection) writeText(w io.Writer, verbose bool) error {
+func (c *netRestrictionsCollection) WriteText(w io.Writer, verbose bool) error {
 	out := &writer{w: w}
 	out.write("ALLOW\n")
 	c.writeList(c.netRestricts.GetAllow(), out)
@@ -728,14 +724,14 @@ type databaseServerCollection struct {
 	servers []types.DatabaseServer
 }
 
-func (c *databaseServerCollection) resources() (r []types.Resource) {
+func (c *databaseServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *databaseServerCollection) writeText(w io.Writer, verbose bool) error {
+func (c *databaseServerCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range c.servers {
 		labels := common.FormatLabels(server.GetDatabase().GetAllLabels(), verbose)
@@ -773,14 +769,14 @@ type databaseCollection struct {
 	databases []types.Database
 }
 
-func (c *databaseCollection) resources() (r []types.Resource) {
+func (c *databaseCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.databases {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *databaseCollection) writeText(w io.Writer, verbose bool) error {
+func (c *databaseCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, database := range c.databases {
 		labels := common.FormatLabels(database.GetAllLabels(), verbose)
@@ -808,14 +804,14 @@ type lockCollection struct {
 	locks []types.Lock
 }
 
-func (c *lockCollection) resources() (r []types.Resource) {
+func (c *lockCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.locks {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *lockCollection) writeText(w io.Writer, verbose bool) error {
+func (c *lockCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"ID", "Target", "Message", "Expires"})
 	for _, lock := range c.locks {
 		target := lock.Target()
@@ -833,14 +829,14 @@ type windowsDesktopServiceCollection struct {
 	services []types.WindowsDesktopService
 }
 
-func (c *windowsDesktopServiceCollection) resources() (r []types.Resource) {
+func (c *windowsDesktopServiceCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.services {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *windowsDesktopServiceCollection) writeText(w io.Writer, verbose bool) error {
+func (c *windowsDesktopServiceCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Address", "Version"})
 	for _, service := range c.services {
 		addr := service.GetAddr()
@@ -857,14 +853,14 @@ type windowsDesktopCollection struct {
 	desktops []types.WindowsDesktop
 }
 
-func (c *windowsDesktopCollection) resources() (r []types.Resource) {
+func (c *windowsDesktopCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.desktops {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *windowsDesktopCollection) writeText(w io.Writer, verbose bool) error {
+func (c *windowsDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, d := range c.desktops {
 		labels := common.FormatLabels(d.GetAllLabels(), verbose)
@@ -893,7 +889,7 @@ type dynamicWindowsDesktopCollection struct {
 	desktops []types.DynamicWindowsDesktop
 }
 
-func (c *dynamicWindowsDesktopCollection) resources() (r []types.Resource) {
+func (c *dynamicWindowsDesktopCollection) Resources() (r []types.Resource) {
 	r = make([]types.Resource, 0, len(c.desktops))
 	for _, resource := range c.desktops {
 		r = append(r, resource)
@@ -901,7 +897,7 @@ func (c *dynamicWindowsDesktopCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *dynamicWindowsDesktopCollection) writeText(w io.Writer, verbose bool) error {
+func (c *dynamicWindowsDesktopCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, d := range c.desktops {
 		labels := common.FormatLabels(d.GetAllLabels(), verbose)
@@ -922,14 +918,14 @@ type tokenCollection struct {
 	tokens []types.ProvisionToken
 }
 
-func (c *tokenCollection) resources() (r []types.Resource) {
+func (c *tokenCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.tokens {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *tokenCollection) writeText(w io.Writer, verbose bool) error {
+func (c *tokenCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, token := range c.tokens {
 		_, err := w.Write([]byte(token.String()))
 		if err != nil {
@@ -943,14 +939,14 @@ type kubeServerCollection struct {
 	servers []types.KubeServer
 }
 
-func (c *kubeServerCollection) resources() (r []types.Resource) {
+func (c *kubeServerCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.servers {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (c *kubeServerCollection) writeText(w io.Writer, verbose bool) error {
+func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range c.servers {
 		kube := server.GetCluster()
@@ -991,7 +987,7 @@ type crownJewelCollection struct {
 	items []*crownjewelv1.CrownJewel
 }
 
-func (c *crownJewelCollection) resources() []types.Resource {
+func (c *crownJewelCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.Resource153ToLegacy(resource))
@@ -1001,7 +997,7 @@ func (c *crownJewelCollection) resources() []types.Resource {
 
 // writeText formats the crown jewels into a table and writes them into w.
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *crownJewelCollection) writeText(w io.Writer, verbose bool) error {
+func (c *crownJewelCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, item := range c.items {
 		labels := common.FormatLabels(item.GetMetadata().GetLabels(), verbose)
@@ -1024,7 +1020,7 @@ type kubeClusterCollection struct {
 	clusters []types.KubeCluster
 }
 
-func (c *kubeClusterCollection) resources() (r []types.Resource) {
+func (c *kubeClusterCollection) Resources() (r []types.Resource) {
 	for _, resource := range c.clusters {
 		r = append(r, resource)
 	}
@@ -1039,7 +1035,7 @@ func (c *kubeClusterCollection) resources() (r []types.Resource) {
 // cluster3      region=northcentralus,resource-group=cluster3,subscription-id=subID
 // cluster4      owner=cluster4,region=southcentralus,resource-group=cluster4,subscription-id=subID
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *kubeClusterCollection) writeText(w io.Writer, verbose bool) error {
+func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, cluster := range c.clusters {
 		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
@@ -1065,7 +1061,7 @@ type installerCollection struct {
 	installers []types.Installer
 }
 
-func (c *installerCollection) resources() []types.Resource {
+func (c *installerCollection) Resources() []types.Resource {
 	var r []types.Resource
 	for _, inst := range c.installers {
 		r = append(r, inst)
@@ -1073,7 +1069,7 @@ func (c *installerCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *installerCollection) writeText(w io.Writer, verbose bool) error {
+func (c *installerCollection) WriteText(w io.Writer, verbose bool) error {
 	for _, inst := range c.installers {
 		if _, err := fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName()); err != nil {
 			return trace.Wrap(err)
@@ -1092,14 +1088,14 @@ type integrationCollection struct {
 	integrations []types.Integration
 }
 
-func (c *integrationCollection) resources() (r []types.Resource) {
+func (c *integrationCollection) Resources() (r []types.Resource) {
 	for _, ig := range c.integrations {
 		r = append(r, ig)
 	}
 	return r
 }
 
-func (c *integrationCollection) writeText(w io.Writer, verbose bool) error {
+func (c *integrationCollection) WriteText(w io.Writer, verbose bool) error {
 	sort.Sort(types.Integrations(c.integrations))
 	var rows [][]string
 	for _, ig := range c.integrations {
@@ -1123,14 +1119,14 @@ type externalAuditStorageCollection struct {
 	externalAuditStorages []*externalauditstorage.ExternalAuditStorage
 }
 
-func (c *externalAuditStorageCollection) resources() (r []types.Resource) {
+func (c *externalAuditStorageCollection) Resources() (r []types.Resource) {
 	for _, a := range c.externalAuditStorages {
 		r = append(r, a)
 	}
 	return r
 }
 
-func (c *externalAuditStorageCollection) writeText(w io.Writer, verbose bool) error {
+func (c *externalAuditStorageCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, a := range c.externalAuditStorages {
 		rows = append(rows, []string{
@@ -1156,7 +1152,7 @@ type databaseServiceCollection struct {
 	databaseServices []types.DatabaseService
 }
 
-func (c *databaseServiceCollection) resources() (r []types.Resource) {
+func (c *databaseServiceCollection) Resources() (r []types.Resource) {
 	for _, service := range c.databaseServices {
 		r = append(r, service)
 	}
@@ -1192,7 +1188,7 @@ func databaseResourceMatchersToString(in []*types.DatabaseResourceMatcher) strin
 // ------------------------------------ --------------------------------------
 // a6065ee9-d5ee-4555-8d47-94a78625277b (Labels: <all databases>)
 // d4e13f2b-0a55-4e0a-b363-bacfb1a11294 (Labels: env=[prod],aws-tag=[xyz abc])
-func (c *databaseServiceCollection) writeText(w io.Writer, verbose bool) error {
+func (c *databaseServiceCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Resource Matchers"})
 
 	for _, dbService := range c.databaseServices {
@@ -1209,7 +1205,7 @@ type loginRuleCollection struct {
 	rules []*loginrulepb.LoginRule
 }
 
-func (l *loginRuleCollection) writeText(w io.Writer, verbose bool) error {
+func (l *loginRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Priority"})
 	for _, rule := range l.rules {
 		t.AddRow([]string{rule.Metadata.Name, strconv.FormatInt(int64(rule.Priority), 10)})
@@ -1218,7 +1214,7 @@ func (l *loginRuleCollection) writeText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-func (l *loginRuleCollection) resources() []types.Resource {
+func (l *loginRuleCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(l.rules))
 	for i, rule := range l.rules {
 		resources[i] = loginrule.ProtoToResource(rule)
@@ -1231,7 +1227,7 @@ type samlIdPServiceProviderCollection struct {
 	serviceProviders []types.SAMLIdPServiceProvider
 }
 
-func (c *samlIdPServiceProviderCollection) resources() []types.Resource {
+func (c *samlIdPServiceProviderCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.serviceProviders))
 	for i, resource := range c.serviceProviders {
 		r[i] = resource
@@ -1239,7 +1235,7 @@ func (c *samlIdPServiceProviderCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *samlIdPServiceProviderCollection) writeText(w io.Writer, verbose bool) error {
+func (c *samlIdPServiceProviderCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})
@@ -1252,7 +1248,7 @@ type botCollection struct {
 	bots []*machineidv1pb.Bot
 }
 
-func (c *botCollection) resources() []types.Resource {
+func (c *botCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.bots))
 	for i, b := range c.bots {
 		resources[i] = types.ProtoResource153ToLegacy(b)
@@ -1260,7 +1256,7 @@ func (c *botCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *botCollection) writeText(w io.Writer, verbose bool) error {
+func (c *botCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Roles"})
 	for _, b := range c.bots {
 		t.AddRow([]string{
@@ -1276,7 +1272,7 @@ type databaseObjectImportRuleCollection struct {
 	rules []*dbobjectimportrulev1.DatabaseObjectImportRule
 }
 
-func (c *databaseObjectImportRuleCollection) resources() []types.Resource {
+func (c *databaseObjectImportRuleCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.rules))
 	for i, b := range c.rules {
 		resources[i] = databaseobjectimportrule.ProtoToResource(b)
@@ -1284,7 +1280,7 @@ func (c *databaseObjectImportRuleCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *databaseObjectImportRuleCollection) writeText(w io.Writer, verbose bool) error {
+func (c *databaseObjectImportRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Priority", "Mapping Count", "DB Label Count"})
 	for _, b := range c.rules {
 		t.AddRow([]string{
@@ -1302,7 +1298,7 @@ type databaseObjectCollection struct {
 	objects []*dbobjectv1.DatabaseObject
 }
 
-func (c *databaseObjectCollection) resources() []types.Resource {
+func (c *databaseObjectCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.objects))
 	for i, b := range c.objects {
 		resources[i] = databaseobject.ProtoToResource(b)
@@ -1310,7 +1306,7 @@ func (c *databaseObjectCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *databaseObjectCollection) writeText(w io.Writer, verbose bool) error {
+func (c *databaseObjectCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Kind", "DB Service", "Protocol"})
 	for _, b := range c.objects {
 		t.AddRow([]string{
@@ -1328,7 +1324,7 @@ type deviceCollection struct {
 	devices []*devicepb.Device
 }
 
-func (c *deviceCollection) resources() []types.Resource {
+func (c *deviceCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.devices))
 	for i, dev := range c.devices {
 		resources[i] = types.DeviceToResource(dev)
@@ -1336,7 +1332,7 @@ func (c *deviceCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *deviceCollection) writeText(w io.Writer, verbose bool) error {
+func (c *deviceCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"ID", "OS Type", "Asset Tag", "Enrollment Status", "Creation Time", "Last Updated"})
 	for _, device := range c.devices {
 		t.AddRow([]string{
@@ -1356,7 +1352,7 @@ type discoveryConfigCollection struct {
 	discoveryConfigs []*discoveryconfig.DiscoveryConfig
 }
 
-func (c *discoveryConfigCollection) resources() []types.Resource {
+func (c *discoveryConfigCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.discoveryConfigs))
 	for i, dc := range c.discoveryConfigs {
 		resources[i] = dc
@@ -1364,7 +1360,7 @@ func (c *discoveryConfigCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *discoveryConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *discoveryConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Discovery Group"})
 	for _, dc := range c.discoveryConfigs {
 		t.AddRow([]string{
@@ -1380,7 +1376,7 @@ type oktaImportRuleCollection struct {
 	importRules []types.OktaImportRule
 }
 
-func (c *oktaImportRuleCollection) resources() []types.Resource {
+func (c *oktaImportRuleCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.importRules))
 	for i, resource := range c.importRules {
 		r[i] = resource
@@ -1388,7 +1384,7 @@ func (c *oktaImportRuleCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *oktaImportRuleCollection) writeText(w io.Writer, verbose bool) error {
+func (c *oktaImportRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, importRule := range c.importRules {
 		t.AddRow([]string{importRule.GetName()})
@@ -1401,7 +1397,7 @@ type oktaAssignmentCollection struct {
 	assignments []types.OktaAssignment
 }
 
-func (c *oktaAssignmentCollection) resources() []types.Resource {
+func (c *oktaAssignmentCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.assignments))
 	for i, resource := range c.assignments {
 		r[i] = oktaassignment.ToResource(resource)
@@ -1409,7 +1405,7 @@ func (c *oktaAssignmentCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *oktaAssignmentCollection) writeText(w io.Writer, verbose bool) error {
+func (c *oktaAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, assignment := range c.assignments {
 		t.AddRow([]string{assignment.GetName()})
@@ -1422,7 +1418,7 @@ type userGroupCollection struct {
 	userGroups []types.UserGroup
 }
 
-func (c *userGroupCollection) resources() []types.Resource {
+func (c *userGroupCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.userGroups))
 	for i, resource := range c.userGroups {
 		r[i] = resource
@@ -1430,7 +1426,7 @@ func (c *userGroupCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *userGroupCollection) writeText(w io.Writer, verbose bool) error {
+func (c *userGroupCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Origin"})
 	for _, userGroup := range c.userGroups {
 		t.AddRow([]string{
@@ -1446,7 +1442,7 @@ type auditQueryCollection struct {
 	auditQueries []*secreports.AuditQuery
 }
 
-func (c *auditQueryCollection) resources() []types.Resource {
+func (c *auditQueryCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.auditQueries))
 	for i, resource := range c.auditQueries {
 		r[i] = resource
@@ -1454,7 +1450,7 @@ func (c *auditQueryCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *auditQueryCollection) writeText(w io.Writer, verbose bool) error {
+func (c *auditQueryCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Title", "Query", "Description"})
 	for _, v := range c.auditQueries {
 		t.AddRow([]string{v.GetName(), v.Spec.Title, v.Spec.Query, v.Spec.Description})
@@ -1467,7 +1463,7 @@ type securityReportCollection struct {
 	items []*secreports.Report
 }
 
-func (c *securityReportCollection) resources() []types.Resource {
+func (c *securityReportCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.items))
 	for i, resource := range c.items {
 		r[i] = resource
@@ -1475,7 +1471,7 @@ func (c *securityReportCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *securityReportCollection) writeText(w io.Writer, verbose bool) error {
+func (c *securityReportCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Title", "Audit Queries", "Description"})
 	for _, v := range c.items {
 		auditQueriesNames := make([]string, 0, len(v.Spec.AuditQueries))
@@ -1492,7 +1488,7 @@ type serverInfoCollection struct {
 	serverInfos []types.ServerInfo
 }
 
-func (c *serverInfoCollection) resources() []types.Resource {
+func (c *serverInfoCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.serverInfos))
 	for i, resource := range c.serverInfos {
 		r[i] = resource
@@ -1500,7 +1496,7 @@ func (c *serverInfoCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *serverInfoCollection) writeText(w io.Writer, verbose bool) error {
+func (c *serverInfoCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Labels"})
 	for _, si := range c.serverInfos {
 		t.AddRow([]string{si.GetName(), printMetadataLabels(si.GetNewLabels())})
@@ -1513,7 +1509,7 @@ type accessListCollection struct {
 	accessLists []*accesslist.AccessList
 }
 
-func (c *accessListCollection) resources() []types.Resource {
+func (c *accessListCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.accessLists))
 	for i, resource := range c.accessLists {
 		r[i] = resource
@@ -1521,7 +1517,7 @@ func (c *accessListCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *accessListCollection) writeText(w io.Writer, verbose bool) error {
+func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
 	for _, al := range c.accessLists {
 		t.AddRow([]string{
@@ -1539,11 +1535,11 @@ type vnetConfigCollection struct {
 	vnetConfig *vnet.VnetConfig
 }
 
-func (c *vnetConfigCollection) resources() []types.Resource {
+func (c *vnetConfigCollection) Resources() []types.Resource {
 	return []types.Resource{types.Resource153ToLegacy(c.vnetConfig)}
 }
 
-func (c *vnetConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *vnetConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	var dnsZoneSuffixes []string
 	for _, dnsZone := range c.vnetConfig.Spec.CustomDnsZones {
 		dnsZoneSuffixes = append(dnsZoneSuffixes, dnsZone.Suffix)
@@ -1561,11 +1557,11 @@ type accessGraphSettings struct {
 	accessGraphSettings *clusterconfigrec.AccessGraphSettings
 }
 
-func (c *accessGraphSettings) resources() []types.Resource {
+func (c *accessGraphSettings) Resources() []types.Resource {
 	return []types.Resource{c.accessGraphSettings}
 }
 
-func (c *accessGraphSettings) writeText(w io.Writer, verbose bool) error {
+func (c *accessGraphSettings) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"SSH Keys Scan"})
 	t.AddRow([]string{
 		c.accessGraphSettings.Spec.SecretsScanConfig,
@@ -1578,7 +1574,7 @@ type accessRequestCollection struct {
 	accessRequests []types.AccessRequest
 }
 
-func (c *accessRequestCollection) resources() []types.Resource {
+func (c *accessRequestCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.accessRequests))
 	for i, resource := range c.accessRequests {
 		r[i] = resource
@@ -1586,7 +1582,7 @@ func (c *accessRequestCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *accessRequestCollection) writeText(w io.Writer, verbose bool) error {
+func (c *accessRequestCollection) WriteText(w io.Writer, verbose bool) error {
 	var t asciitable.Table
 	var rows [][]string
 	for _, al := range c.accessRequests {
@@ -1744,7 +1740,7 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *pluginCollection) resources() []types.Resource {
+func (c *pluginCollection) Resources() []types.Resource {
 	r := make([]types.Resource, len(c.plugins))
 	for i, resource := range c.plugins {
 		r[i] = resource
@@ -1752,7 +1748,7 @@ func (c *pluginCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *pluginCollection) writeText(w io.Writer, verbose bool) error {
+func (c *pluginCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Status"})
 	for _, plugin := range c.plugins {
 		t.AddRow([]string{
@@ -1768,7 +1764,7 @@ type botInstanceCollection struct {
 	items []*machineidv1pb.BotInstance
 }
 
-func (c *botInstanceCollection) resources() []types.Resource {
+func (c *botInstanceCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.ProtoResource153ToLegacy(resource))
@@ -1776,7 +1772,7 @@ func (c *botInstanceCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *botInstanceCollection) writeText(w io.Writer, verbose bool) error {
+func (c *botInstanceCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Bot Name", "Instance ID"}
 
 	// TODO: consider adding additional (possibly verbose) fields showing
@@ -1798,7 +1794,7 @@ type spiffeFederationCollection struct {
 	items []*machineidv1pb.SPIFFEFederation
 }
 
-func (c *spiffeFederationCollection) resources() []types.Resource {
+func (c *spiffeFederationCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.Resource153ToLegacy(resource))
@@ -1806,7 +1802,7 @@ func (c *spiffeFederationCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *spiffeFederationCollection) writeText(w io.Writer, verbose bool) error {
+func (c *spiffeFederationCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Last synced at"}
 
 	var rows [][]string
@@ -1833,7 +1829,7 @@ type workloadIdentityCollection struct {
 	items []*workloadidentityv1pb.WorkloadIdentity
 }
 
-func (c *workloadIdentityCollection) resources() []types.Resource {
+func (c *workloadIdentityCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.ProtoResource153ToLegacy(resource))
@@ -1841,7 +1837,7 @@ func (c *workloadIdentityCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *workloadIdentityCollection) writeText(w io.Writer, verbose bool) error {
+func (c *workloadIdentityCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "SPIFFE ID"}
 
 	var rows [][]string
@@ -1864,7 +1860,7 @@ type workloadIdentityX509RevocationCollection struct {
 	items []*workloadidentityv1pb.WorkloadIdentityX509Revocation
 }
 
-func (c *workloadIdentityX509RevocationCollection) resources() []types.Resource {
+func (c *workloadIdentityX509RevocationCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.ProtoResource153ToLegacy(resource))
@@ -1872,7 +1868,7 @@ func (c *workloadIdentityX509RevocationCollection) resources() []types.Resource 
 	return r
 }
 
-func (c *workloadIdentityX509RevocationCollection) writeText(w io.Writer, verbose bool) error {
+func (c *workloadIdentityX509RevocationCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Serial", "Revoked At", "Expires At", "Reason"}
 
 	var rows [][]string
@@ -1900,7 +1896,7 @@ type staticHostUserCollection struct {
 	items []*userprovisioningpb.StaticHostUser
 }
 
-func (c *staticHostUserCollection) resources() []types.Resource {
+func (c *staticHostUserCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.Resource153ToLegacy(resource))
@@ -1908,7 +1904,7 @@ func (c *staticHostUserCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *staticHostUserCollection) writeText(w io.Writer, verbose bool) error {
+func (c *staticHostUserCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, item := range c.items {
 
@@ -1958,7 +1954,7 @@ type userTaskCollection struct {
 	items []*usertasksv1.UserTask
 }
 
-func (c *userTaskCollection) resources() []types.Resource {
+func (c *userTaskCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.Resource153ToLegacy(resource))
@@ -1968,7 +1964,7 @@ func (c *userTaskCollection) resources() []types.Resource {
 
 // writeText formats the user tasks into a table and writes them into w.
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *userTaskCollection) writeText(w io.Writer, verbose bool) error {
+func (c *userTaskCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, item := range c.items {
 		labels := common.FormatLabels(item.GetMetadata().GetLabels(), verbose)
@@ -1987,11 +1983,11 @@ type autoUpdateConfigCollection struct {
 	config *autoupdatev1pb.AutoUpdateConfig
 }
 
-func (c *autoUpdateConfigCollection) resources() []types.Resource {
+func (c *autoUpdateConfigCollection) Resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.config)}
 }
 
-func (c *autoUpdateConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *autoUpdateConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Tools AutoUpdate Enabled"})
 	t.AddRow([]string{
 		c.config.GetMetadata().GetName(),
@@ -2005,11 +2001,11 @@ type autoUpdateVersionCollection struct {
 	version *autoupdatev1pb.AutoUpdateVersion
 }
 
-func (c *autoUpdateVersionCollection) resources() []types.Resource {
+func (c *autoUpdateVersionCollection) Resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.version)}
 }
 
-func (c *autoUpdateVersionCollection) writeText(w io.Writer, verbose bool) error {
+func (c *autoUpdateVersionCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Tools AutoUpdate Version"})
 	t.AddRow([]string{
 		c.version.GetMetadata().GetName(),
@@ -2023,11 +2019,11 @@ type autoUpdateAgentRolloutCollection struct {
 	rollout *autoupdatev1pb.AutoUpdateAgentRollout
 }
 
-func (c *autoUpdateAgentRolloutCollection) resources() []types.Resource {
+func (c *autoUpdateAgentRolloutCollection) Resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.rollout)}
 }
 
-func (c *autoUpdateAgentRolloutCollection) writeText(w io.Writer, verbose bool) error {
+func (c *autoUpdateAgentRolloutCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Start Version", "Target Version", "Mode", "Schedule", "Strategy"})
 	t.AddRow([]string{
 		c.rollout.GetMetadata().GetName(),
@@ -2045,7 +2041,7 @@ type autoUpdateAgentReportCollection struct {
 	reports []*autoupdatev1pb.AutoUpdateAgentReport
 }
 
-func (c *autoUpdateAgentReportCollection) resources() []types.Resource {
+func (c *autoUpdateAgentReportCollection) Resources() []types.Resource {
 	resources := make([]types.Resource, len(c.reports))
 	for i, report := range c.reports {
 		resources[i] = types.ProtoResource153ToLegacy(report)
@@ -2053,7 +2049,7 @@ func (c *autoUpdateAgentReportCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *autoUpdateAgentReportCollection) writeText(w io.Writer, verbose bool) error {
+func (c *autoUpdateAgentReportCollection) WriteText(w io.Writer, verbose bool) error {
 	groupSet := make(map[string]any)
 	versionsSet := make(map[string]any)
 	for _, report := range c.reports {
@@ -2093,7 +2089,7 @@ type accessMonitoringRuleCollection struct {
 	items []*accessmonitoringrulesv1pb.AccessMonitoringRule
 }
 
-func (c *accessMonitoringRuleCollection) resources() []types.Resource {
+func (c *accessMonitoringRuleCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.items))
 	for _, resource := range c.items {
 		r = append(r, types.Resource153ToLegacy(resource))
@@ -2103,7 +2099,7 @@ func (c *accessMonitoringRuleCollection) resources() []types.Resource {
 
 // writeText formats the user tasks into a table and writes them into w.
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *accessMonitoringRuleCollection) writeText(w io.Writer, verbose bool) error {
+func (c *accessMonitoringRuleCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, item := range c.items {
 		labels := common.FormatLabels(item.GetMetadata().GetLabels(), verbose)
@@ -2122,7 +2118,7 @@ type healthCheckConfigCollection struct {
 	items []*healthcheckconfigv1.HealthCheckConfig
 }
 
-func (c *healthCheckConfigCollection) resources() []types.Resource {
+func (c *healthCheckConfigCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c.items))
 	for _, item := range c.items {
 		out = append(out, types.ProtoResource153ToLegacy(item))
@@ -2130,7 +2126,7 @@ func (c *healthCheckConfigCollection) resources() []types.Resource {
 	return out
 }
 
-func (c *healthCheckConfigCollection) writeText(w io.Writer, verbose bool) error {
+func (c *healthCheckConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Interval", "Timeout", "Healthy Threshold", "Unhealthy Threshold", "DB Labels", "DB Expression"}
 	var rows [][]string
 	for _, item := range c.items {
@@ -2163,7 +2159,7 @@ type scopedRoleCollection struct {
 	items []*scopedaccessv1.ScopedRole
 }
 
-func (c *scopedRoleCollection) resources() []types.Resource {
+func (c *scopedRoleCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c.items))
 	for _, item := range c.items {
 		out = append(out, types.Resource153ToLegacy(item))
@@ -2171,7 +2167,7 @@ func (c *scopedRoleCollection) resources() []types.Resource {
 	return out
 }
 
-func (c *scopedRoleCollection) writeText(w io.Writer, verbose bool) error {
+func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Scope", "Name"}
 	var rows [][]string
 	for _, item := range c.items {
@@ -2191,7 +2187,7 @@ type scopedRoleAssignmentCollection struct {
 	items []*scopedaccessv1.ScopedRoleAssignment
 }
 
-func (c *scopedRoleAssignmentCollection) resources() []types.Resource {
+func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c.items))
 	for _, item := range c.items {
 		out = append(out, types.Resource153ToLegacy(item))
@@ -2199,7 +2195,7 @@ func (c *scopedRoleAssignmentCollection) resources() []types.Resource {
 	return out
 }
 
-func (c *scopedRoleAssignmentCollection) writeText(w io.Writer, verbose bool) error {
+func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Scope", "Name", "Assigns"}
 	var rows [][]string
 

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -2165,11 +2165,11 @@ type autoUpdateBotInstanceReportCollection struct {
 	report *autoupdatev1pb.AutoUpdateBotInstanceReport
 }
 
-func (c *autoUpdateBotInstanceReportCollection) resources() []types.Resource {
+func (c *autoUpdateBotInstanceReportCollection) Resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.report)}
 }
 
-func (c *autoUpdateBotInstanceReportCollection) writeText(w io.Writer, _ bool) error {
+func (c *autoUpdateBotInstanceReportCollection) WriteText(w io.Writer, _ bool) error {
 	t := asciitable.MakeTable([]string{"Update Group", "Version", "Count"})
 	for groupName, groupMetrics := range c.report.GetSpec().GetGroups() {
 		if groupName == "" {

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/tool/common"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
 var (
@@ -72,7 +73,7 @@ func TestDatabaseResourceMatchersToString(t *testing.T) {
 }
 
 type writeTextTest struct {
-	collection          ResourceCollection
+	collection          resources.Collection
 	wantVerboseTable    func() string
 	wantNonVerboseTable func() string
 }
@@ -82,7 +83,7 @@ func (test *writeTextTest) run(t *testing.T) {
 	t.Run("verbose mode", func(t *testing.T) {
 		t.Helper()
 		w := &bytes.Buffer{}
-		err := test.collection.writeText(w, true)
+		err := test.collection.WriteText(w, true)
 		require.NoError(t, err)
 		diff := cmp.Diff(test.wantVerboseTable(), w.String())
 		require.Empty(t, diff)
@@ -90,7 +91,7 @@ func (test *writeTextTest) run(t *testing.T) {
 	t.Run("non-verbose mode", func(t *testing.T) {
 		t.Helper()
 		w := &bytes.Buffer{}
-		err := test.collection.writeText(w, false)
+		err := test.collection.WriteText(w, false)
 		require.NoError(t, err)
 		diff := cmp.Diff(test.wantNonVerboseTable(), w.String())
 		require.Empty(t, diff)
@@ -441,7 +442,7 @@ type autoUpdateConfigBrokenCollection struct {
 	autoUpdateConfigCollection
 }
 
-func (c *autoUpdateConfigBrokenCollection) resources() []types.Resource {
+func (c *autoUpdateConfigBrokenCollection) Resources() []types.Resource {
 	// We use Resource153ToLegacy instead of ProtoResource153ToLegacy.
 	return []types.Resource{types.Resource153ToLegacy(c.config)}
 }

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -112,7 +112,7 @@ func (c *DBCommand) ListDatabases(ctx context.Context, clt *authclient.Client) e
 	coll := &databaseServerCollection{servers: servers}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
+		return trace.Wrap(coll.WriteText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -110,7 +110,7 @@ func (c *DesktopCommand) ListDesktop(ctx context.Context, clt *authclient.Client
 
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
+		return trace.Wrap(coll.WriteText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -203,7 +203,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		}
 
 		// Try looking for a resource handler
-		if resourceHandler, found := resources.Handlers[resources.Kind(newResource.Kind)]; found {
+		if resourceHandler, found := resources.Handlers()[newResource.Kind]; found {
 			opts := resources.CreateOpts{
 				Force:   rc.force,
 				Confirm: rc.confirm,
@@ -231,7 +231,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		// the CreateHandler. UpdateHandlers are preferred over CreateHandler because an update
 		// will not forcibly overwrite a resource unlike with create which requires the force
 		// flag to be set to update an existing resource.
-		if updator, found := rc.UpdateHandlers[resources.Kind(newResource.Kind)]; found {
+		if updator, found := rc.UpdateHandlers[newResource.Kind]; found {
 			if err := updator(ctx, client, newResource); err != nil {
 				return trace.Wrap(err)
 			}
@@ -240,7 +240,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 
 		// TODO(tross) remove the fallback to CreateHandlers once all the resources
 		// have been updated to implement an UpdateHandler.
-		if creator, found := rc.CreateHandlers[resources.Kind(newResource.Kind)]; found {
+		if creator, found := rc.CreateHandlers[newResource.Kind]; found {
 			if err := creator(ctx, client, newResource); err != nil {
 				return trace.Wrap(err)
 			}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
 // EditCommand implements the `tctl edit` command for modifying
@@ -201,11 +202,36 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 			continue
 		}
 
+		// Try looking for a resource handler
+		if resourceHandler, found := resources.Handlers[resources.Kind(newResource.Kind)]; found {
+			opts := resources.CreateOpts{
+				Force:   rc.force,
+				Confirm: rc.confirm,
+			}
+			if err := resourceHandler.Update(ctx, client, newResource, opts); err != nil {
+				// TODO(tross) remove the fallback to CreateHandlers once all the resources
+				// have been updated to implement an UpdateHandler.
+				if trace.IsNotImplemented(err) {
+					if err := resourceHandler.Create(ctx, client, newResource, opts); err != nil {
+						if trace.IsNotImplemented(err) {
+							return trace.BadParameter("updating resources of type %q is not supported", newResource.Kind)
+						}
+						return trace.Wrap(err)
+					}
+					return nil
+				}
+				return trace.Wrap(err)
+			}
+			continue
+		}
+
+		// Else fallback to the legacy logic
+
 		// Use the UpdateHandler if the resource has one, otherwise fallback to using
 		// the CreateHandler. UpdateHandlers are preferred over CreateHandler because an update
 		// will not forcibly overwrite a resource unlike with create which requires the force
 		// flag to be set to update an existing resource.
-		if updator, found := rc.UpdateHandlers[ResourceKind(newResource.Kind)]; found {
+		if updator, found := rc.UpdateHandlers[resources.Kind(newResource.Kind)]; found {
 			if err := updator(ctx, client, newResource); err != nil {
 				return trace.Wrap(err)
 			}
@@ -214,7 +240,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 
 		// TODO(tross) remove the fallback to CreateHandlers once all the resources
 		// have been updated to implement an UpdateHandler.
-		if creator, found := rc.CreateHandlers[ResourceKind(newResource.Kind)]; found {
+		if creator, found := rc.CreateHandlers[resources.Kind(newResource.Kind)]; found {
 			if err := creator(ctx, client, newResource); err != nil {
 				return trace.Wrap(err)
 			}

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -183,7 +184,7 @@ func testEditRole(t *testing.T, clt *authclient.Client) {
 		expected.SetRevision(created.GetRevision())
 		expected.SetLogins(types.Allow, []string{"abcdef"})
 
-		collection := &roleCollection{roles: []types.Role{expected}}
+		collection := resources.NewRoleCollection([]types.Role{expected})
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
 	}
 
@@ -723,7 +724,7 @@ func TestMultipleRoles(t *testing.T) {
 			role.SetLogins(types.Allow, []string{"abcdef"})
 		}
 
-		collection := &roleCollection{roles: roles}
+		collection := resources.NewRoleCollection(roles)
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
 	}
 

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -111,7 +111,7 @@ func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) erro
 	coll := &kubeServerCollection{servers: kubes}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
+		return trace.Wrap(coll.WriteText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -261,7 +261,7 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) er
 	coll := &serverCollection{servers: nodes}
 	switch c.lsFormat {
 	case teleport.Text:
-		if err := coll.writeText(os.Stdout, c.verbose); err != nil {
+		if err := coll.WriteText(os.Stdout, c.verbose); err != nil {
 			return trace.Wrap(err)
 		}
 	case teleport.YAML:

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -63,7 +63,7 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *authclient.C
 	case teleport.Text:
 		// proxies don't have labels.
 		verbose := false
-		return sc.writeText(os.Stdout, verbose)
+		return sc.WriteText(os.Stdout, verbose)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -313,7 +313,7 @@ func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) e
 	mfaKinds := []string{types.KindToken, types.KindCertAuthority}
 	for kind, handler := range resources.Handlers() {
 		if handler.MFARequired() {
-			mfaKinds = append(mfaKinds, string(kind))
+			mfaKinds = append(mfaKinds, kind)
 		}
 	}
 	mfaRequired := rc.withSecrets && slices.ContainsFunc(rc.refs, func(r services.Ref) bool {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -138,7 +138,6 @@ Same as above, but using JSON output:
 func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
 	rc.CreateHandlers = map[resources.Kind]ResourceCreateHandler{
 		types.KindUser:                               rc.createUser,
-		types.KindRole:                               rc.createRole,
 		types.KindTrustedCluster:                     rc.createTrustedCluster,
 		types.KindGithubConnector:                    rc.createGithubConnector,
 		types.KindCertAuthority:                      rc.createCertAuthority,
@@ -202,7 +201,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindGithubConnector:                    rc.updateGithubConnector,
 		types.KindOIDCConnector:                      rc.updateOIDCConnector,
 		types.KindSAMLConnector:                      rc.updateSAMLConnector,
-		types.KindRole:                               rc.updateRole,
 		types.KindClusterNetworkingConfig:            rc.updateClusterNetworkingConfig,
 		types.KindClusterAuthPreference:              rc.updateAuthPreference,
 		types.KindSessionRecordingConfig:             rc.updateSessionRecordingConfig,
@@ -566,101 +564,6 @@ func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *au
 	}
 	fmt.Printf("authentication connector %q has been updated\n", connector.GetName())
 	return nil
-}
-
-// createRole implements `tctl create role.yaml` command.
-func (rc *ResourceCommand) createRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	role, err := services.UnmarshalRole(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := services.ValidateAccessPredicates(role); err != nil {
-		// check for syntax errors in predicates
-		return trace.Wrap(err)
-	}
-	err = services.CheckDynamicLabelsInDenyRules(role)
-	if trace.IsBadParameter(err) {
-		return trace.BadParameter("%s", dynamicLabelWarningMessage(role))
-	} else if err != nil {
-		return trace.Wrap(err)
-	}
-
-	warnAboutKubernetesResources(ctx, rc.config.Logger, role)
-
-	roleName := role.GetName()
-	_, err = client.GetRole(ctx, roleName)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	roleExists := (err == nil)
-	if roleExists && !rc.IsForced() {
-		return trace.AlreadyExists("role %q already exists", roleName)
-	}
-	if _, err := client.UpsertRole(ctx, role); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("role %q has been %s\n", roleName, UpsertVerb(roleExists, rc.IsForced()))
-	return nil
-}
-
-func (rc *ResourceCommand) updateRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	role, err := services.UnmarshalRole(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := services.ValidateAccessPredicates(role); err != nil {
-		// check for syntax errors in predicates
-		return trace.Wrap(err)
-	}
-
-	warnAboutKubernetesResources(ctx, rc.config.Logger, role)
-	warnAboutDynamicLabelsInDenyRule(ctx, rc.config.Logger, role)
-
-	if _, err := client.UpdateRole(ctx, role); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("role %q has been updated\n", role.GetName())
-	return nil
-}
-
-// warnAboutKubernetesResources warns about kubernetes resources
-// if kubernetes_labels are set but kubernetes_resources are not.
-func warnAboutKubernetesResources(ctx context.Context, logger *slog.Logger, r types.Role) {
-	role, ok := r.(*types.RoleV6)
-	// only warn about kubernetes resources for v6 roles
-	if !ok || role.Version != types.V6 {
-		return
-	}
-	if len(role.Spec.Allow.KubernetesLabels) > 0 && len(role.Spec.Allow.KubernetesResources) == 0 {
-		logger.WarnContext(ctx, "role has allow.kubernetes_labels set but no allow.kubernetes_resources, this is probably a mistake - Teleport will restrict access to pods", "role", role.Metadata.Name)
-	}
-	if len(role.Spec.Allow.KubernetesLabels) == 0 && len(role.Spec.Allow.KubernetesResources) > 0 {
-		logger.WarnContext(ctx, "role has allow.kubernetes_resources set but no allow.kubernetes_labels, this is probably a mistake - kubernetes_resources won't be effective", "role", role.Metadata.Name)
-	}
-
-	if len(role.Spec.Deny.KubernetesLabels) > 0 && len(role.Spec.Deny.KubernetesResources) > 0 {
-		logger.WarnContext(ctx, "role has deny.kubernetes_labels set but also has deny.kubernetes_resources set, this is probably a mistake - deny.kubernetes_resources won't be effective", "role", role.Metadata.Name)
-	}
-}
-
-func dynamicLabelWarningMessage(r types.Role) string {
-	return fmt.Sprintf("existing role %q has labels with the %q prefix in its deny rules. This is not recommended due to the volatility of %q labels and is not allowed for new roles",
-		r.GetName(), types.TeleportDynamicLabelPrefix, types.TeleportDynamicLabelPrefix)
-}
-
-// warnAboutDynamicLabelsInDenyRule warns about using dynamic/ labels in deny
-// rules. Only applies to existing roles as adding dynamic/ labels to deny
-// rules in a new role is not allowed.
-func warnAboutDynamicLabelsInDenyRule(ctx context.Context, logger *slog.Logger, r types.Role) {
-	if err := services.CheckDynamicLabelsInDenyRules(r); err == nil {
-		return
-	} else if trace.IsBadParameter(err) {
-		logger.WarnContext(ctx, "existing role has labels with the a dynamic prefix in its deny rules, this is not recommended due to the volatility of dynamic labels and is not allowed for new roles", "role", r.GetName())
-	} else {
-		logger.WarnContext(ctx, "error checking deny rules labels", "error", err)
-	}
 }
 
 // createUser implements `tctl create user.yaml` command.
@@ -1931,11 +1834,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("user %q has been deleted\n", rc.ref.Name)
-	case types.KindRole:
-		if err = client.DeleteRole(ctx, rc.ref.Name); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("role %q has been deleted\n", rc.ref.Name)
 	case types.KindToken:
 		if err = client.DeleteToken(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
@@ -2714,20 +2612,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 		}
 		return nil, trace.NotFound("proxy with ID %q not found", rc.ref.Name)
-	case types.KindRole:
-		if rc.ref.Name == "" {
-			roles, err := client.GetRoles(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return &roleCollection{roles: roles}, nil
-		}
-		role, err := client.GetRole(ctx, rc.ref.Name)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		warnAboutDynamicLabelsInDenyRule(ctx, rc.config.Logger, role)
-		return &roleCollection{roles: []types.Role{role}}, nil
 	case types.KindNamespace:
 		return &namespaceCollection{namespaces: []types.Namespace{types.DefaultNamespace()}}, nil
 	case types.KindTrustedCluster:

--- a/tool/tctl/common/resource_summarizer.go
+++ b/tool/tctl/common/resource_summarizer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
 // CRUD operations for InferenceModel resources
@@ -87,7 +88,7 @@ func (rc *ResourceCommand) updateInferenceModel(
 // getInferenceModels retrieves one or more inference model resources.
 func (rc *ResourceCommand) getInferenceModels(
 	ctx context.Context, clt *authclient.Client,
-) (ResourceCollection, error) {
+) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
 	if rc.ref.Name != "" {
 		req := &summarizerv1.GetInferenceModelRequest{
@@ -136,7 +137,7 @@ func (rc *ResourceCommand) deleteInferenceModel(
 // can be written to an io.Writer in a human-readable format.
 type InferenceModelCollection []*summarizerv1.InferenceModel
 
-func (c InferenceModelCollection) resources() []types.Resource {
+func (c InferenceModelCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c))
 	for _, item := range c {
 		out = append(out, types.ProtoResource153ToLegacy(item))
@@ -144,11 +145,7 @@ func (c InferenceModelCollection) resources() []types.Resource {
 	return out
 }
 
-func (c InferenceModelCollection) Resources() []types.Resource {
-	return c.resources()
-}
-
-func (c InferenceModelCollection) writeText(w io.Writer, verbose bool) error {
+func (c InferenceModelCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Description", "Provider", "Provider Model ID"}
 	var rows [][]string
 	for _, item := range c {
@@ -215,7 +212,7 @@ func (rc *ResourceCommand) createInferenceSecret(
 // getInferenceSecrets retrieves one or more inference secret resources.
 func (rc *ResourceCommand) getInferenceSecrets(
 	ctx context.Context, clt *authclient.Client,
-) (ResourceCollection, error) {
+) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
 	if rc.ref.Name != "" {
 		req := &summarizerv1.GetInferenceSecretRequest{
@@ -263,7 +260,7 @@ func (rc *ResourceCommand) deleteInferenceSecret(
 // can be written to an io.Writer in a human-readable format.
 type inferenceSecretCollection []*summarizerv1.InferenceSecret
 
-func (c inferenceSecretCollection) resources() []types.Resource {
+func (c inferenceSecretCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c))
 	for _, item := range c {
 		out = append(out, types.ProtoResource153ToLegacy(item))
@@ -271,7 +268,7 @@ func (c inferenceSecretCollection) resources() []types.Resource {
 	return out
 }
 
-func (c inferenceSecretCollection) writeText(w io.Writer, verbose bool) error {
+func (c inferenceSecretCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Description"}
 	var rows [][]string
 	for _, item := range c {
@@ -348,7 +345,7 @@ func (rc *ResourceCommand) updateInferencePolicy(
 // getInferencePolicies retrieves one or more inference policy resources.
 func (rc *ResourceCommand) getInferencePolicies(
 	ctx context.Context, clt *authclient.Client,
-) (ResourceCollection, error) {
+) (resources.Collection, error) {
 	ssclt := clt.SummarizerServiceClient()
 	if rc.ref.Name != "" {
 		req := &summarizerv1.GetInferencePolicyRequest{
@@ -397,7 +394,7 @@ func (rc *ResourceCommand) deleteInferencePolicy(
 // can be written to an io.Writer in a human-readable format.
 type InferencePolicyCollection []*summarizerv1.InferencePolicy
 
-func (c InferencePolicyCollection) resources() []types.Resource {
+func (c InferencePolicyCollection) Resources() []types.Resource {
 	out := make([]types.Resource, 0, len(c))
 	for _, item := range c {
 		out = append(out, types.ProtoResource153ToLegacy(item))
@@ -405,11 +402,7 @@ func (c InferencePolicyCollection) resources() []types.Resource {
 	return out
 }
 
-func (c InferencePolicyCollection) Resources() []types.Resource {
-	return c.resources()
-}
-
-func (c InferencePolicyCollection) writeText(w io.Writer, verbose bool) error {
+func (c InferencePolicyCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Name", "Description", "Kinds", "Filter", "Model"}
 	var rows [][]string
 	for _, item := range c {

--- a/tool/tctl/common/resources/collection.go
+++ b/tool/tctl/common/resources/collection.go
@@ -1,0 +1,34 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"io"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// Collection represents a collection of resources.
+// It can contain zero, one, or many resources.
+// Most Collection implementation contain a single kind of resource,
+// but some might return resources of mixed kinds.
+type Collection interface {
+	WriteText(w io.Writer, verbose bool) error
+	Resources() []types.Resource
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -28,15 +28,13 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-// Kind is the resource kind.
-type Kind string
-
-// Handlers is a map of Handler per kind.
+// Handlers returns a map of Handler per kind.
 // This map will be filled as we convert existing resources
 // to the Handler format.
-var Handlers = map[Kind]Handler{
-	types.KindRole: roleHandler,
-	// TODO: convert resources one by one and add them here
+func Handlers() map[string]Handler {
+	return map[string]Handler{
+		types.KindRole: roleHandler(),
+	}
 }
 
 // Handler represents a resource supported by the tctl resource command.

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -1,0 +1,133 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// Kind is the resource kind.
+type Kind string
+
+// Handlers is a map of Handler per kind.
+// This map will be filled as we convert existing resources
+// to the Handler format.
+var Handlers = map[Kind]Handler{
+	// TODO: convert resources one by one and add them here
+}
+
+// Handler represents a resource supported by the tctl resource command.
+// It contains all the information about the resources and the functions
+// to create, update, get and delete it.
+// Some resources might not implement all functions (e.g. some resources are
+// read-only, they cannot be created).
+type Handler struct {
+	getHandler    func(context.Context, *authclient.Client, services.Ref, GetOpts) (Collection, error)
+	createHandler func(context.Context, *authclient.Client, services.UnknownResource, CreateOpts) error
+	updateHandler func(context.Context, *authclient.Client, services.UnknownResource, CreateOpts) error
+	deleteHandler func(context.Context, *authclient.Client, services.Ref) error
+	singleton     bool
+	mfaRequired   bool
+	description   string
+}
+
+// GetOpts contains the possible options when getting a resource.
+type GetOpts struct {
+	// WithSecrets is true if the user set --with-secrets
+	WithSecrets bool
+}
+
+// CreateOpts contains the possible options when creating/updating a resource.
+type CreateOpts struct {
+	// Force is true if the user set --Force
+	Force bool
+	// Confirm is true if the user set --Confirm
+	Confirm bool
+}
+
+// Get queries the cluster to get the desired resource and returns a Collection.
+// Getting with an empty ref.Name returns all resources of the specified ref.Kind.
+func (r *Handler) Get(ctx context.Context, clt *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if r.getHandler == nil {
+		return nil, trace.NotImplemented("resource does not support 'tctl get'")
+	}
+	return r.getHandler(ctx, clt, ref, opts)
+}
+
+// Create takes a raw resource manifest, decodes it, and creates the
+// corresponding resource in Teleport.
+func (r *Handler) Create(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if r.createHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl create'")
+	}
+	return r.createHandler(ctx, clt, raw, opts)
+}
+
+// Update takes a raw resource manifest, decodes it, and updates the
+// corresponding resource in Teleport.
+func (r *Handler) Update(ctx context.Context, clt *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if r.updateHandler == nil {
+		return trace.NotImplemented("resource does not have an update handler")
+	}
+	return r.updateHandler(ctx, clt, raw, opts)
+}
+
+// Delete takes a resource kind and name, and deletes the corresponding resource
+// in Teleport.
+func (r *Handler) Delete(ctx context.Context, clt *authclient.Client, ref services.Ref) error {
+	if r.deleteHandler == nil {
+		return trace.NotImplemented("resource does not support 'tctl delete'")
+	}
+	if ref.Name == "" && !r.singleton {
+		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
+	}
+	return r.deleteHandler(ctx, clt, ref)
+}
+
+// MFARequired indicates that this resource requires MFA to Get the resource.
+func (r *Handler) MFARequired() bool {
+	return r.mfaRequired
+}
+
+// SupportedCommands returns the list of supported tctl commands for this resource Handler.
+func (r *Handler) SupportedCommands() []string {
+	var verbs []string
+	if r.getHandler != nil {
+		verbs = append(verbs, "get")
+	}
+	if r.createHandler != nil {
+		verbs = append(verbs, "create")
+	}
+	if r.deleteHandler != nil {
+		verbs = append(verbs, "rm")
+	}
+	return verbs
+}
+
+// Description returns the description of the Handler's resource.
+// The description is intended for aim users to understand what this resource
+// does and in which case they should interact with it.
+func (r *Handler) Description() string {
+	return r.description
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -34,6 +35,7 @@ type Kind string
 // This map will be filled as we convert existing resources
 // to the Handler format.
 var Handlers = map[Kind]Handler{
+	types.KindRole: roleHandler,
 	// TODO: convert resources one by one and add them here
 }
 
@@ -130,4 +132,12 @@ func (r *Handler) SupportedCommands() []string {
 // does and in which case they should interact with it.
 func (r *Handler) Description() string {
 	return r.description
+}
+
+// upsertVerb generates the correct string form of a verb based on the action taken
+func upsertVerb(exists bool, force bool) string {
+	if !force && exists {
+		return "updated"
+	}
+	return "created"
 }

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -124,6 +124,10 @@ func (r *Handler) SupportedCommands() []string {
 	if r.deleteHandler != nil {
 		verbs = append(verbs, "rm")
 	}
+	if r.updateHandler != nil {
+		verbs = append(verbs, "update")
+	}
+
 	return verbs
 }
 

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -58,7 +58,7 @@ func (r *roleCollection) WriteText(w io.Writer, verbose bool) error {
 }
 
 func printActions(rules []types.Rule) string {
-	pairs := []string{}
+	pairs := make([]string, 0, len(rules))
 	for _, rule := range rules {
 		pairs = append(pairs, fmt.Sprintf("%v:%v", strings.Join(rule.Resources, ","), strings.Join(rule.Verbs, ",")))
 	}

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -1,0 +1,206 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func NewRoleCollection(roles []types.Role) Collection {
+	return &roleCollection{roles: roles}
+}
+
+type roleCollection struct {
+	roles []types.Role
+}
+
+func (r *roleCollection) Resources() (res []types.Resource) {
+	for _, resource := range r.roles {
+		res = append(res, resource)
+	}
+	return res
+}
+
+func (r *roleCollection) WriteText(w io.Writer, verbose bool) error {
+	var rows [][]string
+	for _, r := range r.roles {
+		if r.GetName() == constants.DefaultImplicitRole {
+			continue
+		}
+		rows = append(rows, []string{
+			r.GetMetadata().Name,
+			strings.Join(r.GetLogins(types.Allow), ","),
+			printNodeLabels(r.GetNodeLabels(types.Allow)),
+			printActions(r.GetRules(types.Allow)),
+		})
+	}
+
+	headers := []string{"Role", "Allowed to login as", "Node Labels", "Access to resources"}
+	var t asciitable.Table
+	if verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Access to resources")
+	}
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func printActions(rules []types.Rule) string {
+	pairs := []string{}
+	for _, rule := range rules {
+		pairs = append(pairs, fmt.Sprintf("%v:%v", strings.Join(rule.Resources, ","), strings.Join(rule.Verbs, ",")))
+	}
+	return strings.Join(pairs, ",")
+}
+
+func printNodeLabels(labels types.Labels) string {
+	pairs := []string{}
+	for key, values := range labels {
+		if key == types.Wildcard {
+			return "<all nodes>"
+		}
+		pairs = append(pairs, fmt.Sprintf("%v=%v", key, values))
+	}
+	return strings.Join(pairs, ",")
+}
+
+var roleHandler = Handler{
+	getHandler:    getRole,
+	createHandler: createRole,
+	updateHandler: updateRole,
+	deleteHandler: deleteRole,
+	singleton:     false,
+	mfaRequired:   false,
+	description:   "A set of permissions that can be granted to a user.",
+}
+
+func getRole(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name == "" {
+		roles, err := client.GetRoles(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &roleCollection{roles: roles}, nil
+	}
+	role, err := client.GetRole(ctx, ref.Name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	warnAboutDynamicLabelsInDenyRule(ctx, slog.Default(), role)
+	return &roleCollection{roles: []types.Role{role}}, nil
+
+}
+
+func createRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	role, err := services.UnmarshalRole(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := services.ValidateAccessPredicates(role); err != nil {
+		// check for syntax errors in predicates
+		return trace.Wrap(err)
+	}
+	err = services.CheckDynamicLabelsInDenyRules(role)
+	if trace.IsBadParameter(err) {
+		return trace.BadParameter("%s", dynamicLabelWarningMessage(role))
+	} else if err != nil {
+		return trace.Wrap(err)
+	}
+
+	warnAboutKubernetesResources(ctx, slog.Default(), role)
+
+	roleName := role.GetName()
+	_, err = client.GetRole(ctx, roleName)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	roleExists := (err == nil)
+	if roleExists && !opts.Force {
+		return trace.AlreadyExists("role %q already exists", roleName)
+	}
+	if _, err := client.UpsertRole(ctx, role); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("role %q has been %s\n", roleName, upsertVerb(roleExists, opts.Force))
+	return nil
+}
+
+func updateRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	role, err := services.UnmarshalRole(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := services.ValidateAccessPredicates(role); err != nil {
+		// check for syntax errors in predicates
+		return trace.Wrap(err)
+	}
+
+	warnAboutKubernetesResources(ctx, slog.Default(), role)
+	warnAboutDynamicLabelsInDenyRule(ctx, slog.Default(), role)
+
+	if _, err := client.UpdateRole(ctx, role); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("role %q has been updated\n", role.GetName())
+	return nil
+}
+
+// warnAboutKubernetesResources warns about kubernetes resources
+// if kubernetes_labels are set but kubernetes_resources are not.
+func warnAboutKubernetesResources(ctx context.Context, logger *slog.Logger, r types.Role) {
+	role, ok := r.(*types.RoleV6)
+	// only warn about kubernetes resources for v6 roles
+	if !ok || role.Version != types.V6 {
+		return
+	}
+	if len(role.Spec.Allow.KubernetesLabels) > 0 && len(role.Spec.Allow.KubernetesResources) == 0 {
+		logger.WarnContext(ctx, "role has allow.kubernetes_labels set but no allow.kubernetes_resources, this is probably a mistake - Teleport will restrict access to pods", "role", role.Metadata.Name)
+	}
+	if len(role.Spec.Allow.KubernetesLabels) == 0 && len(role.Spec.Allow.KubernetesResources) > 0 {
+		logger.WarnContext(ctx, "role has allow.kubernetes_resources set but no allow.kubernetes_labels, this is probably a mistake - kubernetes_resources won't be effective", "role", role.Metadata.Name)
+	}
+
+	if len(role.Spec.Deny.KubernetesLabels) > 0 && len(role.Spec.Deny.KubernetesResources) > 0 {
+		logger.WarnContext(ctx, "role has deny.kubernetes_labels set but also has deny.kubernetes_resources set, this is probably a mistake - deny.kubernetes_resources won't be effective", "role", role.Metadata.Name)
+	}
+}
+
+func deleteRole(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.DeleteRole(ctx, ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("role %q has been deleted\n", ref.Name)
+	return nil
+}
+
+func dynamicLabelWarningMessage(r types.Role) string {
+	return fmt.Sprintf("existing role %q has labels with the %q prefix in its deny rules. This is not recommended due to the volatility of %q labels and is not allowed for new roles",
+		r.GetName(), types.TeleportDynamicLabelPrefix, types.TeleportDynamicLabelPrefix)
+}
+
+// warnAboutDynamicLabelsInDenyRule warns about using dynamic/ labels in deny
+// rules. Only applies to existing roles as adding dynamic/ labels to deny
+// rules in a new role is not allowed.
+func warnAboutDynamicLabelsInDenyRule(ctx context.Context, logger *slog.Logger, r types.Role) {
+	if err := services.CheckDynamicLabelsInDenyRules(r); err == nil {
+		return
+	} else if trace.IsBadParameter(err) {
+		logger.WarnContext(ctx, "existing role has labels with the a dynamic prefix in its deny rules, this is not recommended due to the volatility of dynamic labels and is not allowed for new roles", "role", r.GetName())
+	} else {
+		logger.WarnContext(ctx, "error checking deny rules labels", "error", err)
+	}
+}

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package resources
 
 import (
@@ -76,14 +94,16 @@ func printNodeLabels(labels types.Labels) string {
 	return strings.Join(pairs, ",")
 }
 
-var roleHandler = Handler{
-	getHandler:    getRole,
-	createHandler: createRole,
-	updateHandler: updateRole,
-	deleteHandler: deleteRole,
-	singleton:     false,
-	mfaRequired:   false,
-	description:   "A set of permissions that can be granted to a user.",
+func roleHandler() Handler {
+	return Handler{
+		getHandler:    getRole,
+		createHandler: createRole,
+		updateHandler: updateRole,
+		deleteHandler: deleteRole,
+		singleton:     false,
+		mfaRequired:   false,
+		description:   "A set of permissions that can be granted to a user.",
+	}
 }
 
 func getRole(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {


### PR DESCRIPTION
This is my second attempt at fixing the tctl resource command mess.

[The first one was a PR too large to be reviewed.](https://github.com/gravitational/teleport/pull/55381) This one will happen in smaller increments.

The goal is to migrate resources one by one. Because both the old and new system will cohabitate, I cannot move every collection and resource into dedicated packages yet. Some things will stay in `tools/tctl/common` until the migration is done.

Test coverage already exists per-resource, so we'll be able to validate that tests are still passing while migrating the resources.