### PR TITLE
Enable sending messages from main to renderer with acknowledgments

### DIFF
--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.test.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EventEmitter } from 'events';
+
+import Logger, { NullService } from 'teleterm/logger';
+
+import { AwaitableSender } from './awaitableSender';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+test('starts port and add event listeners in constructor', () => {
+  const port = new MockMessagePortMain();
+  new AwaitableSender(port);
+  expect(port.listeners('message')).toHaveLength(1);
+  expect(port.listeners('close')).toHaveLength(1);
+});
+
+test('send posts message and returns a promise that resolves on ack', async () => {
+  const port = new MockMessagePortMain();
+  const sender = new AwaitableSender(port);
+
+  const payload = { foo: 'bar' };
+  const promise = sender.send(payload);
+
+  expect(port.postMessage).toHaveBeenCalledWith({
+    type: 'data',
+    id: expect.any(String),
+    payload,
+  });
+
+  // The other side responds: first emit ack for other id and then an empty message.
+  port.emitMessage({ id: 'wrong-id', type: 'ack' });
+  port.emitMessage(undefined);
+  // Wait a short time and make sure the promise hasn't resolved.
+  const result = await Promise.race([
+    promise.then(() => 'resolved'),
+    new Promise(resolve => setTimeout(() => resolve('pending'), 50)),
+  ]);
+
+  expect(result).toBe('pending');
+
+  // The other side responds again: now emit ack for our send request.
+  const correctId = port.postMessage.mock.calls[0][0].id;
+  port.emitMessage({ id: correctId, type: 'ack' });
+
+  await expect(promise).resolves.toBeUndefined();
+});
+
+test('dispose removes listeners, resolves pending messages, clears map, and resolves disposeSignal', async () => {
+  const port = new MockMessagePortMain();
+  const sender = new AwaitableSender(port);
+  let sendPromise = sender.send(undefined);
+
+  port.close();
+  expect(port.listeners('message')).toHaveLength(0);
+  expect(port.listeners('close')).toHaveLength(0);
+
+  const disposedPromise = sender.whenDisposed();
+
+  // The pending send promise should resolve after dispose
+  await expect(sendPromise).resolves.toBeUndefined();
+  await expect(disposedPromise).resolves.toBeUndefined();
+});
+
+class MockMessagePortMain extends EventEmitter {
+  public postMessage = jest.fn();
+  public start = jest.fn();
+
+  constructor() {
+    super();
+  }
+
+  emitMessage(data: unknown): void {
+    this.emit('message', { data });
+  }
+
+  close(): void {
+    this.emit('close');
+  }
+}

--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.test.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.test.ts
@@ -20,7 +20,10 @@ import { EventEmitter } from 'events';
 
 import Logger, { NullService } from 'teleterm/logger';
 
