### PR TITLE
Move ec2.go from lib/utils to lib/utils/aws

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -62,6 +62,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/tpm"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 var tracer = otel.Tracer("github.com/gravitational/teleport/lib/auth/join")
@@ -283,7 +284,7 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 					`(e.g. /var/lib/teleport/host_uuid)`,
 				params.ID.HostUUID)
 		}
-		params.ec2IdentityDocument, err = utils.GetRawEC2IdentityDocument(ctx)
+		params.ec2IdentityDocument, err = awsutils.GetRawEC2IdentityDocument(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/join_ec2.go
+++ b/lib/auth/join_ec2.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
@@ -281,7 +281,7 @@ func desktopServiceExists(ctx context.Context, presence services.Presence, hostI
 // clearly shows the combination in use since teleport maintains no long-term per-instance state.
 func (a *Server) tryToDetectIdentityReuse(ctx context.Context, req *types.RegisterUsingTokenRequest, iid *imds.InstanceIdentityDocument) error {
 	requestedHostID := req.HostID
-	expectedHostID := utils.NodeIDFromIID(iid)
+	expectedHostID := awsutils.NodeIDFromIID(iid)
 	if requestedHostID != expectedHostID {
 		return trace.AccessDenied("invalid host ID %q, expected %q", requestedHostID, expectedHostID)
 	}

--- a/lib/inventory/metadata/metadata.go
+++ b/lib/inventory/metadata/metadata.go
@@ -37,6 +37,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // Metadata contains the instance "system" metadata.
@@ -123,7 +124,7 @@ func (c *fetchConfig) setDefaults() {
 		c.fetchCloudMetadata = func(ctx context.Context, cloudEnvironment string) *types.CloudMetadata {
 			switch cloudEnvironment {
 			case "aws":
-				iid, err := utils.GetEC2InstanceIdentityDocument(ctx)
+				iid, err := aws.GetEC2InstanceIdentityDocument(ctx)
 				if err != nil {
 					return nil
 				}

--- a/lib/utils/aws/ec2.go
+++ b/lib/utils/aws/ec2.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package aws
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // GetRawEC2IdentityDocument fetches the PKCS7 RSA2048 InstanceIdentityDocument
@@ -42,7 +43,7 @@ func GetRawEC2IdentityDocument(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	iidBytes, err := ReadAtMost(output.Content, teleport.MaxHTTPResponseSize)
+	iidBytes, err := utils.ReadAtMost(output.Content, teleport.MaxHTTPResponseSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/utils/hostid/hostid.go
+++ b/lib/utils/hostid/hostid.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws"
 )
 
 const (
@@ -87,7 +88,7 @@ func Generate(ctx context.Context, joinMethod types.JoinMethod) (string, error) 
 		}
 		return rawID.String(), nil
 	case types.JoinMethodEC2:
-		hostUUID, err := utils.GetEC2NodeID(ctx)
+		hostUUID, err := aws.GetEC2NodeID(ctx)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}


### PR DESCRIPTION
As a result, lib/utils no longer has a dependency on aws-sdk-go.