### PR TITLE
Add health checks to Kubernetes agent and proxy

### DIFF
--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -58,6 +58,14 @@ type KubeServer interface {
 	SetCluster(KubeCluster) error
 	// ProxiedService provides common methods for a proxied service.
 	ProxiedService
+	// GetTargetHealth gets health details for a target Kubernetes cluster.
+	GetTargetHealth() *TargetHealth
+	// SetTargetHealth sets health details for a target Kubernetes cluster.
+	SetTargetHealth(h *TargetHealth)
+	// GetTargetHealthStatus gets the health status of a target Kubernetes cluster.
+	GetTargetHealthStatus() TargetHealthStatus
+	// SetTargetHealthStatus sets the health status of a target Kubernetes cluster.
+	SetTargetHealthStatus(status TargetHealthStatus)
 }
 
 // NewKubernetesServerV3 creates a new kube server instance.
@@ -307,6 +315,55 @@ func (k *KubernetesServerV3) IsEqual(i KubeServer) bool {
 		return deriveTeleportEqualKubernetesServerV3(k, other)
 	}
 	return false
+}
+
+// GetTargetHealth gets health details for a target Kubernetes cluster.
+func (s *KubernetesServerV3) GetTargetHealth() *TargetHealth {
+	return s.GetStatus().GetTargetHealth()
+}
+
+// SetTargetHealth sets health details for a target Kubernetes cluster.
+func (s *KubernetesServerV3) SetTargetHealth(h *TargetHealth) {
+	if s.Status == nil {
+		s.Status = &KubernetesServerStatusV3{}
+	}
+	s.Status.TargetHealth = h
+}
+
+// GetTargetHealthStatus gets the health status of a target Kubernetes cluster.
+func (s *KubernetesServerV3) GetTargetHealthStatus() TargetHealthStatus {
+	health := s.GetStatus().GetTargetHealth()
+	if health == nil {
+		return TargetHealthStatusUnknown
+	}
+	return TargetHealthStatus(health.Status)
+}
+
+// SetTargetHealthStatus sets the health status of a target Kubernetes cluster.
+func (s *KubernetesServerV3) SetTargetHealthStatus(status TargetHealthStatus) {
+	if s.Status == nil {
+		s.Status = &KubernetesServerStatusV3{}
+	}
+	if s.Status.TargetHealth == nil {
+		s.Status.TargetHealth = &TargetHealth{}
+	}
+	s.Status.TargetHealth.Status = string(status)
+}
+
+// GetStatus gets the Kubernetes server status.
+func (s *KubernetesServerV3) GetStatus() *KubernetesServerStatusV3 {
+	if s == nil {
+		return nil
+	}
+	return s.Status
+}
+
+// GetTargetHealth gets the health of a Kubernetes cluster.
+func (s *KubernetesServerStatusV3) GetTargetHealth() *TargetHealth {
+	if s == nil {
+		return nil
+	}
+	return s.TargetHealth
 }
 
 // KubeServers represents a list of kube servers.

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -170,6 +170,10 @@ type ReadProxyAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
 
