### PR TITLE
Add jq to buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -141,6 +141,7 @@ RUN apt-get -y update && \
         git \
         gnupg \
         gzip \
+        jq \
         libc6-dev \
         libelf-dev \
         libpam-dev \


### PR DESCRIPTION
I want to use `jq` in a follow-up PR bash script (for a CI test output rendering issue) after a new buildbox has been published.