### PR TITLE
heal instance identity by re-joining via new join service

### DIFF
--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -50,7 +50,10 @@ func Join(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	if err := params.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if params.ID.HostUUID != "" {
+	if params.AuthClient == nil && params.ID.HostUUID != "" {
+		// This check is skipped if AuthClient is provided because this is a
+		// re-join with an existing identity and the HostUUID will be
+		// maintained.
 		return nil, trace.BadParameter("HostUUID must not be provided to Join, it will be assigned by the Auth server")
 	}
 	if params.ID.Role != types.RoleInstance && params.ID.Role != types.RoleBot {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1057,13 +1057,6 @@ func TestInstanceSelfRepair(t *testing.T) {
 	// the previous Instance and Proxy certs, but enable the SSH service and
 	// provide the token that allows only role Node.
 	process = newStartedProcess(sshToken.GetName(), true)
-	// Wait for the TeleportCredentialsUpdatedEvent which will be emitted after
-	// the rotation logic detects the dangling system role and repairs the
-	// Instance identity.
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
-	_, err = process.WaitForEvent(ctx, TeleportCredentialsUpdatedEvent)
-	require.NoError(t, err)
 	// Get the new Instance identity and make sure it includes both the Proxy
 	// and Node system roles.
 	instanceConnector, err := process.WaitForConnector(InstanceIdentityEvent, logger)
@@ -1072,6 +1065,12 @@ func TestInstanceSelfRepair(t *testing.T) {
 	instanceID := instanceConnector.clientState.Load().identity
 	require.Equal(t, types.RoleInstance, instanceID.ID.Role)
 	assert.ElementsMatch(t, []string{types.RoleProxy.String(), types.RoleNode.String()}, instanceID.SystemRoles)
+	// Make sure the SSH identity becomes available.
+	sshConnector, err := process.WaitForConnector(SSHIdentityEvent, logger)
+	require.NoError(t, err)
+	require.NotNil(t, sshConnector)
+	sshID := sshConnector.clientState.Load().identity
+	require.Equal(t, types.RoleNode, sshID.ID.Role)
 	// Close the process to clean up.
 	require.NoError(t, process.Close())
 	require.NoError(t, process.Wait())


### PR DESCRIPTION
Part of [RFD 27e](https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md). When an agent starts up with a new system role enabled and the Instance identity does not currently allow this role, the agent will now attempt to re-join to get a new Instance identity with all required system roles.

This is replacing the current method, where e.g. if the SSH role is newly added, the agent re-joins to get an SSH-only identity, uses that identity to create a SystemRoleAssertion, and then references the assertion ID to generate new Instance certs. The change is described in detail here https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md#re-joining-with-new-system-roles