### PR TITLE
Fix `tcp scp` getting stuck in symlink loops

### DIFF
--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -211,6 +211,12 @@ func (h *proxyHandlers) Filelist(req *sftp.Request) (_ sftp.ListerAt, err error)
 	return lister, nil
 }
 
+// RealPath canonicalizes a path name, including resolving ".." and
+// following symlinks. Required to implement [sftp.RealPathFileLister].
+func (h *proxyHandlers) RealPath(path string) (string, error) {
+	return h.remoteFS.RealPath(path)
+}
+
 func (h *proxyHandlers) sendSFTPEvent(req *sftp.Request, reqErr error) {
 	wd, err := h.remoteFS.Getwd()
 	if err != nil {

--- a/lib/sshutils/sftp/http.go
+++ b/lib/sshutils/sftp/http.go
@@ -171,6 +171,10 @@ func (h *httpFS) Getwd() (string, error) {
 	return "", nil
 }
 
+func (h *httpFS) RealPath(path string) (string, error) {
+	return path, nil
+}
+
 type nopWriteCloser struct {
 	io.Writer
 }

--- a/lib/sshutils/sftp/local.go
+++ b/lib/sshutils/sftp/local.go
@@ -142,3 +142,11 @@ func (l localFS) Readlink(name string) (string, error) {
 func (l localFS) Getwd() (string, error) {
 	return os.Getwd()
 }
+
+func (l localFS) RealPath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(path)
+}

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -161,6 +161,9 @@ type FileSystem interface {
 	Readlink(name string) (string, error)
 	// Getwd gets the current working directory.
 	Getwd() (string, error)
+	// RealPath canonicalizes a path name, including resolving ".." and
+	// following symlinks.
+	RealPath(path string) (string, error)
 }
 
 // CreateUploadConfig returns a Config ready to upload files over SFTP.
@@ -552,7 +555,7 @@ func (c *Config) transfer(ctx context.Context) error {
 		}
 
 		if fi.IsDir() {
-			if err := c.transferDir(ctx, dstPath, matchedPaths[i], fi); err != nil {
+			if err := c.transferDir(ctx, dstPath, matchedPaths[i], fi, nil); err != nil {
 				return trace.Wrap(err)
 			}
 		} else {
@@ -566,10 +569,22 @@ func (c *Config) transfer(ctx context.Context) error {
 }
 
 // transferDir transfers a directory
-func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo) error {
+func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo, visited map[string]struct{}) error {
+	if visited == nil {
+		visited = make(map[string]struct{})
+	}
+	realSrcPath, err := c.srcFS.RealPath(srcPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, ok := visited[realSrcPath]; ok {
+		c.Log.DebugContext(ctx, "symlink loop detected, directory will be skipped", "link", srcPath, "target", realSrcPath)
+		return nil
+	}
+	visited[realSrcPath] = struct{}{}
 	c.Log.DebugContext(ctx, "transferring contents of directory", "source_fs", c.srcFS.Type(), "source_path", srcPath, "dest_fs", c.dstFS.Type(), "dest_path", dstPath)
 
-	err := c.dstFS.Mkdir(dstPath)
+	err = c.dstFS.Mkdir(dstPath)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return trace.Errorf("error creating %s directory %q: %w", c.dstFS.Type(), dstPath, err)
 	}
@@ -587,7 +602,7 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 		lSubPath := path.Join(srcPath, info.Name())
 
 		if info.IsDir() {
-			if err := c.transferDir(ctx, dstSubPath, lSubPath, info); err != nil {
+			if err := c.transferDir(ctx, dstSubPath, lSubPath, info, visited); err != nil {
 				return trace.Wrap(err)
 			}
 		} else {

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -229,6 +230,12 @@ func (s *sftpHandler) Filelist(req *sftp.Request) (_ sftp.ListerAt, retErr error
 	}
 
 	return sftputils.HandleFilelist(req, nil /* local filesystem */)
+}
+
+// RealPath canonicalizes a path name, including resolving ".." and
+// following symlinks. Required to implement [sftp.RealPathFileLister].
+func (s *sftpHandler) RealPath(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
 }
 
 func (s *sftpHandler) sendSFTPEvent(req *sftp.Request, reqErr error) {


### PR DESCRIPTION
This change fixes `tsh scp` to no longer get caught in symlink loops and repeatedly copy files. When a loop is detected, Teleport logs it and skips traversing that path.

Fixes #23919.

Changelog: Fixed tsh scp getting stuck in symlink loops