### PR TITLE
Refactor WebToken interface

### DIFF
--- a/api/client/sessions.go
+++ b/api/client/sessions.go
@@ -119,29 +119,18 @@ type webSessions struct {
 	c *Client
 }
 
-// GetWebToken returns the web token for the specified request.
-// Implements ReadAccessPoint
+// GetWebToken returns the web token for the specified request
 func (c *Client) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	return c.WebTokens().Get(ctx, req)
-}
-
-// WebTokens returns the web tokens controller
-func (c *Client) WebTokens() types.WebTokenInterface {
-	return &webTokens{c: c}
-}
-
-// Get returns the web token for the specified request
-func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebToken(ctx, &req)
+	resp, err := c.grpc.GetWebToken(ctx, &req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return resp.Token, nil
 }
 
-// List returns the list of all web tokens
-func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebTokens(ctx, &emptypb.Empty{})
+// GetWebTokens returns the list of all web tokens
+func (c *Client) GetWebTokens(ctx context.Context) ([]types.WebToken, error) {
+	resp, err := c.grpc.GetWebTokens(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -152,29 +141,84 @@ func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
 	return out, nil
 }
 
-// Upsert not implemented: can only be called locally.
-func (r *webTokens) Upsert(ctx context.Context, token types.WebToken) error {
+// UpsertWebToken not implemented: can only be called locally.
+func (c *Client) UpsertWebToken(ctx context.Context, token types.WebToken) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// Delete deletes the web token specified with the request
-func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
-	_, err := r.c.grpc.DeleteWebToken(ctx, &req)
+// DeleteWebToken deletes the web token specified with the request
+func (c *Client) DeleteWebToken(ctx context.Context, req types.DeleteWebTokenRequest) error {
+	_, err := c.grpc.DeleteWebToken(ctx, &req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// DeleteAllWebTokens deletes all web tokens
+func (c *Client) DeleteAllWebTokens(ctx context.Context) error {
+	_, err := c.grpc.DeleteAllWebTokens(ctx, &emptypb.Empty{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// WebTokens returns the web tokens controller
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client] methods directly.
+func (c *Client) WebTokens() types.WebTokenInterface {
+	return &webTokens{c: c}
+}
+
+// Get returns the web token for the specified request
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client.GetWebToken] instead.
+func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
+	return r.c.GetWebToken(ctx, req)
+}
+
+// List returns the list of all web tokens
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client.GetWebTokens] instead.
+func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
+	return r.c.GetWebTokens(ctx)
+}
+
+// Upsert not implemented: can only be called locally.
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client.UpsertWebToken] instead.
+func (r *webTokens) Upsert(ctx context.Context, token types.WebToken) error {
+	return r.c.UpsertWebToken(ctx, token)
+}
+
+// Delete deletes the web token specified with the request
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client.DeleteWebToken] instead.
+func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
+	return r.c.DeleteWebToken(ctx, req)
 }
 
 // DeleteAll deletes all web tokens
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client.DeleteAllWebTokens] instead.
 func (r *webTokens) DeleteAll(ctx context.Context) error {
-	_, err := r.c.grpc.DeleteAllWebTokens(ctx, &emptypb.Empty{})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	return r.c.DeleteAllWebTokens(ctx)
 }
 
+// Deprecated: Use [Client] directly.
 type webTokens struct {
 	c *Client
 }

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -434,12 +434,24 @@ func NewWebToken(expires time.Time, spec WebTokenSpecV3) (WebToken, error) {
 }
 
 // WebTokensGetter provides access to web tokens
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client] methods directly such as
+// [Client.GetWebToken], [Client.GetWebTokens], [Client.DeleteWebToken] or
+// [Client.DeleteAllWebTokens]
 type WebTokensGetter interface {
 	// WebTokens returns the tokens manager
 	WebTokens() WebTokenInterface
 }
 
 // WebTokenInterface defines interface for managing web tokens
