### PR TITLE
Support editing the `default_relay_addr` trait in `tctl users`

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -129,6 +129,8 @@ type User interface {
 	SetHostUserGID(gid string)
 	// SetMCPTools sets a list of allowed MCP tools for the user
 	SetMCPTools(mcpTools []string)
+	// SetDefaultRelayAddr sets the trait for the default relay address.
+	SetDefaultRelayAddr(addr string)
 	// GetCreatedBy returns information about user
 	GetCreatedBy() CreatedBy
 	// SetCreatedBy sets created by information
@@ -426,6 +428,18 @@ func (u *UserV2) SetHostUserGID(uid string) {
 // SetMCPTools sets a list of allowed MCP tools for the user
 func (u *UserV2) SetMCPTools(mcpTools []string) {
 	u.setTrait(constants.TraitMCPTools, mcpTools)
+}
+
+// SetDefaultRelayAddr implements [User].
+func (u *UserV2) SetDefaultRelayAddr(addr string) {
+	if addr == "" {
+		delete(u.Spec.Traits, constants.TraitDefaultRelayAddr)
+		return
+	}
+	if u.Spec.Traits == nil {
+		u.Spec.Traits = make(map[string][]string)
+	}
+	u.Spec.Traits[constants.TraitDefaultRelayAddr] = []string{addr}
 }
 
 // GetStatus returns login status of the user

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -198,6 +198,20 @@ func TestUserAdd(t *testing.T) {
 				constants.TraitMCPTools: {"aa", "bb", "get_*"},
 			},
 		},
+		{
+			name: "default relay addr set",
+			args: []string{"--default-relay-addr", "foo"},
+			wantTraits: map[string][]string{
+				constants.TraitDefaultRelayAddr: {"foo"},
+			},
+		},
+		{
+			name: "default relay addr blank",
+			args: []string{"--default-relay-addr", ""},
+			wantTraits: map[string][]string{
+				constants.TraitDefaultRelayAddr: nil,
+			},
+		},
 	}
 
 	for ix, tc := range tests {
@@ -368,6 +382,20 @@ func TestUserUpdate(t *testing.T) {
 			args: []string{"--set-mcp-tools", "aa,bb", "--set-mcp-tools", "get_*"},
 			wantTraits: map[string][]string{
 				constants.TraitMCPTools: {"aa", "bb", "get_*"},
+			},
+		},
+		{
+			name: "default relay addr set",
+			args: []string{"--set-default-relay-addr", "foo"},
+			wantTraits: map[string][]string{
+				constants.TraitDefaultRelayAddr: {"foo"},
+			},
+		},
+		{
+			name: "default relay addr reset",
+			args: []string{"--set-default-relay-addr", ""},
+			wantTraits: map[string][]string{
+				constants.TraitDefaultRelayAddr: nil,
 			},
 		},
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3109,10 +3109,14 @@ func serializeNodes(nodes []types.Server, format string) (string, error) {
 func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string {
 	// Reusable function to get addr or tunnel for each node
 	getAddr := func(n types.Server) string {
-		if n.GetUseTunnel() {
+		switch {
+		case n.GetUseTunnel() && n.GetRelayGroup() != "":
+			return "⟵ Tunnel (relay)"
+		case n.GetUseTunnel():
 			return "⟵ Tunnel"
+		default:
+			return n.GetAddr()
 		}
-		return n.GetAddr()
 	}
 
 	row := make([]string, 0)


### PR DESCRIPTION
This PR adds options to `tctl users add` and `tctl users update` to set the `default_relay_addr` trait on local users. In addition, the listing for tunnel agents that are also connected to a relay in `tsh ls` is updated from the usual `⟵ Tunnel` to `⟵ Tunnel (relay)`.