### PR TITLE
Fix dial failures for peered tunnels

### DIFF
--- a/lib/reversetunnelclient/peer.go
+++ b/lib/reversetunnelclient/peer.go
@@ -49,7 +49,8 @@ func NewPeerDialer(clusterGetter ClusterGetter) PeerDialerFunc {
 			FromPeerProxy: true,
 		}
 
-		conn, err := site.Dial(dialParams)
+		// peered dials should be passthru so we call [localCluster.DialTCP] directly
+		conn, err := site.DialTCP(dialParams)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
This PR immediately dials for peered connections instead of trying to inspect the `TargetServer`. This fixes an issue where SSH nodes were not reachable when using proxy peering and dialing through any proxy other than the one holding the node's connection.