### PR TITLE
[v18] Fixes Datadog Incident Management integration by updating on-call API client

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -593,7 +593,12 @@ func (a *App) tryApproveRequest(ctx context.Context, reqID string, req types.Acc
 		return trace.Wrap(err)
 	}
 
-	if !slices.Contains(oncallUsers, req.GetUser()) {
+	// Ignore casing when matching users.
+	for index, oncallUser := range oncallUsers {
+		oncallUsers[index] = strings.ToLower(oncallUser)
+	}
+
+	if !slices.Contains(oncallUsers, strings.ToLower(req.GetUser())) {
 		log.DebugContext(ctx, "Skipping approval because user is not on-call")
 		return nil
 	}

--- a/integrations/access/datadog/client.go
+++ b/integrations/access/datadog/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,6 +48,20 @@ const (
 	// See documentation for more details:
 	// https://docs.datadoghq.com/account_management/rbac/permissions/#case-and-incident-management
 	IncidentWritePermissions = "incident_write"
+
+	// TeamsManagePermissions is a Datadog permission that allows the role to
+	// create, view, and maage teams in Datadog.
+	//
+	// See documentation for more details:
+	// https://docs.datadoghq.com/account_management/rbac/permissions/#teams
+	TeamsManagePermissions = "teams_manage"
+
+	// OnCallReadPermissions is a Datadog permission that allows the role to
+	// view on-call teams, schedules, escalation policies and overrides.
+	//
+	// See documentation for more details:
+	// https://docs.datadoghq.com/account_management/rbac/permissions/#on-call
+	OnCallReadPermissions = "on_call_read"
 )
 
 // Datadog is a wrapper around resty.Client.
@@ -58,10 +73,6 @@ type Datadog struct {
 	// simpler to integrate with the existing framework. Consider using the official
 	// datadog api client package: https://github.com/DataDog/datadog-api-client-go.
 	client *resty.Client
-
-	// TODO: Remove clientUnstable once on-call API is merged into official API.
-	// See: https://docs.datadoghq.com/api/latest/
-	clientUnstable *resty.Client
 }
 
 // NewDatadogClient creates a new Datadog client for managing incidents.
@@ -88,30 +99,9 @@ func NewDatadogClient(conf DatadogConfig, webProxyAddr string, statusSink common
 		}).
 		OnAfterResponse(onAfterDatadogResponse(statusSink))
 
-	apiEndpointUnstable, err := url.JoinPath(conf.APIEndpoint, APIUnstable)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	clientUnstable := resty.NewWithClient(&http.Client{
-		Timeout: datadogHTTPTimeout,
-		Transport: &http.Transport{
-			MaxConnsPerHost:     datadogMaxConns,
-			MaxIdleConnsPerHost: datadogMaxConns,
-		}}).
-		SetBaseURL(apiEndpointUnstable).
-		SetHeader("Accept", "application/json").
-		SetHeader("Content-Type", "application/json").
-		SetHeader("DD-API-KEY", conf.APIKey).
-		SetHeader("DD-APPLICATION-KEY", conf.ApplicationKey).
-		OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
-			req.SetError(&ErrorResult{})
-			return nil
-		}).OnAfterResponse(onAfterDatadogResponse(statusSink))
-
 	return &Datadog{
-		DatadogConfig:  conf,
-		client:         client,
-		clientUnstable: clientUnstable,
+		DatadogConfig: conf,
+		client:        client,
 	}, nil
 }
 
@@ -143,6 +133,8 @@ func onAfterDatadogResponse(sink common.StatusSink) resty.ResponseMiddleware {
 }
 
 // CheckHealth pings Datadog and ensures required permissions.
