### PR TITLE
[v17] Fix dial failures for peered tunnels

### DIFF
--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -66,6 +66,8 @@ type proxyTunnelStrategy struct {
 	postgresDB   *postgres.TestServer
 
 	log *logrus.Logger
+
+	expectedTunnels int
 }
 
 func newProxyTunnelStrategy(t *testing.T, cluster string, strategy *types.TunnelStrategyV1) *proxyTunnelStrategy {
@@ -154,9 +156,15 @@ func TestProxyTunnelStrategyAgentMesh(t *testing.T) {
 
 // TestProxyTunnelStrategyProxyPeering tests the proxy-peer tunnel strategy.
 func TestProxyTunnelStrategyProxyPeering(t *testing.T) {
-	// TODO(jakule): Fix the test.
-	t.Skip("this test is flaky as it very sensitive to our timeouts")
+	// NOTE(eriktate): Testing database tunnels appears to be flaky (or possibly never works?)
+	// so we currently skip adding a database altogether in order to ensure peered tunnels have
+	// some automatic test coverage. Gating this behind a flag in case we want to restore the
+	// database portion of the test at some point.
+	withDB := false
+	testProxyTunnelStrategyProxyPeering(t, withDB)
+}
 
+func testProxyTunnelStrategyProxyPeering(t *testing.T, withDB bool) {
 	// This test cannot run in parallel as set module changes the global state.
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestBuildType: modules.BuildEnterprise,
@@ -188,11 +196,13 @@ func TestProxyTunnelStrategyProxyPeering(t *testing.T) {
 	// bootstrap a node instance.
 	p.makeNode(t)
 
-	// bootstrap a db instance.
-	p.makeDatabase(t)
+	if withDB {
+		// bootstrap a db instance.
+		p.makeDatabase(t)
+	}
 
 	// wait for the node and db to open reverse tunnels to the first proxy.
-	helpers.WaitForActiveTunnelConnections(t, p.proxies[0].Tunnel, p.cluster, 2)
+	helpers.WaitForActiveTunnelConnections(t, p.proxies[0].Tunnel, p.cluster, p.expectedTunnels)
 
 	// bootstrap the second proxy instance after the node and db have already
 	// established reverse tunnels to the first proxy.
@@ -207,9 +217,11 @@ func TestProxyTunnelStrategyProxyPeering(t *testing.T) {
 	p.waitForNodeToBeReachable(t)
 	p.dialNode(t)
 
-	// make sure we can connect to the database going through any proxy.
-	p.waitForDatabaseToBeReachable(t)
-	p.dialDatabase(t)
+	if withDB {
+		// make sure we can connect to the database going through any proxy.
+		p.waitForDatabaseToBeReachable(t)
+		p.dialDatabase(t)
+	}
 }
 
 // dialNode starts a client conn to a node reachable through a specific proxy.
@@ -402,6 +414,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 	require.NoError(t, node.Start())
 
 	p.node = node
+	p.expectedTunnels += 1
 }
 
 // makeDatabase bootstraps a new teleport db instance.
@@ -491,6 +504,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 	p.db = db
 	p.dbAuthClient = client
 	p.postgresDB = postgresDB
+	p.expectedTunnels += 1
 }
 
 // waitForNodeToBeReachable waits for the node to be reachable from all

--- a/lib/reversetunnelclient/peer.go
+++ b/lib/reversetunnelclient/peer.go
@@ -48,7 +48,8 @@ func NewPeerDialer(server Tunnel) PeerDialerFunc {
 			FromPeerProxy: true,
 		}
 
-		conn, err := site.Dial(dialParams)
+		// peered dials should be passthru so we call [localCluster.DialTCP] directly
+		conn, err := site.DialTCP(dialParams)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Backports #59555 for branch/v18

changelog: Fixed an issue that prevented connecting to agents over peered tunnels when proxy peering was enabled.