### PR TITLE
Fix lint error in node-join/install.sh

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -430,7 +430,7 @@ get_teleport_pid() {
         POTENTIAL_PIDS=$(pgrep -f "teleport start" | xargs echo)
         for PID in ${POTENTIAL_PIDS}; do
             if [ -f /proc/${PID}/exe ]; then
-                EXE=$(basename $(readlink /proc/${PID}/exe))
+                EXE=$(basename "$(readlink /proc/${PID}/exe)")
                 if [[ "${EXE}" == "teleport" ]]; then TELEPORT_PIDS="${PID} ${TELEPORT_PIDS}"; fi
             fi
         done


### PR DESCRIPTION
This fixes a shellcheck lint in install.sh preventing merges to master. See also: https://github.com/gravitational/teleport/actions/runs/18209578752/job/51847397151?pr=59620