+//
+// See: https://docs.datadoghq.com/api/latest/roles/#list-permissions
 func (d *Datadog) CheckHealth(ctx context.Context) error {
 	var result PermissionsBody
 	_, err := d.client.NewRequest().
@@ -153,19 +145,19 @@ func (d *Datadog) CheckHealth(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	for _, permission := range result.Data {
-		// TODO: Verify on-call/teams permissions once required permissions have
-		// been published.
-		if permission.Attributes.Name == IncidentWritePermissions {
+		switch name := permission.Attributes.Name; name {
+		case IncidentWritePermissions, TeamsManagePermissions, OnCallReadPermissions:
 			if permission.Attributes.Restricted {
-				return trace.AccessDenied("missing incident_write permissions")
+				return trace.AccessDenied("missing %s permissions", name)
 			}
-			return nil
 		}
 	}
 	return nil
 }
 
 // Create Incident creates a new Datadog incident.
+//
+// See: https://docs.datadoghq.com/api/latest/incidents/#create-an-incident
 func (d *Datadog) CreateIncident(ctx context.Context, summary string, recipients []common.Recipient, reqData pd.AccessRequestData) (IncidentsData, error) {
 	teams := make([]string, 0, len(recipients))
 	emails := make([]NotificationHandle, 0, len(recipients))
@@ -252,6 +244,8 @@ func (d *Datadog) PostReviewNote(ctx context.Context, incidentID, note string) e
 }
 
 // ResolveIncident resolves an incident and posts a note with resolution details.
+//
+// See: https://docs.datadoghq.com/api/latest/incidents/#update-an-existing-incident
 func (d *Datadog) ResolveIncident(ctx context.Context, incidentID, state string) error {
 	body := IncidentsBody{
 		Data: IncidentsData{
@@ -277,12 +271,29 @@ func (d *Datadog) ResolveIncident(ctx context.Context, incidentID, state string)
 	return trace.Wrap(err)
 }
 
-// GetOncallTeams gets current on call teams.
-func (d *Datadog) GetOncallTeams(ctx context.Context) (OncallTeamsBody, error) {
-	var result OncallTeamsBody
-	_, err := d.clientUnstable.NewRequest().
+// ListTeamsPage returns a page of teams.
+//
+// See: https://docs.datadoghq.com/api/latest/teams/#get-all-teams
+func (d *Datadog) ListTeamsPage(ctx context.Context, pageNum int) (ListTeamsBody, error) {
+	var result ListTeamsBody
+	_, err := d.client.NewRequest().
 		SetContext(ctx).
 		SetResult(&result).
-		Get("on-call/teams")
+		SetQueryParam("page[number]", strconv.Itoa(pageNum)).
+		Get("team")
+	return result, trace.Wrap(err)
+}
+
+// GetTeamOncall gets the team's current on-call users.
+//
+// See: https://docs.datadoghq.com/api/latest/on-call/?s=teams#get-team-on-call-users
+func (d *Datadog) GetTeamOncall(ctx context.Context, teamID string) (OncallTeamsBody, error) {
+	var result OncallTeamsBody
+	_, err := d.client.NewRequest().
+		SetContext(ctx).
+		SetResult(&result).
+		SetPathParam("team_id", teamID).
+		SetQueryParam("include", "responders").
+		Get("on-call/teams/{team_id}/on-call")
 	return result, trace.Wrap(err)
 }

--- a/integrations/access/datadog/types.go
+++ b/integrations/access/datadog/types.go
@@ -37,7 +37,7 @@ type PermissionsBody struct {
 // PermissionsData contains the permissions data.
 type PermissionsData struct {
 	Metadata
-	Attributes PermissionsAttributes `json:"attributes,omitempty"`
+	Attributes PermissionsAttributes `json:"attributes"`
 }
 
 // PermissionsAttributes contains the permissions attributes.
@@ -50,19 +50,19 @@ type PermissionsAttributes struct {
 //
 // See: https://docs.datadoghq.com/api/latest/incidents
 type IncidentsBody struct {
-	Data IncidentsData `json:"data,omitempty"`
+	Data IncidentsData `json:"data"`
 }
 
 // IncidentData contains the incident data.
 type IncidentsData struct {
 	Metadata
-	Attributes IncidentsAttributes `json:"attributes,omitempty"`
+	Attributes IncidentsAttributes `json:"attributes"`
 }
 
 // IncidentsAttributes contains the incident attributes.
 type IncidentsAttributes struct {
 	Title               string               `json:"title,omitempty"`
-	Fields              IncidentsFields      `json:"fields,omitempty"`
+	Fields              IncidentsFields      `json:"fields"`
 	NotificationHandles []NotificationHandle `json:"notification_handles,omitempty"`
 }
 
@@ -97,37 +97,65 @@ type NotificationHandle struct {
 
 // TimelineBody contains the request/response body for an incident timeline request.
 type TimelineBody struct {
-	Data TimelineData `json:"data,omitempty"`
+	Data TimelineData `json:"data"`
 }
 
 // TimelineData contains the incident timeline data.
 type TimelineData struct {
 	Metadata
-	Attributes TimelineAttributes `json:"attributes,omitempty"`
+	Attributes TimelineAttributes `json:"attributes"`
 }
 
 // TimelineAttributes contains the incident timeline attributes.
 type TimelineAttributes struct {
 	CellType string          `json:"cell_type,omitempty"`
-	Content  TimelineContent `json:"content,omitempty"`
+	Content  TimelineContent `json:"content"`
 }
 
-// TimelineContent contains the incident tineline content.
+// TimelineContent contains the incident timeline content.
 type TimelineContent struct {
 	Content string `json:"content,omitempty"`
 }
 
+// ListTeamsBody contains the list of teams data.
+type ListTeamsBody struct {
+	Data []TeamsData  `json:"data,omitempty"`
+	Meta ListMetadata `json:"meta"`
+}
+
+// ListMetadata contains metadata for a list request.
+type ListMetadata struct {
+	Pagination PaginationMetadata `json:"pagination"`
+}
+
+// PaginationMetadata contains pagination metadata.
+type PaginationMetadata struct {
+	Size  int `json:"size"`
+	Total int `json:"total"`
+}
+
+// TeamData contains a team metadata and attributes.
+type TeamsData struct {
+	Metadata
+	Attributes TeamsAttributes `json:"attributes"`
+}
+
+// TeamsAttributes contains a team's attributes.
+type TeamsAttributes struct {
+	Name   string `json:"name,omitempty"`
+	Handle string `json:"handle,omitempty"`
+}
+
 // OncallTeamsBody contains the response body for an on-call teams request.
 type OncallTeamsBody struct {
-	Data     []OncallTeamsData     `json:"data,omitempty"`
+	Data     OncallTeamsData       `json:"data,omitempty"`
 	Included []OncallTeamsIncluded `json:"included,omitempty"`
 }
 
 // OncallTeamsData contains the on-call teams data.
 type OncallTeamsData struct {
 	Metadata
-	Attributes    OncallTeamsAttributes    `json:"attributes,omitempty"`
-	Relationships OncallTeamsRelationships `json:"relationships,omitempty"`
+	Relationships OncallTeamsRelationships `json:"relationships"`
 }
 
 // OncallTeamsAttributes contains the on-call teams attributes.
@@ -138,11 +166,11 @@ type OncallTeamsAttributes struct {
 
 // OncallTeamsRelationships contains the on-call teams relationships.
 type OncallTeamsRelationships struct {
-	OncallUsers OncallUsers `json:"oncall_users,omitempty"`
+	Responders Responders `json:"responders"`
 }
 
-// OncallUsers contains the list of on-call users.
-type OncallUsers struct {
+// Responders contains the list of on-call users.
+type Responders struct {
 	Data []OncallUsersData `json:"data,omitempty"`
 }
 
@@ -154,7 +182,7 @@ type OncallUsersData struct {
 // OncallTeamsIncluded contains the on-call teams included related resources.
 type OncallTeamsIncluded struct {
 	Metadata
-	Attributes OncallTeamsIncludedAttributes `json:"attributes,omitempty"`
+	Attributes OncallTeamsIncludedAttributes `json:"attributes"`
 }
 
 // OncallTeamsIncludedAttributes contains the on-call teams included related resource


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/59616 to branch/v18

Changelog: Fixed auto-approvals in the Datadog Incident Management integration by updating the on-call API client
Changelog: Fixed auto-approvals in the Datadog Incident Management integration to ignore case sensitivity in user emails