### PR TITLE
docs: update resource types related to tctl create

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -697,8 +697,9 @@ These flags are available for all commands: `--debug, --config`. Run
 
 Create or update a Teleport resource from a YAML file.
 
-The supported resource types are: user, node, cluster, role, connector, and device.
-See the [Resources Reference](../infrastructure-as-code/resources.mdx) for complete docs on how to build these yaml files.
+The supported resource types include: user, node, cluster, role, connector, and device.
+See the [Resources Reference](../infrastructure-as-code/resources.mdx) for complete docs on all the 
+resource types and how to build these yaml files.
 
 ```code
 $ tctl create [<flags>] <filename>

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -698,7 +698,7 @@ These flags are available for all commands: `--debug, --config`. Run
 Create or update a Teleport resource from a YAML file.
 
 The supported resource types include: user, node, cluster, role, connector, and device.
-See the [Resources Reference](../infrastructure-as-code/resources.mdx) for complete docs on all the 
+See the [Resources Reference](../infrastructure-as-code/resources.mdx) for complete docs on additional 
 resource types and how to build these yaml files.
 
 ```code

--- a/docs/pages/reference/infrastructure-as-code/resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/resources.mdx
@@ -56,6 +56,9 @@ Here's the list of resources currently exposed via [`tctl`](../cli/tctl.mdx):
 | [role](#role) | A role assumed by interactive and non-interactive users. |
 | connector | Authentication connectors for [Single Sign-On](../../zero-trust-access/sso/sso.mdx) (SSO) for SAML, OIDC and GitHub. |
 | node | A registered SSH node. The same record is displayed via `tctl nodes ls`. |
+| kube_cluster | A registered Kubernetes cluster. |
+| db | A registered database. |
+| app | A registered application. |
 | windows_desktop | A registered Windows desktop. |
 | cluster | A trusted cluster. See [here](../../zero-trust-access/management/admin/trustedclusters.mdx) for more details on connecting clusters together. |
 | [login_rule](#login-rules) | A Login Rule, see the [Login Rules guide](../../zero-trust-access/authentication/login-rules/login-rules.mdx) for more info. |


### PR DESCRIPTION
- Add app, db and kube_cluster as available dynamic resource types for `tctl create`.
- Update cli language on `tctl create` reference that the listed resource types were not all that was available.