### PR TITLE
Tweak deadline errors in relay tunnel conns

### DIFF
--- a/lib/relaytunnel/tunnel_client.go
+++ b/lib/relaytunnel/tunnel_client.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	relaytunnelv1alpha "github.com/gravitational/teleport/gen/proto/go/teleport/relaytunnel/v1alpha"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -610,7 +609,14 @@ func (c *yamuxClientConn) handleStream(stream *yamux.Stream, handleConnection fu
 		}
 	}
 
-	nc := utils.NewConnWithAddr(stream, dst, src)
+	nc := &yamuxStreamConn{
+		Stream: stream,
+
+		// on this side of the connection we are the destination and the peer is
+		// the source, the tunnel server will do the opposite
+		localAddr:  dst,
+		remoteAddr: src,
+	}
 	handleConnection(nc)
 }
 

--- a/lib/relaytunnel/tunnel_common.go
+++ b/lib/relaytunnel/tunnel_common.go
@@ -186,6 +186,8 @@ type yamuxStreamConn struct {
 // Read implements [net.Conn].
 func (c *yamuxStreamConn) Read(b []byte) (int, error) {
 	n, err := c.Stream.Read(b)
+	//nolint:errorlint // this workaround is specifically to work around bad
+	//practices around net.Conn and exact error values
 	if err == yamux.ErrTimeout {
 		// yamux.ErrTimeout.Temporary() returns false, which makes [*tls.Conn]
 		// kill the connection; the correct error to return from Read or Write
@@ -200,6 +202,8 @@ func (c *yamuxStreamConn) Read(b []byte) (int, error) {
 // Write implements [net.Conn].
 func (c *yamuxStreamConn) Write(b []byte) (int, error) {
 	n, err := c.Stream.Write(b)
+	//nolint:errorlint // this workaround is specifically to work around bad
+	//practices around net.Conn and exact error values
 	if err == yamux.ErrTimeout {
 		// yamux.ErrTimeout.Temporary() returns false, which makes [*tls.Conn]
 		// kill the connection; the correct error to return from Read or Write

--- a/lib/relaytunnel/tunnel_common.go
+++ b/lib/relaytunnel/tunnel_common.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -158,4 +159,64 @@ func (l *yamuxLogger) Println(args ...any) {
 	// doing that and just redirect to Print instead
 
 	l.Print(args...)
+}
+
+// yamuxStreamConn is a [net.Conn] that wraps a [*yamux.Stream] to have
+// different local and remote addresses and to return the correct error from
+// Read and Write upon hitting a deadline (which is required for a
+// net/http.Server to correctly handle websockets when using a TLS connection,
+// which will instead result in a killed connection when the TLS layer hits a
+// [yamux.ErrTimeout] from Read, see
+// https://github.com/hashicorp/yamux/issues/156).
+//
+// The implementation of *yamux.Stream and thus of this type (as well as most
+// other net.Conn implementations in the codebase, like *multiplexer.Conn) are
+// not actually fulfilling the (absolutely inane) net.Conn requirement that
+// every method must be safe to call concurrently in any combination;
+// specifically, there must not be multiple concurrent calls to Read or multiple
+// concurrent calls to Write; this is already a requirement for the behavior of
+// TCP-like net.Conns to make any sense, and does not cause issues when using
+// this as the underlying connection for TLS or SSH.
+type yamuxStreamConn struct {
+	*yamux.Stream
+	localAddr  net.Addr
+	remoteAddr net.Addr
+}
+
+// Read implements [net.Conn].
+func (c *yamuxStreamConn) Read(b []byte) (int, error) {
+	n, err := c.Stream.Read(b)
+	if err == yamux.ErrTimeout {
+		// yamux.ErrTimeout.Temporary() returns false, which makes [*tls.Conn]
+		// kill the connection; the correct error to return from Read or Write
+		// in case of a deadline is os.ErrDeadlineExceeded, and seeing as most
+		// things in the stdlib check for methods implemented directly by
+		// errors, we must return it as is without any wrapping
+		err = os.ErrDeadlineExceeded
+	}
+	return n, err
+}
+
+// Write implements [net.Conn].
+func (c *yamuxStreamConn) Write(b []byte) (int, error) {
+	n, err := c.Stream.Write(b)
+	if err == yamux.ErrTimeout {
+		// yamux.ErrTimeout.Temporary() returns false, which makes [*tls.Conn]
+		// kill the connection; the correct error to return from Read or Write
+		// in case of a deadline is os.ErrDeadlineExceeded, and seeing as most
+		// things in the stdlib check for methods implemented directly by
+		// errors, we must return it as is without any wrapping
+		err = os.ErrDeadlineExceeded
+	}
+	return n, err
+}
+
+// LocalAddr implements [net.Conn].
+func (c *yamuxStreamConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+// RemoteAddr implements [net.Conn].
+func (c *yamuxStreamConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
 }

--- a/lib/relaytunnel/tunnel_common_test.go
+++ b/lib/relaytunnel/tunnel_common_test.go
@@ -1,0 +1,63 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relaytunnel
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYamuxStreamConnDeadline(t *testing.T) {
+	t.Parallel()
+
+	conn1, conn2 := net.Pipe()
+
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = t.Output()
+
+	sess1, err := yamux.Client(conn1, cfg)
+	require.NoError(t, err)
+	defer sess1.Close()
+
+	sess2, err := yamux.Server(conn2, cfg)
+	require.NoError(t, err)
+	defer sess2.Close()
+
+	stream, err := sess1.OpenStream()
+	require.NoError(t, err)
+	defer stream.Close()
+
+	streamConn := &yamuxStreamConn{Stream: stream}
+	require.NoError(t, streamConn.SetDeadline(time.Unix(1, 0)))
+
+	n, err := streamConn.Read(make([]byte, 1))
+	require.Zero(t, n)
+
+	//nolint:errorlint // because of bad practices around net.Conn in the
+	// ecosystem, we want the exact error value to be returned rather than a
+	// wrapper; require.Equal checks for deep equality, require.Same relies on
+	// the implementation detail of os.ErrDeadlineExceeded being a pointer, so
+	// we spell out the actual equality instead
+	if err != os.ErrDeadlineExceeded {
+		require.FailNow(t, "expected os.ErrDeadlineExceeded, got %v", err)
+	}
+}

--- a/lib/relaytunnel/tunnel_server.go
+++ b/lib/relaytunnel/tunnel_server.go
@@ -544,5 +544,14 @@ func (c *yamuxServerConn) dial(ctx context.Context, src net.Addr, dst net.Addr) 
 	<-explode
 	stream.SetDeadline(time.Time{})
 
-	return stream, nil
+	nc := &yamuxStreamConn{
+		Stream: stream,
+
+		// on this side of the connection we are the source and the peer is the
+		// destination, the tunnel client will do the opposite
+		localAddr:  src,
+		remoteAddr: dst,
+	}
+
+	return nc, nil
 }


### PR DESCRIPTION
This PR adds a workaround for hashicorp/yamux#156 in the `net.Conn`s returned by the relay tunnel machinery (on both client and server sides, although the client is the one likely to be affected): various go network libraries rely on the ability to set a read deadline in the past to nondestructively unblock read operations on a conn; this is something that's required for connection hijacking in the `net/http.Server`, which is used by connection upgrades like websockets or SPDY (in kube access).

The error returned by a `*yamux.Stream` when hitting a deadline implements `net.Error` and returns true from its `Timeout()` method - which behaves correctly from the point of view of `http.Server` - but returns false from `Temporary()`, which makes `tls.Conn` give up on the connection forever, and prevents streaming kube api commands (like exec or port-forward) from working when going through a tls connection inside a `yamux.Stream`, like it's done in the relay tunnels.

The workaround is to wrap `Read` (and `Write`, for good measure) and replace the `yamux.ErrTimeout` error with `os.ErrDeadlineExceeded`, which fulfills the `net.Conn` contract and interoperates correctly with `http.Server` and `tls.Conn`. The equivalent condition in the regular SSH-based reverse tunnels is not hit because deadlines in there are implemented by pushing the read end of the connection through a `net.Pipe`, which already returns `os.ErrDeadlineExceeded` on a deadline error (`x/crypto/ssh` channels don't currently implement deadlines natively).