### PR TITLE
Fix TestWorkloadIdentityService_SignX509SVIDs flakiness

### DIFF
--- a/lib/auth/machineid/machineidv1/workload_identity_service_test.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service_test.go
@@ -136,7 +136,7 @@ func TestWorkloadIdentityService_SignX509SVIDs(t *testing.T) {
 				require.NoError(t, err)
 
 				// Check TTL
-				require.WithinDuration(t, time.Now().Add(30*time.Minute), cert.NotAfter, 5*time.Second)
+				require.WithinDuration(t, srv.Clock().Now().Add(30*time.Minute), cert.NotAfter, 5*time.Second)
 
 				// Check included public key matches
 				require.Equal(t, privateKey.Public(), cert.PublicKey)
@@ -347,8 +347,8 @@ func TestWorkloadIdentityService_SignJWTSVIDs(t *testing.T) {
 				require.Equal(t, svid.Jti, claims.ID)
 				require.Equal(t, "example.com", claims.Audience[0])
 				require.Equal(t, wantIssuer, claims.Issuer)
-				require.WithinDuration(t, time.Now().Add(30*time.Minute), claims.Expiry.Time(), 5*time.Second)
-				require.WithinDuration(t, time.Now(), claims.IssuedAt.Time(), 5*time.Second)
+				require.WithinDuration(t, srv.Clock().Now().Add(30*time.Minute), claims.Expiry.Time(), 5*time.Second)
+				require.WithinDuration(t, srv.Clock().Now(), claims.IssuedAt.Time(), 5*time.Second)
 			},
 		},
 		{


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/59737

We were using a fake clock initialised to `time.Now()` when setting up the Auth Server, but, when generating an expected timestamp in tests, we were using `time.Now()`. If the test took sufficient time after initialising the fake clock to get to these assertions, then they would fail.

Fixed by ensuring the test assertions also use the fake clock.