### PR TITLE
[v17] Ensure docs pages have intro paragraphs

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -1,3 +1,7 @@
+{/* Disable page structure linting because the changelog is the only page of its
+kind and should not be subject to general structural requirements */}
+{/* lint disable page-structure remark-lint */}
+{/*lint disable absolute-docs-links*/}
 ---
 title: Teleport Changelog
 description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
@@ -5,6 +9,5 @@ tags:
  - reference
  - platform-wide
 ---
-{/*lint disable absolute-docs-links*/}
 
 (!CHANGELOG.md!)

--- a/docs/pages/identity-governance/device-trust/device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/device-trust.mdx
@@ -9,10 +9,6 @@ tags:
  - identity-governance
 ---
 
-(!docs/pages/includes/device-trust/support-notice.mdx!)
-
-## Concepts
-
 Device Trust allows Teleport admins to enforce the use of trusted devices.
 Resources protected by the device mode "required" will enforce the use of a
 trusted device, in addition to establishing the user's identity and enforcing
@@ -26,6 +22,8 @@ Device Trust requires two of the following steps to have been configured:
 
 Categorically, we define these two requirements as Trusted Device management
 and Device Trust enforcement.
+
+(!docs/pages/includes/device-trust/support-notice.mdx!)
 
 ## Trusted Device management
 

--- a/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
@@ -6,7 +6,7 @@ labels:
  - mwi
 ---
 
-## Enforce access and privileges for agents
+With Teleport, you can enforce access and privileges for agents.
 
 Security must be enforced deterministically; AI agents cannot be trusted to follow high-level instructions like "don't delete production". 
 Teleport solves this by issuing each agent its own identity and requiring the agent's actions (for example, database queries) to flow through the Teleport proxy. 
@@ -15,7 +15,7 @@ This allows Teleport to apply Role-Based Access Control (RBAC) at both the netwo
 Teleport can secure any type of infrastructure it supports, such as SSH servers, Kubernetes clusters, databases, or MCP servers, when accessed by agents. 
 All queries, commands, and requests executed by the agent are logged, providing full visibility and [auditability](/reference/monitoring/audit.mdx).
 
-## Interested in a Design Partnership?
+## Interested in a design partnership?
 
 <Admonition type="tip" title="Exploring AI Agents with MWI?">
 If you're exploring how to secure AI Agents with Teleport Machine & Workload Identity, we'd love to hear from you. 

--- a/docs/pages/model-context-preview.mdx
+++ b/docs/pages/model-context-preview.mdx
@@ -7,8 +7,6 @@ tags:
  - zero-trust
 ---
 
