### PR TITLE
Update link to downloads page in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/CompatibilityWarning.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/CompatibilityWarning.tsx
@@ -126,7 +126,7 @@ function buildDownloadUrl(platform: Platform): string {
   let os: string;
   switch (platform) {
     case 'darwin':
-      os = 'mac';
+      os = 'darwin';
       break;
     case 'linux':
       os = 'linux';
@@ -136,7 +136,7 @@ function buildDownloadUrl(platform: Platform): string {
       break;
   }
 
-  return `https://goteleport.com/download/?product=connect&os=${os}`;
+  return `https://goteleport.com/download/client-tools/?os=${os}`;
 }
 
 function getMajorVersion(version: string): string {


### PR DESCRIPTION
This updates the link in Connect so that it leads to the new page and correctly supplies the `os` query param. The new page uses "darwin" instead of "mac".

We don't appear to have any other link to the old downloads page in the project that would use query params (`"goteleport.com.*download\/\?"`)