### PR TITLE
[v18] Tag docs pages with `access-requests`

### DIFF
--- a/docs/pages/identity-governance/access-request-plugins/access-plugin.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/access-plugin.mdx
@@ -2,6 +2,7 @@
 title: How to Build an Access Request Plugin
 description: Manage Access Requests using custom workflows with the Teleport API
 tags:
+ - access-requests
  - how-to
  - zero-trust
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
@@ -4,6 +4,7 @@ description: "Use Teleport's Access Request plugins to least-privilege access wi
 layout: tocless-doc
 sidebar_position: 2
 tags:
+ - access-requests
  - conceptual
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/datadog-hosted.mdx
@@ -3,6 +3,7 @@ title: Access Requests with Datadog Incident Management
 sidebar_label: Datadog
 description: How to set up Teleport's Datadog Incident Management plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/notification-routing-rules.mdx
@@ -3,6 +3,7 @@ title: Routing Access Request Notifications
 description: How to set up Teleport's Access Monitoring Rules to route Access Request notifications
 sidebar_position: 11
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/opsgenie.mdx
@@ -3,6 +3,7 @@ title: Access Requests with Opsgenie
 sidebar_label: Opsgenie
 description: How to set up Teleport's Opsgenie plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/servicenow.mdx
@@ -3,6 +3,7 @@ title: Access Requests with ServiceNow
 sidebar_label: ServiceNow
 description: How to set up Teleport's ServiceNow plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-discord.mdx
@@ -3,6 +3,7 @@ title: Run the Discord Access Request Plugin
 sidebar_label: Discord
 description: How to set up Teleport's Discord plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-email.mdx
@@ -3,6 +3,7 @@ title: Access Requests with Email
 sidebar_label: Email
 description: How to set up the Teleport email plugin to notify users when another user requests elevated privileges.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-jira.mdx
@@ -3,6 +3,7 @@ title: Run the Jira Access Request Plugin
 sidebar_label: Jira
 description: How to set up the Teleport Jira plugin to notify users when another user requests elevated privileges.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-mattermost.mdx
@@ -3,6 +3,7 @@ title: Run the Mattermost Access Request plugin
 sidebar_label: Mattermost
 description: How to set up Teleport's Mattermost plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-msteams.mdx
@@ -3,6 +3,7 @@ title: Access Requests with Microsoft Teams
 sidebar_label: Microsoft Teams
 description: How to set up Teleport's Microsoft Teams plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -3,6 +3,7 @@ title: Run the PagerDuty Access Request Plugin
 sidebar_label: PagerDuty
 description: How to set up Teleport's PagerDuty plugin for privilege elevation approvals.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/ssh-approval-slack.mdx
@@ -3,6 +3,7 @@ title: Run the Slack Access Request Plugin
 description: How to set up Teleport's Slack plugin for privilege elevation approvals.
 sidebar_label: Slack
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -3,6 +3,7 @@ title: Configure Access Requests
 description: Describes the options available for configuring just-in-time access to roles and resources in your Teleport cluster.
 tocDepth: 3
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/access-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/access-requests.mdx
@@ -4,6 +4,7 @@ description: Use just-in-time Access Requests to request elevated privileges.
 layout: tocless-doc
 sidebar_position: 1
 tags:
+ - access-requests
  - conceptual
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
+++ b/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
@@ -2,6 +2,7 @@
 title: Configure Automatic Reviews
 description: Describes how to configure Access Automation Rules for Automatic Reviews.
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
@@ -2,6 +2,7 @@
 title: Teleport Community Edition Role Access Requests
 description: Teleport Community Edition allows users to request access to roles from the CLI.
 tags:
+ - access-requests
  - conceptual
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -3,6 +3,7 @@ title: Resource Access Requests
 description: Teleport allows users to request access to specific resources from the CLI or UI. Requests can be escalated via ChatOps or anywhere else via our flexible Authorization Workflow API.
 tocDepth: 3
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/identity-governance/access-requests/role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/role-requests.mdx
@@ -3,6 +3,7 @@ title: Role Access Requests
 description: Use Just-in-time Access Requests to request new roles with elevated privileges.
 h1: Teleport Role Access Requests
 tags:
+ - access-requests
  - how-to
  - identity-governance
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-datadog.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-datadog Chart Reference
 sidebar_label: teleport-plugin-datadog
 description: Values that can be set using the teleport-plugin-datadog Helm chart
 tags:
+ - access-requests
  - reference
  - identity-governance
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-discord.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-discord Chart Reference
 sidebar_label: teleport-plugin-discord
 description: Values that can be set using the teleport-plugin-discord Helm chart
 tags:
+ - access-requests
  - reference
  - zero-trust
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-email.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-email Chart Reference
 sidebar_label: teleport-plugin-email
 description: Values that can be set using the teleport-plugin-email Helm chart
 tags:
+ - access-requests
  - reference
  - zero-trust
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-jira Chart Reference
 sidebar_label: teleport-plugin-jira
 description: Values that can be set using the teleport-plugin-jira Helm chart
 tags:
+ - access-requests
  - reference
  - identity-governance
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-msteams.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-msteams Chart Reference
 sidebar_label: teleport-plugin-msteams
 description: Values that can be set using the teleport-plugin-msteams Helm chart
 tags:
+ - access-requests
  - reference
  - identity-governance
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-pagerduty Chart Reference
 sidebar_label: teleport-plugin-pagerduty
 description: Values that can be set using the teleport-plugin-pagerduty Helm chart
 tags:
+ - access-requests
  - reference
  - identity-governance
  - privileged-access

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -3,6 +3,7 @@ title: teleport-plugin-slack Chart Reference
 sidebar_label: teleport-plugin-slack
 description: Values that can be set using the teleport-plugin-slack Helm chart
 tags:
+ - access-requests
  - reference
  - identity-governance
  - privileged-access


### PR DESCRIPTION
Backports #59538

Using Teleport for just-in-time Access Requests is a common use case. Tag pages with this use case so users can find related pages when looking for Access Request-related content.