### PR TITLE
MWI: Add 'tbot start ssh-multiplexer' helper

### DIFF
--- a/lib/tbot/cli/start_multiplexer.go
+++ b/lib/tbot/cli/start_multiplexer.go
@@ -1,0 +1,86 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/services/ssh"
+	"github.com/gravitational/trace"
+)
+
+// SSHMultiplexerCommand implements `tbot start ssh-multiplexer` and
+// `tbot configure ssh-multiplexer`.
+type SSHMultiplexerCommand struct {
+	*sharedStartArgs
+	*sharedDestinationArgs
+	*genericMutatorHandler
+
+	// EnableResumption toggles session resumption. It is only set on the target
+	// bot config if `enableResumptionSetByUser` is true.
+	EnableResumption          bool
+	enableResumptionSetByUser bool
+
+	ProxyCommand       []string
+	ProxyTemplatesPath string
+}
+
+// NewSSHMultiplexerCommand initializes the command and flags for kubernetes outputs
+// and returns a struct to contain the parse result.
+func NewSSHMultiplexerCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *SSHMultiplexerCommand {
+	cmd := parentCmd.Command("ssh-multiplexer", fmt.Sprintf("%s tbot with an SSH Multiplexer service.", mode))
+
+	c := &SSHMultiplexerCommand{}
+	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
+	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
+
+	cmd.Flag("enable-resumption", "If set, disables SSH session resumption.").IsSetByUser(&c.enableResumptionSetByUser).BoolVar(&c.EnableResumption)
+	cmd.Flag("proxy-command", "The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.").StringsVar(&c.ProxyCommand)
+	cmd.Flag("proxy-templates-path", "A path to a proxy template config file. Optional.").StringVar(&c.ProxyTemplatesPath)
+
+	return c
+}
+
+func (c *SSHMultiplexerCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error {
+	if err := c.sharedStartArgs.ApplyConfig(cfg, l); err != nil {
+		return trace.Wrap(err)
+	}
+
+	dest, err := c.BuildDestination()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	multiplexer := &ssh.MultiplexerConfig{
+		Destination:        dest,
+		ProxyCommand:       c.ProxyCommand,
+		ProxyTemplatesPath: c.ProxyTemplatesPath,
+	}
+	if c.enableResumptionSetByUser {
+		multiplexer.EnableResumption = &c.EnableResumption
+	}
+
+	cfg.Services = append(cfg.Services, multiplexer)
+
+	return nil
+}

--- a/lib/tbot/cli/start_multiplexer.go
+++ b/lib/tbot/cli/start_multiplexer.go
@@ -23,9 +23,10 @@ import (
 	"log/slog"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/ssh"
-	"github.com/gravitational/trace"
 )
 
 // SSHMultiplexerCommand implements `tbot start ssh-multiplexer` and

--- a/lib/tbot/cli/start_multiplexer_test.go
+++ b/lib/tbot/cli/start_multiplexer_test.go
@@ -21,10 +21,11 @@ package cli
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/services/ssh"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSSHMultiplexerCommand(t *testing.T) {

--- a/lib/tbot/cli/start_multiplexer_test.go
+++ b/lib/tbot/cli/start_multiplexer_test.go
@@ -1,0 +1,83 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/services/ssh"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHMultiplexerCommand(t *testing.T) {
+	testStartConfigureCommand(t, NewSSHMultiplexerCommand, []startConfigureTestCase{
+		{
+			name: "success",
+			args: []string{
+				"start",
+				"ssh-multiplexer",
+				"--destination=/foo",
+				"--proxy-command=fdpass-teleport",
+				"--proxy-command=foo",
+				"--no-enable-resumption",
+				"--proxy-templates-path=/bar.yaml",
+			},
+			assertConfig: func(t *testing.T, cfg *config.BotConfig) {
+				require.Len(t, cfg.Services, 1)
+
+				svc := cfg.Services[0]
+				mx, ok := svc.(*ssh.MultiplexerConfig)
+				require.True(t, ok)
+
+				dir, ok := mx.Destination.(*destination.Directory)
+				require.True(t, ok)
+				require.Equal(t, "/foo", dir.Path)
+
+				require.False(t, mx.SessionResumptionEnabled())
+				require.Equal(t, []string{"fdpass-teleport", "foo"}, mx.ProxyCommand)
+				require.Equal(t, "/bar.yaml", mx.ProxyTemplatesPath)
+			},
+		},
+		{
+			name: "minimal",
+			args: []string{
+				"start",
+				"ssh-multiplexer",
+				"--destination=/foo",
+			},
+			assertConfig: func(t *testing.T, cfg *config.BotConfig) {
+				require.Len(t, cfg.Services, 1)
+
+				svc := cfg.Services[0]
+				mx, ok := svc.(*ssh.MultiplexerConfig)
+				require.True(t, ok)
+
+				dir, ok := mx.Destination.(*destination.Directory)
+				require.True(t, ok)
+				require.Equal(t, "/foo", dir.Path)
+
+				require.True(t, mx.SessionResumptionEnabled())
+				require.Empty(t, mx.ProxyCommand)
+				require.Empty(t, mx.ProxyTemplatesPath)
+			},
+		},
+	})
+}

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -33,8 +33,6 @@ services:
     destination:
       type: directory
       path: /bot/output
-    enable_resumption: null
-    proxy_templates_path: ""
     credential_ttl: 30s
     renewal_interval: 15s
   - type: application-tunnel

--- a/lib/tbot/services/ssh/multiplexer_config.go
+++ b/lib/tbot/services/ssh/multiplexer_config.go
@@ -41,13 +41,13 @@ type MultiplexerConfig struct {
 	// EnableResumption controls whether to enable session resumption for the
 	// SSH proxy.
 	// Call `SessionResumptionEnabled` to get the value with defaults applied.
-	EnableResumption *bool `yaml:"enable_resumption"`
+	EnableResumption *bool `yaml:"enable_resumption,omitempty"`
 	// ProxyTemplatesPath is the path to the directory containing the templates
 	// for the SSH proxy.
 	// This field is optional, if not provided, no templates will be used.
 	// This file is loaded once on start, so changes to the templates will
 	// require a restart of tbot.
-	ProxyTemplatesPath string `yaml:"proxy_templates_path"`
+	ProxyTemplatesPath string `yaml:"proxy_templates_path,omitempty"`
 	// ProxyCommand is the base command to configure OpenSSH to invoke to
 	// connect to the SSH multiplexer. The path to the socket and the target
 	// will be automatically appended.

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -166,6 +166,9 @@ func Run(args []string, stdout io.Writer) error {
 
 		cli.NewApplicationProxyCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
 		cli.NewApplicationProxyCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),
+
+		cli.NewSSHMultiplexerCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
+		cli.NewSSHMultiplexerCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),
 	)
 
 	// Initialize legacy-style commands. These are simple enough to not really


### PR DESCRIPTION
This adds a start/configure helper for the ssh-multiplexer service.

To use, run: `tbot start ssh-multiplexer --destination=/foo ...`

changelog: Added `tbot start ssh-multiplexer` helper to start the SSH multiplexer service without a config file

Closes #59885