### PR TITLE
Add a short intro paragraph to the changelog

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -1,7 +1,3 @@
-{/* Disable page structure linting because the changelog is the only page of its
-kind and should not be subject to general structural requirements */}
-{/* lint disable page-structure remark-lint */}
-{/*lint disable absolute-docs-links*/}
 ---
 title: Teleport Changelog
 description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
@@ -9,5 +5,9 @@ tags:
  - reference
  - platform-wide
 ---
+
+{/*lint disable absolute-docs-links*/}
+
+The Teleport changelog lists changes introduced by each version of Teleport. 
 
 (!CHANGELOG.md!)


### PR DESCRIPTION
Fixes https://github.com/gravitational/docs-website/issues/390

This resolves the expectation in the `remark-lint-page-structure` linter that each page begin with at least one introductory paragraph. The changes in #59542 attempted to ignore the linter, but since the `remark` plugin for including partials preserves line numbers from the original partial file in included AST nodes, the comment directive that ignores the linter takes place after the linter violation. Placing the comment before the violation causes the frontmatter to render incorrectly.

Merging gravitational/docs-website#393 removes the extraneous H1 heading below the first paragraph.