+	// HealthCheckConfigReader defines methods for fetching health check config
+	// resources.
+	services.HealthCheckConfigReader
+
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
@@ -478,6 +482,10 @@ type RemoteProxyAccessPoint interface {
 type ReadKubernetesAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
+
+	// HealthCheckConfigReader defines methods for fetching health check config
+	// resources.
+	services.HealthCheckConfigReader
 
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
@@ -1326,7 +1334,7 @@ type Cache interface {
 	// GitServerGetter defines methods for fetching Git servers.
 	services.GitServerGetter
 
-	// HealthCheckConfigReader defines methods for fetching health checkc config
+	// HealthCheckConfigReader defines methods for fetching health check config
 	// resources.
 	services.HealthCheckConfigReader
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -946,6 +946,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindAccessGraphSettings, services.RO()),
 				types.NewRule(types.KindRelayServer, services.RO()),
 				types.NewRule(types.KindAccessList, services.RO()),
+				types.NewRule(types.KindHealthCheckConfig, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{
@@ -1224,6 +1225,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindLock, services.RO()),
 						types.NewRule(types.KindKubernetesCluster, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
+						types.NewRule(types.KindHealthCheckConfig, services.RO()),
 					},
 				},
 			})

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -272,6 +272,7 @@ func ForProxy(cfg Config) Config {
 		{Kind: types.KindUserTask},
 		{Kind: types.KindGitServer},
 		{Kind: types.KindRelayServer},
+		{Kind: types.KindHealthCheckConfig},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg
@@ -368,6 +369,7 @@ func ForKubernetes(cfg Config) Config {
 		{Kind: types.KindKubeServer},
 		{Kind: types.KindKubernetesCluster},
 		{Kind: types.KindKubeWaitingContainer},
+		{Kind: types.KindHealthCheckConfig},
 	}
 	cfg.QueueSize = defaults.KubernetesQueueSize
 	return cfg

--- a/lib/healthcheck/config.go
+++ b/lib/healthcheck/config.go
@@ -33,12 +33,13 @@ import (
 // healthCheckConfig is an internal health check config type converted from a
 // [*healthcheckconfigv1.HealthCheckConfig] with defaults set.
 type healthCheckConfig struct {
-	name                  string
-	interval              time.Duration
-	timeout               time.Duration
-	healthyThreshold      uint32
-	unhealthyThreshold    uint32
-	databaseLabelMatchers types.LabelMatchers
+	name                    string
+	interval                time.Duration
+	timeout                 time.Duration
+	healthyThreshold        uint32
+	unhealthyThreshold      uint32
+	databaseLabelMatchers   types.LabelMatchers
+	kubernetesLabelMatchers types.LabelMatchers
 }
 
 // newHealthCheckConfig converts a health check config protobuf message into a
@@ -47,12 +48,13 @@ func newHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig) *healthChe
 	spec := cfg.GetSpec()
 	match := spec.GetMatch()
 	return &healthCheckConfig{
-		name:                  cfg.GetMetadata().GetName(),
-		timeout:               cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
-		interval:              cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
-		healthyThreshold:      cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
-		unhealthyThreshold:    cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
-		databaseLabelMatchers: newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
+		name:                    cfg.GetMetadata().GetName(),
+		timeout:                 cmp.Or(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
+		interval:                cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
+		healthyThreshold:        cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
+		unhealthyThreshold:      cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
+		databaseLabelMatchers:   newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
+		kubernetesLabelMatchers: newLabelMatchers(match.GetKubernetesLabelsExpression(), match.GetKubernetesLabels()),
 	}
 }
 
@@ -74,6 +76,8 @@ func (h *healthCheckConfig) getLabelMatchers(kind string) types.LabelMatchers {
 	switch kind {
 	case types.KindDatabase:
 		return h.databaseLabelMatchers
+	case types.KindKubernetesCluster:
+		return h.kubernetesLabelMatchers
 	}
 	// unreachable since we enforce a list of supported target resource kinds,
 	// but empty matchers do the right thing anyway: don't match anything.

--- a/lib/healthcheck/config_test.go
+++ b/lib/healthcheck/config_test.go
@@ -44,6 +44,11 @@ func Test_newHealthCheckConfig(t *testing.T) {
 					Values: []string{"bar", "baz"},
 				}},
 				DbLabelsExpression: `labels["qux"] == "*"`,
+				KubernetesLabels: []*labelv1.Label{{
+					Name:   "app",
+					Values: []string{"web", "api"},
+				}},
+				KubernetesLabelsExpression: `labels["lux"] == "*"`,
 			},
 			Timeout:            durationpb.New(time.Second * 42),
 			Interval:           durationpb.New(time.Second * 43),
@@ -57,7 +62,8 @@ func Test_newHealthCheckConfig(t *testing.T) {
 		"minimal",
 		&healthcheckconfigv1.HealthCheckConfigSpec{
 			Match: &healthcheckconfigv1.Matcher{
-				DbLabelsExpression: `labels["*"] == "*"`,
+				DbLabelsExpression:         `labels["*"] == "*"`,
+				KubernetesLabelsExpression: `labels["*"] == "*"`,
 			},
 		},
 	)
