### PR TITLE
Respect WebIdleTimeout in bearerTokenTTL

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3119,7 +3119,7 @@ func TestNewWebSession(t *testing.T) {
 		LoginTime:  p.a.GetClock().Now().UTC(),
 		SessionTTL: apidefaults.CertDuration,
 	}
-	bearerTokenTTL := min(req.SessionTTL, defaults.BearerTokenTTL)
+	bearerTokenTTL := min(req.SessionTTL, duration)
 
 	ws, _, err := p.a.NewWebSession(ctx, req, nil /* opts */)
 	require.NoError(t, err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -313,6 +313,9 @@ func (a *Server) newWebSession(
 		return nil, nil, trace.Wrap(err)
 	}
 	bearerTokenTTL := min(sessionTTL, defaults.BearerTokenTTL)
+	if idleTimeout > 0 {
+		bearerTokenTTL = min(sessionTTL, idleTimeout)
+	}
 
 	startTime := a.clock.Now()
 	if !req.LoginTime.IsZero() {


### PR DESCRIPTION
The webUI will log a user out due to invalid token if they haven't pinged the server within the idle time, which defaulted to the bearer token default (10 minutes). Instead, we should only default to 10 minutes if the web_idle_timeout is not configured in the cluster config. this aligns with how it is described in the documentation.
docs reference: https://goteleport.com/docs/connect-your-client/web-ui/


changelog: Fix the webUI timeout time to respect the cluster's WebIdleTimeout configuration. 


edit: moving to draft. im doing to see if there is a different mechanism that we can leverage for the same effect, without increasing the bearer token expiry