### PR TITLE
[clientutils] Add CollectWithFallback helper

### DIFF
--- a/api/utils/clientutils/resources_test.go
+++ b/api/utils/clientutils/resources_test.go
@@ -243,3 +243,66 @@ func TestRangeResources(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectWithFallbackk(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		pageFunc     func(context.Context, int, string) ([]string, string, error)
+		fallbackFunc func(context.Context) ([]string, error)
+		err          error
+	}{
+		{
+			name: "happy primary path",
+			pageFunc: func(context.Context, int, string) ([]string, string, error) {
+				return []string{"hello", "world"}, "", nil
+			},
+			fallbackFunc: func(context.Context) ([]string, error) {
+				panic("enexpected call")
+			},
+			err: nil,
+		},
+
+		{
+			name: "fallback fail",
+			pageFunc: func(context.Context, int, string) ([]string, string, error) {
+				return nil, "", trace.NotImplemented("")
+			},
+			fallbackFunc: func(context.Context) ([]string, error) {
+				return nil, trace.BadParameter("")
+			},
+			err: trace.BadParameter(""),
+		},
+		{
+			name: "fallback success",
+			pageFunc: func(context.Context, int, string) ([]string, string, error) {
+				return nil, "", trace.NotImplemented("")
+			},
+			fallbackFunc: func(context.Context) ([]string, error) {
+				return []string{"hello", "world"}, nil
+			},
+			err: nil,
+		},
+		{
+			name: "fallback no match",
+			pageFunc: func(context.Context, int, string) ([]string, string, error) {
+				return nil, "", trace.BadParameter("")
+			},
+			fallbackFunc: func(context.Context) ([]string, error) {
+				panic("enexpected call")
+			},
+			err: trace.BadParameter(""),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := CollectWithFallback(t.Context(), tc.pageFunc, tc.fallbackFunc)
+			if tc.err == nil {
+				require.NotNil(t, out)
+			}
+			require.ErrorIs(t, err, tc.err)
+		})
+	}
+}

--- a/api/utils/clientutils/resources_test.go
+++ b/api/utils/clientutils/resources_test.go
@@ -259,7 +259,7 @@ func TestCollectWithFallbackk(t *testing.T) {
 				return []string{"hello", "world"}, "", nil
 			},
 			fallbackFunc: func(context.Context) ([]string, error) {
-				panic("enexpected call")
+				panic("unexpected call")
 			},
 			err: nil,
 		},

--- a/api/utils/clientutils/resources_test.go
+++ b/api/utils/clientutils/resources_test.go
@@ -244,7 +244,7 @@ func TestRangeResources(t *testing.T) {
 	}
 }
 
-func TestCollectWithFallbackk(t *testing.T) {
+func TestCollectWithFallback(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {

--- a/api/utils/clientutils/resources_test.go
+++ b/api/utils/clientutils/resources_test.go
@@ -290,7 +290,7 @@ func TestCollectWithFallbackk(t *testing.T) {
 				return nil, "", trace.BadParameter("")
 			},
 			fallbackFunc: func(context.Context) ([]string, error) {
-				panic("enexpected call")
+				panic("unexpected call")
 			},
 			err: trace.BadParameter(""),
 		},


### PR DESCRIPTION
This helper is useful when migrating from non-paginated to paginated resource getters. Internally it will use auto page sizing for a given page getter and fall back to unary getter when the remote does not support the new RPC.