### PR TITLE
docs: Convert text links to TileGrid for MWI configuration and deployment 

### DIFF
--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -53,17 +53,17 @@ and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) 
 <TileGrid
   tiles={[
     {
-      icon: <Icon name="aws.svg" size="xl" />,
+      icon: <Icon name="aws" size="xl" />,
       to: "./aws",
       name: "AWS",
     },
     {
-      icon: <Icon name="azureDevops" size="xl" />,
+      icon: <Icon name="azure" size="xl" />,
       to: "./azure",
       name: "Azure",
     },
     {
-      icon: <Icon name="azure-devops.svg" size="xl" />,
+      icon: <Icon name="azureDevops" size="xl" />,
       to: "./azure-devops",
       name: "Azure DevOps",
     },
@@ -98,7 +98,7 @@ and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) 
       name: "Kubernetes",
     },
     {
-      icon: <Icon name="kubernetes-oidc" size="xl" />,
+      icon: <Icon name="kubernetes" size="xl" />,
       to: "./kubernetes-oidc",
       name: "Kubernetes OIDC",
     },
@@ -108,49 +108,15 @@ and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) 
       name: "Linux",
     },
     {
-      icon: <Icon name="linux-tpm" size="xl" />,
+      icon: <Icon name="lock" size="xl" />,
       to: "./linux-tpm",
       name: "Linux TPM",
-    },
-    {
-      icon: <Icon name="spacelift" size="xl" />,
-      to: "./spacelift",
-      name: "Spacelift",
     }
   ]}
 />
 
-### Self-hosted infrastructure
+### Further reading
 
-Read the following guides for how to deploy Machine ID on your cloud platform or
-on-prem infrastructure.
+**CI/CD**
 
-| Platform                               | Installation method                             | Join method                                         |
-|----------------------------------------|-------------------------------------------------|-----------------------------------------------------|
-| [Linux](linux.mdx)                     | Package manager or TAR archive                  | Static join token                                   |
-| [Linux (TPM)](linux-tpm.mdx)           | Package manager or TAR archive                  | Attestation from TPM 2.0                            |
-| [Linux (Bound Keypair)][bound-keypair] | Package manager or TAR archive                  | Bound Keypair                                       |
-| [GCP](gcp.mdx)                         | Package manager, TAR archive, or Kubernetes pod | Identity document signed by GCP                     |
-| [AWS](aws.mdx)                         | Package manager, TAR archive, or Kubernetes pod | Identity document signed by AWS                     |
-| [Azure](azure.mdx)                     | Package manager or TAR archive                  | Identity document signed by Azure                   |
-| [Kubernetes](kubernetes.mdx)           | Kubernetes pod                                  | Identity document signed by your Kubernetes cluster |
-| [Kubernetes OIDC](kubernetes-oidc.mdx) | Kubernetes pod on a cloud provider with OIDC    | Identity document signed by your cloud provider     |
-
-### CI/CD
-
-Read the following guides for how to deploy Machine ID on a continuous
-integration and continuous deployment platform
-
-| Platform                                                                                               | Installation method                                           | Join method                              |
-|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|------------------------------------------|
-| [Azure DevOps](azure-devops.mdx)                                                                       | TAR archive                                                   | Azure DevOps-signed identity document    |
-| [Bitbucket Pipelines](bitbucket.mdx)                                                                   | TAR archive                                                   | Bitbucket-signed identity document       |
-| [CircleCI](circleci.mdx)                                                                               | TAR archive                                                   | CircleCI-signed identity document        |
-| [GitLab](gitlab.mdx)                                                                                   | TAR archive                                                   | GitLab-signed identity document          |
-| [GitHub Actions](github-actions.mdx)                                                                   | Teleport job available through the GitHub Actions marketplace | GitHub-signed identity document.         |
-| [Jenkins](jenkins.mdx)                                                                                 | Package manager or TAR archive                                | Static join token                        |
-| [Spacelift](../../../zero-trust-access/infrastructure-as-code/terraform-provider/spacelift.mdx)             | Docker Image                                                  | Spacelift-signed identity document       |
-| [Terraform Cloud](../../../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud.mdx) | Teleport Terraform Provider via Teleport's Terraform Registry | Terraform Cloud-signed identity document |
-
-
-[bound-keypair]: ../../../reference/machine-workload-identity/machine-id/bound-keypair/getting-started.mdx
+- Learn how to [deploy Machine ID](../../mwi-ci-cd.mdx) in a CI/CD pipeline.

--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -42,14 +42,83 @@ authentication methods:
 
 ## Deployment guides
 
-The guides in this section show you how to deploy Machine ID and join it
-to your cluster. Choose a guide based on the platform where you intend to run
-Machine ID.
+The guides in this section show you how to deploy Machine ID and join it to your cluster. 
+Choose a guide based on the platform where you intend to run Machine ID.
 
 If a specific guide does not exist for your platform, the [Linux
 guide](linux.mdx) is compatible with most platforms. For
 custom approaches, you can also read the [Machine ID Reference](../../../reference/machine-workload-identity/machine-id/machine-id.mdx)
 and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) to plan your deployment.
