### PR TITLE
Fix issue with dry-run access_request.spec.expires overwrite

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3903,8 +3903,15 @@ func getAutoResourceRequest(ctx context.Context, tc *client.TeleportClient, requ
 	req.SetDryRun(true)
 	req.SetRequestReason("Dry run, this request will not be created. If you see this, there is a bug.")
 	if err := tc.WithRootClusterClient(ctx, func(clt authclient.ClientI) error {
-		req, err = clt.CreateAccessRequestV2(ctx, req)
-		return trace.Wrap(err)
+		dryRunReq, err := clt.CreateAccessRequestV2(ctx, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// Copying the computed roles here is not strictly necessary but avoids requiring
+		// the server to recompute the roles when the real request is created, which can be
+		// an expensive operation.
+		req.SetRoles(dryRunReq.GetRoles())
+		return nil
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Issue https://github.com/gravitational/teleport/issues/59606

After `access_request.spec.max_duration` field was introduced we started to set the `spec.expiry` to the `max_duration` if the conditions are met (i.e. max_duration is set and any of the roles allowing the requested resource has .spec.allow.request.max_duration set).

This that if the conditions for setting `max_duration` are met, `access_request.spec.expiry` may not (and usually is not) shorter than the current login session duration.

This in turn means that if such a request goes through the dry-run call first, the `spec.expiry` is set to `spec.max_duration` and [this validation](https://github.com/gravitational/teleport/blob/5c0a0d0243bdee990ade38a7e70778e6bfb6a765/lib/services/access_request.go#L1535-L1537) fails.

This PR is a little bit hacky fix dropping the request from the dry-run as there is no easy way out of this situation on the server side. The proper fix should be covered with https://github.com/gravitational/teleport/issues/46001 (part 2) where we should revisit the whole access request spec and make things less confusing than they are right now.

Backports:

- [x] https://github.com/gravitational/teleport/pull/59924
- [x] https://github.com/gravitational/teleport/pull/59925

changelog: Fix the issue with automatic access requests for `tsh ssh` when `spec.allow.request.max_duration` is set on the requester role.