+//
+// TODO(okraport): DELETE IN v21
+//
+// Deprecated: Use [Client] methods directly such as
+// [Client.GetWebToken], [Client.GetWebTokens], [Client.DeleteWebToken] or
+// [Client.DeleteAllWebTokens]
 type WebTokenInterface interface {
 	// Get returns a token specified by the request.
 	Get(ctx context.Context, req GetWebTokenRequest) (WebToken, error)

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -102,7 +102,7 @@ type Config struct {
 	UserLoginStates         services.UserLoginStates
 	Users                   services.UsersService
 	WebSession              types.WebSessionInterface
-	WebToken                types.WebTokenInterface
+	WebToken                services.WebToken
 	WorkloadIdentity        services.WorkloadIdentities
 	DynamicWindowsDesktops  services.DynamicWindowsDesktops
 	WindowsDesktops         services.WindowsDesktops

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -895,12 +895,6 @@ func (r *Services) GetWebSession(ctx context.Context, req types.GetWebSessionReq
 	return r.Identity.WebSessions().Get(ctx, req)
 }
 
-// GetWebToken returns existing web token described by req.
-// Implements ReadAccessPoint
-func (r *Services) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	return r.Identity.WebTokens().Get(ctx, req)
-}
-
 // GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
 func (r *Services) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
 	return r.IntegrationsTokenGenerator.GenerateAWSOIDCToken(ctx, integration)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2650,72 +2650,62 @@ func (r *webSessionsWithRoles) DeleteAll(ctx context.Context) error {
 	return r.ws.DeleteAll(ctx)
 }
 
-// GetWebToken returns the web token specified with req.
-// Implements auth.ReadAccessPoint.
-func (a *ServerWithRoles) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	return a.WebTokens().Get(ctx, req)
-}
-
 type webSessionsWithRoles struct {
 	c  accessChecker
 	ws types.WebSessionInterface
 }
 
