### PR TITLE
Fix `tsh play` failing without error

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2579,6 +2579,10 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 		}
 	}
 
+	if err := player.Err(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Customer reports that since upgrading to v17, `tsh play` no longer returns an error when it should and instead exits with no output and status code 0.

I took a look and I think this regression was initially introduced by https://github.com/gravitational/teleport/pull/34547 . However, I don't think it became apparent until something got faster (e.g our logging or similar) since there's a log message emitted internally by the streamer, and I think this used to be emitted after the player cleared the screen, but now something got faster, so the log message is emitted before we clear the screen.

changelog: Fixed `tsh play` not returning an error when playing a session fails.