### PR TITLE
[docs] Provide a concrete example of etcd sizing

### DIFF
--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -208,6 +208,23 @@ Use `etcd_mvcc_db_total_size_in_bytes` and `etcd_mvcc_db_total_size_in_use_in_by
 
 Refer to [etcd's maintenance guide](https://etcd.io/docs/v3.6/op-guide/maintenance/) for auto-compaction and defragmentation.
 
+#### Example disk sizing
+
+For a cluster with 50k resources, with average size of 2 KiB and retention history of 5 revisions we would expect
+the dataset to be at least:
+
+```
+50000 * 2 KiB * 5 ≈ 488 MiB
+```
+
+An additional 20-40% safety margin is recommended for metadata and fragmentation overhead.
+
+Given an existing resource you can estimate its size with the following command:
+
+```code
+tctl get <Var name="resource" /> --format=json | awk '{ total += length($0) } END { print total * 2 }'
+```
+
 ## PostgreSQL
 
 PostgreSQL cluster state and audit log storage is available starting from


### PR DESCRIPTION
Add further explanation on etcd defrag schedules. Note we cannot provide the exact schedule without cluster metrics and deployment information. The user is directed to use the etcd metrics to guide them instead.