### PR TITLE
Distinguish downgrades from updates in Connect managed updates

### DIFF
--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -142,7 +142,6 @@ export class WindowsManager {
     // When true, the window should close rather than enter the background mode,
     // as that would block the quit process.
     let isAppQuitting = false;
-    autoUpdater.quitAndInstall();
     // Fired when the app initiates shutdown explicitly, via app.quit().
     app.on('before-quit', () => {
       isAppQuitting = true;

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
@@ -27,7 +27,7 @@ import Logger, { NullService } from 'teleterm/logger';
 
 import { AppUpdateEvent, AppUpdater, AppUpdaterStorage } from './appUpdater';
 
-const mockedAppVersion = '15.0.0';
+const mockedAppVersion = '17.8.0';
 
 jest.mock('electron', () => ({
   app: {
@@ -347,4 +347,56 @@ test('discards previous update if the latest check returns no update', async () 
   await setup.appUpdater.dispose();
   // Check if the app is set to discard the first downloaded update on close.
   expect(setup.nativeUpdater.autoInstallOnAppQuit).toBeFalsy();
+});
+
+test('when the update is older than app isDowngrade is true', async () => {
+  const setup = setUpAppUpdater({
+    clusters: {
+      reachableClusters: [
+        {
+          clusterUri: '/clusters/foo',
+          toolsAutoUpdate: true,
+          toolsVersion: '17.7.5',
+          minToolsVersion: '16.0.0-aa',
+        },
+      ],
+      unreachableClusters: [],
+    },
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-available',
+      update: expect.objectContaining({
+        isDowngrade: true,
+      }),
+    })
+  );
+});
+
+test('when the update is newer than app isDowngrade is false', async () => {
+  const setup = setUpAppUpdater({
+    clusters: {
+      reachableClusters: [
+        {
+          clusterUri: '/clusters/foo',
+          toolsAutoUpdate: true,
+          toolsVersion: '19.7.5',
+          minToolsVersion: '16.0.0-aa',
+        },
+      ],
+      unreachableClusters: [],
+    },
+  });
+
+  await setup.appUpdater.checkForUpdates();
+  expect(setup.lastEvent.value).toEqual(
+    expect.objectContaining({
+      kind: 'update-available',
+      update: expect.objectContaining({
+        isDowngrade: false,
+      }),
+    })
+  );
 });

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
@@ -349,7 +349,7 @@ test('discards previous update if the latest check returns no update', async () 
   expect(setup.nativeUpdater.autoInstallOnAppQuit).toBeFalsy();
 });
 
-test('when the update is older than app isDowngrade is true', async () => {
+test('when the update is older than app updateKind equals downgrade', async () => {
   const setup = setUpAppUpdater({
     clusters: {
       reachableClusters: [
@@ -369,13 +369,13 @@ test('when the update is older than app isDowngrade is true', async () => {
     expect.objectContaining({
       kind: 'update-available',
       update: expect.objectContaining({
-        isDowngrade: true,
+        updateKind: 'downgrade',
       }),
     })
   );
 });
 
-test('when the update is newer than app isDowngrade is false', async () => {
+test('when the update is newer than app updateKind equals upgrade', async () => {
   const setup = setUpAppUpdater({
     clusters: {
       reachableClusters: [
@@ -395,7 +395,7 @@ test('when the update is newer than app isDowngrade is false', async () => {
     expect.objectContaining({
       kind: 'update-available',
       update: expect.objectContaining({
-        isDowngrade: false,
+        updateKind: 'upgrade',
       }),
     })
   );

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -379,8 +379,8 @@ export class AppUpdater {
 }
 
 export interface UpdateInfo extends ElectronUpdateInfo {
-  /** Indicates whether the update version is lower than the current app version. */
-  isDowngrade: boolean;
+  /** Indicates whether the update version is newer or older than the current app version. */
+  updateKind: 'upgrade' | 'downgrade';
 }
 
 export interface AppUpdaterStorage<
@@ -412,7 +412,10 @@ function registerEventHandlers(
   const onUpdateAvailable = (update: ElectronUpdateInfo) => {
     updateInfo = {
       ...update,
-      isDowngrade: compare(app.getVersion(), update.version) === 1,
+      updateKind:
+        compare(update.version, app.getVersion()) === 1
+          ? 'upgrade'
+          : 'downgrade',
     };
     emit({
       kind: 'update-available',

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -24,18 +24,19 @@ import { app } from 'electron';
 import {
   autoUpdater,
   DebUpdater,
+  UpdateInfo as ElectronUpdateInfo,
   MacUpdater,
   AppUpdater as NativeUpdater,
   NsisUpdater,
   ProgressInfo,
   RpmUpdater,
   UpdateCheckResult,
-  UpdateInfo,
 } from 'electron-updater';
 import { ProviderRuntimeOptions } from 'electron-updater/out/providers/Provider';
 
 import type { GetClusterVersionsResponse } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
 import { AbortError } from 'shared/utils/error';
+import { compare } from 'shared/utils/semVer';
 
 import Logger from 'teleterm/logger';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -377,6 +378,11 @@ export class AppUpdater {
   }
 }
 
+export interface UpdateInfo extends ElectronUpdateInfo {
+  /** Indicates whether the update version is lower than the current app version. */
+  isDowngrade: boolean;
+}
+
 export interface AppUpdaterStorage<
   T = {
     /** User-selected cluster managing updates. */
@@ -403,11 +409,14 @@ function registerEventHandlers(
       autoUpdatesStatus: getAutoUpdatesStatus(),
     });
   };
-  const onUpdateAvailable = (update: UpdateInfo) => {
-    updateInfo = update;
+  const onUpdateAvailable = (update: ElectronUpdateInfo) => {
+    updateInfo = {
+      ...update,
+      isDowngrade: compare(app.getVersion(), update.version) === 1,
+    };
     emit({
       kind: 'update-available',
-      update,
+      update: updateInfo,
       autoDownload: getAutoDownload(),
       autoUpdatesStatus: getAutoUpdatesStatus() as AutoUpdatesEnabled,
     });

--- a/web/packages/teleterm/src/services/appUpdater/index.ts
+++ b/web/packages/teleterm/src/services/appUpdater/index.ts
@@ -23,4 +23,3 @@ export type {
   AutoUpdatesDisabled,
   Cluster,
 } from './autoUpdatesStatus';
-export type { UpdateInfo } from 'electron-updater';

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -67,6 +67,7 @@ export interface StoryProps {
     | 'Enabled client updates - v16 cluster'
     | 'Disabled client updates - v17 cluster';
   clusterBarSetToManageUpdates: boolean;
+  isDowngrade: boolean;
   nonTeleportCdn: boolean;
 }
 
@@ -105,6 +106,10 @@ const meta: Meta<StoryProps> = {
       control: { type: 'boolean' },
       description: 'Whether cluster "bar" is manually set to control updates',
     },
+    isDowngrade: {
+      control: { type: 'boolean' },
+      description: 'Whether the app version is newer than the update',
+    },
     step: {
       control: { type: 'radio' },
       options: [
@@ -133,6 +138,7 @@ const meta: Meta<StoryProps> = {
     clusterFoo: 'Enabled client updates - v18 cluster',
     clusterBar: 'Does not exist',
     clusterBarSetToManageUpdates: false,
+    isDowngrade: false,
     step: 'Update available',
     platform: 'darwin',
     nonTeleportCdn: false,
@@ -236,7 +242,8 @@ async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
 
   const updateInfo = makeUpdateInfo(
     storyProps.nonTeleportCdn,
-    status.enabled ? status.version : ''
+    status.enabled ? status.version : '',
+    storyProps.isDowngrade
   );
 
   switch (storyProps.step) {

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -67,7 +67,7 @@ export interface StoryProps {
     | 'Enabled client updates - v16 cluster'
     | 'Disabled client updates - v17 cluster';
   clusterBarSetToManageUpdates: boolean;
-  isDowngrade: boolean;
+  updateKind: 'Upgrade' | 'Downgrade';
   nonTeleportCdn: boolean;
 }
 
@@ -106,9 +106,11 @@ const meta: Meta<StoryProps> = {
       control: { type: 'boolean' },
       description: 'Whether cluster "bar" is manually set to control updates',
     },
-    isDowngrade: {
-      control: { type: 'boolean' },
-      description: 'Whether the app version is newer than the update',
+    updateKind: {
+      control: { type: 'radio' },
+      options: ['Upgrade', 'Downgrade'],
+      description:
+        'Indicates whether the update version is newer or older than the current application version.',
     },
     step: {
       control: { type: 'radio' },
@@ -138,7 +140,7 @@ const meta: Meta<StoryProps> = {
     clusterFoo: 'Enabled client updates - v18 cluster',
     clusterBar: 'Does not exist',
     clusterBarSetToManageUpdates: false,
-    isDowngrade: false,
+    updateKind: 'Upgrade',
     step: 'Update available',
     platform: 'darwin',
     nonTeleportCdn: false,
@@ -243,7 +245,7 @@ async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
   const updateInfo = makeUpdateInfo(
     storyProps.nonTeleportCdn,
     status.enabled ? status.version : '',
-    storyProps.isDowngrade
+    storyProps.updateKind === 'Upgrade' ? 'upgrade' : 'downgrade'
   );
 
   switch (storyProps.step) {

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -76,7 +76,7 @@ const meta: Meta<StoryProps> = {
   argTypes: {
     envVar: {
       control: { type: 'radio' },
-      options: ['Off', 'Set to version (v15)', 'Unset'],
+      options: ['Off', 'Set to version - v15', 'Unset'],
       description: '`TELEPORT_TOOLS_VERSION` value',
     },
     clusterFoo: {

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
@@ -28,27 +28,30 @@ import {
 test('download button is available when autoDownload is false', async () => {
   render(
     <DetailsView
-      updateEvent={makeUpdateAvailableEvent(makeUpdateInfo(false, '18.0.0'), {
-        enabled: true,
-        version: '18.0.0',
-        source: 'highest-compatible',
-        options: {
-          highestCompatibleVersion: '18.0.0',
-          managingClusterUri: undefined,
-          clusters: [
-            {
-              clusterUri: '/cluster/bar',
-              toolsAutoUpdate: true,
-              toolsVersion: '18.0.0',
-              minToolsVersion: '17.0.0-aa',
-              otherCompatibleClusters: [],
-            },
-          ],
-          unreachableClusters: [
-            { clusterUri: '/clusters/foo', errorMessage: 'NET_ERR' },
-          ],
-        },
-      })}
+      updateEvent={makeUpdateAvailableEvent(
+        makeUpdateInfo(false, '18.0.0', false),
+        {
+          enabled: true,
+          version: '18.0.0',
+          source: 'highest-compatible',
+          options: {
+            highestCompatibleVersion: '18.0.0',
+            managingClusterUri: undefined,
+            clusters: [
+              {
+                clusterUri: '/cluster/bar',
+                toolsAutoUpdate: true,
+                toolsVersion: '18.0.0',
+                minToolsVersion: '17.0.0-aa',
+                otherCompatibleClusters: [],
+              },
+            ],
+            unreachableClusters: [
+              { clusterUri: '/clusters/foo', errorMessage: 'NET_ERR' },
+            ],
+          },
+        }
+      )}
       clusterGetter={{
         findCluster: () => undefined,
       }}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
@@ -29,7 +29,7 @@ test('download button is available when autoDownload is false', async () => {
   render(
     <DetailsView
       updateEvent={makeUpdateAvailableEvent(
-        makeUpdateInfo(false, '18.0.0', false),
+        makeUpdateInfo(false, '18.0.0', 'upgrade'),
         {
           enabled: true,
           version: '18.0.0',

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -225,9 +225,9 @@ function AvailableUpdate(props: { update: UpdateInfo; platform: Platform }) {
   return (
     <Stack>
       <Text>
-        {props.update.isDowngrade
-          ? 'The app needs to be downgraded to match the required version.'
-          : 'A new version is available.'}
+        {props.update.updateKind === 'upgrade'
+          ? 'A new version is available.'
+          : 'The app needs to be downgraded to match the required version.'}
       </Text>
       <Flex gap={1} alignItems="center">
         {props.platform === 'darwin' ? (

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -224,7 +224,11 @@ function AvailableUpdate(props: { update: UpdateInfo; platform: Platform }) {
 
   return (
     <Stack>
-      <Text>A new version is available.</Text>
+      <Text>
+        {props.update.isDowngrade
+          ? 'The app needs to be downgraded to match the required version.'
+          : 'A new version is available.'}
+      </Text>
       <Flex gap={1} alignItems="center">
         {props.platform === 'darwin' ? (
           <img alt="App icon" height="50px" src={iconMac} />

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
@@ -28,27 +28,30 @@ import { WidgetView } from './WidgetView';
 test('download button is available when autoDownload is false', async () => {
   render(
     <WidgetView
-      updateEvent={makeUpdateAvailableEvent(makeUpdateInfo(false, '18.0.0'), {
-        enabled: true,
-        version: '18.0.0',
-        source: 'highest-compatible',
-        options: {
-          highestCompatibleVersion: '18.0.0',
-          managingClusterUri: undefined,
-          clusters: [
-            {
-              clusterUri: '/cluster/bar',
-              toolsAutoUpdate: true,
-              toolsVersion: '18.0.0',
-              minToolsVersion: '17.0.0-aa',
-              otherCompatibleClusters: [],
-            },
-          ],
-          unreachableClusters: [
-            { clusterUri: '/clusters/foo', errorMessage: 'NET_ERR' },
-          ],
-        },
-      })}
+      updateEvent={makeUpdateAvailableEvent(
+        makeUpdateInfo(false, '18.0.0', false),
+        {
+          enabled: true,
+          version: '18.0.0',
+          source: 'highest-compatible',
+          options: {
+            highestCompatibleVersion: '18.0.0',
+            managingClusterUri: undefined,
+            clusters: [
+              {
+                clusterUri: '/cluster/bar',
+                toolsAutoUpdate: true,
+                toolsVersion: '18.0.0',
+                minToolsVersion: '17.0.0-aa',
+                otherCompatibleClusters: [],
+              },
+            ],
+            unreachableClusters: [
+              { clusterUri: '/clusters/foo', errorMessage: 'NET_ERR' },
+            ],
+          },
+        }
+      )}
       clusterGetter={{
         findCluster: () => undefined,
       }}

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
@@ -29,7 +29,7 @@ test('download button is available when autoDownload is false', async () => {
   render(
     <WidgetView
       updateEvent={makeUpdateAvailableEvent(
-        makeUpdateInfo(false, '18.0.0', false),
+        makeUpdateInfo(false, '18.0.0', 'upgrade'),
         {
           enabled: true,
           version: '18.0.0',

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -284,19 +284,21 @@ function makeUpdaterContent({
         description: `Downloaded ${formatMB(updateEvent.progress.transferred)} of ${formatMB(updateEvent.progress.total)}`,
       };
     case 'update-available':
-      const { isDowngrade } = updateEvent.update;
+      const { updateKind } = updateEvent.update;
       if (updateEvent.autoDownload) {
         return {
-          description: isDowngrade
-            ? 'Downloading required version…'
-            : 'Update available. Starting download…',
+          description:
+            updateKind === 'upgrade'
+              ? 'Update available. Starting download…'
+              : 'Downloading required version…',
         };
       }
 
       return {
-        description: isDowngrade
-          ? 'Downgrade to required version'
-          : 'Update available',
+        description:
+          updateKind === 'upgrade'
+            ? 'Update available'
+            : 'Downgrade to required version',
         button: {
           name: 'Download',
           action: onDownload,

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -284,14 +284,19 @@ function makeUpdaterContent({
         description: `Downloaded ${formatMB(updateEvent.progress.transferred)} of ${formatMB(updateEvent.progress.total)}`,
       };
     case 'update-available':
+      const { isDowngrade } = updateEvent.update;
       if (updateEvent.autoDownload) {
         return {
-          description: 'Update available. Starting download…',
+          description: isDowngrade
+            ? 'Downloading required version…'
+            : 'Update available. Starting download…',
         };
       }
 
       return {
-        description: 'Update available',
+        description: isDowngrade
+          ? 'Downgrade to required version'
+          : 'Update available',
         button: {
           name: 'Download',
           action: onDownload,

--- a/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
@@ -27,7 +27,7 @@ import { shouldAutoDownload } from 'teleterm/services/appUpdater/autoUpdatesStat
 export function makeUpdateInfo(
   nonTeleportCdn: boolean,
   version: string,
-  isDowngrade: boolean
+  updateKind: 'upgrade' | 'downgrade'
 ): UpdateInfo {
   return {
     files: [
@@ -40,7 +40,7 @@ export function makeUpdateInfo(
       },
     ],
     releaseDate: '',
-    isDowngrade,
+    updateKind,
     version,
     path: '',
     sha512: '',

--- a/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
@@ -26,7 +26,8 @@ import { shouldAutoDownload } from 'teleterm/services/appUpdater/autoUpdatesStat
 
 export function makeUpdateInfo(
   nonTeleportCdn: boolean,
-  version: string
+  version: string,
+  isDowngrade: boolean
 ): UpdateInfo {
   return {
     files: [
@@ -39,6 +40,7 @@ export function makeUpdateInfo(
       },
     ],
     releaseDate: '',
+    isDowngrade,
     version,
     path: '',
     sha512: '',

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -129,6 +129,7 @@ export function makeProps(
     props.appUpdateEvent = {
       kind: 'update-available',
       update: {
+        isDowngrade: false,
         version: '19.0.0',
         files: [
           {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -129,7 +129,7 @@ export function makeProps(
     props.appUpdateEvent = {
       kind: 'update-available',
       update: {
-        isDowngrade: false,
+        updateKind: 'upgrade',
         version: '19.0.0',
         files: [
           {


### PR DESCRIPTION
To avoid confusing users by naming downgrades as "updates", we should customize the messages.

The login dialog widget:
<img width="470" height="116" alt="image" src="https://github.com/user-attachments/assets/93afe81e-8a3e-440c-af89-a3a1be7f31d2" />
<img width="470" height="137" alt="image" src="https://github.com/user-attachments/assets/45452a20-51ef-4947-b1b8-80a1eede91e6" />

Details view:
<img width="470" height="265" alt="image" src="https://github.com/user-attachments/assets/111ae8c3-a70a-462f-885b-1d577e825fc6" />

If you think the messages can be improved, I'm open to suggestions.