-## Coming Soon
-
 Secure Large Language Model (LLM) interactions with infrastructure using Teleport's secure 
 [Model Context Protocol](https://goteleport.com/use-cases/secure-model-context-protocol/) (MCP), 
 delivering fine-grained access control and audit between LLMs and data sources or MCP servers.

--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_access_list` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_access_monitoring_rule` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/app.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_app` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_auth_preference` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/autoupdate_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_autoupdate_config` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/autoupdate_version.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_autoupdate_version` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_cluster_maintenance_config` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_cluster_networking_config` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_database` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_dynamic_windows_desktop` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_github_connector` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/installer.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_installer` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_login_rule` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_oidc_connector` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_okta_import_rule` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_provision_token` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_role` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_saml_connector` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_session_recording_config` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/static_host_user.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_static_host_user` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_trusted_cluster` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_trusted_device` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/user.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_user` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/workload_identity.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the `teleport_workload_identity` data source of the
+Teleport Terraform provider.
+
 
 
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -209,4 +212,3 @@ Optional:
 
 - `key` (String) key is the name of the trait.
 - `values` (List of String) values is the list of trait values.
-

--- a/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -76,4 +79,3 @@ Optional:
 - `description` (String) description is object description.
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
-

--- a/docs/pages/reference/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/terraform-provider/resources/app.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -146,4 +149,3 @@ Optional:
 
 - `end_port` (Number) EndPort describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.
 - `port` (Number) Port describes the start of the range. It must be between 1 and 65535.
-

--- a/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -153,4 +156,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/autoupdate_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -113,4 +116,3 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `name` (String) name is an object name.
-

--- a/docs/pages/reference/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/terraform-provider/resources/autoupdate_version.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -77,4 +80,3 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `name` (String) name is an object name.
-

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -69,4 +72,3 @@ resource "teleport_bot" "example" {
 
 - `role_name` (String) The name of the generated bot role
 - `user_name` (String) The name of the generated bot user
-

--- a/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -67,4 +70,3 @@ Optional:
 
 - `utc_start_hour` (Number) UTCStartHour is the start hour of the maintenance window in UTC.
 - `weekdays` (List of String) Weekdays is an optional list of weekdays. If not specified, an agent upgrade window occurs every day.
-

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -89,4 +92,3 @@ Optional:
 Optional:
 
 - `agent_connection_count` (Number)
-

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -271,4 +274,3 @@ Optional:
 - `mode` (Number) Mode is a TLS connection mode. 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
 - `server_name` (String) ServerName allows to provide custom hostname. This value will override the servername/hostname on a certificate during validation.
 - `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the ca_cert specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
-

--- a/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -82,4 +85,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/github_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -116,4 +119,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/resources/installer.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -119,4 +122,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/login_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -83,4 +86,3 @@ Optional:
 Optional:
 
 - `values` (List of String)
-

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -123,4 +126,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -125,4 +128,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -404,4 +407,3 @@ Optional:
 - `last_rotated_at` (String) LastRotatedAt contains a timestamp of the last time the keypair was rotated, if any. This is not set at initial join.
 - `recovery_count` (Number) RecoveryCount is a count of the total number of recoveries performed using this token. It is incremented for every successful join or rejoin. Recovery is only allowed if this value is less than `.spec.bound_keypair.recovery.limit`, or if the recovery mode is `relaxed` or `insecure`.
 - `registration_secret` (String) RegistrationSecret contains a secret value that may be used for public key registration during the initial join process if no public key is preregistered. If `.spec.bound_keypair.onboarding.initial_public_key` is set, this field will remain empty. Otherwise, if `.spec.bound_keypair.onboarding.registration_secret` is set, that value will be copied here. If that field is unset, a value will be randomly generated.
-

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -594,4 +597,3 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
-

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -158,4 +161,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/terraform-provider/resources/server.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -145,4 +148,3 @@ Optional:
 - `standby` (String) Standby specifies time to switch to the "Standby" phase.
 - `update_clients` (String) UpdateClients specifies time to switch to the "Update clients" phase
 - `update_servers` (String) UpdateServers specifies time to switch to the "Update servers" phase.
-

--- a/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -61,4 +64,3 @@ Optional:
 
 - `mode` (String) Mode controls where (or if) the session is recorded.
 - `proxy_checks_host_keys` (Boolean) ProxyChecksHostKeys is used to control if the proxy will check host keys when in recording mode.
-

--- a/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -92,4 +95,3 @@ Required:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
-

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -82,4 +85,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -64,4 +67,3 @@ Optional:
 
 - `name` (String)
 - `origin` (String)
-

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -136,4 +139,3 @@ Optional:
 
 - `mfa_weakest_device` (Number) mfa_weakest_device reflects what the system knows about the user's weakest MFA device. Note that this is a "best effort" property, in that it can be UNSPECIFIED.
 - `password_state` (Number) password_state reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
-

--- a/docs/pages/reference/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/terraform-provider/resources/workload_identity.mdx
@@ -10,6 +10,9 @@ tags:
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -153,4 +156,3 @@ Optional:
 - `common_name` (String) Common Name (CN) - 2.5.4.3 If empty, the RDN will be omitted from the DN.
 - `organization` (String) Organization (O) - 2.5.4.10 If empty, the RDN will be omitted from the DN.
 - `organizational_unit` (String) Organizational Unit (OU) - 2.5.4.11 If empty, the RDN will be omitted from the DN.
-

--- a/integrations/terraform/examples/resources/teleport_database/introduction.md
+++ b/integrations/terraform/examples/resources/teleport_database/introduction.md
@@ -1,0 +1,2 @@
+Follow [the database dynamic registration guide](../../../enroll-resources/database-access/guides/dynamic-registration.mdx)
+to complete deploying a database_service and access the database resource

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -5,9 +5,6 @@ go 1.24.7
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced
 
-// using our own fork
-replace github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6
-
 // TF provider dependencies
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -538,3 +535,9 @@ replace (
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.4
 )
+
+// Doc generation tooling.
+// (using our fork of github.com/hashicorp/terraform-plugin-docs)
+tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+
+replace github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -1458,8 +1458,8 @@ github.com/gravitational/roundtrip v1.0.2 h1:eOCY0NEKKaB0ksJmvhO6lPMFz1pIIef+vyP
 github.com/gravitational/roundtrip v1.0.2/go.mod h1:fuI1booM2hLRA/B/m5MRAPOU6mBZNYcNycono2UuTw0=
 github.com/gravitational/spdystream v0.0.0-20230512133543-4e46862ca9bf h1:aXnqDSit8L1qhI0+QdbJh+MTUFKXG7qbkZXnfr7L96A=
 github.com/gravitational/spdystream v0.0.0-20230512133543-4e46862ca9bf/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
-github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6 h1:roGf4UO3jjf/vv2fc+ChlWFPISFMkRXFwBUKEtjH3uY=
-github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
+github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf h1:bAsFak60gi442t2x3GuDp5Fww47zUs460NFIPiQJjzg=
+github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
 github.com/gravitational/trace v1.5.0 h1:JbeL2HDGyzgy7G72Z2hP2gExEyA6Y2p7fCiSjyZwCJw=
 github.com/gravitational/trace v1.5.0/go.mod h1:dxezSkKm880IIDx+czWG8fq+pLnXjETBewMgN3jOBlg=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -10,6 +10,9 @@ tags:
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
+This page describes the supported values of the `{{.Name}}` data source of the
+Teleport Terraform provider.
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -10,6 +10,9 @@ tags:
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
+This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
+{{ includefileifexists (printf "./examples/resources/%s/introduction.md" .Name)}}
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}
@@ -27,4 +30,3 @@ Import is supported using the following syntax:
 
 {{codefile "shell" .ImportFile }}
 {{- end }}
-


### PR DESCRIPTION
Prepare the docs for the intro paragraph linter proposed by gravitational/docs-website#383. This replaces the Vale-based intro paragraph linter, which cannot be ignored in comments due to the `raw` scope, with one based on `remark`, which can.

- Add an intro paragraph to each Terraform data source reference. To do so, edit the data source template to use the approach of the resource template, including an intro paragraph with the data source's name.
- Ignore the page-structure linter in the changelog. This needs to happen before the frontmatter block, since, because of the way `remark-includes` works, AST node line numbering is preserved within included partials.
- Get the Device Trust Concepts guide to conform to the expected structure. Currently, it begins with an Admonition, leaving it unclear what the guide is about. Also edit the AI Agent guide.
- Remove the Vale linter for intro paragraphs, since we will add a `remark`-based linter in gravitational/docs-website#383.

Also backports #53474 to add intro paragraphs to Terraform resource reference pages.

Support adding introduction text into Terraform reference pages

* TF docs: add introduction support in generic template

* TF docs: link database guide