### PR TITLE
[v17] Fix `tsh play` failing without error

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2547,6 +2547,10 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 		}
 	}
 
+	if err := player.Err(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Backport #59589 to branch/v17

changelog: Fixed `tsh play` not returning an error when playing a session fails.
