### PR TITLE
[cache] implement generic cache range helper

### DIFF
--- a/lib/cache/app.go
+++ b/lib/cache/app.go
@@ -70,54 +70,25 @@ func newAppCollection(upstream services.Applications, w types.WatchKind) (*colle
 
 // Apps returns application resources within the range [start, end).
 func (c *Cache) Apps(ctx context.Context, start, end string) iter.Seq2[types.Application, error] {
+	ranger := genericRanger[types.Application, appIndex]{
+		cache:         c,
+		collection:    c.collections.apps,
+		index:         appNameIndex,
+		upstreamRange: c.Config.Apps.Apps,
+		// TODO(tross): DELETE IN v21.0.0
+		fallbackGetter: c.Config.Apps.GetApps,
+	}
+
 	return func(yield func(types.Application, error) bool) {
 		ctx, span := c.Tracer.Start(ctx, "cache/Apps")
 		defer span.End()
 
-		rg, err := acquireReadGuard(c, c.collections.apps)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		defer rg.Release()
-
-		if rg.ReadCache() {
-			for a := range rg.store.resources(appNameIndex, start, end) {
-				if !yield(a.Copy(), nil) {
-					return
-				}
-			}
-			return
-		}
-
-		// Release the read guard early since all future reads will be
-		// performed against the upstream.
-		rg.Release()
-
-		for app, err := range c.Config.Apps.Apps(ctx, start, end) {
-			if err != nil {
-				// TODO(tross): DELETE IN v21.0.0
-				if trace.IsNotImplemented(err) {
-					apps, err := c.Config.Apps.GetApps(ctx)
-					if err != nil {
-						yield(nil, err)
-						return
-					}
-
-					for _, app := range apps {
-						if !yield(app, nil) {
-							return
-						}
-					}
-
-					return
-				}
-
-				yield(nil, err)
+		for app, err := range ranger.Range(ctx, start, end) {
+			if !yield(app, err) {
 				return
 			}
 
-			if !yield(app, nil) {
+			if err != nil {
 				return
 			}
 		}

--- a/lib/cache/database.go
+++ b/lib/cache/database.go
@@ -141,57 +141,29 @@ func (c *Cache) ListDatabases(ctx context.Context, limit int, startKey string) (
 
 // RangeDatabases returns database resources within the range [start, end).
 func (c *Cache) RangeDatabases(ctx context.Context, start, end string) iter.Seq2[types.Database, error] {
+	ranger := genericRanger[types.Database, databaseIndex]{
+		cache:         c,
+		collection:    c.collections.dbs,
+		index:         databaseNameIndex,
+		upstreamRange: c.Config.Databases.RangeDatabases,
+		// TODO(lokraszewski): DELETE IN v21.0.0
+		fallbackGetter: c.Config.Databases.GetDatabases,
+	}
+
 	return func(yield func(types.Database, error) bool) {
 		ctx, span := c.Tracer.Start(ctx, "cache/RangeDatabases")
 		defer span.End()
 
-		rg, err := acquireReadGuard(c, c.collections.dbs)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		defer rg.Release()
-
-		if rg.ReadCache() {
-			for database := range rg.store.resources(databaseNameIndex, start, end) {
-				if !yield(database.Copy(), nil) {
-					return
-				}
-			}
-			return
-		}
-
-		rg.Release()
-
-		for database, err := range c.Config.Databases.RangeDatabases(ctx, start, end) {
-			if err != nil {
-				// TODO(lokraszewski): DELETE IN v21.0.0
-				if trace.IsNotImplemented(err) {
-					databases, err := c.Config.Databases.GetDatabases(ctx)
-					if err != nil {
-						yield(nil, err)
-						return
-					}
-
-					for _, database := range databases {
-						if !yield(database, nil) {
-							return
-						}
-					}
-
-					return
-				}
-
-				yield(nil, err)
+		for db, err := range ranger.Range(ctx, start, end) {
+			if !yield(db, err) {
 				return
 			}
 
-			if !yield(database, nil) {
+			if err != nil {
 				return
 			}
 		}
 	}
-
 }
 
 type databaseServerIndex string


### PR DESCRIPTION
Similiar to genericLister this commit adds a generic helper genericRanger for range like cache access.

The ranger also supports fallback to non paginated endpoints in the case the upstream does not implement the required functionality.

Updates existing cache getters that follow this pattern.