### PR TITLE
fix: prevent `crypto/ssh` to block on dialing

### DIFF
--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -383,7 +383,7 @@ func newTLSRoutingWithConnUpgradeDialer(ssh ssh.ClientConfig, params connectPara
 // sshConnect upgrades the underling connection to ssh and connects to the Auth service.
 func sshConnect(ctx context.Context, conn net.Conn, ssh ssh.ClientConfig, dialTimeout time.Duration, addr string) (net.Conn, error) {
 	ssh.Timeout = dialTimeout
-	sconn, err := tracessh.NewClientConnWithDeadline(ctx, conn, addr, &ssh)
+	sconn, err := tracessh.NewClientWithTimeout(ctx, conn, addr, &ssh)
 	if err != nil {
 		return nil, trace.NewAggregate(err, conn.Close())
 	}

--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -51,6 +51,24 @@ const (
 	tracingSupported
 )
 
+// NewClientWithTimeout establishes a new client connection, honoring the earliest of the following:
+//
+// - The context's deadline or cancellation
+// - The timeout specified in the config
+// - A default timeout of 30 seconds if config doesn't specify a timeout
+//
+// - If config.Timeout > 0: the specified timeout is applied in addition to any context deadline.
+// - If config.Timeout == 0: a default timeout of 30 seconds is used to prevent indefinite hangs.
+// - If config.Timeout < 0: only the context's deadline or cancellation is respected if any.
+func NewClientWithTimeout(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (*Client, error) {
+	c, chans, reqs, err := NewClientConnWithTimeout(ctx, conn, addr, config, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(c, chans, reqs, opts...), nil
+}
+
 // NewClient creates a new Client.
 //
 // The server being connected to is probed to determine if it supports

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -15,10 +15,10 @@
 package ssh
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"net"
-	"time"
 
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -127,27 +127,37 @@ func Dial(ctx context.Context, network, addr string, config *ssh.ClientConfig, o
 	if err != nil {
 		return nil, err
 	}
-	c, chans, reqs, err := NewClientConn(ctx, conn, addr, config, opts...)
+	c, err := NewClientWithTimeout(ctx, conn, addr, config, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(c, chans, reqs), nil
+	return c, nil
 }
 
-// NewClientConn creates a new SSH client connection that is passed tracing context so that spans may be correlated
-// properly over the ssh connection.
-func NewClientConn(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+// NewClientConnWithTimeout creates a new SSH client connection that includes tracing context,
+// allowing spans to be properly correlated across the SSH connection.
+//
+// The connection respects the earliest of the following:
+// - The context's deadline or cancellation
+// - The timeout specified in the config
+// - A default timeout of 30 seconds if config doesn't specify a timeout
+//
+// Behavior based on config.Timeout:
+// - If > 0: the timeout is applied in addition to any context deadline.
+// - If == 0: a default timeout of 30 seconds is used to avoid hanging connections.
+// - If < 0: only the context’s deadline or cancellation is used.
+func NewClientConnWithTimeout(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
 	tracer := tracing.NewConfig(opts).TracerProvider.Tracer(instrumentationName)
 	ctx, span := tracer.Start( //nolint:staticcheck,ineffassign // keeping shadowed ctx to avoid accidental missing in the future
 		ctx,
-		"ssh/NewClientConn",
+		"ssh/NewClientConnWithTimeout",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 		oteltrace.WithAttributes(
 			append(
 				peerAttr(conn.RemoteAddr()),
 				attribute.String("address", addr),
 				semconv.RPCServiceKey.String("ssh"),
-				semconv.RPCMethodKey.String("NewClientConn"),
+				semconv.RPCMethodKey.String("NewClientConnWithTimeout"),
 				semconv.RPCSystemKey.String("ssh"),
 			)...,
 		),
@@ -173,17 +183,30 @@ func NewClientConn(ctx context.Context, conn net.Conn, addr string, config *ssh.
 
 	// We aim to close the connection to avoid clients to hang forever
 	// if the server is not responding.
-	ctx, cancel := context.WithTimeout(
-		ctx,
-		getTimeoutOrDefault(ctx, config),
-	)
-	defer cancel()
+
+	// If config.Timeout is negative, we don't set a timeout and restrict
+	// ourselves to the context deadline if any.
+	if config.Timeout >= 0 {
+		newCtx, cancel := context.WithTimeout(
+			ctx,
+			cmp.Or(config.Timeout, defaults.DefaultIOTimeout),
+		)
+		defer cancel()
+		ctx = newCtx
+	}
+
 	stopFn := context.AfterFunc(ctx, func() {
 		_ = conn.Close()
 	})
 
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
+		// if the context was canceled or timed out, return that error instead
+		// of the error from NewClientConn which would be something like
+		// "ssh: handshake failed: read tcp {ip}:{port} -> {ip}:{port} use of closed network connection"
+		if ctx.Err() != nil {
+			return nil, nil, nil, trace.Wrap(ctx.Err())
+		}
 		return nil, nil, nil, trace.Wrap(err)
 	}
 
@@ -199,57 +222,10 @@ func NewClientConn(ctx context.Context, conn net.Conn, addr string, config *ssh.
 		}()
 		go ssh.DiscardRequests(reqs)
 		_ = c.Close()
-		return nil, nil, nil, ctx.Err()
+		return nil, nil, nil, trace.Wrap(ctx.Err())
 	}
 
 	return c, chans, reqs, nil
-}
-
-// getTimeoutOrDefault returns the minimum timeout between the context deadline and the ssh.ClientConfig timeout.
-// If neither is set, it returns a default of 30s.
-func getTimeoutOrDefault(ctx context.Context, cfg *ssh.ClientConfig) time.Duration {
-	// Default to 1 hour if no timeout is set on the config or context
-	// deadline.
-	deadlineTimeout := time.Hour
-	cfgTimeout := time.Hour
-
-	if cfg != nil && cfg.Timeout != 0 {
-		cfgTimeout = cfg.Timeout
-	}
-
-	deadline, ok := ctx.Deadline()
-	if ok {
-		deadlineTimeout = time.Until(deadline)
-		if deadlineTimeout <= 0 {
-			// Deadline exceeded, return immediately.
-			return time.Nanosecond
-		}
-	}
-	if cfg.Timeout != 0 || ok {
-		return min(cfgTimeout, deadlineTimeout)
-	}
-
-	return defaults.DefaultIOTimeout
-
-}
-
-// NewClientConnWithDeadline establishes new client connection with specified deadline
-func NewClientConnWithDeadline(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (*Client, error) {
-	if config.Timeout > 0 {
-		if err := conn.SetReadDeadline(time.Now().Add(config.Timeout)); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	c, chans, reqs, err := NewClientConn(ctx, conn, addr, config, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if config.Timeout > 0 {
-		if err := conn.SetReadDeadline(time.Time{}); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	return NewClient(c, chans, reqs, opts...), nil
 }
 
 // peerAttr returns attributes about the peer address.

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -181,13 +181,10 @@ func NewClientConn(ctx context.Context, conn net.Conn, addr string, config *ssh.
 	stopFn := context.AfterFunc(ctx, func() {
 		_ = conn.Close()
 	})
-	defer stopFn()
 
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)
-	}
-
 	}
 
 	if !stopFn() {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7913,7 +7913,7 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	conn, details, err := modClusterClient.ProxyClient.DialHost(ctx, nodeDetails.Addr, nodeDetails.Cluster, modTC.LocalAgent().ExtendedAgent)
 	require.NoError(t, err)
 	sshConfig := modClusterClient.ProxyClient.SSHConfig(username)
-	modSSHConn, modSSHChans, modSSHReqs, err := tracessh.NewClientConn(ctx, conn, nodeDetails.ProxyFormat(), sshConfig)
+	modSSHConn, modSSHChans, modSSHReqs, err := tracessh.NewClientConnWithTimeout(ctx, conn, nodeDetails.ProxyFormat(), sshConfig)
 	require.NoError(t, err)
 
 	// We pass an empty channel which we close right away to ssh.NewClient

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -721,7 +721,7 @@ func newClientConn(
 		// Use a noop text map propagator so that the tracing context isn't included in
 		// the connection handshake. Since the provided conn will already include the tracing
 		// context we don't want to send it again.
-		conn, chans, reqs, err := tracessh.NewClientConn(ctx, conn, nodeAddress, config, tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator()))
+		conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, conn, nodeAddress, config, tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator()))
 		respCh <- response{conn, chans, reqs, err}
 	}()
 

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -94,7 +94,7 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 
 	// Build a new client connection. This is done to get access to incoming
 	// global requests which dialer.Dial would not provide.
-	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pconn, addr.Addr, &ssh.ClientConfig{
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, pconn, addr.Addr, &ssh.ClientConfig{
 		User:            d.username,
 		Auth:            d.authMethods,
 		HostKeyCallback: callback,

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -774,7 +774,7 @@ func (s *Server) newRemoteClient(ctx context.Context, systemLogin string, netCon
 	// the correct host. It must occur in the list of principals presented by
 	// the remote server.
 	dstAddr := net.JoinHostPort(s.address, "0")
-	client, err := tracessh.NewClientConnWithDeadline(ctx, s.targetConn, dstAddr, clientConfig)
+	client, err := tracessh.NewClientWithTimeout(ctx, s.targetConn, dstAddr, clientConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/git/forward.go
+++ b/lib/srv/git/forward.go
@@ -633,7 +633,7 @@ func (s *ForwardServer) initRemoteConn(ctx context.Context, ccx *sshutils.Connec
 	clientConfig.KeyExchanges = s.cfg.KEXAlgorithms
 	clientConfig.MACs = s.cfg.MACAlgorithms
 
-	s.remoteClient, err = tracessh.NewClientConnWithDeadline(
+	s.remoteClient, err = tracessh.NewClientWithTimeout(
 		s.cfg.ParentContext,
 		s.cfg.TargetConn,
 		s.cfg.DstAddr.String(),

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1739,7 +1739,7 @@ func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAd
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via TCP
-	conn, chans, reqs, err := tracessh.NewClientConn(
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(
 		ctx,
 		pipeNetConn,
 		f.ssh.srv.Addr(),
@@ -2838,7 +2838,7 @@ func TestX11ProxySupport(t *testing.T) {
 	cltConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
 	// Perform ssh handshake and setup client for X11 test server.
-	cltConn, chs, reqs, err := tracessh.NewClientConn(ctx, netConn, node.addr, &cltConfig)
+	cltConn, chs, reqs, err := tracessh.NewClientConnWithTimeout(ctx, netConn, node.addr, &cltConfig)
 	require.NoError(t, err)
 	clt := tracessh.NewClient(cltConn, chs, reqs)
 
@@ -3025,7 +3025,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via proxy subsystem's TCP tunnel
-	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pipeNetConn,
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, pipeNetConn,
 		f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer conn.Close()

--- a/lib/vnet/ssh_handler.go
+++ b/lib/vnet/ssh_handler.go
@@ -167,7 +167,7 @@ func (h *sshHandler) initiateSSHConn(ctx context.Context, targetConn net.Conn, u
 	if err != nil {
 		return nil, trace.Wrap(err, "building SSH client config")
 	}
-	clientConn, clientChans, clientReqs, err := tracessh.NewClientConn(ctx, targetConn, target.addr, clientConfig)
+	clientConn, clientChans, clientReqs, err := tracessh.NewClientConnWithTimeout(ctx, targetConn, target.addr, clientConfig)
 	if err != nil {
 		return nil, trace.Wrap(err, "initiating SSH connection to %s@%s", user, target.addr)
 	}


### PR DESCRIPTION
`crypto/ssh` dialing doesn't support timeouts or context cancellation propagation by default. Although `ssh.ClientConfig` has a field `Timeout`, this field is only used when establishing a new TCP connection but it's never used for ssh handshake.

This means that if the target server never replies and no intermediary closes the connection, the connection will be kept alive forever causing Teleport dialer to deadlock and never recover.

Although teleport `ssh` package has `NewClientConnWithDeadline`, not every Teleport's implementation of `net.Conn` supports read deadlines - or deadlines at all, which means we can have cases where the system also deadlock when using `NewClientConnWithDeadline` and a timeout.

This PR tries to solve it by closing the underlying connection when the minimum time between the context's deadline, the timeout and if none set 30s.


Fixes #60011