@@ -83,6 +89,12 @@ func Test_newHealthCheckConfig(t *testing.T) {
 					},
 					Expression: `labels["qux"] == "*"`,
 				},
+				kubernetesLabelMatchers: types.LabelMatchers{
+					Labels: types.Labels{
+						"app": utils.Strings{"web", "api"},
+					},
+					Expression: `labels["lux"] == "*"`,
+				},
 			},
 		},
 		{
@@ -95,6 +107,10 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				healthyThreshold:   defaults.HealthCheckHealthyThreshold,
 				unhealthyThreshold: defaults.HealthCheckUnhealthyThreshold,
 				databaseLabelMatchers: types.LabelMatchers{
+					Labels:     types.Labels{},
+					Expression: `labels["*"] == "*"`,
+				},
+				kubernetesLabelMatchers: types.LabelMatchers{
 					Labels:     types.Labels{},
 					Expression: `labels["*"] == "*"`,
 				},
@@ -154,20 +170,22 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 		{
 			desc: "all fields equal ignoring labels",
 			a: &healthCheckConfig{
-				name:                  "test",
-				interval:              time.Second,
-				timeout:               500 * time.Millisecond,
-				healthyThreshold:      3,
-				unhealthyThreshold:    5,
-				databaseLabelMatchers: types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
+				name:                    "test",
+				interval:                time.Second,
+				timeout:                 500 * time.Millisecond,
+				healthyThreshold:        3,
+				unhealthyThreshold:      5,
+				databaseLabelMatchers:   types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
+				kubernetesLabelMatchers: types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
 			},
 			b: &healthCheckConfig{
-				name:                  "test",
-				interval:              time.Second,
-				timeout:               500 * time.Millisecond,
-				healthyThreshold:      3,
-				unhealthyThreshold:    5,
-				databaseLabelMatchers: types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
+				name:                    "test",
+				interval:                time.Second,
+				timeout:                 500 * time.Millisecond,
+				healthyThreshold:        3,
+				unhealthyThreshold:      5,
+				databaseLabelMatchers:   types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
+				kubernetesLabelMatchers: types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
 			},
 			want: true,
 		},

--- a/lib/healthcheck/manager.go
+++ b/lib/healthcheck/manager.go
@@ -328,6 +328,10 @@ func (m *manager) updateWorkersLocked(ctx context.Context) {
 // getConfigLocked gets a matching config for the the given resource or returns
 // nil if no config matches.
 func (m *manager) getConfigLocked(ctx context.Context, r types.ResourceWithLabels) *healthCheckConfig {
+	if m.configs == nil {
+		m.logger.DebugContext(ctx, "Health check config unavailable")
+		return nil
+	}
 	for _, cfg := range m.configs {
 		matched, _, err := services.CheckLabelsMatch(
 			types.Allow,

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -67,7 +67,7 @@ func (cfg *workerConfig) checkAndSetDefaults() error {
 		cfg.Log = slog.Default()
 	}
 	if cfg.getTargetHealthTimeout == 0 {
-		cfg.getTargetHealthTimeout = 10 * time.Second
+		cfg.getTargetHealthTimeout = 4 * time.Second
 	}
 	if err := cfg.Target.checkAndSetDefaults(); err != nil {
 		return trace.Wrap(err)

--- a/lib/healthcheck/worker_experimental_test.go
+++ b/lib/healthcheck/worker_experimental_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -87,6 +88,10 @@ func TestGetTargetHealth(t *testing.T) {
 				})
 				assert.NoError(t, err)
 				defer worker.Close()
+				require.Eventually(t, func() bool {
+					health := worker.GetTargetHealth()
+					return health.TransitionReason != string(types.TargetHealthTransitionReasonInit)
+				}, 10*time.Second, 100*time.Millisecond, "health check did not complete")
 				health := worker.GetTargetHealth()
 				assert.Equal(t, test.wantStatus, types.TargetHealthStatus(health.Status))
 				assert.Equal(t, test.wantReason, types.TargetHealthTransitionReason(health.TransitionReason))

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/labels"
@@ -52,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+	"github.com/gravitational/teleport/lib/utils/log"
 )
 
 // TLSServerConfig is a configuration for TLS server
@@ -109,6 +111,8 @@ type TLSServerConfig struct {
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 	// InventoryHandle is used to send kube server heartbeats via the inventory control stream.
 	InventoryHandle inventory.DownstreamHandle
+	// HealthCheckManager manages checking the health of Kubernetes clusters.
+	HealthCheckManager healthcheck.Manager
 }
 
 type awsClientsGetter struct{}
@@ -142,6 +146,9 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	}
 	if c.ConnectedProxyGetter == nil {
 		return trace.BadParameter("missing parameter ConnectedProxyGetter")
+	}
+	if c.HealthCheckManager == nil {
+		return trace.BadParameter("missing parameter HealthCheckManager")
 	}
 
 	if err := c.validateLabelKeys(); err != nil {
@@ -436,7 +443,7 @@ func (t *TLSServer) Shutdown(ctx context.Context) error {
 func (t *TLSServer) close(ctx context.Context) error {
 	var errs []error
 	for _, kubeCluster := range t.fwd.kubeClusters() {
-		errs = append(errs, t.unregisterKubeCluster(ctx, kubeCluster.GetName()))
+		errs = append(errs, t.unregisterKubeCluster(ctx, kubeCluster))
 	}
 	errs = append(errs, t.fwd.Close(), t.Server.Close())
 
@@ -515,7 +522,81 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 		return nil, trace.Wrap(err)
 	}
 	srv.SetExpiry(t.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL))
+
+	// Get the kube cluster health and send it to the auth server.
+	srv.SetTargetHealth(t.getTargetHealth(t.closeContext, cluster))
+
 	return srv, nil
+}
+
+// startHealthCheck starts checking the health of a Kubernetes cluster.
+func (t *TLSServer) startHealthCheck(cluster types.KubeCluster) error {
+	kubeDetails, err := t.fwd.findKubeDetailsByClusterName(cluster.GetName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = t.HealthCheckManager.AddTarget(healthcheck.Target{
+		HealthChecker: kubeDetails,
+		GetResource:   func() types.ResourceWithLabels { return cluster },
+	})
+	return trace.Wrap(err)
+}
+
+// stopHealthCheck stops checking the health of a Kubernetes cluster.
+func (t *TLSServer) stopHealthCheck(cluster types.KubeCluster) error {
+	if err := t.HealthCheckManager.RemoveTarget(cluster); err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// startHeartbeatAndHealthCheck starts heart beats and health checks.
+func (t *TLSServer) startHeartbeatAndHealthCheck(cluster types.KubeCluster) error {
+	if err := t.startHealthCheck(cluster); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := t.startHeartbeat(cluster.GetName()); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// stopHeartbeatAndHealthCheck stops heart beats and health checks.
+func (t *TLSServer) stopHeartbeatAndHealthCheck(cluster types.KubeCluster) error {
+	var errs []error
+	if err := t.stopHealthCheck(cluster); err != nil {
+		errs = append(errs, err)
+	}
+	if err := t.stopHeartbeat(cluster.GetName()); err != nil {
+		errs = append(errs, err)
+	}
+	return trace.NewAggregate(errs...)
+}
+
+// getTargetHealth returns the health of a Kubernetes cluster.
+func (t *TLSServer) getTargetHealth(ctx context.Context, cluster types.KubeCluster) *types.TargetHealth {
+	health, err := t.HealthCheckManager.GetTargetHealth(cluster)
+	if err == nil {
+		return health
+	}
+	if trace.IsNotFound(err) {
+		return &types.TargetHealth{
+			Status:           string(types.TargetHealthStatusUnknown),
+			TransitionReason: string(types.TargetHealthTransitionReasonDisabled),
+			Message:          "Unable to find the Kubernetes cluster",
+		}
+	}
+
+	t.log.WarnContext(ctx, "Failed to get kube cluster health",
+		"kube_cluster", log.StringerAttr(cluster),
+		"error", err,
+	)
+	return &types.TargetHealth{
+		Status:           string(types.TargetHealthStatusUnknown),
+		TransitionReason: string(types.TargetHealthTransitionReasonInternalError),
+		TransitionError:  err.Error(),
+		Message:          "Teleport failed to get the Kubernetes cluster health status (this is a bug)",
+	}
 }
 
 // getKubeClusterWithServiceLabels finds the kube cluster by name, strips the credentials,
@@ -584,14 +665,14 @@ func (t *TLSServer) startStaticClustersHeartbeat() error {
 	// proxy_service will pretend to also be kube_server.
 	if t.KubeServiceType == KubeService ||
 		t.KubeServiceType == LegacyProxyService {
-		t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats")
-		for _, cluster := range t.fwd.kubeClusters() {
-			if err := t.startHeartbeat(cluster.GetName()); err != nil {
+		t.log.DebugContext(t.closeContext, "Starting kubernetes_service heartbeats and health checks")
+		for _, kc := range t.fwd.kubeClusters() {
+			if err := t.startHeartbeatAndHealthCheck(kc); err != nil {
 				return trace.Wrap(err)
 			}
 		}
 	} else {
-		t.log.DebugContext(t.closeContext, "No local kube credentials on proxy, will not start kubernetes_service heartbeats")
+		t.log.DebugContext(t.closeContext, "No local kube credentials on proxy, will not start kubernetes_service heartbeats and health checks")
 	}
 
 	return nil

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -215,8 +216,9 @@ func TestGetServerInfo(t *testing.T) {
 			},
 			AccessPoint:          ap,
 			TLS:                  &tls.Config{},
-			ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
 			GetRotation:          func(role types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
+			ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
+			HealthCheckManager:   &mockHealthCheckManager{},
 		},
 		fwd: &Forwarder{
 			cfg: ForwarderConfig{},
@@ -354,3 +356,13 @@ func TestTLSServerConfig_validateLabelsKey(t *testing.T) {
 		})
 	}
 }
+
+type mockHealthCheckManager struct{}
+
+func (m *mockHealthCheckManager) Start(ctx context.Context) error               { return nil }
+func (m *mockHealthCheckManager) AddTarget(target healthcheck.Target) error     { return nil }
+func (m *mockHealthCheckManager) RemoveTarget(r types.ResourceWithLabels) error { return nil }
+func (m *mockHealthCheckManager) GetTargetHealth(r types.ResourceWithLabels) (*types.TargetHealth, error) {
+	return nil, nil
+}
+func (m *mockHealthCheckManager) Close() error { return nil }

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -242,6 +243,19 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
+	healthCheckManager, err := healthcheck.NewManager(
+		testCtx.Context,
+		healthcheck.ManagerConfig{
+			Component:               teleport.ComponentKube,
+			Events:                  client,
+			HealthCheckConfigReader: client,
+		},
+	)
+	require.NoError(t, err)
+	err = healthCheckManager.Start(testCtx.Context)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, healthCheckManager.Close()) })
+
 	// Create kubernetes service server.
 	testCtx.KubeServer, err = NewTLSServer(TLSServerConfig{
 		ForwarderConfig: ForwarderConfig{
@@ -290,6 +304,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		Log:                  logtest.NewLogger(),
 		InventoryHandle:      inventoryHandle,
 		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
+		HealthCheckManager:   healthCheckManager,
 	})
 	require.NoError(t, err)
 
@@ -371,6 +386,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			return &types.Rotation{}, nil
 		},
 		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
+		HealthCheckManager:   healthCheckManager,
 	})
 	require.NoError(t, err)
 	require.Equal(t, testCtx.KubeServer.Server.ReadTimeout, time.Duration(0), "kube server write timeout must be 0")

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/modules"
@@ -204,6 +205,22 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		return trace.Wrap(err)
 	}
 
+	// Create a health check manager.
+	healthCheckManager, err := healthcheck.NewManager(
+		process.ExitContext(),
+		healthcheck.ManagerConfig{
+			Component:               teleport.ComponentKube,
+			Events:                  accessPoint,
+			HealthCheckConfigReader: accessPoint,
+		},
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := healthCheckManager.Start(process.ExitContext()); err != nil {
+		return trace.Wrap(err)
+	}
+
 	var publicAddr string
 	if len(cfg.Kube.PublicAddrs) > 0 {
 		publicAddr = cfg.Kube.PublicAddrs[0].String()
@@ -243,6 +260,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		Log:                  process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id)),
 		PROXYProtocolMode:    multiplexer.PROXYProtocolOff, // Kube service doesn't need to process unsigned PROXY headers.
 		InventoryHandle:      process.inventoryHandle,
+		HealthCheckManager:   healthCheckManager,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -284,6 +302,9 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		}
 		if asyncEmitter != nil {
 			warnOnErr(process.ExitContext(), asyncEmitter.Close(), logger)
+		}
+		if healthCheckManager != nil {
+			warnOnErr(process.ExitContext(), healthCheckManager.Close(), logger)
 		}
 		warnOnErr(process.ExitContext(), listener.Close(), logger)
 		warnOnErr(process.ExitContext(), conn.Close(), logger)