-// WebTokens returns the web token manager.
-// Implements services.WebTokensGetter.
-func (a *ServerWithRoles) WebTokens() types.WebTokenInterface {
-	return &webTokensWithRoles{c: a, t: a.authServer.WebTokens()}
-}
-
-// Get returns the web token specified with req.
-func (r *webTokensWithRoles) Get(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	if err := r.c.currentUserAction(req.User); err != nil {
-		if err := r.c.authorizeAction(types.KindWebToken, types.VerbRead); err != nil {
+// GetWebToken returns the web token specified with req.
+func (a *ServerWithRoles) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
+	if err := a.currentUserAction(req.User); err != nil {
+		if err := a.authorizeAction(types.KindWebToken, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-	return r.t.Get(ctx, req)
-}
 
-// List returns the list of all web tokens.
-func (r *webTokensWithRoles) List(ctx context.Context) ([]types.WebToken, error) {
-	if err := r.c.authorizeAction(types.KindWebToken, types.VerbList); err != nil {
+	token, err := a.authServer.GetWebToken(ctx, req)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return r.t.List(ctx)
+
+	return token, nil
 }
 
-// Upsert creates a new or updates the existing web token from the specified token.
-// TODO(dmitri): this is currently only implemented for local invocations. This needs to be
-// moved into a more appropriate API
-func (*webTokensWithRoles) Upsert(ctx context.Context, session types.WebToken) error {
-	return trace.NotImplemented(notImplementedMessage)
+// GetWebTokens returns the list of all web tokens.
+func (a *ServerWithRoles) GetWebTokens(ctx context.Context) ([]types.WebToken, error) {
+	if err := a.authorizeAction(types.KindWebToken, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tokens, err := a.authServer.GetWebTokens(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return tokens, nil
 }
 
-// Delete removes the web token specified with req.
-func (r *webTokensWithRoles) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
-	if err := r.c.currentUserAction(req.User); err != nil {
-		if err := r.c.authorizeAction(types.KindWebToken, types.VerbDelete); err != nil {
+// DeleteWebToken removes the web token specified with req.
+func (a *ServerWithRoles) DeleteWebToken(ctx context.Context, req types.DeleteWebTokenRequest) error {
+	if err := a.currentUserAction(req.User); err != nil {
+		if err := a.authorizeAction(types.KindWebToken, types.VerbDelete); err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	return r.t.Delete(ctx, req)
+	return a.authServer.DeleteWebToken(ctx, req)
 }
 
-// DeleteAll removes all web tokens.
-func (r *webTokensWithRoles) DeleteAll(ctx context.Context) error {
-	if err := r.c.authorizeAction(types.KindWebToken, types.VerbList); err != nil {
+// DeleteAllWebTokens removes all web tokens.
+func (a *ServerWithRoles) DeleteAllWebTokens(ctx context.Context) error {
+	if err := a.authorizeAction(types.KindWebToken, types.VerbList); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := r.c.authorizeAction(types.KindWebToken, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return r.t.DeleteAll(ctx)
-}
 
-type webTokensWithRoles struct {
-	c accessChecker
-	t types.WebTokenInterface
+	if err := a.authorizeAction(types.KindWebToken, types.VerbDelete); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.authServer.DeleteAllWebTokens(ctx)
 }
 
 type accessChecker interface {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1574,7 +1574,7 @@ type ClientI interface {
 	types.Events
 
 	types.WebSessionsGetter
-	types.WebTokensGetter
+	services.WebToken
 
 	DynamicDesktopClient() *dynamicwindows.Client
 	GetDynamicWindowsDesktop(ctx context.Context, name string) (types.DynamicWindowsDesktop, error)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -563,7 +563,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		UserLoginStates:         p.AuthServer.Services.UserLoginStates,
 		Users:                   p.AuthServer.Services.Identity,
 		WebSession:              p.AuthServer.Services.Identity.WebSessions(),
-		WebToken:                p.AuthServer.Services.WebTokens(),
+		WebToken:                p.AuthServer.Services.Identity,
 		WorkloadIdentity:        p.AuthServer.Services.WorkloadIdentities,
 		DynamicWindowsDesktops:  p.AuthServer.Services.DynamicWindowsDesktops,
 		WindowsDesktops:         p.AuthServer.Services.WindowsDesktops,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1885,7 +1885,7 @@ func (g *GRPCServer) GetWebToken(ctx context.Context, req *types.GetWebTokenRequ
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := auth.WebTokens().Get(ctx, *req)
+	resp, err := auth.GetWebToken(ctx, *req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1906,7 +1906,7 @@ func (g *GRPCServer) GetWebTokens(ctx context.Context, _ *emptypb.Empty) (*authp
 		return nil, trace.Wrap(err)
 	}
 
-	tokens, err := auth.WebTokens().List(ctx)
+	tokens, err := auth.GetWebTokens(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1932,7 +1932,7 @@ func (g *GRPCServer) DeleteWebToken(ctx context.Context, req *types.DeleteWebTok
 		return nil, trace.Wrap(err)
 	}
 
-	if err := auth.WebTokens().Delete(ctx, *req); err != nil {
+	if err := auth.DeleteWebToken(ctx, *req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1946,7 +1946,7 @@ func (g *GRPCServer) DeleteAllWebTokens(ctx context.Context, _ *emptypb.Empty) (
 		return nil, trace.Wrap(err)
 	}
 
-	if err := auth.WebTokens().DeleteAll(ctx); err != nil {
+	if err := auth.DeleteAllWebTokens(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -385,7 +385,7 @@ func (a *Server) upsertWebSession(ctx context.Context, session types.WebSession)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.WebTokens().Upsert(ctx, token); err != nil {
+	if err := a.UpsertWebToken(ctx, token); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -671,7 +671,7 @@ type Config struct {
 	// WebSession holds regular web sessions.
 	WebSession types.WebSessionInterface
 	// WebToken holds web tokens.
-	WebToken types.WebTokenInterface
+	WebToken services.WebToken
 	// WindowsDesktops is a windows desktop service.
 	WindowsDesktops services.WindowsDesktops
 	// DynamicWindowsDesktops is a dynamic Windows desktop service.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -145,7 +145,7 @@ type testPack struct {
 	databases               *local.DatabaseService
 	databaseServices        *local.DatabaseServicesService
 	webSessionS             types.WebSessionInterface
-	webTokenS               types.WebTokenInterface
+	webTokenS               *local.IdentityService
 	windowsDesktops         *local.WindowsDesktopService
 	dynamicWindowsDesktops  *local.DynamicWindowsDesktopService
 	samlIDPServiceProviders *local.SAMLIdPServiceProviderService
@@ -395,7 +395,7 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	p.appSessionS = idService
 	p.webSessionS = idService.WebSessions()
 	p.snowflakeSessionS = idService
-	p.webTokenS = idService.WebTokens()
+	p.webTokenS = idService
 	p.restrictions = local.NewRestrictionsService(p.backend)
 	p.apps = local.NewAppService(p.backend)
 	p.kubernetes = local.NewKubernetesService(p.backend)

--- a/lib/cache/web_tokens.go
+++ b/lib/cache/web_tokens.go
@@ -22,13 +22,14 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 type webTokenIndex string
 
 const webTokenNameIndex webTokenIndex = "name"
 
-func newWebTokenCollection(upstream types.WebTokenInterface, w types.WatchKind) (*collection[types.WebToken, webTokenIndex], error) {
+func newWebTokenCollection(upstream services.WebToken, w types.WatchKind) (*collection[types.WebToken, webTokenIndex], error) {
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter WebTokenInterface")
 	}
@@ -41,7 +42,7 @@ func newWebTokenCollection(upstream types.WebTokenInterface, w types.WatchKind) 
 				webTokenNameIndex: types.WebToken.GetName,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebToken, error) {
-			installers, err := upstream.List(ctx)
+			installers, err := upstream.GetWebTokens(ctx)
 			return installers, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.WebToken {
@@ -67,7 +68,7 @@ func (c *Cache) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (
 		collection: c.collections.webTokens,
 		index:      webTokenNameIndex,
 		upstreamGet: func(ctx context.Context, s string) (types.WebToken, error) {
-			token, err := c.Config.WebToken.Get(ctx, req)
+			token, err := c.Config.WebToken.GetWebToken(ctx, req)
 			return token, trace.Wrap(err)
 		},
 	}
@@ -86,7 +87,7 @@ func (c *Cache) GetWebTokens(ctx context.Context) ([]types.WebToken, error) {
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		users, err := c.Config.WebToken.List(ctx)
+		users, err := c.Config.WebToken.GetWebTokens(ctx)
 		return users, trace.Wrap(err)
 	}
 

--- a/lib/cache/web_tokens_test.go
+++ b/lib/cache/web_tokens_test.go
@@ -17,6 +17,7 @@
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,9 +37,22 @@ func TestWebTokens(t *testing.T) {
 				User:  "llama",
 			})
 		},
-		create:    p.webTokenS.Upsert,
-		list:      getAllAdapter(p.webTokenS.List),
+		create: p.webTokenS.UpsertWebToken,
+		update: p.webTokenS.UpsertWebToken,
+		cacheGet: func(ctx context.Context, token string) (types.WebToken, error) {
+			return p.cache.GetWebToken(ctx, types.GetWebTokenRequest{
+				Token: token,
+				User:  "llama",
+			})
+		},
+		list:      getAllAdapter(p.webTokenS.GetWebTokens),
 		cacheList: getAllAdapter(p.cache.GetWebTokens),
-		deleteAll: p.webTokenS.DeleteAll,
+		deleteAll: p.webTokenS.DeleteAllWebTokens,
+		delete: func(ctx context.Context, token string) error {
+			return p.webTokenS.DeleteWebToken(ctx, types.DeleteWebTokenRequest{
+				Token: token,
+				User:  "llama",
+			})
+		},
 	}, withSkipPaginationTest())
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2920,7 +2920,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.UserLoginStates = services.UserLoginStates
 	cfg.Users = services.Identity
 	cfg.WebSession = services.Identity.WebSessions()
-	cfg.WebToken = services.Identity.WebTokens()
+	cfg.WebToken = services.Identity
 	cfg.WindowsDesktops = services.WindowsDesktops
 	cfg.WorkloadIdentity = services.WorkloadIdentities
 	cfg.DynamicWindowsDesktops = services.DynamicWindowsDesktops
@@ -2974,7 +2974,7 @@ func (process *TeleportProcess) newAccessCacheForClient(cfg accesspoint.Config, 
 	cfg.UserLoginStates = client.UserLoginStateClient()
 	cfg.Users = client
 	cfg.WebSession = client.WebSessions()
-	cfg.WebToken = client.WebTokens()
+	cfg.WebToken = client
 	cfg.WindowsDesktops = client
 	cfg.DynamicWindowsDesktops = client.DynamicDesktopClient()
 	cfg.AutoUpdateService = client

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -293,7 +293,7 @@ type Identity interface {
 	HeadlessAuthenticationService
 
 	types.WebSessionsGetter
-	types.WebTokensGetter
+	WebToken
 
 	// AppSession defines application session features.
 	AppSession

--- a/lib/services/session.go
+++ b/lib/services/session.go
@@ -19,6 +19,7 @@
 package services
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/gravitational/trace"
@@ -81,6 +82,20 @@ func MarshalWebSession(webSession types.WebSession, opts ...MarshalOption) ([]by
 	default:
 		return nil, trace.BadParameter("unrecognized web session version %T", webSession)
 	}
+}
+
+// WebToken defines an interface for managing web token resources.
+type WebToken interface {
+	// GetWebToken gets a web token.
+	GetWebToken(context.Context, types.GetWebTokenRequest) (types.WebToken, error)
+	// GetWebTokens gets all web tokens.
+	GetWebTokens(context.Context) ([]types.WebToken, error)
+	// UpsertWebToken updates the existing or inserts a new web token.
+	UpsertWebToken(context.Context, types.WebToken) error
+	// DeleteWebToken deletes a web token.
+	DeleteWebToken(context.Context, types.DeleteWebTokenRequest) error
+	// DeleteAllWebTokens deletes all web tokens.
+	DeleteAllWebTokens(context.Context) error
 }
 
 // MarshalWebToken serializes the web token as JSON-encoded payload


### PR DESCRIPTION
This commit aligns the WebToken service interface to be consistent with other services. A legacy wrapper is provided for the API module. No functionality changes have been made.

changelog: Deprecate `WebTokenInterface` in favour of `Client` directly implementing `services.WebToken`