### PR TITLE
Correct Okta integration enrolment page

### DIFF
--- a/docs/pages/identity-governance/okta/okta.mdx
+++ b/docs/pages/identity-governance/okta/okta.mdx
@@ -45,10 +45,10 @@ to align with the state defined by Teleport's RBAC configuration.
 
 ## Get started
 
-To start the enrolment, visit the Teleport Web UI and click **Identity Security** and then
-**Integrations** at the left of the screen. Then under **New Integration** select the **Okta** tile.
+To start the enrolment, visit the Teleport Web UI. From the left sidebar,
+navigate to **Add New** -> **Integration**. Select the **Okta** tile.
 
-![Add Integration plugin](../../../img/enterprise/plugins/integration-plugin.png)
+![Enroll an integration](../../../img/enterprise/plugins/enroll.png)
 
 This will bring you to the SSO integration configuration screen. Read [Guided
 Okta SSO Integration](./guided-sso.mdx) for supplementary instructions as you
@@ -86,8 +86,8 @@ dedicated Identity Security step with guided configuration instructions.
 
 At any point in the guided flow, you can return to the integration status page
 to manage any component of the integration. To open the integration status page
-in the Teleport Web UI, navigate to **Access** -> **Integrations** and click
-anywhere on the Okta integration row.
+in the Teleport Web UI, navigate to **Zero Trust Access** -> **Integrations** and
+click anywhere on the Okta integration row.
 
 ![Okta integration #1](../../../img/enterprise/plugins/okta/okta-status-page-1.png)
 
@@ -101,7 +101,7 @@ You can delete the Okta integration by taking the following steps:
    the corresponding Teleport accounts. Once the Teleport accounts have been
    automatically deleted you can proceed to delete the integration.
 
-2. Navigate to **Access** -> **Integrations** and click anywhere on the Okta
+2. Navigate to **Zero Trust Access** -> **Integrations** and click anywhere on the Okta
    integration row to visit the integration status page.
 
 3. Click **Delete Integration**.  


### PR DESCRIPTION
- Revert a change that added an incorrect image and instructions to visit the Identity Security tab.
- Correct instructions to visit the Access tab to visit the Zero Trust Access tab.