### PR TITLE
[docs] Add app name conflicts to trusted cluster troubleshooting

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -158,6 +158,7 @@ header or move this page.
 */}
 
 An application name should make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 -` allowed).
+It should also be unique across root and leaf clusters if you are deploying in a trusted clusters environment.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
@@ -941,3 +941,10 @@ To troubleshoot, you should start by checking the following information for the 
   `/var/lib/teleport/log` on the server where the Teleport Auth Service for the cluster runs.
 
   If you use Teleport as a managed cloud-based service, the audit log is viewable under **Audit** in the left-hand pane via the Web UI for users with permission to the `event` resources.
+
+
+### Application access within trusted clusters
+
+It is recommended to have unique application names across your entire cluster, root and leafs included. Applications served by leaf clusters are accessed via `app_name.root_proxy_public_addr`
+in the root cluster. When accessing the app via FQDN only, it can lead to ambiguous resolution. If your apps must contain the same name across multiple
+clusters, the most deterministic way to access the correct app is via the web UI's resources page.


### PR DESCRIPTION
This adds a note that we can reference about app name conflicts in root/leaf clusters. Currently, the only deterministic way to access an app with an ambiguous name is through the web UI. otherwise, depending on RBAC and other factors, accessing through FQDN is unreliable.