### PR TITLE
Coordinate session ID with Node in Proxy recording mode

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -834,7 +834,7 @@ const (
 	// will generate and share their own session ID when a new session
 	// is started (session and exec/shell channels accepted).
 	//
-	// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+	// TODO(Joerger): DELETE IN v20.0.0
 	// All v17+ servers set the session ID. v19+ clients stop checking.
 	SessionIDQueryRequest = "session-id-query@goteleport.com"
 
@@ -842,7 +842,7 @@ const (
 	// will generate and share their own session ID when a new session
 	// channel is accepted, rather than when the shell/exec channel is.
 	//
-	// TODO(Joerger): DELETE IN v22.0.0 (1 extra major version grace period)
+	// TODO(Joerger): DELETE IN v21.0.0
 	// all v19+ servers set the session ID directly after accepting the session channel.
 	// clients should stop checking in v21, and servers should stop responding to the query in v22.
 	SessionIDQueryRequestV2 = "session-id-query-v2@goteleport.com"

--- a/constants.go
+++ b/constants.go
@@ -834,14 +834,17 @@ const (
 	// will generate and share their own session ID when a new session
 	// is started (session and exec/shell channels accepted).
 	//
-	// TODO(Joerger): DELETE IN v20.0.0 in favor of v2 below, which allows
-	// the client to know the session ID earlier, which is required for the
-	// proxy forwarding server to coordinate the session ID with target nodes.
+	// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+	// All v17+ servers set the session ID. v19+ clients stop checking.
 	SessionIDQueryRequest = "session-id-query@goteleport.com"
 
 	// SessionIDQueryRequestV2 is sent by clients to ask servers if they
 	// will generate and share their own session ID when a new session
-	// channel is accepted.
+	// channel is accepted, rather than when the shell/exec channel is.
+	//
+	// TODO(Joerger): DELETE IN v22.0.0 (1 extra major version grace period)
+	// all v19+ servers set the session ID directly after accepting the session channel.
+	// clients should stop checking in v21, and servers should stop responding to the query in v22.
 	SessionIDQueryRequestV2 = "session-id-query-v2@goteleport.com"
 
 	// ForceTerminateRequest is an SSH request to forcefully terminate a session.

--- a/constants.go
+++ b/constants.go
@@ -831,8 +831,18 @@ const (
 	CurrentSessionIDRequest = "current-session-id@goteleport.com"
 
 	// SessionIDQueryRequest is sent by clients to ask servers if they
-	// will generate their own session ID when a new session is created.
+	// will generate and share their own session ID when a new session
+	// is started (session and exec/shell channels accepted).
+	//
+	// TODO(Joerger): DELETE IN v20.0.0 in favor of v2 below, which allows
+	// the client to know the session ID earlier, which is required for the
+	// proxy forwarding server to coordinate the session ID with target nodes.
 	SessionIDQueryRequest = "session-id-query@goteleport.com"
+
+	// SessionIDQueryRequestV2 is sent by clients to ask servers if they
+	// will generate and share their own session ID when a new session
+	// channel is accepted.
+	SessionIDQueryRequestV2 = "session-id-query-v2@goteleport.com"
 
 	// ForceTerminateRequest is an SSH request to forcefully terminate a session.
 	ForceTerminateRequest = "x-teleport-force-terminate"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -600,7 +600,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 
 				// Ensure there are no duplicate events, e.g. from proxy recording mode.
 				require.Len(collect, sessionEvents, 4, "%d unexpected duplicate events", len(sessionEvents)-4)
-			}, 10*time.Second, 100*time.Millisecond)
+			}, 20*time.Second, 100*time.Millisecond)
 		})
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -582,24 +582,24 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 						events.SessionDataEvent,
 					},
 				})
-				require.NoError(t, err)
+				require.NoError(collect, err)
 
 				// Check that the events found above in the session stream show up in the backend.
-				require.True(t, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
+				require.True(collect, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
 					return ae.GetID() == start.GetID()
 				}), "expected session events to contain session.start event")
-				require.True(t, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
+				require.True(collect, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
 					return ae.GetID() == end.GetID()
 				}), "expected session events to contain session.end event")
-				require.True(t, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
+				require.True(collect, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
 					return ae.GetID() == leave.GetID()
 				}), "expected session events to contain session.leave event")
-				require.True(t, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
+				require.True(collect, slices.ContainsFunc(sessionEvents, func(ae apievents.AuditEvent) bool {
 					return ae.GetType() == events.SessionDataEvent
 				}), "expected session events to contain session.data event")
 
 				// Ensure there are no duplicate events, e.g. from proxy recording mode.
-				require.Len(t, sessionEvents, 4, "%d unexpected duplicate events", len(sessionEvents)-4)
+				require.Len(collect, sessionEvents, 4, "%d unexpected duplicate events", len(sessionEvents)-4)
 			}, 10*time.Second, 100*time.Millisecond)
 		})
 	}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -326,6 +326,12 @@ type ServerContext struct {
 	// the client of the to-be session ID.
 	newSessionID rsession.ID
 
+	// proxyShouldCreateSessionTracker indicates that a session tracker should be created
+	// for a proxy forwarded session because the node failed to report its session ID after
+	// a session channel request.
+	// TODO(Joerger): DELETE IN v21.0.0 - All v19+ nodes report session ID after session channel
+	proxyShouldCreateSessionTracker bool
+
 	// session holds the active session (if there's an active one).
 	session *session
 
@@ -697,6 +703,16 @@ func (c *ServerContext) GetSessionParams() tracessh.SessionParams {
 	}
 
 	return sessionParams
+}
+
+// proxyShouldCreateSessionTracker indicates that a session tracker should be created
+// for a proxy forwarded session because the node failed to report its session ID after
+// a session channel request.
+// TODO(Joerger): DELETE IN v21.0.0 - All v19+ nodes report session ID after session channel
+func (c *ServerContext) SetProxyShouldCreateSessionTracker() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.proxyShouldCreateSessionTracker = true
 }
 
 // SetNewSessionID sets the ID for a new session in this server context.

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -700,21 +700,10 @@ func (c *ServerContext) GetSessionParams() tracessh.SessionParams {
 }
 
 // SetNewSessionID sets the ID for a new session in this server context.
