### PR TITLE
[v16] Revert "Skip AWS E2E tests to unblock merges (#59953)"

### DIFF
--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -59,10 +59,6 @@ import (
 )
 
 func TestDatabases(t *testing.T) {
-	// AWS E2E tests are disabled because our recreation script is broken
-	// and the necessary infra is not available.
-	t.Skip("Skipping AWS Databases test suite.")
-
 	t.Parallel()
 	testEnabled := os.Getenv(teleport.AWSRunDBTests)
 	if ok, _ := strconv.ParseBool(testEnabled); !ok {

--- a/e2e/aws/eks_test.go
+++ b/e2e/aws/eks_test.go
@@ -61,10 +61,6 @@ func checkRequiredKubeEnvVars(t *testing.T) {
 }
 
 func TestKube(t *testing.T) {
-	// AWS E2E tests are disabled because our recreation script is broken
-	// and the necessary infra is not available.
-	t.Skip("Skipping AWS EKS test suite.")
-
 	t.Parallel()
 	testEnabled := os.Getenv(teleport.KubeRunTests)
 	if ok, _ := strconv.ParseBool(testEnabled); !ok {


### PR DESCRIPTION
This reverts commit b0a940e7ba005f60a1815421f7ae392806ebc1bb.