### PR TITLE
install-node.sh: Fix error with more robust Teleport process checking

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -429,7 +429,7 @@ get_teleport_pid() {
         fi
     done
     # return filtered list of pids with whitespace trimmed from the end
-    echo ${TELEPORT_PIDS%%[[:space::]*}
+    echo ${TELEPORT_PIDS%%[[:space:]]*}
 }
 # returns a command which will start teleport using the config
 get_teleport_start_command() {

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -418,17 +418,24 @@ download() {
 get_download_filename() { echo "${1##*/}"; }
 # gets the pid of any running teleport process (and converts newlines to spaces)
 get_teleport_pid() {
-    check_exists_fatal pgrep xargs basename readlink
-    TELEPORT_PIDS=""
-    POTENTIAL_PIDS=$(pgrep -f "teleport start" | xargs echo)
-    # filter PIDS to look for teleport as base process
-    for PID in ${POTENTIAL_PIDS}; do
-        if [ -f /proc/${PID}/exe ]; then
-            EXE=$(basename $(readlink /proc/${PID}/exe))
-            if [[ "${EXE}" == "teleport" ]]; then TELEPORT_PIDS="${PID} ${TELEPORT_PIDS}"; fi
-        fi
-    done
-    # return filtered list of pids with whitespace trimmed from the end
+    check_exists_fatal pgrep xargs
+    TELEPORT_PIDS=$(pgrep teleport | xargs echo)
+    # if we have procfs available (i.e. on Linux), we do a more detailed check for the binary name
+    # this method also combats issues with install scripts running in cloud-init with "teleport" in
+    # their name (see https://github.com/gravitational/teleport/pull/59452)
+    # for MacOS and Linux without procfs, we just use the original "pgrep teleport" behaviour
+    if [[ -d /proc ]]; then
+        check_exists_fatal basename readlink
+        TELEPORT_PIDS=""
+        POTENTIAL_PIDS=$(pgrep -f "teleport start" | xargs echo)
+        for PID in ${POTENTIAL_PIDS}; do
+            if [ -f /proc/${PID}/exe ]; then
+                EXE=$(basename $(readlink /proc/${PID}/exe))
+                if [[ "${EXE}" == "teleport" ]]; then TELEPORT_PIDS="${PID} ${TELEPORT_PIDS}"; fi
+            fi
+        done
+    fi
+    # return list of pids with whitespace trimmed from the end
     echo ${TELEPORT_PIDS%%[[:space:]]*}
 }
 # returns a command which will start teleport using the config

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -423,7 +423,7 @@ get_teleport_pid() {
     # if we have procfs available (i.e. on Linux), we do a more detailed check for the binary name
     # this method also combats issues with install scripts running in cloud-init with "teleport" in
     # their name (see https://github.com/gravitational/teleport/pull/59452)
-    # for MacOS and Linux without procfs, we just use the original "pgrep teleport" behaviour
+    # for MacOS (and Linux without procfs, if that ever happens), we just use the original behaviour
     if [[ -d /proc ]]; then
         check_exists_fatal basename readlink
         TELEPORT_PIDS=""


### PR DESCRIPTION
#59452 made Teleport process checking more robust, but introduced a bug when running the script in a `sudo bash -c $(curl...)` flow where `pgrep teleport` appears in the script name because the entire script is executed in-line.

This change grabs all the PIDs in the new `pgrep -f` way, then adds a check whether the base process for each PID is named `teleport` or not. This removes false positives.

Tested in Docker and on an Ubuntu 22.04 VM using the copy/pasted command from the web UI.

Closes https://github.com/gravitational/teleport/issues/59689

changelog: Fixes a bug with the check for a running Teleport process in the install-node.sh script.