### PR TITLE
EC2 Auto Discovery: retry matchers

### DIFF
--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -54,11 +55,11 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 	return &output, nil
 }
 
-func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) innerEC2ClientGetter {
-	return func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) matcherEC2ClientGetter {
+	return func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		var roleARN string
-		if assumeRole != nil {
-			roleARN = assumeRole.RoleARN
+		if matcher.AssumeRole != nil {
+			roleARN = matcher.AssumeRole.RoleARN
 		}
 		return &mockEC2Client{
 			output: m[roleARN],
@@ -327,6 +328,26 @@ func TestEC2Watcher(t *testing.T) {
 		require.Fail(t, "unexpected instance: %v", inst)
 	default:
 	}
+}
+
+func TestMatchersToEC2InstanceFetchers(t *testing.T) {
+	ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+		return nil, errors.New("ec2 client getter invocation must not fail when creating fetchers")
+	}
+
+	matchers := []types.AWSMatcher{{
+		Params: &types.InstallerParams{
+			InstallTeleport: true,
+		},
+		Types:   []string{"EC2"},
+		Regions: []string{"us-west-2"},
+		Tags:    map[string]utils.Strings{"*": {"*"}},
+		SSM:     &types.AWSSSM{},
+	}}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), matchers, ec2ClientGetter, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, fetchers)
 }
 
 func TestConvertEC2InstancesToServerInfos(t *testing.T) {

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -56,7 +56,7 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 }
 
 func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) matcherEC2ClientGetter {
-	return func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+	return func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		var roleARN string
 		if matcher.AssumeRole != nil {
 			roleARN = matcher.AssumeRole.RoleARN


### PR DESCRIPTION
After migrating to aws sdk v2, we started to fail fast when the AWS credentials were not valid for a given AWS Matcher.

This means that the service exits when there's an AWS error. This is not the case in v17 branch, where we still use aws sdk v1.

This new behavior also means that if we have 1000 discovery matchers, each with its own assume role, and there's only one that has an invalid assume role, it will exit instead of processing the other 999.

This PR changes the flow to match what we had in v17:
- errors are logged
- service does not exit when there's a error in the AWS SDK (eg, when the credentials are not valid)
- after 5 minutes, the service will retry again to auto discover EC2 instances

v17:
<img width="1285" height="89" alt="image" src="https://github.com/user-attachments/assets/54a19f59-9fc2-4380-a87c-594e3b3d8e87" />

`master` and v18.0.0-v18.2.4:
<img width="1599" height="479" alt="image" src="https://github.com/user-attachments/assets/b3c6c39c-ffa6-4b3f-84ab-11d88783d5df" />

After this PR, the v17 behavior is back:
<img width="1599" height="218" alt="image" src="https://github.com/user-attachments/assets/bd99318f-2684-4620-bdfd-afd2bd7e6d59" />

changelog: Fixed crash of EC2 auto discovery when AWS credentials provided in to the Discovery Service are not valid.