### PR TITLE
[v18] teleport-usage: Bump golang docker image to 1.24

### DIFF
--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.24-bookworm AS builder
 
 WORKDIR /go/src/github.com/gravitational/teleport/examples/teleport-usage
 


### PR DESCRIPTION
Bump the golang docker image for `examples/teleport-usage` from 1.22 to
1.24. Commit 477eb046f13d5 updated `go.mod` to 1.24 and now the
`build-usage-image.yaml` workflow fails with the error:

    go: go.mod requires go >= 1.24.6 (running go 1.22.12; GOTOOLCHAIN=local)

Backport: https://github.com/gravitational/teleport/pull/58191

---

This is a belated backport because I keep thinking post-release
workflows run on master and these things don't need to be backported. I
was wrong.
