### PR TITLE
Fix session recording playback in Safari

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4726,6 +4726,12 @@ func (h *Handler) WithClusterAuthWebSocket(fn ClusterWebsocketHandler) httproute
 		if _, err := fn(w, r, p, sctx, site, ws); err != nil {
 			h.writeErrToWebSocket(r.Context(), ws, err)
 		}
+
+		deadline := time.Now().Add(time.Second)
+		if err := ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), deadline); err != nil {
+			h.logger.ErrorContext(r.Context(), "error writing close message", "error", err)
+		}
+
 		return nil, nil
 	})
 }

--- a/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimelineRenderer.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/Timeline/renderers/TimelineRenderer.ts
@@ -142,7 +142,7 @@ export class TimelineRenderer {
       .then(() => {
         this.render();
 
-        requestIdleCallback(() => {
+        window.setTimeout(() => {
           void this.framesRenderer.loadNonVisibleFrames();
         });
       })

--- a/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
@@ -54,7 +54,7 @@ export interface RecordingPlayerProps<
   TEndEventType extends TEventType = TEventType,
 > {
   duration: number;
-  onTimeChange: (time: number) => void;
+  onTimeChange?: (time: number) => void;
   onToggleSidebar?: () => void;
   onToggleTimeline?: () => void;
   onToggleFullscreen?: () => void;
@@ -108,7 +108,7 @@ export function RecordingPlayer<
       }
 
       controlsRef.current.setTime(time);
-      onTimeChange(time);
+      onTimeChange?.(time);
       eventInfoRef.current.setTime(time);
     });
 
@@ -172,11 +172,13 @@ export function RecordingPlayer<
         overflow="hidden"
         position="relative"
       >
-        <CurrentEventInfo
-          events={events}
-          onSeek={handleSeek}
-          ref={eventInfoRef}
-        />
+        {events?.length > 0 && (
+          <CurrentEventInfo
+            events={events}
+            onSeek={handleSeek}
+            ref={eventInfoRef}
+          />
+        )}
 
         {showPlayButton && (
           <PlayButton onClick={handlePlay}>


### PR DESCRIPTION
Safari is sensitive to websockets not sending a close message, and will error saying the network connection was lost. This would cause the metadata fetching to fail

Next, the fallback to the non-metadata UI would render the new player, which assumed the `onTimeChange` and `events` props were not optional, but they are. This would result in playback not working when clicking play.

This updates the authenticated websocket to send a close message before closing the websocket, which fixes the metadata not loading in Safari. It also fixes the assumption of `onTimeChange`/`events` props existing, so playback in the fallback UI still works. 

Finally, it replaces the usage `requestIdleCallback` as it turns out Safari doesn't support that. That wasn't causing any errors though, I just noticed it during fixing

Fixes #59923

changelog: Fixes an issue with SSH/k8s session recordings not playing in Safari