### PR TITLE
[v18] Fix dial failures for peered tunnels

### DIFF
--- a/lib/reversetunnelclient/peer.go
+++ b/lib/reversetunnelclient/peer.go
@@ -49,7 +49,8 @@ func NewPeerDialer(clusterGetter ClusterGetter) PeerDialerFunc {
 			FromPeerProxy: true,
 		}
 
-		conn, err := site.Dial(dialParams)
+		// peered dials should be passthru so we call [localCluster.DialTCP] directly
+		conn, err := site.DialTCP(dialParams)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Backports #59555 for branch/v18

changelog: Fixed an issue that prevented connecting to agents over peered tunnels when proxy peering was enabled.