### PR TITLE
[v18] Deflake TestIntegrations/DifferentPinnedIP

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -239,7 +239,9 @@ func testDifferentPinnedIP(t *testing.T, suite *integrationTestSuite) {
 	site := teleInstance.GetSiteAPI(helpers.Site)
 	require.NotNil(t, site)
 
-	connectionProblem := func(t require.TestingT, err error, i ...interface{}) {
+	require.NoError(t, teleInstance.WaitForNodeCount(t.Context(), helpers.Site, 1))
+
+	connectionProblem := func(t require.TestingT, err error, i ...any) {
 		require.Error(t, err, i...)
 		require.True(t, trace.IsConnectionProblem(err), "expected a connection problem error, got: %v", err)
 	}


### PR DESCRIPTION
Wait for the SSH node to be ready before dialing it.

Closes #55697
Backports #59792