### PR TITLE
[v18] Remove unused `resource_ids` field

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/access_request.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/access_request.pb.go
@@ -56,10 +56,8 @@ type AccessRequest struct {
 	SuggestedReviewers []string               `protobuf:"bytes,10,rep,name=suggested_reviewers,json=suggestedReviewers,proto3" json:"suggested_reviewers,omitempty"`
 	// thresholds specifies minimum amount of approvers or deniers. Defaults to 'default'
 	ThresholdNames []string `protobuf:"bytes,11,rep,name=threshold_names,json=thresholdNames,proto3" json:"threshold_names,omitempty"`
-	// TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-	// a list of resourceIDs requested in the AccessRequest
-	ResourceIds []*ResourceID `protobuf:"bytes,12,rep,name=resource_ids,json=resourceIds,proto3" json:"resource_ids,omitempty"`
-	Resources   []*Resource   `protobuf:"bytes,13,rep,name=resources,proto3" json:"resources,omitempty"`
+	// List of requested resources.
+	Resources []*Resource `protobuf:"bytes,13,rep,name=resources,proto3" json:"resources,omitempty"`
 	// promoted_access_list_title is the title of the access
 	// list that this access request was promoted to.
 	PromotedAccessListTitle string `protobuf:"bytes,14,opt,name=promoted_access_list_title,json=promotedAccessListTitle,proto3" json:"promoted_access_list_title,omitempty"`
@@ -185,13 +183,6 @@ func (x *AccessRequest) GetSuggestedReviewers() []string {
 func (x *AccessRequest) GetThresholdNames() []string {
 	if x != nil {
 		return x.ThresholdNames
-	}
-	return nil
-}
-
-func (x *AccessRequest) GetResourceIds() []*ResourceID {
-	if x != nil {
-		return x.ResourceIds
 	}
 	return nil
 }
@@ -528,7 +519,7 @@ var File_teleport_lib_teleterm_v1_access_request_proto protoreflect.FileDescript
 
 const file_teleport_lib_teleterm_v1_access_request_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/lib/teleterm/v1/access_request.proto\x12\x18teleport.lib.teleterm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xcd\a\n" +
+	"-teleport/lib/teleterm/v1/access_request.proto\x12\x18teleport.lib.teleterm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x98\a\n" +
 	"\rAccessRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12%\n" +
@@ -541,8 +532,7 @@ const file_teleport_lib_teleterm_v1_access_request_proto_rawDesc = "" +
 	"\areviews\x18\t \x03(\v2-.teleport.lib.teleterm.v1.AccessRequestReviewR\areviews\x12/\n" +
 	"\x13suggested_reviewers\x18\n" +
 	" \x03(\tR\x12suggestedReviewers\x12'\n" +
-	"\x0fthreshold_names\x18\v \x03(\tR\x0ethresholdNames\x12G\n" +
-	"\fresource_ids\x18\f \x03(\v2$.teleport.lib.teleterm.v1.ResourceIDR\vresourceIds\x12@\n" +
+	"\x0fthreshold_names\x18\v \x03(\tR\x0ethresholdNames\x12@\n" +
 	"\tresources\x18\r \x03(\v2\".teleport.lib.teleterm.v1.ResourceR\tresources\x12;\n" +
 	"\x1apromoted_access_list_title\x18\x0e \x01(\tR\x17promotedAccessListTitle\x12F\n" +
 	"\x11assume_start_time\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\x0fassumeStartTime\x12=\n" +
@@ -553,7 +543,7 @@ const file_teleport_lib_teleterm_v1_access_request_proto_rawDesc = "" +
 	"sessionTtl\x12\x1f\n" +
 	"\vreason_mode\x18\x13 \x01(\tR\n" +
 	"reasonMode\x12%\n" +
-	"\x0ereason_prompts\x18\x14 \x03(\tR\rreasonPrompts\"\xac\x02\n" +
+	"\x0ereason_prompts\x18\x14 \x03(\tR\rreasonPromptsJ\x04\b\f\x10\rR\fresource_ids\"\xac\x02\n" +
 	"\x13AccessRequestReview\x12\x16\n" +
 	"\x06author\x18\x01 \x01(\tR\x06author\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x14\n" +
@@ -600,21 +590,20 @@ var file_teleport_lib_teleterm_v1_access_request_proto_depIdxs = []int32{
 	5,  // 0: teleport.lib.teleterm.v1.AccessRequest.created:type_name -> google.protobuf.Timestamp
 	5,  // 1: teleport.lib.teleterm.v1.AccessRequest.expires:type_name -> google.protobuf.Timestamp
 	1,  // 2: teleport.lib.teleterm.v1.AccessRequest.reviews:type_name -> teleport.lib.teleterm.v1.AccessRequestReview
-	2,  // 3: teleport.lib.teleterm.v1.AccessRequest.resource_ids:type_name -> teleport.lib.teleterm.v1.ResourceID
-	4,  // 4: teleport.lib.teleterm.v1.AccessRequest.resources:type_name -> teleport.lib.teleterm.v1.Resource
-	5,  // 5: teleport.lib.teleterm.v1.AccessRequest.assume_start_time:type_name -> google.protobuf.Timestamp
-	5,  // 6: teleport.lib.teleterm.v1.AccessRequest.max_duration:type_name -> google.protobuf.Timestamp
-	5,  // 7: teleport.lib.teleterm.v1.AccessRequest.request_ttl:type_name -> google.protobuf.Timestamp
-	5,  // 8: teleport.lib.teleterm.v1.AccessRequest.session_ttl:type_name -> google.protobuf.Timestamp
-	5,  // 9: teleport.lib.teleterm.v1.AccessRequestReview.created:type_name -> google.protobuf.Timestamp
-	5,  // 10: teleport.lib.teleterm.v1.AccessRequestReview.assume_start_time:type_name -> google.protobuf.Timestamp
-	2,  // 11: teleport.lib.teleterm.v1.Resource.id:type_name -> teleport.lib.teleterm.v1.ResourceID
-	3,  // 12: teleport.lib.teleterm.v1.Resource.details:type_name -> teleport.lib.teleterm.v1.ResourceDetails
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	4,  // 3: teleport.lib.teleterm.v1.AccessRequest.resources:type_name -> teleport.lib.teleterm.v1.Resource
+	5,  // 4: teleport.lib.teleterm.v1.AccessRequest.assume_start_time:type_name -> google.protobuf.Timestamp
+	5,  // 5: teleport.lib.teleterm.v1.AccessRequest.max_duration:type_name -> google.protobuf.Timestamp
+	5,  // 6: teleport.lib.teleterm.v1.AccessRequest.request_ttl:type_name -> google.protobuf.Timestamp
+	5,  // 7: teleport.lib.teleterm.v1.AccessRequest.session_ttl:type_name -> google.protobuf.Timestamp
+	5,  // 8: teleport.lib.teleterm.v1.AccessRequestReview.created:type_name -> google.protobuf.Timestamp
+	5,  // 9: teleport.lib.teleterm.v1.AccessRequestReview.assume_start_time:type_name -> google.protobuf.Timestamp
+	2,  // 10: teleport.lib.teleterm.v1.Resource.id:type_name -> teleport.lib.teleterm.v1.ResourceID
+	3,  // 11: teleport.lib.teleterm.v1.Resource.details:type_name -> teleport.lib.teleterm.v1.ResourceDetails
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_teleterm_v1_access_request_proto_init() }

--- a/gen/proto/go/teleport/lib/teleterm/v1/service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/service.pb.go
@@ -700,8 +700,7 @@ type CreateAccessRequestRequest struct {
 	Roles []string `protobuf:"bytes,3,rep,name=roles,proto3" json:"roles,omitempty"`
 	// suggested_reviewers is a suggested list of reviewers that can review a request.
 	SuggestedReviewers []string `protobuf:"bytes,4,rep,name=suggested_reviewers,json=suggestedReviewers,proto3" json:"suggested_reviewers,omitempty"`
-	// TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-	// a list of resourceIDs requested in the AccessRequest
+	// List of resources to which access is being requested.
 	ResourceIds []*ResourceID `protobuf:"bytes,5,rep,name=resource_ids,json=resourceIds,proto3" json:"resource_ids,omitempty"`
 	// assume_start_time is the time after which the requested access can be assumed.
 	AssumeStartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=assume_start_time,json=assumeStartTime,proto3" json:"assume_start_time,omitempty"`

--- a/gen/proto/ts/teleport/lib/teleterm/v1/access_request_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/access_request_pb.ts
@@ -88,13 +88,8 @@ export interface AccessRequest {
      */
     thresholdNames: string[];
     /**
-     * TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-     * a list of resourceIDs requested in the AccessRequest
+     * List of requested resources.
      *
-     * @generated from protobuf field: repeated teleport.lib.teleterm.v1.ResourceID resource_ids = 12;
-     */
-    resourceIds: ResourceID[];
-    /**
      * @generated from protobuf field: repeated teleport.lib.teleterm.v1.Resource resources = 13;
      */
     resources: Resource[];
@@ -254,7 +249,6 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
             { no: 9, name: "reviews", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => AccessRequestReview },
             { no: 10, name: "suggested_reviewers", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 11, name: "threshold_names", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 12, name: "resource_ids", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => ResourceID },
             { no: 13, name: "resources", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Resource },
             { no: 14, name: "promoted_access_list_title", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 15, name: "assume_start_time", kind: "message", T: () => Timestamp },
@@ -276,7 +270,6 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
         message.reviews = [];
         message.suggestedReviewers = [];
         message.thresholdNames = [];
-        message.resourceIds = [];
         message.resources = [];
         message.promotedAccessListTitle = "";
         message.reasonMode = "";
@@ -322,9 +315,6 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
                     break;
                 case /* repeated string threshold_names */ 11:
                     message.thresholdNames.push(reader.string());
-                    break;
-                case /* repeated teleport.lib.teleterm.v1.ResourceID resource_ids */ 12:
-                    message.resourceIds.push(ResourceID.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 case /* repeated teleport.lib.teleterm.v1.Resource resources */ 13:
                     message.resources.push(Resource.internalBinaryRead(reader, reader.uint32(), options));
@@ -395,9 +385,6 @@ class AccessRequest$Type extends MessageType<AccessRequest> {
         /* repeated string threshold_names = 11; */
         for (let i = 0; i < message.thresholdNames.length; i++)
             writer.tag(11, WireType.LengthDelimited).string(message.thresholdNames[i]);
-        /* repeated teleport.lib.teleterm.v1.ResourceID resource_ids = 12; */
-        for (let i = 0; i < message.resourceIds.length; i++)
-            ResourceID.internalBinaryWrite(message.resourceIds[i], writer.tag(12, WireType.LengthDelimited).fork(), options).join();
         /* repeated teleport.lib.teleterm.v1.Resource resources = 13; */
         for (let i = 0; i < message.resources.length; i++)
             Resource.internalBinaryWrite(message.resources[i], writer.tag(13, WireType.LengthDelimited).fork(), options).join();

--- a/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
@@ -184,8 +184,7 @@ export interface CreateAccessRequestRequest {
      */
     suggestedReviewers: string[];
     /**
-     * TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-     * a list of resourceIDs requested in the AccessRequest
+     * List of resources to which access is being requested.
      *
      * @generated from protobuf field: repeated teleport.lib.teleterm.v1.ResourceID resource_ids = 5;
      */

--- a/lib/teleterm/apiserver/handler/handler_access_requests.go
+++ b/lib/teleterm/apiserver/handler/handler_access_requests.go
@@ -175,15 +175,7 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 		}
 	}
 
-	requestedResourceIDs := make([]*api.ResourceID, 0, len(req.GetRequestedResourceIDs()))
-	for _, r := range req.GetRequestedResourceIDs() {
-		requestedResourceIDs = append(requestedResourceIDs, &api.ResourceID{
-			ClusterName:     r.ClusterName,
-			Kind:            r.Kind,
-			Name:            r.Name,
-			SubResourceName: r.SubResourceName,
-		})
-	}
+	requestedResourceIDs := req.GetRequestedResourceIDs()
 	resources := make([]*api.Resource, len(requestedResourceIDs))
 	for i, r := range requestedResourceIDs {
 		details := req.ResourceDetails[resourceIDToString(r)]
@@ -218,7 +210,6 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 		Reviews:                 reviews,
 		SuggestedReviewers:      req.GetSuggestedReviewers(),
 		ThresholdNames:          thresholdNames,
-		ResourceIds:             requestedResourceIDs,
 		Resources:               resources,
 		PromotedAccessListTitle: req.GetPromotedAccessListTitle(),
 		AssumeStartTime:         getProtoTimestamp(req.GetAssumeStartTime()),
@@ -231,7 +222,7 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 }
 
 // resourceIDToString marshals a ResourceID to a string.
-func resourceIDToString(id *api.ResourceID) string {
+func resourceIDToString(id types.ResourceID) string {
 	if id.SubResourceName == "" {
 		return fmt.Sprintf("/%s/%s/%s", id.ClusterName, id.Kind, id.Name)
 	}

--- a/proto/teleport/lib/teleterm/v1/access_request.proto
+++ b/proto/teleport/lib/teleterm/v1/access_request.proto
@@ -40,9 +40,9 @@ message AccessRequest {
   repeated string suggested_reviewers = 10;
   // thresholds specifies minimum amount of approvers or deniers. Defaults to 'default'
   repeated string threshold_names = 11;
-  // TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-  // a list of resourceIDs requested in the AccessRequest
-  repeated ResourceID resource_ids = 12;
+  reserved "resource_ids";
+  reserved 12;
+  // List of requested resources.
   repeated Resource resources = 13;
   // promoted_access_list_title is the title of the access
   // list that this access request was promoted to.

--- a/proto/teleport/lib/teleterm/v1/service.proto
+++ b/proto/teleport/lib/teleterm/v1/service.proto
@@ -260,8 +260,7 @@ message CreateAccessRequestRequest {
   repeated string roles = 3;
   // suggested_reviewers is a suggested list of reviewers that can review a request.
   repeated string suggested_reviewers = 4;
-  // TODO(avatus) remove the resource_ids field once the changes to rely on resources instead is merged
-  // a list of resourceIDs requested in the AccessRequest
+  // List of resources to which access is being requested.
   repeated ResourceID resource_ids = 5;
   // assume_start_time is the time after which the requested access can be assumed.
   google.protobuf.Timestamp assume_start_time = 6;

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -341,14 +341,6 @@ export const makeAccessRequest = (
   reviews: [],
   suggestedReviewers: ['admin', 'reviewer'],
   thresholdNames: ['default'],
-  resourceIds: [
-    {
-      kind: 'kube_cluster',
-      name: 'minikube',
-      clusterName: 'main',
-      subResourceName: '',
-    },
-  ],
   resources: [
     {
       id: {

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.story.tsx
@@ -85,7 +85,6 @@ const resourceIds: ResourceID[] = [
 const smallAccessRequest = makeAccessRequest();
 const mediumAccessRequest = makeAccessRequest({
   id: '11929070-6886-77eb-90aa-c7223dd735',
-  resourceIds: resourceIds.slice(0, 4),
   resources: resourceIds.slice(0, 4).map(id => ({
     id,
     details: { friendlyName: '', hostname: '' },
@@ -93,7 +92,6 @@ const mediumAccessRequest = makeAccessRequest({
 });
 const largeAccessRequest = makeAccessRequest({
   id: '11929070-6886-77eb-90aa-c7223dd735',
-  resourceIds,
   resources: resourceIds.map(id => ({
     id,
     details: { friendlyName: '', hostname: '' },

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
@@ -54,14 +54,6 @@ const mockedAccessRequest: AccessRequest = {
   reviews: [],
   suggestedReviewers: ['admin', 'reviewer'],
   thresholdNames: ['default'],
-  resourceIds: [
-    {
-      kind: 'kube_cluster',
-      name: 'minikube',
-      clusterName: 'main',
-      subResourceName: '',
-    },
-  ],
   resources: [
     {
       id: {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.test.tsx
@@ -44,7 +44,6 @@ test('makeUiAccessRequest', async () => {
     ],
     suggestedReviewers: ['sugested-reviewer-1'],
     thresholdNames: ['default'],
-    resourceIds: [],
     resources: [
       {
         id: {


### PR DESCRIPTION
Backport #59065 to branch/v18