### PR TITLE
fix: Rename bot instance version expression functions

### DIFF
--- a/lib/auth/machineid/machineidv1/expression/expression.go
+++ b/lib/auth/machineid/machineidv1/expression/expression.go
@@ -63,14 +63,14 @@ func NewBotInstanceExpressionParser() (*typical.Parser[*Environment, bool], erro
 		}),
 	}
 
-	// e.g. `more_than(status.latest_heartbeat.version, "19.0.0")`
-	spec.Functions["more_than"] = typical.BinaryFunction[*Environment](semverGt)
-	// e.g. `less_than(status.latest_heartbeat.version, "19.0.2")`
-	spec.Functions["less_than"] = typical.BinaryFunction[*Environment](semverLt)
+	// e.g. `newer_than(status.latest_heartbeat.version, "19.0.0")`
+	spec.Functions["newer_than"] = typical.BinaryFunction[*Environment](semverGt)
+	// e.g. `older_than(status.latest_heartbeat.version, "19.0.2")`
+	spec.Functions["older_than"] = typical.BinaryFunction[*Environment](semverLt)
 	// e.g. `between(status.latest_heartbeat.version, "19.0.0", "19.0.2")`
 	spec.Functions["between"] = typical.TernaryFunction[*Environment](semverBetween)
-	// e.g. `equals(status.latest_heartbeat.version, "19.1.0")`
-	spec.Functions["equals"] = typical.BinaryFunction[*Environment](semverEq)
+	// e.g. `exact_version(status.latest_heartbeat.version, "19.1.0")`
+	spec.Functions["exact_version"] = typical.BinaryFunction[*Environment](semverEq)
 
 	return typical.NewParser[*Environment, bool](spec)
 }

--- a/lib/auth/machineid/machineidv1/expression/expression_test.go
+++ b/lib/auth/machineid/machineidv1/expression/expression_test.go
@@ -107,9 +107,9 @@ func TestBotInstanceExpressionParser(t *testing.T) {
 			},
 		},
 		{
-			name:     "version equals",
-			expTrue:  `equals(status.latest_heartbeat.version, "19.0.1")`,
-			expFalse: `equals(status.latest_heartbeat.version, "19.0.2-rc.1+56001")`,
+			name:     "exact version",
+			expTrue:  `exact_version(status.latest_heartbeat.version, "19.0.1")`,
+			expFalse: `exact_version(status.latest_heartbeat.version, "19.0.2-rc.1+56001")`,
 		},
 		{
 			name:     "between versions - lower",
@@ -122,14 +122,14 @@ func TestBotInstanceExpressionParser(t *testing.T) {
 			expFalse: `between(status.latest_heartbeat.version, "19.0.0", "19.0.1")`,
 		},
 		{
-			name:     "more than version",
-			expTrue:  `more_than(status.latest_heartbeat.version, "19.0.0")`,
-			expFalse: `more_than(status.latest_heartbeat.version, "19.0.1")`,
+			name:     "newer than version",
+			expTrue:  `newer_than(status.latest_heartbeat.version, "19.0.0")`,
+			expFalse: `newer_than(status.latest_heartbeat.version, "19.0.1")`,
 		},
 		{
-			name:     "less than version",
-			expTrue:  `less_than(status.latest_heartbeat.version, "19.0.2")`,
-			expFalse: `less_than(status.latest_heartbeat.version, "19.0.1")`,
+			name:     "older than version",
+			expTrue:  `older_than(status.latest_heartbeat.version, "19.0.2")`,
+			expFalse: `older_than(status.latest_heartbeat.version, "19.0.1")`,
 		},
 	}
 


### PR DESCRIPTION
## Summary
This change renames the `more_than`, `less_than` and `equal` predicate language functions used to filter bot instances, to be consistent with the flags available for `tctl inventory ls`.

It's a feature that is merged but has not been released, so there are no compatibility concerns.

Updates: https://github.com/gravitational/teleport/issues/57994
RFD: [0222](https://github.com/gravitational/teleport/pull/57888) (see _ Predicate language for instance filters_ section)

## Changes
- Rename `more_than` function to `newer_than`
- Rename `less_than` function to `older_than`
- Rename `equals` function to `exact_version`