### PR TITLE
Tag docs pages with `sso`

### DIFF
--- a/docs/pages/reference/access-controls/login-rules.mdx
+++ b/docs/pages/reference/access-controls/login-rules.mdx
@@ -4,6 +4,7 @@ sidebar_label: Login Rules
 description: Reference documentation for Login Rules
 tocDepth: 3
 tags:
+ - sso
  - conceptual
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/authentication/login-rules/guide.mdx
+++ b/docs/pages/zero-trust-access/authentication/login-rules/guide.mdx
@@ -2,6 +2,7 @@
 title: Set Up Login Rules 
 description: Set up Login Rules to transform user traits
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/authentication/login-rules/login-rules.mdx
+++ b/docs/pages/zero-trust-access/authentication/login-rules/login-rules.mdx
@@ -3,6 +3,7 @@ title: Login Rules
 description: Transform User Traits with Login Rules
 layout: tocless-doc
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
@@ -2,6 +2,7 @@
 title: Deploy Login Rules via Terraform 
 description: Use Teleport's Terraform Provider to deploy Login Rules to your cluster
 tags:
+ - sso
  - how-to
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
@@ -2,6 +2,7 @@
 title: Teleport Role Templates
 description: This guide explains templating in Teleport roles. Templates allow you to enable access to resources depending on the traits of a local or single sign-on user.
 tags:
+ - sso
  - conceptual
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -3,6 +3,7 @@ title: SSO with Active Directory Federation Services
 description: How to configure Teleport access with Active Directory Federation Services
 h1: Single Sign-On with Active Directory Federation Services
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -2,6 +2,7 @@
 title: Teleport Authentication with Microsoft Entra ID (SAML)
 description: How to configure Teleport access with Microsoft Entra ID (formerly Azure AD) as a SAML identity provider.
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/github-sso.mdx
@@ -3,6 +3,7 @@ title: Set up Single Sign-On with GitHub
 description: Setting up GitHub SSO
 videoBanner: XjgN2WWFCX8
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -3,6 +3,7 @@ title: Authentication With GitLab as an SSO provider
 description: How to configure Teleport access using GitLab for SSO
 h1: Teleport SSO Authentication with GitLab
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -3,6 +3,7 @@ title: Teleport Authentication with Google Workspace (G Suite)
 description: How to configure Teleport access with Google Workspace (formerly known as G Suite)
 videoBanner: WTLWc6nnPfk
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/keycloak.mdx
@@ -2,6 +2,7 @@
 title: Teleport Authentication with Keycloak
 description: How to configure Teleport access with Keycloak
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -2,6 +2,7 @@
 title: OAuth2 and OIDC authentication
 description: How to configure Teleport access with OAuth2 or OpenID connect (OIDC)
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -3,6 +3,7 @@ title: Authentication With Okta as an SSO Provider
 description: How to configure Teleport access using Okta for SSO
 videoBanner: SM4Am-i8cj4
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -3,6 +3,7 @@ title: Teleport Authentication with OneLogin as an SSO Provider
 description: How to configure Teleport access using OneLogin as an SSO provider
 h1: Teleport Authentication with OneLogin
 tags:
+ - sso
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -2,6 +2,7 @@
 title: Configure Single Sign-On
 description: How to set up single sign-on (SSO) using Teleport
 tags:
+ - sso
  - conceptual
  - zero-trust
  - privileged-access


### PR DESCRIPTION
Using Teleport to enable authentication with a single sign-on provider is a common use case. Tag pages with this use case so users can find related pages when looking for SSO content.