### PR TITLE
Fix the access graph preview on non-standard roles

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { fireEvent, within } from '@testing-library/react';
+import { fireEvent, waitFor, within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 
 import { render, screen, userEvent } from 'design/utils/testing';
@@ -202,6 +202,27 @@ it('calls onRoleUpdate on each modification in the standard editor', async () =>
     withDefaults({
       metadata: { name: 'new_role_name', description: 'some-description' },
     })
+  );
+});
+
+it('calls onRoleUpdate after the first rendering of a non-standard role', async () => {
+  cfg.isPolicyEnabled = true;
+  const onRoleUpdate = jest.fn();
+  const nonStandardRole = withDefaults({
+    unsupportedField: true,
+  } as any as Role);
+  render(
+    <TestRoleEditor
+      demoMode
+      onRoleUpdate={onRoleUpdate}
+      originalRole={newRoleWithYaml(nonStandardRole)}
+    />
+  );
+  await waitFor(() => {
+    expect(onRoleUpdate).toHaveBeenCalledTimes(1);
+  });
+  expect(onRoleUpdate).toHaveBeenLastCalledWith(
+    withDefaults({ unsupportedField: true } as any as Role)
   );
 });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -103,7 +103,12 @@ export const RoleEditor = ({
 
   useEffect(() => {
     const { roleModel, validationResult } = standardModel;
-    if (roleTesterEnabled && roleModel && validationResult?.isValid) {
+    if (
+      roleTesterEnabled &&
+      roleModel &&
+      !roleModel.requiresReset &&
+      validationResult?.isValid
+    ) {
       onRoleUpdate?.(roleEditorModelToRole(roleModel));
     }
   }, [standardModel, onRoleUpdate, roleTesterEnabled, demoMode]);
@@ -160,6 +165,16 @@ export const RoleEditor = ({
       }
     }, [onRoleUpdate, yamlModel])
   );
+
+  useEffect(() => {
+    const { roleModel } = standardModel;
+    if (
+      roleTesterEnabled &&
+      (roleModel === undefined || roleModel.requiresReset)
+    ) {
+      handleYamlPreview();
+    }
+  }, []);
 
   // Converts standard editor model to a YAML representation.
   const [yamlifyAttempt, yamlifyRole] = useAsync(


### PR DESCRIPTION
This fixes an issue where opening a non-standard role in YAML editor showed an access graph preview with spurious deleted edges. This was the case when non-supported fields were responsible for some of these edges, and the editor mistakenly used a standard model instead of the YAML one to display the diff.