### PR TITLE
[v18] Fix sftp handling of colons in paths

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2585,8 +2585,8 @@ func (tc *TeleportClient) SFTP(ctx context.Context, source []string, destination
 	)
 	defer span.End()
 
-	isDownload := strings.ContainsRune(source[0], ':')
-	isUpload := strings.ContainsRune(destination, ':')
+	isDownload := sftp.IsRemotePath(source[0])
+	isUpload := sftp.IsRemotePath(destination)
 
 	if !isUpload && !isDownload {
 		return trace.BadParameter("no remote destination specified")

--- a/lib/sshutils/sftp/parse_test.go
+++ b/lib/sshutils/sftp/parse_test.go
@@ -272,3 +272,62 @@ func FuzzParseDestination(f *testing.F) {
 		_, _ = ParseDestination(input)
 	})
 }
+
+func TestIsRemotePath(t *testing.T) {
+	t.Parallel()
+	accept := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "remote path",
+			input: "foo:path/to/bar",
+		},
+		{
+			name:  "remote path with user",
+			input: "user@foo:/path/to/bar",
+		},
+		{
+			name:  "empty path",
+			input: "foo:",
+		},
+		{
+			name:  "remote with no slashes",
+			input: "foo:bar",
+		},
+		{
+			name:  "fake Windows path",
+			input: `foo:\valid\unix\file\name\weirdly`,
+		},
+	}
+	for _, tc := range accept {
+		t.Run("accept "+tc.name, func(t *testing.T) {
+			require.True(t, IsRemotePath(tc.input))
+		})
+	}
+	reject := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "local path",
+			input: "path/to/bar",
+		},
+		{
+			name:  "Windows absolute path",
+			input: `C:\path\to\bar`,
+		},
+		{
+			name:  "local path with colon",
+			input: "/foo:bar",
+		},
+		{
+			name: "empty path",
+		},
+	}
+	for _, tc := range reject {
+		t.Run("reject "+tc.name, func(t *testing.T) {
+			require.False(t, IsRemotePath(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
Backport #59615 to branch/v18

changelog: Fixed handling of local tsh scp targets that contain a colon
