### PR TITLE
MWI: Add `tctl` get and delete mappings for `AutoUpdateBotInstanceReport`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3162,7 +3162,7 @@ func (c *Client) GetAutoUpdateBotInstanceReport(ctx context.Context) (*autoupdat
 // DeleteAutoUpdateBotInstanceReport deletes the singleton auto-update bot instance report.
 func (c *Client) DeleteAutoUpdateBotInstanceReport(ctx context.Context) error {
 	client := autoupdatev1pb.NewAutoUpdateServiceClient(c.conn)
-	_, err := client.GetAutoUpdateBotInstanceReport(ctx, &autoupdatev1pb.GetAutoUpdateBotInstanceReportRequest{})
+	_, err := client.DeleteAutoUpdateBotInstanceReport(ctx, &autoupdatev1pb.DeleteAutoUpdateBotInstanceReportRequest{})
 	return trace.Wrap(err)
 }
 

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -277,6 +277,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAutoUpdateAgentRollout, nil
 	case types.KindAutoUpdateAgentReport:
 		return types.KindAutoUpdateAgentReport, nil
+	case types.KindAutoUpdateBotInstanceReport:
+		return types.KindAutoUpdateBotInstanceReport, nil
 	case types.KindGitServer, types.KindGitServer + "s":
 		return types.KindGitServer, nil
 	case types.KindWorkloadIdentityX509Revocation, types.KindWorkloadIdentityX509Revocation + "s":

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
-	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
@@ -2224,7 +2223,7 @@ func (c *scopedRoleAssignmentCollection) writeText(w io.Writer, verbose bool) er
 }
 
 type autoUpdateBotInstanceReportCollection struct {
-	report *autoupdate.AutoUpdateBotInstanceReport
+	report *autoupdatev1pb.AutoUpdateBotInstanceReport
 }
 
 func (c *autoUpdateBotInstanceReportCollection) resources() []types.Resource {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1878,6 +1878,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		types.KindAutoUpdateConfig,
 		types.KindAutoUpdateVersion,
 		types.KindAutoUpdateAgentRollout,
+		types.KindAutoUpdateBotInstanceReport,
 	}
 	if !slices.Contains(singletonResources, rc.ref.Kind) && (rc.ref.Kind == "" || rc.ref.Name == "") {
 		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
@@ -2366,6 +2367,11 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("AutoUpdateAgentRollout has been deleted\n")
+	case types.KindAutoUpdateBotInstanceReport:
+		if err := client.DeleteAutoUpdateBotInstanceReport(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("%s has been deleted\n", types.KindAutoUpdateBotInstanceReport)
 	case types.KindHealthCheckConfig:
 		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
 	case types.KindRelayServer:
@@ -3544,6 +3550,15 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &autoUpdateAgentReportCollection{reports: reports}, nil
+	case types.KindAutoUpdateBotInstanceReport:
+		if rc.ref.Name != "" {
+			return nil, trace.BadParameter("only simple `tctl get %v` can be used", types.KindAutoUpdateBotInstanceReport)
+		}
+		report, err := client.GetAutoUpdateBotInstanceReport(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &autoUpdateBotInstanceReportCollection{report}, nil
 	case types.KindAccessMonitoringRule:
 		if rc.ref.Name != "" {
 			rule, err := client.AccessMonitoringRuleClient().GetAccessMonitoringRule(ctx, rc.ref.Name)


### PR DESCRIPTION
Also fixes copy/paste problem in API Client.