+
+<TileGrid
+  tiles={[
+    {
+      icon: <Icon name="aws.svg" size="xl" />,
+      to: "./aws",
+      name: "AWS",
+    },
+    {
+      icon: <Icon name="azureDevops" size="xl" />,
+      to: "./azure",
+      name: "Azure",
+    },
+    {
+      icon: <Icon name="azure-devops.svg" size="xl" />,
+      to: "./azure-devops",
+      name: "Azure DevOps",
+    },
+    {
+      icon: <Icon name="bitbucket" size="xl" />,
+      to: "./bitbucket",
+      name: "BitBucket Pipelines",
+    },
+    {
+      icon: <Icon name="circleci" size="xl" />,
+      to: "./circleci",
+      name: "CircleCI",
+    },
+    {
+      icon: <Icon name="gitlab" size="xl" />,
+      to: "./gitlab",
+      name: "GitLab CI",
+    },
+    {
+      icon: <Icon name="githubActions" size="xl" />,
+      to: "./github-actions",
+      name: "GitHub Actions",
+    },
+    {
+      icon: <Icon name="googleCloud" size="xl" />,
+      to: "./gcp",
+      name: "Google Cloud",
+    },
+    {
+      icon: <Icon name="kubernetes2" size="xl" />,
+      to: "./kubernetes",
+      name: "Kubernetes",
+    },
+    {
+      icon: <Icon name="kubernetes-oidc" size="xl" />,
+      to: "./kubernetes-oidc",
+      name: "Kubernetes OIDC",
+    },
+    {
+      icon: <Icon name="linux" size="xl" />,
+      to: "./linux",
+      name: "Linux",
+    },
+    {
+      icon: <Icon name="linux-tpm" size="xl" />,
+      to: "./linux-tpm",
+      name: "Linux TPM",
+    },
+    {
+      icon: <Icon name="spacelift" size="xl" />,
+      to: "./spacelift",
+      name: "Spacelift",
+    }
+  ]}
+/>
 
 ### Self-hosted infrastructure
 

--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -108,13 +108,13 @@ and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) 
       name: "Linux",
     },
     {
-      icon: <Icon name="lock" size="xl" />,
+      icon: <Icon name="linux-servers" size="xl" />,
       to: "./linux-tpm",
       name: "Linux TPM",
     },
     {
-      icon: <Icon name="zero-trust.svg" size="xl" />,
-      to: "../reference/machine-workload-identity/machine-id/bound-keypair/getting-started",
+      icon: <Icon name="lock" size="xl" />,
+      to: "../../reference/machine-workload-identity/machine-id/bound-keypair/getting-started",
       name: "Bound Keypair Joining",
     }  
   ]}
@@ -128,42 +128,42 @@ Read the following guides for how to deploy Machine ID on a continuous integrati
   tiles={[
     {
       icon: <Icon name="azureDevops" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/azure-devops",
+      to: "./azure-devops",
       name: "Azure DevOps",
     },
     {
       icon: <Icon name="bitbucket" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/bitbucket",
+      to: "./bitbucket",
       name: "BitBucket Pipelines",
     },
     {
       icon: <Icon name="circleci" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/circleci",
+      to: "./circleci",
       name: "CircleCI",
     },
     {
       icon: <Icon name="gitlab" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/gitlab",
+      to: "./gitlab",
       name: "GitLab CI",
     },
     {
       icon: <Icon name="githubActions" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/github-actions",
+      to: "./github-actions",
       name: "GitHub Actions",
     },
     {
       icon: <Icon name="jenkins" size="xl" />,
-      to: "/docs/machine-workload-identity/machine-id/deployment/jenkins",
+      to: "./jenkins",
       name: "Jenkins",
     },
     {
       icon: <Icon name="spacelift" size="xl" />,
-      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
+      to: "../../zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
       name: "Spacelift",
     },
     {
       icon: <Icon name="terraform" size="xl" />,
-      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud",
+      to: "../../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud",
       name: "Terraform Cloud",
     }
   ]}

--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -111,12 +111,60 @@ and [Architecture](../../../reference/architecture/machine-id-architecture.mdx) 
       icon: <Icon name="lock" size="xl" />,
       to: "./linux-tpm",
       name: "Linux TPM",
-    }
+    },
+    {
+      icon: <Icon name="zero-trust.svg" size="xl" />,
+      to: "../reference/machine-workload-identity/machine-id/bound-keypair/getting-started",
+      name: "Bound Keypair Joining",
+    }  
   ]}
 />
 
-### Further reading
+### CI/CD
 
-**CI/CD**
+Read the following guides for how to deploy Machine ID on a continuous integration and continuous deployment platform.
 
