### PR TITLE
Fix session recording seeking in long inactive periods

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -362,6 +362,14 @@ export class SessionStream<
 
       this.updateLoadedTimes(parsed.startTime, parsed.endTime);
 
+      if (this.state === PlayerState.Loading) {
+        if (this.wasPlayingBeforeSeek) {
+          this.play();
+        } else {
+          this.setState(PlayerState.Paused);
+        }
+      }
+
       return;
     }
 

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -332,6 +332,8 @@ export class SessionStream<
       // mark loading as false as soon as we get any batch event so we can start playing again
       this.loading = false;
 
+      this.pushBatchToBuffer(parsed.events);
+
       if (this.state === PlayerState.Loading) {
         if (this.wasPlayingBeforeSeek) {
           this.play();
@@ -339,8 +341,6 @@ export class SessionStream<
           this.setState(PlayerState.Paused);
         }
       }
-
-      this.pushBatchToBuffer(parsed.events);
 
       const hasEnd =
         parsed.events[parsed.events.length - 1].type === this.endEventType;


### PR DESCRIPTION
There is an issue when seeking into a long period of inactivity (i.e. the period of inactivity is greater than the chunk of events being requested, which is 20 seconds) where the player would enter an infinite "loading" state (it would just keep spinning)

This was due to a couple of issues
- The player would only continue playing if a batch request was received
- The backend would not return the current screen state at the requested time due to there being no events

I also changed the handling of batch events to push the events to the buffer before resuming playback. I don't think the previous behaviour caused any issues but pushing the events to the buffer and updating the loaded range before playing seems like the right order to do things

changelog: Fixes an issue where the new SSH/k8s recording player would indefinitely show a loading spinner when seeking into a long period of inactivity