### PR TITLE
Skip AWS E2E tests to unblock merges

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -60,6 +60,10 @@ import (
 )
 
 func TestDatabases(t *testing.T) {
+	// AWS E2E tests are disabled because our recreation script is broken
+	// and the necessary infra is not available.
+	t.Skip("Skipping AWS Databases test suite.")
+
 	t.Parallel()
 	testEnabled := os.Getenv(teleport.AWSRunDBTests)
 	if ok, _ := strconv.ParseBool(testEnabled); !ok {

--- a/e2e/aws/eks_test.go
+++ b/e2e/aws/eks_test.go
@@ -61,6 +61,10 @@ func checkRequiredKubeEnvVars(t *testing.T) {
 }
 
 func TestKube(t *testing.T) {
+	// AWS E2E tests are disabled because our recreation script is broken
+	// and the necessary infra is not available.
+	t.Skip("Skipping AWS EKS test suite.")
+
 	t.Parallel()
 	testEnabled := os.Getenv(teleport.KubeRunTests)
 	if ok, _ := strconv.ParseBool(testEnabled); !ok {


### PR DESCRIPTION
Our weekly destroy&reconstruct AWS infrastructure script is broken and we are unable to run AWS E2E tests for the time being.

This PR temporarily skips running AWS E2E tests in our CI.