### PR TITLE
Simplify lib/utils loadbalancer

### DIFF
--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -19,12 +19,9 @@
 package utils
 
 import (
-	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"sync/atomic"
 
 	"github.com/gravitational/trace"
@@ -74,38 +71,6 @@ func (c *CloserConn) Context() context.Context {
 // Wait for connection to close.
 func (c *CloserConn) Wait() {
 	<-c.ctx.Done()
-}
-
-// Roundtrip is a single connection simplistic HTTP client
-// that allows us to bypass a connection pool to test load balancing
-// used in tests, as it only supports GET request on /
-func Roundtrip(addr string) (string, error) {
-	conn, err := net.Dial("tcp", addr)
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-	return RoundtripWithConn(conn)
-}
-
-// RoundtripWithConn uses HTTP GET on the existing connection,
-// used in tests as it only performs GET request on /
-func RoundtripWithConn(conn net.Conn) (string, error) {
-	_, err := fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
-	if err != nil {
-		return "", err
-	}
-
-	re, err := http.ReadResponse(bufio.NewReader(conn), nil)
-	if err != nil {
-		return "", err
-	}
-	defer re.Body.Close()
-	out, err := io.ReadAll(re.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }
 
 // Stater is extension interface of the net.Conn for implementations that


### PR DESCRIPTION
This test-only utility was causing test flakiness because it assumed that TCP ports would not be re-used while tests are running.

Resolve the flakiness by removing these assumptions, and further simplify the code by removing some additional lib/utils functionality that was only ever used in tests.

Closes #59712