### PR TITLE
[v17] Refactor tracessh.Client to cover untraced paths - session requests

### DIFF
--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -249,7 +249,8 @@ func TestWrappedSSHConn(t *testing.T) {
 
 // TestGlobalAndSessionRequests tests that the tracing client correctly handles global and session requests.
 func TestGlobalAndSessionRequests(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// pingRequest is an example request type. Whether sent by the server or client in
 	// a global or session context, the receiver should give an ok as the reply.

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -45,31 +45,6 @@ type server struct {
 	hSigner ssh.Signer
 }
 
-func (s *server) Run(errC chan error) {
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			if !errors.Is(err, net.ErrClosed) {
-				errC <- err
-			}
-			return
-		}
-
-		go func() {
-			sconn, chans, reqs, err := ssh.NewServerConn(conn, s.config)
-			if err != nil {
-				errC <- err
-				return
-			}
-			s.handler(sconn, chans, reqs)
-		}()
-	}
-}
-
-func (s *server) Stop() error {
-	return s.listener.Close()
-}
-
 func generateSigner(t *testing.T) ssh.Signer {
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
@@ -91,17 +66,17 @@ func (s *server) GetClient(t *testing.T) (ssh.Conn, <-chan ssh.NewChannel, <-cha
 	return sconn, nc, r
 }
 
-func newServer(t *testing.T, tracingCap tracingCapability, handler func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)) *server {
+const (
+	tracingSupportedVersion   = "SSH-2.0-Teleport"
+	tracingUnsupportedVersion = "SSH-2.0"
+)
+
+func newServer(t *testing.T, version string, handler func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)) *server {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
 	cSigner := generateSigner(t)
 	hSigner := generateSigner(t)
-
-	version := "SSH-2.0-Teleport"
-	if tracingCap != tracingSupported {
-		version = "SSH-2.0"
-	}
 
 	config := &ssh.ServerConfig{
 		NoClientAuth:  true,
@@ -117,7 +92,33 @@ func newServer(t *testing.T, tracingCap tracingCapability, handler func(*ssh.Ser
 		hSigner:  hSigner,
 	}
 
-	t.Cleanup(func() { require.NoError(t, srv.Stop()) })
+	errC := make(chan error, 1)
+	go func() {
+		defer close(errC)
+		for {
+			conn, err := srv.listener.Accept()
+			if err != nil {
+				if !errors.Is(err, net.ErrClosed) {
+					errC <- err
+				}
+				return
+			}
+
+			go func() {
+				sconn, chans, reqs, err := ssh.NewServerConn(conn, srv.config)
+				if err != nil {
+					errC <- err
+					return
+				}
+				srv.handler(sconn, chans, reqs)
+			}()
+		}
+	}()
+
+	t.Cleanup(func() {
+		require.NoError(t, srv.listener.Close())
+		require.NoError(t, <-errC)
+	})
 
 	return srv
 }
@@ -300,8 +301,12 @@ func TestClient(t *testing.T) {
 				ctx:              ctx,
 			}
 
-			srv := newServer(t, tt.tracingSupported, handler.handle)
-			go srv.Run(errChan)
+			version := tracingSupportedVersion
+			if tt.tracingSupported != tracingSupported {
+				version = tracingUnsupportedVersion
+			}
+
+			srv := newServer(t, version, handler.handle)
 
 			tp := sdktrace.NewTracerProvider()
 			conn, chans, reqs := srv.GetClient(t)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1130,7 +1130,7 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 				)
 				assert.NoError(t, err)
 
-				errCh <- nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil, nil)
+				errCh <- nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil)
 				assert.NoError(t, nodeClient.Close())
 			}()
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1262,10 +1262,6 @@ type TeleportClient struct {
 
 	localAgent *LocalKeyAgent
 
-	// OnChannelRequest gets called when SSH channel requests are
-	// received. It's safe to keep it nil.
-	OnChannelRequest tracessh.ChannelRequestCallback
-
 	// OnShellCreated gets called when the shell is created. It's
 	// safe to keep it nil.
 	OnShellCreated ShellCreatedCallback
@@ -2250,7 +2246,7 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 		// Reuse the existing nodeClient we connected above.
 		return nodeClient.RunCommand(ctx, command)
 	}
