### PR TITLE
Provide agentless error message for openssh/eice connection failures

### DIFF
--- a/lib/reversetunnel/local_cluster.go
+++ b/lib/reversetunnel/local_cluster.go
@@ -595,7 +595,7 @@ func getAgentlessErrorMessage(params reversetunnelclient.DialParams, connStr str
   %v
 
 This usually means that the resource is offline or network permissions block the connection.
-Check the resource health status and network permissions`
+Check the resource health status and network permissions.`
 
 	var toAddr string
 	if params.To != nil {


### PR DESCRIPTION

Update error message to provide agentless connection problem reasons when a OpenSSH or EICE server.