-- Learn how to [deploy Machine ID](../../mwi-ci-cd.mdx) in a CI/CD pipeline.
+<TileGrid
+  tiles={[
+    {
+      icon: <Icon name="azureDevops" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/azure-devops",
+      name: "Azure DevOps",
+    },
+    {
+      icon: <Icon name="bitbucket" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/bitbucket",
+      name: "BitBucket Pipelines",
+    },
+    {
+      icon: <Icon name="circleci" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/circleci",
+      name: "CircleCI",
+    },
+    {
+      icon: <Icon name="gitlab" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/gitlab",
+      name: "GitLab CI",
+    },
+    {
+      icon: <Icon name="githubActions" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/github-actions",
+      name: "GitHub Actions",
+    },
+    {
+      icon: <Icon name="jenkins" size="xl" />,
+      to: "/docs/machine-workload-identity/machine-id/deployment/jenkins",
+      name: "Jenkins",
+    },
+    {
+      icon: <Icon name="spacelift" size="xl" />,
+      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/spacelift",
+      name: "Spacelift",
+    },
+    {
+      icon: <Icon name="terraform" size="xl" />,
+      to: "/docs/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-cloud",
+      name: "Terraform Cloud",
+    }
+  ]}
+/>

--- a/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
@@ -14,14 +14,40 @@ issues flexible short-lived identities to workloads in your infrastructure.
 - [Introduction to SPIFFE](./spiffe.mdx): Learn about Secure Production Identity Framework For Everyone (SPIFFE) and how it is implemented by Teleport Workload Identity
 - [Getting Started with Workload Identity](./getting-started.mdx): Getting started with Teleport Workload Identity for SPIFFE and Machine ID
 
-## Guides
-- [Configuring Workload Identity and AWS OIDC Federation](./aws-oidc-federation.mdx): Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
-- [Configuring Workload Identity and AWS Roles Anywhere](./aws-roles-anywhere.mdx): Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
-- [Configuring Workload Identity and Azure Federated Credentials](./azure-federated-credentials.mdx): Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
-- [Configuring Workload Identity and GCP Workload Identity Federation with JWTs](./gcp-workload-identity-federation-jwt.mdx): Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
-- [Workload Identity and tsh](./tsh.mdx): Issuing SPIFFE SVIDs using Workload Identity and tsh
+## Configuration Guides
 
-## Configuration & management
+<TileGrid
+  tiles={[
+    {
+      icon: <Icon name="awsSvg" size="xl" />,
+      to: "./aws-oidc-federation",
+      name: "AWS OIDC Federation",
+    },
+    {
+      icon: <Icon name="aws-identity-center.svg" size="xl" />,
+      to: "./aws-roles-anywhere",
+      name: "AWS Roles Anywhere",
+    },
+    {
+      icon: <Icon name="azure.svg" size="xl" />,
+      to: "./azure-federated-credentials",
+      name: "Azure Federated Credentials",
+    },
+    {
+      icon: <Icon name="googleCloud.svg" size="xl" />,
+      to: "./gcp-workload-identity-federation-jwt",
+      name: "GCP Workload Identity Federation",
+    },
+    {
+      icon: <Icon name="code.svg" size="xl" />,
+      to: "./tsh",
+      name: "Manually issue SPIFFE SVIDs with Teleport CLI tool tsh",
+    }
+  ]}
+/>
+
+
+## Configuration management
 - [Best Practices for Teleport Workload Identity](./best-practices.mdx): Answers common questions and describes best practices for using Teleport Workload Identity in production.
 - [JWT SVIDs](./jwt-svids.mdx): An overview of the JWT SVIDs issued by Teleport Workload Identity
 - [SPIFFE Federation](./federation.mdx): An overview of the Teleport Workload Identity SPIFFE Federation feature.

--- a/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/workload-identity.mdx
@@ -19,27 +19,27 @@ issues flexible short-lived identities to workloads in your infrastructure.
 <TileGrid
   tiles={[
     {
-      icon: <Icon name="awsSvg" size="xl" />,
+      icon: <Icon name="aws" size="xl" />,
       to: "./aws-oidc-federation",
       name: "AWS OIDC Federation",
     },
     {
-      icon: <Icon name="aws-identity-center.svg" size="xl" />,
+      icon: <Icon name="awsIdentity" size="xl" />,
       to: "./aws-roles-anywhere",
       name: "AWS Roles Anywhere",
     },
     {
-      icon: <Icon name="azure.svg" size="xl" />,
+      icon: <Icon name="azure" size="xl" />,
       to: "./azure-federated-credentials",
       name: "Azure Federated Credentials",
     },
     {
-      icon: <Icon name="googleCloud.svg" size="xl" />,
+      icon: <Icon name="googleCloud" size="xl" />,
       to: "./gcp-workload-identity-federation-jwt",
       name: "GCP Workload Identity Federation",
     },
     {
-      icon: <Icon name="code.svg" size="xl" />,
+      icon: <Icon name="code" size="xl" />,
       to: "./tsh",
       name: "Manually issue SPIFFE SVIDs with Teleport CLI tool tsh",
     }


### PR DESCRIPTION
For MWI guides, rather than have "deploy on..." and "access X..." links on the page, scope to a tiled approach. 