### PR TITLE
docs: fix broken TOML syntax

### DIFF
--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -23,13 +23,13 @@ types = ""
 # skip-event-types is a comma-separated list of audit log event types to skip.
 # For example, to forward all audit events except for new app deletion events,
 # you can include the following assignment:
-# skip-event-types = "app.delete"
-skip-event-types: []
+# skip-event-types = ["app.delete"]
+skip-event-types = []
 # skip-session-types is a comma-separated list of session recording event types to skip.
 # For example, to forward all session events except for malformed SQL packet
 # events, you can include the following assignment:
-# skip-session-types = "db.session.malformed_packet"
-skip-session-types: []
+# skip-session-types = ["db.session.malformed_packet"]
+skip-session-types = []
 
 [forward.fluentd]
 ca = "/home/bob/event-handler/ca.crt"


### PR DESCRIPTION
I noticed two problems with the TOML syntax in the event handler docs:
1. It uses a `:` instead of `=`.
2. We suggest using a string for fields that must be lists of strings.

I will add this change to the existing backports for #59651.