### PR TITLE
[v17] Do not enter background mode on `quitAndInstall`

### DIFF
--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -21,6 +21,7 @@ import * as url from 'node:url';
 
 import {
   app,
+  autoUpdater,
   BrowserWindow,
   dialog,
   ipcMain,
@@ -137,10 +138,24 @@ export class WindowsManager {
       },
     });
 
+    // Flag to track if the app tries to quit.
+    // When true, the window should close rather than enter the background mode,
+    // as that would block the quit process.
     let isAppQuitting = false;
-    // Triggered when the app itself initiates shutdown (e.g., via app.quit()),
-    // not when the user manually closes the window.
+    autoUpdater.quitAndInstall();
+    // Fired when the app initiates shutdown explicitly, via app.quit().
     app.on('before-quit', () => {
+      isAppQuitting = true;
+    });
+    // Fired when the app initiates shutdown due to an update.
+    //
+    // When using electron-updater's quitAndInstall, the windows close first,
+    // and then 'before-quit' is emitted. This sequence differs from the normal
+    // quit flow.
+    //
+    // Note: Although we use electron-updater (not Electron's native autoUpdater),
+    // this event is available because electron-updater emulates it.
+    autoUpdater.on('before-quit-for-update', () => {
       isAppQuitting = true;
     });
 


### PR DESCRIPTION
Backport #59574 to branch/v17

changelog: Fixed an issue in Teleport Connect where clicking 'Restart' to apply an update could close the window without actually restarting the app
