### PR TITLE
[flaky] TestReplaceHTTPResponse to use synctest

### DIFF
--- a/lib/utils/mcputils/http_test.go
+++ b/lib/utils/mcputils/http_test.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/gravitational/trace"
 	mcpclient "github.com/mark3labs/mcp-go/client"
@@ -35,54 +35,66 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	listenerutils "github.com/gravitational/teleport/lib/utils/listener"
 	"github.com/gravitational/teleport/lib/utils/mcptest"
 )
 
 func TestReplaceHTTPResponse(t *testing.T) {
 	t.Parallel()
-	ctx := t.Context()
 
-	// Set up a server.
-	mcpServer := mcptest.NewServer()
-	httpServer := mcpserver.NewTestStreamableHTTPServer(mcpServer)
-	t.Cleanup(httpServer.Close)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	// Set up a client with custom transport which calls "ReplaceHTTPResponse".
-	httpClientTransport := newTestReplaceHTTPResponseTransport()
-	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(
-		httpServer.URL+"/mcp",
-		mcpclienttransport.WithHTTPBasicClient(
-			&http.Client{Transport: httpClientTransport},
-		),
-		mcpclienttransport.WithContinuousListening(),
-	)
-	require.NoError(t, err)
-	client := mcpclient.NewClient(mcpClientTransport)
-	require.NoError(t, client.Start(ctx))
+		// Set up a server. Use InMemoryListener for synctest.
+		mcpServer := mcptest.NewServer()
+		listener := listenerutils.NewInMemoryListener()
+		httpServer := http.Server{
+			Handler: mcpserver.NewStreamableHTTPServer(mcpServer),
+		}
+		go httpServer.Serve(listener)
+		t.Cleanup(func() {
+			httpServer.Close()
+		})
 
-	// Initialize client and call a tool.
-	_, err = mcptest.InitializeClient(ctx, client)
-	require.NoError(t, err)
-	mcptest.MustCallServerTool(t, ctx, client)
-	assert.Equal(t, uint32(2), httpClientTransport.countMCPResponse.Load())
+		// Set up a client with custom transport which calls "ReplaceHTTPResponse".
+		httpClientTransport := newTestReplaceHTTPResponseTransport(listener)
+		mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(
+			"http://memory/mcp",
+			mcpclienttransport.WithHTTPBasicClient(
+				&http.Client{Transport: httpClientTransport},
+			),
+			mcpclienttransport.WithContinuousListening(),
+		)
+		require.NoError(t, err)
+		var countMCPNotification atomic.Uint32
+		client := mcpclient.NewClient(mcpClientTransport)
+		client.OnNotification(func(notification mcp.JSONRPCNotification) {
+			countMCPNotification.Add(1)
+		})
+		require.NoError(t, client.Start(ctx))
 
-	// Send notifications from server. Notifications will be sent through SSE.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Greater(collect, httpClientTransport.getCountMethods()["GET"], 0)
-	}, 2*time.Second, 100*time.Millisecond, "client SSE connected")
-	mcpServer.SendNotificationToAllClients("notifications/test", nil)
-	mcpServer.SendNotificationToAllClients("notifications/test", nil)
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Equal(collect, uint32(2), httpClientTransport.countMCPNotification.Load())
-	}, 2*time.Second, 100*time.Millisecond, "expected to receive notification")
+		// Initialize client and call a tool.
+		_, err = mcptest.InitializeClient(ctx, client)
+		require.NoError(t, err)
+		mcptest.MustCallServerTool(t, ctx, client)
+		assert.Equal(t, uint32(2), httpClientTransport.countMCPResponse.Load())
 