-func (c *ServerContext) SetNewSessionID(ctx context.Context, sid rsession.ID, ch ssh.Channel) {
+func (c *ServerContext) SetNewSessionID(ctx context.Context, sid rsession.ID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
 	c.newSessionID = sid
-
-	// inform the client of the session ID that is going to be used in a new
-	// goroutine to reduce latency.
-	go func() {
-		c.Logger.DebugContext(ctx, "Sending current session ID")
-		_, err := ch.SendRequest(teleport.CurrentSessionIDRequest, false, []byte(c.newSessionID))
-		if err != nil {
-			c.Logger.DebugContext(ctx, "Failed to send the current session ID", "error", err)
-		}
-	}()
 }
 
 // GetNewSessionID gets the ID for a new session in this server context.

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -705,7 +705,7 @@ func (c *ServerContext) GetSessionParams() tracessh.SessionParams {
 	return sessionParams
 }
 
-// proxyShouldCreateSessionTracker indicates that a session tracker should be created
+// SetProxyShouldCreateSessionTracker indicates that a session tracker should be created
 // for a proxy forwarded session because the node failed to report its session ID after
 // a session channel request.
 // TODO(Joerger): DELETE IN v21.0.0 - All v19+ nodes report session ID after session channel

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -734,7 +734,7 @@ func (c *ServerContext) SetNewSessionID(ctx context.Context, sid rsession.ID, ch
 }
 
 // GetNewSessionID gets the ID for a new session in this server context.
-func (c *ServerContext) GetNewSessionID(ctx context.Context) rsession.ID {
+func (c *ServerContext) GetNewSessionID() rsession.ID {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.newSessionID

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -901,8 +901,7 @@ func (c *ServerContext) reportStats(conn *utils.TrackingConn) {
 	// sessions are being recorded at the proxy (this would result in double
 	// events).
 	// Do not emit session data for git commands as they have their own events.
-	if c.GetServer().Component() == teleport.ComponentProxy ||
-		c.GetServer().Component() == teleport.ComponentForwardingGit {
+	if c.GetServer().Component() == teleport.ComponentForwardingGit {
 		return
 	}
 	if services.IsRecordAtProxy(c.SessionRecordingConfig.GetMode()) &&

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -944,7 +944,7 @@ func (c *ServerContext) reportStats(conn *utils.TrackingConn) {
 	serverRX.Add(float64(rxBytes))
 }
 
-// shouldHandleRecording returns whether this server context is responsible for
+// ShouldHandleRecording returns whether this server context is responsible for
 // recording session events, including session recording, audit events, and session tracking.
 func (c *ServerContext) ShouldHandleSessionRecording() bool {
 	// The only time this server is not responsible for recording the session is when this

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -322,7 +322,7 @@ type ServerContext struct {
 
 	// newSessionID is set if this server context is going to create a new session.
 	// This field must be set through [ServerContext.SetNewSessionID] for non-join
-	// sessions before as soon as a session channel is accepted in order to inform
+	// sessions as soon as a session channel is accepted in order to inform
 	// the client of the to-be session ID.
 	newSessionID rsession.ID
 
@@ -917,7 +917,8 @@ func (c *ServerContext) reportStats(conn *utils.TrackingConn) {
 	// sessions are being recorded at the proxy (this would result in double
 	// events).
 	// Do not emit session data for git commands as they have their own events.
-	if c.GetServer().Component() == teleport.ComponentForwardingGit {
+	if c.GetServer().Component() == teleport.ComponentProxy ||
+		c.GetServer().Component() == teleport.ComponentForwardingGit {
 		return
 	}
 	if services.IsRecordAtProxy(c.SessionRecordingConfig.GetMode()) &&

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -39,10 +39,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
-	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -102,10 +100,8 @@ func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
 		}, nil
 	}
 
-	// If this is a registered OpenSSH node or proxy recoding mode is
-	// enabled, execute the command on a remote host. This is used by
-	// in-memory forwarding nodes.
-	if types.IsOpenSSHNodeSubKind(ctx.ServerSubKind) || services.IsRecordAtProxy(ctx.SessionRecordingConfig.GetMode()) {
+	// If this is a forwarding node, execute the command on a remote host.
+	if ctx.srv.Component() == teleport.ComponentForwardingNode {
 		return &remoteExec{
 			ctx:     ctx,
 			command: command,

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -149,6 +149,7 @@ func newExecServerContext(t *testing.T, srv Server) *ServerContext {
 		term:     term,
 		emitter:  rec,
 		recorder: rec,
+		scx:      scx,
 	}
 	err = scx.SetSSHRequest(&ssh.Request{Type: sshutils.ExecRequest})
 	require.NoError(t, err)

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -969,7 +969,7 @@ func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 		}
 		// Pass request on unchanged.
 	case teleport.SessionIDQueryRequest:
-		// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+		// TODO(Joerger): DELETE IN v20.0.0
 		// All v17+ servers set the session ID. v19+ clients stop checking.
 
 		// Reply true to session ID query requests, we will set new
@@ -980,7 +980,7 @@ func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 		}
 		return
 	case teleport.SessionIDQueryRequestV2:
-		// TODO(Joerger): DELETE IN v22.0.0 (1 extra major version grace period)
+		// TODO(Joerger): DELETE IN v21.0.0
 		// clients should stop checking in v21, and servers should stop responding to the query in v22.
 
 		// Reply true to session ID query requests, we will set new
@@ -1177,7 +1177,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 	var receiveSessionIDOnce sync.Once
 	receivedSessionID := make(chan session.ID, 1)
 	if s.targetServer.GetSubKind() == types.SubKindTeleportNode {
-		// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+		// TODO(Joerger): DELETE IN v20.0.0
 		// all v19+ servers set the session ID directly after accepting the session channel.
 		// clients should stop checking in v21, and servers should stop responding to the query in v22.
 		willSendSID, _, err := s.remoteClient.SendRequest(ctx, teleport.SessionIDQueryRequestV2, true, nil)

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1264,7 +1264,6 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 		// outdated or an agentless node. Continue with a random session ID and ensure
 		// we create a new session tracker.
 		scx.SetNewSessionID(ctx, session.NewID(), ch)
-		scx.SetProxyShouldCreateSessionTracker()
 	}
 
 	ch = scx.TrackActivity(ch)

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1210,7 +1210,6 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 					}
 
 					newSessionIDFromServer <- *sid
-					close(newSessionIDFromServer)
 				})
 			})
 		} else {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1200,6 +1200,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 			})
 		} else {
 			receivedSessionID <- session.NewID()
+			scx.SetProxyShouldCreateSessionTracker()
 			close(receivedSessionID)
 			s.logger.WarnContext(ctx, "Failed to query session ID from target node. Ensure the targeted Teleport Node is upgraded to v19.0.0+ to avoid duplicate events due to mismatched session IDs.")
 		}

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -160,6 +160,7 @@ func newMockServer(t *testing.T) *mockServer {
 		datadir:             t.TempDir(),
 		MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
 		clock:               clock,
+		component:           teleport.ComponentNode,
 	}
 }
 

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -74,6 +75,7 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 	clusterName := "localhost"
 	_, connCtx := sshutils.NewConnectionContext(ctx, nil, &ssh.ServerConn{Conn: sshConn})
 	scx := &ServerContext{
+		newSessionID:           rsession.NewID(),
 		Logger:                 logtest.NewLogger(),
 		ConnectionContext:      connCtx,
 		env:                    make(map[string]string),

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -95,6 +95,9 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 		},
 		cancelContext: ctx,
 		cancel:        cancel,
