### PR TITLE
[v18] Update electron to 37.6.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,8 +497,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       electron:
-        specifier: 37.4.0
-        version: 37.4.0
+        specifier: 37.6.0
+        version: 37.6.0
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12
@@ -4112,8 +4112,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@37.4.0:
-    resolution: {integrity: sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==}
+  electron@37.6.0:
+    resolution: {integrity: sha512-8AANcn6irYQ7cTAJRY7r0CovWckcGCHUniQecyGhw/jJ25vWwitVhF97skF+EyDztiEI6YBoF0G6tx1s37bO3g==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -11298,7 +11298,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@37.4.0:
+  electron@37.6.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.15.16

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/whatwg-url": "^13.0.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
-    "electron": "37.4.0",
+    "electron": "37.6.0",
     "electron-builder": "^26.0.12",
     "electron-updater": "^6.6.8",
     "electron-vite": "^4.0.0",


### PR DESCRIPTION
Since Electron 38 drops support for macOS 11, we cannot update Electron to the newest version on the release branches (see #59812). Instead, I'm updating Electron to the newest v37.

Once we verify that the update works just fine, I'll backport this to v17 and v16.

https://releases.electronjs.org/release/compare/v37.4.0/v37.6.0