### PR TITLE
[v18] Add IAM user domain if missing for GCP Postgres databases

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/database.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/database.pb.go
@@ -58,7 +58,9 @@ type Database struct {
 	// labels is a list of labels for this database
 	Labels []*Label `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty"`
 	// target_health of the "db_server" that is serving this database.
-	TargetHealth  *TargetHealth `protobuf:"bytes,9,opt,name=target_health,json=targetHealth,proto3" json:"target_health,omitempty"`
+	TargetHealth *TargetHealth `protobuf:"bytes,9,opt,name=target_health,json=targetHealth,proto3" json:"target_health,omitempty"`
+	// gcp_project_id is optional project ID set for GCP Project databases.
+	GcpProjectId  string `protobuf:"bytes,10,opt,name=gcp_project_id,json=gcpProjectId,proto3" json:"gcp_project_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -156,6 +158,13 @@ func (x *Database) GetTargetHealth() *TargetHealth {
 	return nil
 }
 
+func (x *Database) GetGcpProjectId() string {
+	if x != nil {
+		return x.GcpProjectId
+	}
+	return ""
+}
+
 // DatabaseServer (db_server) describes a database heartbeat signal
 // reported from an agent (db_service) that is proxying
 // the database.
@@ -231,7 +240,7 @@ var File_teleport_lib_teleterm_v1_database_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_teleterm_v1_database_proto_rawDesc = "" +
 	"\n" +
-	"'teleport/lib/teleterm/v1/database.proto\x12\x18teleport.lib.teleterm.v1\x1a$teleport/lib/teleterm/v1/label.proto\x1a,teleport/lib/teleterm/v1/target_health.proto\"\xaa\x02\n" +
+	"'teleport/lib/teleterm/v1/database.proto\x12\x18teleport.lib.teleterm.v1\x1a$teleport/lib/teleterm/v1/label.proto\x1a,teleport/lib/teleterm/v1/target_health.proto\"\xd0\x02\n" +
 	"\bDatabase\x12\x10\n" +
 	"\x03uri\x18\x01 \x01(\tR\x03uri\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -241,7 +250,9 @@ const file_teleport_lib_teleterm_v1_database_proto_rawDesc = "" +
 	"\bhostname\x18\x06 \x01(\tR\bhostname\x12\x12\n" +
 	"\x04addr\x18\a \x01(\tR\x04addr\x127\n" +
 	"\x06labels\x18\b \x03(\v2\x1f.teleport.lib.teleterm.v1.LabelR\x06labels\x12K\n" +
-	"\rtarget_health\x18\t \x01(\v2&.teleport.lib.teleterm.v1.TargetHealthR\ftargetHealth\"\xa4\x01\n" +
+	"\rtarget_health\x18\t \x01(\v2&.teleport.lib.teleterm.v1.TargetHealthR\ftargetHealth\x12$\n" +
+	"\x0egcp_project_id\x18\n" +
+	" \x01(\tR\fgcpProjectId\"\xa4\x01\n" +
 	"\x0eDatabaseServer\x12\x10\n" +
 	"\x03uri\x18\x01 \x01(\tR\x03uri\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12\x17\n" +

--- a/gen/proto/ts/teleport/lib/teleterm/v1/database_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/database_pb.ts
@@ -92,6 +92,12 @@ export interface Database {
      * @generated from protobuf field: teleport.lib.teleterm.v1.TargetHealth target_health = 9;
      */
     targetHealth?: TargetHealth;
+    /**
+     * gcp_project_id is optional project ID set for GCP Project databases.
+     *
+     * @generated from protobuf field: string gcp_project_id = 10;
+     */
+    gcpProjectId: string;
 }
 /**
  * DatabaseServer (db_server) describes a database heartbeat signal
@@ -130,7 +136,8 @@ class Database$Type extends MessageType<Database> {
             { no: 6, name: "hostname", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "addr", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 8, name: "labels", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Label },
-            { no: 9, name: "target_health", kind: "message", T: () => TargetHealth }
+            { no: 9, name: "target_health", kind: "message", T: () => TargetHealth },
+            { no: 10, name: "gcp_project_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Database>): Database {
@@ -143,6 +150,7 @@ class Database$Type extends MessageType<Database> {
         message.hostname = "";
         message.addr = "";
         message.labels = [];
+        message.gcpProjectId = "";
         if (value !== undefined)
             reflectionMergePartial<Database>(this, message, value);
         return message;
@@ -178,6 +186,9 @@ class Database$Type extends MessageType<Database> {
                     break;
                 case /* teleport.lib.teleterm.v1.TargetHealth target_health */ 9:
                     message.targetHealth = TargetHealth.internalBinaryRead(reader, reader.uint32(), options, message.targetHealth);
+                    break;
+                case /* string gcp_project_id */ 10:
+                    message.gcpProjectId = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -218,6 +229,9 @@ class Database$Type extends MessageType<Database> {
         /* teleport.lib.teleterm.v1.TargetHealth target_health = 9; */
         if (message.targetHealth)
             TargetHealth.internalBinaryWrite(message.targetHealth, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* string gcp_project_id = 10; */
+        if (message.gcpProjectId !== "")
+            writer.tag(10, WireType.LengthDelimited).string(message.gcpProjectId);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/apiserver/handler/handler_databases.go
+++ b/lib/teleterm/apiserver/handler/handler_databases.go
@@ -74,6 +74,9 @@ func (s *Handler) ListDatabaseServers(ctx context.Context, req *api.ListDatabase
 func newAPIDatabase(db clusters.Database) *api.Database {
 	apiLabels := makeAPILabels(ui.MakeLabelsWithoutInternalPrefixes(db.GetAllLabels()))
 
+	// ignore potential (and unlikely) errors
+	gcpProjectID, _ := db.GetGCPProjectID()
+
 	return &api.Database{
 		Uri:      db.URI.String(),
 		Name:     db.GetName(),
@@ -86,6 +89,7 @@ func newAPIDatabase(db clusters.Database) *api.Database {
 			Error:   db.TargetHealth.TransitionError,
 			Message: db.TargetHealth.Message,
 		},
+		GcpProjectId: gcpProjectID,
 	}
 }
 

--- a/proto/teleport/lib/teleterm/v1/database.proto
+++ b/proto/teleport/lib/teleterm/v1/database.proto
@@ -45,6 +45,8 @@ message Database {
   repeated Label labels = 8;
   // target_health of the "db_server" that is serving this database.
   TargetHealth target_health = 9;
+  // gcp_project_id is optional project ID set for GCP Project databases.
+  string gcp_project_id = 10;
 }
 
 // DatabaseServer (db_server) describes a database heartbeat signal

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -62,6 +62,7 @@ export const makeDatabase = (
   hostname: '',
   addr: '',
   labels: [],
+  gcpProjectId: '',
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -210,7 +210,7 @@ export function ConnectDatabaseActionButton(props: {
 }): React.JSX.Element {
   const appContext = useAppContext();
 
-    function connect(dbUser: string): void {
+  function connect(dbUser: string): void {
     const { uri, name, protocol, gcpProjectId } = props.database;
 
     connectToDatabase(

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -210,11 +210,30 @@ export function ConnectDatabaseActionButton(props: {
 }): React.JSX.Element {
   const appContext = useAppContext();
 
-  function connect(dbUser: string): void {
-    const { uri, name, protocol } = props.database;
+    function adjustDbUser(
+        dbUser: string,
+        protocol: string,
+        gcpProjectId?: string | null
+    ): string {
+        const user = dbUser?.trim();
+        if (!user) return user;
+        if (protocol !== 'postgres') return user;
+        if (!gcpProjectId) return user; // use gcpProjectId as the GCP-hosted check
+        if (user.includes('@')) return user;
+
+        const updated = `${user}@${gcpProjectId}.iam`;
+        return updated;
+    }
+
+
+    function connect(dbUser: string): void {
+    const { uri, name, protocol, gcpProjectId } = props.database;
+
+    const adjustedUser = adjustDbUser(dbUser, protocol, gcpProjectId);
+
     connectToDatabase(
       appContext,
-      { uri, name, protocol, dbUser },
+      { uri, name, protocol, dbUser: adjustedUser },
       { origin: 'resource_table' }
     );
   }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -210,30 +210,12 @@ export function ConnectDatabaseActionButton(props: {
 }): React.JSX.Element {
   const appContext = useAppContext();
 
-    function adjustDbUser(
-        dbUser: string,
-        protocol: string,
-        gcpProjectId?: string | null
-    ): string {
-        const user = dbUser?.trim();
-        if (!user) return user;
-        if (protocol !== 'postgres') return user;
-        if (!gcpProjectId) return user; // use gcpProjectId as the GCP-hosted check
-        if (user.includes('@')) return user;
-
-        const updated = `${user}@${gcpProjectId}.iam`;
-        return updated;
-    }
-
-
     function connect(dbUser: string): void {
     const { uri, name, protocol, gcpProjectId } = props.database;
 
-    const adjustedUser = adjustDbUser(dbUser, protocol, gcpProjectId);
-
     connectToDatabase(
       appContext,
-      { uri, name, protocol, dbUser: adjustedUser },
+      { uri, name, protocol, dbUser, gcpProjectId },
       { origin: 'resource_table' }
     );
   }

--- a/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
@@ -109,6 +109,8 @@ const WaitingForGateway = (props: {
         name: doc.targetName,
         protocol: doc.targetProtocol,
         dbUser: doc.targetUser,
+        // we don't pass gcpProjectId as target so the target user will not be adjusted,
+        // but it should've happened already at this point
       },
       { origin: 'reopened_session' }
     );

--- a/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
@@ -109,8 +109,8 @@ const WaitingForGateway = (props: {
         name: doc.targetName,
         protocol: doc.targetProtocol,
         dbUser: doc.targetUser,
-        // we don't pass gcpProjectId as target so the target user will not be adjusted,
-        // but it should've happened already at this point
+        // We don't pass gcpProjectId as target so the target user will not be adjusted,
+        // but it doesn't matter because it was already adjusted when this doc was created.
       },
       { origin: 'reopened_session' }
     );

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -212,7 +212,7 @@ export function mapToAction(
               name,
               protocol,
               gcpProjectId,
-              dbUser: dbUser.value
+              dbUser: dbUser.value,
             },
             {
               origin: 'search_bar',

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -204,14 +204,15 @@ export function mapToAction(
           placeholder: 'Provide db username',
         },
         perform: dbUser => {
-          const { uri, name, protocol } = result.resource;
+          const { uri, name, protocol, gcpProjectId } = result.resource;
           return connectToDatabase(
             ctx,
             {
               uri,
               name,
               protocol,
-              dbUser: dbUser.value,
+              gcpProjectId,
+              dbUser: dbUser.value
             },
             {
               origin: 'search_bar',


### PR DESCRIPTION
Backport #59431 to branch/v18

changelog: Added automatic `@<project-id>.iam` suffix to GCP Postgres usernames (Teleport Connect)
