### PR TITLE
Add docs for multi-port TCP access without VNet

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/tcp.mdx
@@ -192,10 +192,25 @@ To access the app, [start VNet](../../../connect-your-client/vnet.mdx) and point
 client towards the target port:
 
 ```code
+# Use 8080 for the HTTP server.
 $ curl -I http://tcp-app.teleport.example.com:8080
 HTTP/1.1 200 OK
 
+# Use 5432 for postgres.
 $ psql postgres://postgres@tcp-app.teleport.example.com:5432/postgres
+```
+
+Without VNet, use `tsh proxy app` and specify the target port after the listening port. All
+connections made to the proxy will be routed to that target port.
+
+```code
+# Use 12345 as the listening port and 8080 as the target port.
+$ tsh proxy app tcp-app --port 12345:8080
+Proxying connections to tcp-app:8080 on 127.0.0.1:12345
+
+# Use a random listening port and 5432 as the target port.
+$ tsh proxy app tcp-app --port 0:5432
+Proxying connections to tcp-app:5432 on 127.0.0.1:65060
 ```
 
 <Admonition type="warning">

--- a/docs/pages/enroll-resources/application-access/guides/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/tcp.mdx
@@ -219,15 +219,6 @@ the specification. We&nbsp;strongly recommend specifying only the necessary port
 wide port range that happens to include ports that are meant to be available.
 </Admonition>
 
-{/* TODO: DELETE IN 19.0.0. At this point all compatible servers and clients are going
-to support multiple ports. */}
-
-Support for multiple ports is available in Teleport v17.1+. Connections from Teleport clients that
-do not support multiple ports are routed to the first port from the application specification. An
-Application Service that does not support multiple ports will not be able to handle traffic to a
-multi-port application if it receives such application through [dynamic
-registration](./dynamic-registration.mdx) from an Auth Service.
-
 ### Further reading
 
 - Learn about [access controls](../controls.mdx) for applications.

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -564,7 +564,7 @@ $ tsh proxy app [<flags>] <app>
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `-p, --port` | none | port number | Specify the source port for the local proxy |
+| `-p, --port` | none | port number, port pair | Specify the listening port for the local proxy. Accepts an optional target port of a multi-port TCP app after a colon, e.g. "1234:5678". |
 
 ### [Global Flags](#tsh-global-flags)
 


### PR DESCRIPTION
This feature was originally added in #50429 but I've been putting off documenting it all this time because I deemed it to be a relatively niche use case.