### PR TITLE
Expect the auth backend/cache to be initialized before turning ready

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1329,7 +1329,9 @@ func (i *TeleInstance) Start() error {
 	if i.Config.WindowsDesktop.Enabled {
 		expectedEvents = append(expectedEvents, service.WindowsDesktopReady)
 	}
-
+	if i.Config.Relay.Enabled {
+		expectedEvents = append(expectedEvents, service.RelayReady)
+	}
 	if i.Config.Discovery.Enabled {
 		expectedEvents = append(expectedEvents, service.DiscoveryReady)
 	}


### PR DESCRIPTION
This PR makes the auth unready until it has functional watchers. With cache enabled, this means that all everything is loaded in cache.

Why this change is needed:
- cache init might be slow if we have millions of entries or backend problems, starting to operate without a cache will send all queries to the backend, causing pressure, slower cache population, and potentially more backend issues
  - side note: In [a separate PR](https://github.com/gravitational/teleport.e/pull/7320) I am delaying the start of read-intensive routines until the cache is initialized
- many features rely on the ability to establish watchers, including access plugins, dynamic app/db/kube access, and most of the okta/entra sync logic
- currently, Teleport can start and become ready without a cache nor functioning watchers. In the most extreme cases, a rollout can proceed and break all watchers, leaving the cluster is a broken state

Depends on: https://github.com/gravitational/teleport/pull/59667
Changelog: Auth readiness tuned to wait for cache initialization.