### PR TITLE
docs: update intro guide protocols sub title to resources

### DIFF
--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -102,7 +102,9 @@ The Web UI provides similar access to resources as Teleport Connect, and
 additional access to to Request and Activity logs for users with the right
 permissions.
 
-## Resources
+## Connecting to resources
+
+This section provides an overview of some ways you can use Teleport client tools to connect to resources in your infrastructure.
 
 ### Server access (`ssh`)
 

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -102,7 +102,7 @@ The Web UI provides similar access to resources as Teleport Connect, and
 additional access to to Request and Activity logs for users with the right
 permissions.
 
-## Protocols
+## Resources
 
 ### Server access (`ssh`)
 


### PR DESCRIPTION
generally we use resources instead of titling as protocols.