### PR TITLE
Add OS label for registered servers metric

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -961,6 +961,7 @@ var (
 			Help:      "The number of Teleport services that are connected to an auth server.",
 		},
 		[]string{
+			teleport.TagOS,
 			teleport.TagVersion,
 			teleport.TagAutomaticUpdates,
 		},
@@ -2079,6 +2080,7 @@ func (a *Server) updateAgentMetrics() {
 	registeredAgents.Reset()
 	for agent, count := range imp.RegisteredAgentsCount() {
 		registeredAgents.With(prometheus.Labels{
+			teleport.TagOS:               agent.os,
 			teleport.TagVersion:          agent.version,
 			teleport.TagAutomaticUpdates: agent.automaticUpdates,
 		}).Set(float64(count))

--- a/lib/auth/periodic.go
+++ b/lib/auth/periodic.go
@@ -111,6 +111,8 @@ type instanceMetricsPeriodic struct {
 
 // instanceMetadata contains instance metadata to be exported.
 type instanceMetadata struct {
+	// os is instance Operating System.
+	os string
 	// version specifies the version of the Teleport instance
 	version string
 	// installMethod specifies the Teleport agent installation method
@@ -137,6 +139,7 @@ func (i *instanceMetricsPeriodic) VisitInstance(instance *proto.UpstreamInventor
 	}
 
 	iMetadata := instanceMetadata{
+		os:              metadata.GetOS(),
 		version:         instance.GetVersion(),
 		installMethod:   installMethod,
 		upgraderType:    instance.GetExternalUpgrader(),
@@ -146,6 +149,7 @@ func (i *instanceMetricsPeriodic) VisitInstance(instance *proto.UpstreamInventor
 }
 
 type registeredAgent struct {
+	os               string
 	version          string
 	automaticUpdates string
 }
@@ -160,6 +164,7 @@ func (i *instanceMetricsPeriodic) RegisteredAgentsCount() map[registeredAgent]in
 		}
 
 		agent := registeredAgent{
+			os:               metadata.os,
 			version:          metadata.version,
 			automaticUpdates: automaticUpdates,
 		}

--- a/lib/auth/periodic_test.go
+++ b/lib/auth/periodic_test.go
@@ -20,6 +20,7 @@ package auth
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -246,9 +247,9 @@ func TestRegisteredAgentsCounts(t *testing.T) {
 				{Version: "15.0.0"},
 			},
 			expected: map[registeredAgent]int{
-				{"13.0.0", "false"}: 1,
-				{"14.0.0", "false"}: 1,
-				{"15.0.0", "false"}: 1,
+				{runtime.GOOS, "13.0.0", "false"}: 1,
+				{runtime.GOOS, "14.0.0", "false"}: 1,
+				{runtime.GOOS, "15.0.0", "false"}: 1,
 			},
 		},
 		{
@@ -265,12 +266,12 @@ func TestRegisteredAgentsCounts(t *testing.T) {
 				{Version: "15.0.0"},
 			},
 			expected: map[registeredAgent]int{
-				{"13.0.0", "true"}:  2,
-				{"13.0.0", "false"}: 1,
-				{"14.0.0", "true"}:  2,
-				{"14.0.0", "false"}: 1,
-				{"15.0.0", "true"}:  2,
-				{"15.0.0", "false"}: 1,
+				{runtime.GOOS, "13.0.0", "true"}:  2,
+				{runtime.GOOS, "13.0.0", "false"}: 1,
+				{runtime.GOOS, "14.0.0", "true"}:  2,
+				{runtime.GOOS, "14.0.0", "false"}: 1,
+				{runtime.GOOS, "15.0.0", "true"}:  2,
+				{runtime.GOOS, "15.0.0", "false"}: 1,
 			},
 		},
 	}
@@ -279,7 +280,9 @@ func TestRegisteredAgentsCounts(t *testing.T) {
 			periodic := newInstanceMetricsPeriodic()
 
 			for _, instance := range tt.instance {
-				periodic.VisitInstance(instance, new(proto.UpstreamInventoryAgentMetadata))
+				periodic.VisitInstance(instance, &proto.UpstreamInventoryAgentMetadata{
+					OS: runtime.GOOS,
+				})
 			}
 			require.Equal(t, tt.expected, periodic.RegisteredAgentsCount(), "tt=%q", tt.desc)
 		})

--- a/metrics.go
+++ b/metrics.go
@@ -313,6 +313,10 @@ const (
 	// TagVersion is a prometheus label for version of Teleport built
 	TagVersion = "version"
 
+	// TagOS is a prometheus label for indicating the Operating System
+	// where agent is running (e.g. Darwin, Linux).
+	TagOS = "os"
+
 	// TagGitref is a prometheus label for the gitref of Teleport built
 	TagGitref = "gitref"
 


### PR DESCRIPTION
In this PR added Operation System label for registered servers

Example:
```
# HELP teleport_registered_servers The number of Teleport services that are connected to an auth server.
# TYPE teleport_registered_servers gauge
teleport_registered_servers{automatic_updates="false",os="darwin",version="19.0.0-dev"} 1
```

Related: https://github.com/gravitational/cloud/issues/14225