### PR TITLE
[Web] Improve side navigation search indexing

### DIFF
--- a/web/packages/teleport/src/Navigation/Search.tsx
+++ b/web/packages/teleport/src/Navigation/Search.tsx
@@ -132,7 +132,10 @@ function SearchContent({
       subsection.searchableTags?.some(
         tag =>
           searchInput.length > 0 &&
-          tag.toLowerCase().includes(searchInput.toLocaleLowerCase())
+          (tag.toLowerCase().includes(searchInput.toLocaleLowerCase()) ||
+            subsection?.title
+              ?.toLowerCase()
+              .includes(searchInput.toLocaleLowerCase()))
       )
     )
   );
@@ -241,7 +244,7 @@ const SearchInput = styled.input`
   box-sizing: border-box;
   font-size: ${props => props.theme.fontSizes[2]}px;
   height: 32px;
-  width: 192px;
+  width: 232px;
   ${color}
   ${space}
   ${height}

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -505,7 +505,38 @@ export class FeatureDiscover implements TeleportFeature {
     getLink() {
       return cfg.routes.discover;
     },
-    searchableTags: ['new', 'add', 'enroll', 'resources'],
+    searchableTags: [
+      'new',
+      'add',
+      'enroll',
+      'resources',
+      'discover',
+      'saml',
+      'idp',
+      'grafana',
+      'entra',
+      'aws',
+      'kubernetes',
+      'node',
+      'ssh',
+      'linux',
+      'ubuntu',
+      'centos',
+      'debian',
+      'windows',
+      'desktop',
+      'ec2',
+      'eks',
+      'rds',
+      'mysql',
+      'postgresql',
+      'mariadb',
+      'dynamodb',
+      'cassandra',
+      'azure',
+      'cockroachdb',
+      'mongodb',
+    ],
   };
 
   hasAccess(flags: FeatureFlags) {
@@ -810,7 +841,14 @@ export class FeatureHelpAndSupport implements TeleportFeature {
     getLink() {
       return cfg.routes.support;
     },
-    searchableTags: ['help', 'support', NavTitle.HelpAndSupport],
+    searchableTags: [
+      'help',
+      'support',
+      'contacts',
+      'security',
+      'business',
+      'version',
+    ],
   };
 }
 


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/59053

This PR adds more searchable tags to make the `Add New Resource` page show up when searching various relevant keywords to make it easier to find. This PR also makes an improvement to the search which ensures that searching the title of a navigation item will always yield it in the results, as opposed to relying solely on the predefined list of `searchableTags` (for example, searching for "session & identity locks" previously would not actually return that page in the results, it was only possible to find it by searching "locks").

This PR also makes a slight tweak to the search bar width, as it seems to have regressed at some point and become narrower.

## Demo

### Before

<img width="365" height="764" alt="image" src="https://github.com/user-attachments/assets/adc65672-255e-48ce-a1a4-122c148f5bef" />
<img width="365" height="764" alt="image" src="https://github.com/user-attachments/assets/36032f32-7551-42fd-898b-d3f32c936086" />

### After

<img width="365" height="764" alt="image" src="https://github.com/user-attachments/assets/0a74288c-eb11-4a0d-ae17-db180196f6ea" />
<img width="365" height="764" alt="image" src="https://github.com/user-attachments/assets/0f37e078-a77d-4e08-8363-5b892efabb68" />
