### PR TITLE
Fix an issue docker container launched by MCP commands are not removed sometimes

### DIFF
--- a/lib/srv/mcp/stdio.go
+++ b/lib/srv/mcp/stdio.go
@@ -214,21 +214,31 @@ func makeExecServerRunner(ctx context.Context, session *sessionHandler) (stdioSe
 	// WaitDelay forces a SIGKILL if the process fails to exit 10 seconds after
 	// cmd.Cancel is called. See the WaitDelay doc for details.
 	cmd.WaitDelay = 10 * time.Second
+
 	// We put all shutdown procedures in cmd.Cancel because we are too lazy to
 	// make a separate function. Since cmd.Cancel can be called outside here by
 	// the server handler, we make sure 'cmdCancel' is called to cancel the
 	// command in that case.
-	cmd.Cancel = sync.OnceValue(func() error {
+	//
+	// There is also a race where cmd.Cancel may be called before cmd.Process is
+	// available. To make sure the signal is sent, do not use sync.Once on the
+	// entire "cmd.Cancel". Instead, use sync.Once after cmd.Process non-nil
+	// check so we have a better chance to clean up.
+	signalOnce := sync.OnceValue(func() error {
+		// Use SIGINT for graceful shutdown since stdio servers are
+		// "interactive".
+		logger.DebugContext(ctx, "Sending SIGINT to command")
+		return trace.Wrap(cmd.Process.Signal(syscall.SIGINT))
+	})
+	cmd.Cancel = func() error {
+		logger.DebugContext(ctx, "Canceling command", "has_process", cmd.Process == nil)
 		cmdCancel()
 
 		if cmd.Process != nil {
-			// Use SIGINT for graceful shutdown since stdio servers are
-			// "interactive".
-			logger.DebugContext(ctx, "Sending SIGINT to command")
-			return trace.Wrap(cmd.Process.Signal(syscall.SIGINT))
+			return trace.Wrap(signalOnce())
 		}
 		return nil
-	})
+	}
 
 	// Set host user.
 	hostUser, err := user.Lookup(mcpSpec.RunAsHostUser)

--- a/lib/srv/mcp/stdio_test.go
+++ b/lib/srv/mcp/stdio_test.go
@@ -20,7 +20,7 @@ package mcp
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path"
 	"testing"
@@ -233,7 +233,7 @@ func TestHandleSession_execMCPServer(t *testing.T) {
 			cancelHandlerCtx:   true,
 			waitForHandlerExit: time.Second * 15,
 			afterHandlerStart: func(t *testing.T, testCtx *testContext, containerName string) {
-				time.Sleep(time.Duration(rand.Intn(10000)) * time.Microsecond)
+				time.Sleep(time.Duration(rand.Uint32N(10000)) * time.Microsecond)
 			},
 			// Make sure the container is removed no matter the timing.
 			afterHandlerStop: containerShouldBeRemoved,


### PR DESCRIPTION
fixes #59768
- #59768

changelog: Fixed an issue where Docker containers launched by MCP commands are sometimes not removed

see original ticket for more details of the claude desktop issue.