### PR TITLE
[v18] Fix session recording seeking in long inactive periods

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -362,6 +362,14 @@ export class SessionStream<
 
       this.updateLoadedTimes(parsed.startTime, parsed.endTime);
 
+      if (this.state === PlayerState.Loading) {
+        if (this.wasPlayingBeforeSeek) {
+          this.play();
+        } else {
+          this.setState(PlayerState.Paused);
+        }
+      }
+
       return;
     }
 

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -332,6 +332,8 @@ export class SessionStream<
       // mark loading as false as soon as we get any batch event so we can start playing again
       this.loading = false;
 
+      this.pushBatchToBuffer(parsed.events);
+
       if (this.state === PlayerState.Loading) {
         if (this.wasPlayingBeforeSeek) {
           this.play();
@@ -339,8 +341,6 @@ export class SessionStream<
           this.setState(PlayerState.Paused);
         }
       }
-
-      this.pushBatchToBuffer(parsed.events);
 
       const hasEnd =
         parsed.events[parsed.events.length - 1].type === this.endEventType;


### PR DESCRIPTION
Backport #59637 to branch/v18

changelog: Fixed an issue where the new SSH/Kubernetes recording player would indefinitely show a loading spinner when seeking into a long period of inactivity