-	// Close client and count the requests.
-	require.NoError(t, client.Close())
-	require.Equal(t, map[string]int{
-		"GET":    1, // For listening on SSE events.
-		"POST":   3, // "initialize", "notifications/initialize", and "tools/call".
-		"DELETE": 1, // Close session.
-	}, httpClientTransport.getCountMethods())
+		// Send notifications from server. Notifications will be sent through SSE.
+		synctest.Wait() // Wait for client to establish the GET connection.
+		mcpServer.SendNotificationToAllClients("notifications/test", nil)
+		mcpServer.SendNotificationToAllClients("notifications/test", nil)
+		synctest.Wait() // Wait for client to receive notifications.
+		require.Equal(t, uint32(2), countMCPNotification.Load())
+
+		// Close client and count the requests.
+		require.NoError(t, client.Close())
+		synctest.Wait()
+		require.Equal(t, map[string]int{
+			"GET":    1, // For listening on SSE events.
+			"POST":   3, // "initialize", "notifications/initialize", and "tools/call".
+			"DELETE": 1, // Close session.
+		}, httpClientTransport.getCountMethods())
+	})
 }
 
 type testReplaceHTTPResponseTransport struct {
@@ -90,11 +102,17 @@ type testReplaceHTTPResponseTransport struct {
 	countMethodsMu       sync.Mutex
 	countMCPResponse     atomic.Uint32
 	countMCPNotification atomic.Uint32
+	client               http.Client
 }
 
-func newTestReplaceHTTPResponseTransport() *testReplaceHTTPResponseTransport {
+func newTestReplaceHTTPResponseTransport(inMemoryListener *listenerutils.InMemoryListener) *testReplaceHTTPResponseTransport {
 	return &testReplaceHTTPResponseTransport{
 		countMethods: make(map[string]int),
+		client: http.Client{
+			Transport: &http.Transport{
+				DialContext: inMemoryListener.DialContext,
+			},
+		},
 	}
 }
 
@@ -109,7 +127,7 @@ func (t *testReplaceHTTPResponseTransport) RoundTrip(r *http.Request) (*http.Res
 	t.countMethods[r.Method]++
 	t.countMethodsMu.Unlock()
 
-	resp, err := http.DefaultClient.Do(r)
+	resp, err := t.client.Do(r)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/utils/mcputils/http_test.go
+++ b/lib/utils/mcputils/http_test.go
@@ -32,7 +32,6 @@ import (
 	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	listenerutils "github.com/gravitational/teleport/lib/utils/listener"
@@ -77,7 +76,7 @@ func TestReplaceHTTPResponse(t *testing.T) {
 		_, err = mcptest.InitializeClient(ctx, client)
 		require.NoError(t, err)
 		mcptest.MustCallServerTool(t, ctx, client)
-		assert.Equal(t, uint32(2), httpClientTransport.countMCPResponse.Load())
+		require.Equal(t, uint32(2), httpClientTransport.countMCPResponse.Load())
 
 		// Send notifications from server. Notifications will be sent through SSE.
 		synctest.Wait() // Wait for client to establish the GET connection.
@@ -98,11 +97,10 @@ func TestReplaceHTTPResponse(t *testing.T) {
 }
 
 type testReplaceHTTPResponseTransport struct {
-	countMethods         map[string]int
-	countMethodsMu       sync.Mutex
-	countMCPResponse     atomic.Uint32
-	countMCPNotification atomic.Uint32
-	client               http.Client
+	countMethods     map[string]int
+	countMethodsMu   sync.Mutex
+	countMCPResponse atomic.Uint32
+	client           http.Client
 }
 
 func newTestReplaceHTTPResponseTransport(inMemoryListener *listenerutils.InMemoryListener) *testReplaceHTTPResponseTransport {
@@ -144,6 +142,5 @@ func (t *testReplaceHTTPResponseTransport) ProcessResponse(_ context.Context, re
 }
 
 func (t *testReplaceHTTPResponseTransport) ProcessNotification(_ context.Context, notification *JSONRPCNotification) mcp.JSONRPCMessage {
-	t.countMCPNotification.Add(1)
 	return notification
 }


### PR DESCRIPTION
flaky test failure: https://github.com/gravitational/teleport.e/actions/runs/18058335982/job/51391197702

```
=== CONT  TestReplaceHTTPResponse
2025/09/27 10:53:47 INFO: listening to server forever
    http_test.go:75: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/utils/mcputils/http_test.go:76
        	            				/opt/go/src/runtime/asm_amd64.s:1693
        	Error:      	Not equal: 
        	            	expected: 0x2
        	            	actual  : 0x0
    http_test.go:75: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/utils/mcputils/http_test.go:75
        	Error:      	Condition never satisfied
        	Test:       	TestReplaceHTTPResponse
        	Messages:   	expected to receive notification
--- FAIL: TestReplaceHTTPResponse (2.01s)
===================================================
```

Timing client's go routine is difficult so changed to `synctest`.