### PR TITLE
Replace flaky test `TestIntegrations/RecordingModesSessionTrackers`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -183,7 +183,6 @@ func TestIntegrations(t *testing.T) {
 	t.Run("PAM", suite.bind(testPAM))
 	t.Run("PortForwarding", suite.bind(testPortForwarding))
 	t.Run("ProxyHostKeyCheck", suite.bind(testProxyHostKeyCheck))
-	t.Run("RecordingModesSessionTrackers", suite.bind(testRecordingModesSessionTrackers))
 	t.Run("ReverseTunnelCollapse", suite.bind(testReverseTunnelCollapse))
 	t.Run("RotateRollback", suite.bind(testRotateRollback))
 	t.Run("RotateSuccess", suite.bind(testRotateSuccess))
@@ -1035,83 +1034,6 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 				term.Type("exit\n\r")
 				waitSessionTermination(t, errCh, require.NoError)
 			})
-		})
-	}
-}
-
-func testRecordingModesSessionTrackers(t *testing.T, suite *integrationTestSuite) {
-	ctx := t.Context()
-
-	cfg := suite.defaultServiceConfig()
-	cfg.Auth.Enabled = true
-	cfg.Proxy.DisableWebService = true
-	cfg.Proxy.DisableWebInterface = true
-	cfg.Proxy.Enabled = true
-	cfg.SSH.Enabled = true
-
-	teleport := suite.NewTeleportWithConfig(t, nil, nil, cfg)
-	defer teleport.StopAll()
-
-	// startSession starts an interactive session, users must terminate the
-	// session by typing "exit" in the terminal.
-	startSession := func(username string) (*Terminal, chan error) {
-		term := NewTerminal(250)
-		errCh := make(chan error)
-
-		go func() {
-			cl, err := teleport.NewClient(helpers.ClientConfig{
-				Login:   username,
-				Cluster: helpers.Site,
-				Host:    Host,
-			})
-			if err != nil {
-				errCh <- trace.Wrap(err)
-				return
-			}
-			cl.Stdout = term
-			cl.Stdin = term
-
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-			errCh <- cl.SSH(ctx, nil)
-		}()
-
-		return term, errCh
-	}
-
-	err := teleport.WaitForNodeCount(ctx, helpers.Site, 1)
-	require.NoError(t, err)
-
-	auth := teleport.Process.GetAuthServer()
-	for _, mode := range []string{types.RecordAtNode, types.RecordAtProxy} {
-		t.Run(mode, func(t *testing.T) {
-			rc := types.DefaultSessionRecordingConfig()
-			rc.SetMode(mode)
-
-			_, err := auth.UpsertSessionRecordingConfig(ctx, rc)
-			require.NoError(t, err)
-
-			// Start session.
-			term, errCh := startSession(suite.Me.Username)
-
-			// Validate that the session tracker exists and contains
-			// the correct target address.
-			var sessionID string
-			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				trackers, err := auth.GetActiveSessionTrackers(ctx)
-				require.NoError(t, err)
-				require.Len(t, trackers, 1)
-				require.Equal(t, helpers.HostID, trackers[0].GetAddress())
-				sessionID = trackers[0].GetSessionID()
-			}, 30*time.Second, 100*time.Millisecond)
-
-			// Wait for the session to terminate without error.
-			term.Type("exit\n\r")
-			require.NoError(t, waitForError(errCh, 30*time.Second))
-
-			// Manually clean up the tracker for the session to prevent
-			// it leaking into the next test case.
-			require.NoError(t, auth.RemoveSessionTracker(ctx, sessionID))
 		})
 	}
 }

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -505,10 +505,6 @@ func (s *Server) GetSELinuxEnabled() bool {
 
 // GetInfo returns a services.Server that represents the target server.
 func (s *Server) GetInfo() types.Server {
-	return s.getBasicInfo()
-}
-
-func (s *Server) getBasicInfo() *types.ServerV2 {
 	// Only set the address for non-tunnel nodes.
 	var addr string
 	if !s.targetServer.GetUseTunnel() {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -3068,7 +3068,7 @@ func TestHandlePuTTYWinadj(t *testing.T) {
 	require.Equal(t, "hello once more\n", string(out))
 }
 
-func TestTargetMetadata(t *testing.T) {
+func TestEventMetadata(t *testing.T) {
 	ctx := context.Background()
 	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{


### PR DESCRIPTION
Replace the flaky integration test added in https://github.com/gravitational/teleport/pull/58707 with a more straightforward test focused on the intended behavioral change from that PR.

Will be manually backported into https://github.com/gravitational/teleport/pull/59599, https://github.com/gravitational/teleport/pull/59600, https://github.com/gravitational/teleport/pull/59601

Fixes #59586