### PR TITLE
Make sure we wait for all services before being ready

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1326,6 +1326,9 @@ func (i *TeleInstance) Start() error {
 	if i.Config.Kube.Enabled {
 		expectedEvents = append(expectedEvents, service.KubernetesReady)
 	}
+	if i.Config.WindowsDesktop.Enabled {
+		expectedEvents = append(expectedEvents, service.WindowsDesktopReady)
+	}
 
 	if i.Config.Discovery.Enabled {
 		expectedEvents = append(expectedEvents, service.DiscoveryReady)

--- a/integration/readiness_test.go
+++ b/integration/readiness_test.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/client/debug"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// TestReadiness is a smoke test making sure that Teleport eventually becomes ready.
+// It comes loaded with most services and fails if the instance did not turn ready
+// after 20 seconds.
+func TestReadiness(t *testing.T) {
+	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
+	log := logtest.NewLogger()
+
+	// Test setup: creating a teleport instance running auth and proxy
+	const clusterName = "root.example.com"
+	cfg := helpers.InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      uuid.New().String(),
+		NodeName:    helpers.Loopback,
+		Logger:      log.With("test_component", "test-instance"),
+	}
+	cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
+
+	// Manually create the listeners for kube and windows.
+	kubeListener := helpers.NewListener(t, service.ListenerKube, &cfg.Fds)
+	kubeAddr, err := utils.ParseAddr(kubeListener)
+	require.NoError(t, err)
+	windowsListener := helpers.NewListener(t, service.ListenerWindowsDesktop, &cfg.Fds)
+	windowsAddr, err := utils.ParseAddr(windowsListener)
+
+	require.NoError(t, err)
+	rc := helpers.NewInstance(t, cfg)
+
+	matchAll := []services.ResourceMatcher{
+		{Labels: types.Labels{"*": []string{"*"}}},
+	}
+
+	rcConf := servicecfg.MakeDefaultConfig()
+	rcConf.DataDir = filepath.Join(testDir, "data")
+	rcConf.Auth.Enabled = true
+	rcConf.Proxy.Enabled = true
+	rcConf.Proxy.DisableWebInterface = true
+	rcConf.SSH.Enabled = true
+	rcConf.Apps.Enabled = true
+	rcConf.Apps.ResourceMatchers = matchAll
+	rcConf.Databases.Enabled = true
+	rcConf.Databases.ResourceMatchers = matchAll
+	rcConf.WindowsDesktop.Enabled = true
+	rcConf.WindowsDesktop.ResourceMatchers = matchAll
+	rcConf.WindowsDesktop.ListenAddr = *windowsAddr
+	rcConf.Kube.Enabled = true
+	rcConf.Kube.ResourceMatchers = matchAll
+	rcConf.Kube.ListenAddr = kubeAddr
+	rcConf.Version = "v3"
+	rcConf.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+	// We use the debug service unix socket to check health
+	rcConf.DebugService.Enabled = true
+
+	// Test setup: starting the Teleport instance
+	require.NoError(t, rc.CreateEx(t, nil, rcConf))
+	require.NoError(t, rc.Start())
+
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		debugClt := debug.NewClient(rcConf.DataDir)
+		rdy, err := debugClt.GetReadiness(ctx)
+		require.NoError(t, err)
+		require.True(t, rdy.Ready, "Not yet ready: %q", rdy.Status)
+	}, 20*time.Second, 500*time.Millisecond)
+}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -44,6 +44,7 @@ func (process *TeleportProcess) shouldInitDatabases() bool {
 
 func (process *TeleportProcess) initDatabases() {
 	process.RegisterWithAuthServer(types.RoleDatabase, DatabasesIdentityEvent)
+	process.ExpectService(teleport.ComponentDatabase)
 	process.RegisterCriticalFunc("db.init", process.initDatabaseService)
 }
 

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -47,6 +47,7 @@ import (
 func (process *TeleportProcess) initWindowsDesktopService() {
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id))
 	process.RegisterWithAuthServer(types.RoleWindowsDesktop, WindowsDesktopIdentityEvent)
+	process.ExpectService(teleport.ComponentWindowsDesktop)
 	process.RegisterCriticalFunc("windows_desktop.init", func() error {
 		conn, err := process.WaitForConnector(WindowsDesktopIdentityEvent, logger)
 		if conn == nil {

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -40,6 +40,7 @@ func (process *TeleportProcess) shouldInitDiscovery() bool {
 
 func (process *TeleportProcess) initDiscovery() {
 	process.RegisterWithAuthServer(types.RoleDiscovery, DiscoveryIdentityEvent)
+	process.ExpectService(teleport.ComponentDiscovery)
 	process.RegisterCriticalFunc("discovery.init", process.initDiscoveryService)
 }
 

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -44,6 +44,7 @@ func (process *TeleportProcess) initKubernetes() {
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentKube, process.id))
 
 	process.RegisterWithAuthServer(types.RoleKube, KubeIdentityEvent)
+	process.ExpectService(teleport.ComponentKube)
 	process.RegisterCriticalFunc("kube.init", func() error {
 		conn, err := process.WaitForConnector(KubeIdentityEvent, logger)
 		if conn == nil {

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -58,6 +58,7 @@ import (
 
 func (process *TeleportProcess) initRelay() {
 	process.RegisterWithAuthServer(apitypes.RoleRelay, RelayIdentityEvent)
+	process.ExpectService(teleport.ComponentRelay)
 	process.RegisterCriticalFunc("relay.run", process.runRelayService)
 }
 

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -106,6 +106,8 @@ func (f *processState) update(event Event) {
 	}
 
 	switch event.Name {
+	case TeleportStartingEvent:
+		f.process.logger.DebugContext(f.process.ExitContext(), "Teleport component is starting", "component", component)
 	// If a degraded event was received, always change the state to degraded.
 	case TeleportDegradedEvent:
 		s.state = stateDegraded

--- a/lib/service/state_test.go
+++ b/lib/service/state_test.go
@@ -19,9 +19,14 @@
 package service
 
 import (
+	"context"
 	"testing"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestProcessStateGetState(t *testing.T) {
@@ -89,4 +94,65 @@ func TestProcessStateGetState(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestProcessStateStarting validates that we correctly keep track of the starting services.
+func TestProcessStateStarting(t *testing.T) {
+	t.Parallel()
+	component := teleport.Component("test-component")
+	slowComponent := teleport.Component("slow-component")
+	log := logtest.NewLogger()
+
+	supervisor := NewSupervisor("test-process-state", log)
+	process := &TeleportProcess{
+		Supervisor: supervisor,
+		Clock:      clockwork.NewFakeClock(),
+		logger:     log,
+	}
+	ps, err := newProcessState(process)
+	require.NoError(t, err)
+	process.state = ps
+
+	eventProcessor := newFakeEventProcessor(t.Context(), process)
+
+	require.Equal(t, stateStarting, ps.getState(), "no services are running, we are starting")
+	process.OnHeartbeat(component)(nil)
+	eventProcessor.processEvent()
+	require.Equal(t, stateOK, ps.getState(), "a single service is running, we are healthy")
+
+	process.ExpectService(slowComponent)
+	eventProcessor.processEvent()
+	require.Equal(t, stateStarting, ps.getState(), "we know about a second service starting, we should be in starting state")
+
+	process.OnHeartbeat(component)(nil)
+	eventProcessor.processEvent()
+	require.Equal(t, stateStarting, ps.getState(), "we know about a second service starting, we should still be in starting state")
+
+	process.OnHeartbeat(slowComponent)(nil)
+	eventProcessor.processEvent()
+	require.Equal(t, stateOK, ps.getState(), "two services are running, we are healthy")
+}
+
+// fakeEventProcessor synchronously processes events in tests. The real TeleportProcess
+// has a dedicated routine for that, but testing with asynchronous event processing
+// would be troublesome and flaky.
+type fakeEventProcessor struct {
+	eventCh chan Event
+	ps      *processState
+}
+
+func newFakeEventProcessor(ctx context.Context, process *TeleportProcess) *fakeEventProcessor {
+	eventCh := make(chan Event, 1024)
+	process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
+	process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
+	process.ListenForEvents(ctx, TeleportStartingEvent, eventCh)
+	return &fakeEventProcessor{
+		eventCh: eventCh,
+		ps:      process.state,
+	}
+}
+
+func (f *fakeEventProcessor) processEvent() {
+	evt := <-f.eventCh
+	f.ps.update(evt)
 }


### PR DESCRIPTION
I was looking into tying the auth readiness with its cache health (so we don't end up in a state with no ready cache across all auths during a rollout) and I saw that we are currently reporting ready as soon as one of the sevrice heartbeats. We don't keep track of which services should be heartbeating/reporting ready.

This PR introduces a new `process.ExpectService(component)` function to declare early that we are starting a service and that the process should not be ready without it.

### Regarding backport:

This is not our first attempt at making Teleport wait for its services before turning ready. The last attempts cause regressions and often bricked Teleport. To reduce the risk of backporting a breaking change, this PR will only be partially backported. The `process.ExpectService` logic and tests will be backported but the actual `ExpectService` calls won't. This is required for my next PR which will make the auth wait until cache is ready (I might make this a feature flag though).


Changelog: Fixed a bug causing Teleport to temporarily report ready while some of its services were still starting.

