### PR TITLE
Update JWT introduction for header size configuration

### DIFF
--- a/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/introduction.mdx
@@ -134,7 +134,8 @@ By default, the `Teleport-Jwt-Assertion` header is sent along with every request
 upstream web application.
 
 In some circumstances, including this header can increase the total header size beyond the limits that the
-upstream web application can handle. If needed, you can disable this header on a per-app basis by setting
-`jwt_claims: none` under the `rewrite` configuration for the given application.
+upstream web application can handle. If needed, you can configure Teleport to omit
+this information from the JWT. This will result in a smaller JWT that is less
+likely to exceed the limit. Set `jwt_claims: none` under the `rewrite` configuration for the given application.
 
 You can [read more about the jwt_claims configuration here](../guides/connecting-apps.mdx#configuring-the-jwt-token).


### PR DESCRIPTION
Clarified the option to configure Teleport to omit JWT claims for smaller header size.

I mirrored the wording in another part of the docs that describes the behavior of setting `jwt_claims: none`. The old wording makes it sound like the JWT header will be _entirely_ omitted, which is incorrect.