### PR TITLE
[v16] Unified resources card: Add a gap between the name and the button

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -212,7 +212,7 @@ export function ResourceCard({
           />
           {/* MinWidth is important to prevent descriptions from overflowing. */}
           <Flex flexDirection="column" flex="1" minWidth="0" ml={3} gap={1}>
-            <Flex flexDirection="row" alignItems="center">
+            <Flex flexDirection="row" alignItems="center" gap={1}>
               <SingleLineBox flex="1">
                 <HoverTooltip tipContent={name} showOnlyOnOverflow>
                   <Text typography="h5" fontWeight={300}>
@@ -220,7 +220,7 @@ export function ResourceCard({
                   </Text>
                 </HoverTooltip>
               </SingleLineBox>
-              {hovered && <CopyButton name={name} mr={2} />}
+              {hovered && <CopyButton name={name} />}
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
               </ResourceActionButtonWrapper>


### PR DESCRIPTION
Backport #59416 to branch/v16

I verified using Storybook that this looks fine on v16.