### PR TITLE
Fix tf windows example, undo commit mistake

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -22,78 +22,24 @@ This page describes the supported values of the teleport_dynamic_windows_desktop
 ## Example Usage
 
 ```hcl
-resource "teleport_access_list" "characters" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "characters"
+resource "teleport_dynamic_windows_desktop" "example" {
+  version = "v1"
+  metadata = {
+    name        = "example"
+    description = "Test Windows desktop"
+    labels = {
+      "teleport.dev/origin" = "dynamic" // This label is added on Teleport side by default
     }
   }
+
   spec = {
-    type        = "static" # the access list must be of type "static" to manage its members with Terraform
-    title       = "Characters"
-    description = "The list of game characters."
-    owners = [
-      { name = "dungeon_master" },
-    ]
-    grants = {
-      roles = ["dungeon_access"]
+    addr   = "some.host.com"
+    non_ad = true
+    domain = "my.domain"
+    screen_size = {
+      width  = 800
+      height = 600
     }
-  }
-}
-
-# User member:
-
-resource "teleport_access_list_member" "fighter" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "fighter" # Teleport user name
-    }
-  }
-  spec = {
-    access_list     = teleport_access_list.characters.id
-    membership_kind = 1 # 1 for "MEMBERSHIP_KIND_USER", 2 for "MEMBERSHIP_KIND_LIST"
-  }
-}
-
-# Nested Access List member:
-
-resource "teleport_access_list" "npcs" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "npcs"
-    }
-  }
-  spec = {
-    title       = "NPCs"
-    description = "Non-player characters."
-    owners = [
-      { name = "dungeon_master" }
-    ]
-    grants = {
-      roles = ["dungeon_access"]
-    }
-    audit = {
-      recurrence = {
-        frequency    = 3
-        day_of_month = 15
-      }
-    }
-  }
-}
-
-resource "teleport_access_list_member" "npcs" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = teleport_access_list.npcs.id
-    }
-  }
-  spec = {
-    access_list     = teleport_access_list.characters.id
-    membership_kind = 2 # 1 for "MEMBERSHIP_KIND_USER", 2 for "MEMBERSHIP_KIND_LIST"
   }
 }
 ```

--- a/integrations/terraform/examples/resources/teleport_dynamic_windows_desktop/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_dynamic_windows_desktop/resource.tf
@@ -1,74 +1,20 @@
-resource "teleport_access_list" "characters" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "characters"
+resource "teleport_dynamic_windows_desktop" "example" {
+  version = "v1"
+  metadata = {
+    name        = "example"
+    description = "Test Windows desktop"
+    labels = {
+      "teleport.dev/origin" = "dynamic" // This label is added on Teleport side by default
     }
   }
+
   spec = {
-    type        = "static" # the access list must be of type "static" to manage its members with Terraform
-    title       = "Characters"
-    description = "The list of game characters."
-    owners = [
-      { name = "dungeon_master" },
-    ]
-    grants = {
-      roles = ["dungeon_access"]
+    addr   = "some.host.com"
+    non_ad = true
+    domain = "my.domain"
+    screen_size = {
+      width  = 800
+      height = 600
     }
-  }
-}
-
-# User member:
-
-resource "teleport_access_list_member" "fighter" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "fighter" # Teleport user name
-    }
-  }
-  spec = {
-    access_list     = teleport_access_list.characters.id
-    membership_kind = 1 # 1 for "MEMBERSHIP_KIND_USER", 2 for "MEMBERSHIP_KIND_LIST"
-  }
-}
-
-# Nested Access List member:
-
-resource "teleport_access_list" "npcs" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = "npcs"
-    }
-  }
-  spec = {
-    title       = "NPCs"
-    description = "Non-player characters."
-    owners = [
-      { name = "dungeon_master" }
-    ]
-    grants = {
-      roles = ["dungeon_access"]
-    }
-    audit = {
-      recurrence = {
-        frequency    = 3
-        day_of_month = 15
-      }
-    }
-  }
-}
-
-resource "teleport_access_list_member" "npcs" {
-  header = {
-    version = "v1"
-    metadata = {
-      name = teleport_access_list.npcs.id
-    }
-  }
-  spec = {
-    access_list     = teleport_access_list.characters.id
-    membership_kind = 2 # 1 for "MEMBERSHIP_KIND_USER", 2 for "MEMBERSHIP_KIND_LIST"
   }
 }


### PR DESCRIPTION
We let a small commit mistake slip through https://github.com/gravitational/teleport/pull/56999 and overwrote the TF windows example.

This PR reverts the mistake by checking out the file as it was before:
```
git checkout eb8566949bd24bbf05b2ad41c4a35bcab4cab16f~1 -- integrations/terraform/examples/resources/teleport_dynamic_windows_desktop/resource.tf

make -C integrations/terraform docs
```