### PR TITLE
Add `mcp_tools` and `default_relay_addr` to the trait editor

### DIFF
--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -51,6 +51,8 @@ export const traitsPreset = [
   'logins',
   'windows_logins',
   'github_orgs',
+  'mcp_tools',
+  'default_relay_addr',
 ] as const;
 
 /**

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -55,6 +55,24 @@ export const traitsPreset = [
   'default_relay_addr',
 ] as const;
 
+export const traitDescriptions = {
+  aws_role_arns: 'List of allowed AWS role ARNS',
+  azure_identities: 'List of Azure identities',
+  db_names: 'List of allowed database names',
+  db_roles: 'List of allowed database roles',
+  db_users: 'List of allowed database users',
+  gcp_service_accounts: 'List of GCP service accounts',
+  kubernetes_groups: 'List of allowed Kubernetes groups',
+  kubernetes_users: 'List of allowed Kubernetes users',
+  logins: 'List of allowed logins',
+  windows_logins: 'List of allowed Windows logins',
+  host_user_gid: 'The group ID to use for auto-host-users',
+  host_user_uid: 'The user ID to use for auto-host-users',
+  github_orgs: 'List of allowed GitHub organizations for git command proxy',
+  mcp_tools: 'List of allowed MCP tools',
+  default_relay_addr: 'The relay address that clients should use by default',
+} as const satisfies { [key in (typeof traitsPreset)[number]]: string };
+
 /**
  * TraitsEditor supports add, edit or remove traits functionality.
  * @param isLoading if true, it disables all the inputs in the editor.

--- a/web/packages/teleport/src/Bots/Details/BotDetails.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.tsx
@@ -42,7 +42,7 @@ import MenuItem from 'design/Menu/MenuItem';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
 import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
-import { traitsPreset } from 'shared/components/TraitsEditor/TraitsEditor';
+import { traitDescriptions } from 'shared/components/TraitsEditor/TraitsEditor';
 import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
 
 import {
@@ -430,24 +430,6 @@ const LabelText = styled(Text).attrs({
 const EmptyText = styled(Text)`
   color: ${p => p.theme.colors.text.muted};
 `;
-
-const traitDescriptions: { [key in (typeof traitsPreset)[number]]: string } = {
-  aws_role_arns: 'List of allowed AWS role ARNS',
-  azure_identities: 'List of Azure identities',
-  db_names: 'List of allowed database names',
-  db_roles: 'List of allowed database roles',
-  db_users: 'List of allowed database users',
-  gcp_service_accounts: 'List of GCP service accounts',
-  kubernetes_groups: 'List of allowed Kubernetes groups',
-  kubernetes_users: 'List of allowed Kubernetes users',
-  logins: 'List of allowed logins',
-  windows_logins: 'List of allowed Windows logins',
-  host_user_gid: 'The group ID to use for auto-host-users',
-  host_user_uid: 'The user ID to use for auto-host-users',
-  github_orgs: 'List of allowed GitHub organizations for git command proxy',
-  mcp_tools: 'List of allowed MCP tools',
-  default_relay_addr: 'The relay address that clients should use by default',
-};
 
 function Trait(props: { traitName: string }) {
   const theme = useTheme();

--- a/web/packages/teleport/src/Bots/Details/BotDetails.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.tsx
@@ -445,6 +445,8 @@ const traitDescriptions: { [key in (typeof traitsPreset)[number]]: string } = {
   host_user_gid: 'The group ID to use for auto-host-users',
   host_user_uid: 'The user ID to use for auto-host-users',
   github_orgs: 'List of allowed GitHub organizations for git command proxy',
+  mcp_tools: 'List of allowed MCP tools',
+  default_relay_addr: 'The relay address that clients should use by default',
 };
 
 function Trait(props: { traitName: string }) {


### PR DESCRIPTION
This PR adds the traits `mcp_tools` and `default_relay_addr` to the web UI trait editor list, as well as descriptions for the bot details view.