### PR TITLE
docs: include tbot.exe in windows uninstall instrs

### DIFF
--- a/docs/pages/zero-trust-access/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/zero-trust-access/management/admin/uninstall-teleport.mdx
@@ -220,11 +220,12 @@ Follow the instructions for your Linux distribution:
 
 ### Windows
 
-  Remove the `tsh.exe` and `tctl.exe` binaries from the machine:
+  Remove the `tsh.exe`, `tctl.exe`, and `tbot.exe` binaries from the machine:
 
   ```code
   $ del C:\Path\To\tsh.exe
   $ del C:\Path\To\tctl.exe
+  $ del C:\Path\To\tbot.exe
   ```
 (!docs/pages/includes/uninstall-teleport-connect-windows.mdx!)
 


### PR DESCRIPTION
`tbot.exe` is included in Teleport windows client for v17+, adding to uninstall instrs.