### PR TITLE
Add support for Bedrock models to the session summarizer

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -180,6 +180,7 @@ type InferenceModelSpec struct {
 	// Types that are valid to be assigned to Provider:
 	//
 	//	*InferenceModelSpec_Openai
+	//	*InferenceModelSpec_Bedrock
 	Provider isInferenceModelSpec_Provider `protobuf_oneof:"provider"`
 	// MaxSessionLengthBytes is the maximum session length that can be sent to
 	// inference provider. Currently, it's determined by the size of model's
@@ -247,6 +248,15 @@ func (x *InferenceModelSpec) GetOpenai() *OpenAIProvider {
 	return nil
 }
 
+func (x *InferenceModelSpec) GetBedrock() *BedrockProvider {
+	if x != nil {
+		if x, ok := x.Provider.(*InferenceModelSpec_Bedrock); ok {
+			return x.Bedrock
+		}
+	}
+	return nil
+}
+
 func (x *InferenceModelSpec) GetMaxSessionLengthBytes() int64 {
 	if x != nil {
 		return x.MaxSessionLengthBytes
@@ -264,7 +274,15 @@ type InferenceModelSpec_Openai struct {
 	Openai *OpenAIProvider `protobuf:"bytes,1,opt,name=openai,proto3,oneof"`
 }
 
+type InferenceModelSpec_Bedrock struct {
+	// Bedrock indicates that this model uses Amazon Bedrock as the inference
+	// provider and specifies Bedrock-specific parameters.
+	Bedrock *BedrockProvider `protobuf:"bytes,3,opt,name=bedrock,proto3,oneof"`
+}
+
 func (*InferenceModelSpec_Openai) isInferenceModelSpec_Provider() {}
+
+func (*InferenceModelSpec_Bedrock) isInferenceModelSpec_Provider() {}
 
 // OpenAIProvider specifies OpenAI-specific parameters. It can be used to
 // configure OpenAI or an OpenAI-compatible API, such as LiteLLM.
@@ -344,6 +362,71 @@ func (x *OpenAIProvider) GetBaseUrl() string {
 	return ""
 }
 
+// BedrockProvider specifies parameters specific to Amazon Bedrock.
+type BedrockProvider struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Region is the AWS region which will be used for inference.
+	Region string `protobuf:"bytes,1,opt,name=region,proto3" json:"region,omitempty"`
+	// BedrockModelId specifies a model ID or an inference profile as understood
+	// by the Bedrock API.
+	BedrockModelId string `protobuf:"bytes,2,opt,name=bedrock_model_id,json=bedrockModelId,proto3" json:"bedrock_model_id,omitempty"`
+	// Temperature controls the randomness of the model's output.
+	Temperature   float32 `protobuf:"fixed32,3,opt,name=temperature,proto3" json:"temperature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BedrockProvider) Reset() {
+	*x = BedrockProvider{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BedrockProvider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BedrockProvider) ProtoMessage() {}
+
+func (x *BedrockProvider) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BedrockProvider.ProtoReflect.Descriptor instead.
+func (*BedrockProvider) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *BedrockProvider) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *BedrockProvider) GetBedrockModelId() string {
+	if x != nil {
+		return x.BedrockModelId
+	}
+	return ""
+}
+
+func (x *BedrockProvider) GetTemperature() float32 {
+	if x != nil {
+		return x.Temperature
+	}
+	return 0
+}
+
 // InferenceSecret resource stores session summarization inference provider
 // secrets, such as API keys. They need to be referenced by appropriate
 // provider configuration inside `InferenceModelSpec`.
@@ -365,7 +448,7 @@ type InferenceSecret struct {
 
 func (x *InferenceSecret) Reset() {
 	*x = InferenceSecret{}
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[3]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -377,7 +460,7 @@ func (x *InferenceSecret) String() string {
 func (*InferenceSecret) ProtoMessage() {}
 
 func (x *InferenceSecret) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[3]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -390,7 +473,7 @@ func (x *InferenceSecret) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InferenceSecret.ProtoReflect.Descriptor instead.
 func (*InferenceSecret) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{3}
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *InferenceSecret) GetKind() string {
@@ -439,7 +522,7 @@ type InferenceSecretSpec struct {
 
 func (x *InferenceSecretSpec) Reset() {
 	*x = InferenceSecretSpec{}
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[4]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -451,7 +534,7 @@ func (x *InferenceSecretSpec) String() string {
 func (*InferenceSecretSpec) ProtoMessage() {}
 
 func (x *InferenceSecretSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[4]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -464,7 +547,7 @@ func (x *InferenceSecretSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InferenceSecretSpec.ProtoReflect.Descriptor instead.
 func (*InferenceSecretSpec) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{4}
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *InferenceSecretSpec) GetValue() string {
@@ -491,7 +574,7 @@ type InferencePolicy struct {
 
 func (x *InferencePolicy) Reset() {
 	*x = InferencePolicy{}
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[5]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -503,7 +586,7 @@ func (x *InferencePolicy) String() string {
 func (*InferencePolicy) ProtoMessage() {}
 
 func (x *InferencePolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[5]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -516,7 +599,7 @@ func (x *InferencePolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InferencePolicy.ProtoReflect.Descriptor instead.
 func (*InferencePolicy) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{5}
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *InferencePolicy) GetKind() string {
@@ -572,7 +655,7 @@ type InferencePolicySpec struct {
 
 func (x *InferencePolicySpec) Reset() {
 	*x = InferencePolicySpec{}
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[6]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -584,7 +667,7 @@ func (x *InferencePolicySpec) String() string {
 func (*InferencePolicySpec) ProtoMessage() {}
 
 func (x *InferencePolicySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[6]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -597,7 +680,7 @@ func (x *InferencePolicySpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InferencePolicySpec.ProtoReflect.Descriptor instead.
 func (*InferencePolicySpec) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{6}
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *InferencePolicySpec) GetKinds() []string {
@@ -658,7 +741,7 @@ type Summary struct {
 
 func (x *Summary) Reset() {
 	*x = Summary{}
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +753,7 @@ func (x *Summary) String() string {
 func (*Summary) ProtoMessage() {}
 
 func (x *Summary) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[7]
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +766,7 @@ func (x *Summary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Summary.ProtoReflect.Descriptor instead.
 func (*Summary) Descriptor() ([]byte, []int) {
-	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{7}
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Summary) GetSessionId() string {
@@ -752,9 +835,10 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
-	"\x04spec\x18\x05 \x01(\v2*.teleport.summarizer.v1.InferenceModelSpecR\x04spec\"\x9b\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.summarizer.v1.InferenceModelSpecR\x04spec\"\xe0\x01\n" +
 	"\x12InferenceModelSpec\x12@\n" +
-	"\x06openai\x18\x01 \x01(\v2&.teleport.summarizer.v1.OpenAIProviderH\x00R\x06openai\x127\n" +
+	"\x06openai\x18\x01 \x01(\v2&.teleport.summarizer.v1.OpenAIProviderH\x00R\x06openai\x12C\n" +
+	"\abedrock\x18\x03 \x01(\v2'.teleport.summarizer.v1.BedrockProviderH\x00R\abedrock\x127\n" +
 	"\x18max_session_length_bytes\x18\x02 \x01(\x03R\x15maxSessionLengthBytesB\n" +
 	"\n" +
 	"\bprovider\"\xa2\x01\n" +
@@ -762,7 +846,11 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x0fopenai_model_id\x18\x01 \x01(\tR\ropenaiModelId\x12 \n" +
 	"\vtemperature\x18\x02 \x01(\x01R\vtemperature\x12+\n" +
 	"\x12api_key_secret_ref\x18\x03 \x01(\tR\x0fapiKeySecretRef\x12\x19\n" +
-	"\bbase_url\x18\x04 \x01(\tR\abaseUrl\"\xd5\x01\n" +
+	"\bbase_url\x18\x04 \x01(\tR\abaseUrl\"u\n" +
+	"\x0fBedrockProvider\x12\x16\n" +
+	"\x06region\x18\x01 \x01(\tR\x06region\x12(\n" +
+	"\x10bedrock_model_id\x18\x02 \x01(\tR\x0ebedrockModelId\x12 \n" +
+	"\vtemperature\x18\x03 \x01(\x02R\vtemperature\"\xd5\x01\n" +
 	"\x0fInferenceSecret\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -811,38 +899,40 @@ func file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_summarizer_v1_summarizer_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
 	(SummaryState)(0),             // 0: teleport.summarizer.v1.SummaryState
 	(*InferenceModel)(nil),        // 1: teleport.summarizer.v1.InferenceModel
 	(*InferenceModelSpec)(nil),    // 2: teleport.summarizer.v1.InferenceModelSpec
 	(*OpenAIProvider)(nil),        // 3: teleport.summarizer.v1.OpenAIProvider
-	(*InferenceSecret)(nil),       // 4: teleport.summarizer.v1.InferenceSecret
-	(*InferenceSecretSpec)(nil),   // 5: teleport.summarizer.v1.InferenceSecretSpec
-	(*InferencePolicy)(nil),       // 6: teleport.summarizer.v1.InferencePolicy
-	(*InferencePolicySpec)(nil),   // 7: teleport.summarizer.v1.InferencePolicySpec
-	(*Summary)(nil),               // 8: teleport.summarizer.v1.Summary
-	(*v1.Metadata)(nil),           // 9: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),       // 11: google.protobuf.Struct
+	(*BedrockProvider)(nil),       // 4: teleport.summarizer.v1.BedrockProvider
+	(*InferenceSecret)(nil),       // 5: teleport.summarizer.v1.InferenceSecret
+	(*InferenceSecretSpec)(nil),   // 6: teleport.summarizer.v1.InferenceSecretSpec
+	(*InferencePolicy)(nil),       // 7: teleport.summarizer.v1.InferencePolicy
+	(*InferencePolicySpec)(nil),   // 8: teleport.summarizer.v1.InferencePolicySpec
+	(*Summary)(nil),               // 9: teleport.summarizer.v1.Summary
+	(*v1.Metadata)(nil),           // 10: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),       // 12: google.protobuf.Struct
 }
 var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
-	9,  // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
+	10, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
 	2,  // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
 	3,  // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
-	9,  // 3: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
-	5,  // 4: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	9,  // 5: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
-	7,  // 6: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
-	0,  // 7: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
-	10, // 8: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
-	10, // 9: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
-	11, // 10: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	4,  // 3: teleport.summarizer.v1.InferenceModelSpec.bedrock:type_name -> teleport.summarizer.v1.BedrockProvider
+	10, // 4: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
+	6,  // 5: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	10, // 6: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 7: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
+	0,  // 8: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
+	11, // 9: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
+	11, // 10: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
+	12, // 11: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_proto_init() }
@@ -852,6 +942,7 @@ func file_teleport_summarizer_v1_summarizer_proto_init() {
 	}
 	file_teleport_summarizer_v1_summarizer_proto_msgTypes[1].OneofWrappers = []any{
 		(*InferenceModelSpec_Openai)(nil),
+		(*InferenceModelSpec_Bedrock)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -859,7 +950,7 @@ func file_teleport_summarizer_v1_summarizer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -43,6 +43,9 @@ message InferenceModelSpec {
     // Openai indicates that this model uses OpenAI as the inference provider
     // and specifies OpenAI-specific parameters.
     OpenAIProvider openai = 1;
+    // Bedrock indicates that this model uses Amazon Bedrock as the inference
+    // provider and specifies Bedrock-specific parameters.
+    BedrockProvider bedrock = 3;
   }
   // MaxSessionLengthBytes is the maximum session length that can be sent to
   // inference provider. Currently, it's determined by the size of model's
@@ -77,6 +80,17 @@ message OpenAIProvider {
   // such as LiteLLM. In such case, the `api_key_secret_ref` must point to a
   // secret that contains the API key for that custom API.
   string base_url = 4;
+}
+
+// BedrockProvider specifies parameters specific to Amazon Bedrock.
+message BedrockProvider {
+  // Region is the AWS region which will be used for inference.
+  string region = 1;
+  // BedrockModelId specifies a model ID or an inference profile as understood
+  // by the Bedrock API.
+  string bedrock_model_id = 2;
+  // Temperature controls the randomness of the model's output.
+  float temperature = 3;
 }
 
 // InferenceSecret resource stores session summarization inference provider

--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -23,7 +23,6 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/modules"
 )
 
 // NewInferenceModel creates a new InferenceModel resource with the given name
@@ -79,10 +78,6 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 			return trace.BadParameter("spec.openai.openai_model_id is required")
 		}
 	case *summarizerv1.InferenceModelSpec_Bedrock:
-		// TODO(bl-nero): Relax this condition once we implement spend controls.
-		if modules.GetModules().Features().Cloud {
-			return trace.BadParameter("Amazon Bedrock models are unavailable in Teleport Cloud")
-		}
 		if p.Bedrock.GetBedrockModelId() == "" {
 			return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
 		}

--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -23,6 +23,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 // NewInferenceModel creates a new InferenceModel resource with the given name
@@ -66,7 +67,6 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 	provider := m.GetSpec().GetProvider()
 	switch p := provider.(type) {
 	case nil:
-		m.GetSpec().ProtoReflect().GetUnknown()
 		return trace.BadParameter(
 			// Unfortunately, there's no way to tell between a missing and
 			// unsupported one once the object is parsed from YAML. There may be a
@@ -77,6 +77,17 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 	case *summarizerv1.InferenceModelSpec_Openai:
 		if p.Openai.GetOpenaiModelId() == "" {
 			return trace.BadParameter("spec.openai.openai_model_id is required")
+		}
+	case *summarizerv1.InferenceModelSpec_Bedrock:
+		// TODO(bl-nero): Relax this condition once we implement spend controls.
+		if modules.GetModules().Features().Cloud {
+			return trace.BadParameter("Amazon Bedrock models are unavailable in Teleport Cloud")
+		}
+		if p.Bedrock.GetBedrockModelId() == "" {
+			return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
+		}
+		if p.Bedrock.GetRegion() == "" {
+			return trace.BadParameter("spec.bedrock.region is required")
 		}
 	}
 

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -24,72 +24,124 @@ import (
 
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestValidateInferenceModel(t *testing.T) {
 	t.Parallel()
-	valid := NewInferenceModel("my-model", &summarizerv1.InferenceModelSpec{
+	validOpenAI := NewInferenceModel("my-model", &summarizerv1.InferenceModelSpec{
 		Provider: &summarizerv1.InferenceModelSpec_Openai{
 			Openai: &summarizerv1.OpenAIProvider{
 				OpenaiModelId: "gpt-4o",
 			},
 		},
 	})
-	require.NoError(t, ValidateInferenceModel(valid))
+	validBedrock := NewInferenceModel("my-model", &summarizerv1.InferenceModelSpec{
+		Provider: &summarizerv1.InferenceModelSpec_Bedrock{
+			Bedrock: &summarizerv1.BedrockProvider{
+				BedrockModelId: "amazon.nova-lite-v1:0",
+				Region:         "us-west-2",
+			},
+		},
+	})
+	require.NoError(t, ValidateInferenceModel(validOpenAI))
+	require.NoError(t, ValidateInferenceModel(validBedrock))
 
 	cases := []struct {
-		fn  func(m *summarizerv1.InferenceModel)
-		msg string
+		base *summarizerv1.InferenceModel
+		fn   func(m *summarizerv1.InferenceModel)
+		msg  string
 	}{
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Kind = "other" },
-			msg: "kind must be inference_model, got other",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Kind = "other" },
+			msg:  "kind must be inference_model, got other",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.SubKind = "foo" },
-			msg: "subkind must be empty",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.SubKind = "foo" },
+			msg:  "subkind must be empty",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Version = "" },
-			msg: "version is required",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Version = "" },
+			msg:  "version is required",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Version = types.V2 },
-			msg: "unsupported version v2, supported: v1",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Version = types.V2 },
+			msg:  "unsupported version v2, supported: v1",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Metadata = nil },
-			msg: "metadata is required",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Metadata = nil },
+			msg:  "metadata is required",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Metadata.Name = "" },
-			msg: "metadata.name is required",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Metadata.Name = "" },
+			msg:  "metadata.name is required",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Metadata.Name = "teleport-cloud-default" },
-			msg: "metadata.name \"teleport-cloud-default\" is reserved",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Metadata.Name = "teleport-cloud-default" },
+			msg:  "metadata.name \"teleport-cloud-default\" is reserved",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Spec = nil },
-			msg: "spec is required",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Spec = nil },
+			msg:  "spec is required",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Spec.Provider = nil },
-			msg: "missing or unsupported inference provider in spec, supported providers: openai",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Spec.Provider = nil },
+			msg:  "missing or unsupported inference provider in spec, supported providers: openai",
 		},
 		{
-			fn:  func(m *summarizerv1.InferenceModel) { m.Spec.GetOpenai().OpenaiModelId = "" },
-			msg: "spec.openai.openai_model_id is required",
+			base: validOpenAI,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Spec.GetOpenai().OpenaiModelId = "" },
+			msg:  "spec.openai.openai_model_id is required",
+		},
+		{
+			base: validBedrock,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Spec.GetBedrock().BedrockModelId = "" },
+			msg:  "spec.bedrock.bedrock_model_id is required",
+		},
+		{
+			base: validBedrock,
+			fn:   func(m *summarizerv1.InferenceModel) { m.Spec.GetBedrock().Region = "" },
+			msg:  "spec.bedrock.region is required",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.msg, func(t *testing.T) {
-			m := proto.CloneOf(valid)
+			m := proto.CloneOf(tc.base)
 			tc.fn(m)
 			assert.ErrorIs(t, ValidateInferenceModel(m), &trace.BadParameterError{Message: tc.msg})
 		})
 	}
+}
+
+func TestValidateInferenceModel_Cloud(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	})
+	m := NewInferenceModel("my-model", &summarizerv1.InferenceModelSpec{
+		Provider: &summarizerv1.InferenceModelSpec_Bedrock{
+			Bedrock: &summarizerv1.BedrockProvider{
+				BedrockModelId: "amazon.nova-lite-v1:0",
+				Region:         "us-west-2",
+			},
+		},
+	})
+	assert.ErrorIs(t, ValidateInferenceModel(m), &trace.BadParameterError{
+		Message: "Amazon Bedrock models are unavailable in Teleport Cloud",
+	})
 }
 
 func TestValidateInferenceSecret(t *testing.T) {

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -24,8 +24,6 @@ import (
 
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
 func TestValidateInferenceModel(t *testing.T) {
@@ -122,26 +120,6 @@ func TestValidateInferenceModel(t *testing.T) {
 			assert.ErrorIs(t, ValidateInferenceModel(m), &trace.BadParameterError{Message: tc.msg})
 		})
 	}
-}
-
-func TestValidateInferenceModel_Cloud(t *testing.T) {
-	modulestest.SetTestModules(t, modulestest.Modules{
-		TestBuildType: modules.BuildEnterprise,
-		TestFeatures: modules.Features{
-			Cloud: true,
-		},
-	})
-	m := NewInferenceModel("my-model", &summarizerv1.InferenceModelSpec{
-		Provider: &summarizerv1.InferenceModelSpec_Bedrock{
-			Bedrock: &summarizerv1.BedrockProvider{
-				BedrockModelId: "amazon.nova-lite-v1:0",
-				Region:         "us-west-2",
-			},
-		},
-	})
-	assert.ErrorIs(t, ValidateInferenceModel(m), &trace.BadParameterError{
-		Message: "Amazon Bedrock models are unavailable in Teleport Cloud",
-	})
 }
 
 func TestValidateInferenceSecret(t *testing.T) {

--- a/e_imports.go
+++ b/e_imports.go
@@ -56,6 +56,8 @@ import (
 	_ "github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	_ "github.com/aws/aws-sdk-go-v2/service/athena"
 	_ "github.com/aws/aws-sdk-go-v2/service/athena/types"
+	_ "github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	_ "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	_ "github.com/aws/aws-sdk-go-v2/service/glue"
 	_ "github.com/aws/aws-sdk-go-v2/service/glue/types"
 	_ "github.com/aws/aws-sdk-go-v2/service/identitystore"

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.19.10
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.6
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.31.0
@@ -281,8 +282,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
-
-require github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0
 
 require (
 	cel.dev/expr v0.24.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -282,6 +282,8 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
 
+require github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0
+
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go v0.121.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -830,6 +830,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5 h1:0t/Dr8fwx
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5/go.mod h1:NUciQYiEOln3pubY8iovZkWZdJrBTnoPPW3JTIk9QAI=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 h1:OC3hqQ29uyNsftVHwdbfHpDopEBViNFypjy9N5eDsMw=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6/go.mod h1:I1paYl0qAaXc+6AmLtylg4ApBC0/HEs5myhVIcy4Nng=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 h1:xdYdX+JpIFByMG8JQe9iWM9CqepyjhenukxTVQnuCbM=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0/go.mod h1:c1Ik+59wgLIJFhsSY8cAnw6QooiogpTZKP0rtkVcpCQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1 h1:sYEBub6ZSeElTUaelJkffTHj6HdmUsTF5H4B2XI/OiQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1/go.mod h1:FQ3H4KZGNJ7xNstwjgtKtWM99QtU1y2Y2vGdOSqEPZ8=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5 h1:BX2h98b2Jz3PvWxoxdf+xJXm728Ho8yNdkxX1ANlNTM=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.254.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.32.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.65.0 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -782,6 +782,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.9 h1:w9LnHqTq8MEdlnyhV4Bwfizd65lf
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.9/go.mod h1:LGEP6EK4nj+bwWNdrvX/FnDTFowdBNwcSPuZu/ouFys=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 h1:OC3hqQ29uyNsftVHwdbfHpDopEBViNFypjy9N5eDsMw=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6/go.mod h1:I1paYl0qAaXc+6AmLtylg4ApBC0/HEs5myhVIcy4Nng=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 h1:xdYdX+JpIFByMG8JQe9iWM9CqepyjhenukxTVQnuCbM=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0/go.mod h1:c1Ik+59wgLIJFhsSY8cAnw6QooiogpTZKP0rtkVcpCQ=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.254.1 h1:7p9bJCZ/b3EJXXARW7JMEs2IhsnI4YFHpfXQfgMh0eg=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.254.1/go.mod h1:M8WWWIfXmxA4RgTXcI/5cSByxRqjgne32Sh0VIbrn0A=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.32.5 h1:33b2m5B6xyH/ciB3qbzG9qECQLh5Q40O0Af5ZFi4/bY=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.31.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -832,6 +832,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5 h1:0t/Dr8fwx
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5/go.mod h1:NUciQYiEOln3pubY8iovZkWZdJrBTnoPPW3JTIk9QAI=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 h1:OC3hqQ29uyNsftVHwdbfHpDopEBViNFypjy9N5eDsMw=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6/go.mod h1:I1paYl0qAaXc+6AmLtylg4ApBC0/HEs5myhVIcy4Nng=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 h1:xdYdX+JpIFByMG8JQe9iWM9CqepyjhenukxTVQnuCbM=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0/go.mod h1:c1Ik+59wgLIJFhsSY8cAnw6QooiogpTZKP0rtkVcpCQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1 h1:sYEBub6ZSeElTUaelJkffTHj6HdmUsTF5H4B2XI/OiQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1/go.mod h1:FQ3H4KZGNJ7xNstwjgtKtWM99QtU1y2Y2vGdOSqEPZ8=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5 h1:BX2h98b2Jz3PvWxoxdf+xJXm728Ho8yNdkxX1ANlNTM=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dax v1.29.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.31.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -852,6 +852,8 @@ github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5 h1:0t/Dr8fwx
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.40.5/go.mod h1:NUciQYiEOln3pubY8iovZkWZdJrBTnoPPW3JTIk9QAI=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6 h1:OC3hqQ29uyNsftVHwdbfHpDopEBViNFypjy9N5eDsMw=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.6/go.mod h1:I1paYl0qAaXc+6AmLtylg4ApBC0/HEs5myhVIcy4Nng=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 h1:xdYdX+JpIFByMG8JQe9iWM9CqepyjhenukxTVQnuCbM=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0/go.mod h1:c1Ik+59wgLIJFhsSY8cAnw6QooiogpTZKP0rtkVcpCQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1 h1:sYEBub6ZSeElTUaelJkffTHj6HdmUsTF5H4B2XI/OiQ=
 github.com/aws/aws-sdk-go-v2/service/dax v1.29.1/go.mod h1:FQ3H4KZGNJ7xNstwjgtKtWM99QtU1y2Y2vGdOSqEPZ8=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.50.5 h1:BX2h98b2Jz3PvWxoxdf+xJXm728Ho8yNdkxX1ANlNTM=

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -488,7 +488,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		cfg.WorkloadIdentity = workloadIdentity
 	}
 	if cfg.Summarizer == nil {
-		summarizer, err := local.NewSummarizerService(cfg.Backend)
+		summarizer, err := local.NewSummarizerService(local.SummarizerServiceConfig{
+			Backend: cfg.Backend,
+			// TODO(bl-nero): Relax this condition once we implement spend controls.
+			EnableBedrock: !modules.GetModules().Features().Cloud,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err, "creating Summarizer service")
 		}

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -326,7 +326,10 @@ func SetModules(m Modules) {
 	modules = m
 }
 
-// GetModules returns the modules interface
+// GetModules returns the modules interface. It only works in the auth service
+// process, so any code that may be executed in a different context needs to
+// obtain modules or derived options from an auth-specific caller or an RPC
+// call to the auth server.
 func GetModules() Modules {
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/lib/services/local/summarizer.go
+++ b/lib/services/local/summarizer.go
@@ -219,17 +219,40 @@ const (
 	inferencePolicyPrefix = "inference_policies"
 )
 
+// SummarizerServiceConfig provides data necessary to initialize a
+// [SummarizerService].
+type SummarizerServiceConfig struct {
+	// Backend is the resource storage backend.
+	Backend backend.Backend
+	// EnableBedrock enables access to Amazon Bedrock models. Currently, this
+	// should only be turned on outside Teleport Cloud. Setting it to true allows
+	// creating inference_model resources that use the Bedrock inference
+	// provider.
+	EnableBedrock bool
+}
+
 // NewSummarizerService returns a service that manages summarization
 // configuration resources in the backend.
-func NewSummarizerService(b backend.Backend) (*SummarizerService, error) {
+func NewSummarizerService(cfg SummarizerServiceConfig) (*SummarizerService, error) {
+	validateInferenceModel := func(m *summarizerv1.InferenceModel) error {
+		err := summarizer.ValidateInferenceModel(m)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !cfg.EnableBedrock && m.GetSpec().GetBedrock() != nil {
+			return trace.BadParameter("Amazon Bedrock models are unavailable in Teleport Cloud")
+		}
+		return nil
+	}
+
 	modelService, err := generic.NewServiceWrapper(
 		generic.ServiceConfig[*summarizerv1.InferenceModel]{
-			Backend:       b,
+			Backend:       cfg.Backend,
 			ResourceKind:  types.KindInferenceModel,
 			BackendPrefix: backend.NewKey(inferenceModelPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*summarizerv1.InferenceModel],
 			UnmarshalFunc: services.UnmarshalProtoResource[*summarizerv1.InferenceModel],
-			ValidateFunc:  summarizer.ValidateInferenceModel,
+			ValidateFunc:  validateInferenceModel,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -237,7 +260,7 @@ func NewSummarizerService(b backend.Backend) (*SummarizerService, error) {
 
 	secretService, err := generic.NewServiceWrapper(
 		generic.ServiceConfig[*summarizerv1.InferenceSecret]{
-			Backend:       b,
+			Backend:       cfg.Backend,
 			ResourceKind:  types.KindInferenceSecret,
 			BackendPrefix: backend.NewKey(inferenceSecretPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*summarizerv1.InferenceSecret],
@@ -250,7 +273,7 @@ func NewSummarizerService(b backend.Backend) (*SummarizerService, error) {
 
 	policyService, err := generic.NewServiceWrapper(
 		generic.ServiceConfig[*summarizerv1.InferencePolicy]{
-			Backend:       b,
+			Backend:       cfg.Backend,
 			ResourceKind:  types.KindInferencePolicy,
 			BackendPrefix: backend.NewKey(inferencePolicyPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*summarizerv1.InferencePolicy],


### PR DESCRIPTION
- Add protocol buffers
- Add validation
- Add dependency on Bedrock SDK
- Move GenerateTestSession to the OSS code

RFD: https://github.com/gravitational/teleport.e/pull/7357
Contributes to https://github.com/gravitational/teleport.e/issues/7216
Followed up by https://github.com/gravitational/teleport.e/pull/7381