### PR TITLE
fix(app): prevent premature removal of app servers from session cache

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -379,21 +379,6 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 		break
 	}
 
-	t.mu.Lock()
-	// Only attempt to tidy up the list of servers if they weren't altered
-	// while the dialing happened. Since the lock is only held initially when
-	// making the servers copy and released during the dials, another dial attempt
-	// may have already happened and modified the list of servers.
-	if len(servers) == len(t.c.servers) {
-		// eliminate any servers from the head of the list that were unreachable
-		if i < len(t.c.servers) {
-			t.c.servers = t.c.servers[i:]
-		} else {
-			t.c.servers = nil
-		}
-	}
-	t.mu.Unlock()
-
 	if conn != nil || err != nil {
 		return conn, trace.Wrap(err)
 	}


### PR DESCRIPTION
When a user accesses an app and a new session (i.e. app server certificate)  is created, the teleport proxy caches a `session` object for the entire duration of that certificate.

The session context includes the list of app servers available at the time the session is created. This list is static and is used to dial the target app service via reverse tunnel. This is already suboptimal, as new app servers (app services with different `host_id`) that can join later will be ingored. This static list exists to create some affinity and the same proxy forwards the user requests to the same app service.

The core issue liest in a piece of code that this PR removes. That code prunes app servers from the session list if the proxy fails to connect to them.
This is problematic beause an app server might have temporarily gone offline (e.g. restarted or dropped the connection), and it gets removed permanently. Even if it later reconnects to the cluster, the session will no longer include it, causing all future requests to fail because the list of servers is now empty.

This issue is especially harmful for machine clients that automatically retry on disconnection. As retries continue, the session removes all servers, leading to permanent failure state. Since the session is cached for the full certificate duration, the only workaround is to manually restart the teleport proxy to refresh the session state.

This PR removes the session pruning logic as a temporary fix, allowing clients to retry dialing to previously failed app servers if they reconnect during the session.

Changelog: Fixed issue where temporarily unreachable app servers were permanently removed from session cache, causing persistent connection failures: `no application servers remaining to connect`.