### PR TITLE
[v17] Fix persistence of `metadata.description` for Bot resource

### DIFF
--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -726,8 +726,9 @@ func botFromUserAndRole(user types.User, role types.Role) (*pb.Bot, error) {
 		Kind:    types.KindBot,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
-			Name:    botName,
-			Expires: expiry,
+			Name:        botName,
+			Expires:     expiry,
+			Description: user.GetMetadata().Description,
 		},
 		Status: &pb.BotStatus{
 			UserName: user.GetName(),
@@ -822,6 +823,9 @@ func botToUserAndRole(bot *pb.Bot, now time.Time, createdBy string) (types.User,
 	// previous user before writing if necessary
 	userMeta.Labels[types.BotGenerationLabel] = "0"
 	userMeta.Expires = userAndRoleExpiryFromBot(bot)
+	// We track the Bot description within the User description field because
+	// the Role description already has a message.
+	userMeta.Description = bot.Metadata.Description
 	user.SetMetadata(userMeta)
 
 	traits := map[string][]string{}

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -147,6 +147,7 @@ func TestCreateBot(t *testing.T) {
 							"my-label":       "my-value",
 							"my-other-label": "my-other-value",
 						},
+						Description: "Property of US Robotics and Mechanical Men.",
 					},
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{testRole.GetName()},
@@ -176,6 +177,7 @@ func TestCreateBot(t *testing.T) {
 						"my-label":       "my-value",
 						"my-other-label": "my-other-value",
 					},
+					Description: "Property of US Robotics and Mechanical Men.",
 				},
 				Spec: &machineidv1pb.BotSpec{
 					Roles: []string{testRole.GetName()},
@@ -204,6 +206,7 @@ func TestCreateBot(t *testing.T) {
 						"my-label":               "my-value",
 						"my-other-label":         "my-other-value",
 					},
+					Description: "Property of US Robotics and Mechanical Men.",
 				},
 				Spec: types.UserSpecV2{
 					CreatedBy: types.CreatedBy{
@@ -1664,6 +1667,7 @@ func TestGetBot(t *testing.T) {
 						"my-label":       "my-value",
 						"my-other-label": "my-other-value",
 					},
+					Description: "The maze wasn't meant for you",
 				},
 				Spec: &machineidv1pb.BotSpec{
 					Roles: []string{testRole.GetName()},


### PR DESCRIPTION
Backport #59524 to branch/v17

changelog: Fixed persistence of `metadata.description` field for the Bot resource