--- a/lib/services/health_check_config.go
+++ b/lib/services/health_check_config.go
@@ -71,8 +71,6 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 		return trace.BadParameter("spec is missing")
 	case s.Spec.Match == nil:
 		return trace.BadParameter("spec.match is missing")
-	case len(s.Spec.Match.DbLabels) == 0 && len(s.Spec.Match.DbLabelsExpression) == 0:
-		return trace.BadParameter("at least one of spec.match.db_labels or spec.match.db_labels_expression must be set")
 	}
 
 	for _, label := range s.Spec.Match.DbLabels {
@@ -83,6 +81,17 @@ func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
 	if expr := s.Spec.Match.DbLabelsExpression; len(expr) > 0 {
 		if _, err := parseLabelExpression(expr); err != nil {
 			return trace.BadParameter("invalid spec.db_labels_expression: %v", err)
+		}
+	}
+
+	for _, label := range s.Spec.Match.KubernetesLabels {
+		if err := validateLabel(label); err != nil {
+			return trace.BadParameter("invalid spec.kubernetes_labels: %v", err)
+		}
+	}
+	if expr := s.Spec.Match.KubernetesLabelsExpression; len(expr) > 0 {
+		if _, err := parseLabelExpression(expr); err != nil {
+			return trace.BadParameter("invalid spec.kubernetes_labels_expression: %v", err)
 		}
 	}
 

--- a/lib/services/health_check_config_test.go
+++ b/lib/services/health_check_config_test.go
@@ -200,22 +200,6 @@ func TestValidateHealthCheckConfig(t *testing.T) {
 			requireErr: errContains("spec.match is missing"),
 		},
 		{
-			name: "missing matcher is invalid",
-			in: &healthcheckconfigv1.HealthCheckConfig{
-				Version: types.V1,
-				Kind:    types.KindHealthCheckConfig,
-				Metadata: &headerv1.Metadata{
-					Name: "example",
-				},
-				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
-					Match:    &healthcheckconfigv1.Matcher{},
-					Timeout:  durationpb.New(time.Second),
-					Interval: durationpb.New(2 * time.Second),
-				},
-			},
-			requireErr: errContains("at least one of spec.match.db_labels or spec.match.db_labels_expression must be set"),
-		},
-		{
 			name: "invalid label matcher",
 			in: &healthcheckconfigv1.HealthCheckConfig{
 				Version: types.V1,


### PR DESCRIPTION
This is part of Kubernetes health check integration.

Implements core health check logic for Kubernetes.

In this PR:
- Added functions `CheckHealth` and `GetProtocol` to `kubeDetails`
- Added a `HealthCheckManager` field to the Kubernetes `TLSServerConfig`
- Kube agent and proxy now instantiate a `HealthCheckManager`
- Added a `HealthCheckConfigReader` to interfaces `ReadKubernetesAccessPoint` and `ReadProxyAccessPoint`
- Added `HealthCheckConfig` read-only permissions for proxy and kube
- Added `HealthCheckConfig` watching for proxy and kube
- Added functions to `KubeServer` interface and `KubernetesServerV3` struct:
    - `GetTargetHealth() TargetHealth`
    - `SetTargetHealth(h TargetHealth)`
    - `GetTargetHealthStatus() TargetHealthStatus`
    - `SetTargetHealthStatus(status TargetHealthStatus)`

Relates to:
- #58413