### PR TITLE
Implement multi-agent in server discovery for GCP and Azure

### DIFF
--- a/api/types/matchers_azure.go
+++ b/api/types/matchers_azure.go
@@ -90,6 +90,18 @@ func (m *AzureMatcher) CheckAndSetDefaults() error {
 			m.Params.Azure = &AzureInstallerParams{}
 		}
 
+		if m.Params.Suffix != "" {
+			if !isAlphanumericIncluding(m.Params.Suffix, '-') {
+				return trace.BadParameter("install.suffix can only contain alphanumeric characters and hyphens")
+			}
+		}
+
+		if m.Params.UpdateGroup != "" {
+			if !isAlphanumericIncluding(m.Params.UpdateGroup, '-') {
+				return trace.BadParameter("install.update_group can only contain alphanumeric characters and hyphens")
+			}
+		}
+
 		switch m.Params.JoinMethod {
 		case JoinMethodAzure, "":
 			m.Params.JoinMethod = JoinMethodAzure

--- a/api/types/matchers_azure_test.go
+++ b/api/types/matchers_azure_test.go
@@ -119,6 +119,26 @@ func TestAzureMatcherCheckAndSetDefaults(t *testing.T) {
 			},
 			errCheck: isBadParameterErr,
 		},
+		{
+			name: "invalid install suffix",
+			in: &AzureMatcher{
+				Types: []string{"vm"},
+				Params: &InstallerParams{
+					Suffix: "$SHELL",
+				},
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "invalid update groups",
+			in: &AzureMatcher{
+				Types: []string{"vm"},
+				Params: &InstallerParams{
+					UpdateGroup: "$SHELL",
+				},
+			},
+			errCheck: isBadParameterErr,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.in.CheckAndSetDefaults()

--- a/api/types/matchers_gcp.go
+++ b/api/types/matchers_gcp.go
@@ -82,6 +82,18 @@ func (m *GCPMatcher) CheckAndSetDefaults() error {
 			m.Params = &InstallerParams{}
 		}
 
+		if m.Params.Suffix != "" {
+			if !isAlphanumericIncluding(m.Params.Suffix, '-') {
+				return trace.BadParameter("install.suffix can only contain alphanumeric characters and hyphens")
+			}
+		}
+
+		if m.Params.UpdateGroup != "" {
+			if !isAlphanumericIncluding(m.Params.UpdateGroup, '-') {
+				return trace.BadParameter("install.update_group can only contain alphanumeric characters and hyphens")
+			}
+		}
+
 		switch m.Params.JoinMethod {
 		case JoinMethodGCP, "":
 			m.Params.JoinMethod = JoinMethodGCP

--- a/api/types/matchers_gcp_test.go
+++ b/api/types/matchers_gcp_test.go
@@ -148,6 +148,28 @@ func TestGCPMatcherCheckAndSetDefaults(t *testing.T) {
 			},
 			errCheck: isBadParameterErr,
 		},
+		{
+			name: "invalid install suffix",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Params: &InstallerParams{
+					Suffix: "$SHELL",
+				},
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "invalid update groups",
+			in: &GCPMatcher{
+				Types:      []string{"gce"},
+				ProjectIDs: []string{"project001"},
+				Params: &InstallerParams{
+					UpdateGroup: "$SHELL",
+				},
+			},
+			errCheck: isBadParameterErr,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.in.CheckAndSetDefaults()

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1612,6 +1612,8 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 				installerParams.JoinMethod = matcher.InstallParams.JoinParams.Method
 				installerParams.JoinToken = matcher.InstallParams.JoinParams.TokenName
 				installerParams.ScriptName = matcher.InstallParams.ScriptName
+				installerParams.Suffix = matcher.InstallParams.Suffix
+				installerParams.UpdateGroup = matcher.InstallParams.UpdateGroup
 				if matcher.InstallParams.Azure != nil {
 					installerParams.Azure = &types.AzureInstallerParams{
 						ClientID: matcher.InstallParams.Azure.ClientID,
@@ -1645,6 +1647,8 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 				installerParams.JoinMethod = matcher.InstallParams.JoinParams.Method
 				installerParams.JoinToken = matcher.InstallParams.JoinParams.TokenName
 				installerParams.ScriptName = matcher.InstallParams.ScriptName
+				installerParams.Suffix = matcher.InstallParams.Suffix
+				installerParams.UpdateGroup = matcher.InstallParams.UpdateGroup
 			}
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3898,6 +3898,7 @@ func TestApplyDiscoveryConfig(t *testing.T) {
 							Azure: &AzureInstallParams{
 								ClientID: "abcd1234",
 							},
+							Suffix: "blue",
 						},
 					},
 				},
@@ -3916,6 +3917,7 @@ func TestApplyDiscoveryConfig(t *testing.T) {
 							Azure: &types.AzureInstallerParams{
 								ClientID: "abcd1234",
 							},
+							Suffix: "blue",
 						},
 						Regions:        []string{"*"},
 						ResourceTags:   types.Labels{"*": []string{"*"}},
@@ -4750,6 +4752,7 @@ func TestDiscoveryConfig(t *testing.T) {
 								"method":     "iam",
 							},
 							"script_name": "installer-custom",
+							"suffix":      "blue",
 						},
 						"ssm": cfgMap{
 							"document_name": "hello_document",
@@ -4772,6 +4775,7 @@ func TestDiscoveryConfig(t *testing.T) {
 					ScriptName:      "installer-custom",
 					InstallTeleport: true,
 					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+					Suffix:          "blue",
 				},
 				SSM: &types.AWSSSM{DocumentName: "hello_document"},
 				AssumeRole: &types.AssumeRole{

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1826,6 +1826,14 @@ type InstallParams struct {
 	// Valid values: script, eice.
 	// Optional.
 	EnrollMode string `yaml:"enroll_mode"`
+	// Suffix indicates the installation suffix for the teleport installation.
+	// Set this value if you want multiple installations of Teleport.
+	// See --install-suffix flag in teleport-update program.
+	Suffix string `yaml:"suffix,omitempty"`
+	// UpdateGroup indicates the update group for the teleport installation.
+	// This value is used to group installations in order to update them in batches.
+	// See --group flag in teleport-update program.
+	UpdateGroup string `yaml:"update_group,omitempty"`
 }
 
 const (
@@ -1843,6 +1851,8 @@ func (ip *InstallParams) parse() (*types.InstallerParams, error) {
 		InstallTeleport: true,
 		SSHDConfig:      ip.SSHDConfig,
 		EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_UNSPECIFIED,
+		Suffix:          ip.Suffix,
+		UpdateGroup:     ip.UpdateGroup,
 	}
 
 	switch ip.EnrollMode {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1343,6 +1343,8 @@ func (s *Server) handleAzureInstances(instances *server.AzureInstances) error {
 		ScriptName:      instances.ScriptName,
 		PublicProxyAddr: instances.PublicProxyAddr,
 		ClientID:        instances.ClientID,
+		InstallSuffix:   instances.InstallSuffix,
+		UpdateGroup:     instances.UpdateGroup,
 	}
 	if err := s.azureInstaller.Run(s.ctx, req); err != nil {
 		return trace.Wrap(err)
@@ -1436,6 +1438,8 @@ func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
 		ScriptName:      instances.ScriptName,
 		PublicProxyAddr: instances.PublicProxyAddr,
 		SSHKeyAlgo:      sshKeyAlgo,
+		InstallSuffix:   instances.InstallSuffix,
+		UpdateGroup:     instances.UpdateGroup,
 	}
 	if err := s.gcpInstaller.Run(s.ctx, req); err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -23,8 +23,10 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 
@@ -49,12 +51,16 @@ type AzureRunRequest struct {
 	ScriptName      string
 	PublicProxyAddr string
 	ClientID        string
+	InstallSuffix   string
+	UpdateGroup     string
+
+	randReader func(b []byte) (n int, err error)
 }
 
 // Run runs a command on a set of virtual machines and then blocks until the
 // commands have completed.
 func (ai *AzureInstaller) Run(ctx context.Context, req AzureRunRequest) error {
-	script, err := getInstallerScript(req.ScriptName, req.PublicProxyAddr, req.ClientID)
+	script, err := getInstallerScript(req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -78,14 +84,14 @@ func (ai *AzureInstaller) Run(ctx context.Context, req AzureRunRequest) error {
 	return trace.Wrap(g.Wait())
 }
 
-func getInstallerScript(installerName, publicProxyAddr, clientID string) (string, error) {
-	installerURL, err := url.Parse(fmt.Sprintf("https://%s/v1/webapi/scripts/installer/%v", publicProxyAddr, installerName))
+func getInstallerScript(req AzureRunRequest) (string, error) {
+	installerURL, err := url.Parse(fmt.Sprintf("https://%s/v1/webapi/scripts/installer/%v", req.PublicProxyAddr, req.ScriptName))
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	if clientID != "" {
+	if req.ClientID != "" {
 		q := installerURL.Query()
-		q.Set("azure-client-id", clientID)
+		q.Set("azure-client-id", req.ClientID)
 		installerURL.RawQuery = q.Encode()
 	}
 
@@ -95,8 +101,28 @@ func getInstallerScript(installerName, publicProxyAddr, clientID string) (string
 	// work around this, we generate a random string and append it as a comment
 	// to the script, forcing Azure to see each invocation as unique.
 	nonce := make([]byte, 8)
-	// No big deal if rand.Read fails, the script is still valid.
-	_, _ = rand.Read(nonce)
+	switch {
+	case req.randReader != nil:
+		_, _ = req.randReader(nonce)
+	default:
+		// No big deal if rand.Read fails, the script is still valid.
+		_, _ = rand.Read(nonce)
+	}
 	script := fmt.Sprintf("curl -s -L %s| bash -s $@ #%x", installerURL, nonce)
+
+	var envVars []string
+	if req.InstallSuffix != "" {
+		safeInstallSuffix := shsprintf.EscapeDefaultContext(req.InstallSuffix)
+		envVars = append(envVars, fmt.Sprintf("TELEPORT_INSTALL_SUFFIX=%q", safeInstallSuffix))
+	}
+	if req.UpdateGroup != "" {
+		safeUpdateGroup := shsprintf.EscapeDefaultContext(req.UpdateGroup)
+		envVars = append(envVars, fmt.Sprintf("TELEPORT_UPDATE_GROUP=%q", safeUpdateGroup))
+	}
+
+	if len(envVars) > 0 {
+		script = fmt.Sprintf("export %s; %s", strings.Join(envVars, " "), script)
+	}
+
 	return script, nil
 }

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -1,0 +1,95 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInstallerScript(t *testing.T) {
+	fakeNonce := "12345678"
+	fakeNonceHex := hex.EncodeToString([]byte(fakeNonce))
+	basicReq := func() AzureRunRequest {
+		return AzureRunRequest{
+			PublicProxyAddr: "proxy:443",
+			ScriptName:      "scriptName",
+			randReader: func(b []byte) (n int, err error) {
+				copy(b, fakeNonce)
+				return len(b), nil
+			},
+		}
+	}
+	for _, tt := range []struct {
+		name           string
+		req            func() AzureRunRequest
+		expectedScript string
+	}{
+		{
+			name:           "basic",
+			req:            basicReq,
+			expectedScript: "curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName| bash -s $@ #" + fakeNonceHex,
+		},
+		{
+			name: "with client id",
+			req: func() AzureRunRequest {
+				req := basicReq()
+				req.ClientID = "clientID"
+				return req
+			},
+			expectedScript: "curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName?azure-client-id=clientID| bash -s $@ #" + fakeNonceHex,
+		},
+		{
+			name: "with suffix installation",
+			req: func() AzureRunRequest {
+				req := basicReq()
+				req.InstallSuffix = "suffix"
+				return req
+			},
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX="suffix"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName| bash -s $@ #` + fakeNonceHex,
+		},
+		{
+			name: "with update group",
+			req: func() AzureRunRequest {
+				req := basicReq()
+				req.UpdateGroup = "updateGroup"
+				return req
+			},
+			expectedScript: `export TELEPORT_UPDATE_GROUP="updateGroup"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName| bash -s $@ #` + fakeNonceHex,
+		},
+		{
+			name: "with install suffix and update group",
+			req: func() AzureRunRequest {
+				req := basicReq()
+				req.InstallSuffix = "suffix"
+				req.UpdateGroup = "updateGroup"
+				return req
+			},
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX="suffix" TELEPORT_UPDATE_GROUP="updateGroup"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName| bash -s $@ #` + fakeNonceHex,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			script, err := getInstallerScript(tt.req())
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedScript, script)
+		})
+	}
+}

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -49,6 +49,14 @@ type AzureInstances struct {
 	// ScriptName is the name of the script to execute on the instances to
 	// install Teleport.
 	ScriptName string
+	// InstallSuffix indicates the installation suffix for the teleport installation.
+	// Set this value if you want multiple installations of Teleport.
+	// See --install-suffix flag in teleport-update program.
+	InstallSuffix string
+	// UpdateGroup indicates the update group for the teleport installation.
+	// This value is used to group installations in order to update them in batches.
+	// See --group flag in teleport-update program.
+	UpdateGroup string
 	// PublicProxyAddr is the address of the proxy the discovered node should use
 	// to connect to the cluster.
 	PublicProxyAddr string
@@ -141,6 +149,8 @@ type azureInstanceFetcher struct {
 	DiscoveryConfigName string
 	Integration         string
 	Logger              *slog.Logger
+	InstallSuffix       string
+	UpdateGroup         string
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
@@ -156,6 +166,8 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 	}
 
 	if cfg.Matcher.Params != nil {
+		ret.InstallSuffix = cfg.Matcher.Params.Suffix
+		ret.UpdateGroup = cfg.Matcher.Params.UpdateGroup
 		ret.Parameters = map[string]string{
 			"token":           cfg.Matcher.Params.JoinToken,
 			"scriptName":      cfg.Matcher.Params.ScriptName,
@@ -254,6 +266,8 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Inst
 			PublicProxyAddr: f.Parameters["publicProxyAddr"],
 			Parameters:      []string{f.Parameters["token"]},
 			ClientID:        f.ClientID,
+			InstallSuffix:   f.InstallSuffix,
+			UpdateGroup:     f.UpdateGroup,
 		}})
 	}
 

--- a/lib/srv/server/gcp_installer.go
+++ b/lib/srv/server/gcp_installer.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 
@@ -49,6 +50,8 @@ type GCPRunRequest struct {
 	ScriptName      string
 	PublicProxyAddr string
 	SSHKeyAlgo      cryptosuites.Algorithm
+	InstallSuffix   string
+	UpdateGroup     string
 }
 
 // Run runs a command on a set of virtual machines and then blocks until the
@@ -68,11 +71,7 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 					Zone:      inst.Zone,
 					Name:      inst.Name,
 				},
-				Script: getGCPInstallerScript(
-					req.ScriptName,
-					req.PublicProxyAddr,
-					req.Params,
-				),
+				Script:     getGCPInstallerScript(req),
 				SSHKeyAlgo: req.SSHKeyAlgo,
 			}
 			return trace.Wrap(gcp.RunCommand(ctx, &runRequest))
@@ -81,10 +80,25 @@ func (gi *GCPInstaller) Run(ctx context.Context, req GCPRunRequest) error {
 	return trace.Wrap(g.Wait())
 }
 
-func getGCPInstallerScript(installerName, publicProxyAddr string, params []string) string {
-	return fmt.Sprintf("curl -s -L https://%s/v1/webapi/scripts/installer/%s | bash -s %s",
-		publicProxyAddr,
-		installerName,
-		strings.Join(params, " "),
+func getGCPInstallerScript(req GCPRunRequest) string {
+	script := fmt.Sprintf("curl -s -L https://%s/v1/webapi/scripts/installer/%s | bash -s %s",
+		req.PublicProxyAddr,
+		req.ScriptName,
+		strings.Join(req.Params, " "),
 	)
+
+	var envVars []string
+	if req.InstallSuffix != "" {
+		safeInstallSuffix := shsprintf.EscapeDefaultContext(req.InstallSuffix)
+		envVars = append(envVars, fmt.Sprintf("TELEPORT_INSTALL_SUFFIX=%q", safeInstallSuffix))
+	}
+	if req.UpdateGroup != "" {
+		safeUpdateGroup := shsprintf.EscapeDefaultContext(req.UpdateGroup)
+		envVars = append(envVars, fmt.Sprintf("TELEPORT_UPDATE_GROUP=%q", safeUpdateGroup))
+	}
+
+	if len(envVars) > 0 {
+		script = fmt.Sprintf("export %s; %s", strings.Join(envVars, " "), script)
+	}
+	return script
 }

--- a/lib/srv/server/gcp_installer_test.go
+++ b/lib/srv/server/gcp_installer_test.go
@@ -1,0 +1,78 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGCPInstallerScript(t *testing.T) {
+	basicReq := func() GCPRunRequest {
+		return GCPRunRequest{
+			PublicProxyAddr: "proxy:443",
+			ScriptName:      "scriptName",
+		}
+	}
+	for _, tt := range []struct {
+		name           string
+		req            func() GCPRunRequest
+		expectedScript string
+	}{
+		{
+			name:           "basic",
+			req:            basicReq,
+			expectedScript: "curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName | bash -s ",
+		},
+		{
+			name: "with suffix installation",
+			req: func() GCPRunRequest {
+				req := basicReq()
+				req.InstallSuffix = "suffix"
+				return req
+			},
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX="suffix"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName | bash -s `,
+		},
+		{
+			name: "with update group",
+			req: func() GCPRunRequest {
+				req := basicReq()
+				req.UpdateGroup = "updateGroup"
+				return req
+			},
+			expectedScript: `export TELEPORT_UPDATE_GROUP="updateGroup"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName | bash -s `,
+		},
+		{
+			name: "with install suffix and update group",
+			req: func() GCPRunRequest {
+				req := basicReq()
+				req.InstallSuffix = "suffix"
+				req.UpdateGroup = "updateGroup"
+				return req
+			},
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX="suffix" TELEPORT_UPDATE_GROUP="updateGroup"; curl -s -L https://proxy:443/v1/webapi/scripts/installer/scriptName | bash -s `,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			script := getGCPInstallerScript(tt.req())
+			require.Equal(t, tt.expectedScript, script)
+		})
+	}
+}

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -46,6 +46,14 @@ type GCPInstances struct {
 	// ScriptName is the name of the script to execute on the instances to
 	// install Teleport.
 	ScriptName string
+	// InstallSuffix indicates the installation suffix for the teleport installation.
+	// Set this value if you want multiple installations of Teleport.
+	// See --install-suffix flag in teleport-update program.
+	InstallSuffix string
+	// UpdateGroup indicates the update group for the teleport installation.
+	// This value is used to group installations in order to update them in batches.
+	// See --group flag in teleport-update program.
+	UpdateGroup string
 	// PublicProxyAddr is the address of the proxy the discovered node should use
 	// to connect to the cluster.
 	PublicProxyAddr string
@@ -127,6 +135,8 @@ type gcpInstanceFetcher struct {
 	projectsClient      gcp.ProjectsClient
 	DiscoveryConfigName string
 	Integration         string
+	InstallSuffix       string
+	UpdateGroup         string
 }
 
 func newGCPInstanceFetcher(cfg gcpFetcherConfig) *gcpInstanceFetcher {
@@ -146,6 +156,8 @@ func newGCPInstanceFetcher(cfg gcpFetcherConfig) *gcpInstanceFetcher {
 			"scriptName":      cfg.Matcher.Params.ScriptName,
 			"publicProxyAddr": cfg.Matcher.Params.PublicProxyAddr,
 		}
+		fetcher.InstallSuffix = cfg.Matcher.Params.Suffix
+		fetcher.UpdateGroup = cfg.Matcher.Params.UpdateGroup
 	}
 	return fetcher
 }
@@ -205,6 +217,8 @@ func (f *gcpInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Instan
 					ScriptName:      f.Parameters["scriptName"],
 					PublicProxyAddr: f.Parameters["publicProxyAddr"],
 					Parameters:      []string{f.Parameters["token"]},
+					InstallSuffix:   f.InstallSuffix,
+					UpdateGroup:     f.UpdateGroup,
 				}})
 			}
 		}


### PR DESCRIPTION
<details><summary>Demo Azure</summary>
<img width="2050" height="1584" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/1dbfc39e-859e-490f-aa3a-96dd57a78f93" />

</details>

<details><summary>Demo GCP</summary>
<img width="1095" height="1009" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/193297d5-efd6-4119-ba2c-008a5fa3c3bb" />

</details>

See [RFD 224](https://github.com/gravitational/teleport/pull/58824) and [EC2 Implementation](https://github.com/gravitational/teleport/pull/59173)

It also includes a fix for the EC2 implementation.
Prev, it was only possible to set the Suffix and UpdateGroup using the `discovery_config` resource.
This PR also changes the file config parser logic to allow those params to be set in a `teleport.yaml/discovery_service.aws[].install` matcher.


changelog: Added support for multiple agents in Azure and GCP Server auto discovery, allowing instance access from different Teleport clusters.