### PR TITLE
feat(webui): New bot instances experience

### DIFF
--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -40,7 +40,7 @@ export function SearchPanel({
   updateSearch: (s: string) => void;
   pageIndicators?: { from: number; to: number; total: number };
   filter: ResourceFilter;
-  disableSearch: boolean;
+  disableSearch?: boolean;
   hideAdvancedSearch?: boolean;
   extraChildren?: JSX.Element;
 }) {

--- a/web/packages/shared/components/TextEditor/TextEditor.mock.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.mock.tsx
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+jest.mock('./TextEditor', () => {
+  return {
+    __esModule: true,
+    default: MockTextEditor,
+  };
+});
+
+/**
+ * How to use this?
+ *
+ * Import "shared/components/TextEditor/TextEditor.mock" in your test file and
+ * the mock will be setup for you. It can be used to test the content only, no
+ * other features are available in the mock.
+ */
+
+function MockTextEditor(props: { data?: [{ content: string }] }) {
+  return (
+    <div data-testid="mock-text-editor">
+      {props.data?.map(d => (
+        <div key={d.content}>{d.content}</div>
+      ))}
+    </div>
+  );
+}

--- a/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
@@ -1,0 +1,215 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createMemoryHistory } from 'history';
+import { MemoryRouter, Router } from 'react-router';
+
+import Box from 'design/Box/Box';
+
+import { Route } from 'teleport/components/Router';
+import cfg from 'teleport/config';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
+import {
+  getBotInstanceError,
+  getBotInstanceSuccess,
+  listBotInstancesError,
+  listBotInstancesForever,
+  listBotInstancesSuccess,
+} from 'teleport/test/helpers/botInstances';
+
+import { BotInstances } from './BotInstances';
+
+const meta = {
+  title: 'Teleport/BotInstances',
+  component: Wrapper,
+  beforeEach: () => {
+    queryClient.clear(); // Prevent cached data sharing between stories
+  },
+} satisfies Meta<typeof Wrapper>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+const listBotInstancesSuccessHandler = listBotInstancesSuccess({
+  bot_instances: [
+    {
+      bot_name: 'ansible-worker',
+      instance_id: crypto.randomUUID(),
+      active_at_latest: '2025-07-22T10:54:00Z',
+      host_name_latest: 'my-svc.my-namespace.svc.cluster-domain.example',
+      join_method_latest: 'github',
+      os_latest: 'linux',
+      version_latest: '4.4.0',
+    },
+    {
+      bot_name: 'ansible-worker',
+      instance_id: crypto.randomUUID(),
+      active_at_latest: '2025-07-22T10:54:00Z',
+      host_name_latest: 'win-123a',
+      join_method_latest: 'tpm',
+      os_latest: 'windows',
+      version_latest: '4.3.18+ab12hd',
+    },
+    {
+      bot_name: 'ansible-worker',
+      instance_id: crypto.randomUUID(),
+      active_at_latest: '2025-07-22T10:54:00Z',
+      host_name_latest: 'mac-007',
+      join_method_latest: 'kubernetes',
+      os_latest: 'darwin',
+      version_latest: '3.9.99',
+    },
+    {
+      bot_name: 'ansible-worker',
+      instance_id: crypto.randomUUID(),
+      active_at_latest: '2025-07-22T10:54:00Z',
+      host_name_latest: 'aws:g49dh27dhjm3',
+      join_method_latest: 'ec2',
+      os_latest: 'linux',
+      version_latest: '1.3.2',
+    },
+    {
+      bot_name: 'ansible-worker',
+      instance_id: crypto.randomUUID(),
+    },
+  ],
+  next_page_token: '',
+});
+
+export const Happy: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        listBotInstancesSuccessHandler,
+        getBotInstanceSuccess({
+          bot_instance: {
+            spec: {
+              instance_id: 'a55259e8-9b17-466f-9d37-ab390ca4024e',
+            },
+          },
+          yaml: 'kind: bot_instance\nversion: v1\n',
+        }),
+      ],
+    },
+  },
+};
+
+export const ErrorLoadingList: Story = {
+  parameters: {
+    msw: {
+      handlers: [listBotInstancesError(500, 'something went wrong')],
+    },
+  },
+};
+
+export const StillLoadingList: Story = {
+  parameters: {
+    msw: {
+      handlers: [listBotInstancesForever()],
+    },
+  },
+};
+
+export const NoListPermission: Story = {
+  args: {
+    hasBotInstanceListPermission: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        listBotInstancesError(
+          500,
+          'this call should never be made without permissions'
+        ),
+      ],
+    },
+  },
+};
+
+export const NoReadPermission: Story = {
+  args: {
+    hasBotInstanceReadPermission: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        listBotInstancesSuccessHandler,
+        getBotInstanceError(
+          500,
+          'this call should never be made without permissions'
+        ),
+      ],
+    },
+  },
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
+function Wrapper(props?: {
+  hasBotInstanceListPermission?: boolean;
+  hasBotInstanceReadPermission?: boolean;
+}) {
+  const {
+    hasBotInstanceListPermission = true,
+    hasBotInstanceReadPermission = true,
+  } = props ?? {};
+
+  const history = createMemoryHistory({
+    initialEntries: ['/web/bots/instances'],
+  });
+
+  const customAcl = makeAcl({
+    botInstances: {
+      ...defaultAccess,
+      read: hasBotInstanceReadPermission,
+      list: hasBotInstanceListPermission,
+    },
+  });
+
+  const ctx = createTeleportContext({
+    customAcl,
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <TeleportProviderBasic teleportCtx={ctx}>
+          <Router history={history}>
+            <Route path={cfg.routes.botInstances}>
+              <Box height={820} overflow={'auto'}>
+                <BotInstances />
+              </Box>
+            </Route>
+          </Router>
+        </TeleportProviderBasic>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}

--- a/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
@@ -17,14 +17,14 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
+import { createMemoryHistory } from 'history';
 import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Router } from 'react-router';
 
 import { darkTheme } from 'design/theme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
-  fireEvent,
   render,
   screen,
   testQueryClient,
@@ -34,13 +34,17 @@ import {
 } from 'design/utils/testing';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
+import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { listBotInstances } from 'teleport/services/bot/bot';
-import { makeAcl } from 'teleport/services/user/makeAcl';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
 import {
+  getBotInstanceSuccess,
   listBotInstancesError,
   listBotInstancesSuccess,
 } from 'teleport/test/helpers/botInstances';
+
+import 'shared/components/TextEditor/TextEditor.mock';
 
 import { ContextProvider } from '..';
 import { BotInstances } from './BotInstances';
@@ -50,6 +54,9 @@ jest.mock('teleport/services/bot/bot', () => {
   return {
     listBotInstances: jest.fn((...all) => {
       return actual.listBotInstances(...all);
+    }),
+    getBotInstance: jest.fn((...all) => {
+      return actual.getBotInstance(...all);
     }),
   };
 });
@@ -83,11 +90,11 @@ describe('BotInstances', () => {
       })
     );
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    expect(screen.getByText('No active instances found')).toBeInTheDocument();
+    expect(screen.getByText('No active instances')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Bot instances are ephemeral, and disappear once all issued credentials have expired.'
@@ -96,13 +103,13 @@ describe('BotInstances', () => {
   });
 
   it('Shows an error state', async () => {
-    server.use(listBotInstancesError(500, 'server error'));
+    server.use(listBotInstancesError(500, 'something went wrong'));
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    expect(screen.getByText('Error: server error')).toBeInTheDocument();
+    expect(screen.getByText('something went wrong')).toBeInTheDocument();
   });
 
   it('Shows an unsupported sort error state', async () => {
@@ -110,11 +117,11 @@ describe('BotInstances', () => {
       'unsupported sort, only bot_name:asc is supported, but got "blah" (desc = true)';
     server.use(listBotInstancesError(400, testErrorMessage));
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    const { user } = renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    expect(screen.getByText(`Error: ${testErrorMessage}`)).toBeInTheDocument();
+    expect(screen.getByText(testErrorMessage)).toBeInTheDocument();
 
     server.use(
       listBotInstancesSuccess({
@@ -123,30 +130,22 @@ describe('BotInstances', () => {
       })
     );
 
-    const resetButton = screen.getByText('Reset sort');
-    expect(resetButton).toBeInTheDocument();
-    fireEvent.click(resetButton);
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
+    const resetButton = screen.getByRole('button', { name: 'Reset sort' });
+    await user.click(resetButton);
 
-    expect(
-      screen.queryByText(`Error: ${testErrorMessage}`)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(testErrorMessage)).not.toBeInTheDocument();
   });
 
   it('Shows an unauthorised error state', async () => {
-    render(<BotInstances />, {
-      wrapper: makeWrapper(
-        makeAcl({
-          botInstances: {
-            list: false,
-            create: true,
-            edit: true,
-            remove: true,
-            read: true,
-          },
-        })
-      ),
+    renderComponent({
+      customAcl: makeAcl({
+        botInstances: {
+          ...defaultAccess,
+          list: false,
+        },
+      }),
     });
 
     expect(
@@ -168,7 +167,7 @@ describe('BotInstances', () => {
             instance_id: '5e885c66-1af3-4a36-987d-a604d8ee49d2',
             active_at_latest: '2025-05-19T07:32:00Z',
             host_name_latest: 'test-hostname',
-            join_method_latest: 'test-join-method',
+            join_method_latest: 'github',
             version_latest: '1.0.0-dev-a12b3c',
           },
           {
@@ -180,19 +179,76 @@ describe('BotInstances', () => {
       })
     );
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    expect(screen.getByText('test-bot-1')).toBeInTheDocument();
-    expect(screen.getByText('5e885c6')).toBeInTheDocument();
+    expect(screen.getByText('test-bot-1/5e885c6')).toBeInTheDocument();
     expect(screen.getByText('28 minutes ago')).toBeInTheDocument();
     expect(screen.getByText('test-hostname')).toBeInTheDocument();
-    expect(screen.getByText('test-join-method')).toBeInTheDocument();
+    expect(screen.getByTestId('res-icon-github')).toBeInTheDocument();
     expect(screen.getByText('v1.0.0-dev-a12b3c')).toBeInTheDocument();
   });
 
+  it('Selects an item', async () => {
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+
+    server.use(
+      listBotInstancesSuccess({
+        bot_instances: [
+          {
+            bot_name: 'test-bot-1',
+            instance_id: '5e885c66-1af3-4a36-987d-a604d8ee49d2',
+            active_at_latest: '2025-05-19T07:32:00Z',
+            host_name_latest: 'test-hostname',
+            join_method_latest: 'github',
+            version_latest: '1.0.0-dev-a12b3c',
+          },
+          {
+            bot_name: 'test-bot-2',
+            instance_id: '3c3aae3e-de25-4824-a8e9-5a531862f19a',
+          },
+        ],
+        next_page_token: '',
+      })
+    );
+
+    server.use(
+      getBotInstanceSuccess({
+        bot_instance: {
+          spec: {
+            instance_id: '3c3aae3e-de25-4824-a8e9-5a531862f19a',
+          },
+        },
+        yaml: 'kind: bot_instance\nversion: v1\n',
+      })
+    );
+
+    const { user } = renderComponent();
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
+
+    expect(
+      screen.queryByRole('heading', { name: 'Resource YAML' })
+    ).not.toBeInTheDocument();
+
+    const item2 = screen.getByRole('listitem', {
+      name: 'test-bot-2/3c3aae3e-de25-4824-a8e9-5a531862f19a',
+    });
+    await user.click(item2);
+
+    expect(
+      screen.getByRole('heading', { name: 'Resource YAML' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('kind: bot_instance version: v1')
+    ).toBeInTheDocument();
+  });
+
   it('Allows paging', async () => {
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+
     jest.mocked(listBotInstances).mockImplementation(
       ({ pageToken }) =>
         new Promise(resolve => {
@@ -200,7 +256,7 @@ describe('BotInstances', () => {
             bot_instances: [
               {
                 bot_name: `test-bot`,
-                instance_id: `00000000-0000-4000-0000-000000000000`,
+                instance_id: crypto.randomUUID(),
                 active_at_latest: `2025-05-19T07:32:00Z`,
                 host_name_latest: 'test-hostname',
                 join_method_latest: 'test-join-method',
@@ -214,73 +270,61 @@ describe('BotInstances', () => {
 
     expect(listBotInstances).toHaveBeenCalledTimes(0);
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    const { user } = renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    const [nextButton] = screen.getAllByTitle('Next page');
+    const moreAction = screen.getByRole('button', { name: 'Load More' });
 
     expect(listBotInstances).toHaveBeenCalledTimes(1);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    await waitFor(() => expect(nextButton).toBeEnabled());
-    fireEvent.click(nextButton);
+    await waitFor(() => expect(moreAction).toBeEnabled());
+    await user.click(moreAction);
 
     expect(listBotInstances).toHaveBeenCalledTimes(2);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '.next',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    await waitFor(() => expect(nextButton).toBeEnabled());
-    fireEvent.click(nextButton);
+    await waitFor(() => expect(moreAction).toBeEnabled());
+    await user.click(moreAction);
 
     expect(listBotInstances).toHaveBeenCalledTimes(3);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '.next.next',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
-
-    const [prevButton] = screen.getAllByTitle('Previous page');
-
-    await waitFor(() => expect(prevButton).toBeEnabled());
-    fireEvent.click(prevButton);
-
-    // This page's data will have been cached
-    expect(listBotInstances).toHaveBeenCalledTimes(3);
-
-    await waitFor(() => expect(prevButton).toBeEnabled());
-    fireEvent.click(prevButton);
-
-    // This page's data will have been cached
-    expect(listBotInstances).toHaveBeenCalledTimes(3);
   });
 
   it('Allows filtering (search)', async () => {
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+
     jest.mocked(listBotInstances).mockImplementation(
       ({ pageToken }) =>
         new Promise(resolve => {
@@ -288,7 +332,7 @@ describe('BotInstances', () => {
             bot_instances: [
               {
                 bot_name: `test-bot`,
-                instance_id: `00000000-0000-4000-0000-000000000000`,
+                instance_id: crypto.randomUUID(),
                 active_at_latest: `2025-05-19T07:32:00Z`,
                 host_name_latest: 'test-hostname',
                 join_method_latest: 'test-join-method',
@@ -301,56 +345,56 @@ describe('BotInstances', () => {
     );
 
     expect(listBotInstances).toHaveBeenCalledTimes(0);
-
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    const { user, history } = renderComponent();
+    jest.spyOn(history, 'push');
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
     expect(listBotInstances).toHaveBeenCalledTimes(1);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    const [nextButton] = screen.getAllByTitle('Next page');
-    await waitFor(() => expect(nextButton).toBeEnabled());
-    fireEvent.click(nextButton);
+    const moreAction = screen.getByRole('button', { name: 'Load More' });
+    await waitFor(() => expect(moreAction).toBeEnabled());
+    await user.click(moreAction);
 
     expect(listBotInstances).toHaveBeenCalledTimes(2);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '.next',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    jest.useRealTimers(); // Required as user.type() uses setTimeout internally
-
     const search = screen.getByPlaceholderText('Search...');
-    await waitFor(() => expect(search).toBeEnabled());
-    await userEvent.click(search);
-    await userEvent.paste('test-search-term');
+    await userEvent.type(search, 'test-search-term');
     await userEvent.type(search, '{enter}');
 
+    expect(history.push).toHaveBeenLastCalledWith({
+      pathname: '/web/bots/instances',
+      search: 'query=test-search-term',
+    });
     expect(listBotInstances).toHaveBeenCalledTimes(3);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
-        pageToken: '', // Search should reset to the first page
+        pageSize: 32,
+        pageToken: '', // Should reset to the first page
         searchTerm: 'test-search-term',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
@@ -359,6 +403,8 @@ describe('BotInstances', () => {
   });
 
   it('Allows filtering (query)', async () => {
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+
     jest.mocked(listBotInstances).mockImplementation(
       ({ pageToken }) =>
         new Promise(resolve => {
@@ -366,7 +412,7 @@ describe('BotInstances', () => {
             bot_instances: [
               {
                 bot_name: `test-bot`,
-                instance_id: `00000000-0000-4000-0000-000000000000`,
+                instance_id: crypto.randomUUID(),
                 active_at_latest: `2025-05-19T07:32:00Z`,
                 host_name_latest: 'test-hostname',
                 join_method_latest: 'test-join-method',
@@ -379,57 +425,61 @@ describe('BotInstances', () => {
     );
 
     expect(listBotInstances).toHaveBeenCalledTimes(0);
-
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    const { user, history } = renderComponent();
+    jest.spyOn(history, 'push');
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
     expect(listBotInstances).toHaveBeenCalledTimes(1);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    const [nextButton] = screen.getAllByTitle('Next page');
-    await waitFor(() => expect(nextButton).toBeEnabled());
-    fireEvent.click(nextButton);
+    const moreAction = screen.getByRole('button', { name: 'Load More' });
+    await waitFor(() => expect(moreAction).toBeEnabled());
+    await user.click(moreAction);
 
     expect(listBotInstances).toHaveBeenCalledTimes(2);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '.next',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+    const advancedToggle = screen.getByLabelText('Advanced');
+    expect(advancedToggle).not.toBeChecked();
+    await userEvent.click(advancedToggle);
+    expect(advancedToggle).toBeChecked();
 
     const search = screen.getByPlaceholderText('Search...');
-    await waitFor(() => expect(search).toBeEnabled());
-    await userEvent.click(screen.getByLabelText('Advanced'));
-    await userEvent.click(search);
-    await userEvent.paste(`status.latest_heartbeat.hostname == "host-1"`);
+    await userEvent.type(search, 'test-query');
     await userEvent.type(search, '{enter}');
 
+    expect(history.push).toHaveBeenLastCalledWith({
+      pathname: '/web/bots/instances',
+      search: 'query=test-query&is_advanced=1',
+    });
     expect(listBotInstances).toHaveBeenCalledTimes(3);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
-        pageToken: '', // Search should reset to the first page
-        searchTerm: '',
-        query: `status.latest_heartbeat.hostname == "host-1"`,
+        pageSize: 32,
+        pageToken: '', // Should reset to the first page
+        searchTerm: undefined,
+        query: 'test-query',
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
@@ -438,6 +488,8 @@ describe('BotInstances', () => {
   });
 
   it('Allows sorting', async () => {
+    jest.useRealTimers(); // Required as userEvent.type() uses setTimeout internally
+
     jest.mocked(listBotInstances).mockImplementation(
       ({ pageToken }) =>
         new Promise(resolve => {
@@ -459,51 +511,52 @@ describe('BotInstances', () => {
 
     expect(listBotInstances).toHaveBeenCalledTimes(0);
 
-    render(<BotInstances />, { wrapper: makeWrapper() });
+    const { user } = renderComponent();
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
-
-    const lastHeartbeatHeader = screen.getByText('Last heartbeat');
 
     expect(listBotInstances).toHaveBeenCalledTimes(1);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'DESC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    fireEvent.click(lastHeartbeatHeader);
+    const dirAction = screen.getByRole('button', { name: 'Sort direction' });
+    await user.click(dirAction);
 
     expect(listBotInstances).toHaveBeenCalledTimes(2);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
+        query: undefined,
         sortDir: 'ASC',
         sortField: 'active_at_latest',
       },
       expect.anything()
     );
 
-    const botHeader = screen.getByText('Bot');
-    fireEvent.click(botHeader);
+    const sortFieldAction = screen.getByRole('button', { name: 'Sort by' });
+    await user.click(sortFieldAction);
+    const option = screen.getByRole('menuitem', { name: 'Bot name' });
+    await user.click(option);
 
     expect(listBotInstances).toHaveBeenCalledTimes(3);
     expect(listBotInstances).toHaveBeenLastCalledWith(
       {
-        pageSize: 30,
+        pageSize: 32,
         pageToken: '',
         searchTerm: '',
-        query: '',
-        sortDir: 'DESC',
+        query: undefined,
+        sortDir: 'ASC',
         sortField: 'bot_name',
       },
       expect.anything()
@@ -511,17 +564,36 @@ describe('BotInstances', () => {
   });
 });
 
-function makeWrapper(
-  customAcl: ReturnType<typeof makeAcl> = makeAcl({
-    botInstances: {
-      list: true,
-      create: true,
-      edit: true,
-      remove: true,
-      read: true,
-    },
-  })
-) {
+function renderComponent(options?: { customAcl?: ReturnType<typeof makeAcl> }) {
+  const {
+    customAcl = makeAcl({
+      botInstances: {
+        ...defaultAccess,
+        read: true,
+        list: true,
+      },
+    }),
+  } = options ?? {};
+
+  const user = userEvent.setup();
+  const history = createMemoryHistory({
+    initialEntries: ['/web/bots/instances'],
+  });
+  return {
+    ...render(<BotInstances />, {
+      wrapper: makeWrapper({ customAcl, history }),
+    }),
+    user,
+    history,
+  };
+}
+
+function makeWrapper(options: {
+  customAcl: ReturnType<typeof makeAcl>;
+  history: ReturnType<typeof createMemoryHistory>;
+}) {
+  const { customAcl, history } = options ?? {};
+
   return ({ children }: PropsWithChildren) => {
     const ctx = createTeleportContext({
       customAcl,
@@ -531,7 +603,11 @@ function makeWrapper(
         <QueryClientProvider client={testQueryClient}>
           <ConfiguredThemeProvider theme={darkTheme}>
             <InfoGuidePanelProvider data-testid="blah">
-              <ContextProvider ctx={ctx}>{children}</ContextProvider>
+              <ContextProvider ctx={ctx}>
+                <Router history={history}>
+                  <Route path={cfg.routes.botInstances}>{children}</Route>
+                </Router>
+              </ContextProvider>
             </InfoGuidePanelProvider>
           </ConfiguredThemeProvider>
         </QueryClientProvider>

--- a/web/packages/teleport/src/BotInstances/BotInstances.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.tsx
@@ -16,21 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
+import { useCallback, useMemo, useRef } from 'react';
 import { useHistory, useLocation } from 'react-router';
+import styled, { css } from 'styled-components';
 
 import { Alert } from 'design/Alert/Alert';
-import Box from 'design/Box/Box';
-import { SortType } from 'design/DataTable/types';
-import { Indicator } from 'design/Indicator/Indicator';
-import { Mark } from 'design/Mark/Mark';
-import {
-  InfoExternalTextLink,
-  InfoGuideButton,
-  InfoParagraph,
-  ReferenceLinks,
-} from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
+import { CardTile } from 'design/CardTile/CardTile';
+import Flex from 'design/Flex/Flex';
+import { Question } from 'design/Icon';
+import Text from 'design/Text';
+import { SearchPanel } from 'shared/components/Search';
+import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
 
 import { EmptyState } from 'teleport/Bots/List/EmptyState/EmptyState';
 import {
@@ -38,164 +35,135 @@ import {
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout/Layout';
-import cfg from 'teleport/config';
 import { listBotInstances } from 'teleport/services/bot/bot';
 import { BotInstanceSummary } from 'teleport/services/bot/types';
 import useTeleport from 'teleport/useTeleport';
 
-import { BotInstancesList } from './List/BotInstancesList';
+import { BotInstanceDetails } from './Details/BotInstanceDetails';
+import { InfoGuide } from './InfoGuide';
+import {
+  BotInstancesList,
+  BotInstancesListControls,
+} from './List/BotInstancesList';
 
 export function BotInstances() {
   const history = useHistory();
   const location = useLocation<{ prevPageTokens?: readonly string[] }>();
   const queryParams = new URLSearchParams(location.search);
-  const pageToken = queryParams.get('page') ?? '';
-  const searchTerm = queryParams.get('search') ?? '';
   const query = queryParams.get('query') ?? '';
+  const isAdvancedQuery = queryParams.get('is_advanced') ?? '';
   const sortField = queryParams.get('sort_field') || 'active_at_latest';
   const sortDir = queryParams.get('sort_dir') || 'DESC';
+  const selectedItemId = queryParams.get('selected');
+
+  const listRef = useRef<BotInstancesListControls | null>(null);
 
   const ctx = useTeleport();
   const flags = ctx.getFeatureFlags();
-  const canListInstances = flags.listBotInstances;
+  const hasListPermission = flags.listBotInstances;
 
-  const { isPending, isFetching, isSuccess, isError, error, data } = useQuery({
-    enabled: canListInstances,
+  const {
+    isSuccess,
+    data,
+    isLoading,
+    isFetchingNextPage,
+    error,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    enabled: hasListPermission,
     queryKey: [
       'bot_instances',
       'list',
-      searchTerm,
-      query,
-      pageToken,
       sortField,
       sortDir,
       query,
+      isAdvancedQuery,
     ],
-    queryFn: ({ signal }) =>
+    queryFn: ({ pageParam, signal }) =>
       listBotInstances(
         {
-          pageSize: 30,
-          pageToken,
-          searchTerm,
-          query,
+          pageSize: 32,
+          pageToken: pageParam,
           sortField,
           sortDir,
+          searchTerm: isAdvancedQuery ? undefined : query,
+          query: isAdvancedQuery ? query : undefined,
         },
         signal
       ),
+    initialPageParam: '',
+    getNextPageParam: data => data?.next_page_token,
     placeholderData: keepPreviousData,
     staleTime: 30_000, // Cached pages are valid for 30 seconds
   });
 
-  const { prevPageTokens = [] } = location.state ?? {};
-  const hasNextPage = !!data?.next_page_token;
-  const hasPrevPage = !!pageToken;
-
-  const handleFetchNext = useCallback(() => {
-    const search = new URLSearchParams(location.search);
-    search.set('page', data?.next_page_token ?? '');
-
-    history.replace(
-      {
-        pathname: location.pathname,
-        search: search.toString(),
-      },
-      {
-        prevPageTokens: [...prevPageTokens, pageToken],
-      }
-    );
-  }, [
-    data?.next_page_token,
-    history,
-    location.pathname,
-    location.search,
-    pageToken,
-    prevPageTokens,
-  ]);
-
-  const handleFetchPrev = useCallback(() => {
-    const prevTokens = [...prevPageTokens];
-    const nextToken = prevTokens.pop();
-
-    const search = new URLSearchParams(location.search);
-    search.set('page', nextToken ?? '');
-
-    history.replace(
-      {
-        pathname: location.pathname,
-        search: search.toString(),
-      },
-      {
-        prevPageTokens: prevTokens,
-      }
-    );
-  }, [history, location.pathname, location.search, prevPageTokens]);
-
-  const handleSearchChange = useCallback(
-    (term: string) => {
-      const search = new URLSearchParams(location.search);
-      search.set('search', term);
-      search.delete('query');
-      search.delete('page');
-
-      history.push({
-        pathname: `${location.pathname}`,
-        search: search.toString(),
-      });
-    },
-    [history, location.pathname, location.search]
-  );
-
   const handleQueryChange = useCallback(
-    (exp: string) => {
+    (query: string, isAdvanced: boolean) => {
       const search = new URLSearchParams(location.search);
-      search.set('query', exp);
-      search.delete('search');
-      search.delete('page');
+      if (query) {
+        search.set('query', query);
+      } else {
+        search.delete('query');
+      }
+      if (isAdvanced) {
+        search.set('is_advanced', '1');
+      } else {
+        search.delete('is_advanced');
+      }
 
       history.push({
         pathname: `${location.pathname}`,
         search: search.toString(),
       });
+
+      listRef.current?.scrollToTop();
     },
     [history, location.pathname, location.search]
   );
-
-  const onItemSelected = useCallback(
-    (item: BotInstanceSummary) => {
-      history.push(
-        cfg.getBotInstanceDetailsRoute({
-          botName: item.bot_name,
-          instanceId: item.instance_id,
-        })
-      );
-    },
-    [history]
-  );
-
-  const sortType: SortType = {
-    fieldName: sortField,
-    dir: sortDir.toLowerCase() === 'desc' ? 'DESC' : 'ASC',
-  };
 
   const handleSortChanged = useCallback(
-    (sortType: SortType) => {
+    (sortField: string, sortDir: string) => {
       const search = new URLSearchParams(location.search);
-      search.set('sort_field', sortType.fieldName);
-      search.set('sort_dir', sortType.dir);
-      search.delete('page');
+      search.set('sort_field', sortField);
+      search.set('sort_dir', sortDir);
 
       history.replace({
         pathname: location.pathname,
         search: search.toString(),
       });
+
+      listRef.current?.scrollToTop();
     },
     [history, location.pathname, location.search]
   );
 
-  const hasUnsupportedSortError = isUnsupportedSortError(error);
+  const handleItemSelected = useCallback(
+    (item: BotInstanceSummary | null) => {
+      const search = new URLSearchParams(location.search);
+      if (item) {
+        search.set('selected', `${item.bot_name}/${item.instance_id}`);
+      } else {
+        search.delete('selected');
+      }
 
-  if (!canListInstances) {
+      history.push({
+        pathname: location.pathname,
+        search: search.toString(),
+      });
+    },
+    [history, location.pathname, location.search]
+  );
+
+  const [selectedBotName, selectedInstanceId] =
+    selectedItemId?.split('/') ?? [];
+
+  const flatData = useMemo(
+    () => (isSuccess ? data.pages.flatMap(page => page.bot_instances) : null),
+    [data?.pages, isSuccess]
+  );
+
+  if (!hasListPermission) {
     return (
       <FeatureBox>
         <Alert kind="info" mt={4}>
@@ -214,103 +182,96 @@ export function BotInstances() {
         <InfoGuideButton config={{ guide: <InfoGuide /> }} />
       </FeatureHeader>
 
-      {isPending ? (
-        <Box data-testid="loading" textAlign="center" m={10}>
-          <Indicator />
-        </Box>
-      ) : undefined}
-
-      {isError && hasUnsupportedSortError ? (
-        <Alert
-          kind="warning"
-          primaryAction={{
-            content: 'Reset sort',
-            onClick: () => {
-              handleSortChanged({ fieldName: 'bot_name', dir: 'ASC' });
-            },
+      <Container>
+        <SearchPanel
+          filter={{
+            query: isAdvancedQuery ? query : undefined,
+            search: isAdvancedQuery ? undefined : query,
           }}
-        >
-          {`Error: ${error.message}`}
-        </Alert>
-      ) : undefined}
-
-      {isError && !hasUnsupportedSortError ? (
-        <Alert kind="danger">{`Error: ${error.message}`}</Alert>
-      ) : undefined}
-
-      {isSuccess ? (
-        <BotInstancesList
-          data={data.bot_instances}
-          fetchStatus={isFetching ? 'loading' : ''}
-          onFetchNext={hasNextPage ? handleFetchNext : undefined}
-          onFetchPrev={hasPrevPage ? handleFetchPrev : undefined}
-          onSearchChange={handleSearchChange}
-          onQueryChange={handleQueryChange}
-          searchTerm={searchTerm}
-          query={query}
-          onItemSelected={onItemSelected}
-          sortType={sortType}
-          onSortChanged={handleSortChanged}
+          updateSearch={query => handleQueryChange(query, false)}
+          updateQuery={query => handleQueryChange(query, true)}
         />
-      ) : undefined}
+        <ContentContainer>
+          <ListAndDetailsContainer $listOnlyMode={!selectedItemId}>
+            <BotInstancesList
+              ref={listRef}
+              data={flatData}
+              isLoading={isLoading}
+              isFetchingNextPage={isFetchingNextPage}
+              error={error}
+              hasNextPage={hasNextPage}
+              sortField={sortField}
+              sortDir={sortDir === 'DESC' ? 'DESC' : 'ASC'}
+              onSortChanged={handleSortChanged}
+              onLoadNextPage={fetchNextPage}
+              selectedItem={selectedItemId}
+              onItemSelected={handleItemSelected}
+            />
+            {selectedItemId ? (
+              <BotInstanceDetails
+                key={selectedItemId}
+                botName={selectedBotName}
+                instanceId={selectedInstanceId}
+                onClose={() => handleItemSelected(null)}
+              />
+            ) : undefined}
+          </ListAndDetailsContainer>
+          {!selectedItemId ? (
+            <DashboardContainer>
+              <QuestionIcon size={'extra-large'} />
+              <DashboardHelpText>
+                Select an instance to see full details.
+              </DashboardHelpText>
+            </DashboardContainer>
+          ) : undefined}
+        </ContentContainer>
+      </Container>
     </FeatureBox>
   );
 }
 
-const InfoGuide = () => (
-  <Box>
-    <InfoParagraph>
-      A{' '}
-      <InfoExternalTextLink
-        target="_blank"
-        href={InfoGuideReferenceLinks.BotInstances.href}
-      >
-        Bot Instance
-      </InfoExternalTextLink>{' '}
-      identifies a single lineage of{' '}
-      <InfoExternalTextLink
-        target="_blank"
-        href={InfoGuideReferenceLinks.Bots.href}
-      >
-        bot
-      </InfoExternalTextLink>{' '}
-      identities, even through certificate renewals and rejoins. When the{' '}
-      <Mark>tbot</Mark> client first authenticates to a cluster, a Bot Instance
-      is generated and its UUID is embedded in the returned client identity.
-    </InfoParagraph>
-    <InfoParagraph>
-      Bot Instances track a variety of information about <Mark>tbot</Mark>{' '}
-      instances, including regular heartbeats which include basic information
-      about the <Mark>tbot</Mark> host, like its architecture and OS version.
-    </InfoParagraph>
-    <InfoParagraph>
-      {' '}
-      Bot Instances have a relatively short lifespan and are set to expire after
-      the most recent identity issued for that instance will expire. If the{' '}
-      <Mark>tbot</Mark> client associated with a particular Bot Instance renews
-      or rejoins, the expiration of the bot instance is reset. This is designed
-      to allow users to list Bot Instances for an accurate view of the number of
-      active <Mark>tbot</Mark> clients interacting with their Teleport cluster.
-    </InfoParagraph>
-    <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
-  </Box>
-);
+const Container = styled(Flex)`
+  flex-direction: column;
+  flex: 1;
+  overflow: auto;
+  gap: ${props => props.theme.space[2]}px;
+`;
 
-const InfoGuideReferenceLinks = {
-  BotInstances: {
-    title: 'What are Bot instances',
-    href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bot-instances',
-  },
-  Bots: {
-    title: 'What are Bots',
-    href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bots',
-  },
-  Tctl: {
-    title: 'Use tctl to manage bot instances',
-    href: 'https://goteleport.com/docs/reference/cli/tctl/#tctl-bots-instances-add',
-  },
-};
+const ContentContainer = styled(Flex)`
+  flex: 1;
+  overflow: auto;
+  gap: ${props => props.theme.space[2]}px;
+`;
 
-const isUnsupportedSortError = (error: Error | null | undefined) => {
-  return error?.message && error.message.includes('unsupported sort');
-};
+const ListAndDetailsContainer = styled(CardTile)<{ $listOnlyMode: boolean }>`
+  flex-direction: row;
+  overflow: auto;
+  padding: 0;
+  gap: 0;
+  margin: ${props => props.theme.space[1]}px;
+
+  ${p =>
+    p.$listOnlyMode
+      ? css`
+          min-width: 300px;
+          max-width: 400px;
+        `
+      : ''}
+`;
+
+const DashboardContainer = styled(Flex)`
+  flex-direction: column;
+  overflow: auto;
+  flex-basis: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+
+const DashboardHelpText = styled(Text)`
+  color: ${props => props.theme.colors.text.muted};
+  text-align: center;
+`;
+
+const QuestionIcon = styled(Question)`
+  color: ${props => props.theme.colors.text.muted};
+`;

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.story.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.story.tsx
@@ -1,0 +1,127 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { CardTile } from 'design/CardTile';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
+import {
+  getBotInstanceError,
+  getBotInstanceForever,
+  getBotInstanceSuccess,
+} from 'teleport/test/helpers/botInstances';
+
+import { BotInstanceDetails } from './BotInstanceDetails';
+
+const meta = {
+  title: 'Teleport/BotInstances/Details',
+  component: Wrapper,
+  beforeEach: () => {
+    queryClient.clear(); // Prevent cached data sharing between stories
+  },
+} satisfies Meta<typeof Wrapper>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Happy: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        getBotInstanceSuccess({
+          bot_instance: {
+            spec: {
+              instance_id: 'a55259e8-9b17-466f-9d37-ab390ca4024e',
+            },
+          },
+          yaml: 'kind: bot_instance\nversion: v1\n',
+        }),
+      ],
+    },
+  },
+};
+
+export const ErrorLoadingList: Story = {
+  parameters: {
+    msw: {
+      handlers: [getBotInstanceError(500, 'something went wrong')],
+    },
+  },
+};
+
+export const StillLoadingList: Story = {
+  parameters: {
+    msw: {
+      handlers: [getBotInstanceForever()],
+    },
+  },
+};
+
+export const NoReadPermission: Story = {
+  args: {
+    hasBotInstanceReadPermission: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [getBotInstanceError(500, 'this call should never be made')],
+    },
+  },
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
+function Wrapper(props?: { hasBotInstanceReadPermission?: boolean }) {
+  const { hasBotInstanceReadPermission = true } = props ?? {};
+
+  const customAcl = makeAcl({
+    botInstances: {
+      ...defaultAccess,
+      read: hasBotInstanceReadPermission,
+    },
+  });
+
+  const ctx = createTeleportContext({
+    customAcl,
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TeleportProviderBasic teleportCtx={ctx}>
+        <CardTile height={820} overflow={'auto'} p={0}>
+          <BotInstanceDetails
+            botName="ansible-worker"
+            instanceId="a55259e8-9b17-466f-9d37-ab390ca4024e"
+            onClose={() => {}}
+          />
+        </CardTile>
+      </TeleportProviderBasic>
+    </QueryClientProvider>
+  );
+}

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
@@ -17,44 +17,30 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { createMemoryHistory } from 'history';
 import { setupServer } from 'msw/node';
-import { PropsWithChildren } from 'react';
-import { MemoryRouter, Router } from 'react-router';
+import { ComponentProps, PropsWithChildren } from 'react';
 
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
-import { copyToClipboard } from 'design/utils/copyToClipboard';
 import {
-  fireEvent,
   render,
   screen,
   testQueryClient,
+  userEvent,
   waitForElementToBeRemoved,
 } from 'design/utils/testing';
 
-import { Route } from 'teleport/components/Router';
-import cfg from 'teleport/config';
+import 'shared/components/TextEditor/TextEditor.mock';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
 import {
   getBotInstanceError,
   getBotInstanceSuccess,
 } from 'teleport/test/helpers/botInstances';
 
 import { BotInstanceDetails } from './BotInstanceDetails';
-
-jest.mock('shared/components/TextEditor/TextEditor', () => {
-  return {
-    __esModule: true,
-    default: MockTextEditor,
-  };
-});
-
-jest.mock('design/utils/copyToClipboard', () => {
-  return {
-    __esModule: true,
-    copyToClipboard: jest.fn(),
-  };
-});
 
 const server = setupServer();
 
@@ -71,85 +57,19 @@ afterEach(async () => {
 
 afterAll(() => server.close());
 
-const withSuccessResponse = () => {
-  server.use(
-    getBotInstanceSuccess({
-      bot_instance: {
-        spec: {
-          instance_id: '4fa10e68-f2e0-4cf9-ad5b-1458febcd827',
-        },
-      },
-      yaml: 'kind: bot_instance\nversion: v1\n',
-    })
-  );
-};
-
-const withErrorResponse = () => {
-  server.use(getBotInstanceError(500));
-};
-
 describe('BotIntanceDetails', () => {
-  it('Allows back navigation', async () => {
-    const history = createMemoryHistory({
-      initialEntries: [
-        '/web/bot/test-bot-name/instance/4fa10e68-f2e0-4cf9-ad5b-1458febcd827',
-      ],
-    });
-    history.goBack = jest.fn();
-
+  it('Allows close action', async () => {
+    const onClose = jest.fn();
     withSuccessResponse();
 
-    renderComponent({ history });
+    const { user } = renderComponent({ onClose });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
-    const backButton = screen.getByLabelText('back');
-    fireEvent.click(backButton);
+    const closeButton = screen.getByLabelText('close');
+    await user.click(closeButton);
 
-    expect(history.goBack).toHaveBeenCalledTimes(1);
-  });
-
-  it('Shows the short instance id', async () => {
-    withSuccessResponse();
-
-    renderComponent();
-
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
-
-    expect(screen.getByText('4fa10e6')).toBeInTheDocument();
-  });
-
-  it('Allows the full instance id to be copied', async () => {
-    withSuccessResponse();
-
-    renderComponent();
-
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
-
-    const copyButton = screen.getByLabelText('copy');
-    fireEvent.click(copyButton);
-
-    expect(copyToClipboard).toHaveBeenCalledTimes(1);
-    expect(copyToClipboard).toHaveBeenLastCalledWith(
-      '4fa10e68-f2e0-4cf9-ad5b-1458febcd827'
-    );
-  });
-
-  it('Shows a docs link', async () => {
-    const onClick = jest.fn(e => {
-      e.preventDefault();
-    });
-
-    withSuccessResponse();
-
-    renderComponent({ onDocsLinkClicked: onClick });
-
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
-
-    const docsButton = screen.getByText('View Documentation');
-    fireEvent.click(docsButton);
-
-    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('Shows full yaml', async () => {
@@ -171,57 +91,92 @@ describe('BotIntanceDetails', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
+    expect(screen.getByText('something went wrong')).toBeInTheDocument();
+  });
+
+  it('Shows a permisison warning', async () => {
+    withErrorResponse();
+
+    renderComponent({
+      hasBotInstanceReadPermission: false,
+    });
+
     expect(
-      screen.getByText('Error: 500', { exact: false })
+      screen.getByText('You do not have permission to read Bot instances', {
+        exact: false,
+      })
     ).toBeInTheDocument();
+
+    expect(screen.getByText('bot_instance.read')).toBeInTheDocument();
   });
 });
 
-const renderComponent = async (options?: {
-  history?: ReturnType<typeof createMemoryHistory>;
-  onDocsLinkClicked?: (e: unknown) => void;
-}) => {
-  const { onDocsLinkClicked } = options ?? {};
-  render(
-    <BotInstanceDetails onDocsLinkClickedForTesting={onDocsLinkClicked} />,
-    {
-      wrapper: makeWrapper(options),
-    }
-  );
+const renderComponent = (
+  options?: Partial<ComponentProps<typeof BotInstanceDetails>> & {
+    hasBotInstanceReadPermission?: boolean;
+  }
+) => {
+  const {
+    botName = 'test-bot-name',
+    instanceId = '4fa10e68-f2e0-4cf9-ad5b-1458febcd827',
+    onClose = jest.fn(),
+    ...rest
+  } = options ?? {};
+  const user = userEvent.setup();
+  return {
+    ...render(
+      <BotInstanceDetails
+        botName={botName}
+        instanceId={instanceId}
+        onClose={onClose}
+      />,
+      {
+        wrapper: makeWrapper(rest),
+      }
+    ),
+    user,
+  };
 };
 
-function makeWrapper(options?: {
-  history?: ReturnType<typeof createMemoryHistory>;
-}) {
-  const {
-    history = createMemoryHistory({
-      initialEntries: [
-        '/web/bot/test-bot-name/instance/4fa10e68-f2e0-4cf9-ad5b-1458febcd827',
-      ],
-    }),
-  } = options ?? {};
+function makeWrapper(options?: { hasBotInstanceReadPermission?: boolean }) {
+  const { hasBotInstanceReadPermission = true } = options ?? {};
 
+  const customAcl = makeAcl({
+    botInstances: {
+      ...defaultAccess,
+      read: hasBotInstanceReadPermission,
+    },
+  });
+
+  const ctx = createTeleportContext({
+    customAcl,
+  });
   return (props: PropsWithChildren) => {
     return (
-      <MemoryRouter>
-        <QueryClientProvider client={testQueryClient}>
+      <QueryClientProvider client={testQueryClient}>
+        <TeleportProviderBasic teleportCtx={ctx}>
           <ConfiguredThemeProvider theme={darkTheme}>
-            <Router history={history}>
-              <Route path={cfg.routes.botInstance}>{props.children}</Route>
-            </Router>
+            {props.children}
           </ConfiguredThemeProvider>
-        </QueryClientProvider>
-      </MemoryRouter>
+        </TeleportProviderBasic>
+      </QueryClientProvider>
     );
   };
 }
 
-function MockTextEditor(props: { data?: [{ content: string }] }) {
-  return (
-    <div data-testid="mock-text-editor">
-      {props.data?.map(d => (
-        <div key={d.content}>{d.content}</div>
-      ))}
-    </div>
+const withSuccessResponse = () => {
+  server.use(
+    getBotInstanceSuccess({
+      bot_instance: {
+        spec: {
+          instance_id: '4fa10e68-f2e0-4cf9-ad5b-1458febcd827',
+        },
+      },
+      yaml: 'kind: bot_instance\nversion: v1\n',
+    })
   );
-}
+};
+
+const withErrorResponse = () => {
+  server.use(getBotInstanceError(500, 'something went wrong'));
+};

--- a/web/packages/teleport/src/BotInstances/InfoGuide.tsx
+++ b/web/packages/teleport/src/BotInstances/InfoGuide.tsx
@@ -1,0 +1,83 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from 'design/Box/Box';
+import { Mark } from 'design/Mark/Mark';
+import {
+  InfoExternalTextLink,
+  InfoParagraph,
+  ReferenceLinks,
+} from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
+
+export function InfoGuide() {
+  return (
+    <Box>
+      <InfoParagraph>
+        A{' '}
+        <InfoExternalTextLink
+          target="_blank"
+          href={InfoGuideReferenceLinks.BotInstances.href}
+        >
+          Bot Instance
+        </InfoExternalTextLink>{' '}
+        identifies a single lineage of{' '}
+        <InfoExternalTextLink
+          target="_blank"
+          href={InfoGuideReferenceLinks.Bots.href}
+        >
+          bot
+        </InfoExternalTextLink>{' '}
+        identities, even through certificate renewals and rejoins. When the{' '}
+        <Mark>tbot</Mark> client first authenticates to a cluster, a Bot
+        Instance is generated and its UUID is embedded in the returned client
+        identity.
+      </InfoParagraph>
+      <InfoParagraph>
+        Bot Instances track a variety of information about <Mark>tbot</Mark>{' '}
+        instances, including regular heartbeats which include basic information
+        about the <Mark>tbot</Mark> host, like its architecture and OS version.
+      </InfoParagraph>
+      <InfoParagraph>
+        {' '}
+        Bot Instances have a relatively short lifespan and are set to expire
+        after the most recent identity issued for that instance will expire. If
+        the <Mark>tbot</Mark> client associated with a particular Bot Instance
+        renews or rejoins, the expiration of the bot instance is reset. This is
+        designed to allow users to list Bot Instances for an accurate view of
+        the number of active <Mark>tbot</Mark> clients interacting with their
+        Teleport cluster.
+      </InfoParagraph>
+      <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
+    </Box>
+  );
+}
+
+const InfoGuideReferenceLinks = {
+  BotInstances: {
+    title: 'What are Bot instances',
+    href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bot-instances',
+  },
+  Bots: {
+    title: 'What are Bots',
+    href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bots',
+  },
+  Tctl: {
+    title: 'Use tctl to manage bot instances',
+    href: 'https://goteleport.com/docs/reference/cli/tctl/#tctl-bots-instances-add',
+  },
+};

--- a/web/packages/teleport/src/BotInstances/InfoGuide.tsx
+++ b/web/packages/teleport/src/BotInstances/InfoGuide.tsx
@@ -53,10 +53,9 @@ export function InfoGuide() {
         about the <Mark>tbot</Mark> host, like its architecture and OS version.
       </InfoParagraph>
       <InfoParagraph>
-        {' '}
         Bot Instances have a relatively short lifespan and are set to expire
-        after the most recent identity issued for that instance will expire. If
-        the <Mark>tbot</Mark> client associated with a particular Bot Instance
+        after the most recent identity issued for that instance expires. If the{' '}
+        <Mark>tbot</Mark> client associated with a particular Bot Instance
         renews or rejoins, the expiration of the bot instance is reset. This is
         designed to allow users to list Bot Instances for an accurate view of
         the number of active <Mark>tbot</Mark> clients interacting with their

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.story.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.story.tsx
@@ -159,10 +159,7 @@ function Wrapper(
           sortField={sortField}
           sortDir={sortDir}
           selectedItem={selected}
-          onSortChanged={function (
-            sortField: string,
-            sortDir: 'ASC' | 'DESC'
-          ): void {
+          onSortChanged={(sortField: string, sortDir: 'ASC' | 'DESC') => {
             setSortField(sortField);
             setSortDir(sortDir);
             listRef.current?.scrollToTop();

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.story.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.story.tsx
@@ -1,0 +1,188 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient } from '@tanstack/react-query';
+import { ComponentProps, useRef, useState } from 'react';
+
+import { CardTile } from 'design/CardTile/CardTile';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+import { BotInstanceSummary } from 'teleport/services/bot/types';
+
+import { BotInstancesList, BotInstancesListControls } from './BotInstancesList';
+
+const meta = {
+  title: 'Teleport/BotInstances/List',
+  component: Wrapper,
+  beforeEach: () => {
+    queryClient.clear(); // Prevent cached data sharing between stories
+  },
+} satisfies Meta<typeof Wrapper>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Happy: Story = {};
+
+export const Empty: Story = {
+  args: {
+    data: [],
+  },
+};
+
+export const ErrorLoadingList: Story = {
+  args: {
+    error: new Error('something went wrong'),
+  },
+};
+
+export const NoMoreToLoad: Story = {
+  args: {
+    hasNextPage: false,
+  },
+};
+
+export const LoadingMore: Story = {
+  args: {
+    isFetchingNextPage: true,
+  },
+};
+
+export const UnsupportedSort: Story = {
+  args: {
+    error: new Error('unsupported sort: something went wrong'),
+  },
+};
+
+export const StillLoadingList: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
+function Wrapper(
+  props?: Partial<
+    Pick<
+      ComponentProps<typeof BotInstancesList>,
+      'error' | 'isLoading' | 'hasNextPage' | 'isFetchingNextPage' | 'data'
+    >
+  >
+) {
+  const {
+    data = [
+      {
+        bot_name: 'ansible-worker',
+        instance_id: `966c0850-9bb5-4ed7-af2d-4b1f202a936a`,
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'my-svc.my-namespace.svc.cluster-domain.example',
+        join_method_latest: 'github',
+        os_latest: 'linux',
+        version_latest: '2.4.0',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: 'ac7135ce-fde6-4a91-bd77-ba7419e1c175',
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'win-123a',
+        join_method_latest: 'tpm',
+        os_latest: 'windows',
+        version_latest: '4.3.18+ab12hd',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: '5283f4a9-c49b-4876-be48-b5f83000e612',
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'mac-007',
+        join_method_latest: 'kubernetes',
+        os_latest: 'darwin',
+        version_latest: '3.9.99',
+      },
+    ],
+    error = null,
+    hasNextPage = true,
+    isFetchingNextPage = false,
+    isLoading = false,
+  } = props ?? {};
+
+  const [allData, setAllData] = useState(data);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<string>('active_at_latest');
+  const [sortDir, setSortDir] = useState<'ASC' | 'DESC'>('ASC');
+
+  const listRef = useRef<BotInstancesListControls | null>(null);
+
+  const ctx = createTeleportContext();
+
+  return (
+    <TeleportProviderBasic teleportCtx={ctx}>
+      <CardTile
+        height={600}
+        width={400}
+        overflow={'auto'}
+        p={0}
+        flexDirection={'row'}
+      >
+        <BotInstancesList
+          ref={listRef}
+          data={allData}
+          isLoading={isLoading}
+          isFetchingNextPage={isFetchingNextPage}
+          error={error}
+          hasNextPage={hasNextPage}
+          sortField={sortField}
+          sortDir={sortDir}
+          selectedItem={selected}
+          onSortChanged={function (
+            sortField: string,
+            sortDir: 'ASC' | 'DESC'
+          ): void {
+            setSortField(sortField);
+            setSortDir(sortDir);
+            listRef.current?.scrollToTop();
+          }}
+          onLoadNextPage={() =>
+            setAllData(existing => {
+              const newData = (data ?? []).map(i => {
+                return {
+                  ...i,
+                  instance_id: crypto.randomUUID(),
+                };
+              });
+              return [...(existing ?? []), ...newData];
+            })
+          }
+          onItemSelected={function (item: BotInstanceSummary | null): void {
+            setSelected(item ? `${item.bot_name}/${item.instance_id}` : null);
+          }}
+        />
+      </CardTile>
+    </TeleportProviderBasic>
+  );
+}

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.test.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ComponentProps, PropsWithChildren } from 'react';
+
+import darkTheme from 'design/theme/themes/darkTheme';
+import { ConfiguredThemeProvider } from 'design/ThemeProvider';
+import {
+  render,
+  screen,
+  testQueryClient,
+  userEvent,
+} from 'design/utils/testing';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { TeleportProviderBasic } from 'teleport/mocks/providers';
+
+import { BotInstancesList } from './BotInstancesList';
+
+jest.mock('design/utils/copyToClipboard', () => {
+  return {
+    __esModule: true,
+    copyToClipboard: jest.fn(),
+  };
+});
+
+afterEach(async () => {
+  jest.clearAllMocks();
+});
+
+describe('BotIntancesList', () => {
+  it('renders items', async () => {
+    renderComponent();
+
+    expect(screen.getByText('ansible-worker/966c085')).toBeInTheDocument();
+    expect(screen.getByText('ansible-worker/ac7135c')).toBeInTheDocument();
+    expect(screen.getByText('ansible-worker/5283f4a')).toBeInTheDocument();
+  });
+
+  it('select an item', async () => {
+    const onItemSelected = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        onItemSelected,
+      },
+    });
+
+    const item2 = screen.getByRole('listitem', {
+      name: 'ansible-worker/ac7135ce-fde6-4a91-bd77-ba7419e1c175',
+    });
+    await user.click(item2);
+
+    expect(onItemSelected).toHaveBeenCalledTimes(1);
+    expect(onItemSelected).toHaveBeenLastCalledWith({
+      active_at_latest: '2025-07-22T10:54:00Z',
+      bot_name: 'ansible-worker',
+      host_name_latest: 'win-123a',
+      instance_id: 'ac7135ce-fde6-4a91-bd77-ba7419e1c175',
+      join_method_latest: 'tpm',
+      os_latest: 'windows',
+      version_latest: '4.3.18+ab12hd',
+    });
+  });
+
+  it('Shows a loading state', async () => {
+    renderComponent({
+      props: {
+        isLoading: true,
+      },
+    });
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+  });
+
+  it('Shows an empty state', async () => {
+    renderComponent({
+      props: {
+        data: [],
+      },
+    });
+
+    expect(screen.getByText('No active instances')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Bot instances are ephemeral, and disappear once all issued credentials have expired.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('Shows an error', async () => {
+    renderComponent({
+      props: {
+        error: new Error('something went wrong'),
+      },
+    });
+
+    expect(screen.getByText('something went wrong')).toBeInTheDocument();
+  });
+
+  it('Allows fetch more action', async () => {
+    const onLoadNextPage = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        hasNextPage: true,
+        onLoadNextPage,
+      },
+    });
+
+    const action = screen.getByText('Load More');
+    await user.click(action);
+
+    expect(onLoadNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('Prevents next page action when no page', async () => {
+    const onLoadNextPage = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        hasNextPage: false,
+        onLoadNextPage,
+      },
+    });
+
+    const action = screen.getByText('Load More');
+    await user.click(action);
+
+    expect(action).toBeDisabled();
+    expect(onLoadNextPage).not.toHaveBeenCalled();
+  });
+
+  it('Prevents next page action when loading next page', async () => {
+    const onLoadNextPage = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        hasNextPage: true,
+        isFetchingNextPage: true,
+        onLoadNextPage,
+      },
+    });
+
+    const action = screen.getByText('Load More');
+    await user.click(action);
+
+    expect(action).toBeDisabled();
+    expect(onLoadNextPage).not.toHaveBeenCalled();
+  });
+
+  it('Allows sort change', async () => {
+    const onSortChanged = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        onSortChanged,
+        sortField: 'active_at_latest',
+        sortDir: 'DESC',
+      },
+    });
+
+    const fieldAction = screen.getByRole('button', { name: 'Sort by' });
+    await user.click(fieldAction);
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Bot name' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Recent' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Hostname' })
+    ).toBeInTheDocument();
+    const versionOption = screen.getByRole('menuitem', { name: 'Version' });
+    await user.click(versionOption);
+
+    expect(onSortChanged).toHaveBeenLastCalledWith('version_latest', 'DESC');
+
+    const dirAction = screen.getByRole('button', { name: 'Sort direction' });
+    await user.click(dirAction);
+
+    // The component under test does not keep sort state so the sort field will
+    // be 'active_at_latest' on the next change.
+    expect(onSortChanged).toHaveBeenLastCalledWith('active_at_latest', 'ASC');
+  });
+
+  it('Shows an unsupported sort error', async () => {
+    const onSortChanged = jest.fn();
+
+    const { user } = renderComponent({
+      props: {
+        onSortChanged,
+        sortField: 'active_at_latest',
+        sortDir: 'DESC',
+        error: new Error('unsupported sort: foo'),
+      },
+    });
+
+    expect(screen.getByText('unsupported sort: foo')).toBeInTheDocument();
+
+    const resetAction = screen.getByRole('button', { name: 'Reset sort' });
+    await user.click(resetAction);
+
+    expect(onSortChanged).toHaveBeenLastCalledWith('bot_name', 'ASC');
+  });
+});
+
+const renderComponent = (options?: {
+  props: Partial<ComponentProps<typeof BotInstancesList>>;
+}) => {
+  const { props } = options ?? {};
+  const {
+    data = mockData,
+    isLoading = false,
+    isFetchingNextPage = false,
+    error = null,
+    hasNextPage = true,
+    sortField = 'bot_name',
+    sortDir = 'ASC',
+    selectedItem = null,
+    onSortChanged = jest.fn(),
+    onLoadNextPage = jest.fn(),
+    onItemSelected = jest.fn(),
+  } = props ?? {};
+
+  const user = userEvent.setup();
+  return {
+    ...render(
+      <BotInstancesList
+        data={data}
+        isLoading={isLoading}
+        isFetchingNextPage={isFetchingNextPage}
+        error={error}
+        hasNextPage={hasNextPage}
+        sortField={sortField}
+        sortDir={sortDir}
+        selectedItem={selectedItem}
+        onSortChanged={onSortChanged}
+        onLoadNextPage={onLoadNextPage}
+        onItemSelected={onItemSelected}
+      />,
+      {
+        wrapper: makeWrapper(),
+      }
+    ),
+    user,
+  };
+};
+
+function makeWrapper() {
+  const ctx = createTeleportContext();
+  return (props: PropsWithChildren) => {
+    return (
+      <QueryClientProvider client={testQueryClient}>
+        <TeleportProviderBasic teleportCtx={ctx}>
+          <ConfiguredThemeProvider theme={darkTheme}>
+            {props.children}
+          </ConfiguredThemeProvider>
+        </TeleportProviderBasic>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const mockData = [
+  {
+    bot_name: 'ansible-worker',
+    instance_id: `966c0850-9bb5-4ed7-af2d-4b1f202a936a`,
+    active_at_latest: '2025-07-22T10:54:00Z',
+    host_name_latest: 'my-svc.my-namespace.svc.cluster-domain.example',
+    join_method_latest: 'github',
+    os_latest: 'linux',
+    version_latest: '2.4.0',
+  },
+  {
+    bot_name: 'ansible-worker',
+    instance_id: 'ac7135ce-fde6-4a91-bd77-ba7419e1c175',
+    active_at_latest: '2025-07-22T10:54:00Z',
+    host_name_latest: 'win-123a',
+    join_method_latest: 'tpm',
+    os_latest: 'windows',
+    version_latest: '4.3.18+ab12hd',
+  },
+  {
+    bot_name: 'ansible-worker',
+    instance_id: '5283f4a9-c49b-4876-be48-b5f83000e612',
+    active_at_latest: '2025-07-22T10:54:00Z',
+    host_name_latest: 'mac-007',
+    join_method_latest: 'kubernetes',
+    os_latest: 'darwin',
+    version_latest: '3.9.99',
+  },
+];

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -16,148 +16,231 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { format } from 'date-fns/format';
-import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
-import { parseISO } from 'date-fns/parseISO';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import styled from 'styled-components';
 
-import { Info } from 'design/Alert/Alert';
-import { Cell, LabelCell } from 'design/DataTable/Cells';
-import Table from 'design/DataTable/Table';
-import { FetchingConfig, SortType } from 'design/DataTable/types';
-import Flex from 'design/Flex';
+import { Alert, Info } from 'design/Alert/Alert';
+import Box from 'design/Box/Box';
+import { ButtonSecondary } from 'design/Button/Button';
+import Flex from 'design/Flex/Flex';
+import { Indicator } from 'design/Indicator/Indicator';
 import Text from 'design/Text';
-import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
-import { SearchPanel } from 'shared/components/Search';
-import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
+import { SortMenu } from 'shared/components/Controls/SortMenu';
 
+import { Instance } from 'teleport/Bots/Details/Instance';
 import { BotInstanceSummary } from 'teleport/services/bot/types';
 
-const MonoText = styled(Text)`
-  font-family: ${({ theme }) => theme.fonts.mono};
-`;
+export const BotInstancesList = forwardRef(InternalBotInstancesList);
 
-export function BotInstancesList({
-  data,
-  fetchStatus,
-  onFetchNext,
-  onFetchPrev,
-  searchTerm,
-  query,
-  onSearchChange,
-  onQueryChange,
-  onItemSelected,
-  sortType,
-  onSortChanged,
-}: {
-  data: BotInstanceSummary[];
-  searchTerm: string;
-  query: string;
-  onSearchChange: (term: string) => void;
-  onQueryChange: (term: string) => void;
-  onItemSelected: (item: BotInstanceSummary) => void;
-  sortType: SortType;
-  onSortChanged: (sortType: SortType) => void;
-} & Omit<FetchingConfig, 'onFetchMore'>) {
-  const tableData = data.map(x => ({
-    ...x,
-    host_name_latest: x.host_name_latest ?? '-',
-    instanceIdDisplay: x.instance_id.substring(0, 7),
-    version_latest: x.version_latest ? `v${x.version_latest}` : '-',
-    active_at_latest: x.active_at_latest
-      ? `${formatDistanceToNowStrict(parseISO(x.active_at_latest))} ago`
-      : '-',
-    activeAtLocal: x.active_at_latest
-      ? format(parseISO(x.active_at_latest), 'PP, p z')
-      : '-',
-  }));
+export type BotInstancesListControls = {
+  scrollToTop: () => void;
+};
+
+function InternalBotInstancesList(
+  props: {
+    data: BotInstanceSummary[] | null | undefined;
+    isLoading: boolean;
+    isFetchingNextPage: boolean;
+    error: Error | null | undefined;
+    hasNextPage: boolean;
+    sortField: string;
+    sortDir: 'ASC' | 'DESC';
+    selectedItem: string | null;
+    onSortChanged: (sortField: string, sortDir: 'ASC' | 'DESC') => void;
+    onLoadNextPage: () => void;
+    onItemSelected: (item: BotInstanceSummary | null) => void;
+  },
+  ref: React.RefObject<BotInstancesListControls | null>
+) {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    error,
+    hasNextPage,
+    sortField,
+    sortDir,
+    selectedItem,
+    onSortChanged,
+    onLoadNextPage,
+    onItemSelected,
+  } = props;
+
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  useImperativeHandle(ref, () => {
+    return {
+      scrollToTop() {
+        contentRef.current?.scrollTo({ top: 0, behavior: 'instant' });
+      },
+    };
+  }, [contentRef]);
+
+  const hasError = !!error;
+  const hasData = !hasError && !isLoading;
+  const hasUnsupportedSortError = isUnsupportedSortError(error);
+
+  const makeOnSelectedCallback = (instance: BotInstanceSummary) => () => {
+    onItemSelected(instance);
+  };
 
   return (
-    <Table<(typeof tableData)[number]>
-      data={tableData}
-      fetching={{
-        fetchStatus,
-        onFetchNext,
-        onFetchPrev,
-        disableLoadingIndicator: true,
-      }}
-      serversideProps={{
-        sort: sortType,
-        setSort: onSortChanged,
-        serversideSearchPanel: (
-          <SearchPanel
-            updateSearch={onSearchChange}
-            updateQuery={onQueryChange}
-            hideAdvancedSearch={false}
-            filter={{ search: searchTerm, query }}
-            disableSearch={fetchStatus !== ''}
-          />
-        ),
-      }}
-      row={{
-        onClick: onItemSelected,
-        getStyle: () => ({ cursor: 'pointer' }),
-      }}
-      columns={[
-        {
-          key: 'bot_name',
-          headerText: 'Bot',
-          isSortable: true,
-        },
-        {
-          key: 'instanceIdDisplay',
-          headerText: 'ID',
-          isSortable: false,
-          render: ({ instance_id, instanceIdDisplay }) => (
-            <Cell>
-              <Flex inline alignItems={'center'} gap={1} mr={0}>
-                <MonoText>{instanceIdDisplay}</MonoText>
-                <CopyButton name={instance_id} />
-              </Flex>
-            </Cell>
-          ),
-        },
-        {
-          key: 'join_method_latest',
-          headerText: 'Method',
-          isSortable: false,
-          render: ({ join_method_latest }) =>
-            join_method_latest ? (
-              <LabelCell data={[join_method_latest]} />
-            ) : (
-              <Cell>{'-'}</Cell>
-            ),
-        },
-        {
-          key: 'host_name_latest',
-          headerText: 'Hostname',
-          isSortable: true,
-        },
-        {
-          key: 'version_latest',
-          headerText: 'Version (tbot)',
-          isSortable: true,
-        },
-        {
-          key: 'active_at_latest',
-          headerText: 'Last heartbeat',
-          isSortable: true,
-          render: ({ active_at_latest, activeAtLocal }) => (
-            <Cell>
-              <HoverTooltip tipContent={activeAtLocal}>
-                <span>{active_at_latest}</span>
-              </HoverTooltip>
-            </Cell>
-          ),
-        },
-      ]}
-      emptyText="No active instances found"
-      emptyButton={
-        <Info mt={5}>
-          Bot instances are ephemeral, and disappear once all issued credentials
-          have expired.
-        </Info>
-      }
-    />
+    <Container>
+      <TitleContainer>
+        <TitleText>Currently Active</TitleText>
+        <SortMenu
+          current={{
+            fieldName: sortField,
+            dir: sortDir,
+          }}
+          fields={sortFields}
+          onChange={value => {
+            onSortChanged(value.fieldName, value.dir);
+          }}
+        />
+      </TitleContainer>
+
+      <Divider />
+
+      {isLoading ? (
+        <Box data-testid="loading" textAlign="center" m={10}>
+          <Indicator />
+        </Box>
+      ) : undefined}
+
+      {hasError && hasUnsupportedSortError ? (
+        <Alert
+          m={3}
+          kind="warning"
+          primaryAction={{
+            content: 'Reset sort',
+            onClick: () => {
+              onSortChanged('bot_name', 'ASC');
+            },
+          }}
+        >
+          {error.message}
+        </Alert>
+      ) : undefined}
+
+      {hasError && !hasUnsupportedSortError ? (
+        <Alert m={3} kind="danger" details={error.message}>
+          Failed to fetch instances
+        </Alert>
+      ) : undefined}
+
+      {hasData ? (
+        <>
+          {data && data.length > 0 ? (
+            <ContentContainer ref={contentRef}>
+              {data.map((instance, i) => (
+                <React.Fragment key={`${instance.instance_id}`}>
+                  {i === 0 ? undefined : <Divider />}
+                  <Instance
+                    isSelectable
+                    onSelected={makeOnSelectedCallback(instance)}
+                    isSelected={
+                      `${instance.bot_name}/${instance.instance_id}` ==
+                      selectedItem
+                    }
+                    data={{
+                      id: instance.instance_id,
+                      botName: instance.bot_name,
+                      version: instance.version_latest,
+                      hostname: instance.host_name_latest,
+                      activeAt: instance.active_at_latest,
+                      method: instance.join_method_latest,
+                      os: instance.os_latest,
+                    }}
+                  />
+                </React.Fragment>
+              ))}
+
+              <Divider />
+
+              <LoadMoreContainer>
+                <ButtonSecondary
+                  onClick={() => onLoadNextPage()}
+                  disabled={!hasNextPage || isFetchingNextPage}
+                >
+                  Load More
+                </ButtonSecondary>
+              </LoadMoreContainer>
+            </ContentContainer>
+          ) : (
+            <Box p={3}>
+              <EmptyText>No active instances</EmptyText>
+              <Info mt={5}>
+                Bot instances are ephemeral, and disappear once all issued
+                credentials have expired.
+              </Info>
+            </Box>
+          )}
+        </>
+      ) : undefined}
+    </Container>
   );
 }
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 300px;
+  max-width: 400px;
+`;
+
+const TitleContainer = styled(Flex)`
+  align-items: center;
+  justify-content: space-between;
+  gap: ${p => p.theme.space[2]}px;
+  padding-left: ${p => p.theme.space[3]}px;
+  padding-right: ${p => p.theme.space[3]}px;
+  min-height: ${p => p.theme.space[8]}px;
+`;
+
+export const TitleText = styled(Text).attrs({
+  as: 'h2',
+  typography: 'h2',
+})``;
+
+const ContentContainer = styled.div`
+  overflow: auto;
+`;
+
+const LoadMoreContainer = styled(Flex)`
+  justify-content: center;
+  padding: ${props => props.theme.space[3]}px;
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  flex-shrink: 0;
+  background-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
+`;
+
+const EmptyText = styled(Text)`
+  color: ${p => p.theme.colors.text.muted};
+`;
+
+const isUnsupportedSortError = (error: Error | null | undefined) => {
+  return !!error && error.message.includes('unsupported sort');
+};
+
+const sortFields = [
+  {
+    value: 'bot_name' as const,
+    label: 'Bot name',
+  },
+  {
+    value: 'active_at_latest' as const,
+    label: 'Recent',
+  },
+  {
+    value: 'version_latest' as const,
+    label: 'Version',
+  },
+  {
+    value: 'host_name_latest' as const,
+    label: 'Hostname',
+  },
+];

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -48,7 +48,7 @@ function InternalBotInstancesList(
     selectedItem: string | null;
     onSortChanged: (sortField: string, sortDir: 'ASC' | 'DESC') => void;
     onLoadNextPage: () => void;
-    onItemSelected: (item: BotInstanceSummary | null) => void;
+    onItemSelected: (item: BotInstanceSummary) => void;
   },
   ref: React.RefObject<BotInstancesListControls | null>
 ) {

--- a/web/packages/teleport/src/Bots/Details/Instance.story.tsx
+++ b/web/packages/teleport/src/Bots/Details/Instance.story.tsx
@@ -57,11 +57,14 @@ export default meta;
 export const Item: Story = {
   args: {
     id: '686750f5-0f21-4a6f-b151-fa11a603701d',
+    botName: '',
     activeAt: new Date('2025-07-18T14:54:32Z').getTime(),
     hostname: 'my-svc.my-namespace.svc.cluster-domain.example',
     method: 'kubernetes',
     version: '4.4.0',
     os: 'linux',
+    isSelectable: true,
+    isSelected: false,
   },
 };
 
@@ -82,26 +85,43 @@ export const ItemWithLongValues: Story = {
   },
 };
 
+export const ItemWithLongValuesAndBotName: Story = {
+  args: {
+    id: 'fa11a603701dfa11a603701dfa11a603701dfa11a603701dfa11a603701dfa113701d',
+    botName: 'ansible-worker-ansible-worker-ansible-worker-ansible-worker',
+    activeAt: new Date('2025-07-18T14:54:32Z').getTime(),
+    hostname: 'hostnamehostnamehostnamehostnamehostnamehostnamehostnamehostnam',
+    method: 'kubernetes',
+    version: '4.4.0-fa11a60',
+    os: 'linux',
+  },
+};
+
 type Props = {
-  id: Parameters<typeof Instance>[0]['id'];
-  version?: Parameters<typeof Instance>[0]['version'];
-  hostname?: Parameters<typeof Instance>[0]['hostname'];
+  id: Parameters<typeof Instance>[0]['data']['id'];
+  botName?: Parameters<typeof Instance>[0]['data']['botName'];
+  version?: Parameters<typeof Instance>[0]['data']['version'];
+  hostname?: Parameters<typeof Instance>[0]['data']['hostname'];
   activeAt?: number;
-  method?: Parameters<typeof Instance>[0]['method'];
-  os?: Parameters<typeof Instance>[0]['os'];
+  method?: Parameters<typeof Instance>[0]['data']['method'];
+  os?: Parameters<typeof Instance>[0]['data']['os'];
+  isSelectable?: Parameters<typeof Instance>[0]['isSelectable'];
+  isSelected?: Parameters<typeof Instance>[0]['isSelected'];
 };
 function Wrapper(props: Props) {
+  const { isSelectable, isSelected, activeAt, ...data } = props;
   return (
     <TeleportProviderBasic>
       <Container>
         <Container400>
           <Instance
-            {...props}
-            activeAt={
-              props.activeAt
-                ? new Date(props.activeAt).toISOString()
-                : undefined
-            }
+            isSelectable={isSelectable}
+            isSelected={isSelected}
+            onSelected={undefined}
+            data={{
+              ...data,
+              activeAt: activeAt ? new Date(activeAt).toISOString() : undefined,
+            }}
           />
         </Container400>
       </Container>

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.tsx
@@ -130,12 +130,14 @@ export function InstancesPanel(props: { botName: string }) {
                   <React.Fragment key={`${instance.instance_id}`}>
                     {i === 0 && j === 0 ? undefined : <Divider />}
                     <Instance
-                      id={instance.instance_id}
-                      activeAt={instance.active_at_latest}
-                      hostname={instance.host_name_latest}
-                      method={instance.join_method_latest}
-                      version={instance.version_latest}
-                      os={instance.os_latest}
+                      data={{
+                        id: instance.instance_id,
+                        version: instance.version_latest,
+                        hostname: instance.host_name_latest,
+                        activeAt: instance.active_at_latest,
+                        method: instance.join_method_latest,
+                        os: instance.os_latest,
+                      }}
                     />
                   </React.Fragment>
                 ))

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -188,7 +188,6 @@ const cfg = {
     bots: '/web/bots',
     bot: '/web/bot/:botName',
     botInstances: '/web/bots/instances',
-    botInstance: '/web/bot/:botName/instance/:instanceId',
     botsNew: '/web/bots/new/:type?',
     workloadIdentities: '/web/workloadidentities',
     console: '/web/cluster/:clusterId/console',
@@ -848,10 +847,6 @@ const cfg = {
 
   getWorkloadIdentitiesRoute() {
     return generatePath(cfg.routes.workloadIdentities);
-  },
-
-  getBotInstanceDetailsRoute(params: { botName: string; instanceId: string }) {
-    return generatePath(cfg.routes.botInstance, params);
   },
 
   getBotsNewRoute(type?: string) {

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -53,7 +53,6 @@ import { AccountPage } from './Account';
 import { AuditContainer as Audit } from './Audit';
 import { AuthConnectorsContainer as AuthConnectors } from './AuthConnectors';
 import { BotInstances } from './BotInstances/BotInstances';
-import { BotInstanceDetails } from './BotInstances/Details/BotInstanceDetails';
 import { Bots } from './Bots';
 import { AddBots } from './Bots/Add';
 import { BotDetails } from './Bots/Details/BotDetails';
@@ -303,18 +302,11 @@ export class FeatureBotInstances implements TeleportFeature {
   }
 }
 
+// TODO(nicholasmarais1158) Remove this feature stub when teleport.e no longer
+// uses it.
 export class FeatureBotInstanceDetails implements TeleportFeature {
-  parent = FeatureBotInstances;
-
-  route = {
-    title: 'Bot instance details',
-    path: cfg.routes.botInstance,
-    exact: true,
-    component: BotInstanceDetails,
-  };
-
   hasAccess() {
-    return true;
+    return false;
   }
 }
 
@@ -829,7 +821,6 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureBots(),
     new FeatureBotDetails(),
     new FeatureBotInstances(),
-    new FeatureBotInstanceDetails(),
     new FeatureAddBotsShortcut(),
     new FeatureJoinTokens(),
     new FeatureRoles(),

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -223,6 +223,7 @@ class TeleportContext implements types.Context {
       gitServers:
         userContext.getGitServersAccess().list &&
         userContext.getGitServersAccess().read,
+      readBotInstances: userContext.getBotInstancesAccess().read,
       listBotInstances: userContext.getBotInstancesAccess().list,
       listWorkloadIdentities: userContext.getWorkloadIdentityAccess().list,
     };
@@ -268,6 +269,7 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   editBots: false,
   removeBots: false,
   gitServers: false,
+  readBotInstances: false,
   listBotInstances: false,
   listWorkloadIdentities: false,
 };

--- a/web/packages/teleport/src/test/helpers/botInstances.ts
+++ b/web/packages/teleport/src/test/helpers/botInstances.ts
@@ -51,7 +51,19 @@ export const getBotInstanceSuccess = (mock: GetBotInstanceResponse) =>
     return HttpResponse.json(mock);
   });
 
-export const getBotInstanceError = (status: number) =>
+export const getBotInstanceError = (
+  status: number,
+  error: string | null = null
+) =>
   http.get(cfg.api.botInstance.read, () => {
-    return new HttpResponse(null, { status });
+    return HttpResponse.json({ error: { message: error } }, { status });
   });
+
+export const getBotInstanceForever = () =>
+  http.get(
+    cfg.api.botInstance.read,
+    () =>
+      new Promise(() => {
+        /* never resolved */
+      })
+  );

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -207,6 +207,7 @@ export interface FeatureFlags {
   externalAuditStorage: boolean;
   listBots: boolean;
   readBots: boolean;
+  readBotInstances: boolean;
   listBotInstances: boolean;
   addBots: boolean;
   editBots: boolean;


### PR DESCRIPTION
## Summary
This change is a reimagining of the bland and boring Bot Instances list and details pages. It uses a master-details layout. All previous features are still available; paging, sorting, search, yaml view. It paves the way towards providing a dashboard-like experience in the near future.

The old Bot Instance details page is no longer needed. The _feature_ has been stubbed temporarily to prevent its removal change breaking `teleport.e`.

Updates: https://github.com/gravitational/teleport/issues/57994
Changelog: Added advanced search and sorting to the bot instances list in the web UI

## Changes
- Rebuild UI
- Add stories and tests
- Make `disableSearch` prop optional for SearchPanel component
- Add a mock for TextEditor
- Stub bot instance page feature
- Make instance items selectable - they're used on the Bot details screen also

## Demo

https://github.com/user-attachments/assets/4cbd4135-e4aa-4afb-ba08-d375cc94552d

## Reviewer notes
Creating bot instances (as well as heartbeat records) requires running tbot to enrol an instance. To make testing this feature easier, I've used a SQL script to insert instance resources into the backend directly. Here's the script;
[bot_instances.sql](https://github.com/user-attachments/files/22433503/bot_instances.sql)

```
$ sqlite3 <your cluster's data dir>/backend/sqlite.db
sqlite> .read bot_instances.sql
```

**Be sure to restart your cluster afterwards - the cache will not be notified of the changes.**