-	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, tc.OnChannelRequest, nil))
+	return trace.Wrap(nodeClient.RunInteractiveShell(ctx, types.SessionPeerMode, nil, nil))
 }
 
 func (tc *TeleportClient) runShellOrCommandOnMultipleNodes(ctx context.Context, clt *ClusterClient, nodes []TargetNode, command []string) error {
@@ -2407,7 +2403,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	}
 
 	// running shell with a given session means "join" it:
-	err = nc.RunInteractiveShell(ctx, mode, session, tc.OnChannelRequest, beforeStart)
+	err = nc.RunInteractiveShell(ctx, mode, session, beforeStart)
 	return trace.Wrap(err)
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -393,7 +393,7 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 // RunInteractiveShell creates an interactive shell on the node and copies stdin/stdout/stderr
 // to and from the node and local shell. This will block until the interactive shell on the node
 // is terminated.
-func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.SessionParticipantMode, sessToJoin types.SessionTracker, chanReqCallback tracessh.ChannelRequestCallback, beforeStart func(io.Writer)) error {
+func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.SessionParticipantMode, sessToJoin types.SessionTracker, beforeStart func(io.Writer)) error {
 	ctx, span := c.Tracer.Start(
 		ctx,
 		"nodeClient/RunInteractiveShell",
@@ -422,7 +422,7 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 		return trace.Wrap(err)
 	}
 
-	if err = nodeSession.runShell(ctx, mode, c.TC.OnChannelRequest, beforeStart, c.TC.OnShellCreated); err != nil {
+	if err = nodeSession.runShell(ctx, mode, beforeStart, c.TC.OnShellCreated); err != nil {
 		var exitErr *ssh.ExitError
 		var exitMissingErr *ssh.ExitMissingError
 		switch err := trace.Unwrap(err); {
@@ -623,7 +623,8 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string, opts ...R
 		return trace.Wrap(err)
 	}
 	defer nodeSession.Close()
-	err = nodeSession.runCommand(ctx, types.SessionPeerMode, command, c.TC.OnChannelRequest, c.TC.OnShellCreated, c.TC.Config.InteractiveCommand)
+
+	err = nodeSession.runCommand(ctx, types.SessionPeerMode, command, c.TC.OnShellCreated, c.TC.Config.InteractiveCommand)
 	if err != nil {
 		c.TC.SetExitStatus(getExitStatus(err))
 	}

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -192,7 +192,7 @@ func (ns *NodeSession) NodeClient() *NodeClient {
 	return ns.nodeClient
 }
 
-func (ns *NodeSession) regularSession(ctx context.Context, chanReqCallback tracessh.ChannelRequestCallback, sessionCallback func(s *tracessh.Session) error) error {
+func (ns *NodeSession) regularSession(ctx context.Context, sessionCallback func(s *tracessh.Session) error) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/regularSession",
@@ -200,7 +200,7 @@ func (ns *NodeSession) regularSession(ctx context.Context, chanReqCallback trace
 	)
 	defer span.End()
 
-	session, err := ns.createServerSession(ctx, chanReqCallback)
+	session, err := ns.createServerSession(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -212,7 +212,7 @@ func (ns *NodeSession) regularSession(ctx context.Context, chanReqCallback trace
 
 type interactiveCallback func(serverSession *tracessh.Session, shell io.ReadWriteCloser) error
 
-func (ns *NodeSession) createServerSession(ctx context.Context, chanReqCallback tracessh.ChannelRequestCallback) (*tracessh.Session, error) {
+func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Session, error) {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/createServerSession",
@@ -220,7 +220,7 @@ func (ns *NodeSession) createServerSession(ctx context.Context, chanReqCallback 
 	)
 	defer span.End()
 
-	sess, err := ns.nodeClient.Client.NewSessionWithRequestCallback(ctx, chanReqCallback)
+	sess, err := ns.nodeClient.Client.NewSession(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -288,7 +288,7 @@ func selectKeyAgent(ctx context.Context, tc *TeleportClient) sshagent.ClientGett
 
 // interactiveSession creates an interactive session on the remote node, executes
 // the given callback on it, and waits for the session to end
-func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.SessionParticipantMode, chanReqCallback tracessh.ChannelRequestCallback, sessionCallback interactiveCallback) error {
+func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.SessionParticipantMode, sessionCallback interactiveCallback) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/interactiveSession",
@@ -302,7 +302,7 @@ func (ns *NodeSession) interactiveSession(ctx context.Context, mode types.Sessio
 		termType = teleport.SafeTerminalType
 	}
 	// create the server-side session:
-	sess, err := ns.createServerSession(ctx, chanReqCallback)
+	sess, err := ns.createServerSession(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -518,8 +518,8 @@ func (s *sessionWriter) Write(p []byte) (int, error) {
 }
 
 // runShell executes user's shell on the remote node under an interactive session
-func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipantMode, chanReqCallback tracessh.ChannelRequestCallback, beforeStart func(io.Writer), shellCallback ShellCreatedCallback) error {
-	return ns.interactiveSession(ctx, mode, chanReqCallback, func(s *tracessh.Session, shell io.ReadWriteCloser) error {
+func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipantMode, beforeStart func(io.Writer), shellCallback ShellCreatedCallback) error {
+	return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, shell io.ReadWriteCloser) error {
 		w := &sessionWriter{
 			tshOut:  ns.nodeClient.TC.Stdout,
 			session: s,
@@ -547,7 +547,7 @@ func (ns *NodeSession) runShell(ctx context.Context, mode types.SessionParticipa
 
 // runCommand executes a "exec" request either in interactive mode (with a
 // TTY attached) or non-intractive mode (no TTY).
-func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionParticipantMode, cmd []string, chanReqCallback tracessh.ChannelRequestCallback, shellCallback ShellCreatedCallback, interactive bool) error {
+func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionParticipantMode, cmd []string, shellCallback ShellCreatedCallback, interactive bool) error {
 	ctx, span := ns.nodeClient.Tracer.Start(
 		ctx,
 		"nodeClient/runCommand",
@@ -561,7 +561,7 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// keyboard based signals will be propogated to the TTY on the server which is
 	// where all signal handling will occur.
 	if interactive {
-		return ns.interactiveSession(ctx, mode, chanReqCallback, func(s *tracessh.Session, term io.ReadWriteCloser) error {
+		return ns.interactiveSession(ctx, mode, func(s *tracessh.Session, term io.ReadWriteCloser) error {
 			err := s.Start(ctx, strings.Join(cmd, " "))
 			if err != nil {
 				return trace.Wrap(err)
@@ -588,7 +588,7 @@ func (ns *NodeSession) runCommand(ctx context.Context, mode types.SessionPartici
 	// Unfortunately at the moment the Go SSH library Teleport uses does not
 	// support sending SSH_MSG_DISCONNECT. Instead we close the SSH channel and
 	// SSH client, and try and exit as gracefully as possible.
-	return ns.regularSession(ctx, chanReqCallback, func(s *tracessh.Session) error {
+	return ns.regularSession(ctx, func(s *tracessh.Session) error {
 		errCh := make(chan error, 1)
 		go func() {
 			errCh <- s.Run(ctx, strings.Join(cmd, " "))

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -1348,7 +1348,7 @@ func prepareToReceiveSessionID(ctx context.Context, log *logrus.Entry, nc *clien
 		sid, err := session.ParseID(string(req.Payload))
 		if err != nil {
 			log.WithError(err).Warn("Unable to parse session ID.")
-			return nil
+			return
 		}
 
 		if gotSessionID.CompareAndSwap(false, true) {

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -872,7 +872,7 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 
 	// Establish SSH connection to the server. This function will block until
 	// either an error occurs or it completes successfully.
-	if err = nc.RunInteractiveShell(ctx, t.participantMode, t.tracker, nil, beforeStart); err != nil {
+	if err = nc.RunInteractiveShell(ctx, t.participantMode, t.tracker, beforeStart); err != nil {
 		if !t.closedByClient.Load() {
 			t.stream.WriteError(err.Error())
 		}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/59291 to branch/v17