### PR TITLE
MWI: Add `/webapi/.../machine-id/bot-instance/metrics` endpoint

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -583,3 +583,7 @@ const MaxPIVPINCacheTTL = time.Hour
 // routine running in every auth server. Any report older than this period should
 // be considered stale.
 const AutoUpdateAgentReportPeriod = time.Minute
+
+// AutoUpdateBotInstanceReportPeriod is the period of the autoupdate bot instance
+// reporting routine.
+const AutoUpdateBotInstanceReportPeriod = time.Minute

--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1053,6 +1053,15 @@
           },
           {
             "resources": [
+              "autoupdate_bot_instance_report"
+            ],
+            "verbs": [
+              "list",
+              "read"
+            ]
+          },
+          {
+            "resources": [
               "git_server"
             ],
             "verbs": [

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1707,7 +1707,7 @@ func (a *Server) runPeriodicOperations() {
 		})
 		ticker.Push(interval.SubInterval[periodicIntervalKey]{
 			Key:           autoUpdateBotInstanceReportKey,
-			Duration:      constants.AutoUpdateAgentReportPeriod,
+			Duration:      constants.AutoUpdateBotInstanceReportPeriod,
 			FirstDuration: retryutils.HalfJitter(10 * time.Second),
 			Jitter:        retryutils.SeventhJitter,
 		})

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -1064,7 +1064,7 @@ func (s *Service) GetAutoUpdateBotInstanceReport(ctx context.Context, _ *autoupd
 		authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbList),
 	}
 	if !slices.Contains(authErrors, nil) {
-		return nil, trace.Wrap(authErrors[0])
+		return nil, trace.NewAggregate(authErrors...)
 	}
 
 	report, err := s.backend.GetAutoUpdateBotInstanceReport(ctx)

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"log/slog"
 	"maps"
