### PR TITLE
Use cache for ProvisionToken resource access in AWS OIDC deploy service

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -197,6 +197,9 @@ type ReadProxyAccessPoint interface {
 	// GetUIConfig returns configuration for the UI served by the proxy service
 	GetUIConfig(ctx context.Context) (types.UIConfig, error)
 
+	// GetToken finds and returns token by ID
+	GetToken(ctx context.Context, token string) (types.ProvisionToken, error)
+
 	// GetRole returns role by name
 	GetRole(ctx context.Context, name string) (types.Role, error)
 
@@ -330,6 +333,9 @@ type ReadProxyAccessPoint interface {
 	GetRelayServer(ctx context.Context, name string) (*presencev1.RelayServer, error)
 	// ListRelayServers returns a paginated list of relay server heartbeats.
 	ListRelayServers(ctx context.Context, pageSize int, pageToken string) (_ []*presencev1.RelayServer, nextPageToken string, _ error)
+
+	// ListIntegrations returns a paginated list of all integration resources.
+	ListIntegrations(ctx context.Context, pageSize int, nextToken string) ([]types.Integration, string, error)
 }
 
 // SnowflakeSessionWatcher is watcher interface used by Snowflake web session watcher.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5787,7 +5787,8 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	integrationAWSOIDCServiceServer, err := integrationv1.NewAWSOIDCService(&integrationv1.AWSOIDCServiceConfig{
 		Authorizer:            cfg.Authorizer,
 		IntegrationService:    integrationServiceServer,
-		Cache:                 cfg.AuthServer,
+		Cache:                 cfg.AuthServer.Cache,
+		TokenCreator:          cfg.AuthServer,
 		ProxyPublicAddrGetter: cfg.AuthServer.getProxyPublicAddr,
 		Clock:                 cfg.AuthServer.clock,
 	})

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -216,12 +216,14 @@ func TestRBAC(t *testing.T) {
 
 	_, err = localClient.CreateIntegration(ctx, ig)
 	require.NoError(t, err)
+	backend := &mockCache{}
 
 	awsoidService, err := NewAWSOIDCService(&AWSOIDCServiceConfig{
 		IntegrationService:    resourceSvc,
 		Authorizer:            resourceSvc.authorizer,
 		ProxyPublicAddrGetter: func() string { return "128.0.0.1" },
-		Cache:                 &mockCache{},
+		Cache:                 backend,
+		TokenCreator:          backend,
 	})
 	require.NoError(t, err)
 

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -325,21 +325,22 @@ type DeployServiceClient interface {
 type defaultDeployServiceClient struct {
 	CallerIdentityGetter
 	*ecs.Client
-	tokenServiceClient TokenService
+	tokenGetter  TokenGetter
+	tokenCreator TokenCreator
 }
 
 // GetToken returns a provision token by name.
 func (d *defaultDeployServiceClient) GetToken(ctx context.Context, name string) (types.ProvisionToken, error) {
-	return d.tokenServiceClient.GetToken(ctx, name)
+	return d.tokenGetter.GetToken(ctx, name)
 }
 
 // UpsertToken creates or updates a provision token.
 func (d *defaultDeployServiceClient) UpsertToken(ctx context.Context, token types.ProvisionToken) error {
-	return d.tokenServiceClient.UpsertToken(ctx, token)
+	return d.tokenCreator.UpsertToken(ctx, token)
 }
 
 // NewDeployServiceClient creates a new DeployServiceClient using a AWSClientRequest.
-func NewDeployServiceClient(ctx context.Context, clientReq *AWSClientRequest, tokenServiceClient TokenService) (DeployServiceClient, error) {
+func NewDeployServiceClient(ctx context.Context, clientReq *AWSClientRequest, tokenGetter TokenGetter, tokenCreator TokenCreator) (DeployServiceClient, error) {
 	ecsClient, err := newECSClient(ctx, clientReq)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -353,7 +354,8 @@ func NewDeployServiceClient(ctx context.Context, clientReq *AWSClientRequest, to
 	return &defaultDeployServiceClient{
 		Client:               ecsClient,
 		CallerIdentityGetter: stsClient,
-		tokenServiceClient:   tokenServiceClient,
+		tokenGetter:          tokenGetter,
+		tokenCreator:         tokenCreator,
 	}, nil
 }
 

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken.go
@@ -39,9 +39,18 @@ const (
 
 // TokenService defines the required methods to upsert the Provision Token used by the Deploy Service.
 type TokenService interface {
+	TokenGetter
+	TokenCreator
+}
+
+// TokenGetter defines the required method to get a Provision Token.
+type TokenGetter interface {
 	// GetToken returns a provision token by name.
 	GetToken(ctx context.Context, name string) (types.ProvisionToken, error)
+}
 
+// TokenCreator defines the required method to create or update a Provision Token.
+type TokenCreator interface {
 	// UpsertToken creates or updates a provision token.
 	UpsertToken(ctx context.Context, token types.ProvisionToken) error
 }

--- a/lib/integrations/awsoidc/deployservice_vcr_test.go
+++ b/lib/integrations/awsoidc/deployservice_vcr_test.go
@@ -134,7 +134,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		resp, err := DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -151,7 +151,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		resp, err := DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -168,7 +168,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		_, err = DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -180,7 +180,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		resp, err := DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -197,7 +197,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		resp, err := DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -214,7 +214,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		_, err = DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -226,7 +226,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		_, err = DeployService(ctx, clt, deployServiceReqFunc("cluster1002"))
@@ -238,7 +238,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		resp, err := DeployService(ctx, clt, deployServiceReqFunc("tenant-a.teleport.sh"))
@@ -255,7 +255,7 @@ func TestDeployDBService(t *testing.T) {
 		defer r.Stop()
 
 		awsClientRecorder := awsClientReqFunc(r.GetDefaultClient())
-		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore)
+		clt, err := NewDeployServiceClient(ctx, awsClientRecorder, &tokenStore, &tokenStore)
 		require.NoError(t, err)
 
 		deployReq := deployServiceReqFunc("marco-test.teleport.sh")

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4291,10 +4291,6 @@ func (process *TeleportProcess) initProxy() error {
 
 		return nil
 	})
-	process.RegisterFunc("update.aws-oidc.deploy.service", func() error {
-		err := process.initAWSOIDCDeployServiceUpdater(process.Config.Proxy.AutomaticUpgradesChannels)
-		return trace.Wrap(err)
-	})
 	return nil
 }
 
@@ -5961,6 +5957,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			})
 		}
 	}
+
+	process.RegisterFunc("update.aws-oidc.deploy.service", func() error {
+		err := process.initAWSOIDCDeployServiceUpdater(process.Config.Proxy.AutomaticUpgradesChannels, accessPoint)
+		return trace.Wrap(err)
+	})
 
 	return nil
 }


### PR DESCRIPTION
The AWS OIDC Service was not using the cache for listing ProvisionTokens.

All reads must use cache.