### PR TITLE
[v18] MWI: Customizable Argo CD cluster name template

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -179,10 +179,10 @@ is non-empty).
 `argocd.clusterNameTemplate` determines the format of cluster names
 in Argo CD. It is a Go template string that supports the following variables:
 
-  - {{.ClusterName}} - Name of the Teleport cluster
-  - {{.KubeName}} - Name of the Kubernetes cluster resource
+  - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
 
-By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+By default, the following template will be used: "\{\{.ClusterName\}\}-\{\{.KubeName\}\}".
 
 ## `persistence`
 

--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -170,6 +170,20 @@ clusters will be allowed to operate on.
 allowed to operate on cluster-scoped resources (only when `argocd.namespaces`
 is non-empty).
 
+### `argocd.clusterNameTemplate`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`argocd.clusterNameTemplate` determines the format of cluster names
+in Argo CD. It is a Go template string that supports the following variables:
+
+  - {{.ClusterName}} - Name of the Teleport cluster
+  - {{.KubeName}} - Name of the Kubernetes cluster resource
+
+By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+
 ## `persistence`
 
 `persistence` controls how the tbot agent stores its data.

--- a/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
@@ -486,6 +486,15 @@ namespaces:
 # applicable when `namespaces` is non-empty.
 cluster_resources: true
 
+# cluster_name_template determines the format of cluster names in Argo CD. It is
+# a Go template string that supports the following variables:
+#
+#   - {{.ClusterName}} - Name of the Teleport cluster
+#   - {{.KubeName}} - Name of the Kubernetes cluster resource
+#
+# By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+cluster_name_template: "{{.KubeName}}"
+
 # The following configuration fields are available across most output types.
 # Note that `roles` and `destination` are not supported for this output type.
 

--- a/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
@@ -492,7 +492,7 @@ cluster_resources: true
 #   - {{.ClusterName}} - Name of the Teleport cluster
 #   - {{.KubeName}} - Name of the Kubernetes cluster resource
 #
-# By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+# By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}"
 cluster_name_template: "{{.KubeName}}"
 
 # The following configuration fields are available across most output types.

--- a/examples/chart/tbot/.lint/argocd.yaml
+++ b/examples/chart/tbot/.lint/argocd.yaml
@@ -19,3 +19,4 @@ argocd:
     - dev
     - prod
   clusterResources: true
+  clusterNameTemplate: "{{.KubeName}}"

--- a/examples/chart/tbot/templates/_config.tpl
+++ b/examples/chart/tbot/templates/_config.tpl
@@ -68,6 +68,9 @@ outputs:
     {{- if .Values.argocd.clusterResources }}
     cluster_resources: {{ .Values.argocd.clusterResources }}
     {{- end }}
+    {{- if .Values.argocd.clusterNameTemplate }}
+    cluster_name_template: {{ .Values.argocd.clusterNameTemplate | quote }}
+    {{- end }}
 {{- end }}
 {{- if .Values.outputs }}
 {{- toYaml .Values.outputs | nindent 2}}

--- a/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
@@ -34,7 +34,8 @@ should match the snapshot (argocd):
           join_method: kubernetes
           token: my-token
         outputs:
-        - cluster_resources: true
+        - cluster_name_template: '{{.KubeName}}'
+          cluster_resources: true
           namespaces:
           - dev
           - prod

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -85,6 +85,14 @@ argocd:
   # allowed to operate on cluster-scoped resources (only when `argocd.namespaces`
   # is non-empty).
   clusterResources: false
+  # argocd.clusterNameTemplate(string) -- determines the format of cluster names
+  # in Argo CD. It is a Go template string that supports the following variables:
+  #
+  #   - {{.ClusterName}} - Name of the Teleport cluster
+  #   - {{.KubeName}} - Name of the Kubernetes cluster resource
+  #
+  # By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+  clusterNameTemplate: ""
 
 # persistence -- controls how the tbot agent stores its data.
 #

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -88,10 +88,10 @@ argocd:
   # argocd.clusterNameTemplate(string) -- determines the format of cluster names
   # in Argo CD. It is a Go template string that supports the following variables:
   #
-  #   - {{.ClusterName}} - Name of the Teleport cluster
-  #   - {{.KubeName}} - Name of the Kubernetes cluster resource
+  #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
   #
-  # By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+  # By default, the following template will be used: "\{\{.ClusterName\}\}-\{\{.KubeName\}\}".
   clusterNameTemplate: ""
 
 # persistence -- controls how the tbot agent stores its data.

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -348,8 +348,17 @@ func (s *ArgoCDOutput) renderSecret(cluster *argoClusterCredentials) (*corev1.Se
 		return nil, trace.Wrap(err, "marshaling cluster credentials")
 	}
 
+	name, err := kubeconfig.ContextNameFromTemplate(
+		s.cfg.ClusterNameTemplate,
+		cluster.teleportClusterName,
+		cluster.kubeClusterName,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "templating cluster name")
+	}
+
 	data := map[string][]byte{
-		"name":   []byte(kubeconfig.ContextName(cluster.teleportClusterName, cluster.kubeClusterName)),
+		"name":   []byte(name),
 		"server": []byte(cluster.addr),
 		"config": configJSON,
 	}

--- a/lib/tbot/services/k8s/argocd_output_config.go
+++ b/lib/tbot/services/k8s/argocd_output_config.go
@@ -25,11 +25,14 @@ import (
 	"github.com/gravitational/trace"
 	"k8s.io/apimachinery/pkg/api/validation"
 
+	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
 )
 
 const ArgoCDOutputServiceType = "kubernetes/argo-cd"
