### PR TITLE
Docs: add section about suffix installations in server discovery

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -267,6 +267,13 @@ discovery_service:
       tags:
         "env": "prod" # Match virtual machines where tag:env=prod
       install:
+        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
         azure:
           # Optional: If the VMs to discover have more than one managed
           # identity assigned to them, set the client ID here to the client
@@ -279,6 +286,11 @@ discovery_service:
 - Adjust the keys under `discovery_service.azure` to match your Azure environment,
   specifically the regions and tags you want to associate with the Discovery
   Service.
+- Set the `install.suffix` key to install teleport in a non-global location, allowing
+  for multiple, simultaneously installations from different clusters.
+  Requires [agent managed updates](../../../upgrading/agent-managed-updates.mdx).
+- When using [agent managed updates](../../../upgrading/agent-managed-updates.mdx), you can
+  configure the update group by setting the `install.update_group` key.
 
 ## Step 6/6. [Optional] Customize the default installer script
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -275,6 +275,13 @@ discovery_service:
       labels:
         "env": "prod" # Match virtual machines where label:env=prod
       install:
+        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
         public_proxy_addr: "<Var name="teleport.example.com" />:443"
 ```
 
@@ -283,6 +290,11 @@ discovery_service:
 - Adjust the keys under `discovery_service.gcp` to match your GCP environment,
   specifically the projects, locations, service accounts, and tags you want to associate with the Discovery
   Service.
+- Set the `install.suffix` key to install teleport in a non-global location, allowing
+  for multiple, simultaneously installations from different clusters.
+  Requires [agent managed updates](../../../upgrading/agent-managed-updates.mdx).
+- When using [agent managed updates](../../../upgrading/agent-managed-updates.mdx), you can
+  configure the update group by setting the `install.update_group` key.
 
 ### GCP credentials
 

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -38,6 +38,13 @@ discovery_service:
    - types: ["ec2"]
      regions: ["us-east-1","us-west-1"]
      install:
+        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
         join_params:
           token_name: aws-discovery-iam-token
           method: iam
@@ -50,3 +57,8 @@ discovery_service:
 - Adjust the keys under `discovery_service.aws` to match your EC2 environment,
   specifically the regions and tags you want to associate with the Discovery
   Service.
+- Set the `install.suffix` key to install teleport in a non-global location, allowing
+  for multiple, simultaneously installations from different clusters.
+  Requires [agent managed updates](../../upgrading/agent-managed-updates.mdx).
+- When using [agent managed updates](../../upgrading/agent-managed-updates.mdx), you can
+  configure the update group by setting the `install.update_group` key.


### PR DESCRIPTION
See [RFD 224](https://github.com/gravitational/teleport/pull/58824) and [EC2 Implementation](https://github.com/gravitational/teleport/pull/59173) and [Azure/GCP implementation](https://github.com/gravitational/teleport/pull/59656)