### PR TITLE
[v18] [teleport-update] Fix SELinux warning and error breaking `teleport-update remove`

### DIFF
--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -226,6 +226,9 @@ func diagnoseWrongDomain(procCtx *selinuxContext, logger *slog.Logger) error {
 // ModuleInstalled returns true if the SSH SELinux module is installed.
 func ModuleInstalled() (bool, error) {
 	selinuxType, err := readConfig(selinuxTypeTag)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
 	if err != nil {
 		return false, trace.Wrap(err, "failed to find SELinux type")
 	}

--- a/lib/selinux/selinux_linux.go
+++ b/lib/selinux/selinux_linux.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Backport #59977 to branch/v18

changelog: fix selinux warning in teleport-update output and error during remove
