### PR TITLE
docs: Clarify Per-Session MFA limitations for OpenSSH clients

### DIFF
--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -228,8 +228,7 @@ window, a new MFA check will be requested for new connections.
 
 Current limitations for this feature are:
 
-- For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
-  (The OpenSSH `ssh` client does not work with per-session MFA).
+- VNet SSH must be used for per-session MFA when using an OpenSSH client (`ssh`, `scp`).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
 - For desktop access, only WebAuthn devices are supported.
 - When accessing a


### PR DESCRIPTION
The page was never updated to reflect that Per-Session MFA is now possible with OpenSSH clients if using VNet SSH.