### PR TITLE
[v16] [docs] Add app name conflicts to trusted cluster troubleshooting

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -155,6 +155,7 @@ header or move this page.
 */}
 
 An application name should make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 -` allowed).
+It should also be unique across root and leaf clusters if you are deploying in a trusted clusters environment.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
+++ b/docs/pages/zero-trust-access/management/admin/trustedclusters.mdx
@@ -940,3 +940,9 @@ To troubleshoot, you should start by checking the following information for the 
 
   If you use Teleport as a managed cloud-based service, you can access the audit log from the
   Teleport Web UI by selecting **Management**, then clicking **Audit Log** in the Activity section.
+
+### Application access within trusted clusters
+
+It is recommended to have unique application names across your entire cluster, root and leafs included. Applications served by leaf clusters are accessed via `app_name.root_proxy_public_addr`
+in the root cluster. When accessing the app via FQDN only, it can lead to ambiguous resolution. If your apps must contain the same name across multiple
+clusters, the most deterministic way to access the correct app is via the web UI's resources page.


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/59700