### PR TITLE
feat: Bot instances design review

### DIFF
--- a/web/packages/shared/components/Controls/SortMenu.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.tsx
@@ -19,7 +19,7 @@
 import React, { useState } from 'react';
 
 import { ButtonBorder, Flex, Menu, MenuItem } from 'design';
-import { ArrowDown, ArrowUp, SortAscending, SortDescending } from 'design/Icon';
+import { ArrowDown, ArrowUp } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 
 export type SortMenuSort<T extends object> = {
@@ -31,12 +31,10 @@ export const SortMenu = <T extends object>({
   current,
   fields,
   onChange,
-  alternateIcons = false,
 }: {
   current: SortMenuSort<T>;
   fields: { value: SortMenuSort<T>['fieldName']; label: string }[];
   onChange: (value: SortMenuSort<T>) => void;
-  alternateIcons?: boolean;
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>(null);
 
@@ -112,21 +110,9 @@ export const SortMenu = <T extends object>({
           size="small"
         >
           {current.dir === 'ASC' ? (
-            <>
-              {alternateIcons ? (
-                <SortAscending size={'medium'} />
-              ) : (
-                <ArrowUp size={12} />
-              )}
-            </>
+            <ArrowUp size={12} />
           ) : (
-            <>
-              {alternateIcons ? (
-                <SortDescending size={'medium'} />
-              ) : (
-                <ArrowDown size={12} />
-              )}
-            </>
+            <ArrowDown size={12} />
           )}
         </ButtonBorder>
       </HoverTooltip>

--- a/web/packages/shared/components/Controls/SortMenu.tsx
+++ b/web/packages/shared/components/Controls/SortMenu.tsx
@@ -19,7 +19,7 @@
 import React, { useState } from 'react';
 
 import { ButtonBorder, Flex, Menu, MenuItem } from 'design';
-import { ArrowDown, ArrowUp } from 'design/Icon';
+import { ArrowDown, ArrowUp, SortAscending, SortDescending } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 
 export type SortMenuSort<T extends object> = {
@@ -31,10 +31,12 @@ export const SortMenu = <T extends object>({
   current,
   fields,
   onChange,
+  alternateIcons = false,
 }: {
   current: SortMenuSort<T>;
   fields: { value: SortMenuSort<T>['fieldName']; label: string }[];
   onChange: (value: SortMenuSort<T>) => void;
+  alternateIcons?: boolean;
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>(null);
 
@@ -110,9 +112,21 @@ export const SortMenu = <T extends object>({
           size="small"
         >
           {current.dir === 'ASC' ? (
-            <ArrowUp size={12} />
+            <>
+              {alternateIcons ? (
+                <SortAscending size={'medium'} />
+              ) : (
+                <ArrowUp size={12} />
+              )}
+            </>
           ) : (
-            <ArrowDown size={12} />
+            <>
+              {alternateIcons ? (
+                <SortDescending size={'medium'} />
+              ) : (
+                <ArrowDown size={12} />
+              )}
+            </>
           )}
         </ButtonBorder>
       </HoverTooltip>

--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -16,12 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ComponentProps, useEffect, useState, type JSX } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';
 import InputSearch from 'design/DataTable/InputSearch';
 import { PageIndicatorText } from 'design/DataTable/Pager/PageIndicatorText';
+import { FlexProps } from 'design/Flex/Flex';
 import { AdvancedSearchToggle } from 'shared/components/AdvancedSearchToggle';
 
 // eslint-disable-next-line no-restricted-imports -- FIXME
@@ -44,7 +45,7 @@ export function SearchPanel({
   disableSearch?: boolean;
   hideAdvancedSearch?: boolean;
   extraChildren?: JSX.Element;
-  mb?: ComponentProps<typeof Flex>['mb'];
+  mb?: FlexProps['mb'];
 }) {
   const [query, setQuery] = useState(filter.search || filter.query || '');
   const [isAdvancedSearch, setIsAdvancedSearch] = useState(!!filter.query);

--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState, type JSX } from 'react';
+import { ComponentProps, useEffect, useState, type JSX } from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';
@@ -35,6 +35,7 @@ export function SearchPanel({
   disableSearch,
   hideAdvancedSearch,
   extraChildren,
+  mb = 3,
 }: {
   updateQuery?: (s: string) => void;
   updateSearch: (s: string) => void;
@@ -43,6 +44,7 @@ export function SearchPanel({
   disableSearch?: boolean;
   hideAdvancedSearch?: boolean;
   extraChildren?: JSX.Element;
+  mb?: ComponentProps<typeof Flex>['mb'];
 }) {
   const [query, setQuery] = useState(filter.search || filter.query || '');
   const [isAdvancedSearch, setIsAdvancedSearch] = useState(!!filter.query);
@@ -72,7 +74,7 @@ export function SearchPanel({
       justifyContent="space-between"
       alignItems="center"
       width="100%"
-      mb={3}
+      mb={mb}
     >
       <Flex style={{ width: '100%' }} alignItems="center">
         <StyledFlex

--- a/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.story.tsx
@@ -203,7 +203,7 @@ function Wrapper(props?: {
         <TeleportProviderBasic teleportCtx={ctx}>
           <Router history={history}>
             <Route path={cfg.routes.botInstances}>
-              <Box height={820} overflow={'auto'}>
+              <Box height={820}>
                 <BotInstances />
               </Box>
             </Route>

--- a/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
@@ -229,16 +229,20 @@ describe('BotInstances', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading'));
 
     expect(
-      screen.queryByRole('heading', { name: 'Resource YAML' })
+      screen.queryByRole('heading', {
+        name: 'test-bot-2/3c3aae3e-de25-4824-a8e9-5a531862f19a',
+      })
     ).not.toBeInTheDocument();
 
-    const item2 = screen.getByRole('listitem', {
+    const item = screen.getByRole('listitem', {
       name: 'test-bot-2/3c3aae3e-de25-4824-a8e9-5a531862f19a',
     });
-    await user.click(item2);
+    await user.click(item);
 
     expect(
-      screen.getByRole('heading', { name: 'Resource YAML' })
+      screen.getByRole('heading', {
+        name: 'test-bot-2/3c3aae3e-de25-4824-a8e9-5a531862f19a',
+      })
     ).toBeInTheDocument();
 
     expect(

--- a/web/packages/teleport/src/BotInstances/BotInstances.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.tsx
@@ -176,8 +176,8 @@ export function BotInstances() {
   }
 
   return (
-    <FeatureBox>
-      <FeatureHeader justifyContent="space-between">
+    <FeatureBox hideBottomSpacing>
+      <FeatureHeader justifyContent="space-between" mb={0}>
         <FeatureHeaderTitle>Bot Instances</FeatureHeaderTitle>
         <InfoGuideButton config={{ guide: <InfoGuide /> }} />
       </FeatureHeader>
@@ -190,6 +190,7 @@ export function BotInstances() {
           }}
           updateSearch={query => handleQueryChange(query, false)}
           updateQuery={query => handleQueryChange(query, true)}
+          mb={2}
         />
         <ContentContainer>
           <ListAndDetailsContainer $listOnlyMode={!selectedItemId}>
@@ -234,7 +235,7 @@ const Container = styled(Flex)`
   flex-direction: column;
   flex: 1;
   overflow: auto;
-  gap: ${props => props.theme.space[2]}px;
+  padding-bottom: ${props => props.theme.space[3]}px;
 `;
 
 const ContentContainer = styled(Flex)`

--- a/web/packages/teleport/src/BotInstances/BotInstances.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.tsx
@@ -178,7 +178,7 @@ export function BotInstances() {
   return (
     <FeatureBox>
       <FeatureHeader justifyContent="space-between">
-        <FeatureHeaderTitle>Bot instances</FeatureHeaderTitle>
+        <FeatureHeaderTitle>Bot Instances</FeatureHeaderTitle>
         <InfoGuideButton config={{ guide: <InfoGuide /> }} />
       </FeatureHeader>
 

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
@@ -149,5 +149,5 @@ const ContentContainer = styled.div`
 const YamlContaner = styled(Flex)`
   flex: 1;
   border-radius: ${props => props.theme.space[2]}px;
-  background-color: ${({ theme }) => theme.colors.levels.elevated};
+  background-color: ${({ theme }) => theme.colors.levels.surface};
 `;

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
@@ -57,14 +57,14 @@ export function BotInstanceDetails(props: {
   return (
     <Container>
       <TitleContainer>
-        <Flex gap={2} alignItems={'center'}>
-          <HoverTooltip placement="top" tipContent={'Close'}>
-            <ButtonIcon onClick={() => onClose()} aria-label="close">
-              <Cross size="medium" />
-            </ButtonIcon>
-          </HoverTooltip>
-          <TitleText>Resource YAML</TitleText>
-        </Flex>
+        <TitleText>
+          {botName}/{instanceId}
+        </TitleText>
+        <HoverTooltip placement="top" tipContent={'Close'}>
+          <ButtonIcon onClick={() => onClose()} aria-label="close">
+            <Cross size="medium" />
+          </ButtonIcon>
+        </HoverTooltip>
       </TitleContainer>
       <Divider />
       <ContentContainer>
@@ -90,7 +90,7 @@ export function BotInstanceDetails(props: {
         {isSuccess && data.yaml ? (
           <YamlContaner>
             <TextEditor
-              bg="levels.elevated"
+              bg="levels.sunken"
               data={[
                 {
                   content: data.yaml,
@@ -113,6 +113,7 @@ const Container = styled.section`
   border-left-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
   border-left-width: 1px;
   border-left-style: solid;
+  overflow: hidden;
 `;
 
 const TitleContainer = styled(Flex)`
@@ -120,13 +121,18 @@ const TitleContainer = styled(Flex)`
   justify-content: space-between;
   height: ${p => p.theme.space[8]}px;
   padding-left: ${p => p.theme.space[3]}px;
+  padding-right: ${p => p.theme.space[3]}px;
   gap: ${p => p.theme.space[2]}px;
+  overflow: hidden;
 `;
 
 export const TitleText = styled(Text).attrs({
   as: 'h2',
   typography: 'h2',
-})``;
+})`
+  flex: 1;
+  white-space: nowrap;
+`;
 
 const Divider = styled.div`
   height: 1px;

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -96,7 +96,6 @@ function InternalBotInstancesList(
           onChange={value => {
             onSortChanged(value.fieldName, value.dir);
           }}
-          alternateIcons
         />
       </TitleContainer>
 

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -96,6 +96,7 @@ function InternalBotInstancesList(
           onChange={value => {
             onSortChanged(value.fieldName, value.dir);
           }}
+          alternateIcons
         />
       </TitleContainer>
 

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -86,7 +86,7 @@ function InternalBotInstancesList(
   return (
     <Container>
       <TitleContainer>
-        <TitleText>Currently Active</TitleText>
+        <TitleText>Active Instances</TitleText>
         <SortMenu
           current={{
             fieldName: sortField,

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -132,7 +132,7 @@ function InternalBotInstancesList(
       {hasData ? (
         <>
           {data && data.length > 0 ? (
-            <ContentContainer ref={contentRef}>
+            <ContentContainer ref={contentRef} data-scrollbar="default">
               {data.map((instance, i) => (
                 <React.Fragment key={`${instance.instance_id}`}>
                   {i === 0 ? undefined : <Divider />}

--- a/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
+++ b/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
@@ -56,7 +56,7 @@ describe('DeleteDialog', () => {
     expect(screen.getByText('Delete test-bot-name?')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Alternatively, you can lock a bot to stop all of its activity.'
+        'Alternatively, you can lock a bot to stop all of its activity immediately.'
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Delete Bot')).toBeEnabled();
@@ -99,7 +99,7 @@ describe('DeleteDialog', () => {
     });
     expect(
       screen.queryByText(
-        'Alternatively, you can lock a bot to stop all of its activity.'
+        'Alternatively, you can lock a bot to stop all of its activity immediately.'
       )
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Lock Bot')).not.toBeInTheDocument();

--- a/web/packages/teleport/src/Bots/Delete/DeleteDialog.tsx
+++ b/web/packages/teleport/src/Bots/Delete/DeleteDialog.tsx
@@ -92,15 +92,19 @@ export function DeleteDialog(props: {
       <DialogHeader>
         <DialogTitle>Delete {botName}?</DialogTitle>
       </DialogHeader>
-      <DialogContent>
+      <DialogContent maxWidth={540}>
         <div>
           <P>
-            Deleting a bot is permanent and cannot be undone. All bot instances
-            will terminate immediately.
+            Deleting a bot is permanent and cannot be undone. Bot instances
+            remain active until their issued credentials expire.
+            {showLockAlternative
+              ? ''
+              : ' To terminate active instances immediately, lock the bot before deleting it.'}
           </P>
           {showLockAlternative ? (
             <P>
-              Alternatively, you can lock a bot to stop all of its activity.
+              Alternatively, you can lock a bot to stop all of its activity
+              immediately.
             </P>
           ) : undefined}
         </div>

--- a/web/packages/teleport/src/Bots/Details/Instance.tsx
+++ b/web/packages/teleport/src/Bots/Details/Instance.tsx
@@ -64,7 +64,7 @@ export function Instance(props: {
     <Container
       $isSelectable={!!isSelectable}
       $isSelected={!!isSelected}
-      onClick={onSelected ? () => onSelected() : undefined}
+      onClick={onSelected}
       onKeyUp={
         onSelected
           ? event => {

--- a/web/packages/teleport/src/Bots/Details/Instance.tsx
+++ b/web/packages/teleport/src/Bots/Details/Instance.tsx
@@ -157,7 +157,8 @@ const Container = styled(Flex)<{
       ? css`
           border-left: ${p.theme.space[1]}px solid
             ${p.theme.colors.interactive.solid.primary.default};
-          background-color: ${p.theme.colors.interactive.tonal.neutral[0]};
+          padding-left: ${props => props.theme.space[3] - p.theme.space[1]}px;
+          background-color: ${p.theme.colors.levels.sunken};
         `
       : ''}
 
@@ -167,10 +168,12 @@ const Container = styled(Flex)<{
           cursor: pointer;
 
           &:hover {
-            background-color: ${p.theme.colors.interactive.tonal.neutral[0]};
+            background-color: ${p.theme.colors.levels.sunken};
           }
-          &:active {
-            background-color: ${p.theme.colors.interactive.tonal.neutral[1]};
+          &:active,
+          &:focus {
+            outline: none;
+            background-color: ${p.theme.colors.levels.deep};
           }
         `
       : ''}

--- a/web/packages/teleport/src/Bots/Details/Instance.tsx
+++ b/web/packages/teleport/src/Bots/Details/Instance.tsx
@@ -64,7 +64,16 @@ export function Instance(props: {
     <Container
       $isSelectable={!!isSelectable}
       $isSelected={!!isSelected}
-      onClick={() => onSelected?.()}
+      onClick={onSelected ? () => onSelected() : undefined}
+      onKeyUp={
+        onSelected
+          ? event => {
+              if (event.key === 'Enter') {
+                onSelected();
+              }
+            }
+          : undefined
+      }
       role="listitem"
       tabIndex={0}
       aria-label={`${botName}/${id}`}


### PR DESCRIPTION
## Summary
This change includes a variety of design tweaks as a result of a design review.

Updates: https://github.com/gravitational/teleport/issues/57994

## Changes
- Tweak titles
- Move details close button to the right
- Use darker colour for YAML background
- Various spacing and layout refinements
- Allow list items to be selected by pressing ENTER (once in focus)
- Use default browser style for scrollbar on the list (affects chrome and safari only)
- Fix content jump on selected list item
- Clarify messaging for delete bot behaviour
- ~Use sort-specific icons for sort menu (optional override as this component is used elsewhere also)~

## Demo
_after_
<img width="1201" height="957" alt="Screenshot 2025-10-03 at 11 08 14" src="https://github.com/user-attachments/assets/ea16fa47-4f1e-417d-a35a-b9c57031dc1d" />

_before_
<img width="1201" height="957" alt="Screenshot 2025-10-03 at 11 08 52" src="https://github.com/user-attachments/assets/776bf14f-50df-48d5-b5c3-4241aa327799" />
