### PR TITLE
fix: react-query mutation function signatures

### DIFF
--- a/web/packages/teleport/src/Bots/Edit/EditDialog.tsx
+++ b/web/packages/teleport/src/Bots/Edit/EditDialog.tsx
@@ -43,7 +43,7 @@ import {
 import Validation from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 
-import { editBot, fetchRoles } from 'teleport/services/bot/bot';
+import { editBotMutationFunction, fetchRoles } from 'teleport/services/bot/bot';
 import { FlatBot } from 'teleport/services/bot/types';
 import useTeleport from 'teleport/useTeleport';
 
@@ -82,7 +82,7 @@ export function EditDialog(props: {
     error: saveError,
     isPending: isSubmitting,
   } = useMutation({
-    mutationFn: editBot,
+    mutationFn: editBotMutationFunction,
     onSuccess: newData => {
       const key = createGetBotQueryKey({ botName: newData.name });
       queryClient.setQueryData(key, newData);

--- a/web/packages/teleport/src/lib/locks/useResourceLock.ts
+++ b/web/packages/teleport/src/lib/locks/useResourceLock.ts
@@ -21,8 +21,8 @@ import { useCallback } from 'react';
 
 import { LockResourceKind } from 'teleport/LocksV2/NewLock/common';
 import {
-  createLock,
-  deleteLock,
+  createLockMutationFn,
+  deleteLockMutationFn,
   listLocks,
 } from 'teleport/services/locks/locks';
 import { createQueryHook } from 'teleport/services/queryHelpers';
@@ -70,7 +70,7 @@ export function useResourceLock(opts: {
     isPending: unlockPending,
     error: unlockError,
   } = useMutation({
-    mutationFn: deleteLock,
+    mutationFn: deleteLockMutationFn,
     onSuccess: (_, vars) => {
       queryClient.setQueryData(listLocksQueryKey(queryVars), existingLocks => {
         return existingLocks?.filter(lock => lock.name !== vars.uuid);
@@ -83,7 +83,7 @@ export function useResourceLock(opts: {
     isPending: lockPending,
     error: lockError,
   } = useMutation({
-    mutationFn: createLock,
+    mutationFn: createLockMutationFn,
     onSuccess: newLock => {
       queryClient.setQueryData(listLocksQueryKey(queryVars), existingLocks => {
         return existingLocks ? [...existingLocks, newLock] : [newLock];
@@ -95,7 +95,7 @@ export function useResourceLock(opts: {
   // locks may affect other resources
   const canUnlock =
     hasRemovePermission &&
-    data &&
+    !!data &&
     data.length > 0 &&
     data.reduce(
       (acc, lock) =>

--- a/web/packages/teleport/src/services/bot/bot.ts
+++ b/web/packages/teleport/src/services/bot/bot.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MutationFunction } from '@tanstack/react-query';
+
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import {
@@ -139,6 +141,11 @@ export async function fetchRoles(
     signal
   );
 }
+
+export const editBotMutationFunction: MutationFunction<
+  FlatBot,
+  { botName: string; req: EditBotRequest }
+> = vars => editBot(vars);
 
 export async function editBot(
   variables: { botName: string; req: EditBotRequest },

--- a/web/packages/teleport/src/services/locks/locks.ts
+++ b/web/packages/teleport/src/services/locks/locks.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MutationFunction } from '@tanstack/react-query';
+
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
@@ -65,6 +67,13 @@ export async function listLocks(
   }
 }
 
+export const createLockMutationFn: MutationFunction<
+  Lock,
+  CreateLockRequest
+> = vars => {
+  return createLock(vars);
+};
+
 export async function createLock(
   variables: CreateLockRequest,
   signal?: AbortSignal
@@ -76,6 +85,13 @@ export async function createLock(
   );
   return makeLock(json);
 }
+
+export const deleteLockMutationFn: MutationFunction<
+  unknown,
+  { uuid: string }
+> = vars => {
+  return deleteLock(vars);
+};
 
 export async function deleteLock(
   variables: { uuid: string },


### PR DESCRIPTION
## Summary
This change fixes the signatures of mutation functions passed to react-query's `useMutation` hook. The second parameter to a mutationFn is a context object and not an AbortSignal - mutations do not support abort signals. A change in `@tanstack/react-query` v5.90.2 highlights this misuse as type errors.

This is not a user facing issue, at least not on our current version of react-query.

Blocks: https://github.com/gravitational/teleport/pull/59802

## Changes
- Type mutation functions explicitly using `MutationFunction<TData, TVariables>`
- Don't pass an abort signal to fetch