### PR TITLE
Update pnpm to 10.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
+  "packageManager": "pnpm@10.18.0+sha512.e804f889f1cecc40d572db084eec3e4881739f8dec69c0ff10d2d1beff9a4e309383ba27b5b750059d7f4c149535b6cd0d2cb1ed3aeb739239a4284a68f40cfa",
   "engines": {
     "node": "^22"
   }


### PR DESCRIPTION
Monthly update of pnpm. 10.16.1 -> 10.18.0 brings a couple of patches that improve how different commands respect `minimumReleaseAge` that we've recently enabled.

https://github.com/pnpm/pnpm/releases