+	"slices"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -1055,8 +1056,15 @@ func (s *Service) GetAutoUpdateBotInstanceReport(ctx context.Context, _ *autoupd
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindAutoUpdateBotInstanceReport, types.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	// Because this report also powers the bot instance dashboard in the Web UI
+	// we allow users with `bot_instance:list` as well as `autoupdate_bot_instance_report:read`
+	// and return the first error if both checks fail.
+	authErrors := []error{
+		authCtx.CheckAccessToKind(types.KindAutoUpdateBotInstanceReport, types.VerbRead),
+		authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbList),
+	}
+	if !slices.Contains(authErrors, nil) {
+		return nil, trace.Wrap(authErrors[0])
 	}
 
 	report, err := s.backend.GetAutoUpdateBotInstanceReport(ctx)

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -363,6 +363,17 @@ func TestServiceAccess(t *testing.T) {
 			allowedVerbs: []string{types.VerbRead},
 		},
 		{
+			name: "GetAutoUpdateBotInstanceReport",
+			allowedStates: []authz.AdminActionAuthState{
+				authz.AdminActionAuthUnauthorized,
+				authz.AdminActionAuthNotRequired,
+				authz.AdminActionAuthMFAVerified,
+				authz.AdminActionAuthMFAVerifiedWithReuse,
+			},
+			kind:         types.KindBotInstance,
+			allowedVerbs: []string{types.VerbList},
+		},
+		{
 			name: "DeleteAutoUpdateBotInstanceReport",
 			allowedStates: []authz.AdminActionAuthState{
 				authz.AdminActionAuthNotRequired,

--- a/lib/auth/machineid/machineidv1/expression/expression.go
+++ b/lib/auth/machineid/machineidv1/expression/expression.go
@@ -52,11 +52,8 @@ func NewBotInstanceExpressionParser() (*typical.Parser[*Environment, bool], erro
 		"status.latest_heartbeat.one_shot": typical.DynamicVariable(func(env *Environment) (bool, error) {
 			return env.GetLatestHeartbeat().GetOneShot(), nil
 		}),
-		"status.latest_heartbeat.version": typical.DynamicVariable(func(env *Environment) (*semver.Version, error) {
-			if env.GetLatestHeartbeat().GetVersion() == "" {
-				return nil, nil
-			}
-			return semver.NewVersion(env.LatestHeartbeat.Version)
+		"status.latest_heartbeat.version": typical.DynamicVariable(func(env *Environment) (string, error) {
+			return env.GetLatestHeartbeat().GetVersion(), nil
 		}),
 		"status.latest_authentication.join_method": typical.DynamicVariable(func(env *Environment) (string, error) {
 			return env.GetLatestAuthentication().GetJoinMethod(), nil
@@ -69,8 +66,6 @@ func NewBotInstanceExpressionParser() (*typical.Parser[*Environment, bool], erro
 	spec.Functions["older_than"] = typical.BinaryFunction[*Environment](semverLt)
 	// e.g. `between(status.latest_heartbeat.version, "19.0.0", "19.0.2")`
 	spec.Functions["between"] = typical.TernaryFunction[*Environment](semverBetween)
-	// e.g. `exact_version(status.latest_heartbeat.version, "19.1.0")`
-	spec.Functions["exact_version"] = typical.BinaryFunction[*Environment](semverEq)
 
 	return typical.NewParser[*Environment, bool](spec)
 }

--- a/lib/auth/machineid/machineidv1/expression/expression_test.go
+++ b/lib/auth/machineid/machineidv1/expression/expression_test.go
@@ -108,8 +108,8 @@ func TestBotInstanceExpressionParser(t *testing.T) {
 		},
 		{
 			name:     "exact version",
-			expTrue:  `exact_version(status.latest_heartbeat.version, "19.0.1")`,
-			expFalse: `exact_version(status.latest_heartbeat.version, "19.0.2-rc.1+56001")`,
+			expTrue:  `status.latest_heartbeat.version == "19.0.1"`,
+			expFalse: `status.latest_heartbeat.version == "19.0.2-rc.1+56001"`,
 		},
 		{
 			name:     "between versions - lower",

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -212,6 +212,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindAutoUpdateVersion, RW()),
 					types.NewRule(types.KindAutoUpdateConfig, RW()),
 					types.NewRule(types.KindAutoUpdateAgentRollout, RO()),
+					types.NewRule(types.KindAutoUpdateBotInstanceReport, RO()),
 					types.NewRule(types.KindGitServer, RW()),
 					types.NewRule(types.KindWorkloadIdentityX509Revocation, RW()),
 					types.NewRule(types.KindHealthCheckConfig, RW()),

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1174,6 +1174,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/machine-id/bot-instance", h.WithClusterAuth(h.listBotInstances))
 	// GET Machine ID bot instances (paged)
 	h.GET("/v2/webapi/sites/:site/machine-id/bot-instance", h.WithClusterAuth(h.listBotInstancesV2))
+	// GET Machine ID bot instance metrics.
+	h.GET("/webapi/sites/:site/machine-id/bot-instance/metrics", h.WithClusterAuth(h.botInstanceMetrics))
 
 	// List workload identities
 	h.GET("/webapi/sites/:site/workload-identity", h.WithClusterAuth(h.listWorkloadIdentities))

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -549,7 +549,10 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 	// If no report is available yet, we return a NotFound error. The frontend
 	// will treat this as if the proxy doesn't support this endpoint yet.
 	report, err := clt.GetAutoUpdateBotInstanceReport(ctx)
-	if err != nil {
+	switch {
+	case trace.IsNotFound(err):
+		return nil, trace.NotFound("Bot instance metrics are not yet ready")
+	case err != nil:
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -652,11 +653,16 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 	}
 
 	return BotInstanceMetricsResponse{
-		UpgradeStatuses: statuses,
+		RefreshAfterSeconds: int(constants.AutoUpdateBotInstanceReportPeriod.Seconds()),
+		UpgradeStatuses:     statuses,
 	}, nil
 }
 
 type BotInstanceMetricsResponse struct {
+	// RefreshAfterSeconds is the amount of time (in seconds) after receiving
+	// this response the client should poll for new metrics.
+	RefreshAfterSeconds int `json:"refresh_after_seconds"`
+
 	// UpgradeStatuses contains instance counts by "upgrade status".
 	UpgradeStatuses BotInstanceUpgradeStatuses `json:"upgrade_statuses"`
 }

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -582,7 +582,7 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 		},
 		Unsupported: BotInstanceUpgradeStatus{
 			Filter: fmt.Sprintf(
-				"version_lt(%[1]s, %[2]q) || version_gte(%[1]s, %[3]q)",
+				"older_than(%[1]s, %[2]q) || %[1]s == %[3]q || newer_than(%[1]s, %[3]q)",
 				versionField,
 				lowerBound(targetVersion.Major-1),
 				lowerBound(targetVersion.Major+1),
@@ -590,7 +590,7 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 		},
 		PatchAvailable: BotInstanceUpgradeStatus{
 			Filter: fmt.Sprintf(
-				"version_gte(%[1]s, %[2]q) && version_lt(%[1]s, %[3]q)",
+				"between(%[1]s, %[2]q, %[3]q)",
 				versionField,
 				lowerBound(targetVersion.Major),
 				targetVersion,
@@ -598,7 +598,7 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 		},
 		RequiresUpgrade: BotInstanceUpgradeStatus{
 			Filter: fmt.Sprintf(
-				"version_gte(%[1]s, %[2]q) && version_lt(%[1]s, %[3]q)",
+				"between(%[1]s, %[2]q, %[3]q)",
 				versionField,
 				lowerBound(targetVersion.Major-1),
 				lowerBound(targetVersion.Major),

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -546,8 +546,7 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 		return nil, trace.Wrap(err)
 	}
 
-	// If no report is available yet, we return a NotFound error. The frontend
-	// will treat this as if the proxy doesn't support this endpoint yet.
+	// If no report is available yet, we return a NotFound error.
 	report, err := clt.GetAutoUpdateBotInstanceReport(ctx)
 	switch {
 	case trace.IsNotFound(err):

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -576,6 +576,7 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 	const versionField = "status.latest_heartbeat.version"
 
 	statuses := BotInstanceUpgradeStatuses{
+		UpdatedAt: report.GetSpec().GetTimestamp().AsTime(),
 		UpToDate: BotInstanceUpgradeStatus{
 			Filter: fmt.Sprintf("%[1]s == %[2]q", versionField, targetVersion),
 		},
@@ -652,20 +653,19 @@ func (h *Handler) botInstanceMetrics(_ http.ResponseWriter, r *http.Request, _ h
 	}
 
 	return BotInstanceMetricsResponse{
-		UpdatedAt:       report.GetSpec().GetTimestamp().AsTime(),
 		UpgradeStatuses: statuses,
 	}, nil
 }
 
 type BotInstanceMetricsResponse struct {
-	// UpdatedAt is when these metrics were last updated.
-	UpdatedAt time.Time `json:"updated_at"`
-
 	// UpgradeStatuses contains instance counts by "upgrade status".
 	UpgradeStatuses BotInstanceUpgradeStatuses `json:"upgrade_statuses"`
 }
 
 type BotInstanceUpgradeStatuses struct {
+	// UpdatedAt is when these metrics were last updated.
+	UpdatedAt time.Time `json:"updated_at"`
+
 	// UpToDate means the instance matches the desired version.
 	UpToDate BotInstanceUpgradeStatus `json:"up_to_date"`
 

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -1268,12 +1268,16 @@ func TestBotInstanceMetrics_NotFound(t *testing.T) {
 	pack := env.proxies[0].authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
 	clusterName := env.server.ClusterName()
 
-	// No report yet should return a NotFound.
+	// No report yet should return an empty `UpgradeStatuses`.
 	endpoint := pack.clt.Endpoint(
 		"webapi", "sites", clusterName, "machine-id", "bot-instance", "metrics",
 	)
-	_, err := pack.clt.Get(ctx, endpoint, url.Values{})
-	require.True(t, trace.IsNotFound(err))
+	rsp, err := pack.clt.Get(ctx, endpoint, url.Values{})
+	require.NoError(t, err)
+
+	var body BotInstanceMetricsResponse
+	require.NoError(t, json.Unmarshal(rsp.Bytes(), &body))
+	require.Nil(t, body.UpgradeStatuses)
 }
 
 func TestBotInstanceMetrics_Success(t *testing.T) {

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -1338,7 +1338,7 @@ func TestBotInstanceMetrics_Success(t *testing.T) {
 	require.Equal(t,
 		BotInstanceUpgradeStatus{
 			Count:  100010,
-			Filter: `version_lt(status.latest_heartbeat.version, "18.0.0-aa") || version_gte(status.latest_heartbeat.version, "20.0.0-aa")`,
+			Filter: `older_than(status.latest_heartbeat.version, "18.0.0-aa") || status.latest_heartbeat.version == "20.0.0-aa" || newer_than(status.latest_heartbeat.version, "20.0.0-aa")`,
 		},
 		body.UpgradeStatuses.Unsupported,
 	)
@@ -1347,7 +1347,7 @@ func TestBotInstanceMetrics_Success(t *testing.T) {
 	require.Equal(t,
 		BotInstanceUpgradeStatus{
 			Count:  1100,
-			Filter: `version_gte(status.latest_heartbeat.version, "19.0.0-aa") && version_lt(status.latest_heartbeat.version, "19.1.1")`,
+			Filter: `between(status.latest_heartbeat.version, "19.0.0-aa", "19.1.1")`,
 		},
 		body.UpgradeStatuses.PatchAvailable,
 	)
@@ -1356,7 +1356,7 @@ func TestBotInstanceMetrics_Success(t *testing.T) {
 	require.Equal(t,
 		BotInstanceUpgradeStatus{
 			Count:  10000,
-			Filter: `version_gte(status.latest_heartbeat.version, "18.0.0-aa") && version_lt(status.latest_heartbeat.version, "19.0.0-aa")`,
+			Filter: `between(status.latest_heartbeat.version, "18.0.0-aa", "19.0.0-aa")`,
 		},
 		body.UpgradeStatuses.RequiresUpgrade,
 	)

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -1296,6 +1296,7 @@ func TestBotInstanceMetrics_Success(t *testing.T) {
 				},
 			},
 		})
+	require.NoError(t, err)
 
 	err = env.server.Auth().
 		SetAutoUpdateBotInstanceReport(ctx, &autoupdate.AutoUpdateBotInstanceReportSpec{


### PR DESCRIPTION
Adds a Web API endpoint exposing the bot upgrade status metrics described in [RFD 222: Bot Instances at Scale](https://github.com/gravitational/teleport/pull/57888).

The RFD doesn't fully define the statuses, so here's what I've taken them to mean:

| Status | Definition |
| --- | --- |
| Up to date | Running the exact `<major>.<minor>.<patch>-<pre>` version |
| Patch available | Running the right `<major>` version, but an older `<minor>`, `<patch>`, or `<pre>` |
| Requires upgrade | Running any version in the previous (N-1) `<major>` series |
| Unsupported | Running any newer version, or any version older than the previous (N-1) `<major>` series |

The desired version is taken from the `autoupdate_version` resource's `spec.tools.target_version`, or if there is no such resource, the proxy version, which matches the proxy ping endpoint's `auto_update.tools_version` definition.
