### PR TITLE
docs: update curl commands to use variable for proxy name

### DIFF
--- a/docs/pages/cloud-faq.mdx
+++ b/docs/pages/cloud-faq.mdx
@@ -199,10 +199,10 @@ Server ID                            Hostname              Services        Agent
 
 Teleport Enterprise Cloud allocates a different set of ports to each tenant. To see which
 ports are available for your Teleport Enterprise Cloud tenant, run a command similar to the
-following, replacing `example.teleport.sh` with your tenant domain:
+following, replacing <Var name="example.teleport.sh" /> with your tenant domain:
 
 ```code
-$ curl https://example.teleport.sh/webapi/ping | jq '.proxy'
+$ curl https://<Var name="example.teleport.sh" />/webapi/ping | jq '.proxy'
 ```
 
 The output should resemble the following, including the unique ports assigned to

--- a/docs/pages/reference/deployment/networking.mdx
+++ b/docs/pages/reference/deployment/networking.mdx
@@ -184,11 +184,11 @@ In those cases, they can set up separate listeners in the config file.
 
 Cloud-hosted Teleport deployments allocate a different set of ports to each
 tenant's Proxy Service. To see which ports are available for your Teleport
-tenant, run a command similar to the following, replacing `example.teleport.sh`
+tenant, run a command similar to the following, replacing <Var name="example.teleport.sh" />
 with your tenant domain:
 
 ```code
-$ curl https://example.teleport.sh/webapi/ping | jq '.proxy'
+$ curl https://<Var name="example.teleport.sh" />/webapi/ping | jq '.proxy'
 ```
 
 The output should resemble the following, including the unique ports assigned to

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -29,11 +29,11 @@ You can think of Teleport cluster components in three tiers:
 
 In Teleport Enterprise Cloud, we manage the Auth Service and Proxy Service for
 you. You can determine the current version of these services by running the
-following command, where `mytenant` is the name of your Teleport Enterprise
+following command, where <Var name="mytenant" /> is the name of your Teleport Enterprise
 Cloud tenant:
 
 ```code
-$ curl -s https://mytenant.teleport.sh/webapi/find | jq '.server_version'
+$ curl -s https://<Var name="mytenant" />.teleport.sh/webapi/find | jq '.server_version'
 ```
 
 ## Upgrading a self-hosted Teleport cluster

--- a/docs/pages/zero-trust-access/management/operations/tls-routing.mdx
+++ b/docs/pages/zero-trust-access/management/operations/tls-routing.mdx
@@ -34,10 +34,10 @@ Cloud.
 
 If you use Teleport Cloud, see which ports and networking settings the Proxy
 Service is configured to use in your Teleport Cloud tenant. Run the following
-command, replacing `mytenant.teleport.sh` with your tenant address:
+command, replacing <Var name="mytenant.teleport.sh" /> with your tenant address:
 
 ```code
-$ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
+$ curl https://<Var name="mytenant.teleport.sh" />/webapi/ping | jq '.proxy'
 ```
 
 ## Step 1/7. Upgrade Teleport


### PR DESCRIPTION
Update to use `Var` in `curl` examples where instructed to substitute url/tenante name.