### PR TITLE
[v17] TestIntegrations/PortForwarding: Increase timeout for `waitForSessionToBeEstablished`

### DIFF
--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -281,9 +281,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			cl.Stdin = term
 			cl.Labels = tt.labels
 
-			sshSessionCtx, sshSessionCancel := context.WithCancel(t.Context())
-			go cl.SSH(sshSessionCtx, []string{})
-			defer sshSessionCancel()
+			go cl.SSH(t.Context(), []string{})
 
 			timeout, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 			defer cancel()

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -281,11 +281,11 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			cl.Stdin = term
 			cl.Labels = tt.labels
 
-			sshSessionCtx, sshSessionCancel := context.WithCancel(context.Background())
+			sshSessionCtx, sshSessionCancel := context.WithCancel(t.Context())
 			go cl.SSH(sshSessionCtx, []string{})
 			defer sshSessionCancel()
 
-			timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			timeout, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 			defer cancel()
 			_, err = waitForSessionToBeEstablished(timeout, apidefaults.Namespace, site)
 			require.NoError(t, err)


### PR DESCRIPTION
Backport #59424 to branch/v17