### PR TITLE
Enable client cache in integration tests of lib/teleterm

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -1258,7 +1258,6 @@ func TestALPNSNIProxyDatabaseAccess(t *testing.T) {
 	})
 
 	t.Run("teleterm db gateways cert renewal", func(t *testing.T) {
-		t.Log("Flaky tests detector please trigger :~)")
 		testTeletermDbGatewaysCertRenewal(t, pack)
 	})
 }
@@ -1317,7 +1316,6 @@ func TestALPNSNIProxyAppAccess(t *testing.T) {
 	})
 
 	t.Run("teleterm app gateways cert renewal", func(t *testing.T) {
-		t.Log("Flaky tests detector please trigger :~)")
 		t.Run("without per-session MFA", func(t *testing.T) {
 			makeTC := func(t *testing.T) (*libclient.TeleportClient, mfa.WebauthnLoginFunc) {
 				user, _ := pack.CreateUser(t)

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -1258,6 +1258,7 @@ func TestALPNSNIProxyDatabaseAccess(t *testing.T) {
 	})
 
 	t.Run("teleterm db gateways cert renewal", func(t *testing.T) {
+		t.Log("Flaky tests detector please trigger :~)")
 		testTeletermDbGatewaysCertRenewal(t, pack)
 	})
 }
@@ -1316,6 +1317,7 @@ func TestALPNSNIProxyAppAccess(t *testing.T) {
 	})
 
 	t.Run("teleterm app gateways cert renewal", func(t *testing.T) {
+		t.Log("Flaky tests detector please trigger :~)")
 		t.Run("without per-session MFA", func(t *testing.T) {
 			makeTC := func(t *testing.T) (*libclient.TeleportClient, mfa.WebauthnLoginFunc) {
 				user, _ := pack.CreateUser(t)

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -52,7 +52,6 @@ import (
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	libclient "github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/client/mfa"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -258,11 +258,8 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 		Clock:            fakeClock,
 		Storage:          storage,
 		TshdEventsClient: tshdEventsClient,
-		CreateClientCacheFunc: func(newClient clientcache.NewClientFunc) (daemon.ClientCache, error) {
-			return clientcache.NewNoCache(newClient), nil
-		},
-		KubeconfigsDir: t.TempDir(),
-		AgentsDir:      t.TempDir(),
+		KubeconfigsDir:   t.TempDir(),
+		AgentsDir:        t.TempDir(),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -890,11 +887,8 @@ func testTeletermAppGatewayTargetPortValidation(t *testing.T, pack *appaccess.Pa
 		daemonService, err := daemon.New(daemon.Config{
 			Storage:          storage,
 			TshdEventsClient: tshdEventsClient,
-			CreateClientCacheFunc: func(newClient clientcache.NewClientFunc) (daemon.ClientCache, error) {
-				return clientcache.NewNoCache(newClient), nil
-			},
-			KubeconfigsDir: t.TempDir(),
-			AgentsDir:      t.TempDir(),
+			KubeconfigsDir:   t.TempDir(),
+			AgentsDir:        t.TempDir(),
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() {


### PR DESCRIPTION
The cache was disabled in https://github.com/gravitational/teleport/pull/39417 because of flaky tests. There were some issues with the cache and the old `client.ProxyClient` that we couldn't quite resolve (https://github.com/gravitational/teleport/issues/39268, https://github.com/gravitational/teleport/issues/20906#issuecomment-1992137366).

We ended up suspecting it had something to do with how the old client closed connections and how complex it was in general (https://github.com/gravitational/teleport/issues/39268#issuecomment-2003403209). At the time we were in the process of moving from the SSH client to the gRPC client which was supposed to be a lot simpler.

Back then I made a todo item for myself to re-enable the cache once lib/teleterm is migrated to the gRPC client. This eventually happened in https://github.com/gravitational/teleport/pull/40562. I had a couple of free minutes left today so I decided to create this PR. We don't want the cache to be disabled in tests because we might miss issues and regressions in the cache which would otherwise be surfaced early by the tests.

If those tests end up being flaky again, I'll revert this PR.