-import { AwaitableSender } from './awaitableSender';
+import {
+  AwaitableSender,
+  MessageAcknowledgementError,
+} from './awaitableSender';
 
 beforeAll(() => {
   Logger.init(new NullService());
@@ -76,7 +79,7 @@ test('dispose removes listeners, resolves pending messages, clears map, and reso
   const disposedPromise = sender.whenDisposed();
 
   // The pending send promise should resolve after dispose
-  await expect(sendPromise).resolves.toBeUndefined();
+  await expect(sendPromise).rejects.toThrow(MessageAcknowledgementError);
   await expect(disposedPromise).resolves.toBeUndefined();
 });
 

--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
@@ -1,0 +1,101 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MessageEvent, MessagePortMain } from 'electron';
+
+import Logger from 'teleterm/logger';
+
+export type Message = MessageData | MessageAck;
+
+export interface MessageData {
+  id: string;
+  type: 'data';
+  payload: unknown;
+}
+
+export interface MessageAck {
+  id: string;
+  type: 'ack';
+}
+
+function isMessageAck(v: unknown): v is MessageAck {
+  return typeof v === 'object' && 'type' in v && v.type === 'ack';
+}
+
+/**
+ * Enables sending messages from the main process to the renderer
+ * and awaiting delivery confirmation.
+ *
+ * Unlike the standard `webContents.send()` API, which is push-based,
+ * `AwaitableSender` is pull-based — the renderer must explicitly subscribe
+ * to receive messages.
+ */
+export class AwaitableSender<T> {
+  private logger = new Logger('AwaitableSender');
+  private messages = new Map<string, { resolve: () => void }>();
+  private disposeSignal = Promise.withResolvers<void>();
+
+  constructor(private port: MessagePortMain) {
+    this.port.start();
+    this.port.on('message', this.processMessage);
+    this.port.on('close', this.dispose);
+  }
+
+  /** Sends a message and awaits delivery confirmation. */
+  send(payload: T): Promise<void> {
+    const id = crypto.randomUUID();
+
+    return new Promise(resolve => {
+      this.messages.set(id, { resolve });
+      const message: MessageData = { type: 'data', id, payload };
+      this.port.postMessage(message);
+    });
+  }
+
+  /** Returns a promise that resolves when the sender is disposed. */
+  whenDisposed(): Promise<void> {
+    return this.disposeSignal.promise;
+  }
+
+  private processMessage = (event: MessageEvent): void => {
+    const message = event.data;
+    if (!isMessageAck(message)) {
+      return;
+    }
+    const item = this.messages.get(message.id);
+    if (item) {
+      item.resolve();
+      this.messages.delete(message.id);
+    }
+  };
+
+  private dispose = (): void => {
+    this.port.off('message', this.processMessage);
+    this.port.off('close', this.dispose);
+
+    if (this.messages.size) {
+      this.logger.warn(
+        `Sender was disposed before confirming delivery of ${this.messages.size} message(s).`
+      );
+    }
+    for (const q of this.messages.values()) {
+      q.resolve();
+    }
+    this.disposeSignal.resolve();
+  };
+}

--- a/web/packages/teleterm/src/mainProcess/awaitableSender/index.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './awaitableSender';

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -274,6 +274,7 @@ export default function createMainProcessClient(): MainProcessClient {
  * The main process is expected to create an `AwaitableSender` using the received port,
  * enabling it to send messages that require acknowledgments from the renderer.
  */
+// eslint-disable-next-line unused-imports/no-unused-vars
 function startAwaitableSenderListener<T>(
   channel: string,
   listener: (value: T) => void


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/25806

Part 1/2 of moving cluster state to the main process.

Currently, the only way to stream messages from the main process to the renderer is via `webContents.send()`
However, this API has two key limitations:
* The sender has no knowledge of whether there's an active receiver on the renderer side.
* There's no guarantee that the renderer has actually received and processed the message.

This becomes problematic when we move the cluster service to the main process.
Previously, state updates were synchronous and local. For example:
```ts
await clusterService.syncRootCluster(uri); // updates the service state
const cluster = await clusterService.findCluster(uri);
```

In this model, `findCluster` always operates on the updated state.

However, once the cluster state is moved to the main process and communication is done via `webContents.send()`, the flow becomes asynchronous and prone to race conditions:

```ts
ipcRenderer.addListener(RendererIpc.ClusterStateChanged, (state) => {
  clusterService.setState(state);
});
...
await ipcRenderer.invoke('sync-cluster', uri);
// The main process handler updates the state and sends a message to the renderer.
// But there's no guarantee that the renderer has received and applied the state update
// by the time the IPC call resolves.
```

This lack of delivery acknowledgment breaks the assumption that the renderer state is up to date after the call completes.

To solve this, `AwaitableSender` introduces a message acknowledgment mechanism: the renderer must explicitly ACK each message it receives. This provides a guarantee that all state updates have been processed before the handler on the main process side resolves.

An alternative would be to avoid relying on local state updates and always return the updated state directly from IPC handlers. However, this would require changing existing assumptions across the codebase and risks introducing subtle bugs in places that currently rely on the state being updated immediately.