### PR TITLE
[teleport-update] Fix SELinux warning and error breaking `teleport-update remove`

### DIFF
--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -226,6 +226,9 @@ func diagnoseWrongDomain(procCtx *selinuxContext, logger *slog.Logger) error {
 // ModuleInstalled returns true if the SSH SELinux module is installed.
 func ModuleInstalled() (bool, error) {
 	selinuxType, err := readConfig(selinuxTypeTag)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
 	if err != nil {
 		return false, trace.Wrap(err, "failed to find SELinux type")
 	}

--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
The `selinux.ModuleInstalled` function fails when it cannot find SELinux configuration. This function was recently introduced in `teleport-update` to support installing the SELinux SSH service module. It is called on systems that do not support SELinux.

As a result:
- A number of teleport-update subcommands now emit a loud warning on systems without SELinux.
- `teleport-update remove` no longer works with these systems, as the error is fatal

```
2025-10-02T22:23:35.520Z WARN [UPDATER]   Failed to remove SELinux module. error:[
ERROR REPORT:
Original Error: *fs.PathError open /etc/selinux/config: no such file or directory
Stack Trace:
/home/ubuntu/mounts/teleport/lib/selinux/read_config_linux.go:31 github.com/gravitational/teleport/lib/selinux.readConfig
/home/ubuntu/mounts/teleport/lib/selinux/selinux_linux.go:222 github.com/gravitational/teleport/lib/selinux.ModuleInstalled
/home/ubuntu/mounts/teleport/lib/autoupdate/agent/setup.go:426 github.com/gravitational/teleport/lib/autoupdate/agent.(*Namespace).removeSELinux
/home/ubuntu/mounts/teleport/lib/autoupdate/agent/setup.go:274 github.com/gravitational/teleport/lib/autoupdate/agent.(*Namespace).Setup
/home/ubuntu/mounts/teleport/lib/autoupdate/agent/updater.go:1238 github.com/gravitational/teleport/lib/autoupdate/agent.(*Updater).Setup
/home/ubuntu/mounts/teleport/tool/teleport-update/main.go:495 main.cmdSetup
/home/ubuntu/mounts/teleport/tool/teleport-update/main.go:255 main.Run
/home/ubuntu/mounts/teleport/tool/teleport-update/main.go:73 main.main
/home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/runtime/proc.go:285 runtime.main
/home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-arm64/src/runtime/asm_arm64.s:1268 runtime.goexit
User Message: failed to check if SELinux module is installed
failed to find SELinux type
open /etc/selinux/config: no such file or directory] agent/setup.go:275
```

changelog: fix selinux warning in teleport-update output and error during remove

Goal (internal): https://github.com/gravitational/cloud/issues/14225