+		// If proxy forwarding is being used (proxy recording, agentless), then remote session must be set.
+		// Otherwise, this field is ignored.
+		RemoteSession: mockSSHSession(t),
 	}
 
 	err = scx.SetExecRequest(&localExec{Ctx: scx})

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1297,6 +1297,9 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 			}
 		}
 	case teleport.SessionIDQueryRequest:
+		// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+		// All v17+ servers set the session ID. v19+ clients stop checking.
+
 		// Reply true to session ID query requests, we will set new
 		// session IDs for new sessions during the shel/exec channel
 		// request.
@@ -1305,6 +1308,9 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 		}
 		return
 	case teleport.SessionIDQueryRequestV2:
+		// TODO(Joerger): DELETE IN v22.0.0 (1 extra major version grace period)
+		// clients should stop checking in v21, and servers should stop responding to the query in v22.
+
 		// Reply true to session ID query requests, we will set new
 		// session IDs for new sessions directly after accepting the
 		// session channel request.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1297,7 +1297,7 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 			}
 		}
 	case teleport.SessionIDQueryRequest:
-		// TODO(Joerger): DELETE IN v21.0.0 (1 extra major version grace period)
+		// TODO(Joerger): DELETE IN v20.0.0
 		// All v17+ servers set the session ID. v19+ clients stop checking.
 
 		// Reply true to session ID query requests, we will set new
@@ -1308,7 +1308,7 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 		}
 		return
 	case teleport.SessionIDQueryRequestV2:
