### PR TITLE
fix: ensure all tsh spans are rooted to the command

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1585,12 +1585,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	stopTracing := initializeTracing(&cf)
 	defer stopTracing()
 
-	// start the span for the command and update the config context so that all spans created
-	// in the future will be rooted at this span.
-	ctx, span := cf.tracer.Start(cf.Context, command)
-	cf.Context = ctx
-	defer span.End()
-
 	if err := client.ValidateAgentKeyOption(cf.AddKeysToAgent); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1929,9 +1923,14 @@ func initializeTracing(cf *CLIConf) func() {
 	cf.TracingProvider = tracing.NoopProvider()
 	cf.tracer = cf.TracingProvider.Tracer(teleport.ComponentTSH)
 
-	// flush ensures that the spans are all attempted to be written when tsh exits.
+	// flush ends the root span and ensures that the spans are all attempted to be written when tsh exits.
+	var rootSpan oteltrace.Span
 	flush := func(provider *tracing.Provider) func() {
 		return func() {
+			if rootSpan != nil {
+				rootSpan.End()
+			}
+
 			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(cf.Context), time.Second)
 			defer cancel()
 			err := provider.Shutdown(shutdownCtx)
@@ -1976,6 +1975,9 @@ func initializeTracing(cf *CLIConf) func() {
 
 		cf.TracingProvider = provider
 		cf.tracer = provider.Tracer(teleport.ComponentTSH)
+		// Start the root span for the command and update the config context so
+		// that all spans created in the future will be rooted at this span.
+		cf.Context, rootSpan = cf.tracer.Start(cf.Context, cf.command)
 		return flush(provider)
 	// All commands besides ssh are only traced if the user explicitly requested
 	// tracing. For ssh, a random number of spans may be sampled if the Proxy is
@@ -2000,6 +2002,9 @@ func initializeTracing(cf *CLIConf) func() {
 	}
 	cf.TracingProvider = provider
 	cf.tracer = provider.Tracer(teleport.ComponentTSH)
+	// Start the root span for the command and update the config context so
+	// that all spans created in the future will be rooted at this span.
+	cf.Context, rootSpan = cf.tracer.Start(cf.Context, cf.command)
 
 	if cf.command == "login" {
 		// Don't call RetryWithRelogin below if the user is trying to log in.


### PR DESCRIPTION
Since https://github.com/gravitational/teleport/pull/57841 `tsh` now collects traces while creating the tracing client, but these traces have not been rooted to the main span for the `tsh` command. An example for `tsh ls` looks like the following, with 4 traces not rooted to the main `ls` span.
<img width="1280" height="707" alt="image" src="https://github.com/user-attachments/assets/ee941c04-dd9b-4535-8676-c457973c4f74" />

This PR makes sure to create the root span for the command immediately, before trying to create the tracing client, so that all traces are properly rooted. Here's the same view with this change in place, all the same spans are collected but they're now all rooted to the `ls` command.
<img width="1283" height="259" alt="Screenshot 2025-10-03 at 12 45 43 PM" src="https://github.com/user-attachments/assets/d9bfbb03-8a58-443f-b98c-12e2bf381a32" />