+
+var defaultArgoClusterNameTemplate = kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}")
 
 // ArgoCDOutputConfig contains configuration for the service that registers
 // Kubernetes cluster credentials in Argo CD.
@@ -77,6 +80,15 @@ type ArgoCDOutputConfig struct {
 	// credentials will be allowed to operate on cluster-scoped resources (only
 	// when Namespaces is non-empty).
 	ClusterResources bool `yaml:"cluster_resources,omitempty"`
+
+	// cluster_name_template determines the format of cluster names in Argo CD.
+	// It is a "text/template" string that supports the following variables:
+	//
+	//   - {{.ClusterName}} - Name of the Teleport cluster
+	//   - {{.KubeName}} - Name of the Kubernetes cluster resource
+	//
+	// By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
+	ClusterNameTemplate string `yaml:"cluster_name_template,omitempty"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.
@@ -121,6 +133,14 @@ func (o *ArgoCDOutputConfig) CheckAndSetDefaults() error {
 
 	if o.ClusterResources && len(o.Namespaces) == 0 {
 		return trace.BadParameter("cluster_resources is only applicable if namespaces is also set")
+	}
+
+	if o.ClusterNameTemplate == "" {
+		o.ClusterNameTemplate = defaultArgoClusterNameTemplate
+	} else {
+		if _, err := kubeconfig.ContextNameFromTemplate(o.ClusterNameTemplate, "", ""); err != nil {
+			return trace.BadParameter("cluster_name_template is invalid: %v", err)
+		}
 	}
 
 	return nil

--- a/lib/tbot/services/k8s/argocd_output_config_test.go
+++ b/lib/tbot/services/k8s/argocd_output_config_test.go
@@ -54,9 +54,10 @@ func TestArgoCDOutput_YAML(t *testing.T) {
 				SecretAnnotations: map[string]string{
 					"my-annotation": "value",
 				},
-				Project:          "super-secret-project",
-				Namespaces:       []string{"prod", "dev"},
-				ClusterResources: true,
+				Project:             "super-secret-project",
+				Namespaces:          []string{"prod", "dev"},
+				ClusterResources:    true,
+				ClusterNameTemplate: "{{.KubeName}}",
 			},
 		},
 		{
@@ -85,8 +86,9 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Name: "foo", Labels: make(map[string]string)},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 		},
@@ -97,8 +99,9 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Labels: map[string]string{"foo": "bar"}},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 		},
@@ -106,9 +109,10 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 			name: "no_selectors",
 			in: func() *ArgoCDOutputConfig {
 				return &ArgoCDOutputConfig{
-					Selectors:        []*KubernetesSelector{},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
+					Selectors:           []*KubernetesSelector{},
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "at least one selector is required",
@@ -120,8 +124,9 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "one of 'name' and 'labels' must be specified",
@@ -133,8 +138,9 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Labels: map[string]string{"foo": "bar"}},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "NOT VALID",
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "NOT VALID",
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "secret_name_prefix may only include lowercase letters, numbers, '-' and '.' characters",
@@ -146,9 +152,10 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Labels: map[string]string{"foo": "bar"}},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
-					Namespaces:       []string{""},
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					Namespaces:          []string{""},
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "namespaces[0] cannot be blank",
@@ -160,9 +167,10 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Labels: map[string]string{"foo": "bar"}},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
-					Namespaces:       []string{"foo,"},
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					Namespaces:          []string{"foo,"},
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "namespaces[0] is not a valid namespace name",
@@ -174,13 +182,28 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 					Selectors: []*KubernetesSelector{
 						{Labels: map[string]string{"foo": "bar"}},
 					},
-					SecretNamespace:  "argocd",
-					SecretNamePrefix: "argo-cluster",
-					Namespaces:       []string{},
-					ClusterResources: true,
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					Namespaces:          []string{},
+					ClusterResources:    true,
+					ClusterNameTemplate: "{{.KubeName}}",
 				}
 			},
 			wantErr: "cluster_resources is only applicable if namespaces is also set",
+		},
+		{
+			name: "invalid cluster_name_template",
+			in: func() *ArgoCDOutputConfig {
+				return &ArgoCDOutputConfig{
+					Selectors: []*KubernetesSelector{
+						{Labels: map[string]string{"foo": "bar"}},
+					},
+					SecretNamespace:     "argocd",
+					SecretNamePrefix:    "argo-cluster",
+					ClusterNameTemplate: "{{.InvalidVariable}}",
+				}
+			},
+			wantErr: "can't evaluate field InvalidVariable",
 		},
 		{
 			name: "defaults",
@@ -195,8 +218,9 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 				Selectors: []*KubernetesSelector{
 					{Labels: map[string]string{"foo": "bar"}},
 				},
-				SecretNamespace:  "my-pod-namespace",
-				SecretNamePrefix: "teleport.argocd-cluster",
+				SecretNamespace:     "my-pod-namespace",
+				SecretNamePrefix:    "teleport.argocd-cluster",
+				ClusterNameTemplate: "{{.ClusterName}}-{{.KubeName}}",
 			},
 		},
 	}

--- a/lib/tbot/services/k8s/testdata/TestArgoCDOutput_YAML/full.golden
+++ b/lib/tbot/services/k8s/testdata/TestArgoCDOutput_YAML/full.golden
@@ -17,3 +17,4 @@ namespaces:
   - prod
   - dev
 cluster_resources: true
+cluster_name_template: '{{.KubeName}}'


### PR DESCRIPTION
Backport #59541 to branch/v18

changelog: MWI: Added support for customizing cluster names with a template to the `kubernetes/argo-cd` output.