-		// TODO(Joerger): DELETE IN v22.0.0 (1 extra major version grace period)
+		// TODO(Joerger): DELETE IN v21.0.0
 		// clients should stop checking in v21, and servers should stop responding to the query in v22.
 
 		// Reply true to session ID query requests, we will set new

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1675,7 +1675,7 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 		// inform the client of the session ID that is going to be used in a new
 		// goroutine to reduce latency.
 		go func() {
-			s.logger.DebugContext(ctx, "Sending current session ID")
+			s.logger.DebugContext(ctx, "Sending current session ID", "sid", sid)
 			_, err := ch.SendRequest(teleport.CurrentSessionIDRequest, false, []byte(sid))
 			if err != nil {
 				s.logger.DebugContext(ctx, "Failed to send the current session ID", "error", err)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -3677,19 +3677,22 @@ func TestSessionParams(t *testing.T) {
 					require.NoError(t, err)
 					t.Cleanup(func() { require.NoError(t, se.Close()) })
 
+					// If this isn't a join session, wait for the server to send the session ID.
+					sid := baseCase.params.JoinSessionID
+					if sid == "" {
+						select {
+						case sid = <-sidC:
+						case <-time.After(time.Second):
+							t.Fatalf("Failed to received session ID from server")
+						}
+					}
+
 					if sessionCase.envVars != nil {
 						err := se.SetEnvs(ctx, sessionCase.envVars)
 						require.NoError(t, err)
 					}
 
 					require.NoError(t, se.Shell(ctx))
-
-					var sid string
-					select {
-					case sid = <-sidC:
-					case <-time.After(time.Second):
-						t.Fatalf("Failed to received session ID from server")
-					}
 
 					sessionTracker, err := f.ssh.srv.termHandlers.SessionRegistry.SessionTrackerService.GetSessionTracker(ctx, sid)
 					require.NoError(t, err)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -824,19 +824,11 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		return nil, nil, trace.BadParameter("session creation only supported in context of ssh access or proxying permit")
 	}
 
-	sid := scx.GetNewSessionID(ctx)
-	if sid == "" {
-		// Some flows (particularly tests) do not set the session ID ahead of time.
-		sid = rsession.NewID()
-		scx.SetNewSessionID(ctx, sid, ch)
-		r.logger.WarnContext(ctx, "newSessionID should be set prior to session creation. If this log is seen outside of tests, this is a bug.")
-	}
-
 	serverSessions.Inc()
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
-		ID:   sid,
+		ID:   scx.GetNewSessionID(),
 		TerminalParams: rsession.TerminalParams{
 			W: teleport.DefaultTerminalWidth,
 			H: teleport.DefaultTerminalHeight,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -366,7 +366,7 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	scx.setSession(ctx, sess, ch)
+	scx.setSession(ctx, sess)
 	s.addSession(sess)
 	scx.Logger.InfoContext(ctx, "Creating interactive session", "session_id", sess.id)
 
@@ -400,7 +400,7 @@ func (s *SessionRegistry) JoinSession(ctx context.Context, ch ssh.Channel, scx *
 		return trace.BadParameter("Unrecognized session participant mode: %q", mode)
 	}
 
-	scx.setSession(ctx, session, ch)
+	scx.setSession(ctx, session)
 
 	// Update the in-memory data structure that a party member has joined.
 	if err := session.join(ch, scx, mode); err != nil {
@@ -440,7 +440,7 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 
 	// Start a non-interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
-	scx.setSession(ctx, sess, channel)
+	scx.setSession(ctx, sess)
 
 	err = sess.startExec(ctx, channel, scx)
 	if err != nil {
@@ -828,7 +828,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
-		ID:   rsession.NewID(),
+		ID:   scx.GetSetNewSessionID(ctx, ch),
 		TerminalParams: rsession.TerminalParams{
 			W: teleport.DefaultTerminalWidth,
 			H: teleport.DefaultTerminalHeight,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -824,11 +824,16 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		return nil, nil, trace.BadParameter("session creation only supported in context of ssh access or proxying permit")
 	}
 
+	sid := scx.GetNewSessionID(ctx)
+	if sid == "" {
+		return nil, nil, trace.BadParameter("newSessionID should be set prior to session creation")
+	}
+
 	serverSessions.Inc()
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
 		Kind: types.SSHSessionKind,
-		ID:   scx.GetSetNewSessionID(ctx, ch),
+		ID:   sid,
 		TerminalParams: rsession.TerminalParams{
 			W: teleport.DefaultTerminalWidth,
 			H: teleport.DefaultTerminalHeight,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1540,12 +1540,13 @@ func (s *session) startTerminal(ctx context.Context, scx *ServerContext) error {
 
 	// allocate a terminal or take the one previously allocated via a
 	// separate "allocate TTY" SSH request
-	var err error
 	if s.term = scx.GetTerm(); s.term != nil {
 		scx.SetTerm(nil)
-	} else if s.term, err = NewTerminal(scx); err != nil {
+	} else if term, err := NewTerminal(scx); err != nil {
 		s.logger.InfoContext(ctx, "Unable to allocate new terminal.", "error", err)
 		return trace.Wrap(err)
+	} else {
+		s.term = term
 	}
 
 	if err := s.term.Run(ctx); err != nil {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -826,7 +826,10 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 
 	sid := scx.GetNewSessionID(ctx)
 	if sid == "" {
-		return nil, nil, trace.BadParameter("newSessionID should be set prior to session creation")
+		// Some flows (particularly tests) do not set the session ID ahead of time.
+		sid = rsession.NewID()
+		scx.SetNewSessionID(ctx, sid, ch)
+		r.logger.WarnContext(ctx, "newSessionID should be set prior to session creation. If this log is seen outside of tests, this is a bug.")
 	}
 
 	serverSessions.Inc()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -911,7 +911,7 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		return nil, nil, trace.Wrap(err)
 	}
 
-	sess.recorder, err = newRecorder(sess, scx)
+	sess.recorder, err = newRecorder(sess, scx, sessType)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -1559,7 +1559,7 @@ func (s *session) startTerminal(ctx context.Context, scx *ServerContext) error {
 
 // newRecorder creates a new [events.SessionPreparerRecorder] to be used as the recorder
 // of the passed in session.
-func newRecorder(s *session, ctx *ServerContext) (events.SessionPreparerRecorder, error) {
+func newRecorder(s *session, ctx *ServerContext, sessType sessionType) (events.SessionPreparerRecorder, error) {
 	// determine session recording mode. in theory we could choose to only do this in the unhappy
 	// path since thats the only place we use it, but we do it here to ensure that any test coverage
 	// we have for this code will always enforce its permit requirements.
@@ -1580,7 +1580,7 @@ func newRecorder(s *session, ctx *ServerContext) (events.SessionPreparerRecorder
 	}
 
 	// Don't record non-interactive sessions when enhanced recording is disabled.
-	if ctx.GetTerm() == nil && !ctx.srv.GetBPF().Enabled() {
+	if sessType == sessionTypeNonInteractive && !ctx.srv.GetBPF().Enabled() {
 		return events.WithNoOpPreparer(events.NewDiscardRecorder()), nil
 	}
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -2391,7 +2391,7 @@ func (s *session) trackSession(ctx context.Context, teleportUser string, policyS
 	// - this is a non-interactive session
 	// - the session was initiated by a bot
 	svc := s.registry.SessionTrackerService
-	if (s.registry.Srv.Component() == teleport.ComponentForwardingNode && !s.registry.Srv.GetInfo().IsOpenSSHNode()) ||
+	if (s.registry.Srv.Component() == teleport.ComponentForwardingNode && !s.registry.Srv.GetInfo().IsOpenSSHNode() && !s.scx.proxyShouldCreateSessionTracker) ||
 		sessType == sessionTypeNonInteractive ||
 		s.scx.Identity.BotName != "" {
 		svc = nil

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -949,7 +949,7 @@ func TestTrackingSession(t *testing.T) {
 			interactive:   true,
 			assertion:     require.NoError,
 			createAssertion: func(t *testing.T, count int) {
-				require.Equal(t, 1, count)
+				require.Equal(t, 0, count)
 			},
 		},
 		{
@@ -963,23 +963,23 @@ func TestTrackingSession(t *testing.T) {
 			},
 		},
 		{
-			name:          "proxy with proxy recording mode",
+			name:          "forwarding node with proxy recording mode",
 			component:     teleport.ComponentForwardingNode,
 			recordingMode: types.RecordAtProxy,
 			interactive:   true,
 			assertion:     require.NoError,
 			createAssertion: func(t *testing.T, count int) {
-				require.Equal(t, 0, count)
+				require.Equal(t, 1, count)
 			},
 		},
 		{
-			name:          "proxy with node recording mode",
+			name:          "forwarding node with node recording mode (agentless)",
 			component:     teleport.ComponentForwardingNode,
 			recordingMode: types.RecordAtNode,
 			interactive:   true,
 			assertion:     require.NoError,
 			createAssertion: func(t *testing.T, count int) {
-				require.Equal(t, 0, count)
+				require.Equal(t, 1, count)
 			},
 		},
 		{

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -949,7 +949,7 @@ func TestTrackingSession(t *testing.T) {
 			interactive:   true,
 			assertion:     require.NoError,
 			createAssertion: func(t *testing.T, count int) {
-				require.Equal(t, 0, count)
+				require.Equal(t, 1, count)
 			},
 		},
 		{
@@ -969,7 +969,7 @@ func TestTrackingSession(t *testing.T) {
 			interactive:   true,
 			assertion:     require.NoError,
 			createAssertion: func(t *testing.T, count int) {
-				require.Equal(t, 1, count)
+				require.Equal(t, 0, count)
 			},
 		},
 		{

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -964,7 +964,7 @@ func TestTrackingSession(t *testing.T) {
 		},
 		{
 			name:          "proxy with proxy recording mode",
-			component:     teleport.ComponentProxy,
+			component:     teleport.ComponentForwardingNode,
 			recordingMode: types.RecordAtProxy,
 			interactive:   true,
 			assertion:     require.NoError,
@@ -974,7 +974,7 @@ func TestTrackingSession(t *testing.T) {
 		},
 		{
 			name:          "proxy with node recording mode",
-			component:     teleport.ComponentProxy,
+			component:     teleport.ComponentForwardingNode,
 			recordingMode: types.RecordAtNode,
 			interactive:   true,
 			assertion:     require.NoError,
@@ -1186,7 +1186,7 @@ func TestCloseProxySession(t *testing.T) {
 	ctx := t.Context()
 
 	srv := newMockServer(t)
-	srv.component = teleport.ComponentProxy
+	srv.component = teleport.ComponentForwardingNode
 
 	reg, err := NewSessionRegistry(SessionRegistryConfig{
 		Srv:                   srv,
@@ -1233,7 +1233,7 @@ func TestCloseRemoteSession(t *testing.T) {
 	ctx := t.Context()
 
 	srv := newMockServer(t)
-	srv.component = teleport.ComponentProxy
+	srv.component = teleport.ComponentForwardingNode
 
 	// init a session registry
 	reg, _ := NewSessionRegistry(SessionRegistryConfig{

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -38,8 +38,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 )
 
@@ -120,7 +118,7 @@ func NewTerminal(ctx *ServerContext) (Terminal, error) {
 
 	// If this is not a Teleport node, find out what mode the cluster is in and
 	// return the correct terminal.
-	if types.IsOpenSSHNodeSubKind(ctx.ServerSubKind) || services.IsRecordAtProxy(ctx.SessionRecordingConfig.GetMode()) {
+	if ctx.srv.Component() == teleport.ComponentForwardingNode {
 		return newRemoteTerminal(ctx)
 	}
 	return newLocalTerminal(ctx)

--- a/lib/sshutils/utils.go
+++ b/lib/sshutils/utils.go
@@ -19,12 +19,20 @@
 package sshutils
 
 import (
+	"context"
+	"log/slog"
 	"net"
 	"strconv"
+	"sync/atomic"
+	"time"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
+
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -61,4 +69,85 @@ func NewSSHConnMetadataWithUser(conn ssh.ConnMetadata, user string) SSHConnMetad
 // User returns the user ID for this connection.
 func (s SSHConnMetadataWithUser) User() string {
 	return s.user
+}
+
+// SessionIDStatus indicates whether the session ID was received from
+// the server or not, and if not why
+type SessionIDStatus int
+
+const (
+	// SessionIDReceived indicates the the session ID was received
+	SessionIDReceived SessionIDStatus = iota + 1
+	// SessionIDNotSent indicates that the server set the session ID
+	// but didn't send it to us
+	SessionIDNotSent
+	// SessionIDNotModified indicates that the server used the session
+	// ID that was set by us
+	SessionIDNotModified
+)
+
+// PrepareToReceiveSessionID configures the TeleportClient to listen for
+// the server to send the session ID it's using. The returned function
+// will return the current session ID from the server or a reason why
+// one wasn't received.
+func PrepareToReceiveSessionID(ctx context.Context, log *slog.Logger, client *tracessh.Client) func() (session.ID, SessionIDStatus) {
+	// send the session ID received from the server
+	var gotSessionID atomic.Bool
+	sessionIDFromServer := make(chan session.ID, 1)
+
+	client.HandleSessionRequest(ctx, teleport.CurrentSessionIDRequest, func(ctx context.Context, req *ssh.Request) {
+		// only handle the first session ID request
+		if gotSessionID.Load() {
+			return
+		}
+
+		sid, err := session.ParseID(string(req.Payload))
+		if err != nil {
+			log.WarnContext(ctx, "Unable to parse session ID", "error", err)
+			return
+		}
+
+		if gotSessionID.CompareAndSwap(false, true) {
+			sessionIDFromServer <- *sid
+		}
+	})
+
+	// If the session is about to close and we haven't received a session
+	// ID yet, ask if the server even supports sending one. Send the
+	// request in a new goroutine so session establishment won't be
+	// blocked on making this request
+	serverWillSetSessionID := make(chan bool, 1)
+	go func() {
+		resp, _, err := client.SendRequest(ctx, teleport.SessionIDQueryRequest, true, nil)
+		if err != nil {
+			log.WarnContext(ctx, "Failed to send session ID query request", "error", err)
+			serverWillSetSessionID <- false
+		} else {
+			serverWillSetSessionID <- resp
+		}
+	}()
+
+	waitForSessionID := func() (session.ID, SessionIDStatus) {
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+
+		for {
+			select {
+			case sessionID := <-sessionIDFromServer:
+				return sessionID, SessionIDReceived
+			case sessionIDIsComing := <-serverWillSetSessionID:
+				if !sessionIDIsComing {
+					return "", SessionIDNotModified
+				}
+				// the server will send the session ID, continue
+				// waiting for it
+			case <-ctx.Done():
+				return "", SessionIDNotSent
+			case <-timer.C:
+				return "", SessionIDNotSent
+			}
+		}
+	}
+
+	return waitForSessionID
 }

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -29,7 +29,6 @@ import (
 	"net"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -58,7 +57,6 @@ import (
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/session"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -1327,83 +1325,4 @@ func (c *remoteClientCache) Close() error {
 	c.clients = nil
 
 	return trace.NewAggregate(errors...)
-}
-
-// sessionIDStatus indicates whether the session ID was received from
-// the server or not, and if not why
-type sessionIDStatus int
-
-const (
-	// sessionIDReceived indicates the the session ID was received
-	sessionIDReceived sessionIDStatus = iota + 1
-	// sessionIDNotSent indicates that the server set the session ID
-	// but didn't send it to us
-	sessionIDNotSent
-	// sessionIDNotModified indicates that the server used the session
-	// ID that was set by us
-	sessionIDNotModified
-)
-
-// prepareToReceiveSessionID configures the TeleportClient to listen for
-// the server to send the session ID it's using. The returned function
-// will return the current session ID from the server or a reason why
-// one wasn't received.
-func prepareToReceiveSessionID(ctx context.Context, log *slog.Logger, nc *client.NodeClient) func() (session.ID, sessionIDStatus) {
-	// send the session ID received from the server
-	var gotSessionID atomic.Bool
-	sessionIDFromServer := make(chan session.ID, 1)
-
-	nc.Client.HandleSessionRequest(ctx, teleport.CurrentSessionIDRequest, func(ctx context.Context, req *ssh.Request) {
-		// only handle the first session ID request
-		if gotSessionID.Load() {
-			return
-		}
-
-		sid, err := session.ParseID(string(req.Payload))
-		if err != nil {
-			log.WarnContext(ctx, "Unable to parse session ID", "error", err)
-			return
-		}
-
-		if gotSessionID.CompareAndSwap(false, true) {
-			sessionIDFromServer <- *sid
-		}
-	})
-
-	// If the session is about to close and we haven't received a session
-	// ID yet, ask if the server even supports sending one. Send the
-	// request in a new goroutine so session establishment won't be
-	// blocked on making this request
-	serverWillSetSessionID := make(chan bool, 1)
-	go func() {
-		resp, _, err := nc.Client.SendRequest(ctx, teleport.SessionIDQueryRequest, true, nil)
-		if err != nil {
-			log.WarnContext(ctx, "Failed to send session ID query request", "error", err)
-			serverWillSetSessionID <- false
-		} else {
-			serverWillSetSessionID <- resp
-		}
-	}()
-
-	return func() (session.ID, sessionIDStatus) {
-		timer := time.NewTimer(10 * time.Second)
-		defer timer.Stop()
-
-		for {
-			select {
-			case sessionID := <-sessionIDFromServer:
-				return sessionID, sessionIDReceived
-			case sessionIDIsComing := <-serverWillSetSessionID:
-				if !sessionIDIsComing {
-					return session.ID(""), sessionIDNotModified
-				}
-				// the server will send the session ID, continue
-				// waiting for it
-			case <-ctx.Done():
-				return session.ID(""), sessionIDNotSent
-			case <-timer.C:
-				return session.ID(""), sessionIDNotSent
-			}
-		}
-	}
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -843,7 +843,7 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 		writeSessionCtx, writeSessionCancel := context.WithCancel(ctx)
 		defer writeSessionCancel()
 
-		waitForSessionID := libsshutils.PrepareToReceiveSessionID(writeSessionCtx, t.logger, nc.Client)
+		waitForSessionID := libsshutils.PrepareToReceiveSessionID(writeSessionCtx, t.logger, nc.Client, false)
 
 		// wait in a new goroutine because the server won't set a
 		// session ID until we start the session.

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -847,6 +847,8 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 
 		// wait in a new goroutine because the server won't set a
 		// session ID until we start the session.
+		// Note: before v19.0.0, the session ID isn't set until during
+		// the shell request, rather than right after the session request.
 		go func() {
 			defer close(sessionDataSent)
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -861,6 +861,8 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 		// wait in a new goroutine because the server won't set a
 		// session ID until we start the session.
 		go func() {
+			defer close(sessionDataSent)
+
 			ctx, cancel := context.WithTimeout(writeSessionCtx, 10*time.Second)
 			defer cancel()
 


### PR DESCRIPTION
Changelog: Fix a bug in Proxy recording mode where Teleport Node sessions would result in duplicate audit events with a different session ID.

### Details

<details>
<summary>Overview</summary>

When Proxy recording mode is enabled, Teleport Node sessions consist of two actual SSH server sessions - one in an ephemeral Proxy Forwarding Node, and one on the Teleport Node. Currently, these two sessions are handled separately and mistakenly share the same responsibilities, resulting in duplicate audit events and session trackers with mismatched session IDs.

This PR introduces two primary changes to fix the above issue:
- Coordinate the session ID between the Teleport Node and the Proxy Forwarding Node sessions.
- Properly delegate session recording responsibilities to the forwarding Node:
  - recording the session
  - emitting audit events
  - creating the session tracker backend resource
- Add "session-id-query-v2@goteleport.com" global server request. See the flow and backwards compatibility sections below for details.

</details>

<details>
<summary>Session ID coordination flow</summary>

In v17+ servers, the current session ID is sent to the client after a session is started. However, a session is not "started" until the shell/exec request is handled. By this time, the Forwarding Node has already created its own session with a unique ID and made decisions about whether to create a session tracker, emit events, etc.

```mermaid
sequenceDiagram
  participant Client
  participant Proxy
  participant Forwarding Node
  participant Teleport Node

  Client ->> Proxy: ssh Dial
  Proxy ->> Forwarding Node: Create new ephemeral Forwarding Node and forward connection
  Client ->> Forwarding Node: ssh "session" channel request
  Forwarding Node ->> Teleport Node: ssh "session" channel request
  Teleport Node ->> Forwarding Node: Accept session channel
  Forwarding Node ->> Client: Accept session channel
  Client ->> Forwarding Node: ssh "shell" channel request
  Note over Forwarding Node: Start session (set ID, create tracker, start recorder, emit events)
  Forwarding Node ->> Client: send "current-session-id@goteleport.com"
  Forwarding Node ->> Teleport Node: ssh "shell" channel request
  Note over Teleport Node: Start session (set ID, create tracker, start terminal, emit events)
  Teleport Node ->> Forwarding Node: send "current-session-id@goteleport.com"
  Client <<->> Teleport Node: Forwarded shell session success
```

In the new flow, the session ID is set and sent to the client as soon as the "session" channel is handled. This allows the Forwarding Node to save the session ID and use it when the session is started. Now that the session ID is shared by both server sessions, session responsibilities are properly delegated without any mismatches or duplicates.

Note that in the new flow, the Forwarding Node does not accept the session channel until it receives the current session ID from the Teleport Node. In order to determine whether the session ID will be sent, the Forwarding Node must determine whether the current session ID will actually be sent.  only waits for the session ID to be sent if it receives a reply with the `session-id-query-v2@goteleport.com` request.

```mermaid
sequenceDiagram
  participant Client
  participant Proxy
  participant Forwarding Node
  participant Teleport Node

  Client ->> Proxy: ssh Dial
  Proxy ->> Forwarding Node: Create new ephemeral Forwarding Node and forward connection
  Client ->> Forwarding Node: ssh "session" channel request
  Forwarding Node ->> Teleport Node: ssh "session" channel request
  Teleport Node ->> Forwarding Node: Accept session channel and set session ID
  Forwarding Node ->> Teleport Node: send "session-id-query-v2@goteleport.com" request
  Note over Forwarding Node: If the above query returns true, wait for the current session ID. Otherwise, set new session ID
  Teleport Node ->> Forwarding Node: send "current-session-id@goteleport.com"
  Forwarding Node ->> Client: Accept session channel
  Forwarding Node ->> Client: send "current-session-id@goteleport.com"
  Client ->> Forwarding Node: ssh "shell" channel request
  Note over Forwarding Node: Start session (start terminal, start recorder, emit events)
  Forwarding Node ->> Teleport Node: ssh "shell" channel request
  Note over Teleport Node: Start session (create tracker, start terminal)
  Client <<->> Teleport Node: Forwarded shell session success
```

</details>

<details>
<summary>Backwards Compatibility</summary>

This change is backwards compatible in the sense that if either the Node or Proxy is outdated, every session responsibility will still be delegated to at least one of the two services. However, the outdated component may still result in duplicate and mismatched audit events and session trackers:
- An outdated Node will not send the session ID in time for the Forwarding Node to use it. As a result, the Proxy will create its own session ID and its own session tracker. The node will continue to emit audit events with the mismatched session ID.
- An outdated Proxy will not use the session ID sent by the Teleport Node. It will also continue to create a session tracker, resulting in a duplicate session tracker that doesn't match the Teleport Node session ID. However, only the proxy will emit audit events and these events will match the session ID of the session recording.

To enable the above, this PR introduces the "session-id-query-v2@goteleport.com" global server request. The Forwarding Node sends this request to determine whether it should wait for the Teleport Node to send the current session ID. If the Teleport Node does not reply to this request (old Teleport Node), the Forwarding Node will continue with its own session ID like it does currently.

Note that the original "session-id-query@goteleport.com" has been marked for deletion in v20, and "session-id-query-v2@goteleport.com" is marked for deletion in v21. If extended backwards compatibility is a concern (> 1 major version), servers can continue to reply for an additional major version or even though no v19+/v20+ client (respectively) will send the query.

</details>

<details>
<summary>Manual Tests</summary>

Last run: (292d06481de838ddb075090e413fa27b71a7db09)
- [x] Proxy recording mode:
  - [x] Teleport Node
    - [x] Start a session and use `teleport status` to get the session ID. it should appear in the session list (e.g. `tsh session ls`).
    - [x] End the session. Observe session `start`, `end`, `data`, and `leave` events are emitted with the same session ID.
      - [x] No duplicate events
      - [x] these events should have the `forwarded_by` and `recording_mode: proxy` fields.
  - [x] Agentless Node
     - [x] Start a session and use `teleport status` to get the session ID. it should appear in the session list (e.g. `tsh session ls`).
    - [x] End the session. Observe session `start`, `end`, `data`,  and `leave` events are emitted with the same session ID.
      - [x] these events should have the `forwarded_by` and `recording_mode: proxy` fields.
- [x] Node recording mode:
  - [x] Teleport Node
    - [x] Start a session and use `teleport status` to get the session ID. it should appear in the session list (e.g. `tsh session ls`).
    - [x] End the session. Observe session `start`, `end`, `data`, , and `leave` events are emitted with the same session ID.
      - [x] these events should **not** have the `forwarded_by` and `recording_mode: proxy` fields.
  - [x] Agentless Node
     - [x] Start a session and use `teleport status` to get the session ID. it should appear in the session list (e.g. `tsh session ls`).
    - [x] End the session. Observe session `start`, `end`, `data`, and `leave` events are emitted with the same session ID.
      - [x] these events should have the `forwarded_by` and `recording_mode: proxy` fields.


Backwards compatibility:
| Proxy | Node | Mismatched ID w/ tracker | Duplicate events |  ✅  |
|------|-------|------|------|-------|
| new | new | no | no  | ✅ |
| new | old  | no | yes | ✅ |
| old  | new | yes | no  | ✅ |
| old  | old   | yes | yes | ✅ |

</details>

Depends on https://github.com/gravitational/teleport/pull/59206

Fixes https://github.com/gravitational/teleport/issues/42263, https://github.com/gravitational/teleport/issues/20063